### PR TITLE
[Operator] Add masked_select op[IluvatarCorex]

### DIFF
--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -333,3 +333,20 @@ def test_perf_index_select():
         sizes=SIZES,
     )
     bench.run()
+
+
+def test_masked_select():
+    def masked_select_args(dtype, batch, size):
+        inp = torch.randn([batch, size], dtype=dtype, device="cuda")
+        mask = torch.randn([batch, size], dtype=dtype, device="cuda") < 0.3
+        return (inp, mask)
+
+    bench = Benchmark(
+        op_name="masked_select",
+        torch_op=torch.masked_select,
+        arg_func=masked_select_args,
+        dtypes=FLOAT_DTYPES,
+        batch=REDUCTION_BATCH,
+        sizes=SIZES,
+    )
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -137,6 +137,7 @@ def enable(lib=aten_lib):
     lib.impl("masked_fill", masked_fill, "CUDA")
     lib.impl("_unique2", _unique2, "CUDA")
     lib.impl("nonzero", nonzero, "CUDA")
+    lib.impl("masked_select", masked_select, "CUDA")
 
 
 class use_gems:

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -42,6 +42,7 @@ from .le import le, le_scalar
 from .log_softmax import log_softmax
 from .lt import lt, lt_scalar
 from .masked_fill import masked_fill
+from .masked_select import masked_select
 from .max import max, max_dim
 from .maximum import maximum
 from .mean import mean, mean_dim
@@ -216,4 +217,5 @@ __all__ = [
     "masked_fill",
     "_unique2",
     "nonzero",
+    "masked_select",
 ]

--- a/src/flag_gems/ops/cumsum.py
+++ b/src/flag_gems/ops/cumsum.py
@@ -5,6 +5,8 @@ import torch
 import triton
 import triton.language as tl
 
+from ..utils import libentry
+
 
 @triton.jit(do_not_specialize=["n_elements", "part_num"])
 def scan_part_sum_kernel(

--- a/src/flag_gems/ops/masked_select.py
+++ b/src/flag_gems/ops/masked_select.py
@@ -1,0 +1,68 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.utils import broadcastable_to, libentry
+
+
+def cfggen():
+    configs = [
+        triton.Config({"BLOCK_SIZE": bs}, num_warps=w)
+        for w in [4, 8, 16, 32]
+        for bs in [256, 512, 1024, 2048, 4096]
+    ]
+    return configs
+
+
+@libentry()
+@triton.autotune(configs=cfggen(), key=["n_elements"])
+@triton.jit
+def masked_select_kernel(
+    inp_ptr,
+    select_mask_ptr,
+    prefix_sum_ptr,
+    out_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    inp = tl.load(inp_ptr + offsets, mask=mask, other=0.0)
+    select_mask = tl.load(select_mask_ptr + offsets, mask=mask, other=0.0).to(tl.int1)
+    out_offset = tl.load(prefix_sum_ptr + offsets, mask=mask, other=0.0) - 1
+
+    tl.store(out_ptr + out_offset, inp, mask=(select_mask and mask))
+
+
+def masked_select(inp, mask):
+    logging.debug("GEMS MASKED SELECT")
+
+    inp_shape = tuple(inp.shape)
+    mask_shape = tuple(mask.shape)
+
+    if broadcastable_to(mask_shape, inp_shape):
+        mask = mask.expand(inp.shape)
+    elif broadcastable_to(inp_shape, mask_shape):
+        inp = inp.expand(mask.shape)
+    else:
+        raise RuntimeError(
+            "The shapes of the `mask` and the `input` tensor must be broadcastable"
+        )
+
+    inp = inp.contiguous()
+    mask = mask.contiguous()
+
+    mask_flattened = mask.ravel()
+
+    prefix_sum = mask_flattened.cumsum(axis=0)
+    out = torch.empty(prefix_sum[-1].item(), dtype=inp.dtype, device=inp.device)
+
+    n_elements = inp.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    with torch.cuda.device(inp.device):
+        masked_select_kernel[grid](inp, mask_flattened, prefix_sum, out, n_elements)
+    return out

--- a/src/flag_gems/ops/masked_select.py
+++ b/src/flag_gems/ops/masked_select.py
@@ -4,7 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
-from flag_gems.utils import broadcastable_to, libentry
+from ..utils import broadcastable, libentry
 
 
 def cfggen():
@@ -44,14 +44,10 @@ def masked_select(inp, mask):
     inp_shape = tuple(inp.shape)
     mask_shape = tuple(mask.shape)
 
-    if broadcastable_to(mask_shape, inp_shape):
-        mask = mask.expand(inp.shape)
-    elif broadcastable_to(inp_shape, mask_shape):
-        inp = inp.expand(mask.shape)
-    else:
-        raise RuntimeError(
-            "The shapes of the `mask` and the `input` tensor must be broadcastable"
-        )
+    assert broadcastable(
+        inp_shape, mask_shape
+    ), "The shapes of the `mask` and the `input` tensor must be broadcastable"
+    inp, mask = torch.broadcast_tensors(inp, mask)
 
     inp = inp.contiguous()
     mask = mask.contiguous()

--- a/src/flag_gems/utils/__init__.py
+++ b/src/flag_gems/utils/__init__.py
@@ -1,6 +1,12 @@
 from .libentry import libentry
 from .pointwise_dynamic import pointwise_dynamic
-from .shape_utils import broadcastable_to, dim_compress, offset_calculator, restride_dim
+from .shape_utils import (
+    broadcastable,
+    broadcastable_to,
+    dim_compress,
+    offset_calculator,
+    restride_dim,
+)
 
 __all__ = [
     "libentry",
@@ -9,4 +15,5 @@ __all__ = [
     "restride_dim",
     "offset_calculator",
     "broadcastable_to",
+    "broadcastable",
 ]

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -927,3 +927,19 @@ def test_accuracy_index_select(shape, dim, dtype):
         res_out = torch.index_select(inp, dim, index)
 
     gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.parametrize("shape", REDUCTION_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("threshold", [0.3, 0.5, 0.7])
+def test_accuracy_masked_select(shape, dtype, threshold):
+    inp = torch.randn(shape, dtype=dtype, device="cuda")
+    mask = torch.randn(shape, dtype=dtype, device="cuda") < threshold
+
+    ref_inp = to_reference(inp)
+    ref_mask = to_reference(mask)
+    ref_out = torch.masked_select(ref_inp, ref_mask)
+    with flag_gems.use_gems():
+        res_out = torch.masked_select(inp, mask)
+
+    gems_assert_equal(res_out, ref_out)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add masked_select op
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
```
benchmark/test_reduction_perf.py::test_masked_select Operator masked_select Performance Test (torch.float16)
Size        Torch Latency (ms)   Gems Latency (ms)
--------------------------------------------------
1024                  0.080896            0.229376
6144                  0.223232            0.415744
11264                 0.365568              0.4608
16384                 0.503808            0.515072
21504                 0.646144            0.596992
26624                  0.78336            0.713728
31744                 0.924672            0.830464
36864                  1.06394            0.948224
41984                  1.20218             1.06598
47104                  1.33632             1.18272
52224                  1.47661             1.30048
57344                  1.61485             1.41824
62464                  1.75411             1.53702
67584                  1.88928             1.65376
72704                  2.03264             1.77152
77824                  2.16576             1.88826
Operator masked_select Performance Test (torch.float32)
Size        Torch Latency (ms)   Gems Latency (ms)
--------------------------------------------------
1024                  0.075776            0.229376
6144                    0.2304            0.410624
11264                  0.37888            0.461824
16384                 0.524288            0.519168
21504                  0.67072            0.632832
26624                 0.817152            0.758784
31744                  0.96256            0.884736
36864                  1.10592             1.01171
41984                  1.24723             1.13766
47104                  1.39059             1.26464
52224                  1.53395             1.39162
57344                  1.68038             1.51757
62464                  1.82784             1.64352
67584                  1.97018             1.77152
72704                  2.11558             1.89747
77824                   2.2528             2.02342
Operator masked_select Performance Test (torch.bfloat16)
Size        Torch Latency (ms)   Gems Latency (ms)
--------------------------------------------------
1024                  0.075776            0.229376
6144                  0.223232            0.412672
11264                 0.364544            0.459776
16384                 0.505856            0.513024
21504                  0.64512            0.596992
26624                 0.785408            0.713728
31744                 0.923648            0.830464
36864                  1.06291            0.948224
41984                   1.1991             1.06496
47104                  1.33734             1.18272
52224                  1.47456             1.30048
57344                  1.61382             1.41824
62464                  1.75411             1.53702
67584                  1.89542             1.65478
72704                  2.03366             1.77152
77824                  2.16371             1.88826
PASSED
```