### PR TITLE
optimize layernorm forward

### DIFF
--- a/src/flag_gems/ops/layernorm.py
+++ b/src/flag_gems/ops/layernorm.py
@@ -188,19 +188,6 @@ def layer_norm_loop_kernel(
         tl.store(out_ptr + pid * N + n_offsets, out)
 
 
-def cfggen():
-    block_m = [1, 2, 4]
-    block_n = [1024, 2048, 4096]
-    warps = [4, 8, 16]
-    configs = [
-        triton.Config({"BLOCK_ROW_SIZE": m, "BLOCK_COL_SIZE": n}, num_warps=w)
-        for m in block_m
-        for n in block_n
-        for w in warps
-    ]
-    return configs
-
-
 @libentry()
 @triton.autotune(
     configs=[

--- a/src/flag_gems/ops/layernorm.py
+++ b/src/flag_gems/ops/layernorm.py
@@ -8,6 +8,186 @@ import triton.language as tl
 from ..utils import libentry
 
 
+def heuristics_for_num_warps(tile_size):
+    # it affects occupancy
+    if tile_size < 2048:
+        return 4
+    elif tile_size < 4096:
+        return 8
+    else:
+        return 16
+
+
+@triton.jit
+def prev_multiple_of(a, b):
+    # the largest x<a that x%b ==0
+    return tl.cdiv(a, b) * b - b
+
+
+@libentry()
+@triton.jit(do_not_specialize=["eps"])
+def layer_norm_persistent_kernel(
+    in_ptr,
+    out_ptr,
+    weight_ptr,
+    bias_ptr,
+    out_mean_ptr,  # pointer to the mean
+    out_rstd_ptr,  # pointer to the 1/std
+    M,
+    N,
+    eps,
+    TILE_N: tl.constexpr,
+):
+    # using 1d tile makes code clean
+    # Map the program id to the row of X and Y it should compute.
+    pid = tl.program_id(0)
+
+    n_offsets = tl.arange(0, TILE_N)
+    mask = n_offsets < N
+
+    x = tl.load(in_ptr + pid * N + n_offsets, mask, other=0.0).to(tl.float32)
+    m = tl.sum(x) / N
+    d = x - m  # deviation
+    s = tl.where(mask, d * d, 0)
+    sum_square = tl.sum(s)  # sum of square of deviation
+    var = sum_square / N
+    rstd = tl.math.rsqrt(var + eps)
+
+    tl.store(out_mean_ptr + pid, m)
+    tl.store(out_rstd_ptr + pid, rstd)
+
+    w = tl.load(weight_ptr + n_offsets, mask=mask)
+    b = tl.load(bias_ptr + n_offsets, mask=mask)
+    out = (x - m) * rstd * w + b
+
+    tl.store(out_ptr + pid * N + n_offsets, out, mask=mask)
+
+
+@libentry()
+@triton.jit(do_not_specialize=["eps"])
+def layer_norm_persistent_kernel_multiline(
+    in_ptr,
+    out_ptr,
+    weight_ptr,
+    bias_ptr,
+    out_mean_ptr,  # pointer to the mean
+    out_rstd_ptr,  # pointer to the 1/std
+    M,
+    N,
+    eps,
+    TILE_M: tl.constexpr,
+    TILE_N: tl.constexpr,
+):
+    # Map the program id to the row of X and Y it should compute.
+    pid = tl.program_id(0)
+    m_offsets = pid * TILE_M + tl.arange(0, TILE_M)
+    m_mask = m_offsets < M
+
+    n_offsets = tl.arange(0, TILE_N)[None, :]
+    n_mask = n_offsets < N
+    mask = m_mask[:, None] & n_mask
+
+    x = tl.load(in_ptr + m_offsets[:, None] * N + n_offsets, mask, other=0.0).to(
+        tl.float32
+    )
+    m = tl.sum(x, axis=1) / N
+    d = x - m[:, None]  # deviation
+    s = tl.where(mask, d * d, 0)
+    sum_square = tl.sum(s, axis=1)  # sum of square of deviation
+    var = sum_square / N
+    rstd = tl.math.rsqrt(var + eps)
+
+    tl.store(out_mean_ptr + m_offsets, m, mask=m_mask)
+    tl.store(out_rstd_ptr + m_offsets, rstd, mask=m_mask)
+
+    w = tl.load(weight_ptr + n_offsets, mask=n_mask)
+    b = tl.load(bias_ptr + n_offsets, mask=n_mask)
+    out = (x - m[:, None]) * rstd[:, None] * w + b
+
+    tl.store(out_ptr + m_offsets[:, None] * N + n_offsets, out, mask=mask)
+
+
+@libentry()
+@triton.jit(do_not_specialize=["eps"])
+def layer_norm_loop_kernel(
+    in_ptr,
+    out_ptr,
+    weight_ptr,
+    bias_ptr,
+    out_mean_ptr,  # pointer to the mean
+    out_rstd_ptr,  # pointer to the 1/std
+    M,
+    N,
+    eps,
+    TILE_N: tl.constexpr,
+):
+    # Map the program id to the row of X and Y it should compute.
+    pid = tl.program_id(0)
+
+    # Compute mean
+    m = tl.zeros((TILE_N,), dtype=tl.float32)  # mean
+    s = tl.zeros((TILE_N,), dtype=tl.float32)  # sum((x - m)^2)
+    cnt = tl.zeros((TILE_N,), dtype=tl.int32)
+    num_steps = tl.cdiv(N, TILE_N)
+    for step in range(0, num_steps - 1, 1):
+        start_n = step * TILE_N
+        n_offsets = start_n + tl.arange(0, TILE_N)
+        x = tl.load(in_ptr + pid * N + n_offsets).to(tl.float32)
+        new_m = m + (x - m) / (step + 1)
+        new_s = s + (x - new_m) * (x - m)
+        cnt += 1
+        m = new_m
+        s = new_s
+
+    # the last step
+    for step in range(num_steps - 1, num_steps, 1):
+        start_n = step * TILE_N
+        n_offsets = start_n + tl.arange(0, TILE_N)
+        mask = n_offsets < N
+        x = tl.load(in_ptr + pid * N + n_offsets, mask=mask).to(tl.float32)
+        new_m = tl.where(mask, m + (x - m) / (step + 1), m)
+        new_s = tl.where(mask, s + (x - new_m) * (x - m), s)
+        cnt += mask.to(tl.int32)
+        m = new_m
+        s = new_s
+
+    final_m = tl.sum(m * cnt) / N
+    var = tl.sum(s + cnt * (m - final_m) * (m - final_m)) / N
+    rstd = tl.math.rsqrt(var + eps)
+    m = final_m
+    # Write mean / rstd
+    tl.store(out_mean_ptr + pid, m)
+    tl.store(out_rstd_ptr + pid, rstd)
+
+    # reverse the order of the second sweep
+    # Normalize and apply linear transformation
+    prev_multiple = prev_multiple_of(N, TILE_N)
+    # the first step, masking is needed
+    for start_n in range(0, TILE_N, TILE_N):
+        n_offsets = (prev_multiple - start_n) + tl.arange(0, TILE_N)
+        mask = n_offsets < N
+        x = tl.load(
+            in_ptr + pid * N + n_offsets,
+            mask=mask,
+            other=0.0,
+            eviction_policy="evict_first",
+        ).to(tl.float32)
+        w = tl.load(weight_ptr + n_offsets, mask=mask)
+        b = tl.load(bias_ptr + n_offsets, mask=mask)
+        out = w * (x - m) * rstd + b
+        tl.store(out_ptr + pid * N + n_offsets, out, mask=mask)
+
+    for start_n in range(TILE_N, N, TILE_N):
+        n_offsets = (prev_multiple - start_n) + tl.arange(0, TILE_N)
+        x = tl.load(in_ptr + pid * N + n_offsets, eviction_policy="evict_first").to(
+            tl.float32
+        )
+        w = tl.load(weight_ptr + n_offsets)
+        b = tl.load(bias_ptr + n_offsets)
+        out = w * (x - m) * rstd + b
+        tl.store(out_ptr + pid * N + n_offsets, out)
+
+
 def cfggen():
     block_m = [1, 2, 4]
     block_n = [1024, 2048, 4096]
@@ -19,74 +199,6 @@ def cfggen():
         for w in warps
     ]
     return configs
-
-
-@libentry()
-@triton.autotune(configs=cfggen(), key=["M", "N"])
-@triton.jit(do_not_specialize=["eps"])
-def layer_norm_kernel(
-    X,
-    Y,
-    W,
-    B,
-    Mean,  # pointer to the mean
-    Rstd,  # pointer to the 1/std
-    M,
-    N,
-    eps,
-    BLOCK_ROW_SIZE: tl.constexpr,
-    BLOCK_COL_SIZE: tl.constexpr,
-):
-    # Map the program id to the row of X and Y it should compute.
-    pid = tl.program_id(0)
-    row = pid * BLOCK_ROW_SIZE + tl.arange(0, BLOCK_ROW_SIZE)[:, None]
-    row_mask = row < M
-    X += row * N
-    Y += row * N
-
-    # Compute mean
-    _mean = tl.zeros([BLOCK_ROW_SIZE, BLOCK_COL_SIZE], dtype=tl.float32)
-    for off in range(0, N, BLOCK_COL_SIZE):
-        cols = off + tl.arange(0, BLOCK_COL_SIZE)[None, :]
-        col_mask = cols < N
-        mask = row_mask and col_mask
-
-        a = tl.load(X + cols, mask, other=0.0).to(tl.float32)
-        _mean += a
-    mean = tl.sum(_mean, axis=1) / N
-    mean = mean[:, None]
-
-    # Compute variance
-    _var = tl.zeros([BLOCK_ROW_SIZE, BLOCK_COL_SIZE], dtype=tl.float32)
-    for off in range(0, N, BLOCK_COL_SIZE):
-        cols = off + tl.arange(0, BLOCK_COL_SIZE)[None, :]
-        col_mask = cols < N
-        mask = row_mask and col_mask
-
-        x = tl.load(X + cols, mask, other=0.0).to(tl.float32)
-        x = tl.where(col_mask, x - mean, 0.0)
-        _var += x * x
-    var = tl.sum(_var, axis=1) / N
-    var = var[:, None]
-    rstd = 1 / tl.sqrt(var + eps)
-    # Write mean / rstd
-    tl.store(Mean + row, mean)
-    tl.store(Rstd + row, rstd)
-
-    # Normalize and apply linear transformation
-    for off in range(0, N, BLOCK_COL_SIZE):
-        cols = off + tl.arange(0, BLOCK_COL_SIZE)[None, :]
-        col_mask = cols < N
-        mask = row_mask and col_mask
-
-        w = tl.load(W + cols, col_mask)
-        b = tl.load(B + cols, col_mask)
-        x = tl.load(X + cols, mask, other=0.0).to(tl.float32)
-        x = tl.where(col_mask, x - mean, 0.0)
-        x_hat = x * rstd
-        y = x_hat * w + b
-        # Write output
-        tl.store(Y + cols, y, mask=mask)
 
 
 @libentry()
@@ -211,16 +323,68 @@ class LayerNorm(torch.autograd.Function):
         # M = math.prod(x.shape[:dim])
         N = math.prod(normalized_shape)
         M = x.numel() // N
+
         x = x.contiguous()
         weight = weight.contiguous()
         bias = bias.contiguous()
         y = torch.empty_like(x)
         mean = torch.empty(M, dtype=x.dtype, device=x.device)
         rstd = torch.empty(M, dtype=x.dtype, device=x.device)
-        grid = lambda META: (triton.cdiv(M, META["BLOCK_ROW_SIZE"]),)
 
         with torch.cuda.device(x.device):
-            layer_norm_kernel[grid](x, y, weight, bias, mean, rstd, M, N, eps)
+            if N <= 128:
+                TILE_N = triton.next_power_of_2(N)
+                TILE_M = triton.cdiv(1024, TILE_N)
+                grid = (triton.cdiv(M, TILE_M), 1, 1)
+                num_warps = heuristics_for_num_warps(TILE_M * TILE_N)
+                layer_norm_persistent_kernel_multiline[grid](
+                    x,
+                    y,
+                    weight,
+                    bias,
+                    mean,
+                    rstd,
+                    M,
+                    N,
+                    eps,
+                    TILE_M,
+                    TILE_N,
+                    num_warps=num_warps,
+                )
+            elif N <= 4096:
+                TILE_N = triton.next_power_of_2(N)
+                grid = (M, 1, 1)
+                num_warps = heuristics_for_num_warps(TILE_N)
+                layer_norm_persistent_kernel[grid](
+                    x,
+                    y,
+                    weight,
+                    bias,
+                    mean,
+                    rstd,
+                    M,
+                    N,
+                    eps,
+                    TILE_N,
+                    num_warps=num_warps,
+                )
+            else:
+                TILE_N = 4096
+                grid = (M, 1, 1)
+                num_warps = heuristics_for_num_warps(TILE_N)
+                layer_norm_loop_kernel[grid](
+                    x,
+                    y,
+                    weight,
+                    bias,
+                    mean,
+                    rstd,
+                    M,
+                    N,
+                    eps,
+                    TILE_N,
+                    num_warps=num_warps,
+                )
         ctx.save_for_backward(x, weight, mean, rstd)
         ctx.M = M
         ctx.N = N

--- a/tests/test_norm_ops.py
+++ b/tests/test_norm_ops.py
@@ -76,7 +76,7 @@ def test_accuracy_groupnorm(N, C, H, W, num_groups, dtype):
 # TODO: failed at (1, 2) (2~32, 40499) (200, 2~64) (200~4096, 40999)
 @pytest.mark.layer_norm
 @pytest.mark.parametrize(
-    "shape", [(1, 40999)] if QUICK_MODE else [(1, 40999), (4096, 256)]
+    "shape", [(1, 40999)] if QUICK_MODE else [(1, 40999), (4096, 256), (4096, 100)]
 )
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_accuracy_layernorm(shape, dtype):


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Performance Optimization

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

Optimize forward pass of layernorm, now we use one of the three kernels dependending on reduction size

1. Persistent multiline kernel: when `reduction size <=128`;
2. Persistent kernel: when `128 < reduction size <=4096`. It uses 1d tile and saves some indexing & masking;
3. Loop Kernel: when `reduction size > 4096`. 
   It uses a variant of welford algorithm for computing variance, which saves an extra loading of the input. 
   It also uses other tricks like reversing the second loop to increase L2 hit rate when reduction size is not too large; 
   Evicting more eagerly in the second loop; 
   Specializing the last iteration to avoid masking on other iteration.



### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

Here are the benchmark results on RTX-3090.

#### before

cpu mode timing

```text
test_reduction_perf.py Operator layernorm Performance Test (torch.float16)
Size    Torch Latency (ms)    Gems Latency (ms)    Gems Speedup
---------------------------------------------------------------
1024             0.0102525            0.0792787           0.129
6144             0.0539834            0.0644283           0.838
11264            0.0992241            0.0794113            1.25
16384              0.14798             0.135344            1.09
21504              0.19665             0.194108            1.01
26624             0.244713             0.254988            0.96
31744             0.285166                0.307           0.929
36864             0.338827             0.357343           0.948
41984             0.387447             0.407603           0.951
47104             0.428396             0.458027           0.935
52224             0.475049             0.507055           0.937
57344             0.518136             0.556219           0.932
62464             0.569083             0.604323           0.942
67584             0.614141             0.656674           0.935
72704             0.653114             0.705179           0.926
77824             0.699226             0.756339           0.924
Operator layernorm Performance Test (torch.float32)
Size    Torch Latency (ms)    Gems Latency (ms)    Gems Speedup
---------------------------------------------------------------
1024             0.0150514            0.0633936           0.237
6144             0.0939577            0.0865922            1.09
11264              0.16951             0.202276           0.838
16384             0.242892               0.3167           0.767
21504             0.318454             0.416455           0.765
26624             0.397542             0.517825           0.768
31744             0.471809             0.614384           0.768
36864             0.561043             0.718137           0.781
41984             0.622455             0.814443           0.764
47104             0.694413              0.90966           0.763
52224             0.771752              1.00866           0.765
57344             0.849227              1.10915           0.766
62464              0.92143              1.20739           0.763
67584              1.00197              1.31215           0.764
72704              1.07565              1.40777           0.764
77824               1.1676              1.50991           0.773
Operator layernorm Performance Test (torch.bfloat16)
Size    Torch Latency (ms)    Gems Latency (ms)    Gems Speedup
---------------------------------------------------------------
1024             0.0101285            0.0633092            0.16
6144             0.0543299            0.0636106           0.854
11264              0.10011            0.0803981            1.25
16384             0.151164             0.136883             1.1
21504             0.195308             0.195153             1.0
26624             0.247512             0.255802           0.968
31744             0.288948             0.308058           0.938
36864             0.339835              0.35763            0.95
41984             0.389078             0.408352           0.953
47104             0.431145             0.458213           0.941
52224             0.475008             0.506602           0.938
57344             0.515749             0.556207           0.927
62464             0.563612             0.607139           0.928
67584             0.612329             0.656966           0.932
72704             0.652153             0.706296           0.923
77824             0.700632             0.757162           0.925
```


cuda mode timing

```text
test_reduction_perf.py Operator layernorm Performance Test (torch.float16)
Size    Torch Latency (ms)    Gems Latency (ms)    Gems Speedup
---------------------------------------------------------------
1024              0.013312              0.01024             1.3
6144               0.05632             0.038912            1.45
11264             0.101376             0.080896            1.25
16384             0.149504              0.13824            1.08
21504              0.19968             0.195584            1.02
26624             0.246784             0.257024            0.96
31744             0.287744             0.309248            0.93
36864             0.342016             0.359424           0.952
41984             0.390144               0.4096           0.953
47104              0.43008             0.459776           0.935
52224             0.475136             0.508928           0.934
57344             0.519168              0.55808            0.93
62464             0.572416             0.606208           0.944
67584              0.61952             0.658432           0.941
72704             0.653312              0.70656           0.925
77824             0.710656              0.75776           0.938
Operator layernorm Performance Test (torch.float32)
Size    Torch Latency (ms)    Gems Latency (ms)    Gems Speedup
---------------------------------------------------------------
1024              0.017408              0.01536            1.13
6144              0.096256             0.089088            1.08
11264             0.171008             0.203776           0.839
16384             0.244736             0.318464           0.768
21504             0.320512             0.418816           0.765
26624             0.397312             0.520192           0.764
31744             0.470016             0.615424           0.764
36864             0.557056             0.720896           0.773
41984             0.622592             0.816128           0.763
47104              0.69632             0.910336           0.765
52224             0.776192              1.01069           0.768
57344             0.848896              1.11002           0.765
62464             0.922624              1.20832           0.764
67584               1.0025              1.30867           0.766
72704              1.07725              1.40698           0.766
77824              1.16736              1.51245           0.772
Operator layernorm Performance Test (torch.bfloat16)
Size    Torch Latency (ms)    Gems Latency (ms)    Gems Speedup
---------------------------------------------------------------
1024              0.013312              0.01024             1.3
6144              0.057344             0.038912            1.47
11264             0.101376             0.082944            1.22
16384             0.149504              0.13824            1.08
21504             0.198656             0.197632            1.01
26624             0.246624             0.257024            0.96
31744             0.287744             0.309248            0.93
36864              0.33792             0.359424            0.94
41984             0.387072             0.410624           0.943
47104             0.438272             0.459776           0.953
52224             0.475136             0.509056           0.933
57344             0.519168             0.557056           0.932
62464             0.564224             0.610304           0.924
67584             0.610304             0.657408           0.928
72704              0.65024             0.707584           0.919
77824             0.703488             0.758816           0.927
```

#### After

cpu-mode timing
```text
test_reduction_perf.py Operator layernorm Performance Test (torch.float16)
Size    Torch Latency (ms)    Gems Latency (ms)    Gems Speedup
---------------------------------------------------------------
1024             0.0100327             0.066107           0.152
6144             0.0539818             0.124814           0.432
11264            0.0996938             0.074445            1.34
16384             0.145836             0.111036            1.31
21504             0.193913             0.151223            1.28
26624             0.243227             0.188586            1.29
31744             0.287275             0.226547            1.27
36864             0.340659              0.26407            1.29
41984             0.385496              0.30374            1.27
47104             0.430817             0.340443            1.27
52224             0.474201             0.378162            1.25
57344             0.516725             0.416777            1.24
62464             0.567326              0.45388            1.25
67584             0.606309             0.492827            1.23
72704             0.651885             0.529122            1.23
77824              0.71089             0.568332            1.25
Operator layernorm Performance Test (torch.float32)
Size    Torch Latency (ms)    Gems Latency (ms)    Gems Speedup
---------------------------------------------------------------
1024             0.0153615            0.0663347           0.232
6144             0.0943303            0.0731363            1.29
11264             0.168936             0.149472            1.13
16384             0.243501             0.223247            1.09
21504             0.318337             0.303555            1.05
26624             0.394454             0.380226            1.04
31744             0.470876             0.455038            1.03
36864             0.555541             0.531961            1.04
41984             0.622823             0.607893            1.02
47104             0.695291             0.680414            1.02
52224             0.774846             0.761748            1.02
57344             0.849177             0.838091            1.01
62464             0.922314             0.909388            1.01
67584              1.00176             0.991296            1.01
72704              1.07602              1.06251            1.01
77824               1.1634              1.14813            1.01
Operator layernorm Performance Test (torch.bfloat16)
Size    Torch Latency (ms)    Gems Latency (ms)    Gems Speedup
---------------------------------------------------------------
1024             0.0101304            0.0635226           0.159
6144             0.0549207            0.0625584           0.878
11264             0.099654            0.0693154            1.44
16384             0.146019             0.106422            1.37
21504             0.194268             0.145978            1.33
26624             0.243556             0.183239            1.33
31744             0.289899             0.220377            1.32
36864             0.340016             0.258661            1.31
41984             0.387771              0.29838             1.3
47104             0.432248             0.335079            1.29
52224             0.472394             0.373223            1.27
57344             0.511883             0.410697            1.25
62464             0.571961             0.448678            1.27
67584             0.603934             0.486935            1.24
72704              0.65877             0.522965            1.26
77824             0.704553             0.562981            1.25
```

cuda-mode timing

```text
test_reduction_perf.py Operator layernorm Performance Test (torch.float16)
Size    Torch Latency (ms)    Gems Latency (ms)    Gems Speedup
---------------------------------------------------------------
1024              0.013312              0.01024             1.3
6144              0.055296             0.039936            1.38
11264             0.101376               0.0768            1.32
16384             0.149504              0.11264            1.33
21504              0.19968             0.153408             1.3
26624              0.24576             0.190464            1.29
31744             0.287744             0.228352            1.26
36864             0.340992              0.26624            1.28
41984             0.390144             0.305152            1.28
47104             0.431008             0.342016            1.26
52224              0.47616             0.379904            1.25
57344             0.519168             0.417792            1.24
62464             0.572416              0.45568            1.26
67584              0.61952             0.493568            1.26
72704             0.653312             0.531456            1.23
77824             0.709664             0.571392            1.24
Operator layernorm Performance Test (torch.float32)
Size    Torch Latency (ms)    Gems Latency (ms)    Gems Speedup
---------------------------------------------------------------
1024              0.017408             0.014336            1.21
6144              0.096256             0.074752            1.29
11264             0.171008             0.151552            1.13
16384             0.244736             0.226304            1.08
21504              0.32032             0.306176            1.05
26624             0.397312             0.381952            1.04
31744             0.470016              0.45568            1.03
36864             0.557056             0.531456            1.05
41984             0.622592             0.610304            1.02
47104              0.69632             0.683008            1.02
52224             0.776192             0.761856            1.02
57344             0.848896             0.839648            1.01
62464             0.923648              0.91136            1.01
67584               1.0025              0.99136            1.01
72704              1.07725              1.06394            1.01
77824              1.16736              1.14893            1.02
Operator layernorm Performance Test (torch.bfloat16)
Size    Torch Latency (ms)    Gems Latency (ms)    Gems Speedup
---------------------------------------------------------------
1024              0.013312             0.011264            1.18
6144              0.057344             0.043008            1.33
11264             0.101376              0.07168            1.41
16384             0.149504              0.10752            1.39
21504             0.198656             0.147456            1.35
26624              0.24576             0.185344            1.33
31744             0.287744             0.222208            1.29
36864              0.33792              0.26112            1.29
41984             0.387072             0.300032            1.29
47104              0.44032             0.336896            1.31
52224             0.475136             0.374784            1.27
57344             0.519168             0.412672            1.26
62464             0.564224              0.45056            1.25
67584             0.610304             0.488448            1.25
72704              0.65024             0.524288            1.24
77824             0.703488             0.565248            1.24
```
