### PR TITLE
[Operator] Add repeat_interleave_self_int op

### DIFF
--- a/benchmark/test_pointwise_perf.py
+++ b/benchmark/test_pointwise_perf.py
@@ -630,3 +630,20 @@ def test_perf_repeat():
         sizes=SIZES,
     )
     bench.run()
+
+
+def test_perf_repeat_interleave_self_int():
+    def repeat_interleave_self_int_arg(dtype, batch, size):
+        inp = torch.randn([batch, size], dtype=dtype, device="cuda")
+        repeats = 2
+        return inp, repeats
+
+    bench = Benchmark(
+        op_name="repeat_interleave_self_int",
+        torch_op=torch.repeat_interleave,
+        arg_func=repeat_interleave_self_int_arg,
+        dtypes=FLOAT_DTYPES,
+        batch=POINTWISE_BATCH,
+        sizes=SIZES,
+    )
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -150,6 +150,7 @@ def enable(lib=aten_lib):
     lib.impl("masked_select", masked_select, "CUDA")
     lib.impl("stack", stack, "CUDA")
     lib.impl("hstack", hstack, "CUDA")
+    lib.impl("repeat_interleave.self_int", repeat_interleave_self_int, "CUDA")
 
 
 class use_gems:

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -78,6 +78,7 @@ from .randn_like import randn_like
 from .reciprocal import reciprocal
 from .relu import relu
 from .repeat import repeat
+from .repeat_interleave import repeat_interleave_self_int
 from .resolve_conj import resolve_conj
 from .resolve_neg import resolve_neg
 from .rms_norm import rms_norm
@@ -233,4 +234,5 @@ __all__ = [
     "masked_select",
     "stack",
     "hstack",
+    "repeat_interleave_self_int",
 ]

--- a/src/flag_gems/ops/repeat_interleave.py
+++ b/src/flag_gems/ops/repeat_interleave.py
@@ -1,0 +1,64 @@
+import torch
+import triton
+
+from ..utils.pointwise_dynamic import pointwise_dynamic
+from ..utils.shape_utils import c_contiguous_stride, volume
+from ..utils.tensor_wrapper import StridedBuffer
+
+
+@pointwise_dynamic(num_inputs=1, promotion_methods=[(0, "DEFAULT")])
+@triton.jit
+def copy_func(x):
+    return x
+
+
+def repeat_interleave_self_int(inp, repeats, dim=None, *, output_size=None):
+    if dim is None:
+        nelems = volume(inp.shape)
+        inp_shape = [
+            nelems,
+        ]
+        inp_stride = [
+            1,
+        ]
+        output_shape = [
+            nelems,
+        ]
+        dim = 0
+    else:
+        if (dim < -inp.ndim) or (dim >= inp.ndim):
+            raise IndexError(
+                "Dimension out of range (expected to be in range of [{}, {}], but got {})".format(
+                    -inp.ndim, inp.ndim - 1, dim
+                )
+            )
+        inp_shape = list(inp.shape)
+        inp_stride = list(inp.stride())
+        output_shape = list(inp.shape)
+
+    if dim < 0:
+        dim = dim + len(inp_shape)
+
+    output_shape[dim] *= repeats
+
+    if output_size is not None and output_size != output_shape[dim]:
+        raise RuntimeError(
+            "repeat_interleave: Invalid output_size, expected {} but got {}".format(
+                output_shape[dim], output_size
+            )
+        )
+
+    output = torch.empty(output_shape, dtype=inp.dtype, device=inp.device)
+
+    if repeats == 0:
+        return output
+
+    in_view_stride = inp_stride[: dim + 1] + [0] + inp_stride[dim + 1 :]
+    out_view_shape = inp_shape[: dim + 1] + [repeats] + inp_shape[dim + 1 :]
+    out_view_stride = c_contiguous_stride(out_view_shape)
+
+    in_view = StridedBuffer(inp, out_view_shape, in_view_stride)
+    out_view = StridedBuffer(output, out_view_shape, out_view_stride)
+    ndim = len(out_view_shape)
+    copy_func.instantiate(ndim)(in_view, out0=out_view)
+    return output

--- a/src/flag_gems/ops/repeat_interleave.py
+++ b/src/flag_gems/ops/repeat_interleave.py
@@ -2,7 +2,7 @@ import torch
 import triton
 
 from ..utils.pointwise_dynamic import pointwise_dynamic
-from ..utils.shape_utils import c_contiguous_stride, volume
+from ..utils.shape_utils import c_contiguous_stride
 from ..utils.tensor_wrapper import StridedBuffer
 
 
@@ -14,16 +14,7 @@ def copy_func(x):
 
 def repeat_interleave_self_int(inp, repeats, dim=None, *, output_size=None):
     if dim is None:
-        nelems = volume(inp.shape)
-        inp_shape = [
-            nelems,
-        ]
-        inp_stride = [
-            1,
-        ]
-        output_shape = [
-            nelems,
-        ]
+        inp = inp.flatten()
         dim = 0
     else:
         if (dim < -inp.ndim) or (dim >= inp.ndim):
@@ -32,9 +23,9 @@ def repeat_interleave_self_int(inp, repeats, dim=None, *, output_size=None):
                     -inp.ndim, inp.ndim - 1, dim
                 )
             )
-        inp_shape = list(inp.shape)
-        inp_stride = list(inp.stride())
-        output_shape = list(inp.shape)
+    inp_shape = list(inp.shape)
+    inp_stride = list(inp.stride())
+    output_shape = list(inp.shape)
 
     if dim < 0:
         dim = dim + len(inp_shape)

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -976,3 +976,21 @@ def test_accuracy_allclose(shape, dtype, equal_nan, gen_nan):
     ref_out = torch.allclose(ref_inp1, ref_inp2, rtol, atol, equal_nan=equal_nan)
 
     assert res_out == ref_out
+
+
+REPEAT_INTERLEAVE_REPEATS = [2]
+REPEAT_INTERLEAVE_DIM = [-1, 0]
+
+
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dim", REPEAT_INTERLEAVE_DIM)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_repeat_interleave_self_int(shape, dim, dtype):
+    inp = torch.randn(shape, dtype=dtype, device="cuda")
+    repeats = 2
+    ref_inp = to_reference(inp)
+
+    ref_out = torch.repeat_interleave(ref_inp, repeats, dim)
+    with flag_gems.use_gems():
+        res_out = torch.repeat_interleave(ref_inp, repeats, dim)
+    gems_assert_equal(res_out, ref_out)

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -1034,11 +1034,18 @@ def test_accuracy_allclose(shape, dtype, equal_nan, gen_nan):
     assert res_out == ref_out
 
 
+REPEAT_INTERLEAVE_SHAPES = [
+    (1,),
+    (1024, 1024),
+    (20, 320, 15),
+    (16, 128, 64, 60),
+    (16, 7, 57, 32, 29),
+]
 REPEAT_INTERLEAVE_REPEATS = [2]
-REPEAT_INTERLEAVE_DIM = [-1, 0]
+REPEAT_INTERLEAVE_DIM = [-1, 0, None]
 
 
-@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("shape", REPEAT_INTERLEAVE_SHAPES)
 @pytest.mark.parametrize("dim", REPEAT_INTERLEAVE_DIM)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_accuracy_repeat_interleave_self_int(shape, dim, dtype):


### PR DESCRIPTION
### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

Tested on NV-A100
```
benchmark/test_pointwise_perf.py::test_perf_repeat_interleave_self_int Operator repeat_interleave_self_int Performance Test (torch.float16)
Size        Torch Latency (ms)   Gems Latency (ms)
--------------------------------------------------
1024                  0.019456            0.012288
6144                   0.05632            0.036864
11264                 0.096256             0.06144
16384                 0.136192            0.084992
21504                 0.177152            0.169984
26624                 0.216064            0.171008
31744                    0.256            0.172032
36864                 0.295936            0.246784
41984                 0.334848            0.247808
47104                 0.374784            0.249856
52224                  0.41472            0.323584
57344                 0.454656            0.325632
62464                 0.494592            0.326656
67584                 0.533504            0.400384
72704                  0.57344            0.402432
77824                 0.612352            0.402432
Operator repeat_interleave_self_int Performance Test (torch.float32)
Size        Torch Latency (ms)   Gems Latency (ms)
--------------------------------------------------
1024                  0.017408            0.014336
6144                  0.065536            0.055296
11264                 0.111616            0.094208
16384                  0.15872            0.134144
21504                   0.2048            0.198656
26624                 0.251904            0.226304
31744                 0.297984            0.254976
36864                 0.345088            0.295936
41984                 0.392192            0.336896
47104                 0.438272            0.375808
52224                   0.4864            0.417792
57344                  0.53248            0.457728
62464                  0.57856            0.497664
67584                 0.625664            0.539648
72704                 0.672768            0.581632
77824                 0.718848             0.61952
Operator repeat_interleave_self_int Performance Test (torch.bfloat16)
Size        Torch Latency (ms)   Gems Latency (ms)
--------------------------------------------------
1024                  0.017408            0.012288
6144                   0.05632            0.036864
11264                  0.09728            0.060416
16384                 0.137216            0.086016
21504                 0.176128            0.169984
26624                 0.216064            0.171008
31744                 0.254976            0.172032
36864                 0.294912            0.246784
41984                 0.334848            0.248832
47104                 0.374784            0.249856
52224                  0.41472            0.323584
57344                 0.453632            0.324608
62464                 0.494592            0.326656
67584                 0.533504            0.400384
72704                  0.57344            0.402432
77824                 0.612352            0.402432
PASSED
```