### PR TITLE
[Operator] fix: fix pytorch 2.4 tanh backward bug

### DIFF
--- a/src/flag_gems/ops/stack.py
+++ b/src/flag_gems/ops/stack.py
@@ -34,7 +34,7 @@ def stack(
             )
         if s != inp0_shape:
             raise RuntimeError(
-                f"stack expects each tensor to be equal size, but got {inp0_shape} at entry 0 and {s} at entry {i+1}"
+                f"stack expects each tensor to be equal size, but got {inp0_shape} at entry 0 and {s} at entry {i + 1}"
             )
 
     if dim < 0:

--- a/src/flag_gems/ops/tanh.py
+++ b/src/flag_gems/ops/tanh.py
@@ -22,17 +22,64 @@ except ImportError:
     except ImportError:
         from triton.language.libdevice import tanh as _tanh
 
+"""
+#------------- this is a torch2.4 solution ---------------#
 
 @pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
 @triton.jit
-def tanh_forward(x):
+def tanh_forward_kernel(x: torch.Tensor):
     return _tanh(x.to(tl.float32))
 
+@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
+@triton.jit
+def tanh_backward_kernel(y: torch.Tensor, dy: torch.Tensor):
+    return dy * (1.0 - pow(y.to(tl.float32), 2))
+
+@torch.library.custom_op("gems::tanh_forward", mutates_args=())
+def tanh_forward(x: torch.Tensor) -> torch.Tensor:
+    return tanh_forward_kernel(x)
+
+@torch.library.custom_op("gems::tanh_backward", mutates_args=())
+def tanh_backward(y: torch.Tensor, dy: torch.Tensor) -> torch.Tensor:
+    return tanh_backward_kernel(y, dy)
+
+@torch.library.impl_abstract("gems::tanh_forward")
+def fake_tanh_forward(x: torch.Tensor) -> torch.Tensor:
+    return x
+
+@torch.library.impl_abstract("gems::tanh_backward")
+def fake_tanh_backward(y: torch.Tensor, dy: torch.Tensor) -> torch.Tensor:
+    return dy
+"""
+
+torch.library.define("gems::tanh_forward", "(Tensor x) -> Tensor")
+torch.library.define("gems::tanh_backward", "(Tensor y, Tensor dy) -> Tensor")
 
 @pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
 @triton.jit
-def tanh_backward(y, dy):
+def tanh_forward_kernel(x: torch.Tensor):
+    return _tanh(x.to(tl.float32))
+
+@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
+@triton.jit
+def tanh_backward_kernel(y: torch.Tensor, dy: torch.Tensor):
     return dy * (1.0 - pow(y.to(tl.float32), 2))
+
+@torch.library.impl("gems::tanh_forward", "cuda")
+def tanh_forward(x: torch.Tensor) -> torch.Tensor:
+    return tanh_forward_kernel(x)
+
+@torch.library.impl("gems::tanh_backward", "cuda")
+def tanh_backward(y: torch.Tensor, dy: torch.Tensor) -> torch.Tensor:
+    return tanh_backward_kernel(y, dy)
+
+@torch.library.impl_abstract("gems::tanh_forward")
+def fake_tanh_forward(x: torch.Tensor) -> torch.Tensor:
+    return x
+
+@torch.library.impl_abstract("gems::tanh_backward")
+def fake_tanh_backward(y: torch.Tensor, dy: torch.Tensor) -> torch.Tensor:
+    return dy
 
 
 class Tanh(torch.autograd.Function):
@@ -40,20 +87,20 @@ class Tanh(torch.autograd.Function):
     def forward(ctx, A):
         logging.debug("GEMS TANH FORWARD")
         if A.requires_grad is True:
-            out = tanh_forward(A.to(torch.float32))
+            out = torch.ops.gems.tanh_forward(A.to(torch.float32))
             ctx.save_for_backward(out)
             return out.to(A.dtype)
         else:
-            out = tanh_forward(A)
+            out = torch.ops.gems.tanh_forward(A)
             return out
 
     @staticmethod
     def backward(ctx, out_grad):
         logging.debug("GEMS TANH BACKWARD")
         (out,) = ctx.saved_tensors
-        in_grad = tanh_backward(out, out_grad)
+        in_grad = torch.ops.gems.tanh_backward(out, out_grad)
         return in_grad
 
-
-def tanh(A):
+def tanh(A: torch.Tensor):
     return Tanh.apply(A)
+    

--- a/tools/code_coverage/coverage_diff_discard.py
+++ b/tools/code_coverage/coverage_diff_discard.py
@@ -54,11 +54,11 @@ def get_info_file_lines(info_file, discard_file):
                     continue
             elif line.startswith("LF:"):
                 lf = line.split(":")
-                print(f"LF:{ int(lf[1])+ num_rm_lines}")
+                print(f"LF:{int(lf[1]) + num_rm_lines}")
                 continue
             elif line.startswith("LH:"):
                 lh = line.split(":")
-                print(f"LH:{ int(lh[1])+ num_rm_lines}")
+                print(f"LH:{int(lh[1]) + num_rm_lines}")
                 continue
             print(line)
 


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
#### 根据issue 249修复 bug
问题代码：
```python
import flag_gems
import torch

flag_gems.enable()

def f(x, y):
    a = torch.tanh(y)
    b = x - y
    return flag_gems.fused.gelu_and_mul(a, b)

x = torch.randn(10,device="cuda")
y = torch.randn(10,device="cuda")

F = torch.compile(f)

print(F(x, y))
```
- issue 249写明是在backward时的bug，我观察发现感觉不是backward的问题，在torch 2.4的环境下进行测试时。发现是带autograd.Funcion 和 torch.compile一起使用时会有Fake Tensor的报错，但同样测试一些不带autograd的算子，例如cos就不会导致这个错误。
- 了解到pointwise_dynamic会自动生成triton算子，在autograd.Function里。应当在生成的triton算子外再包一层custom ops较为妥当。并对额外包的一层算子注册它自己的FakeTensor。考虑到本仓库需要的torch版本是2.2以上，这里给出两种实现方式。
- 注释中这个方法强烈需求custom ops，它是在torch2.4才加入的新特性

同时也怀疑其他使用torch.autograd.Function 和 AutogradCUDA 的wrapper里也需要修复。

### Issue
https://github.com/FlagOpen/FlagGems/issues/249

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
