### PR TITLE
add assertion that argnums from OPDesc matches that from scalar_fn

### DIFF
--- a/src/flag_gems/ops/bitwise_not.py
+++ b/src/flag_gems/ops/bitwise_not.py
@@ -5,7 +5,7 @@ import triton
 from ..utils import pointwise_dynamic
 
 
-@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, "DEFAULT")])
+@pointwise_dynamic(is_tensor=[True], promotion_methods=[(0, "DEFAULT")])
 @triton.jit
 def bitwise_not_func(x):
     return ~x

--- a/src/flag_gems/utils/pointwise_dynamic.py
+++ b/src/flag_gems/utils/pointwise_dynamic.py
@@ -633,6 +633,9 @@ class PointwiseDynamicFunction:
         self._op_desc = op_desc
 
         assert isinstance(scalar_fn, JITFunction)
+        assert op_desc.num_inputs() == len(
+            scalar_fn.arg_names
+        ), f"Mismatch arg nums: {op_desc.num_inputs()} from OPDESC vs {len(scalar_fn.arg_names)} from scalar_fn."
         self._scalar_fn = scalar_fn
         self._scalar_fn_cache_key = scalar_fn.cache_key
         self.pid = os.getpid()


### PR DESCRIPTION
1. add assertion that argnums from OPDesc matches that from scalar_fn
2. fix mismatch in `bitwise_not`.