### PR TITLE
add ignore_index for cross_entropy_loss

### DIFF
--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -158,21 +158,26 @@ def test_accuracy_argmax(shape, dim, keepdim, dtype):
 @pytest.mark.parametrize("size_average", [None, True, False])
 @pytest.mark.parametrize("reduce", [None, True, False])
 @pytest.mark.parametrize("reduction", ["mean", "none", "sum"])
+@pytest.mark.parametrize("ignore_index", [2, 4, 6, 8, -100])
 @pytest.mark.parametrize("shape", REDUCTION_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_accuracy_cross_entropy_loss(shape, dtype, size_average, reduce, reduction):
+def test_accuracy_cross_entropy_loss(
+    shape, dtype, size_average, reduce, ignore_index, reduction
+):
     inp = torch.randn(shape, dtype=dtype, device="cuda", requires_grad=True)
     dim = 1
     up_limit = shape[dim] - 1
     target_shape = list(shape)
     del target_shape[dim]
     target = torch.randint(0, up_limit, target_shape, device="cuda")
-
     ref_inp = to_reference(inp, True)
     ref_target = to_reference(target)
 
     criterion = torch.nn.CrossEntropyLoss(
-        size_average=size_average, reduce=reduce, reduction=reduction
+        size_average=size_average,
+        reduce=reduce,
+        ignore_index=ignore_index,
+        reduction=reduction,
     )
 
     ref_out = criterion(ref_inp, ref_target)


### PR DESCRIPTION
add ignore_index for cross_entropy_loss:
default ignore_index is -100, means no need to ignore.
 ignore_index value should be within [0, C-1]. 