### PR TITLE
[operator] fix libentry to support triton 2.3

### DIFF
--- a/benchmark/performance_utils.py
+++ b/benchmark/performance_utils.py
@@ -7,7 +7,7 @@ import flag_gems
 
 from .conftest import CPU_MODE
 
-WARMUP = 10
+WARMUP = 100
 REPETITION = 1000
 
 

--- a/src/flag_gems/fused/skip_layernorm.py
+++ b/src/flag_gems/fused/skip_layernorm.py
@@ -9,7 +9,7 @@ from ..utils import libentry
 
 
 @libentry()
-@triton.jit
+@triton.jit(do_not_specialize=["eps"])
 def skip_layer_norm_kernel(
     Y,  # pointer to the output
     X,  # pointer to the input

--- a/src/flag_gems/fused/skip_rms_norm.py
+++ b/src/flag_gems/fused/skip_rms_norm.py
@@ -9,7 +9,7 @@ from ..utils import libentry
 
 
 @libentry()
-@triton.jit
+@triton.jit(do_not_specialize=["eps"])
 def skip_rms_norm_kernel(
     Y,  # pointer to the output
     X,  # pointer to the input

--- a/src/flag_gems/ops/addmm.py
+++ b/src/flag_gems/ops/addmm.py
@@ -53,7 +53,7 @@ from ..utils import libentry
     ],
     key=["M", "N", "K"],
 )
-@triton.jit
+@triton.jit(do_not_specialize=["alpha", "beta"])
 def addmm_kernel(
     a_ptr,
     b_ptr,

--- a/src/flag_gems/ops/cross_entropy_loss.py
+++ b/src/flag_gems/ops/cross_entropy_loss.py
@@ -40,7 +40,7 @@ class Reduction(IntEnum):
         ),
     },
 )
-@triton.jit
+@triton.jit(do_not_specialize=["mean_num"])
 def log_softmax_and_mul_kernel(
     output_ptr,
     input_ptr,
@@ -95,7 +95,7 @@ def log_softmax_and_mul_kernel(
         ),
     },
 )
-@triton.jit
+@triton.jit(do_not_specialize=["mean_num"])
 def softmax_and_sub_kernel(
     output_ptr,
     input_ptr,
@@ -158,7 +158,7 @@ def softmax_and_sub_kernel(
         ),
     },
 )
-@triton.jit
+@triton.jit(do_not_specialize=["mean_num"])
 def softmax_and_sub_reduce_kernel(
     output_ptr,
     input_ptr,

--- a/src/flag_gems/ops/dropout.py
+++ b/src/flag_gems/ops/dropout.py
@@ -41,7 +41,7 @@ del _offset
         "N",
     ],
 )
-@triton.jit
+@triton.jit(do_not_specialize=["p", "philox_seed", "philox_offset"])
 def dropout_forward_kernel(
     X,
     Y,
@@ -82,7 +82,7 @@ def dropout_forward_kernel(
         "N",
     ],
 )
-@triton.jit
+@triton.jit(do_not_specialize=["p", "philox_seed", "philox_offset"])
 def dropout_backward_kernel(
     DY,
     DX,

--- a/src/flag_gems/ops/groupnorm.py
+++ b/src/flag_gems/ops/groupnorm.py
@@ -8,7 +8,7 @@ from ..utils import libentry
 
 
 @libentry()
-@triton.jit
+@triton.jit(do_not_specialize=["eps"])
 def group_norm_kernel(
     X,
     Y,

--- a/src/flag_gems/ops/layernorm.py
+++ b/src/flag_gems/ops/layernorm.py
@@ -23,7 +23,7 @@ def cfggen():
 
 @libentry()
 @triton.autotune(configs=cfggen(), key=["M", "N"])
-@triton.jit
+@triton.jit(do_not_specialize=["eps"])
 def layer_norm_kernel(
     X,
     Y,

--- a/src/flag_gems/ops/rms_norm.py
+++ b/src/flag_gems/ops/rms_norm.py
@@ -9,7 +9,7 @@ from ..utils import libentry
 
 
 @libentry()
-@triton.jit
+@triton.jit(do_not_specialize=["eps"])
 def rms_norm_kernel(
     Y,  # pointer to the output
     X,  # pointer to the input

--- a/src/flag_gems/ops/triu.py
+++ b/src/flag_gems/ops/triu.py
@@ -27,7 +27,7 @@ def cfggen_batch():
 
 @libentry()
 @triton.autotune(configs=cfggen(), key=["M", "N"])
-@triton.jit
+@triton.jit(do_not_specialize=["diagonal"])
 def triu_kernel(
     X,
     Y,
@@ -55,7 +55,7 @@ def triu_kernel(
 
 @libentry()
 @triton.autotune(configs=cfggen_batch(), key=["batch", "MN", "N", "diagonal"])
-@triton.jit
+@triton.jit(do_not_specialize=["diagonal"])
 def triu_batch_kernel(
     X,
     Y,

--- a/src/flag_gems/ops/var_mean.py
+++ b/src/flag_gems/ops/var_mean.py
@@ -33,7 +33,7 @@ def welford_func(mean_x, count_x, M_x, mean_y, count_y, M_y):
 
 @libentry()
 @triton.autotune(configs=cfggen(), key=["M", "N"])
-@triton.jit
+@triton.jit(do_not_specialize=["correction"])
 def var_mean_welford_kernel(
     X,
     Var,
@@ -112,7 +112,7 @@ def var_mean_kernel_1(
 @triton.heuristics(
     values={"BLOCK_N": lambda args: triton.next_power_of_2(args["BLOCK_NUM"])},
 )
-@triton.jit
+@triton.jit(do_not_specialize=["correction"])
 def var_mean_kernel_2(
     Acc,
     Average,

--- a/src/flag_gems/ops/vector_norm.py
+++ b/src/flag_gems/ops/vector_norm.py
@@ -210,7 +210,7 @@ def l0_norm_kernel_2(Mid, Out, MID_SIZE, BLOCK_MID: tl.constexpr):
 
 @libentry()
 @triton.autotune(configs=cfggen(), key=["M", "N"])
-@triton.jit
+@triton.jit(do_not_specialize=["ord"])
 def v_norm_kernel(X, Out, M, N, ord, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
     pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     X = X + pid * N
@@ -231,7 +231,7 @@ def v_norm_kernel(X, Out, M, N, ord, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexp
 
 
 @libentry()
-@triton.jit
+@triton.jit(do_not_specialize=["ord"])
 def l1_norm_kernel_1(X, Mid, ord, M, BLOCK_SIZE: tl.constexpr):
     pid = tl.program_id(0)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
@@ -245,7 +245,7 @@ def l1_norm_kernel_1(X, Mid, ord, M, BLOCK_SIZE: tl.constexpr):
 
 
 @libentry()
-@triton.jit
+@triton.jit(do_not_specialize=["ord"])
 def l1_norm_kernel_2(Mid, Out, ord, MID_SIZE, BLOCK_MID: tl.constexpr):
     offset = tl.arange(0, BLOCK_MID)
     Mid = Mid + offset

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -38,6 +38,13 @@ class LibEntry(triton.KernelInterface):
         for arg in dns_args:
             if hasattr(arg, "data_ptr"):
                 entry_key.append(str(arg.dtype))
+            elif isinstance(arg, int):
+                if -(2**31) <= arg and arg <= 2**31 - 1:
+                    entry_key.append("i32")
+                elif 2**63 <= arg and arg <= 2**64 - 1:
+                    entry_key.append("u64")
+                else:
+                    entry_key.append("i64")
             else:
                 entry_key.append(type(arg))
         # const args passed by position


### PR DESCRIPTION
1. modified libentry arguments collection, cache key generation and constexpr collection
2. specify dns arguments for operators
3. works for triton 2.2 and 2.3