### PR TITLE
[bugfix] benchmark of floor_div & remainder called wrong argument fun…

### DIFF
--- a/benchmark/test_pointwise_perf.py
+++ b/benchmark/test_pointwise_perf.py
@@ -114,7 +114,7 @@ def test_perf_floordiv_int():
     bench = Benchmark(
         op_name="floor_div",
         torch_op=torch.floor_divide,
-        arg_func=binary_args,
+        arg_func=binary_int_args,
         dtypes=INT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,
@@ -126,7 +126,7 @@ def test_perf_remainder():
     bench = Benchmark(
         op_name="remainder",
         torch_op=torch.remainder,
-        arg_func=binary_args,
+        arg_func=binary_int_args,
         dtypes=INT_DTYPES,
         batch=POINTWISE_BATCH,
         sizes=SIZES,


### PR DESCRIPTION
…ction

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
[Benchmark]
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
[Bug Fix]
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
benchmarks use binary_args to initialize the input tensors of floor_div and remainder, but need binary_int_args instead.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
