### PR TITLE
work in progress optimize softmax: use better task partitioning

### DIFF
--- a/src/flag_gems/ops/softmax.py
+++ b/src/flag_gems/ops/softmax.py
@@ -10,106 +10,286 @@ from ..utils import libentry
 @libentry()
 @triton.autotune(
     configs=[
-        triton.Config({"BLOCK_M": 1}, num_stages=4),
-        triton.Config({"BLOCK_M": 1}, num_stages=5),
-        triton.Config({"BLOCK_M": 2}, num_stages=4),
-        triton.Config({"BLOCK_M": 2}, num_stages=5),
-        triton.Config({"BLOCK_M": 4}, num_stages=4),
-        triton.Config({"BLOCK_M": 4}, num_stages=5),
-        triton.Config({"BLOCK_M": 8}, num_stages=4),
-        triton.Config({"BLOCK_M": 8}, num_stages=5),
+        triton.Config({"TILE_K": 32}),
+        triton.Config({"TILE_K": 64}),
+        triton.Config({"TILE_K": 128}),
+        triton.Config({"TILE_K": 256}),
+        triton.Config({"TILE_K": 512}),
+        triton.Config({"TILE_K": 1024}),
     ],
     key=[
-        "M",
-        "N",
+        "K",
     ],
 )
 @triton.heuristics(
     values={
-        "BLOCK_N": lambda args: triton.next_power_of_2(args["N"]),
-        "num_warps": lambda args: (
-            4 if args["N"] <= 1024 else (8 if args["N"] <= 2048 else 16)
-        ),
+        "TILE_N": lambda args: max(1, 1024 // args["TILE_K"]),
+        "ONE_TILE_PER_CTA": lambda args: args["TILE_N"] >= args["N"],
     },
 )
 @triton.jit
-def softmax_kernel(
+def softmax_kernel_non_inner(
     output_ptr,
     input_ptr,
     M,
     N,
     K,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
 ):
-    pid_m = tl.program_id(0)
     pid_k = tl.program_id(1)
-    m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    n_offset = tl.arange(0, BLOCK_N)
-    offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
-    mask = m_offset[:, None] < M and n_offset[None, :] < N
-    input_ptrs = input_ptr + offset
-    inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
-    row_minus_max = inp - tl.max(inp, axis=1)[:, None]
-    numerator = tl.exp(row_minus_max)
-    denominator = tl.sum(numerator, axis=1)[:, None]
-    softmax_output = numerator / denominator
-    output_ptrs = output_ptr + offset
-    tl.store(output_ptrs, softmax_output, mask=mask)
+    pid_m = tl.program_id(0)
+
+    k_offsets = pid_k * TILE_K + tl.arange(0, TILE_K)
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)
+        offset = pid_m * N * K + n_offsets[:, None] * K + k_offsets
+        mask = (n_offsets[:, None] < N) & (k_offsets < K)
+        input_ptrs = input_ptr + offset
+        inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+        m = tl.max(inp, 0)
+        e = tl.exp(inp - m[None, :])
+        z = tl.sum(e, 0)
+        out = e / z
+        output_ptrs = output_ptr + offset
+        tl.store(output_ptrs, out, mask=mask)
+    else:
+        m = tl.full([TILE_K], value=float("-inf"), dtype=tl.float32)
+        z = tl.full([TILE_K], value=0.0, dtype=tl.float32)
+
+        n_offsets = tl.arange(0, TILE_N)
+        offset = pid_m * N * K + n_offsets[:, None] * K + k_offsets
+        for _ in range(0, N, TILE_N):
+            mask = (n_offsets[:, None] < N) & (k_offsets < K)
+            input_ptrs = input_ptr + offset
+            inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+            m_new = tl.maximum(m, tl.max(inp, 0))
+            alpha = m - m_new
+            z = z * tl.exp(alpha) + tl.sum(tl.exp(inp - m_new[None, :]), axis=0)
+            m = m_new
+            n_offsets += TILE_N
+            offset += TILE_N * K
+
+        n_offsets = tl.arange(0, TILE_N)
+        offset = pid_m * N * K + n_offsets[:, None] * K + k_offsets
+        for _ in range(0, N, TILE_N):
+            mask = (n_offsets[:, None] < N) & (k_offsets < K)
+            input_ptrs = input_ptr + offset
+            inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+            o = tl.exp(inp - m[None, :]) / z[None, :]
+            output_ptrs = output_ptr + offset
+            tl.store(output_ptrs, o, mask=mask)
+            n_offsets += TILE_N
+            offset += TILE_N * K
 
 
 @libentry()
 @triton.autotune(
     configs=[
-        triton.Config({"BLOCK_M": 1}, num_stages=4),
-        triton.Config({"BLOCK_M": 1}, num_stages=5),
-        triton.Config({"BLOCK_M": 2}, num_stages=4),
-        triton.Config({"BLOCK_M": 2}, num_stages=5),
-        triton.Config({"BLOCK_M": 4}, num_stages=4),
-        triton.Config({"BLOCK_M": 4}, num_stages=5),
-        triton.Config({"BLOCK_M": 8}, num_stages=4),
-        triton.Config({"BLOCK_M": 8}, num_stages=5),
+        triton.Config({"TILE_N": 32}),
+        triton.Config({"TILE_N": 64}),
+        triton.Config({"TILE_N": 128}),
+        triton.Config({"TILE_N": 256}),
+        triton.Config({"TILE_N": 512}),
+        triton.Config({"TILE_N": 1024}),
+    ],
+    key=["N"],
+)
+@triton.heuristics(
+    values={
+        "TILE_M": lambda args: max(1, 1024 // args["TILE_N"]),
+        "ONE_TILE_PER_CTA": lambda args: args["TILE_N"] >= args["N"],
+    },
+)
+@triton.jit
+def softmax_kernel_inner(
+    output_ptr,
+    input_ptr,
+    M,
+    N,
+    TILE_M: tl.constexpr,
+    TILE_N: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    m_offsets = pid_m * TILE_M + tl.arange(0, TILE_M)
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)
+        offset = m_offsets[:, None] * N + n_offsets
+        input_ptrs = input_ptr + offset
+        mask = (m_offsets[:, None] < M) & (n_offsets < N)
+        inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+        m = tl.max(inp, 1)
+        e = tl.exp(inp - m[:, None])
+        z = tl.sum(e, 1)
+        out = e / z[:, None]
+        output_ptrs = output_ptr + offset
+        tl.store(output_ptrs, out, mask=mask)
+    else:
+        m = tl.full([TILE_M], value=float("-inf"), dtype=tl.float32)
+        z = tl.full([TILE_M], value=0.0, dtype=tl.float32)
+
+        n_offsets = tl.arange(0, TILE_N)
+        offset = m_offsets[:, None] * N + n_offsets
+        for _ in range(0, N, TILE_N):
+            mask = (m_offsets[:, None] < M) & (n_offsets < N)
+            input_ptrs = input_ptr + offset
+            inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+            m_new = tl.maximum(m, tl.max(inp, 1))
+            alpha = m - m_new
+            z = z * tl.exp(alpha) + tl.sum(tl.exp(inp - m_new[:, None]), axis=1)
+            m = m_new
+            n_offsets += TILE_N
+            offset += TILE_N
+
+        n_offsets = tl.arange(0, TILE_N)
+        offset = m_offsets[:, None] * N + n_offsets
+        for _ in range(0, N, TILE_N):
+            mask = (m_offsets[:, None] < M) & (n_offsets < N)
+            input_ptrs = input_ptr + offset
+            inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+            o = tl.exp(inp - m[:, None]) / z[:, None]
+            output_ptrs = output_ptr + offset
+            tl.store(output_ptrs, o, mask=mask)
+            n_offsets += TILE_N
+            offset += TILE_N
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"TILE_K": 32}),
+        triton.Config({"TILE_K": 64}),
+        triton.Config({"TILE_K": 128}),
+        triton.Config({"TILE_K": 256}),
+        triton.Config({"TILE_K": 512}),
+        triton.Config({"TILE_K": 1024}),
     ],
     key=[
-        "M",
-        "N",
+        "K",
     ],
 )
 @triton.heuristics(
     values={
-        "BLOCK_N": lambda args: triton.next_power_of_2(args["N"]),
-        "num_warps": lambda args: (
-            4 if args["N"] <= 1024 else (8 if args["N"] <= 2048 else 16)
-        ),
+        "TILE_N": lambda args: max(1, 1024 // args["TILE_K"]),
+        "ONE_TILE_PER_CTA": lambda args: args["TILE_N"] >= args["N"],
     },
 )
 @triton.jit
-def softmax_backward_kernel(
+def softmax_backward_kernel_non_inner(
     out_ptr,
     out_grad_ptr,
     in_grad_ptr,
     M,
     N,
     K,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
 ):
     pid_m = tl.program_id(0)
     pid_k = tl.program_id(1)
-    m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    n_offset = tl.arange(0, BLOCK_N)
-    offsets = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
-    mask = m_offset[:, None] < M and n_offset[None, :] < N
-    out_ptrs = out_ptr + offsets
-    out = tl.load(out_ptrs, mask=mask)
-    out_grad_ptrs = out_grad_ptr + offsets
-    out_grad = tl.load(out_grad_ptrs, mask=mask)
+    offsets_k = pid_k * TILE_K + tl.arange(0, TILE_K)
 
-    scale = tl.sum(out * out_grad, 1)
-    in_grad = out * (out_grad - scale[:, None])
+    if ONE_TILE_PER_CTA:
+        offsets_n = tl.arange(0, TILE_N)
+        offsets = pid_m * N * K + offsets_n[:, None] * K + offsets_k
+        mask = (offsets_n < N)[:, None] & (offsets_k < K)
+        out_tile = tl.load(out_ptr + offsets, mask=mask)
+        out_grad_tile = tl.load(out_grad_ptr + offsets, mask=mask)
+        scale = tl.sum(out_tile * out_grad_tile, axis=0)
+        in_grad_tile = out_tile * (out_grad_tile - scale[None, :])
+        tl.store(in_grad_ptr + offsets, in_grad_tile, mask=mask)
+    else:
+        offsets_n = tl.arange(0, TILE_N)
+        offsets = pid_m * N * K + offsets_n[:, None] * K + offsets_k
+        scale = tl.zeros([TILE_N, TILE_K], dtype=tl.float32)
+        for _ in range(0, N, TILE_N):
+            mask = (offsets_n < N)[:, None] & (offsets_k < K)
+            out_tile = tl.load(out_ptr + offsets, mask=mask)
+            out_grad_tile = tl.load(out_grad_ptr + offsets, mask=mask)
+            scale += out_tile * out_grad_tile
+            offsets_n += TILE_N
+            offsets += TILE_N * K
+        scale = tl.sum(scale, axis=0)  # (TILE_K)
 
-    in_grad_ptrs = in_grad_ptr + offsets
-    tl.store(in_grad_ptrs, in_grad, mask=mask)
+        offsets_n = tl.arange(0, TILE_N)
+        offsets = pid_m * N * K + offsets_n[:, None] * K + offsets_k
+        for _ in range(0, N, TILE_N):
+            mask = (offsets_n < N)[:, None] & (offsets_k < K)
+            out_tile = tl.load(out_ptr + offsets, mask=mask)
+            out_grad_tile = tl.load(out_grad_ptr + offsets, mask=mask)
+            in_grad_tile = out_tile * (out_grad_tile - scale[None, :])
+            tl.store(in_grad_ptr + offsets, in_grad_tile, mask=mask)
+            offsets_n += TILE_N
+            offsets += TILE_N * K
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"TILE_N": 32}),
+        triton.Config({"TILE_N": 64}),
+        triton.Config({"TILE_N": 128}),
+        triton.Config({"TILE_N": 256}),
+        triton.Config({"TILE_N": 512}),
+        triton.Config({"TILE_N": 1024}),
+    ],
+    key=["N"],
+)
+@triton.heuristics(
+    values={
+        "TILE_M": lambda args: max(1, 1024 // args["TILE_N"]),
+        "ONE_TILE_PER_CTA": lambda args: args["TILE_N"] >= args["N"],
+    },
+)
+@triton.jit
+def softmax_backward_kernel_inner(
+    out_ptr,
+    out_grad_ptr,
+    in_grad_ptr,
+    M,
+    N,
+    TILE_M: tl.constexpr,
+    TILE_N: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    m_offsets = pid_m * TILE_M + tl.arange(0, TILE_M)
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)
+        offsets = m_offsets[:, None] * N + n_offsets
+        mask = (m_offsets[:, None] < M) & (n_offsets < N)
+        out_tile = tl.load(out_ptr + offsets, mask=mask)
+        out_grad_tile = tl.load(out_grad_ptr + offsets, mask=mask)
+        scale = tl.sum(out_tile * out_grad_tile, 1)
+        in_grad_tile = out_tile * (out_grad_tile - scale[:, None])
+        tl.store(in_grad_ptr + offsets, in_grad_tile, mask=mask)
+    else:
+        scale = tl.zeros([TILE_M, TILE_N], dtype=tl.float32)
+
+        n_offsets = tl.arange(0, TILE_N)
+        offsets = m_offsets[:, None] * N + n_offsets
+        for _ in range(0, N, TILE_N):
+            mask = (m_offsets[:, None] < M) & (n_offsets < N)
+            out_tile = tl.load(out_ptr + offsets, mask=mask)
+            out_grad_tile = tl.load(out_grad_ptr + offsets, mask=mask)
+            scale += out_tile * out_grad_tile
+            n_offsets += TILE_N
+            offsets += TILE_N
+        scale = tl.sum(scale, 1)  # (TILE_M,)
+
+        n_offsets = tl.arange(0, TILE_N)
+        offsets = m_offsets[:, None] * N + n_offsets
+        for _ in range(0, N, TILE_N):
+            mask = (m_offsets[:, None] < M) & (n_offsets < N)
+            out_tile = tl.load(out_ptr + offsets, mask=mask)
+            out_grad_tile = tl.load(out_grad_ptr + offsets, mask=mask)
+            in_grad_tile = out_tile * (out_grad_tile - scale[:, None])
+            tl.store(in_grad_ptr + offsets, in_grad_tile, mask=mask)
+            n_offsets += TILE_N
+            offsets += TILE_N
 
 
 class Softmax(torch.autograd.Function):
@@ -122,24 +302,30 @@ class Softmax(torch.autograd.Function):
         M = 1
         N = x.shape[dim]
         for i in range(dim):
-            M *= x.shape[i]
+            M *= x.shape[i]  # pre_dim
         inp = x.contiguous()
         if dtype is None:
             dtype = x.dtype
         out = torch.empty_like(inp, dtype=dtype)
-        K = inp.numel() // M // N
+        K = inp.numel() // M // N  # post_dim
 
-        grid = lambda meta: (
-            triton.cdiv(M, meta["BLOCK_M"]),
-            K,
-        )
-        softmax_kernel[grid](
-            out,
-            inp,
-            M,
-            N,
-            K,
-        )
+        if K > 1:
+            grid = lambda meta: (M, triton.cdiv(K, meta["TILE_K"]), 1)
+            softmax_kernel_non_inner[grid](
+                out,
+                inp,
+                M,
+                N,
+                K,
+            )
+        else:
+            grid = lambda meta: (triton.cdiv(M, meta["TILE_M"]), 1, 1)
+            softmax_kernel_inner[grid](
+                out,
+                inp,
+                M,
+                N,
+            )
         ctx.save_for_backward(out)
         ctx.dim = dim
         return out
@@ -161,18 +347,25 @@ class Softmax(torch.autograd.Function):
         in_grad = torch.empty_like(out)
         K = out.numel() // M // N
 
-        grid = lambda meta: (
-            triton.cdiv(M, meta["BLOCK_M"]),
-            K,
-        )
-        softmax_backward_kernel[grid](
-            out,
-            out_grad,
-            in_grad,
-            M,
-            N,
-            K,
-        )
+        if K > 1:
+            grid = lambda meta: (M, triton.cdiv(K, meta["TILE_K"]), 1)
+            softmax_backward_kernel_non_inner[grid](
+                out,
+                out_grad,
+                in_grad,
+                M,
+                N,
+                K,
+            )
+        else:
+            grid = lambda meta: (triton.cdiv(M, meta["TILE_M"]), 1, 1)
+            softmax_backward_kernel_inner[grid](
+                out,
+                out_grad,
+                in_grad,
+                M,
+                N,
+            )
         return in_grad, None, None
 
 

--- a/src/flag_gems/ops/softmax.py
+++ b/src/flag_gems/ops/softmax.py
@@ -18,6 +18,8 @@ from ..utils import libentry
         triton.Config({"TILE_K": 1024}),
     ],
     key=[
+        "M",
+        "N",
         "K",
     ],
 )
@@ -94,7 +96,7 @@ def softmax_kernel_non_inner(
         triton.Config({"TILE_N": 512}),
         triton.Config({"TILE_N": 1024}),
     ],
-    key=["N"],
+    key=["M", "N"],
 )
 @triton.heuristics(
     values={
@@ -167,6 +169,8 @@ def softmax_kernel_inner(
         triton.Config({"TILE_K": 1024}),
     ],
     key=[
+        "M",
+        "N",
         "K",
     ],
 )
@@ -236,7 +240,7 @@ def softmax_backward_kernel_non_inner(
         triton.Config({"TILE_N": 512}),
         triton.Config({"TILE_N": 1024}),
     ],
-    key=["N"],
+    key=["M", "N"],
 )
 @triton.heuristics(
     values={

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -535,8 +535,8 @@ def test_accuracy_skip_rmsnorm(shape, dtype):
 
 @pytest.mark.parametrize("shape", REDUCTION_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_accuracy_softmax(shape, dtype):
-    dim = 1
+@pytest.mark.parametrize("dim", [0, 1])
+def test_accuracy_softmax(shape, dtype, dim):
     inp = torch.randn(shape, dtype=dtype, device="cuda", requires_grad=True)
     ref_inp = to_reference(inp, True)
 


### PR DESCRIPTION
Use different kernels (inner & non_inner) for softmax forward & backward.
    1. inner: for reduction the last dim(and the input is preprocessed to be contiguous)
    2. inner: for reduce along other dimensions(and the input is preprocessed to be contiguous)

Both have `ONE_TILE_PER_CTA` static condition
    1. when `ONE_TILE_PER_CTA` is True, load only one tile per cta without looping over reduction dim
    2. when `ONE_TILE_PER_CTA` is False, use online softmax normalizer algorithm to save one swipe over the input.


The `non_inner` kernels now have a better task partitioning to achieve better coalescing in global memory access. For a contiguous tensor with shape `(M, N, K)`, and the reduction is applied in axis-1, if `K>1`, it is considered a non-inner reduction.
In this case, the shape of the data tile is `(TILE_N, TILE_K)`. When `TILE_K` is large enough, access to global memory can be coalesced.