### PR TITLE
[Benchmark] simplify benchmark and increase perf test scale

### DIFF
--- a/benchmark/performance_utils.py
+++ b/benchmark/performance_utils.py
@@ -80,7 +80,7 @@ DEFAULT_BATCH = 1
 POINTWISE_BATCH = 1024
 REDUCTION_BATCH = 1024
 BLAS_BATCH = 16
-SIZES = [i * 64 for i in range(1, 21)]
+SIZES = [i * 1024 for i in range(1, 81, 5)]
 
 
 def unary_arg(dtype, batch, size):

--- a/benchmark/test_blas_perf.py
+++ b/benchmark/test_blas_perf.py
@@ -1,11 +1,9 @@
-import pytest
 import torch
 
 from .performance_utils import BLAS_BATCH, DEFAULT_BATCH, FLOAT_DTYPES, SIZES, Benchmark
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_addmm(dtype):
+def test_perf_addmm():
     def addmm_args(dtype, batch, size):
         bias = torch.randn(
             [
@@ -22,15 +20,14 @@ def test_perf_addmm(dtype):
         op_name="addmm",
         torch_op=torch.addmm,
         arg_func=addmm_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=DEFAULT_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_bmm(dtype):
+def test_perf_bmm():
     def bmm_args(dtype, batch, size):
         inp1 = torch.randn([batch, size, size], dtype=dtype, device="cuda")
         inp2 = torch.randn([batch, size, size], dtype=dtype, device="cuda")
@@ -40,15 +37,14 @@ def test_perf_bmm(dtype):
         op_name="bmm",
         torch_op=torch.bmm,
         arg_func=bmm_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=BLAS_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_mm(dtype):
+def test_perf_mm():
     def mm_args(dtype, batch, size):
         inp1 = torch.randn([size, size], dtype=dtype, device="cuda")
         inp2 = torch.randn([size, size], dtype=dtype, device="cuda")
@@ -58,15 +54,14 @@ def test_perf_mm(dtype):
         op_name="mm",
         torch_op=torch.mm,
         arg_func=mm_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=DEFAULT_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_mv(dtype):
+def test_perf_mv():
     def mv_args(dtype, batch, size):
         inp1 = torch.randn([size, size], dtype=dtype, device="cuda")
         inp2 = torch.randn([size], dtype=dtype, device="cuda")
@@ -76,15 +71,14 @@ def test_perf_mv(dtype):
         op_name="mv",
         torch_op=torch.mv,
         arg_func=mv_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=BLAS_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_outer(dtype):
+def test_perf_outer():
     def outer_args(dtype, batch, size):
         inp1 = torch.randn([size], dtype=dtype, device="cuda")
         inp2 = torch.randn([size], dtype=dtype, device="cuda")
@@ -94,7 +88,7 @@ def test_perf_outer(dtype):
         op_name="outer",
         torch_op=torch.outer,
         arg_func=outer_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=DEFAULT_BATCH,
         sizes=SIZES,
     )

--- a/benchmark/test_fused_perf.py
+++ b/benchmark/test_fused_perf.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 
 import flag_gems
@@ -13,8 +12,7 @@ from .performance_utils import (
 )
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_gelu_and_mul(dtype):
+def test_perf_gelu_and_mul():
     def torch_op(x, y):
         return torch.mul(torch.nn.functional.gelu(x), y)
 
@@ -24,7 +22,7 @@ def test_perf_gelu_and_mul(dtype):
         op_name="gelu_and_mul",
         torch_op=torch_op,
         arg_func=binary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
@@ -32,8 +30,7 @@ def test_perf_gelu_and_mul(dtype):
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_silu_and_mul(dtype):
+def test_perf_silu_and_mul():
     def torch_op(x, y):
         return torch.mul(torch.nn.functional.silu(x), y)
 
@@ -43,7 +40,7 @@ def test_perf_silu_and_mul(dtype):
         op_name="silu_and_mul",
         torch_op=torch_op,
         arg_func=binary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
@@ -51,8 +48,7 @@ def test_perf_silu_and_mul(dtype):
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_skip_layernorm(dtype):
+def test_perf_skip_layernorm():
     def skip_layernorm_args(dtype, batch, size):
         inp = torch.randn([batch, size], dtype=dtype, device="cuda")
         residual = torch.randn([batch, size], dtype=dtype, device="cuda")
@@ -89,7 +85,7 @@ def test_perf_skip_layernorm(dtype):
         op_name="skip_layernorm",
         torch_op=torch_op,
         arg_func=skip_layernorm_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
@@ -97,8 +93,7 @@ def test_perf_skip_layernorm(dtype):
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_skip_rmsnorm(dtype):
+def test_perf_skip_rmsnorm():
     def skip_rmsnorm_args(dtype, batch, size):
         inp = torch.randn([batch, size], dtype=dtype, device="cuda")
         residual = torch.randn([batch, size], dtype=dtype, device="cuda")
@@ -131,7 +126,7 @@ def test_perf_skip_rmsnorm(dtype):
         op_name="skip_rmsnorm",
         torch_op=torch_op,
         arg_func=skip_rmsnorm_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )

--- a/benchmark/test_pointwise_perf.py
+++ b/benchmark/test_pointwise_perf.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 
 from .performance_utils import (
@@ -15,411 +14,379 @@ from .performance_utils import (
 )
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_abs(dtype):
+def test_perf_abs():
     bench = Benchmark(
         op_name="abs",
         torch_op=torch.abs,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_add(dtype):
+def test_perf_add():
     bench = Benchmark(
         op_name="add",
         torch_op=torch.add,
         arg_func=binary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", INT_DTYPES)
-def test_perf_bitwiseand(dtype):
+def test_perf_bitwiseand():
     bench = Benchmark(
         op_name="bitwiseand",
         torch_op=torch.bitwise_and,
         arg_func=binary_int_args,
-        dtype=dtype,
+        dtypes=INT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", INT_DTYPES)
-def test_perf_bitwisenot(dtype):
+def test_perf_bitwisenot():
     bench = Benchmark(
         op_name="bitwisenot",
         torch_op=torch.bitwise_not,
         arg_func=unary_int_arg,
-        dtype=dtype,
+        dtypes=INT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", INT_DTYPES)
-def test_perf_bitwiseor(dtype):
+def test_perf_bitwiseor():
     bench = Benchmark(
         op_name="bitwiseor",
         torch_op=torch.bitwise_or,
         arg_func=binary_int_args,
-        dtype=dtype,
+        dtypes=INT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_clamp(dtype):
+def test_perf_clamp():
     bench = Benchmark(
         op_name="clamp",
         torch_op=torch.clamp,
         arg_func=ternary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_cos(dtype):
+def test_perf_cos():
     bench = Benchmark(
         op_name="cos",
         torch_op=torch.cos,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_div(dtype):
+def test_perf_div():
     bench = Benchmark(
         op_name="div",
         torch_op=torch.div,
         arg_func=binary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_dropout(dtype):
+def test_perf_dropout():
     bench = Benchmark(
         op_name="dropout",
         torch_op=torch.nn.Dropout(p=0.5),
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_eq(dtype):
+def test_perf_eq():
     bench = Benchmark(
         op_name="eq",
         torch_op=torch.eq,
         arg_func=binary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_exp(dtype):
+def test_perf_exp():
     bench = Benchmark(
         op_name="exp",
         torch_op=torch.exp,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_ge(dtype):
+def test_perf_ge():
     bench = Benchmark(
         op_name="ge",
         torch_op=torch.ge,
         arg_func=binary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_gelu(dtype):
+def test_perf_gelu():
     bench = Benchmark(
         op_name="gelu",
         torch_op=torch.nn.functional.gelu,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_gt(dtype):
+def test_perf_gt():
     bench = Benchmark(
         op_name="gt",
         torch_op=torch.gt,
         arg_func=binary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_isinf(dtype):
+def test_perf_isinf():
     bench = Benchmark(
         op_name="isinf",
         torch_op=torch.isinf,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_isnan(dtype):
+def test_perf_isnan():
     bench = Benchmark(
         op_name="isnan",
         torch_op=torch.isnan,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_le(dtype):
+def test_perf_le():
     bench = Benchmark(
         op_name="le",
         torch_op=torch.le,
         arg_func=binary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_lt(dtype):
+def test_perf_lt():
     bench = Benchmark(
         op_name="lt",
         torch_op=torch.lt,
         arg_func=binary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_mul(dtype):
+def test_perf_mul():
     bench = Benchmark(
         op_name="mul",
         torch_op=torch.mul,
         arg_func=binary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_ne(dtype):
+def test_perf_ne():
     bench = Benchmark(
         op_name="ne",
         torch_op=torch.ne,
         arg_func=binary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_neg(dtype):
+def test_perf_neg():
     bench = Benchmark(
         op_name="neg",
         torch_op=torch.neg,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_pow(dtype):
+def test_perf_pow():
     bench = Benchmark(
         op_name="pow",
         torch_op=torch.pow,
         arg_func=binary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_reciprocal(dtype):
+def test_perf_reciprocal():
     bench = Benchmark(
         op_name="reciprocal",
         torch_op=torch.reciprocal,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_relu(dtype):
+def test_perf_relu():
     bench = Benchmark(
         op_name="relu",
         torch_op=torch.nn.functional.relu,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_rsqrt(dtype):
+def test_perf_rsqrt():
     bench = Benchmark(
         op_name="rsqrt",
         torch_op=torch.rsqrt,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_sigmoid(dtype):
+def test_perf_sigmoid():
     bench = Benchmark(
         op_name="sigmoid",
         torch_op=torch.sigmoid,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_silu(dtype):
+def test_perf_silu():
     bench = Benchmark(
         op_name="silu",
         torch_op=torch.nn.functional.silu,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_sin(dtype):
+def test_perf_sin():
     bench = Benchmark(
         op_name="sin",
         torch_op=torch.sin,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_sub(dtype):
+def test_perf_sub():
     bench = Benchmark(
         op_name="sub",
         torch_op=torch.sub,
         arg_func=binary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_tanh(dtype):
+def test_perf_tanh():
     bench = Benchmark(
         op_name="tanh",
         torch_op=torch.tanh,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_triu(dtype):
+def test_perf_triu():
     bench = Benchmark(
         op_name="triu",
         torch_op=torch.triu,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_where(dtype):
+def test_perf_where():
     def where_args(dtype, batch, size):
         inp1 = torch.randn([batch, size], dtype=dtype, device="cuda")
         inp2 = torch.randn([batch, size], dtype=dtype, device="cuda")
@@ -430,59 +397,55 @@ def test_perf_where(dtype):
         op_name="where",
         torch_op=torch.where,
         arg_func=where_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_isclose(dtype):
+def test_perf_isclose():
     bench = Benchmark(
         op_name="isclose",
         torch_op=torch.isclose,
         arg_func=binary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", INT_DTYPES)
-def test_perf_isclose_int(dtype):
+def test_perf_isclose_int():
     bench = Benchmark(
         op_name="isclose",
         torch_op=torch.isclose,
         arg_func=binary_int_args,
-        dtype=dtype,
+        dtypes=INT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_allclose(dtype):
+def test_perf_allclose():
     bench = Benchmark(
         op_name="allclose",
         torch_op=torch.allclose,
         arg_func=binary_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", INT_DTYPES)
-def test_perf_allclose_int(dtype):
+def test_perf_allclose_int():
     bench = Benchmark(
         op_name="allclose",
         torch_op=torch.allclose,
         arg_func=binary_int_args,
-        dtype=dtype,
+        dtypes=INT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )

--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 
 from .performance_utils import (
@@ -11,60 +10,55 @@ from .performance_utils import (
 )
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_all(dtype):
+def test_perf_all():
     bench = Benchmark(
         op_name="all",
         torch_op=torch.all,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_amax(dtype):
+def test_perf_amax():
     bench = Benchmark(
         op_name="amax",
         torch_op=torch.amax,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_any(dtype):
+def test_perf_any():
     bench = Benchmark(
         op_name="any",
         torch_op=torch.any,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_argmax(dtype):
+def test_perf_argmax():
     bench = Benchmark(
         op_name="argmax",
         torch_op=torch.argmax,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_cross_entropy_loss(dtype):
+def test_perf_cross_entropy_loss():
     def cross_entropy_loss_args(dtype, batch, size):
         inp = torch.randn([batch, size], dtype=dtype, device="cuda")
         target = torch.randint(
@@ -81,15 +75,14 @@ def test_perf_cross_entropy_loss(dtype):
         op_name="cross_entropy_loss",
         torch_op=torch.nn.CrossEntropyLoss(),
         arg_func=cross_entropy_loss_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_cumsum(dtype):
+def test_perf_cumsum():
     def cumsum_args(dtype, batch, size):
         inp = torch.randn([batch, size], dtype=dtype, device="cuda")
         return inp, 1
@@ -98,15 +91,14 @@ def test_perf_cumsum(dtype):
         op_name="cumsum",
         torch_op=torch.cumsum,
         arg_func=cumsum_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_groupnorm(dtype):
+def test_perf_groupnorm():
     def group_norm_args(dtype, batch, size):
         C = 16
         G = 16
@@ -131,15 +123,14 @@ def test_perf_groupnorm(dtype):
         op_name="groupnorm",
         torch_op=torch.nn.functional.group_norm,
         arg_func=group_norm_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=BLAS_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_layernorm(dtype):
+def test_perf_layernorm():
     def layer_norm_args(dtype, batch, size):
         inp = torch.randn([batch, size], dtype=dtype, device="cuda")
         weight = torch.randn(
@@ -169,124 +160,115 @@ def test_perf_layernorm(dtype):
         op_name="layernorm",
         torch_op=torch.layer_norm,
         arg_func=layer_norm_args,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_log_softmax(dtype):
+def test_perf_log_softmax():
     bench = Benchmark(
         op_name="log_softmax",
         torch_op=torch.nn.functional.log_softmax,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_max(dtype):
+def test_perf_max():
     bench = Benchmark(
         op_name="max",
         torch_op=torch.max,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_mean(dtype):
+def test_perf_mean():
     bench = Benchmark(
         op_name="mean",
         torch_op=torch.mean,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_min(dtype):
+def test_perf_min():
     bench = Benchmark(
         op_name="min",
         torch_op=torch.min,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_prod(dtype):
+def test_perf_prod():
     bench = Benchmark(
         op_name="prod",
         torch_op=torch.prod,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_softmax(dtype):
+def test_perf_softmax():
     bench = Benchmark(
         op_name="softmax",
         torch_op=torch.nn.functional.softmax,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_sum(dtype):
+def test_perf_sum():
     bench = Benchmark(
         op_name="sum",
         torch_op=torch.sum,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_var_mean(dtype):
+def test_perf_var_mean():
     bench = Benchmark(
         op_name="var_mean",
         torch_op=torch.var_mean,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_vector_norm(dtype):
+def test_perf_vector_norm():
     bench = Benchmark(
         op_name="vector_norm",
         torch_op=torch.linalg.vector_norm,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=REDUCTION_BATCH,
         sizes=SIZES,
     )

--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -1,4 +1,3 @@
-import pytest
 import torch
 
 from .performance_utils import (
@@ -10,8 +9,7 @@ from .performance_utils import (
 )
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_rand(dtype):
+def test_perf_rand():
     def rand_kwargs(dtype, batch, size):
         return {"size": (batch, size), "dtype": dtype, "device": "cuda"}
 
@@ -19,7 +17,7 @@ def test_perf_rand(dtype):
         op_name="rand",
         torch_op=torch.rand,
         arg_func=None,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
         kwargs_func=rand_kwargs,
@@ -27,8 +25,7 @@ def test_perf_rand(dtype):
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_randn(dtype):
+def test_perf_randn():
     def randn_kwargs(dtype, batch, size):
         return {"size": (batch, size), "dtype": dtype, "device": "cuda"}
 
@@ -36,7 +33,7 @@ def test_perf_randn(dtype):
         op_name="randn",
         torch_op=torch.randn,
         arg_func=None,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
         kwargs_func=randn_kwargs,
@@ -44,13 +41,12 @@ def test_perf_randn(dtype):
     bench.run()
 
 
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_perf_rand_like(dtype):
+def test_perf_rand_like():
     bench = Benchmark(
         op_name="rand_like",
         torch_op=torch.rand_like,
         arg_func=unary_arg,
-        dtype=dtype,
+        dtypes=FLOAT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
     )


### PR DESCRIPTION
1. remove pytest parameter dtype and initialize data types in Benchmark constructor. this allow vendors to collect speedup data easier.
2. scale up performance test shape to over 1M.