### PR TITLE
[Operator] Add repeat_interleave_tensor

### DIFF
--- a/benchmark/test_pointwise_perf.py
+++ b/benchmark/test_pointwise_perf.py
@@ -647,3 +647,27 @@ def test_perf_repeat_interleave_self_int():
         sizes=SIZES,
     )
     bench.run()
+
+
+def test_perf_repeat_interleave_tensor():
+    def repeat_interleave_tensor_arg(dtype, batch, size):
+        repeats = torch.randint(
+            low=0,
+            high=0x7F,
+            size=[
+                size,
+            ],
+            dtype=dtype,
+            device="cuda",
+        )
+        return (repeats,)
+
+    bench = Benchmark(
+        op_name="repeat_interleave_tensor",
+        torch_op=torch.repeat_interleave,
+        arg_func=repeat_interleave_tensor_arg,
+        dtypes=[torch.int32],
+        batch=POINTWISE_BATCH,
+        sizes=SIZES,
+    )
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -154,6 +154,7 @@ def enable(lib=aten_lib):
     lib.impl("cat", cat, "CUDA")
     lib.impl("repeat_interleave.self_int", repeat_interleave_self_int, "CUDA")
     lib.impl("vstack", vstack, "CUDA")
+    lib.impl("repeat_interleave.Tensor", repeat_interleave_tensor, "CUDA")
 
 
 class use_gems:

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -79,7 +79,7 @@ from .randn_like import randn_like
 from .reciprocal import reciprocal
 from .relu import relu
 from .repeat import repeat
-from .repeat_interleave import repeat_interleave_self_int
+from .repeat_interleave import repeat_interleave_self_int, repeat_interleave_tensor
 from .resolve_conj import resolve_conj
 from .resolve_neg import resolve_neg
 from .rms_norm import rms_norm
@@ -239,4 +239,5 @@ __all__ = [
     "cat",
     "repeat_interleave_self_int",
     "vstack",
+    "repeat_interleave_tensor",
 ]

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -10,6 +10,7 @@ from .accuracy_utils import (
     FLOAT_DTYPES,
     INT_DTYPES,
     POINTWISE_SHAPES,
+    UT_SHAPES_1D,
     gems_assert_close,
     gems_assert_equal,
     to_reference,
@@ -430,3 +431,15 @@ def test_accuracy_repeat(shape, sizes, dtype):
         res_out = inp.repeat(*sizes)
 
     gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.parametrize("shape", UT_SHAPES_1D)
+@pytest.mark.parametrize("dtype", [torch.int32])
+def test_accuracy_repeat_interleave_tensor(shape, dtype):
+    repeats = torch.randint(0, 30, shape, dtype=dtype, device="cuda")
+    ref_repeats = to_reference(repeats)
+    ref_out = torch.repeat_interleave(ref_repeats)
+
+    with flag_gems.use_gems():
+        res_out = torch.repeat_interleave(repeats)
+    gems_assert_equal(res_out, ref_out)

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -433,6 +433,7 @@ def test_accuracy_repeat(shape, sizes, dtype):
     gems_assert_close(res_out, ref_out, dtype)
 
 
+@pytest.mark.repeat_interleave
 @pytest.mark.parametrize("shape", UT_SHAPES_1D)
 @pytest.mark.parametrize("dtype", [torch.int32])
 def test_accuracy_repeat_interleave_tensor(shape, dtype):


### PR DESCRIPTION
### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

Tested on NV-A100
```
benchmark/test_pointwise_perf.py::test_perf_repeat_interleave_tensor 
Operator repeat_interleave_tensor Performance Test (dtype=torch.int32, mode=cuda)
Size    Torch Latency (ms)    Gems Latency (ms)    Gems Speedup
---------------------------------------------------------------
1024              0.095232             0.259072           0.368
6144              0.094208             0.277504           0.339
11264             0.093184             0.279552           0.333
16384             0.095232             0.278528           0.342
21504             0.100352             0.278528            0.36
26624               0.1024             0.280576           0.365
31744             0.103424               0.2816           0.367
36864             0.103424             0.285696           0.362
41984             0.103424              0.28672           0.361
47104             0.104448             0.285696           0.366
52224             0.104448             0.287744           0.363
57344             0.104448             0.287744           0.363
62464             0.104448             0.288768           0.362
67584             0.104448             0.295936           0.353
72704             0.104448             0.297984           0.351
77824             0.106496             0.304128            0.35
PASSED
```