### PR TITLE
Memory efficient dropout

### DIFF
--- a/src/flag_gems/ops/dropout.py
+++ b/src/flag_gems/ops/dropout.py
@@ -76,7 +76,6 @@ def dropout_forward_kernel(
 @triton.jit
 def dropout_backward_kernel(
     DY,
-    MASK,
     DX,
     N,
     p,
@@ -118,25 +117,21 @@ class NativeDropout(torch.autograd.Function):
         O = torch.empty_like(x)
         N = x.numel()
         grid_fn = lambda meta: (triton.cdiv(N, meta["N_BLOCK_SIZE"]),)
-        inc = triton.cdiv(N, BLOCK_SIZE)
-        philox_seed, philox_offset = philox_cuda_seed_offset(inc)
+        philox_seed, philox_offset = philox_cuda_seed_offset(N)
         dropout_forward_kernel[grid_fn](x, O, N, p, philox_seed, philox_offset)
-        ctx.save_for_backward(Mask)
         ctx.p = p
         ctx.philox_seed = philox_seed
         ctx.philox_offset = philox_offset
-        return O, Mask
+        return O, None
 
     @staticmethod
     def backward(ctx, grad_outputs, kwargs):
         logging.debug("GEMS NATIVE DROPOUT BACKWARD")
-        (Mask,) = ctx.saved_tensors
-        scale = 1.0 / (1.0 - ctx.p)
         grad_outputs = grad_outputs.contiguous()
         grad_inputs = torch.empty_like(grad_outputs)
         N = grad_outputs.numel()
         grid_fn = lambda meta: (triton.cdiv(N, meta["N_BLOCK_SIZE"]),)
-        dropout_backward_kernel[grid_fn](grad_outputs, grad_inputs, N, p, ctx.philox_seed, ctx.philox_offset)
+        dropout_backward_kernel[grid_fn](grad_outputs, grad_inputs, N, ctx.p, ctx.philox_seed, ctx.philox_offset)
         return grad_inputs, None, None
 
 

--- a/src/flag_gems/utils/random_utils.py
+++ b/src/flag_gems/utils/random_utils.py
@@ -1,0 +1,15 @@
+import torch
+
+# This function returns the current state of the default Philox RNG in seed and offset and
+# updates the next offset by adding `increment`.
+def philox_cuda_seed_offset(increment, device=None):
+    device = device or torch.cuda.current_device()
+    gen = torch.cuda.default_generators[device]
+    state_copy = gen.get_state()
+    c0, c1, c2, _ = state_copy.view(torch.int32)
+    seed, offset = int(c0), int(c2)
+    increment = (increment + 3) // 4 * 4
+    c2 += increment
+    # get_state returns a new tensor, so it needs set_state to update the actual generator state.
+    gen.set_state(state_copy)
+    return seed, offset

--- a/tests/flag_gems/op_accu_test.py
+++ b/tests/flag_gems/op_accu_test.py
@@ -343,6 +343,9 @@ def test_accuracy_dropout(shape, dtype, p):
     with flag_gems.use_gems():
         res_out = torch.nn.functional.dropout(inp, p, True)
 
+    # nz_ref = torch.sum(ref_out == 0.0)
+    # nz_res = torch.sum(res_out == 0.0)
+
     num_equal = torch.sum(torch.isclose(ref_out, res_out)).item()
     exp_equal = (p * p + (1 - p) * (1 - p)) * inp.numel()
     assert (


### PR DESCRIPTION
The Philox RNG algorithm is solely determined by its input state, a 4 int32 tuple (c0, c1, c2, c3). Pytorch uses c0 for seed, c1 for thread counter, and c2 for intra-thead counter (aka offset), whereas in Triton c0 used for seed, and c1 used for offset. The crucial issue is Triton RNG using int32 offsets lacks randomness. This may have negative impact on large model trainings. Triton does allow an int64 offset, but then it won't split it up in two int32 counters in the algorithm. This discrepancy makes it hard for us to align the dropout implementation with Pytorch.

 


