### PR TITLE
add reduce_dim=M for tests for mv op

### DIFF
--- a/tests/test_blas_ops.py
+++ b/tests/test_blas_ops.py
@@ -83,7 +83,7 @@ def test_accuracy_mv(M, N, dtype):
     with flag_gems.use_gems():
         res_out = torch.mv(matrix, vector)
 
-    gems_assert_close(res_out, ref_out, dtype)
+    gems_assert_close(res_out, ref_out, dtype, reduce_dim=M)
 
 
 @pytest.mark.outer


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
OP Test

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Other

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add reduce_dim=M for `test_accuracy_mv`.
Since mv is an operator where reduction is involved, reduce_dim should be considered in tests for correctness, following our convention in other tests.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
No changes to the operator.