### PR TITLE
Use int64 indexing when needed & fix argmax

### DIFF
--- a/src/flag_gems/ops/argmax.py
+++ b/src/flag_gems/ops/argmax.py
@@ -98,8 +98,11 @@ def argmax_kernel(
         mask = m_offset[:, None] < M and n_offset[None, :] < N
         inp_ptrs = inp + offset
         inp_vals = tl.load(inp_ptrs, mask=mask, other=-float("inf"))
-        local_max = tl.max(inp_vals, 1)
-        local_argmax = tl.argmax(inp_vals, 1)
+        local_max, local_argmax = tl.max(
+            inp_vals, 1, return_indices=True, return_indices_tie_break_left=True
+        )
+        # if return indices is not supported, call a tl.argmax in addition
+        # local_argmax = tl.argmax(inp_vals, 1)
         update = local_max > max_values
         max_values = tl.where(update, local_max, max_values)
         argmax_values = tl.where(update, start_n + local_argmax, argmax_values)

--- a/src/flag_gems/ops/triu.py
+++ b/src/flag_gems/ops/triu.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils.shape_utils import can_use_int32_index
 
 
 def cfggen():
@@ -98,7 +99,7 @@ def triu(A, diagonal=0):
     A = A.contiguous()
     out = torch.empty_like(A)
     assert len(A.shape) > 1, "Input tensor must have at least 2 dimensions"
-    use_int64_index = A.numel() > INT32_MAX or A.element_size() * A.numel() > INT32_MAX
+    use_int64_index = not can_use_int32_index(A)
     M, N = A.shape[-2:]
     with torch.cuda.device(A.device):
         if len(A.shape) == 2:

--- a/src/flag_gems/ops/triu.py
+++ b/src/flag_gems/ops/triu.py
@@ -36,8 +36,11 @@ def triu_kernel(
     diagonal,
     M_BLOCK_SIZE: tl.constexpr,
     N_BLOCK_SIZE: tl.constexpr,
+    INT64_INDEX: tl.constexpr = False,
 ):
     pid = tl.program_id(0)
+    if INT64_INDEX:
+        pid = pid.to(tl.int64)
     row = pid * M_BLOCK_SIZE + tl.arange(0, M_BLOCK_SIZE)[:, None]
     m_mask = row < M
     X += row * N
@@ -65,9 +68,13 @@ def triu_batch_kernel(
     diagonal,
     BATCH_BLOCK_SIZE: tl.constexpr,
     MN_BLOCK_SIZE: tl.constexpr,
+    INT64_INDEX: tl.constexpr = False,
 ):
     batch_id = tl.program_id(0)
     mn_id = tl.program_id(1)
+    if INT64_INDEX:
+        batch_id = batch_id.to(tl.int64)
+        mn_id = mn_id.to(tl.int64)
     row = batch_id * BATCH_BLOCK_SIZE + tl.arange(0, BATCH_BLOCK_SIZE)[:, None]
     batch_mask = row < batch
     X += row * MN
@@ -83,16 +90,20 @@ def triu_batch_kernel(
     tl.store(Y + cols, y, mask=mask)
 
 
+INT32_MAX = torch.iinfo(torch.int32).max
+
+
 def triu(A, diagonal=0):
     logging.debug("GEMS TRIU")
     A = A.contiguous()
     out = torch.empty_like(A)
     assert len(A.shape) > 1, "Input tensor must have at least 2 dimensions"
+    use_int64_index = A.numel() > INT32_MAX or A.element_size() * A.numel() > INT32_MAX
     M, N = A.shape[-2:]
     with torch.cuda.device(A.device):
         if len(A.shape) == 2:
             grid = lambda meta: (triton.cdiv(M, meta["M_BLOCK_SIZE"]),)
-            triu_kernel[grid](A, out, M, N, diagonal)
+            triu_kernel[grid](A, out, M, N, diagonal, INT64_INDEX=use_int64_index)
         else:
             batch = int(torch.numel(A) / M / N)
             B = A.view(batch, -1)
@@ -100,6 +111,8 @@ def triu(A, diagonal=0):
                 triton.cdiv(batch, meta["BATCH_BLOCK_SIZE"]),
                 triton.cdiv(M * N, meta["MN_BLOCK_SIZE"]),
             )
-            triu_batch_kernel[grid](B, out, batch, M * N, N, diagonal)
+            triu_batch_kernel[grid](
+                B, out, batch, M * N, N, diagonal, INT64_INDEX=use_int64_index
+            )
             out = out.view(A.shape)
     return out


### PR DESCRIPTION
1. fix amax, armax and triu, use int64 indexing when the largest tens…or's size_in_bytes exceed int32's max;
2. change the tiling scheme for argmax to loop in the reduction dimension, instead of data-size-dependent-tile-size