### PR TITLE
use functools.lru_cache(None) instead of functools.cache for python 3…

### DIFF
--- a/src/flag_gems/utils/code_cache.py
+++ b/src/flag_gems/utils/code_cache.py
@@ -4,7 +4,7 @@ from pathlib import Path
 import shutil
 
 
-@functools.cache
+@functools.lru_cache(maxsize=None) # this is the same as functools.cache in Python 3.9+
 def cache_dir_path() -> Path:
     """Return the cache directory for generated files in flaggems."""
     _cache_dir = os.environ.get("FLAGGEMS_CACHE_DIR")


### PR DESCRIPTION
use functools.lru_cache(None) instead of functools.cache for python 3.8 compatability