### PR TITLE
[Operator] Fix embedding op backward with bf16

### DIFF
--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -199,9 +199,7 @@ def test_apply_rotary_pos_emb(
 @pytest.mark.parametrize("N", [8] if TO_CPU else [128, 256, 4096])
 @pytest.mark.parametrize("padding_idx", [None, -1, 1, 2])
 @pytest.mark.parametrize("scale_grad_by_freq", [True, False])
-@pytest.mark.parametrize(
-    "dtype", [torch.float16, torch.float32]
-)  # triton.atomic_add still not support bf16
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_embedding(EmbeddingSize, Batch, M, N, padding_idx, scale_grad_by_freq, dtype):
     indices = torch.randint(
         0, EmbeddingSize, (Batch, M), device="cuda", requires_grad=False


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description
Fix embedding op backward with bf16. Before atomic_add(bf16), we convert both ptr and data to fp32.

### Issue
- Resolves #305


### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
