### PR TITLE
[Operator] Add diag op and related tests(#252)

### DIFF
--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -3,12 +3,13 @@ import random
 import pytest
 import torch
 
-from .attri_util import FLOAT_DTYPES, INT_DTYPES, BenchLevel
+from .attri_util import BOOL_DTYPES, FLOAT_DTYPES, INT_DTYPES, BenchLevel
 from .performance_utils import (
     Config,
     GenericBenchmark,
     GenericBenchmark2DOnly,
     GenericBenchmarkExcluse1D,
+    GenericBenchmarkExcluse3D,
     generate_tensor_input,
 )
 
@@ -243,4 +244,23 @@ def test_perf_upsample_nearest2d():
         torch_op=torch._C._nn.upsample_nearest2d,
         dtypes=FLOAT_DTYPES,
     )
+    bench.run()
+
+
+@pytest.mark.diag
+def test_perf_diag():
+    def diag_input_fn(shape, dtype, device):
+        input = generate_tensor_input(shape, dtype, device)
+        diagonal = random.randint(-4, 4)
+        yield input, {
+            "diagonal": diagonal,
+        },
+
+    bench = GenericBenchmarkExcluse3D(
+        input_fn=diag_input_fn,
+        op_name="diag",
+        torch_op=torch.diag,
+        dtypes=FLOAT_DTYPES + INT_DTYPES + BOOL_DTYPES,
+    )
+
     bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -161,6 +161,7 @@ def enable(lib=aten_lib):
     lib.impl("repeat_interleave.Tensor", repeat_interleave_tensor, "CUDA")
     lib.impl("repeat_interleave.self_Tensor", repeat_interleave_self_tensor, "CUDA")
     lib.impl("randperm", randperm, "CUDA")
+    lib.impl("diag", diag, "CUDA")
 
 
 class use_gems:

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -19,6 +19,7 @@ from .clamp import clamp, clamp_tensor
 from .cos import cos
 from .cross_entropy_loss import cross_entropy_loss
 from .cumsum import cumsum, normed_cumsum
+from .diag import diag
 from .div import div_mode, floor_divide, remainder, true_divide
 from .dropout import native_dropout
 from .embedding import embedding
@@ -134,6 +135,7 @@ __all__ = [
     "clamp",
     "clamp_tensor",
     "cos",
+    "diag",
     "pad",
     "cumsum",
     "normed_cumsum",

--- a/src/flag_gems/ops/diag.py
+++ b/src/flag_gems/ops/diag.py
@@ -1,0 +1,99 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def diag_1d_to_2d_kernel(
+    data_ptr, output_ptr, N, M, stride, diagonal: tl.constexpr, BLOCK_SIZE: tl.constexpr
+):
+    idx = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+    if diagonal >= 0:
+        row_idx = idx
+        col_idx = row_idx + diagonal
+    else:
+        col_idx = idx
+        row_idx = col_idx - diagonal
+
+    mask = (row_idx < M) & (col_idx < M)
+
+    diag_value = tl.load(data_ptr + idx * stride, mask=idx < N, other=0)
+
+    out_offset = row_idx * M + col_idx
+    tl.store(output_ptr + out_offset, diag_value, mask=mask)
+
+
+@triton.jit
+def diag_2d_to_1d_kernel(
+    data_ptr,
+    output_ptr,
+    N,
+    M,
+    stride0,
+    stride1,
+    diagonal: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    idx = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+
+    if diagonal >= 0:
+        row_idx = idx
+        col_idx = row_idx + diagonal
+    else:
+        col_idx = idx
+        row_idx = col_idx - diagonal
+    mask = (row_idx < N) & (col_idx < M)
+
+    diag_value = tl.load(
+        data_ptr + row_idx * stride0 + col_idx * stride1, mask=mask, other=0
+    )
+    tl.store(output_ptr + idx, diag_value, mask=mask)
+
+
+def diag_1d_to_2d(x, diagonal=0):
+    N = x.shape[0]
+    M = N + abs(diagonal)
+    output = torch.zeros((M, M), dtype=x.dtype, device=x.device)
+
+    stride = x.stride(0)
+    BLOCK_SIZE = 128
+
+    grid = lambda meta: (triton.cdiv(N, BLOCK_SIZE),)
+
+    with torch.cuda.device(x.device):
+        diag_1d_to_2d_kernel[grid](
+            x, output, N, M, stride, diagonal, BLOCK_SIZE=BLOCK_SIZE
+        )
+    return output
+
+
+def diag_2d_to_1d(x, diagonal=0):
+    N, M = x.shape
+    if diagonal >= 0:
+        diag_len = min(N, M - diagonal)
+    else:
+        diag_len = min(N + diagonal, M)
+    if diag_len <= 0:
+        return torch.empty(0, dtype=x.dtype, device=x.device)
+    output = torch.empty(diag_len, dtype=x.dtype, device=x.device)
+    stride0 = x.stride(0)
+    stride1 = x.stride(1)
+    BLOCK_SIZE = 128
+
+    grid = lambda meta: (triton.cdiv(diag_len, BLOCK_SIZE),)
+
+    with torch.cuda.device(x.device):
+        diag_2d_to_1d_kernel[grid](
+            x, output, N, M, stride0, stride1, diagonal, BLOCK_SIZE=BLOCK_SIZE
+        )
+    return output
+
+
+def diag(x, diagonal=0):
+    if x.dim() == 1:
+        return diag_1d_to_2d(x, diagonal)
+    elif x.dim() == 2:
+        return diag_2d_to_1d(x, diagonal)
+    else:
+        raise ValueError("Input must be a 1D or 2D tensor.")

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -812,3 +812,20 @@ def test_accuracy_repeat_interleave_self_tensor(shape, dim, dtype):
     with flag_gems.use_gems():
         res_out = torch.repeat_interleave(inp, repeats, dim)
     gems_assert_equal(res_out, ref_out)
+
+
+# Test diag op
+@pytest.mark.diag
+@pytest.mark.parametrize(
+    "shape", [(1024, 1), (1024), (1024, 1024), (512, 1024), (798, 798)]
+)
+@pytest.mark.parametrize("diagonal", [-2, -1, 0, 1, 2])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_diag(shape, diagonal, dtype):
+    inp = torch.randn(shape, dtype=dtype, device="cuda")
+    ref_inp = to_reference(inp)
+
+    ref_out = torch.diag(ref_inp, diagonal)
+    with flag_gems.use_gems():
+        res_out = torch.diag(inp, diagonal)
+    gems_assert_equal(res_out, ref_out)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
 Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add diag op kernel and related tests
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

Resolves #252 
### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
Operator: diag  Performance Test (dtype=torch.bfloat16, mode=cuda, level=comprehensive)
|Size    |     Torch Latency (ms)  |  Gems Latency (ms)  |       Gems Speedup    |     Size Detail|
|----------|------------------------------|-------------------------|------------------|-------|
|N/A               |    0.005120|            0.004096 |              1.250   |       ([torch.Size([64, 64])], {'diagonal': -4})|
|N/A                |   0.007168  |          0.006144   |            1.167     |     ([torch.Size([4096, 4096])], {'diagonal': 4})|
|N/A                 |  0.006144    |        0.006144     |          1.000       |   ([torch.Size([4])], {'diagonal': 4})|
|N/A                  | 0.012288      |      0.011264       |        1.091         | ([torch.Size([1024])], {'diagonal': 4})|

Operator: diag  Performance Test (dtype=torch.float16, mode=cuda, level=comprehensive)
|Size       |  Torch Latency (ms) |   Gems Latency (ms)  |       Gems Speedup   |      Size Detail|
|-----------|-------------------|-----------------------|------------------------|-------------|
|N/A      |             0.005120      |      0.004096      |         1.250   |       ([torch.Size([64, 64])], {'diagonal': 0})|
|N/A       |            0.007168       |     0.006144       |        1.167    |      ([torch.Size([4096, 4096])], {'diagonal': 3})|
|N/A       |            0.006144       |     0.006144       |        1.000     |     ([torch.Size([4])], {'diagonal': 4})|
|N/A        |           0.012288        |    0.021504       |        **0.571**      |    ([torch.Size([1024])], {'diagonal': 2})|

I don't know why the performance of the diag op implemented with Triton is worse than the PyTorch implementation when the dtype is float16 and diagonal is 3.
