### PR TITLE
Optimize softmax

### DIFF
--- a/.github/workflows/python-test.yaml
+++ b/.github/workflows/python-test.yaml
@@ -29,7 +29,8 @@ jobs:
           CUDA_VISIBLE_DEVICES=1 pytest -s tests/test_binary_pointwise_ops.py &
           CUDA_VISIBLE_DEVICES=2 pytest -s tests/test_blas_ops.py &
           CUDA_VISIBLE_DEVICES=3 pytest -s tests/test_reduction_ops.py &
-          CUDA_VISIBLE_DEVICES=4 pytest -s tests/test_special_ops.py && wait
+          CUDA_VISIBLE_DEVICES=4 pytest -s tests/test_special_ops.py &
+          CUDA_VISIBLE_DEVICES=5 pytest -s tests/test_libentry.py && wait
 
   container-model-test:
     runs-on: [self-hosted, docker]

--- a/src/flag_gems/ops/softmax.py
+++ b/src/flag_gems/ops/softmax.py
@@ -10,52 +10,154 @@ from ..utils import libentry
 @libentry()
 @triton.autotune(
     configs=[
-        triton.Config({"BLOCK_M": 1}, num_stages=4),
-        triton.Config({"BLOCK_M": 1}, num_stages=5),
-        triton.Config({"BLOCK_M": 2}, num_stages=4),
-        triton.Config({"BLOCK_M": 2}, num_stages=5),
-        triton.Config({"BLOCK_M": 4}, num_stages=4),
-        triton.Config({"BLOCK_M": 4}, num_stages=5),
-        triton.Config({"BLOCK_M": 8}, num_stages=4),
-        triton.Config({"BLOCK_M": 8}, num_stages=5),
+        triton.Config(
+            {"TILE_K": 32},
+        ),
+        triton.Config({"TILE_K": 64}),
+        triton.Config({"TILE_K": 128}),
+        triton.Config(
+            {"TILE_K": 256},
+        ),
+        triton.Config({"TILE_K": 512}),
+        triton.Config({"TILE_K": 1024}),
     ],
     key=[
-        "M",
-        "N",
+        "K",
     ],
 )
 @triton.heuristics(
     values={
-        "BLOCK_N": lambda args: triton.next_power_of_2(args["N"]),
-        "num_warps": lambda args: (
-            4 if args["N"] <= 1024 else (8 if args["N"] <= 2048 else 16)
-        ),
+        "TILE_N": lambda args: max(1, 1024 // args["TILE_K"]),
+        "ONE_TILE_PER_CTA": lambda args: args["TILE_N"] >= args["N"],
     },
 )
 @triton.jit
-def softmax_kernel(
+def softmax_kernel_non_inner(
     output_ptr,
     input_ptr,
     M,
     N,
     K,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    pid_k = tl.program_id(1)
+    pid_m = tl.program_id(0)
+
+    k_offsets = pid_k * TILE_K + tl.arange(0, TILE_K)
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)
+        offset = pid_m * N * K + n_offsets[:, None] * K + k_offsets
+        mask = (n_offsets[:, None] < N) & (k_offsets < K)
+        input_ptrs = input_ptr + offset
+        inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+        m = tl.max(inp, 0)
+        e = tl.exp(inp - m[None, :])
+        z = tl.sum(e, 0)
+        out = e / z
+        output_ptrs = output_ptr + offset
+        tl.store(output_ptrs, out, mask=mask)
+    else:
+        m = tl.full([TILE_K], value=float("-inf"), dtype=tl.float32)
+        z = tl.full([TILE_K], value=0.0, dtype=tl.float32)
+
+        n_offsets = tl.arange(0, TILE_N)
+        offset = pid_m * N * K + n_offsets[:, None] * K + k_offsets
+        for _ in range(0, N, TILE_N):
+            mask = (n_offsets[:, None] < N) & (k_offsets < K)
+            input_ptrs = input_ptr + offset
+            inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+            m_new = tl.maximum(m, tl.max(inp, 0))
+            alpha = m - m_new
+            z = z * tl.exp(alpha) + tl.sum(tl.exp(inp - m_new[None, :]), axis=0)
+            m = m_new
+            n_offsets += TILE_N
+            offset += TILE_N * K
+
+        n_offsets = tl.arange(0, TILE_N)
+        offset = pid_m * N * K + n_offsets[:, None] * K + k_offsets
+        for _ in range(0, N, TILE_N):
+            mask = (n_offsets[:, None] < N) & (k_offsets < K)
+            input_ptrs = input_ptr + offset
+            inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+            o = tl.exp(inp - m[None, :]) / z[None, :]
+            output_ptrs = output_ptr + offset
+            tl.store(output_ptrs, o, mask=mask)
+            n_offsets += TILE_N
+            offset += TILE_N * K
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"TILE_N": 32}),
+        triton.Config({"TILE_N": 64}),
+        triton.Config({"TILE_N": 128}),
+        triton.Config({"TILE_N": 256}),
+        triton.Config({"TILE_N": 512}),
+        triton.Config({"TILE_N": 1024}),
+    ],
+    key=["N"],
+)
+@triton.heuristics(
+    values={
+        "TILE_M": lambda args: max(1, 1024 // args["TILE_N"]),
+        "ONE_TILE_PER_CTA": lambda args: args["TILE_N"] >= args["N"],
+    },
+)
+@triton.jit
+def softmax_kernel_inner(
+    output_ptr,
+    input_ptr,
+    M,
+    N,
+    TILE_M: tl.constexpr,
+    TILE_N: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
 ):
     pid_m = tl.program_id(0)
-    pid_k = tl.program_id(1)
-    m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    n_offset = tl.arange(0, BLOCK_N)
-    offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
-    mask = m_offset[:, None] < M and n_offset[None, :] < N
-    input_ptrs = input_ptr + offset
-    inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
-    row_minus_max = inp - tl.max(inp, axis=1)[:, None]
-    numerator = tl.exp(row_minus_max)
-    denominator = tl.sum(numerator, axis=1)[:, None]
-    softmax_output = numerator / denominator
-    output_ptrs = output_ptr + offset
-    tl.store(output_ptrs, softmax_output, mask=mask)
+    m_offsets = pid_m * TILE_M + tl.arange(0, TILE_M)
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)
+        offset = m_offsets[:, None] * N + n_offsets
+        input_ptrs = input_ptr + offset
+        mask = (m_offsets[:, None] < M) & (n_offsets < N)
+        inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+        m = tl.max(inp, 1)
+        e = tl.exp(inp - m[:, None])
+        z = tl.sum(e, 1)
+        out = e / z[:, None]
+        output_ptrs = output_ptr + offset
+        tl.store(output_ptrs, out, mask=mask)
+    else:
+        m = tl.full([TILE_M], value=float("-inf"), dtype=tl.float32)
+        z = tl.full([TILE_M], value=0.0, dtype=tl.float32)
+
+        n_offsets = tl.arange(0, TILE_N)
+        offset = m_offsets[:, None] * N + n_offsets
+        for _ in range(0, N, TILE_N):
+            mask = (m_offsets[:, None] < M) & (n_offsets < N)
+            input_ptrs = input_ptr + offset
+            inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+            m_new = tl.maximum(m, tl.max(inp, 1))
+            alpha = m - m_new
+            z = z * tl.exp(alpha) + tl.sum(tl.exp(inp - m_new[:, None]), axis=1)
+            m = m_new
+            n_offsets += TILE_N
+            offset += TILE_N
+
+        n_offsets = tl.arange(0, TILE_N)
+        offset = m_offsets[:, None] * N + n_offsets
+        for _ in range(0, N, TILE_N):
+            mask = (m_offsets[:, None] < M) & (n_offsets < N)
+            input_ptrs = input_ptr + offset
+            inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+            o = tl.exp(inp - m[:, None]) / z[:, None]
+            output_ptrs = output_ptr + offset
+            tl.store(output_ptrs, o, mask=mask)
+            n_offsets += TILE_N
+            offset += TILE_N
 
 
 @libentry()
@@ -122,24 +224,30 @@ class Softmax(torch.autograd.Function):
         M = 1
         N = x.shape[dim]
         for i in range(dim):
-            M *= x.shape[i]
+            M *= x.shape[i]  # pre_dim
         inp = x.contiguous()
         if dtype is None:
             dtype = x.dtype
         out = torch.empty_like(inp, dtype=dtype)
-        K = inp.numel() // M // N
+        K = inp.numel() // M // N  # post_dim
 
-        grid = lambda meta: (
-            triton.cdiv(M, meta["BLOCK_M"]),
-            K,
-        )
-        softmax_kernel[grid](
-            out,
-            inp,
-            M,
-            N,
-            K,
-        )
+        if K > 1:
+            grid = lambda meta: (M, triton.cdiv(K, meta["TILE_K"]), 1)
+            softmax_kernel_non_inner[grid](
+                out,
+                inp,
+                M,
+                N,
+                K,
+            )
+        else:
+            grid = lambda meta: (triton.cdiv(M, meta["TILE_M"]), 1, 1)
+            softmax_kernel_inner[grid](
+                out,
+                inp,
+                M,
+                N,
+            )
         ctx.save_for_backward(out)
         ctx.dim = dim
         return out

--- a/src/flag_gems/ops/softmax.py
+++ b/src/flag_gems/ops/softmax.py
@@ -10,14 +10,10 @@ from ..utils import libentry
 @libentry()
 @triton.autotune(
     configs=[
-        triton.Config(
-            {"TILE_K": 32},
-        ),
+        triton.Config({"TILE_K": 32}),
         triton.Config({"TILE_K": 64}),
         triton.Config({"TILE_K": 128}),
-        triton.Config(
-            {"TILE_K": 256},
-        ),
+        triton.Config({"TILE_K": 256}),
         triton.Config({"TILE_K": 512}),
         triton.Config({"TILE_K": 1024}),
     ],

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -51,7 +51,6 @@ class LibEntry(triton.KernelInterface):
             # 2. kwargs,
             # 3. all all other captured arguments in CompiledKernel from Autotunner & Heuristics
             # when kwargs & captured args conflict, captured args have higher priority
-            print(kernel.constants)
             for k, v in kernel.constants.items():
                 arg_name = self.arg_names[int(k)]
                 kwargs[arg_name] = v

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -35,24 +35,18 @@ class LibEntry(triton.KernelInterface):
             kernel = self.kernel_cache[entry_key]
 
         # collect all the arguments to the kernel, all non-constexpr arguments
-        k_args = [
-            arg
-            for i, arg in enumerate(args)
-            if i in self.kernel_arg_indices
-        ]
+        k_args = [arg for i, arg in enumerate(args) if i in self.kernel_arg_indices]
         if len(k_args) < len(self.kernel_arg_indices):
-            for p in self.jit_function.params[len(args):]:
+            for p in self.jit_function.params[len(args) :]:
                 if not p.is_constexpr:
                     if p.name in kwargs:
                         k_args.append(kwargs[p.name])
                     else:
                         k_args.append(p.default)
 
-
         grid = kwargs["grid"]
         if callable(grid):
-            # collect all arguments to the grid fn，
-            # ie:
+            # collect all arguments to the grid fn，ie:
             # 1. args,
             # 2. kwargs,
             # 3. all all other captured arguments in CompiledKernel from Autotunner & Heuristics

--- a/tests/test_libentry.py
+++ b/tests/test_libentry.py
@@ -1,0 +1,169 @@
+from contextlib import nullcontext as does_not_raise
+
+import torch
+import triton
+from triton import language as tl
+
+from flag_gems.utils import libentry
+
+
+def softmax_inner_decorator_cascade(x, dim, dtype=None):
+    assert dim >= -x.ndim and dim < x.ndim, "Invalid dim"
+    dim = dim % x.ndim
+    M = 1
+    N = x.shape[dim]
+    for i in range(dim):
+        M *= x.shape[i]  # pre_dim
+    inp = x.contiguous()
+    if dtype is None:
+        dtype = x.dtype
+    out = torch.empty_like(inp, dtype=dtype)
+
+    grid = lambda meta: (triton.cdiv(M, meta["TILE_M"]), 1, 1)
+    softmax_kernel_inner[grid](
+        out,
+        inp,
+        M,
+        N,
+        DUMMY=60,
+    )
+    return out
+
+
+def softmax_inner_pass_kernel_arg_via_kw(x, dim, dtype=None):
+    assert dim >= -x.ndim and dim < x.ndim, "Invalid dim"
+    dim = dim % x.ndim
+    M = 1
+    N = x.shape[dim]
+    for i in range(dim):
+        M *= x.shape[i]  # pre_dim
+    inp = x.contiguous()
+    if dtype is None:
+        dtype = x.dtype
+    out = torch.empty_like(inp, dtype=dtype)
+
+    grid = lambda meta: (triton.cdiv(M, meta["TILE_M"]), 1, 1)
+    softmax_kernel_inner[grid](
+        out,
+        inp,
+        M,
+        N=N,
+        DUMMY=60,
+    )
+    return out
+
+
+def softmax_inner_kernel_arg_apply_default(x, dim, dtype=None):
+    assert dim >= -x.ndim and dim < x.ndim, "Invalid dim"
+    dim = dim % x.ndim
+    M = 1
+    N = x.shape[dim]
+    for i in range(dim):
+        M *= x.shape[i]  # pre_dim
+    inp = x.contiguous()
+    if dtype is None:
+        dtype = x.dtype
+    out = torch.empty_like(inp, dtype=dtype)
+
+    grid = lambda meta: (triton.cdiv(M, meta["TILE_M"]), 1, 1)
+    softmax_kernel_inner[grid](
+        out,
+        inp,
+        M,
+        N,
+    )
+    return out
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"TILE_N": 32}),
+        triton.Config({"TILE_N": 64}),
+        triton.Config({"TILE_N": 128}),
+        triton.Config({"TILE_N": 256}),
+        triton.Config({"TILE_N": 512}),
+        triton.Config({"TILE_N": 1024}),
+    ],
+    key=["N"],
+)
+@triton.heuristics(
+    values={
+        "TILE_M": lambda args: 1024 // args["TILE_N"],
+        "ONE_TILE_PER_CTA": lambda args: args["TILE_N"] >= args["N"],
+    },
+)
+@triton.jit
+def softmax_kernel_inner(
+    output_ptr,
+    input_ptr,
+    M,
+    N,
+    TILE_M: tl.constexpr,
+    TILE_N: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+    DUMMY=42,
+):
+    _ = DUMMY
+    pid_m = tl.program_id(0)
+    m_offsets = pid_m * TILE_M + tl.arange(0, TILE_M)
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)
+        offset = m_offsets[:, None] * N + n_offsets
+        input_ptrs = input_ptr + offset
+        mask = (m_offsets[:, None] < M) & (n_offsets < N)
+        inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+        m = tl.max(inp, 1)
+        e = tl.exp(inp - m[:, None])
+        z = tl.sum(e, 1)
+        out = e / z[:, None]
+        output_ptrs = output_ptr + offset
+        tl.store(output_ptrs, out, mask=mask)
+    else:
+        m = tl.full([TILE_M], value=float("-inf"), dtype=tl.float32)
+        z = tl.full([TILE_M], value=0.0, dtype=tl.float32)
+
+        n_offsets = tl.arange(0, TILE_N)
+        offset = m_offsets[:, None] * N + n_offsets
+        for _ in range(0, N, TILE_N):
+            mask = (m_offsets[:, None] < M) & (n_offsets < N)
+            input_ptrs = input_ptr + offset
+            inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+            m_new = tl.maximum(m, tl.max(inp, 1))
+            alpha = m - m_new
+            z = z * tl.exp(alpha) + tl.sum(tl.exp(inp - m_new[:, None]), axis=1)
+            m = m_new
+            n_offsets += TILE_N
+            offset += TILE_N
+
+        n_offsets = tl.arange(0, TILE_N)
+        offset = m_offsets[:, None] * N + n_offsets
+        for _ in range(0, N, TILE_N):
+            mask = (m_offsets[:, None] < M) & (n_offsets < N)
+            input_ptrs = input_ptr + offset
+            inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+            o = tl.exp(inp - m[:, None]) / z[:, None]
+            output_ptrs = output_ptr + offset
+            tl.store(output_ptrs, o, mask=mask)
+            n_offsets += TILE_N
+            offset += TILE_N
+
+
+def test_decorator_cascade():
+    # to test inner decorator can use arguments supplied by outer decorator
+    # and grid function can use arguments supplied by all the decorator
+    x = torch.randn((128, 128, 128), device="cuda")
+    with does_not_raise():
+        _ = softmax_inner_decorator_cascade(x, dim=2)
+
+
+def test_pass_kernel_arg_via_kw():
+    x = torch.randn((128, 128, 128), device="cuda")
+    with does_not_raise():
+        _ = softmax_inner_pass_kernel_arg_via_kw(x, dim=2)
+
+
+def test_kernel_arg_apply_default():
+    x = torch.randn((128, 128, 128), device="cuda")
+    with does_not_raise():
+        _ = softmax_inner_kernel_arg_apply_default(x, dim=2)

--- a/tests/test_libentry.py
+++ b/tests/test_libentry.py
@@ -1,10 +1,23 @@
-from contextlib import nullcontext as does_not_raise
+from contextlib import contextmanager
 
 import torch
 import triton
 from triton import language as tl
 
 from flag_gems.utils import libentry
+
+
+# not_raises is copied from https://gist.github.com/oisinmulvihill/45c14271fad7794a4a52516ecb784e69
+@contextmanager
+def not_raises(ExpectedException):
+    try:
+        yield
+
+    except ExpectedException as error:
+        raise AssertionError(f"Raised exception {error} when it should not!")
+
+    except Exception as error:
+        raise AssertionError(f"An unexpected exception {error} raised.")
 
 
 def softmax_inner_decorator_cascade(x, dim, dtype=None):
@@ -153,17 +166,17 @@ def test_decorator_cascade():
     # to test inner decorator can use arguments supplied by outer decorator
     # and grid function can use arguments supplied by all the decorator
     x = torch.randn((128, 128, 128), device="cuda")
-    with does_not_raise():
+    with not_raises(KeyError):
         _ = softmax_inner_decorator_cascade(x, dim=2)
 
 
 def test_pass_kernel_arg_via_kw():
     x = torch.randn((128, 128, 128), device="cuda")
-    with does_not_raise():
+    with not_raises(KeyError):
         _ = softmax_inner_pass_kernel_arg_via_kw(x, dim=2)
 
 
 def test_kernel_arg_apply_default():
     x = torch.randn((128, 128, 128), device="cuda")
-    with does_not_raise():
+    with not_raises(KeyError):
         _ = softmax_inner_kernel_arg_apply_default(x, dim=2)

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -535,8 +535,8 @@ def test_accuracy_skip_rmsnorm(shape, dtype):
 
 @pytest.mark.parametrize("shape", REDUCTION_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_accuracy_softmax(shape, dtype):
-    dim = 1
+@pytest.mark.parametrize("dim", [0, 1])
+def test_accuracy_softmax(shape, dtype, dim):
     inp = torch.randn(shape, dtype=dtype, device="cuda", requires_grad=True)
     ref_inp = to_reference(inp, True)
 


### PR DESCRIPTION
1. use different kernels (inner & non_inner) for softmax forward
   a. inner: for reduction the last dim(and the input is preprocessed to be contiguous)
 a. inner: for reduce along other dimensions(and the input is preprocessed to be contiguous)
3. both have `ONE_TILE_PER_CTA` static condition
   a. when `ONE_TILE_PER_CTA` is True,  load only one tile per cta without looping over reduction dim
   b. when `ONE_TILE_PER_CTA` is False, use online softmax normalizer algorithm to save one swipe over the input.

We can leave other optimizations(optimize accordign to input layout or two-pass-reduction) for future PRs