### PR TITLE
add backward for softmax

### DIFF
--- a/src/gems/__enable__.py
+++ b/src/gems/__enable__.py
@@ -53,7 +53,7 @@ def enable(lib=aten_lib):
     lib.impl("sub.out", sub, "CUDA")
     lib.impl("triu", triu, "CUDA")
     lib.impl("triu.out", triu, "CUDA")
-    lib.impl("softmax.int", softmax, "CUDA")
+    lib.impl("softmax.int", softmax, "AutogradCUDA")
 
 
 class use_gems:

--- a/src/gems/softmax.py
+++ b/src/gems/softmax.py
@@ -55,7 +55,52 @@ def softmax_kernel(
     tl.store(output_ptrs, softmax_output, mask=mask)
 
 
-def softmax(x, dim=1, dtype=None, out=None):
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": 1}, num_stages=4),
+        triton.Config({"BLOCK_M": 1}, num_stages=5),
+        triton.Config({"BLOCK_M": 2}, num_stages=4),
+        triton.Config({"BLOCK_M": 2}, num_stages=5),
+        triton.Config({"BLOCK_M": 4}, num_stages=4),
+        triton.Config({"BLOCK_M": 4}, num_stages=5),
+        triton.Config({"BLOCK_M": 8}, num_stages=4),
+        triton.Config({"BLOCK_M": 8}, num_stages=5),
+    ],
+    key=[
+        "M",
+        "N",
+    ],
+)
+@triton.heuristics(
+    values={
+        "BLOCK_N": lambda args: triton.next_power_of_2(args["N"]),
+        "num_warps": lambda args: 4
+        if args["N"] <= 1024
+        else (8 if args["N"] <= 2048 else 16),
+    },
+)
+@triton.jit
+def softmax_backward_kernel(out_ptr, out_grad_ptr, in_grad_ptr, M, N, K, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
+    pid_m = tl.program_id(0)
+    pid_k = tl.program_id(1)
+    m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    n_offset = tl.arange(0, BLOCK_N)
+    offsets = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
+    mask = m_offset[:, None] < M and n_offset[None, :] < N
+    out_ptrs = out_ptr + offsets
+    out = tl.load(out_ptrs, mask=mask)
+    out_grad_ptrs = out_grad_ptr + offsets
+    out_grad = tl.load(out_grad_ptrs, mask=mask)
+
+    scale = tl.sum(out * out_grad, 1)
+    in_grad = out * (out_grad - scale[:, None])
+
+    in_grad_ptrs = in_grad_ptr + offsets
+    tl.store(in_grad_ptrs, in_grad, mask=mask)
+
+
+def softmax_func(x, dim=1, dtype=None, ):
     if __debug__:
         print("GEMS SOFTMAX")
 
@@ -71,8 +116,7 @@ def softmax(x, dim=1, dtype=None, out=None):
 
     if dtype is None:
         dtype = x.dtype
-    if out is None:
-        out = torch.empty_like(x, dtype=dtype, device="cuda")
+    out = torch.empty_like(x, dtype=dtype)
 
     grid = lambda meta: (
         triton.cdiv(M, meta["BLOCK_M"]),
@@ -86,3 +130,58 @@ def softmax(x, dim=1, dtype=None, out=None):
         K,
     )
     return out
+
+
+def softmax_backward(out, out_grad, dim=1):
+    if __debug__:
+        print("GEMS SOFTMAX VJP")
+
+    assert dim >= -out.ndim and dim < out.ndim, "Invalid dim"
+    dim = dim % out.ndim
+    M = 1
+    N = out.shape[dim]
+    for i in range(dim):
+        M *= out.shape[i]
+
+    # NOTE: ensure contiguous?
+    in_grad = torch.empty_like(out)
+
+    out = out.contiguous()
+    out = out.reshape(M, N, -1)
+    K = out.numel() // M // N
+
+    out_grad = out_grad.contiguous().reshape(M, N, -1)
+
+    grid = lambda meta: (
+        triton.cdiv(M, meta["BLOCK_M"]),
+        K,
+    )
+    softmax_backward_kernel[grid](
+        out,
+        out_grad,
+        in_grad,
+        M,
+        N,
+        K,
+    )
+    return in_grad
+
+
+class Softmax(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, dim, dtype):
+        out = softmax_func(x, dim=dim, dtype=dtype)
+        ctx.save_for_backward(out)
+        ctx.dim = dim
+        return out
+
+    @staticmethod
+    def backward(ctx, out_grad):
+        dim = ctx.dim
+        out, = ctx.saved_tensors
+        in_grad = softmax_backward(out, out_grad, dim)
+        return in_grad, None, None
+
+
+def softmax(x, dim=-1, dtype=None):
+    return Softmax.apply(x, dim, dtype)

--- a/tests/gems/op_accu_test.py
+++ b/tests/gems/op_accu_test.py
@@ -367,7 +367,7 @@ def test_accuracy_sub(shape, alpha, dtype):
 @pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.bfloat16])
 def test_accuracy_softmax(shape, dtype):
     dim = 1
-    inp = torch.randn(shape, dtype=dtype, device="cuda")
+    inp = torch.randn(shape, dtype=dtype, device="cuda", requires_grad=True)
 
     ref_out = torch.nn.functional.softmax(inp, dim=dim)
     res_out = gems.softmax(inp, dim=dim)
@@ -375,6 +375,14 @@ def test_accuracy_softmax(shape, dtype):
     maxdiff = torch.max(torch.abs(ref_out - res_out))
     assert torch.allclose(
         ref_out, res_out, atol=1e-3, rtol=1e-3
+    ), f"max diff: {maxdiff}"
+
+    out_grad = torch.randn_like(inp)
+    ref_in_grad, = torch.autograd.grad(ref_out, inp, out_grad)
+    res_in_grad, = torch.autograd.grad(res_out, inp, out_grad)
+    maxdiff = torch.max(torch.abs(ref_in_grad - res_in_grad))
+    assert torch.allclose(
+        ref_in_grad, res_in_grad, atol=1e-3, rtol=1e-3
     ), f"max diff: {maxdiff}"
 
 


### PR DESCRIPTION
Add triton kernel for softmax backward(as an example for registering a kernel for autograd key). This is than by registering a function that support autograd to `softmax.int`. This may not be the best practice.

Other alternatives are:
1. register a kernel for `_softmax_backward_data`.
2. register a kernel for `_softmax`(so as not to implement backward for softmax).

