### PR TITLE
[Operator] Fix rand/randn/rand_like grid and seed error

### DIFF
--- a/src/flag_gems/ops/rand_like.py
+++ b/src/flag_gems/ops/rand_like.py
@@ -6,6 +6,8 @@ import triton
 from flag_gems.ops.rand import rand_kernel
 from flag_gems.utils.random_utils import philox_cuda_seed_offset
 
+UNROLL = 4
+
 
 def rand_like(
     x, *, dtype=None, layout=None, device=None, pin_memory=None, memory_format=None
@@ -17,8 +19,11 @@ def rand_like(
         dtype = x.dtype
     out = torch.empty_like(x, device=device, dtype=dtype)
     N = x.numel()
-    grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK"]),)
-    philox_seed, philox_offset = philox_cuda_seed_offset(N)
+    grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK"] * UNROLL),)
+    # (TODO) Using Triton autotuner makes kernel parameters opaque to the caller,
+    # hence we cannot obtain the per thread offset as in Pytorch.
+    increment = triton.cdiv(N, UNROLL)
+    philox_seed, philox_offset = philox_cuda_seed_offset(increment)
     with torch.cuda.device(x.device):
         rand_kernel[grid_fn](out, N, philox_seed, philox_offset)
     return out

--- a/src/flag_gems/ops/randn.py
+++ b/src/flag_gems/ops/randn.py
@@ -74,6 +74,9 @@ def randn_kernel(
     tl.store(out_ptr + off_3, n3, mask=off_3 < N, eviction_policy="evict_first")
 
 
+UNROLL = 4
+
+
 def randn(size, *, dtype=None, layout=None, device=None, pin_memory=None):
     logging.debug("GEMS RANDN")
     if dtype is None:
@@ -82,8 +85,11 @@ def randn(size, *, dtype=None, layout=None, device=None, pin_memory=None):
         device = torch.device("cuda")
     out = torch.empty(size, device=device, dtype=dtype)
     N = volume(size)
-    grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK"]),)
-    philox_seed, philox_offset = philox_cuda_seed_offset(N)
+    grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK"] * UNROLL),)
+    # (TODO) Using Triton autotuner makes kernel parameters opaque to the caller,
+    # hence we cannot obtain the per thread offset as in Pytorch.
+    increment = triton.cdiv(N, UNROLL)
+    philox_seed, philox_offset = philox_cuda_seed_offset(increment)
     with torch.cuda.device(device):
         randn_kernel[grid_fn](out, N, philox_seed, philox_offset)
     return out


### PR DESCRIPTION
We observed that the kernel of the rand class operator writes data four times the size of a BLOCK each time, but the grid issued for processing is handled based on the amount of data each kernel processes per BLOCK. Consequently, we emulated the dropout mechanism to modify the grid processing logic, and similarly, we adapted the seed calculation parameters based on the dropout approach.