### PR TITLE
Obtain the maximum value of a two-dimensional discontinuous tensor without performing time-consuming continuous operations

### DIFF
--- a/src/flag_gems/ops/max.py
+++ b/src/flag_gems/ops/max.py
@@ -148,8 +148,9 @@ def max_2d_uncontiguous(inp):
                                                         inp.stride(0),inp.stride(1),
                                                         inp.shape[0],inp.shape[1],
                                                         mid,
-                                                        256)
-        max_kernel_2[(1, 1, 1)](mid, out, inp.shape[0], 256)
+                                                        512)
+        block_mid = triton.next_power_of_2(inp.shape[0])
+        max_kernel_2[(1, 1, 1)](mid, out, inp.shape[0], block_mid)
         return out
     
     if inp.shape[0]>4096:
@@ -160,8 +161,9 @@ def max_2d_uncontiguous(inp):
                                                 inp.stride(0),inp.stride(1),
                                                 inp.shape[0],inp.shape[1],
                                                 mid,
-                                                2)
-        max_kernel_2[(1, 1, 1)](mid, out, inp.shape[0], triton.next_power_of_2(inp.shape[0]))
+                                                512)
+        block_mid = triton.next_power_of_2(inp.shape[0])
+        max_kernel_2[(1, 1, 1)](mid, out, inp.shape[0], block_mid)
         return out
     
 def max(inp: torch.Tensor):

--- a/src/flag_gems/ops/max.py
+++ b/src/flag_gems/ops/max.py
@@ -173,7 +173,7 @@ def max_2d_uncontiguous(inp):
 
 def max(inp: torch.Tensor):
     logging.debug("GEMS MAX")
-    if inp.ndim == 2 and inp.is_contiguous() == False:
+    if inp.ndim == 2 and inp.is_contiguous() is False:
         out = max_2d_uncontiguous(inp)
         return out
     inp = inp.contiguous()

--- a/tests/test_general_reduction_ops.py
+++ b/tests/test_general_reduction_ops.py
@@ -124,10 +124,21 @@ def test_accuracy_max_without_dim(shape, dtype):
 
 
 @pytest.mark.max
-@pytest.mark.parametrize("shape", REDUCTION_SHAPES)
+@pytest.mark.parametrize(
+    "shape", REDUCTION_SHAPES + [(4963, 6030), (1294, 30), (4025, 111), (204, 137)]
+)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_accuracy_max_without_dim_uncontiguous(shape, dtype):
-    inp = torch.randn(shape, dtype=dtype, device="cuda")[::2, ::2]
+    inp = torch.randn(shape, dtype=dtype, device="cuda")[..., ::2, ::2]
+    ref_inp = to_reference(inp)
+
+    ref_out = torch.max(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.max(inp)
+
+    gems_assert_equal(res_out, ref_out)
+
+    inp = torch.randn(shape, dtype=dtype, device="cuda")[..., ::3, ::5]
     ref_inp = to_reference(inp)
 
     ref_out = torch.max(ref_inp)


### PR DESCRIPTION
测试脚本:
```
import torch
import flag_gems
torch.manual_seed(1)
for i in range(10):
    A = torch.randn((4096, 2560), dtype=torch.bfloat16, device="cuda")[::2,::2]

    with flag_gems.use_gems():
        triton_out = torch.max(A)
import time

A = torch.randn((4096, 2560), dtype=torch.bfloat16, device="cuda")[::2,::2]
with flag_gems.use_gems():
    start_time = time.time()
    for _ in range(10000):
        triton_out = torch.max(A)
    gems_time = time.time() - start_time

print(f"shape:{A.shape},gems_time:{gems_time}")

A = torch.randn((4096, 4096), dtype=torch.bfloat16, device="cuda")[::2,::2]
with flag_gems.use_gems():
    start_time = time.time()
    for _ in range(10000):
        triton_out = torch.max(A)
    gems_time = time.time() - start_time

print(f"shape:{A.shape},gems_time:{gems_time}")

A = torch.randn((3053, 2560), dtype=torch.bfloat16, device="cuda")[::2,::2]
with flag_gems.use_gems():
    # 使用GEMS的时间
    start_time = time.time()
    for _ in range(10000):
        triton_out = torch.max(A)
    gems_time = time.time() - start_time

print(f"shape:{A.shape},gems_time:{gems_time}")


A = torch.randn((6013, 5024), dtype=torch.bfloat16, device="cuda")[::2,::2]
with flag_gems.use_gems():
    start_time = time.time()
    for _ in range(10000):
        triton_out = torch.max(A)
    gems_time = time.time() - start_time

print(f"shape:{A.shape},gems_time:{gems_time}")

A = torch.randn((331, 532), dtype=torch.bfloat16, device="cuda")[::2,::2]
with flag_gems.use_gems():
    start_time = time.time()
    for _ in range(10000):
        triton_out = torch.max(A)
    gems_time = time.time() - start_time

print(f"shape:{A.shape},gems_time:{gems_time}")

```
原来的时间：
<img width="263" alt="企业微信截图_17316689691077" src="https://github.com/user-attachments/assets/e121449d-de9b-461e-afa1-2cc2e4807211">
本pr的时间：
<img width="254" alt="企业微信截图_17316688991443" src="https://github.com/user-attachments/assets/d7c8bb7b-2e33-44aa-a19d-55bb2cfda64b">
测试环境:A100 80GB,考虑到for循环次数较多，因此没有添加LAUNCH_BLOCKING环境变量