### PR TITLE
[bugfix] upcast input tensor to fp64 for cpu reference

### DIFF
--- a/tests/test_norm_ops.py
+++ b/tests/test_norm_ops.py
@@ -148,8 +148,8 @@ def test_accuracy_weightnorm(shape, dtype, dim):
     v = torch.randn(shape, dtype=dtype, device="cuda", requires_grad=True)
     g = torch.randn(shape[dim], dtype=dtype, device="cuda", requires_grad=True)
 
-    ref_v = to_reference(v, False)
-    ref_g = to_reference(g, False)
+    ref_v = to_reference(v, True)
+    ref_g = to_reference(g, True)
 
     ref_w_out, ref_norm_out = torch._weight_norm_interface(ref_v, ref_g, dim)
     with flag_gems.use_gems():
@@ -160,7 +160,7 @@ def test_accuracy_weightnorm(shape, dtype, dim):
     )
 
     res_w_grad = torch.randn_like(v)
-    ref_w_grad = to_reference(res_w_grad, False)
+    ref_w_grad = to_reference(res_w_grad, True)
 
     ref_v_grad, ref_g_grad = torch.autograd.grad(
         ref_w_out, (ref_v, ref_g), grad_outputs=ref_w_grad

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -455,7 +455,7 @@ def test_pad(shape, dtype, pad_mode, contiguous):
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
 def test_upsample_bicubic2d_aa(dtype, shape, scale, align_corners):
     input = torch.rand(shape, dtype=dtype, device="cuda")
-    ref_i = to_reference(input)
+    ref_i = to_reference(input, True)
     output_size = tuple([int(input.shape[i + 2] * scale[i]) for i in range(2)])
     ref_out = torch._C._nn._upsample_bicubic2d_aa(
         ref_i, output_size=output_size, align_corners=align_corners


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
OP Test
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
upcast input tensor to fp64 for cpu reference. so that weight_norm and upsample_bicubic2d_aa could run fp16 tests in cpu mode.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
