### PR TITLE
try to import tl.math functions from different paths

### DIFF
--- a/src/flag_gems/fused/gelu_and_mul.py
+++ b/src/flag_gems/fused/gelu_and_mul.py
@@ -6,12 +6,20 @@ import triton.language as tl
 
 from ..utils import pointwise_dynamic
 
+try:
+    from triton.language.extra.cuda.libdevice import erf, pow, tanh
+except ImportError:
+    try:
+        from triton.language.math import erf, pow, tanh
+    except ImportError:
+        from triton.language.libdevice import erf, pow, tanh
+
 
 @pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
 @triton.jit
 def gelu_none_and_mul_kernel(x, y):
     x_fp32 = x.to(tl.float32)
-    x_gelu = 0.5 * x_fp32 * (1 + tl.math.erf(x_fp32 * 0.7071067811))
+    x_gelu = 0.5 * x_fp32 * (1 + erf(x_fp32 * 0.7071067811))
     return x_gelu * y
 
 
@@ -24,11 +32,7 @@ def gelu_tanh_and_mul_kernel(x, y):
         * x_fp32
         * (
             1
-            + tl.math.tanh(
-                x_fp32
-                * 0.79788456
-                * (1 + 0.044715 * tl.math.pow(x_fp32.to(tl.float32), 2))
-            )
+            + tanh(x_fp32 * 0.79788456 * (1 + 0.044715 * pow(x_fp32.to(tl.float32), 2)))
         )
     )
     return x_gelu * y

--- a/src/flag_gems/ops/gelu.py
+++ b/src/flag_gems/ops/gelu.py
@@ -5,12 +5,20 @@ import triton.language as tl
 
 from ..utils import pointwise_dynamic
 
+try:
+    from triton.language.extra.cuda.libdevice import erf, pow, tanh
+except ImportError:
+    try:
+        from triton.language.math import erf, pow, tanh
+    except ImportError:
+        from triton.language.libdevice import erf, pow, tanh
+
 
 @pointwise_dynamic(promotion_methods=[(0, "DEFAULT")])
 @triton.jit
 def gelu_none(x):
     scale: tl.constexpr = 0.7071067811
-    output = 0.5 * x * (1 + tl.math.erf(x * scale))
+    output = 0.5 * x * (1 + erf(x * scale))
     return output
 
 
@@ -18,14 +26,7 @@ def gelu_none(x):
 @triton.jit
 def gelu_tanh(x):
     output = (
-        0.5
-        * x
-        * (
-            1
-            + tl.math.tanh(
-                x * 0.79788456 * (1 + 0.044715 * tl.math.pow(x.to(tl.float32), 2))
-            )
-        )
+        0.5 * x * (1 + tanh(x * 0.79788456 * (1 + 0.044715 * pow(x.to(tl.float32), 2))))
     )
     return output
 

--- a/src/flag_gems/ops/groupnorm.py
+++ b/src/flag_gems/ops/groupnorm.py
@@ -6,6 +6,14 @@ import triton.language as tl
 
 from ..utils import libentry
 
+try:
+    from triton.language.extra.cuda.libdevice import rsqrt
+except ImportError:
+    try:
+        from triton.language.math import rsqrt
+    except ImportError:
+        from triton.language.libdevice import rsqrt
+
 
 @libentry()
 @triton.jit(do_not_specialize=["eps"])
@@ -49,7 +57,7 @@ def group_norm_kernel(
     x = tl.where(xy_mask, X_val - mean, 0.0)
 
     var = tl.sum(x * x) / num_elements
-    rstd = tl.math.rsqrt(var + eps)
+    rstd = rsqrt(var + eps)
     x_hat = x * rstd
 
     weight = tl.load(W_ptr, mask=wb_mask, other=0.0)[:, None]

--- a/src/flag_gems/ops/isinf.py
+++ b/src/flag_gems/ops/isinf.py
@@ -5,11 +5,19 @@ import triton.language as tl
 
 from ..utils import pointwise_dynamic
 
+try:
+    from triton.language.extra.cuda.libdevice import isinf as _isinf
+except ImportError:
+    try:
+        from triton.language.math import isinf as _isinf
+    except ImportError:
+        from triton.language.libdevice import isinf as _isinf
+
 
 @pointwise_dynamic(promotion_methods=[(0, "ALWAYS_BOOL")])
 @triton.jit
 def isinf_func(x):
-    return tl.math.isinf(x.to(tl.float32))
+    return _isinf(x.to(tl.float32))
 
 
 def isinf(A):

--- a/src/flag_gems/ops/isnan.py
+++ b/src/flag_gems/ops/isnan.py
@@ -5,11 +5,19 @@ import triton.language as tl
 
 from ..utils import pointwise_dynamic
 
+try:
+    from triton.language.extra.cuda.libdevice import isnan as _isnan
+except ImportError:
+    try:
+        from triton.language.math import isnan as _isnan
+    except ImportError:
+        from triton.language.libdevice import isnan as _isnan
+
 
 @pointwise_dynamic(promotion_methods=[(0, "ALWAYS_BOOL")])
 @triton.jit
 def isnan_func(x):
-    return tl.math.isnan(x.to(tl.float32))
+    return _isnan(x.to(tl.float32))
 
 
 def isnan(A):

--- a/src/flag_gems/ops/pow.py
+++ b/src/flag_gems/ops/pow.py
@@ -5,11 +5,19 @@ import triton.language as tl
 
 from ..utils import pointwise_dynamic
 
+try:
+    from triton.language.extra.cuda.libdevice import pow as _pow
+except ImportError:
+    try:
+        from triton.language.math import pow as _pow
+    except ImportError:
+        from triton.language.libdevice import pow as _pow
+
 
 @pointwise_dynamic(promotion_methods=[(0, 1, "BOOL_TO_LONG")])
 @triton.jit
 def pow_func(x, exponent):
-    return tl.math.pow(x.to(tl.float32), exponent)
+    return _pow(x.to(tl.float32), exponent)
 
 
 def pow_tensor_tensor(A, exponent):
@@ -20,7 +28,7 @@ def pow_tensor_tensor(A, exponent):
 @pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "BOOL_TO_LONG")])
 @triton.jit
 def pow_func_tensor_scalar(x, exponent):
-    return tl.math.pow(x.to(tl.float32), exponent)
+    return _pow(x.to(tl.float32), exponent)
 
 
 def pow_tensor_scalar(A, exponent):
@@ -31,7 +39,7 @@ def pow_tensor_scalar(A, exponent):
 @pointwise_dynamic(is_tensor=[False, True], promotion_methods=[(0, 1, "BOOL_TO_LONG")])
 @triton.jit
 def pow_func_scalar_tensor(x, exponent):
-    return tl.math.pow(x.to(tl.float32), exponent)
+    return _pow(x.to(tl.float32), exponent)
 
 
 def pow_scalar(A, exponent):

--- a/src/flag_gems/ops/sigmoid.py
+++ b/src/flag_gems/ops/sigmoid.py
@@ -7,12 +7,20 @@ import triton.language as tl
 
 from ..utils import pointwise_dynamic
 
+try:
+    from triton.language.extra.cuda.libdevice import exp2
+except ImportError:
+    try:
+        from triton.language.math import exp2
+    except ImportError:
+        from triton.language.libdevice import exp2
+
 
 @pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
 @triton.jit
 def sigmoid_forward(x):
     log2e: tl.constexpr = math.log2(math.e)
-    return 1 / (1 + tl.math.exp2(-x.to(tl.float32) * log2e))
+    return 1 / (1 + exp2(-x.to(tl.float32) * log2e))
 
 
 @pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])

--- a/src/flag_gems/ops/silu.py
+++ b/src/flag_gems/ops/silu.py
@@ -6,6 +6,14 @@ import triton.language as tl
 
 from ..utils import pointwise_dynamic
 
+try:
+    from triton.language.extra.cuda.libdevice import div_rn
+except ImportError:
+    try:
+        from triton.language.math import div_rn
+    except ImportError:
+        from triton.language.libdevice import div_rn
+
 
 @pointwise_dynamic(promotion_methods=[(0, "DEFAULT")])
 @triton.jit
@@ -20,7 +28,7 @@ def silu_forward(x):
 def silu_backward(x, dy):
     dy_fp32 = dy.to(tl.float32)
     x_fp32 = x.to(tl.float32)
-    sigma = tl.math.div_rn(1.0, 1.0 + tl.exp(-x_fp32))
+    sigma = div_rn(1.0, 1.0 + tl.exp(-x_fp32))
     dx = dy_fp32 * sigma * (1.0 + x_fp32 * (1.0 - sigma))
     return dx
 

--- a/src/flag_gems/ops/tanh.py
+++ b/src/flag_gems/ops/tanh.py
@@ -6,17 +6,33 @@ import triton.language as tl
 
 from ..utils import pointwise_dynamic
 
+try:
+    from triton.language.extra.cuda.libdevice import pow
+except ImportError:
+    try:
+        from triton.language.math import pow
+    except ImportError:
+        from triton.language.libdevice import pow
+
+try:
+    from triton.language.extra.cuda.libdevice import tanh as _tanh
+except ImportError:
+    try:
+        from triton.language.math import tanh as _tanh
+    except ImportError:
+        from triton.language.libdevice import tanh as _tanh
+
 
 @pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
 @triton.jit
 def tanh_forward(x):
-    return tl.math.tanh(x.to(tl.float32))
+    return _tanh(x.to(tl.float32))
 
 
 @pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
 @triton.jit
 def tanh_backward(y, dy):
-    return dy * (1.0 - tl.math.pow(y.to(tl.float32), 2))
+    return dy * (1.0 - pow(y.to(tl.float32), 2))
 
 
 class Tanh(torch.autograd.Function):

--- a/src/flag_gems/ops/vector_norm.py
+++ b/src/flag_gems/ops/vector_norm.py
@@ -7,6 +7,14 @@ import triton.language as tl
 
 from ..utils import dim_compress, libentry
 
+try:
+    from triton.language.extra.cuda.libdevice import pow
+except ImportError:
+    try:
+        from triton.language.math import pow
+    except ImportError:
+        from triton.language.libdevice import pow
+
 
 def cfggen():
     block_m = [1, 2, 4, 8]
@@ -224,9 +232,9 @@ def v_norm_kernel(X, Out, M, N, ord, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexp
         mask = row_mask and col_mask
 
         a = tl.load(X + cols, mask, other=0.0).to(tl.float32)
-        _sum += tl.math.pow(tl.abs(a), ord)
+        _sum += pow(tl.abs(a), ord)
     sum = tl.sum(_sum, axis=1)
-    out = tl.math.pow(sum, 1 / ord)[:, None]
+    out = pow(sum, 1 / ord)[:, None]
     tl.store(Out, out, row_mask)
 
 
@@ -240,7 +248,7 @@ def l1_norm_kernel_1(X, Mid, ord, M, BLOCK_SIZE: tl.constexpr):
     mask = offset < M
 
     x = tl.load(X, mask=mask, other=0.0).to(tl.float32)
-    mid = tl.sum(tl.math.pow(tl.abs(x), ord))
+    mid = tl.sum(pow(tl.abs(x), ord))
     tl.store(Mid, mid)
 
 
@@ -251,7 +259,7 @@ def l1_norm_kernel_2(Mid, Out, ord, MID_SIZE, BLOCK_MID: tl.constexpr):
     Mid = Mid + offset
     mask = offset < MID_SIZE
     mid = tl.load(Mid, mask=mask, other=0.0).to(tl.float32)
-    out = tl.math.pow(tl.sum(mid), 1 / ord)
+    out = pow(tl.sum(mid), 1 / ord)
     tl.store(Out, out)
 
 


### PR DESCRIPTION
try to import tl.math functions from different path at various versions of triton

## why
triton moves some of the function in `tl.math` to `tl.extra.cuda.libdevice`, which *breaks* backward compatibility, so we work around it.



## how

Since PR #98 changes the way to inline function, now we can directly *call* a JITFunction in another JITFunction.

but from where should we import the inlined function? well, ... try except

```python
try:
    from triton.language.extra.cuda.libdevice import rsqrt
except ImportError:
    try:
        from triton.language.math import rsqrt
    except ImportError:
        from triton.language.libdevice import rsqrt
```

## Caveats
Never mask a symbol(redefine it with the same name) which is used in JITFunction, since the `DependencyFinder` would find the latest value.

For example, `src/flag_gems/ops/tanh.py`

```python
try:
    from triton.language.extra.cuda.libdevice import tanh as _tanh
except ImportError:
    try:
        from triton.language.math import tanh as _tanh
    except ImportError:
        from triton.language.libdevice import tanh as _tanh


@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
@triton.jit
def tanh_forward(x):
    return _tanh(x.to(tl.float32))

...

# CAUTION: it would mask tanh if we do not import tanh as _tanh
def tanh(A): 
    return Tanh.apply(A)
```

We import tanh as `_tanh` to avoid masking that name later.