### PR TITLE
[Test] Add bfloat16 test for  rand, randn & uniform

### DIFF
--- a/tests/test_distribution_ops.py
+++ b/tests/test_distribution_ops.py
@@ -20,7 +20,7 @@ def test_accuracy_normal(shape, dtype):
 
 
 @pytest.mark.parametrize("shape", DISTRIBUTION_SHAPES)
-@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_accuracy_uniform(shape, dtype):
     x = torch.randn(size=shape, dtype=dtype, device="cuda")
     with flag_gems.use_gems():

--- a/tests/test_tensor_constructor_ops.py
+++ b/tests/test_tensor_constructor_ops.py
@@ -12,7 +12,7 @@ from .accuracy_utils import (
 
 
 @pytest.mark.parametrize("shape", DISTRIBUTION_SHAPES)
-@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_accuracy_rand(shape, dtype):
     with flag_gems.use_gems():
         res_out = torch.rand(shape, dtype=dtype, device="cuda")
@@ -21,7 +21,7 @@ def test_accuracy_rand(shape, dtype):
 
 
 @pytest.mark.parametrize("shape", DISTRIBUTION_SHAPES)
-@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_accuracy_randn(shape, dtype):
     with flag_gems.use_gems():
         res_out = torch.randn(shape, dtype=dtype, device="cuda")


### PR DESCRIPTION
In k-s test, scipy do not support bfloat16, Since now we have seperate k-s test to another file, bfloat16 should be tested in  rand, randn & uniform.