### PR TITLE
Floordiv int

### DIFF
--- a/benchmark/performance_utils.py
+++ b/benchmark/performance_utils.py
@@ -119,8 +119,24 @@ def unary_int_arg(dtype, batch, size):
 
 
 def binary_args(dtype, batch, size):
-    inp1 = torch.randn([batch, size], dtype=dtype, device="cuda")
-    inp2 = torch.randn([batch, size], dtype=dtype, device="cuda")
+    if dtype in FLOAT_DTYPES:
+        inp1 = torch.randn([batch, size], dtype=dtype, device="cuda")
+        inp2 = torch.randn([batch, size], dtype=dtype, device="cuda")
+    elif dtype in INT_DTYPES:
+        inp1 = torch.randint(
+            torch.iinfo(dtype).min,
+            torch.iinfo(dtype).max,
+            [batch, size],
+            dtype=dtype,
+            device="cuda",
+        )
+        inp2 = torch.randint(
+            torch.iinfo(dtype).min,
+            torch.iinfo(dtype).max,
+            [batch, size],
+            dtype=dtype,
+            device="cuda",
+        )
     return inp1, inp2
 
 

--- a/benchmark/test_pointwise_perf.py
+++ b/benchmark/test_pointwise_perf.py
@@ -110,6 +110,30 @@ def test_perf_div():
     bench.run()
 
 
+def test_perf_floordiv_int():
+    bench = Benchmark(
+        op_name="floor_div",
+        torch_op=torch.floor_divide,
+        arg_func=binary_args,
+        dtypes=INT_DTYPES,
+        batch=POINTWISE_BATCH,
+        sizes=SIZES,
+    )
+    bench.run()
+
+
+def test_perf_remainder():
+    bench = Benchmark(
+        op_name="remainder",
+        torch_op=torch.remainder,
+        arg_func=binary_args,
+        dtypes=INT_DTYPES,
+        batch=POINTWISE_BATCH,
+        sizes=SIZES,
+    )
+    bench.run()
+
+
 def test_perf_dropout():
     bench = Benchmark(
         op_name="dropout",

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -40,6 +40,7 @@ def enable(lib=aten_lib):
     lib.impl("true_divide.Scalar", true_divide, "CUDA")
     lib.impl("floor_divide", floor_divide, "CUDA")
     lib.impl("floor_divide.Scalar", floor_divide, "CUDA")
+    lib.impl("remainder.Tensor", remainder, "CUDA")
     lib.impl("native_dropout", native_dropout, "AutogradCUDA")
     lib.impl("erf", erf, "CUDA")
     lib.impl("embedding", embedding, "AutogradCUDA")

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -18,7 +18,7 @@ from .clamp import clamp, clamp_tensor
 from .cos import cos
 from .cross_entropy_loss import cross_entropy_loss
 from .cumsum import cumsum, normed_cumsum
-from .div import div_mode, floor_divide, true_divide
+from .div import div_mode, floor_divide, remainder, true_divide
 from .dropout import native_dropout
 from .embedding import embedding
 from .eq import eq, eq_scalar
@@ -128,6 +128,7 @@ __all__ = [
     "true_divide",
     "div_mode",
     "floor_divide",
+    "remainder",
     "zeros",
     "ones",
     "full",

--- a/src/flag_gems/ops/div.py
+++ b/src/flag_gems/ops/div.py
@@ -77,22 +77,52 @@ def trunc_divide(A, B):
         return A / B
 
 
+@triton.jit
+def _int_floordiv(x, y):
+    # TODO: request Triton to add an integer remainder builtin
+    # The semantic of Triton floordiv differs from Pytorch/Numpy
+    # Triton floordiv equates to
+    #     (x - np.fmod(x, y)) / y
+    # whereas Pytorch floordiv is
+    #     (x - np.remainder(x, y)) y
+    # The results show a one off difference when
+    #     C1) x and y have opposite signs
+    # and C2) x is not multiples of y.
+    # Apart from the above, there's an erroneous case x // 0 returns -1
+    # whereas in Pytorch x // 0 returns -1 if x >=0 and -2 if x < 0
+    # but this special case is coalesced into the c1 and c2 check so
+    # there's extra handling.
+    r = x % y
+    c1 = r != 0
+    c2 = (x < 0) ^ (y < 0)
+    return tl.where(c1 & c2, x // y - 1, x // y)
+
+
 @pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
 @triton.jit
 def floor_div_func(x, y):
-    return tl.math.floor(div_rd(x, y))
+    if x.type.scalar.is_int() & x.type.scalar.is_int():
+        return _int_floordiv(x, y)
+    else:
+        return tl.math.floor(div_rd(x, y))
 
 
 @pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "DEFAULT")])
 @triton.jit
 def floor_div_func_tensor_scalar(x, y):
-    return tl.math.floor(div_rd(x, y))
+    if x.type.scalar.is_int() & x.type.scalar.is_int():
+        return _int_floordiv(x, y)
+    else:
+        return tl.math.floor(div_rd(x, y))
 
 
 @pointwise_dynamic(is_tensor=[False, True], promotion_methods=[(0, 1, "DEFAULT")])
 @triton.jit
 def floor_div_func_scalar_tensor(x, y):
-    return tl.math.floor(div_rd(x, y))
+    if x.type.scalar.is_int() & x.type.scalar.is_int():
+        return _int_floordiv(x, y)
+    else:
+        return tl.math.floor(div_rd(x, y))
 
 
 def floor_divide(A, B):
@@ -118,3 +148,42 @@ def div_mode(A, B, rounding_mode=None):
     else:
         msg = f"div expected rounding_mode to be one of None, 'trunc', or 'floor' but found {rounding_mode}."
         raise ValueError(msg)
+
+
+@triton.jit
+def _remainder(x, y):
+    r = x % y
+    c1 = r != 0
+    c2 = (x < 0) ^ (y < 0)
+    return tl.where(c1 & c2, r + y, r)
+
+
+@pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def rem_tt(x, y):
+    return _remainder(x, y)
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def rem_ts(x, y):
+    return _remainder(x, y)
+
+
+@pointwise_dynamic(is_tensor=[False, True], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def rem_st(x, y):
+    return _remainder(x, y)
+
+
+def remainder(A, B):
+    logging.debug("GEMS FLOOR_DIVIDE")
+    if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
+        return rem_tt(A, B)
+    elif isinstance(A, torch.Tensor):
+        return rem_ts(A, B)
+    elif isinstance(B, torch.Tensor):
+        return rem_st(A, B)
+    else:
+        # Both scalar
+        return A % B

--- a/tests/accuracy_utils.py
+++ b/tests/accuracy_utils.py
@@ -8,6 +8,10 @@ major, minor = torch.__version__.split(".")[:2]
 skip_expr = major < "2" or minor < "2"
 skip_reason = "PyTorch < 2.2.0 does not support"
 
+INT16_MIN = torch.iinfo(torch.int16).min
+INT16_MAX = torch.iinfo(torch.int16).max
+INT32_MIN = torch.iinfo(torch.int32).min
+INT32_MAX = torch.iinfo(torch.int32).max
 
 RESOLUTION = {
     torch.bool: 0,

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -317,6 +317,17 @@ def test_accuracy_floor_div_int(shape, dtype):
 
     gems_assert_equal(res_out, ref_out)
 
+    for d in inp2.flatten()[:100]:
+        ref_out = ref_inp1 // d
+        with flag_gems.use_gems():
+            res_out = inp1 // d
+        gems_assert_equal(res_out, ref_out)
+
+        ref_out = d // ref_inp1
+        with flag_gems.use_gems():
+            res_out = d // ref_inp1
+        gems_assert_equal(res_out, ref_out)
+
 
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", INT_DTYPES)
@@ -342,12 +353,18 @@ def test_accuracy_remainder(shape, dtype):
     with flag_gems.use_gems():
         res_out = inp1 % inp2
 
-    if not torch.equal(res_out, ref_out):
-        print(inp1[res_out != ref_out])
-        print(inp2[res_out != ref_out])
-        print(res_out[res_out != ref_out])
-        print(ref_out[res_out != ref_out])
     gems_assert_equal(res_out, ref_out)
+
+    for d in inp2.flatten()[:100]:
+        ref_out = ref_inp1 % d
+        with flag_gems.use_gems():
+            res_out = inp1 % d
+        gems_assert_equal(res_out, ref_out)
+
+        ref_out = d % ref_inp1
+        with flag_gems.use_gems():
+            res_out = d % ref_inp1
+        gems_assert_equal(res_out, ref_out)
 
 
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -292,6 +292,65 @@ def test_accuracy_floor_div(shape, dtype):
 
 
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", INT_DTYPES)
+def test_accuracy_floor_div_int(shape, dtype):
+    inp1 = torch.randint(
+        torch.iinfo(dtype).min,
+        torch.iinfo(dtype).max,
+        shape,
+        dtype=dtype,
+        device="cuda",
+    )
+    inp2 = torch.randint(
+        torch.iinfo(dtype).min,
+        torch.iinfo(dtype).max,
+        shape,
+        dtype=dtype,
+        device="cuda",
+    )
+    ref_inp1 = to_reference(inp1, False)
+    ref_inp2 = to_reference(inp2, False)
+
+    ref_out = ref_inp1 // ref_inp2
+    with flag_gems.use_gems():
+        res_out = inp1 // inp2
+
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", INT_DTYPES)
+def test_accuracy_remainder(shape, dtype):
+    inp1 = torch.randint(
+        torch.iinfo(dtype).min,
+        torch.iinfo(dtype).max,
+        shape,
+        dtype=dtype,
+        device="cuda",
+    )
+    inp2 = torch.randint(
+        torch.iinfo(dtype).min,
+        torch.iinfo(dtype).max,
+        shape,
+        dtype=dtype,
+        device="cuda",
+    )
+    ref_inp1 = to_reference(inp1, False)
+    ref_inp2 = to_reference(inp2, False)
+
+    ref_out = ref_inp1 % ref_inp2
+    with flag_gems.use_gems():
+        res_out = inp1 % inp2
+
+    if not torch.equal(res_out, ref_out):
+        print(inp1[res_out != ref_out])
+        print(inp2[res_out != ref_out])
+        print(res_out[res_out != ref_out])
+        print(ref_out[res_out != ref_out])
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_accuracy_eq(shape, dtype):
     inp1 = torch.randint(0, 10, shape, dtype=dtype, device="cuda")


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

Op

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix and new feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Added the Pytorch/numpy typed remainder and floor divide for integers. The summarized procedure for the Triton Pytorch conversion for floordiv is:

```
def floordiv(x, y):
    if x % y != 0 and x < 0 ^ y < 0:
        return x // y - 1
    else:
        return x // y

def _remainder(x, y):
    if x % y != 0 and x < 0 ^ y < 0:
        return r + y
    else:
        return r
```

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
Performance for bs=1024 on A100:
```
benchmark/test_pointwise_perf.py Operator floor_div Performance Test (torch.int16)
Size        Torch Latency (ms)   Gems Latency (ms)
--------------------------------------------------
1024                  0.016096            0.014752
6144                  0.042016            0.040128
11264                 0.067136            0.066112
16384                 0.089888            0.089728
21504                 0.114112            0.113856
26624                 0.136992            0.136608
31744                 0.160384            0.160576
36864                 0.184832            0.254016
41984                  0.20832            0.264128
47104                   0.2312            0.273408
52224                 0.254592            0.284448
57344                 0.278144            0.293824
62464                 0.302272            0.303968
67584                 0.325568            0.368288
72704                 0.349024            0.383584
77824                   0.3728            0.397408
Operator floor_div Performance Test (torch.int32)
Size        Torch Latency (ms)   Gems Latency (ms)
--------------------------------------------------
1024                  0.018592            0.018432
6144                  0.068288            0.067712
11264                 0.113728            0.114752
16384                  0.15904            0.159264
21504                  0.20624              0.2064
26624                 0.252416            0.251648
31744                 0.297088             0.29792
36864                 0.343968            0.344928
41984                  0.38992            0.390944
47104                 0.436352            0.435488
52224                   0.4832            0.481312
57344                  0.52992            0.526112
62464                 0.576384            0.571968
67584                  0.62144            0.617504
72704                 0.667744            0.662816
77824                 0.714848            0.707328

benchmark/test_pointwise_perf.py Operator remainder Performance Test (torch.int16)
Size        Torch Latency (ms)   Gems Latency (ms)
--------------------------------------------------
1024                   0.01504            0.013792
6144                   0.03936            0.040768
11264                   0.0656            0.066432
16384                  0.08928            0.089376
21504                  0.11216            0.112736
26624                 0.134464            0.136032
31744                 0.158048            0.159904
36864                  0.18032            0.248384
41984                 0.203264            0.259488
47104                 0.226496            0.269952
52224                 0.249952             0.28176
57344                 0.272832            0.291872
62464                 0.295104            0.302176
67584                 0.318432             0.36064
72704                 0.340352             0.37616
77824                 0.364448            0.391904
Operator remainder Performance Test (torch.int32)
Size        Torch Latency (ms)   Gems Latency (ms)
--------------------------------------------------
1024                  0.018112            0.018304
6144                  0.066912            0.067456
11264                 0.112992            0.113664
16384                 0.158304             0.15904
21504                 0.205536            0.206144
26624                 0.250944            0.251488
31744                 0.296448             0.29776
36864                 0.343392            0.344064
41984                 0.389312            0.390112
47104                 0.436384            0.436096
52224                 0.481824             0.48032
57344                  0.52912             0.52592
62464                  0.57488             0.57184
67584                 0.620736            0.617632
72704                 0.667008            0.662144
77824                 0.714208             0.70736
```
