### PR TITLE
[Optimization] CrossEntropyLoss

### DIFF
--- a/src/flag_gems/ops/cross_entropy_loss.py
+++ b/src/flag_gems/ops/cross_entropy_loss.py
@@ -525,7 +525,7 @@ class CrossEntropyLoss(torch.autograd.Function):
         inp = inp.contiguous()
         tgt = target.contiguous()
         weight = weight.contiguous()
-        out = torch.empty(shape, dtype=inp.dtype, device=inp.device)
+        out = torch.empty(shape, dtype=torch.float32, device=inp.device)
         grid = lambda meta: (N, triton.cdiv(D, meta["BLOCK_D"]))
 
         if tgt.ndim == dim:
@@ -595,7 +595,7 @@ class CrossEntropyLoss(torch.autograd.Function):
             if reduction == 1:
                 ctx.mean_num = N * D if tgt.ndim == dim else w_tgt.item()
 
-        return out
+        return out.to(inp.dtype)
 
     @staticmethod
     def backward(ctx, out_grad):


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Performance Optimization
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
apply fusion on celoss kernel and sum kernel of weight.
avoid memory copy from device to host by disabling context saving when input tensor doesn't require gradient.
achieve over 200% relative performance on average compared to aten (only 13% before)

A100-benchmark performance
![截屏2024-11-20 17 48 52](https://github.com/user-attachments/assets/4ae1217f-f113-4715-bb96-6905f92f826f)

### Issue
<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
