### PR TITLE
[Operator] Add upsample_nearest2d op [MooreThreads]

### DIFF
--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -171,6 +171,35 @@ def test_perf_upsample_bicubic2d_aa():
     bench.run()
 
 
+def test_perf_upsample_nearest2d():
+    def upsample_nearest2d_kwargs(dtype, batch, size):
+        channel = 16
+        scale_factors = (2, 2)
+        shape = (batch, channel, size, size)
+        output_size = (
+            int(shape[2] * scale_factors[0]),
+            int(shape[3] * scale_factors[1]),
+        )
+        input = torch.randn(size=shape, device="cuda", dtype=dtype)
+        return {
+            "input": input,
+            "output_size": output_size,
+            "scales_h": None,
+            "scales_w": None,
+        }
+
+    bench = Benchmark(
+        op_name="upsample_nearest2d",
+        torch_op=torch._C._nn.upsample_nearest2d,
+        arg_func=None,
+        dtypes=FLOAT_DTYPES,
+        batch=16,
+        sizes=[(128 * i) for i in range(1, 12)],
+        kwargs_func=upsample_nearest2d_kwargs,
+    )
+    bench.run()
+
+
 def test_perf_arange():
     def arange_kwargs(dtype, batch, size):
         return {

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -147,6 +147,7 @@ def enable(lib=aten_lib):
     lib.impl("masked_fill", masked_fill, "CUDA")
     lib.impl("_unique2", _unique2, "CUDA")
     lib.impl("_upsample_bicubic2d_aa", _upsample_bicubic2d_aa, "CUDA")
+    lib.impl("upsample_nearest2d", upsample_nearest2d, "CUDA")
     lib.impl("nonzero", nonzero, "CUDA")
     lib.impl("repeat", repeat, "CUDA")
     lib.impl("masked_select", masked_select, "CUDA")

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -99,6 +99,7 @@ from .triu import triu
 from .uniform import uniform_
 from .unique import _unique2
 from .upsample_bicubic2d_aa import _upsample_bicubic2d_aa
+from .upsample_nearest2d import upsample_nearest2d
 from .var_mean import var_mean
 from .vector_norm import vector_norm
 from .vstack import vstack
@@ -233,6 +234,7 @@ __all__ = [
     "masked_fill",
     "_unique2",
     "_upsample_bicubic2d_aa",
+    "upsample_nearest2d",
     "nonzero",
     "repeat",
     "masked_select",

--- a/src/flag_gems/ops/upsample_nearest2d.py
+++ b/src/flag_gems/ops/upsample_nearest2d.py
@@ -1,0 +1,88 @@
+import logging
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+
+def configs():
+    block = [1024, 2048]
+    warps = [4, 8]
+    return [
+        triton.Config({"BLOCK_SIZE": bs}, num_warps=wp) for bs in block for wp in warps
+    ]
+
+
+@triton.autotune(configs=configs(), key=["N", "C", "OH", "OW"])
+@triton.heuristics(
+    {
+        "SAME_H": lambda args: args["OH"] == args["IH"],
+        "SAME_W": lambda args: args["OW"] == args["IW"],
+    }
+)
+@triton.jit
+def upsample_nearest2d_kernel(
+    ptr_o,
+    ptr_i,
+    N,
+    C,
+    OH,
+    OW,
+    IH,
+    IW,
+    reciprocal_scale_h,
+    reciprocal_scale_w,
+    BLOCK_SIZE: tl.constexpr,
+    SAME_H: tl.constexpr,
+    SAME_W: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    ow = idx % OW
+    oh = idx // OW % OH
+    c = idx // OW // OH % C
+    n = idx // OW // OH // C % N
+    if SAME_H:
+        ih = oh
+    else:
+        # tl.floor() cannot be found in 2.3.1, using int trunc
+        ih = tl.minimum((oh * reciprocal_scale_h).to(tl.int32), IH - 1)
+    if SAME_W:
+        iw = ow
+    else:
+        iw = tl.minimum((ow * reciprocal_scale_w).to(tl.int32), IW - 1)
+    offset_o = ((n * C + c) * OH + oh) * OW + ow
+    offset_i = ((n * C + c) * IH + ih) * IW + iw
+    data = tl.load(ptr_i + offset_i)
+    tl.store(ptr_o + offset_o, data)
+
+
+def upsample_nearest2d(
+    input: torch.Tensor,
+    output_size: Tuple[int],
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> torch.Tensor:
+    logging.debug("GEMS UPSAMPLE NEAREST2D")
+    assert input.is_cuda
+    assert input.ndim == 4, "The ndim of input must be 4"
+    assert len(output_size) == 2, "The len of output_size must be 2"
+    OH, OW = output_size
+    N, C, IH, IW = input.shape
+    if scales_h is not None:
+        reciprocal_scale_h = 1 / scales_h
+    else:
+        reciprocal_scale_h = IH / OH
+    if scales_w is not None:
+        reciprocal_scale_w = 1 / scales_w
+    else:
+        reciprocal_scale_w = IW / OW
+    # allocate output
+    output = torch.empty((N, C, OH, OW), device=input.device, dtype=input.dtype)
+    total_threads = N * C * OH * OW
+    grid = lambda META: (triton.cdiv(total_threads, META["BLOCK_SIZE"]),)
+    upsample_nearest2d_kernel[grid](
+        output, input, N, C, OH, OW, IH, IW, reciprocal_scale_h, reciprocal_scale_w
+    )
+    return output

--- a/tests/accuracy_utils.py
+++ b/tests/accuracy_utils.py
@@ -61,6 +61,16 @@ STACK_SHAPES = [
     [(20, 320, 15), (20, 320, 15), (20, 320, 15)],
 ]
 
+
+UPSAMPLE_SHAPES = [
+    (32, 16, 128, 128),
+    (15, 37, 256, 256),
+    (3, 5, 127, 127),
+    (128, 192, 42, 51),
+    (3, 7, 1023, 1025),
+]
+
+
 FLOAT_DTYPES = [torch.float16, torch.float32, torch.bfloat16]
 ALL_FLOAT_DTYPES = FLOAT_DTYPES + [torch.float64]
 INT_DTYPES = [torch.int16, torch.int32]

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -13,6 +13,7 @@ from .accuracy_utils import (
     SPECIAL_SHAPES,
     STACK_DIM_LIST,
     STACK_SHAPES,
+    UPSAMPLE_SHAPES,
     UT_SHAPES_1D,
     UT_SHAPES_2D,
     gems_assert_close,
@@ -472,6 +473,20 @@ def test_upsample_bicubic2d_aa(dtype, shape, scale, align_corners):
 
     reduce_dim = span(scale[0]) * span(scale[1])
     gems_assert_close(res_out, ref_out, dtype, reduce_dim=reduce_dim)
+
+
+@pytest.mark.upsample_nearest2d
+@pytest.mark.parametrize("scale", [(2, 2), (2.1, 3.7), (1.3, 5.1), (0.3, 0.5)])
+@pytest.mark.parametrize("shape", UPSAMPLE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_upsample_nearest2d(dtype, shape, scale):
+    input = torch.randn(shape, dtype=dtype, device="cuda")
+    ref_i = to_reference(input).to(torch.float32)
+    output_size = [int(input.shape[i + 2] * scale[i]) for i in range(2)]
+    ref_out = torch._C._nn.upsample_nearest2d(ref_i, output_size=output_size).to(dtype)
+    with flag_gems.use_gems():
+        res_out = torch._C._nn.upsample_nearest2d(input, output_size=output_size)
+    gems_assert_close(res_out, ref_out, dtype)
 
 
 @pytest.mark.arange


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator `upsample_nearest2d`

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/native_functions.yaml#L12777C6-L12777C7
func: upsample_nearest2d(Tensor self, SymInt[2] output_size, float? scales_h=None, float? scales_w=None) -> Tensor

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
![image](https://github.com/user-attachments/assets/2d2370a8-2b9a-4c7f-92e0-14639e4371ea)

