### PR TITLE
[Operator] fix index_select bug [MooreThreads]

### DIFF
--- a/src/flag_gems/ops/index_select.py
+++ b/src/flag_gems/ops/index_select.py
@@ -28,7 +28,7 @@ def index_select_kernel(
     pid_y = tl.program_id(axis=1)
     rows_offsets = pid_x * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     rows_mask = rows_offsets < M
-    cols_offsets = pid_y + tl.arange(0, BLOCK_N)
+    cols_offsets = pid_y * BLOCK_N + tl.arange(0, BLOCK_N)
     cols_mask = cols_offsets < N
 
     block_mask = rows_mask and cols_mask

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -907,7 +907,7 @@ def test_accuracy_gather_out(out_shape, inp_shape, dim, dtype):
     gems_assert_equal(res_out, ref_out)
 
 
-@pytest.mark.parametrize("shape", REDUCTION_SHAPES)
+@pytest.mark.parametrize("shape", [(8192, 256 * i) for i in range(1, 10, 2)])
 @pytest.mark.parametrize("dim", DIM_LIST)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_accuracy_index_select(shape, dim, dtype):


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description
We found an issue with the definition of `cols_offsets` in the `index_select` operator. When `N` is larger than `BLOCK_N`, the indices cannot cover all the input columns.

### Issue
- **Test 1:** With the input dimension of `REDUCTION_SHAPES=(4096,n)`,  we forced `BLOCK_N=2048`. When `dim=0`, `test_reduction_ops.py::test_accuracy_index_select` failed.
- **Test 2:** We increased the original input dimension to `REDUCTION_SHAPES=(4096*m,n)`. When `dim=0`, `test_reduction_ops.py::test_accuracy_index_select` failed.
```
======================================== short test summary info =========================================
FAILED tests/test_reduction_ops.py::test_accuracy_index_select[dtype0-0-shape0] - AssertionError
FAILED tests/test_reduction_ops.py::test_accuracy_index_select[dtype0-0-shape1] - AssertionError
FAILED tests/test_reduction_ops.py::test_accuracy_index_select[dtype0-0-shape2] - AssertionError
FAILED tests/test_reduction_ops.py::test_accuracy_index_select[dtype0-0-shape3] - AssertionError
FAILED tests/test_reduction_ops.py::test_accuracy_index_select[dtype0-0-shape4] - AssertionError
FAILED tests/test_reduction_ops.py::test_accuracy_index_select[dtype1-0-shape0] - AssertionError
FAILED tests/test_reduction_ops.py::test_accuracy_index_select[dtype1-0-shape1] - AssertionError
FAILED tests/test_reduction_ops.py::test_accuracy_index_select[dtype1-0-shape2] - AssertionError
FAILED tests/test_reduction_ops.py::test_accuracy_index_select[dtype1-0-shape3] - AssertionError
FAILED tests/test_reduction_ops.py::test_accuracy_index_select[dtype1-0-shape4] - AssertionError
FAILED tests/test_reduction_ops.py::test_accuracy_index_select[dtype2-0-shape0] - AssertionError
FAILED tests/test_reduction_ops.py::test_accuracy_index_select[dtype2-0-shape1] - AssertionError
FAILED tests/test_reduction_ops.py::test_accuracy_index_select[dtype2-0-shape2] - AssertionError
FAILED tests/test_reduction_ops.py::test_accuracy_index_select[dtype2-0-shape3] - AssertionError
FAILED tests/test_reduction_ops.py::test_accuracy_index_select[dtype2-0-shape4] - AssertionError
=============================== 15 failed, 15 passed, 1 warning in 11.51s ================================
```

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Advice
We suggest to increase the input dimensions in the test cases, ensuring that the input dimensions are larger than the dimensions of the Triton sub-blocks, in order to improve test accuracy.
