### PR TITLE
[codegen] generate gsl(grid-stride-loop) style pointwise kernel 

### DIFF
--- a/src/flag_gems/ops/sigmoid.py
+++ b/src/flag_gems/ops/sigmoid.py
@@ -1,5 +1,4 @@
 import logging
-import math
 
 import torch
 import triton
@@ -11,7 +10,8 @@ from ..utils import pointwise_dynamic
 @pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
 @triton.jit
 def sigmoid_forward(x):
-    log2e: tl.constexpr = math.log2(math.e)
+    log2e = 1.4426950408889634  # math.log2(math.e)
+    # NOTE: do not assign to constexpr since it cannot in inlined into a loop
     return 1 / (1 + tl.math.exp2(-x.to(tl.float32) * log2e))
 
 

--- a/src/flag_gems/utils/pointwise_dynamic.py
+++ b/src/flag_gems/utils/pointwise_dynamic.py
@@ -360,8 +360,9 @@ def generate_destination_passing_pointwise_wrapper(
         wrapper_docstring = docstring_for_destination_passing_wrapper(op_desc)
         code.writeline(wrapper_docstring)
 
-        code.writeline("shape = out0.shape")
-        code.writeline("num_tasks = volume(shape)")
+        if rank > 0:
+            code.writeline("shape = out0.shape")
+            code.writeline("num_tasks = volume(shape)")
 
         if rank > 0:
             code.writeline("tile_size = min(8192, triton.next_power_of_2(num_tasks))")
@@ -373,7 +374,6 @@ def generate_destination_passing_pointwise_wrapper(
                 "tiles_per_cta = triton.cdiv(num_tasks, tile_size * num_ctas)"
             )
         else:
-            code.writeline("tile_size = 32")
             code.writeline("num_warps = 1")
             code.writeline("num_ctas = 1")
         code.writeline("grid = (num_ctas, 1, 1)")


### PR DESCRIPTION
generate gsl(grid-stride-loop) style pointwise kernel to avoid grid_s…ize exceeding the max grid size.

example jit function

```python
@triton.jit
def _jit_function(
    in0_ptr: tl.tensor, # of tl.pointer_type
    in1_ptr: tl.tensor, # of tl.pointer_type
    out0_ptr: tl.tensor, # of tl.pointer_type
    in0_stride0: int, in0_stride1: int, in0_stride2: int, # strides for in0
    in1_stride0: int, in1_stride1: int, in1_stride2: int, # strides for in1
    out0_stride0: int, out0_stride1: int, out0_stride2: int, # strides for out0
    s0: int, s1: int, s2: int, # task_space
    num_tasks: int,
    tile_size: tl.constexpr,
    tiles_per_cta,
):
    # task id & masking
    pid = tl.program_id(0)
    num_ctas = tl.num_programs(0)
    init_tid = pid * tile_size + tl.arange(0, tile_size)
    for j in range(0, tiles_per_cta):
        tid = init_tid + j * tile_size * num_ctas
        mask = tid < num_tasks

        # multi index recontruction
        i2 = tid % s2
        tid //= s2
        i1 = tid % s1
        tid //= s1
        i0 = tid % s0

        # loads
        in0 = tl.load(in0_ptr + i0 * in0_stride0 + i1 * in0_stride1 + i2 * in0_stride2, mask=mask)
        in1 = tl.load(in1_ptr + i0 * in1_stride0 + i1 * in1_stride1 + i2 * in1_stride2, mask=mask)

        # compute
        out0 = in0 + in1

        # stores
        tl.store(out0_ptr + i0 * out0_stride0 + i1 * out0_stride1 + i2 * out0_stride2, out0, mask=mask)
```

example wrapper

```python
def _wrapper_out(in0: torch.Tensor, in1: torch.Tensor, out0: torch.Tensor):
    """Generated wrapper function with Pointwise: (Tensor, Tensor, Tensor) -> (Tensor)"""
    shape = out0.shape
    num_tasks = volume(shape)
    tile_size = min(8192, triton.next_power_of_2(num_tasks))
    num_warps = 4 if tile_size <= 1024 else (8 if tile_size <= 4096 else 16)
    num_ctas = min(65535, triton.cdiv(num_tasks, tile_size))
    tiles_per_cta = triton.cdiv(num_tasks, tile_size * num_ctas)
    grid = (num_ctas, 1, 1)

    # strides of each tensor argument w.r.t the task space
    in0_strides = broadcasted_stride(in0.shape, in0.stride(), shape)
    in1_strides = broadcasted_stride(in1.shape, in1.stride(), shape)
    out0_strides = out0.stride()

    # kernel launch
    with torch.cuda.device(in0.device):
        _jit_function[grid](
            in0, in1, out0,
            in0_strides[0], in0_strides[1], # stride for in0
            in1_strides[0], in1_strides[1], # stride for in1
            out0_strides[0], out0_strides[1], # stride for out0
            shape[0], shape[1], # task indexing space
            num_tasks, # num tasks
            tiles_per_cta=tiles_per_cta, # tiles_per_cta
            tile_size=tile_size,
            num_warps=num_warps,
        )
    return out0
```