### PR TITLE
[bugfix] mark eps as dns arg instead of constexpr

### DIFF
--- a/src/flag_gems/ops/weightnorm.py
+++ b/src/flag_gems/ops/weightnorm.py
@@ -236,7 +236,7 @@ def norm_kernel(
     v_shape0,
     v_shape1,
     v_shape2,
-    eps: tl.constexpr,
+    eps,
     BLOCK_ROW_SIZE: tl.constexpr,
     BLOCK_COL_SIZE: tl.constexpr,
 ):
@@ -274,7 +274,7 @@ def norm_bwd_kernel(
     v_shape0,
     v_shape1,
     v_shape2,
-    eps: tl.constexpr,
+    eps,
     BLOCK_ROW_SIZE: tl.constexpr,
     BLOCK_COL_SIZE: tl.constexpr,
 ):


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
same issue as https://github.com/FlagOpen/FlagGems/pull/235. norm_kernel and norm_bwd_kernel with eps as dns argument and constexpr at the same time doesn't work on triton 2.1.
since eps is not necessary for kernel compilation, here mark it as dns.

### Issue
Issue from Iluvatar


<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
