### PR TITLE
[bugfix] mark eps as dns arg instead of constexpr

### DIFF
--- a/src/flag_gems/ops/weightnorm.py
+++ b/src/flag_gems/ops/weightnorm.py
@@ -44,7 +44,7 @@ def weight_norm_kernel_last(
     g,
     M,
     N,
-    eps: tl.constexpr,
+    eps,
     BLOCK_ROW_SIZE: tl.constexpr,
     BLOCK_COL_SIZE: tl.constexpr,
 ):
@@ -84,7 +84,7 @@ def weight_norm_kernel_first(
     g,
     M,
     N,
-    eps: tl.constexpr,
+    eps,
     BLOCK_ROW_SIZE: tl.constexpr,
     BLOCK_COL_SIZE: tl.constexpr,
 ):
@@ -126,7 +126,7 @@ def weight_norm_bwd_kernel_last(
     norm,
     M,
     N,
-    eps: tl.constexpr,
+    eps,
     BLOCK_ROW_SIZE: tl.constexpr,
     BLOCK_COL_SIZE: tl.constexpr,
 ):
@@ -176,7 +176,7 @@ def weight_norm_bwd_kernel_first(
     norm,
     M,
     N,
-    eps: tl.constexpr,
+    eps,
     BLOCK_ROW_SIZE: tl.constexpr,
     BLOCK_COL_SIZE: tl.constexpr,
 ):


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
[Operator]
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
[Bug Fix]
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
weight norm with eps as dns argument and constexpr at the same time doesn't work on triton 2.1.
since eps is not necessary for kernel compilation, here mark it as dns.
### Issue
Issue from Iluvatar
<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
