### PR TITLE
[Fix] where errors on zero dim cpu tensor inputs

### DIFF
--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -112,6 +112,7 @@ def enable(lib=aten_lib):
     lib.impl("topk", topk, "CUDA")
     lib.impl("var_mean.correction", var_mean, "CUDA")
     lib.impl("linalg_vector_norm", vector_norm, "CUDA")
+    lib.impl("where.self_out", where_self_out, "CUDA")
     lib.impl("where.self", where_self, "CUDA")
     lib.impl("where.ScalarSelf", where_scalar_self, "CUDA")
     lib.impl("where.ScalarOther", where_scalar_other, "CUDA")

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -107,7 +107,7 @@ from .var_mean import var_mean
 from .vector_norm import vector_norm
 from .vstack import vstack
 from .weightnorm import weight_norm, weight_norm_interface
-from .where import where_scalar_other, where_scalar_self, where_self
+from .where import where_scalar_other, where_scalar_self, where_self, where_self_out
 from .zeros import zeros
 from .zeros_like import zeros_like
 
@@ -233,6 +233,7 @@ __all__ = [
     "log_softmax",
     "outer",
     "cross_entropy_loss",
+    "where_self_out",
     "where_self",
     "where_scalar_self",
     "where_scalar_other",

--- a/src/flag_gems/ops/where.py
+++ b/src/flag_gems/ops/where.py
@@ -1,5 +1,6 @@
 import logging
 
+import torch
 import triton
 import triton.language as tl
 
@@ -7,39 +8,74 @@ from ..utils import pointwise_dynamic
 
 
 @pointwise_dynamic(
-    is_tensor=[True, True, True], promotion_methods=[(1, 2, "NO_OPMATH")]
+    is_tensor=[True, True, True],
+    promotion_methods=[(1, 2, "NO_OPMATH")],
 )
 @triton.jit
-def where_self_func(condition, self, other):
+def where_inner(condition, self, other):
     return tl.where(condition, self, other)
+
+
+def where_self_out(condition, self, other, out=None):
+    logging.debug("GEMS WHERE_SELF_OUT")
+    result_type = torch.result_type(self, other)
+    if out is not None:
+        assert (
+            out.dtype == result_type
+        ), f"Expected out type to be {result_type}, but got {out.dtype}."
+
+    c, a, b = list(
+        map(
+            lambda x: x if isinstance(x, torch.Tensor) else torch.tensor(x),
+            (condition, self, other),
+        )
+    )
+
+    if a.dtype != result_type:
+        a = a.to(result_type)
+    if b.dtype != result_type:
+        b = b.to(result_type)
+
+    devices = map(lambda x: x.device, (c, a, b))
+    devices = list(filter(lambda k: k.type != "cpu", devices))
+
+    assert len(devices), "CPU only. There seems a mistake to dispatch to here."
+
+    device = devices[0]
+    if c.device != device and c.ndim == 0:
+        c = c.to(device)
+    if a.device != device and a.ndim == 0:
+        a = a.to(device)
+    if b.device != device and b.ndim == 0:
+        b = b.to(device)
+
+    assert (
+        len(set(devices)) == 1
+    ), f"Expected all tensors to be on the same device, but found at least two devices, {devices}"
+    assert (
+        c.dtype == torch.bool
+    ), f"where expected condition to be a boolean tensor, but got a tensor with dtype {condition.dtype}"
+
+    if out is None:
+        out_shape = torch.broadcast_shapes(c.shape, a.shape, b.shape)
+        out = torch.empty(out_shape, dtype=result_type, device=device)
+
+    ndim = max(c.ndim, a.ndim, b.ndim)
+    where_inner.instantiate(ndim)
+    where_inner(c, a, b, out0=out)
+    return out
 
 
 def where_self(condition, self, other):
     logging.debug("GEMS WHERE_SELF")
-    return where_self_func(condition, self, other)
-
-
-@pointwise_dynamic(
-    is_tensor=[True, False, True], promotion_methods=[(1, 2, "NO_OPMATH")]
-)
-@triton.jit
-def where_scalar_self_func(condition, self, other):
-    return tl.where(condition, self, other)
+    return where_self_out(condition, self, other)
 
 
 def where_scalar_self(condition, self, other):
     logging.debug("GEMS WHERE_SCALAR_SELF")
-    return where_scalar_self_func(condition, self, other)
-
-
-@pointwise_dynamic(
-    is_tensor=[True, True, False], promotion_methods=[(1, 2, "NO_OPMATH")]
-)
-@triton.jit
-def where_scalar_other_func(condition, self, other):
-    return tl.where(condition, self, other)
+    return where_self_out(condition, self, other)
 
 
 def where_scalar_other(condition, self, other):
     logging.debug("GEMS WHERE_SCALAR_OTHER")
-    return where_scalar_other_func(condition, self, other)
+    return where_self_out(condition, self, other)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix and New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

Now `where` is able to handle cross device inputs with ndim=0.

Error case,

```
cond = torch.randint(0, 2, (10, ), dtype=torch.bool, device='cuda')

torch.where(cond, torch.tensor(0), torch.tensor(1))
```

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
