### PR TITLE
[bugfix] convert inp of index_select to enable cpu mode

### DIFF
--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -917,9 +917,9 @@ def test_accuracy_index_select(shape, dim, dtype):
 
     index = torch.randint(0, index_size, [floor(index_size * 0.8)], device="cuda")
 
-    # ref_inp = to_reference(inp)
-    # ref_index = to_reference(index)
-    ref_out = torch.index_select(inp, dim, index)
+    ref_inp = to_reference(inp)
+    ref_index = to_reference(index)
+    ref_out = torch.index_select(ref_inp, dim, ref_index)
     with flag_gems.use_gems():
         res_out = torch.index_select(inp, dim, index)
 


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
[OP Test]
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
[Buf Fix]
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
convert input tensor and index to specific device for reference. otherwise the ref_out will not be on CPU when option --device is cpu.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
