### PR TITLE
[test] Add device option for named_op

### DIFF
--- a/tests/test_named_ops.py
+++ b/tests/test_named_ops.py
@@ -190,7 +190,17 @@ if __name__ == "__main__":
         "--all", action="store_true", help="test for all ops in the op list"
     )
     parser.add_argument("--name", type=str, help="test for a specific op")
+    parser.add_argument(
+        "--device",
+        action="store",
+        default="cuda",
+        choices=["cuda", "cpu"],
+        help="device to run reference tests on. Choose 'cuda' or 'cpu'. Default is 'cuda'.",
+    )
     args = parser.parse_args()
+
+    device = args.device
+    print(f"Running tests on device: {device}...")
 
     op_nums = 0
     op_list = []
@@ -207,8 +217,8 @@ if __name__ == "__main__":
         for file_name, collection in op_name_to_unit_test_maps.items():
             for op, uts in collection.items():
                 for ut in uts:
-                    cmd = f"{file_name}::{ut}"
-                    result = pytest.main(["-s", cmd])
+                    cmd = f"{file_name}::{ut} --device {device}"
+                    result = pytest.main(["-s", cmd, "--device", device])
         print("final_result: ", final_result)
         exit(final_result)
 
@@ -224,7 +234,7 @@ if __name__ == "__main__":
                     for ut in uts:
                         cmd = f"{file_name}::{ut}"
                         print(cmd)
-                        result = pytest.main(["-s", cmd])
+                        result = pytest.main(["-s", cmd, "--device", device])
                         final_result += result
         print("final_result: ", final_result)
         exit(final_result)


### PR DESCRIPTION
```
usage: test_named_ops.py [-h] [--all] [--name NAME] [--device {cuda,cpu}]

options:
  -h, --help           show this help message and exit
  --all                test for all ops in the op list
  --name NAME          test for a specific op
  --device {cuda,cpu}  device to run reference tests on. Choose 'cuda' or 'cpu'. Default is 'cuda'.
```