### PR TITLE
[Runtime] Heuristic expression allowing python3.8

### DIFF
--- a/src/flag_gems/ops/argmax.py
+++ b/src/flag_gems/ops/argmax.py
@@ -43,6 +43,10 @@ def argmax_kernel_2(mid_value, mid_index, out, mid_size, BLOCK_MID: tl.constexpr
     tl.store(out, out_val)
 
 
+def heur_block_n(args):
+    return triton.next_power_of_2(args["N"])
+
+
 @libentry()
 @triton.autotune(
     configs=[
@@ -59,7 +63,9 @@ def argmax_kernel_2(mid_value, mid_index, out, mid_size, BLOCK_MID: tl.constexpr
     ],
 )
 @triton.heuristics(
-    values={"BLOCK_N": lambda args: triton.next_power_of_2(args["N"])},
+    {
+        "BLOCK_N": heur_block_n,
+    }
 )
 @triton.jit
 def argmax_kernel(

--- a/src/flag_gems/ops/bmm.py
+++ b/src/flag_gems/ops/bmm.py
@@ -7,6 +7,18 @@ import triton.language as tl
 from ..utils import libentry
 
 
+def heur_divisible_m(args):
+    return args["M"] % args["TILE_M"] == 0
+
+
+def heur_divisible_n(args):
+    return args["N"] % args["TILE_N"] == 0
+
+
+def heur_divisible_k(args):
+    return args["K"] % args["TILE_K"] == 0
+
+
 @libentry()
 @triton.autotune(
     configs=[
@@ -75,9 +87,9 @@ from ..utils import libentry
 )
 @triton.heuristics(
     {
-        "DIVISIBLE_M": lambda args: args["M"] % args["TILE_M"] == 0,
-        "DIVISIBLE_N": lambda args: args["N"] % args["TILE_N"] == 0,
-        "DIVISIBLE_K": lambda args: args["K"] % args["TILE_K"] == 0,
+        "DIVISIBLE_M": heur_divisible_m,
+        "DIVISIBLE_N": heur_divisible_n,
+        "DIVISIBLE_K": heur_divisible_k,
     }
 )
 @triton.jit

--- a/src/flag_gems/ops/cross_entropy_loss.py
+++ b/src/flag_gems/ops/cross_entropy_loss.py
@@ -15,6 +15,19 @@ class Reduction(IntEnum):
     SUM = 2
 
 
+def heur_block_n(args):
+    return triton.next_power_of_2(args["N"])
+
+
+def heur_num_warps(args):
+    if args["N"] <= 1024:
+        return 4
+    elif args["N"] <= 2048:
+        return 8
+    else:
+        return 16
+
+
 @libentry()
 @triton.autotune(
     configs=[
@@ -33,12 +46,10 @@ class Reduction(IntEnum):
     ],
 )
 @triton.heuristics(
-    values={
-        "BLOCK_N": lambda args: triton.next_power_of_2(args["N"]),
-        "num_warps": lambda args: (
-            4 if args["N"] <= 1024 else (8 if args["N"] <= 2048 else 16)
-        ),
-    },
+    {
+        "BLOCK_N": heur_block_n,
+        "num_warps": heur_num_warps,
+    }
 )
 @triton.jit(do_not_specialize=["mean_num"])
 def log_softmax_and_mul_kernel(
@@ -88,12 +99,10 @@ def log_softmax_and_mul_kernel(
     ],
 )
 @triton.heuristics(
-    values={
-        "BLOCK_N": lambda args: triton.next_power_of_2(args["N"]),
-        "num_warps": lambda args: (
-            4 if args["N"] <= 1024 else (8 if args["N"] <= 2048 else 16)
-        ),
-    },
+    {
+        "BLOCK_N": heur_block_n,
+        "num_warps": heur_num_warps,
+    }
 )
 @triton.jit(do_not_specialize=["mean_num"])
 def softmax_and_sub_kernel(
@@ -151,12 +160,10 @@ def softmax_and_sub_kernel(
     ],
 )
 @triton.heuristics(
-    values={
-        "BLOCK_N": lambda args: triton.next_power_of_2(args["N"]),
-        "num_warps": lambda args: (
-            4 if args["N"] <= 1024 else (8 if args["N"] <= 2048 else 16)
-        ),
-    },
+    {
+        "BLOCK_N": heur_block_n,
+        "num_warps": heur_num_warps,
+    }
 )
 @triton.jit(do_not_specialize=["mean_num"])
 def softmax_and_sub_reduce_kernel(

--- a/src/flag_gems/ops/cumsum.py
+++ b/src/flag_gems/ops/cumsum.py
@@ -7,6 +7,10 @@ import triton.language as tl
 from ..utils import libentry
 
 
+def heur_block_n(args):
+    return triton.next_power_of_2(args["N"])
+
+
 @libentry()
 @triton.autotune(
     configs=[
@@ -23,7 +27,9 @@ from ..utils import libentry
     ],
 )
 @triton.heuristics(
-    values={"BLOCK_N": lambda args: triton.next_power_of_2(args["N"])},
+    {
+        "BLOCK_N": heur_block_n,
+    }
 )
 @triton.jit
 def cumsum_kernel(

--- a/src/flag_gems/ops/dropout.py
+++ b/src/flag_gems/ops/dropout.py
@@ -9,10 +9,26 @@ from ..utils.random_utils import philox_cuda_seed_offset, uint_to_uniform_float
 UNROLL = 4
 
 
+def heur_block(args):
+    if args["N"] <= 512:
+        return 512
+    else:
+        return 1024
+
+
+def heur_num_warps(args):
+    if args["N"] <= 512:
+        return 4
+    elif args["N"] <= 1024:
+        return 8
+    else:
+        return 16
+
+
 @triton.heuristics(
-    values={
-        "BLOCK": lambda args: 512 if args["N"] <= 512 else 1024,
-        "num_warps": lambda args: 4 if args["N"] <= 512 else 8 if args["N"] <= 1024 else 16,  # fmt: skip
+    {
+        "BLOCK": heur_block,
+        "num_warps": heur_num_warps,
     }
 )
 @triton.jit(do_not_specialize=["p", "philox_seed", "philox_offset"])
@@ -66,9 +82,9 @@ def dropout_forward_kernel(
 
 
 @triton.heuristics(
-    values={
-        "BLOCK": lambda args: 512 if args["N"] <= 512 else 1024,
-        "num_warps": lambda args: 4 if args["N"] <= 512 else 8 if args["N"] <= 1024 else 16,  # fmt: skip
+    {
+        "BLOCK": heur_block,
+        "num_warps": heur_num_warps,
     }
 )
 @triton.jit(do_not_specialize=["p", "philox_seed", "philox_offset"])

--- a/src/flag_gems/ops/log_softmax.py
+++ b/src/flag_gems/ops/log_softmax.py
@@ -7,6 +7,19 @@ import triton.language as tl
 from ..utils import libentry
 
 
+def heur_block_n(args):
+    return triton.next_power_of_2(args["N"])
+
+
+def heur_num_warps(args):
+    if args["N"] <= 1024:
+        return 4
+    elif args["N"] <= 2048:
+        return 8
+    else:
+        return 16
+
+
 @libentry()
 @triton.autotune(
     configs=[
@@ -25,12 +38,10 @@ from ..utils import libentry
     ],
 )
 @triton.heuristics(
-    values={
-        "BLOCK_N": lambda args: triton.next_power_of_2(args["N"]),
-        "num_warps": lambda args: (
-            4 if args["N"] <= 1024 else (8 if args["N"] <= 2048 else 16)
-        ),
-    },
+    {
+        "BLOCK_N": heur_block_n,
+        "num_warps": heur_num_warps,
+    }
 )
 @triton.jit
 def log_softmax_kernel(
@@ -76,12 +87,10 @@ def log_softmax_kernel(
     ],
 )
 @triton.heuristics(
-    values={
-        "BLOCK_N": lambda args: triton.next_power_of_2(args["N"]),
-        "num_warps": lambda args: (
-            4 if args["N"] <= 1024 else (8 if args["N"] <= 2048 else 16)
-        ),
-    },
+    {
+        "BLOCK_N": heur_block_n,
+        "num_warps": heur_num_warps,
+    }
 )
 @triton.jit
 def log_softmax_backward_kernel(

--- a/src/flag_gems/ops/max.py
+++ b/src/flag_gems/ops/max.py
@@ -38,6 +38,10 @@ def max_kernel_2(mid, out, mid_size, BLOCK_MID: tl.constexpr):
     tl.store(out, max_val)
 
 
+def heur_block_n(args):
+    return triton.next_power_of_2(args["N"])
+
+
 @libentry()
 @triton.autotune(
     configs=[
@@ -54,7 +58,9 @@ def max_kernel_2(mid, out, mid_size, BLOCK_MID: tl.constexpr):
     ],
 )
 @triton.heuristics(
-    values={"BLOCK_N": lambda args: triton.next_power_of_2(args["N"])},
+    {
+        "BLOCK_N": heur_block_n,
+    }
 )
 @triton.jit
 def max_kernel(

--- a/src/flag_gems/ops/min.py
+++ b/src/flag_gems/ops/min.py
@@ -38,6 +38,10 @@ def min_kernel_2(mid, out, mid_size, BLOCK_MID: tl.constexpr):
     tl.store(out, min_val)
 
 
+def heur_block_n(args):
+    return triton.next_power_of_2(args["N"])
+
+
 @libentry()
 @triton.autotune(
     configs=[
@@ -54,7 +58,9 @@ def min_kernel_2(mid, out, mid_size, BLOCK_MID: tl.constexpr):
     ],
 )
 @triton.heuristics(
-    values={"BLOCK_N": lambda args: triton.next_power_of_2(args["N"])},
+    {
+        "BLOCK_N": heur_block_n,
+    }
 )
 @triton.jit
 def min_kernel(

--- a/src/flag_gems/ops/mm.py
+++ b/src/flag_gems/ops/mm.py
@@ -7,6 +7,10 @@ import triton.language as tl
 from ..utils import libentry
 
 
+def heur_even_k(args):
+    return args["K"] % (args["BLOCK_K"] * args["SPLIT_K"]) == 0
+
+
 @libentry()
 @triton.autotune(
     configs=[
@@ -107,7 +111,7 @@ from ..utils import libentry
 )
 @triton.heuristics(
     {
-        "EVEN_K": lambda args: args["K"] % (args["BLOCK_K"] * args["SPLIT_K"]) == 0,
+        "EVEN_K": heur_even_k,
     }
 )
 @triton.jit

--- a/src/flag_gems/ops/prod.py
+++ b/src/flag_gems/ops/prod.py
@@ -61,6 +61,10 @@ def prod(inp, *, dtype=None):
     return out
 
 
+def heur_block_n(args):
+    return triton.next_power_of_2(args["N"])
+
+
 @libentry()
 @triton.autotune(
     configs=[
@@ -77,7 +81,9 @@ def prod(inp, *, dtype=None):
     ],
 )
 @triton.heuristics(
-    values={"BLOCK_N": lambda args: triton.next_power_of_2(args["N"])},
+    {
+        "BLOCK_N": heur_block_n,
+    }
 )
 @triton.jit
 def prod_kernel(

--- a/src/flag_gems/ops/rand.py
+++ b/src/flag_gems/ops/rand.py
@@ -8,10 +8,26 @@ from flag_gems.utils.random_utils import philox_cuda_seed_offset, uint_to_unifor
 from flag_gems.utils.shape_utils import volume
 
 
+def heur_block(args):
+    if args["N"] <= 512:
+        return 512
+    else:
+        return 1024
+
+
+def heur_num_warps(args):
+    if args["N"] <= 512:
+        return 4
+    elif args["N"] <= 1024:
+        return 8
+    else:
+        return 16
+
+
 @triton.heuristics(
-    values={
-        "BLOCK": lambda args: 512 if args["N"] <= 512 else 1024,
-        "num_warps": lambda args: 4 if args["N"] <= 512 else 8 if args["N"] <= 1024 else 16,  # fmt: skip
+    {
+        "BLOCK": heur_block,
+        "num_warps": heur_num_warps,
     }
 )
 @triton.jit(do_not_specialize=["philox_seed", "philox_offset"])

--- a/src/flag_gems/ops/randn.py
+++ b/src/flag_gems/ops/randn.py
@@ -20,10 +20,26 @@ except AttributeError:
         return r * tl.cos(th), r * tl.sin(th)
 
 
+def heur_block(args):
+    if args["N"] <= 512:
+        return 512
+    else:
+        return 1024
+
+
+def heur_num_warps(args):
+    if args["N"] <= 512:
+        return 4
+    elif args["N"] <= 1024:
+        return 8
+    else:
+        return 16
+
+
 @triton.heuristics(
-    values={
-        "BLOCK": lambda args: 512 if args["N"] <= 512 else 1024,
-        "num_warps": lambda args: 4 if args["N"] <= 512 else 8 if args["N"] <= 1024 else 16,  # fmt: skip
+    {
+        "BLOCK": heur_block,
+        "num_warps": heur_num_warps,
     }
 )
 @triton.jit(do_not_specialize=["philox_seed", "philox_offset"])

--- a/src/flag_gems/ops/softmax.py
+++ b/src/flag_gems/ops/softmax.py
@@ -6,13 +6,18 @@ import triton.language as tl
 
 from ..utils import libentry
 
+MAX_TILE_K = 8192
+NUM_SMS = torch.cuda.get_device_properties(
+    torch.cuda.current_device()
+).multi_processor_count
 
-def heuristics_for_tile_k(m, k, max_tile_k, num_sms):
+
+def heur_tile_k(args):
     tile_k = 1
-    upper_bound = min(k, max_tile_k)
+    upper_bound = min(args["K"], MAX_TILE_K)
     while tile_k <= upper_bound:
-        num_blocks = m * triton.cdiv(k, tile_k)
-        num_waves = num_blocks / num_sms
+        num_blocks = args["M"] * triton.cdiv(args["K"], tile_k)
+        num_waves = num_blocks / NUM_SMS
         if (num_waves > 1) and (tile_k * 2 <= upper_bound):
             tile_k *= 2
         else:
@@ -20,30 +25,31 @@ def heuristics_for_tile_k(m, k, max_tile_k, num_sms):
     return tile_k
 
 
+def heur_tile_n_non_inner(args):
+    return triton.cdiv(8192, args["TILE_K"])
+
+
+def heur_one_tile_per_cta(args):
+    return args["TILE_N"] >= args["N"]
+
+
+def heur_num_warps_non_inner(args):
+    tile_size = args["TILE_N"] * args["TILE_K"]
+    if tile_size < 2048:
+        return 4
+    elif tile_size < 4096:
+        return 8
+    else:
+        return 16
+
+
 @triton.heuristics(
-    values={
-        "TILE_K": lambda args: heuristics_for_tile_k(
-            args["M"],
-            args["K"],
-            8192,
-            torch.cuda.get_device_properties(
-                torch.cuda.current_device()
-            ).multi_processor_count,
-        )
+    {
+        "TILE_K": heur_tile_k,
+        "TILE_N": heur_tile_n_non_inner,
+        "ONE_TILE_PER_CTA": heur_one_tile_per_cta,
+        "num_warps": heur_num_warps_non_inner,
     }
-)
-@triton.heuristics(values={"TILE_N": lambda args: triton.cdiv(8192, args["TILE_K"])})
-@triton.heuristics(
-    values={
-        "ONE_TILE_PER_CTA": lambda args: args["TILE_N"] >= args["N"],
-    },
-)
-@triton.heuristics(
-    values={
-        "num_warps": lambda args: heuristics_for_num_warps(
-            args["TILE_N"] * args["TILE_K"]
-        )
-    },
 )
 @triton.jit
 def softmax_kernel_non_inner(
@@ -103,15 +109,6 @@ def softmax_kernel_non_inner(
             tl.store(output_ptr + offsets, o, mask=mask)
 
 
-def heuristics_for_num_warps(tile_size):
-    if tile_size < 2048:
-        return 4
-    elif tile_size < 4096:
-        return 8
-    else:
-        return 16
-
-
 @triton.jit
 def next_multiple_of(a, b):
     # the smallest x>=a that x%b ==0
@@ -124,20 +121,29 @@ def prev_multiple_of(a, b):
     return tl.cdiv(a, b) * b - b
 
 
+def heur_tile_n_inner(args):
+    if args["N"] <= (32 * 1024):
+        return triton.next_power_of_2(args["N"])
+    else:
+        return 4096
+
+
+def heur_num_warps_inner(args):
+    tile_size = args["TILE_N"]
+    if tile_size < 2048:
+        return 4
+    elif tile_size < 4096:
+        return 8
+    else:
+        return 16
+
+
 @triton.heuristics(
-    values={
-        "TILE_N": lambda args: triton.next_power_of_2(args["N"])
-        if args["N"] <= (32 * 1024)
-        else 4096
-    },
-)
-@triton.heuristics(
-    values={
-        "ONE_TILE_PER_CTA": lambda args: args["TILE_N"] >= args["N"],
-    },
-)
-@triton.heuristics(
-    values={"num_warps": lambda args: heuristics_for_num_warps(args["TILE_N"])},
+    {
+        "TILE_N": heur_tile_n_inner,
+        "ONE_TILE_PER_CTA": heur_one_tile_per_cta,
+        "num_warps": heur_num_warps_inner,
+    }
 )
 @triton.jit
 def softmax_kernel_inner(
@@ -209,6 +215,10 @@ def softmax_kernel_inner(
             tl.store(output_ptr + n_offsets, o)
 
 
+def heur_tile_n_bwd_non_inner(args):
+    return max(1, 1024 // args["TILE_K"])
+
+
 # ------------------------  backward -------------------------------
 @libentry()
 @triton.autotune(
@@ -227,9 +237,9 @@ def softmax_kernel_inner(
     ],
 )
 @triton.heuristics(
-    values={
-        "TILE_N": lambda args: max(1, 1024 // args["TILE_K"]),
-        "ONE_TILE_PER_CTA": lambda args: args["TILE_N"] >= args["N"],
+    {
+        "TILE_N": heur_tile_n_bwd_non_inner,
+        "ONE_TILE_PER_CTA": heur_one_tile_per_cta,
     },
 )
 @triton.jit
@@ -282,6 +292,10 @@ def softmax_backward_kernel_non_inner(
             offsets += TILE_N * K
 
 
+def heru_tile_m(args):
+    return max(1, 1024 // args["TILE_N"])
+
+
 @libentry()
 @triton.autotune(
     configs=[
@@ -296,8 +310,8 @@ def softmax_backward_kernel_non_inner(
 )
 @triton.heuristics(
     values={
-        "TILE_M": lambda args: max(1, 1024 // args["TILE_N"]),
-        "ONE_TILE_PER_CTA": lambda args: args["TILE_N"] >= args["N"],
+        "TILE_M": heru_tile_m,
+        "ONE_TILE_PER_CTA": heur_one_tile_per_cta,
     },
 )
 @triton.jit

--- a/src/flag_gems/ops/var_mean.py
+++ b/src/flag_gems/ops/var_mean.py
@@ -108,9 +108,15 @@ def var_mean_kernel_1(
     tl.store(Count, count)
 
 
+def heur_block_n(args):
+    return triton.next_power_of_2(args["BLOCK_NUM"])
+
+
 @libentry()
 @triton.heuristics(
-    values={"BLOCK_N": lambda args: triton.next_power_of_2(args["BLOCK_NUM"])},
+    {
+        "BLOCK_N": heur_block_n,
+    }
 )
 @triton.jit(do_not_specialize=["correction"])
 def var_mean_kernel_2(


### PR DESCRIPTION
For python before version 3.10.10, lambda expression might cause python inspect error. It is fixed [here](https://github.com/python/cpython/pull/99654) , but requires higher version.
To support python3.8, we redefine all lambda expressions in triton.Heuristics as functions.