### PR TITLE
save mean and rstd in float32 when the inputs are in half-precision fp types

### DIFF
--- a/src/flag_gems/ops/layernorm.py
+++ b/src/flag_gems/ops/layernorm.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils.type_utils import get_accumulator_dtype
 
 
 @triton.jit
@@ -324,8 +325,9 @@ class LayerNorm(torch.autograd.Function):
 
         # NOTE: when the input is half-precision(either float16 or bfloat16)
         # these statistical data saved for backward is in single precision
-        mean = torch.empty(M, dtype=torch.float32, device=x.device)
-        rstd = torch.empty(M, dtype=torch.float32, device=x.device)
+        acc_type = get_accumulator_dtype(x.dtype)
+        mean = torch.empty(M, dtype=acc_type, device=x.device)
+        rstd = torch.empty(M, dtype=acc_type, device=x.device)
 
         with torch.cuda.device(x.device):
             if N <= 128:

--- a/src/flag_gems/utils/type_utils.py
+++ b/src/flag_gems/utils/type_utils.py
@@ -1,3 +1,4 @@
+import torch
 from torch._prims_common import ELEMENTWISE_TYPE_PROMOTION_KIND, elementwise_dtypes
 
 
@@ -7,3 +8,14 @@ def type_promotion(*args, type_promotion: ELEMENTWISE_TYPE_PROMOTION_KIND):
         type_promotion_kind=type_promotion,
     )
     return computation_dtype, result_dtype
+
+
+_accumulator_dtype_map = {
+    torch.bfloat16: torch.float32,
+    torch.float16: torch.float32,
+    torch.complex32: torch.complex64,
+}
+
+
+def get_accumulator_dtype(dtype: torch.dtype) -> torch.dtype:
+    return _accumulator_dtype_map.get(dtype, dtype)

--- a/tests/test_norm_ops.py
+++ b/tests/test_norm_ops.py
@@ -74,11 +74,21 @@ def test_accuracy_groupnorm(N, C, H, W, num_groups, dtype):
     gems_assert_close(res_bias_grad, ref_bias_grad, dtype, reduce_dim=N * HW)
 
 
-# TODO: failed at (1, 2) (2~32, 40499) (200, 2~64) (200~4096, 40999)
 @pytest.mark.layer_norm
 @pytest.mark.native_layer_norm
 @pytest.mark.parametrize(
-    "shape", [(1, 40999)] if QUICK_MODE else [(1, 40999), (4096, 256), (4096, 100)]
+    "shape",
+    [(1, 40999)]
+    if QUICK_MODE
+    else [
+        (1, 2),
+        (1, 40999),
+        (4096, 256),
+        (4096, 100),
+        (16, 40499),
+        (200, 36),
+        (300, 400999),
+    ],
 )
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_accuracy_layernorm(shape, dtype):
@@ -110,8 +120,8 @@ def test_accuracy_layernorm(shape, dtype):
     ref_mean = torch.mean(ref_inp, dim=1)
     ref_var = torch.var(ref_inp, dim=1, correction=0)
     ref_rstd = torch.rsqrt(ref_var + eps)
-    gems_assert_close(res_mean, ref_mean, dtype)
-    gems_assert_close(res_rstd, ref_rstd, dtype)
+    gems_assert_close(res_mean, ref_mean, res_mean.dtype)
+    gems_assert_close(res_rstd, ref_rstd, res_rstd.dtype)
     gems_assert_close(res_out, ref_out, dtype)
 
     out_grad = torch.randn_like(inp)

--- a/tests/test_norm_ops.py
+++ b/tests/test_norm_ops.py
@@ -81,13 +81,11 @@ def test_accuracy_groupnorm(N, C, H, W, num_groups, dtype):
     [(1, 40999)]
     if QUICK_MODE
     else [
-        (1, 2),
-        (1, 40999),
-        (4096, 256),
-        (4096, 100),
-        (16, 40499),
         (200, 36),
-        (300, 400999),
+        (4096, 100),
+        (1, 40999),
+        (100, 40499),
+        (4096, 256),
     ],
 )
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
fix layer_norm_backward: save mean and rstd in float32 when the inputs are in half-precision floating point dtypes to avoid numerical instability or errors

NOTE: Aten's implementation also saves mean and rstd in fp32 in these cases

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
