### PR TITLE
Avoid calling external library in rhs of assignemnts to tl.constexpr

### DIFF
--- a/src/flag_gems/ops/sigmoid.py
+++ b/src/flag_gems/ops/sigmoid.py
@@ -1,5 +1,4 @@
 import logging
-import math
 
 import torch
 import triton
@@ -19,7 +18,10 @@ except ImportError:
 @pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
 @triton.jit
 def sigmoid_forward(x):
-    log2e: tl.constexpr = math.log2(math.e)
+    # log2e: tl.constexpr = math.log2(math.e)
+    # triton 3.0.0 disallow calling non-jitted function inside jitted function, even if it is in
+    # the rhs of an assignment to a constexpr, so we use numeric literal instead to work around this.
+    log2e: tl.constexpr = 1.4426950408889634
     return 1 / (1 + exp2(-x.to(tl.float32) * log2e))
 
 


### PR DESCRIPTION
Avoid calling external library in rhs of assignemnts to tl.constexpr, as disallowed in triton3.0.0, use numeric literal instead.



See https://github.com/triton-lang/triton/issues/4321 for more details.