### PR TITLE
add program_id & num_programs that returns tensor in tl.int64 

### DIFF
--- a/src/flag_gems/fused/rotary_embedding.py
+++ b/src/flag_gems/fused/rotary_embedding.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
@@ -40,7 +41,7 @@ def apply_rotary_pos_emb_kernel(
     ROTARY_INTERLEAVED: tl.constexpr,
     MAX_POSITION_EMBEDDINGS: tl.constexpr,
 ):
-    s_id = tl.program_id(0)
+    s_id = tle.program_id(0)
 
     if pos_ptr is None:
         pos_id = s_id % seq_len

--- a/src/flag_gems/fused/skip_layernorm.py
+++ b/src/flag_gems/fused/skip_layernorm.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
@@ -26,7 +27,7 @@ def skip_layer_norm_kernel(
     eps,  # epsilon to avoid division by zero
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     Y += pid * y_stride_r
     X += pid * x_stride_r
     R += pid * r_stride_r

--- a/src/flag_gems/fused/skip_rms_norm.py
+++ b/src/flag_gems/fused/skip_rms_norm.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
@@ -25,7 +26,7 @@ def skip_rms_norm_kernel(
     eps,  # epsilon to avoid division by zero
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     Y += pid * y_stride_r
     X += pid * x_stride_r
     R += pid * r_stride_r

--- a/src/flag_gems/ops/addmm.py
+++ b/src/flag_gems/ops/addmm.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
@@ -74,8 +75,8 @@ def addmm_kernel(
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
 ):
-    pid_m = tl.program_id(0)
-    pid_n = tl.program_id(1)
+    pid_m = tle.program_id(0)
+    pid_n = tle.program_id(1)
 
     offs_am = pid_m * BLOCK_SIZE_M + tl.arange(0, BLOCK_SIZE_M)
     offs_bn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)

--- a/src/flag_gems/ops/all.py
+++ b/src/flag_gems/ops/all.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from ..utils import dim_compress, libentry
+from ..utils import triton_lang_extension as tle
 
 
 # torch.all: Tests if all elements in input evaluate to True. If the dtype of input
@@ -36,7 +37,7 @@ def all_kernel_dim(
     BLOCK_N: tl.constexpr,
 ):
     # Map the program id to the row of inp it should compute.
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     rows = pid * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     inp = inp + rows * N
     out = out + rows
@@ -63,7 +64,7 @@ def all_kernel_1(
     mid_size,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     inp_ptrs = inp + offset
     mask = offset < n_elements

--- a/src/flag_gems/ops/amax.py
+++ b/src/flag_gems/ops/amax.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from ..utils import dim_compress, libentry
+from ..utils import triton_lang_extension as tle
 from ..utils.shape_utils import can_use_int32_index
 
 
@@ -18,7 +19,7 @@ def amax_kernel_1(
     BLOCK_SIZE: tl.constexpr,
     INT64_INDEX: tl.constexpr = False,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     if INT64_INDEX:
         pid = pid.to(tl.int64)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
@@ -62,7 +63,7 @@ def amax_kernel(
     INT64_INDEX: tl.constexpr = False,
 ):
     # Map the program id to the row of inp it should compute.
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     if INT64_INDEX:
         pid = pid.to(tl.int64)
     rows = pid * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]

--- a/src/flag_gems/ops/amax.py
+++ b/src/flag_gems/ops/amax.py
@@ -7,7 +7,6 @@ import triton.language as tl
 
 from ..utils import dim_compress, libentry
 from ..utils import triton_lang_extension as tle
-from ..utils.shape_utils import can_use_int32_index
 
 
 @libentry()
@@ -17,11 +16,8 @@ def amax_kernel_1(
     mid,
     M,
     BLOCK_SIZE: tl.constexpr,
-    INT64_INDEX: tl.constexpr = False,
 ):
     pid = tle.program_id(0)
-    if INT64_INDEX:
-        pid = pid.to(tl.int64)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     inp_ptrs = inp + offset
     mask = offset < M
@@ -60,12 +56,9 @@ def amax_kernel(
     N,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
-    INT64_INDEX: tl.constexpr = False,
 ):
     # Map the program id to the row of inp it should compute.
     pid = tle.program_id(0)
-    if INT64_INDEX:
-        pid = pid.to(tl.int64)
     rows = pid * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     inp = inp + rows * N
     out = out + rows
@@ -92,7 +85,6 @@ def amax(inp, dim=None, keepdim=False):
         block_mid = triton.next_power_of_2(mid_size)
         dtype = inp.dtype
         mid = torch.empty((mid_size,), dtype=dtype, device=inp.device)
-        use_int64_index = not can_use_int32_index(inp)
         if not keepdim:
             out = torch.empty([], dtype=dtype, device=inp.device)
         else:
@@ -102,7 +94,10 @@ def amax(inp, dim=None, keepdim=False):
             out = torch.empty(shape, dtype=dtype, device=inp.device)
         with torch.cuda.device(inp.device):
             amax_kernel_1[(mid_size, 1)](
-                inp, mid, M, block_size, INT64_INDEX=use_int64_index
+                inp,
+                mid,
+                M,
+                block_size,
             )
             amax_kernel_2[(1, 1)](
                 mid, out, mid_size, block_mid
@@ -117,7 +112,6 @@ def amax(inp, dim=None, keepdim=False):
         shape = list(inp.shape)
         dim = [d % inp.ndim for d in dim]
         inp = dim_compress(inp, dim)
-        use_int64_index = not can_use_int32_index(inp)
         N = 1
         for i in dim:
             N *= shape[i]
@@ -128,7 +122,7 @@ def amax(inp, dim=None, keepdim=False):
 
         grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
         with torch.cuda.device(inp.device):
-            amax_kernel[grid](inp, out, M, N, INT64_INDEX=use_int64_index)
+            amax_kernel[grid](inp, out, M, N)
         if not keepdim:
             out = out.squeeze(dim=dim)
         return out

--- a/src/flag_gems/ops/any.py
+++ b/src/flag_gems/ops/any.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from ..utils import dim_compress, libentry
+from ..utils import triton_lang_extension as tle
 
 
 # torch.any: Tests if any elements in input evaluate to True. If the dtype of input
@@ -36,7 +37,7 @@ def any_kernel_dim(
     BLOCK_N: tl.constexpr,
 ):
     # Map the program id to the row of inp it should compute.
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     rows = pid * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     inp = inp + rows * N
     out = out + rows
@@ -63,7 +64,7 @@ def any_kernel_1(
     mid_size,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     inp_ptrs = inp + offset
     mask = offset < n_elements

--- a/src/flag_gems/ops/arange.py
+++ b/src/flag_gems/ops/arange.py
@@ -6,12 +6,13 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
 @triton.jit
 def arange_func(y_ptr, start, end, step, size, BLOCK_SIZE: tl.constexpr):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     y_ptr += pid * BLOCK_SIZE
     step_offset = pid * BLOCK_SIZE * step
 

--- a/src/flag_gems/ops/argmax.py
+++ b/src/flag_gems/ops/argmax.py
@@ -7,7 +7,6 @@ import triton.language as tl
 
 from ..utils import libentry
 from ..utils import triton_lang_extension as tle
-from ..utils.shape_utils import can_use_int32_index
 
 
 @libentry()
@@ -18,11 +17,8 @@ def argmax_kernel_1(
     mid_index,
     M,
     BLOCK_SIZE: tl.constexpr,
-    INT64_INDEX: tl.constexpr = False,
 ):
     pid = tle.program_id(0)
-    if INT64_INDEX:
-        pid = pid.to(tl.int64)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     inp_ptrs = inp + offset
     mask = offset < M
@@ -78,14 +74,10 @@ def argmax_kernel(
     K,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
-    INT64_INDEX: tl.constexpr = False,
 ):
     # set offset
     pid_m = tle.program_id(0)
     pid_k = tle.program_id(1)
-    if INT64_INDEX:
-        pid_m = pid_m.to(tl.int64)
-        pid_k = pid_k.to(tl.int64)
     m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
 
     max_values = tl.full([BLOCK_M], dtype=tl.float32, value=float("-inf"))
@@ -120,7 +112,6 @@ def argmax(inp, dim=None, keepdim=False, *, dtype=None):
         block_size = triton.next_power_of_2(math.ceil(math.sqrt(M)))
         mid_size = triton.cdiv(M, block_size)
         block_mid = triton.next_power_of_2(mid_size)
-        use_int64_index = not can_use_int32_index(inp)
 
         mid_value = torch.empty((mid_size,), dtype=dtype, device=inp.device)
         mid_index = torch.empty((mid_size,), dtype=torch.int64, device=inp.device)
@@ -139,7 +130,6 @@ def argmax(inp, dim=None, keepdim=False, *, dtype=None):
                 mid_index,
                 M,
                 block_size,
-                INT64_INDEX=use_int64_index,
             )
             argmax_kernel_2[(1, 1, 1)](mid_value, mid_index, out, mid_size, block_mid)
         return out
@@ -152,7 +142,6 @@ def argmax(inp, dim=None, keepdim=False, *, dtype=None):
         K = inp.numel() // M // N
 
         inp = inp.contiguous()
-        use_int64_index = not can_use_int32_index(inp)
 
         shape_list = list(shape)
         shape_list[dim] = 1
@@ -171,7 +160,6 @@ def argmax(inp, dim=None, keepdim=False, *, dtype=None):
                 M,
                 N,
                 K,
-                INT64_INDEX=use_int64_index,
             )
 
         return out_index

--- a/src/flag_gems/ops/argmax.py
+++ b/src/flag_gems/ops/argmax.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 from ..utils.shape_utils import can_use_int32_index
 
 
@@ -19,7 +20,7 @@ def argmax_kernel_1(
     BLOCK_SIZE: tl.constexpr,
     INT64_INDEX: tl.constexpr = False,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     if INT64_INDEX:
         pid = pid.to(tl.int64)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
@@ -80,8 +81,8 @@ def argmax_kernel(
     INT64_INDEX: tl.constexpr = False,
 ):
     # set offset
-    pid_m = tl.program_id(0)
-    pid_k = tl.program_id(1)
+    pid_m = tle.program_id(0)
+    pid_k = tle.program_id(1)
     if INT64_INDEX:
         pid_m = pid_m.to(tl.int64)
         pid_k = pid_k.to(tl.int64)

--- a/src/flag_gems/ops/bmm.py
+++ b/src/flag_gems/ops/bmm.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 def heur_divisible_m(args):
@@ -109,20 +110,20 @@ def bmm_kernel(
     DIVISIBLE_K: tl.constexpr,
 ):
     # batch offsets
-    pid_b = tl.program_id(2)
+    pid_b = tle.program_id(2)
     A += pid_b * M * K
     B += pid_b * K * N
     O += pid_b * M * N
 
-    pidx = tl.program_id(0)
-    pidy = tl.program_id(1)
+    pidx = tle.program_id(0)
+    pidy = tle.program_id(1)
 
     if GROUP_M == 1:
         pid_m, pid_n = pidx, pidy
     else:
         # reorder CTAs
-        gridx = tl.num_programs(0)
-        gridy = tl.num_programs(1)
+        gridx = tle.num_programs(0)
+        gridy = tle.num_programs(1)
         pid = pidx + pidy * gridx
 
         num_CTA_per_group = gridy * GROUP_M

--- a/src/flag_gems/ops/bmm.py
+++ b/src/flag_gems/ops/bmm.py
@@ -130,10 +130,9 @@ def bmm_kernel(
 
         group_id = pid // num_CTA_per_group
         inner_group_id = pid % num_CTA_per_group
-        if (group_id * GROUP_M + GROUP_M) > gridx:
-            GROUP_SIZE = gridx % GROUP_M
-        else:
-            GROUP_SIZE = GROUP_M
+        GROUP_SIZE = tl.where(
+            (group_id * GROUP_M + GROUP_M) > gridx, gridx % GROUP_M, GROUP_M
+        )
         pid_m = group_id * GROUP_M + inner_group_id % GROUP_SIZE
         pid_n = inner_group_id // GROUP_SIZE
 

--- a/src/flag_gems/ops/cross_entropy_loss.py
+++ b/src/flag_gems/ops/cross_entropy_loss.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
@@ -29,8 +30,8 @@ def celoss_indices_kernel(
     BLOCK_C: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
-    pid_d = tl.program_id(0)
-    pid_n = tl.program_id(1)
+    pid_d = tle.program_id(0)
+    pid_n = tle.program_id(1)
     offset_d = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)
 
     tgt_ptrs = tgt_ptr + pid_n * D + offset_d
@@ -93,8 +94,8 @@ def celoss_probability_kernel(
     BLOCK_C: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
-    pid_d = tl.program_id(0)
-    pid_n = tl.program_id(1)
+    pid_d = tle.program_id(0)
+    pid_n = tle.program_id(1)
     offset_d = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)
 
     tmp_max = tl.zeros([BLOCK_C, BLOCK_D], dtype=tl.float32)
@@ -158,8 +159,8 @@ def celoss_indices_smooth_kernel(
     BLOCK_C: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
-    pid_d = tl.program_id(0)
-    pid_n = tl.program_id(1)
+    pid_d = tle.program_id(0)
+    pid_n = tle.program_id(1)
     offset_d = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)
 
     tgt_ptrs = tgt_ptr + pid_n * D + offset_d
@@ -243,8 +244,8 @@ def celoss_indices_bwd(
     BLOCK_C: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
-    pid_d = tl.program_id(0)
-    pid_n = tl.program_id(1)
+    pid_d = tle.program_id(0)
+    pid_n = tle.program_id(1)
     offset_d = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)
 
     tgt_ptrs = tgt_ptr + pid_n * D + offset_d
@@ -318,8 +319,8 @@ def celoss_probability_bwd(
     BLOCK_C: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
-    pid_d = tl.program_id(0)
-    pid_n = tl.program_id(1)
+    pid_d = tle.program_id(0)
+    pid_n = tle.program_id(1)
     offset_d = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)
 
     out_grad_ptrs = out_grad_ptr + pid_n * D + offset_d
@@ -408,8 +409,8 @@ def celoss_indices_smooth_bwd(
     BLOCK_C: tl.constexpr,
     BLOCK_D: tl.constexpr,
 ):
-    pid_d = tl.program_id(0)
-    pid_n = tl.program_id(1)
+    pid_d = tle.program_id(0)
+    pid_n = tle.program_id(1)
     offset_d = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)
 
     tgt_ptrs = tgt_ptr + pid_n * D + offset_d

--- a/src/flag_gems/ops/cumsum.py
+++ b/src/flag_gems/ops/cumsum.py
@@ -7,6 +7,8 @@ import triton.language as tl
 
 from flag_gems.utils import libentry
 
+from ..utils import triton_lang_extension as tle
+
 
 @libentry()
 @triton.jit(do_not_specialize=["n_elements", "part_num"])
@@ -18,7 +20,7 @@ def scan_part_sum_kernel(
     part_num,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offset < n_elements
 
@@ -53,7 +55,7 @@ def add_base_sum_kernel(
     part_num,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offset < n_elements
 
@@ -79,9 +81,9 @@ def scan_part_sum_abc_kernel(
     part_num,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid_a = tl.program_id(0)
-    pid_b = tl.program_id(1)
-    pid_c = tl.program_id(2)
+    pid_a = tle.program_id(0)
+    pid_b = tle.program_id(1)
+    pid_c = tle.program_id(2)
 
     a_idx = pid_a
     b_idx = pid_b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
@@ -124,9 +126,9 @@ def add_base_sum_abc_kernel(
     part_num,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid_a = tl.program_id(0)
-    pid_b = tl.program_id(1)
-    pid_c = tl.program_id(2)
+    pid_a = tle.program_id(0)
+    pid_b = tle.program_id(1)
+    pid_c = tle.program_id(2)
 
     a_idx = pid_a
     b_idx = pid_b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
@@ -219,7 +221,7 @@ def cumsum(inp, dim=1, *, dtype=None):
 @libentry()
 @triton.jit(do_not_specialize=["K"])
 def normed_cumsum_kernel(inp, out, K, BLOCK: tl.constexpr):
-    row_start = tl.program_id(0) * K
+    row_start = tle.program_id(0) * K
     row_off = tl.arange(0, BLOCK)
     x = tl.load(inp + row_start + row_off, mask=row_off < K, other=0)
     if x.dtype.is_fp16():
@@ -261,9 +263,9 @@ def block_cumsum_kernel(
     # One CTA processes a (r, t*tile) chunk
     # rows = [ grid.y, grid.y + r )
     # cols = [ grid.x * t * tile, (grid.x + 1) * t * tile )
-    gridx = tl.program_id(0).to(tl.int64)
-    gridy = tl.program_id(1).to(tl.int64)
-    n_chunks = tl.num_programs(0)
+    gridx = tle.program_id(0).to(tl.int64)
+    gridy = tle.program_id(1).to(tl.int64)
+    n_chunks = tle.num_programs(0)
 
     for row in range(gridy * r, min((gridy + 1) * r, R)):
         curr_cumsum = tl.zeros((1,), tl.float32)
@@ -330,9 +332,9 @@ def block_update_kernel(
     # One CTA processes a (r, t*tile) chunk
     # rows = [ grid.y, grid.y + r )
     # cols = [ grid.x * t * tile, (grid.x + 1) * t * tile )
-    gridx = tl.program_id(0).to(tl.int64)
-    gridy = tl.program_id(1).to(tl.int64)
-    n_gridx = tl.num_programs(1)
+    gridx = tle.program_id(0).to(tl.int64)
+    gridy = tle.program_id(1).to(tl.int64)
+    n_gridx = tle.num_programs(1)
 
     base += gridy * n_gridx + gridx
     rscale_ptr += gridy * rscale_stride

--- a/src/flag_gems/ops/diag.py
+++ b/src/flag_gems/ops/diag.py
@@ -2,12 +2,14 @@ import torch
 import triton
 import triton.language as tl
 
+from ..utils import triton_lang_extension as tle
+
 
 @triton.jit
 def diag_1d_to_2d_kernel(
     data_ptr, output_ptr, N, M, stride, diagonal: tl.constexpr, BLOCK_SIZE: tl.constexpr
 ):
-    idx = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    idx = tle.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
 
     if diagonal >= 0:
         row_idx = idx
@@ -35,7 +37,7 @@ def diag_2d_to_1d_kernel(
     diagonal: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
-    idx = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    idx = tle.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
 
     if diagonal >= 0:
         row_idx = idx

--- a/src/flag_gems/ops/dropout.py
+++ b/src/flag_gems/ops/dropout.py
@@ -6,6 +6,8 @@ import triton.language as tl
 
 from flag_gems.utils.random_utils import philox_cuda_seed_offset, uint_to_uniform_float
 
+from ..utils import triton_lang_extension as tle
+
 
 def heur_block(args):
     if args["N"] <= 512:
@@ -44,7 +46,7 @@ def dropout_forward_kernel(
     philox_offset = philox_offset.to(tl.int64)
     c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
-    i4 = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    i4 = tle.program_id(0) * BLOCK + tl.arange(0, BLOCK)
     c0 += i4
     _O = c0 * 0
     r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, _O, _O)
@@ -59,7 +61,7 @@ def dropout_forward_kernel(
     mask3 = r3 > p
     p = 1.0 / (1.0 - p)
 
-    off_0 = tl.program_id(0) * BLOCK * UNROLL + tl.arange(0, BLOCK)
+    off_0 = tle.program_id(0) * BLOCK * UNROLL + tl.arange(0, BLOCK)
     off_1 = off_0 + BLOCK
     off_2 = off_1 + BLOCK
     off_3 = off_2 + BLOCK
@@ -101,7 +103,7 @@ def dropout_backward_kernel(
     philox_offset = philox_offset.to(tl.int64)
     c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
-    i4 = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    i4 = tle.program_id(0) * BLOCK + tl.arange(0, BLOCK)
     c0 += i4
     _O = c0 * 0
     r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, _O, _O)
@@ -114,7 +116,7 @@ def dropout_backward_kernel(
     mask1 = r1 > p
     mask2 = r2 > p
     mask3 = r3 > p
-    off_0 = tl.program_id(0) * BLOCK * UNROLL + tl.arange(0, BLOCK)
+    off_0 = tle.program_id(0) * BLOCK * UNROLL + tl.arange(0, BLOCK)
     off_1 = off_0 + BLOCK
     off_2 = off_1 + BLOCK
     off_3 = off_2 + BLOCK

--- a/src/flag_gems/ops/embedding.py
+++ b/src/flag_gems/ops/embedding.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
@@ -17,7 +18,7 @@ def embedding_kernel(
     N: tl.constexpr,  # number of columns in X
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     out_ptr += pid * N
     in_ptr += pid
 
@@ -38,7 +39,7 @@ def indice_freq_kernel(
     elem_cnt: tl.constexpr,  # number of columns in X
     INDICE_BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     block_start = pid * INDICE_BLOCK_SIZE
 
     offsets = block_start + tl.arange(0, INDICE_BLOCK_SIZE)
@@ -59,7 +60,7 @@ def embedding_backward_kernel(
     N: tl.constexpr,  # number of columns in X
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     grad_out += pid * N
     indices += pid
 
@@ -87,8 +88,8 @@ def embedding_grad_scale_kernel(
     N,
     BLOCK_SIZE: tl.constexpr,
 ):
-    row_start = tl.program_id(0)
-    row_step = tl.num_programs(0)
+    row_start = tle.program_id(0)
+    row_step = tle.num_programs(0)
 
     for row_idx in range(row_start, n_rows, row_step):
         embedding_scale = 1.0

--- a/src/flag_gems/ops/exponential_.py
+++ b/src/flag_gems/ops/exponential_.py
@@ -6,6 +6,8 @@ import triton.language as tl
 
 from flag_gems.utils.random_utils import philox_cuda_seed_offset, uint_to_uniform_float
 
+from ..utils import triton_lang_extension as tle
+
 
 def heur_block(args):
     if args["N"] <= 512:
@@ -44,7 +46,7 @@ def fused_exponential_kernel(
     philox_offset = philox_offset.to(tl.int64)
     c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
-    i4 = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    i4 = tle.program_id(0) * BLOCK + tl.arange(0, BLOCK)
     c0 += i4
     _O = c0 * 0
     r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, _O, _O)
@@ -54,7 +56,7 @@ def fused_exponential_kernel(
         y0 = transform_exponential(d0, lambd, eps)
         y1 = transform_exponential(d1, lambd, eps)
         UNROLL = 2
-        start = tl.program_id(0).to(tl.uint64) * BLOCK * UNROLL
+        start = tle.program_id(0).to(tl.uint64) * BLOCK * UNROLL
         off_0 = start + tl.arange(0, BLOCK)
         off_1 = off_0 + BLOCK
         tl.store(out_ptr + off_0, y0, mask=off_0 < N, eviction_policy="evict_first")
@@ -69,7 +71,7 @@ def fused_exponential_kernel(
         y2 = transform_exponential(f2, lambd, eps)
         y3 = transform_exponential(f3, lambd, eps)
         UNROLL = 4
-        start = tl.program_id(0).to(tl.uint64) * BLOCK * UNROLL
+        start = tle.program_id(0).to(tl.uint64) * BLOCK * UNROLL
         off_0 = start + tl.arange(0, BLOCK)
         off_1 = off_0 + BLOCK
         off_2 = off_1 + BLOCK

--- a/src/flag_gems/ops/fill.py
+++ b/src/flag_gems/ops/fill.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
@@ -15,7 +16,7 @@ def fill_scalar_kernel(
     value_scalar,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     cols = tl.arange(0, BLOCK_SIZE)
     offset = pid * BLOCK_SIZE + cols
     tl.store(out_ptr + offset, value_scalar, mask=offset < N)
@@ -29,7 +30,7 @@ def fill_tensor_kernel(
     value_ptr,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     cols = tl.arange(0, BLOCK_SIZE)
     offset = pid * BLOCK_SIZE + cols
     value_scalar = tl.load(value_ptr)  # load the value from the tensor.

--- a/src/flag_gems/ops/full.py
+++ b/src/flag_gems/ops/full.py
@@ -6,6 +6,8 @@ import triton.language as tl
 
 from flag_gems.utils.shape_utils import volume
 
+from ..utils import triton_lang_extension as tle
+
 
 @triton.jit(do_not_specialize=["fill_value"])
 def full_kernel(
@@ -14,7 +16,7 @@ def full_kernel(
     fill_value,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(axis=0)
+    pid = tle.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
     offsets = block_start + tl.arange(0, BLOCK_SIZE)
     mask = offsets < n_elements

--- a/src/flag_gems/ops/gather.py
+++ b/src/flag_gems/ops/gather.py
@@ -16,6 +16,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("import triton.language as tl")
     code.newline()
     code.writeline("from flag_gems.utils import libentry")
+    code.writeline("from flag_gems.utils import triton_lang_extension as tle")
     code.newline()
     code.newline()
     return code
@@ -87,8 +88,8 @@ def generate_gather_kernel(
 
     # Kernel Code
     with code.indent():
-        code.writeline("pid_x = tl.program_id(0)")
-        code.writeline("pid_y = tl.program_id(1)")
+        code.writeline("pid_x = tle.program_id(0)")
+        code.writeline("pid_y = tle.program_id(1)")
         code.writeline(
             "rows_offsets = pid_x * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]"
         )

--- a/src/flag_gems/ops/groupnorm.py
+++ b/src/flag_gems/ops/groupnorm.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 try:
     from triton.language.extra.cuda.libdevice import rsqrt
@@ -32,7 +33,7 @@ def group_norm_kernel(
     BLOCK_GROUP_SIZE: tl.constexpr,
     BLOCK_HW_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     group = pid % num_groups
     num_elements = group_size * HW
     group_offset = tl.arange(0, BLOCK_GROUP_SIZE)
@@ -85,7 +86,7 @@ def group_norm_backward_kernel(
     BLOCK_GROUP_SIZE: tl.constexpr,
     BLOCK_HW_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     group = pid % num_groups
     num_elements = group_size * HW
 
@@ -141,7 +142,7 @@ def weight_bias_backward_kernel(
     BLOCK_N: tl.constexpr,
     BLOCK_HW: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     group = pid // group_size
     n_offset = tl.arange(0, BLOCK_N)
     hw_offset = tl.arange(0, BLOCK_HW)

--- a/src/flag_gems/ops/index_select.py
+++ b/src/flag_gems/ops/index_select.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import dim_compress, libentry
+from ..utils import triton_lang_extension as tle
 
 
 def cfggen():
@@ -24,8 +25,8 @@ def cfggen():
 def index_select_kernel(
     inp, out, M, N, index, index_len, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr
 ):
-    pid_x = tl.program_id(axis=0)
-    pid_y = tl.program_id(axis=1)
+    pid_x = tle.program_id(axis=0)
+    pid_y = tle.program_id(axis=1)
     rows_offsets = pid_x * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     rows_mask = rows_offsets < M
     cols_offsets = pid_y * BLOCK_N + tl.arange(0, BLOCK_N)

--- a/src/flag_gems/ops/isin.py
+++ b/src/flag_gems/ops/isin.py
@@ -6,6 +6,7 @@ import triton.language as tl
 
 from flag_gems.utils.libentry import libentry
 
+from ..utils import triton_lang_extension as tle
 from .all import reduce_all
 from .any import reduce_any
 from .unique import _unique2
@@ -63,8 +64,8 @@ def isin_by_comparation_kernel(
     tiles_per_cta: int,
     invert: tl.constexpr,
 ):
-    pid = tl.program_id(0)
-    ctas_num = tl.num_programs(0)
+    pid = tle.program_id(0)
+    ctas_num = tle.num_programs(0)
     # grid-stride-loop style kernel
     for j in range(0, tiles_per_cta):
         global_pid = pid + j * ctas_num
@@ -169,8 +170,8 @@ def isin_by_search_kernel(
     tiles_per_cta: int,
     invert: tl.constexpr,
 ):
-    pid = tl.program_id(0)
-    ctas_num = tl.num_programs(0)
+    pid = tle.program_id(0)
+    ctas_num = tle.num_programs(0)
     # grid-stride-loop style kernel
     for j in range(0, tiles_per_cta):
         global_pid = pid + j * ctas_num

--- a/src/flag_gems/ops/layernorm.py
+++ b/src/flag_gems/ops/layernorm.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 from ..utils.type_utils import get_accumulator_dtype
 
 
@@ -35,7 +36,7 @@ def layer_norm_persistent_kernel(
 ):
     # using 1d tile makes code clean
     # Map the program id to the row of X and Y it should compute.
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
 
     n_offsets = tl.arange(0, TILE_N)
     mask = n_offsets < N
@@ -78,7 +79,7 @@ def layer_norm_persistent_kernel_multiline(
     TILE_N: tl.constexpr,
 ):
     # Map the program id to the row of X and Y it should compute.
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     m_offsets = pid * TILE_M + tl.arange(0, TILE_M)
     m_mask = m_offsets < M
 
@@ -129,7 +130,7 @@ def layer_norm_loop_kernel(
     TILE_N: tl.constexpr,
 ):
     # Map the program id to the row of X and Y it should compute.
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
 
     # Compute mean
     m = tl.zeros((TILE_N,), dtype=tl.float32)  # mean
@@ -217,7 +218,7 @@ def layer_norm_backward_kernel(
     BLOCK_ROW_SIZE: tl.constexpr,
     BLOCK_COL_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0) * BLOCK_ROW_SIZE + tl.arange(0, BLOCK_ROW_SIZE)[:, None]
+    pid = tle.program_id(0) * BLOCK_ROW_SIZE + tl.arange(0, BLOCK_ROW_SIZE)[:, None]
     row_mask = pid < M
     dY += pid * N
     X += pid * N
@@ -283,7 +284,7 @@ def weight_bias_backward_kernel(
     BLOCK_ROW_SIZE: tl.constexpr,
     BLOCK_COL_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0) * BLOCK_COL_SIZE + tl.arange(0, BLOCK_COL_SIZE)[None, :]
+    pid = tle.program_id(0) * BLOCK_COL_SIZE + tl.arange(0, BLOCK_COL_SIZE)[None, :]
     col_mask = pid < N
     dY += pid
     X += pid

--- a/src/flag_gems/ops/log_softmax.py
+++ b/src/flag_gems/ops/log_softmax.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 def heur_block_n(args):
@@ -49,8 +50,8 @@ def log_softmax_kernel(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
-    pid_m = tl.program_id(0)
-    pid_k = tl.program_id(1)
+    pid_m = tle.program_id(0)
+    pid_k = tle.program_id(1)
     m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     n_offset = tl.arange(0, BLOCK_N)
     offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
@@ -95,8 +96,8 @@ def log_softmax_backward_kernel(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
-    pid_m = tl.program_id(0)
-    pid_k = tl.program_id(1)
+    pid_m = tle.program_id(0)
+    pid_k = tle.program_id(1)
     m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     n_offset = tl.arange(0, BLOCK_N)
 

--- a/src/flag_gems/ops/masked_fill.py
+++ b/src/flag_gems/ops/masked_fill.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import broadcastable_to, libentry
+from ..utils import triton_lang_extension as tle
 
 
 def cfggen():
@@ -20,7 +21,7 @@ def cfggen():
 @triton.autotune(configs=cfggen(), key=["N"])
 @triton.jit
 def masked_fill_kernel(inp, expand_mask, value, out, N, BLOCK_SIZE: tl.constexpr):
-    pid = tl.program_id(axis=0)
+    pid = tle.program_id(axis=0)
     offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offsets < N
 
@@ -36,7 +37,7 @@ def masked_fill_kernel(inp, expand_mask, value, out, N, BLOCK_SIZE: tl.constexpr
 @triton.autotune(configs=cfggen(), key=["N"])
 @triton.jit
 def masked_fill_kernel_self(inp, expand_mask, value, out, N, BLOCK_SIZE: tl.constexpr):
-    pid = tl.program_id(axis=0)
+    pid = tle.program_id(axis=0)
     offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offsets < N
 

--- a/src/flag_gems/ops/masked_select.py
+++ b/src/flag_gems/ops/masked_select.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import broadcastable, libentry
+from ..utils import triton_lang_extension as tle
 
 
 def cfggen():
@@ -27,7 +28,7 @@ def masked_select_kernel(
     n_elements,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(axis=0)
+    pid = tle.program_id(axis=0)
     offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offsets < n_elements
 

--- a/src/flag_gems/ops/max.py
+++ b/src/flag_gems/ops/max.py
@@ -7,6 +7,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
@@ -17,7 +18,7 @@ def max_kernel_1(
     M,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     inp_ptrs = inp + offset
     mask = offset < M
@@ -66,8 +67,8 @@ def max_kernel(
     BLOCK_N: tl.constexpr,
 ):
     # set offset
-    pid_m = tl.program_id(0)
-    pid_k = tl.program_id(1)
+    pid_m = tle.program_id(0)
+    pid_k = tle.program_id(1)
     m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     result_value = tl.full([BLOCK_M], value=-float("inf"), dtype=tl.float32)
     result_index = tl.zeros([BLOCK_M], dtype=tl.int64)

--- a/src/flag_gems/ops/mean.py
+++ b/src/flag_gems/ops/mean.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from ..utils import dim_compress, libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
@@ -16,7 +17,7 @@ def mean_kernel_1(
     M,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     inp_ptrs = inp + offset
     mask = offset < M
@@ -66,7 +67,7 @@ def mean(inp, *, dtype=None):
 @triton.jit
 def mean_dim_kernel(X, Mean, M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
     # Map the program id to the row of X it should compute.
-    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    pid = tle.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     X = X + pid * N
     Mean = Mean + pid
     row_mask = pid < M

--- a/src/flag_gems/ops/min.py
+++ b/src/flag_gems/ops/min.py
@@ -7,6 +7,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
@@ -17,7 +18,7 @@ def min_kernel_1(
     M,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     inp_ptrs = inp + offset
     mask = offset < M
@@ -71,8 +72,8 @@ def min_kernel(
     BLOCK_N: tl.constexpr,
 ):
     # set offset
-    pid_m = tl.program_id(0)
-    pid_k = tl.program_id(1)
+    pid_m = tle.program_id(0)
+    pid_k = tle.program_id(1)
     m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     n_offset = tl.arange(0, BLOCK_N)
     offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k

--- a/src/flag_gems/ops/mm.py
+++ b/src/flag_gems/ops/mm.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 def heur_even_k(args):
@@ -137,8 +138,8 @@ def mm_kernel(
     EVEN_K: tl.constexpr,
 ):
     # matrix multiplication
-    pid = tl.program_id(0)
-    pid_z = tl.program_id(1)
+    pid = tle.program_id(0)
+    pid_z = tle.program_id(1)
     grid_m = tl.cdiv(M, BLOCK_M)
     grid_n = tl.cdiv(N, BLOCK_N)
     # re-order program ID for better L2 performance

--- a/src/flag_gems/ops/multinomial.py
+++ b/src/flag_gems/ops/multinomial.py
@@ -7,6 +7,8 @@ import triton.language as tl
 from flag_gems.utils import libentry
 from flag_gems.utils.random_utils import philox_cuda_seed_offset, uniform
 
+from ..utils import triton_lang_extension as tle
+
 
 @libentry()
 @triton.heuristics(
@@ -25,8 +27,8 @@ def multinomial_with_replacement(
     #           |   dist0.batch0 | dist0.batch1 | dist0.batch2 ...
     #   grid.y  |   dist1.batch0 | dist1.batch1 | dist1.batch2 ...
     #           |   dist2.batch0 | dist2.batch1 | dist2.batch2 ...
-    y_off = tl.program_id(1) * N
-    n = tl.program_id(0) * NBLOCK + tl.arange(0, NBLOCK)
+    y_off = tle.program_id(1) * N
+    n = tle.program_id(0) * NBLOCK + tl.arange(0, NBLOCK)
     rv, _, _, _ = uniform(philox_seed, philox_offset, y_off + n)
 
     # Do a binary search for each random number on the cumulative probabilities.
@@ -38,7 +40,7 @@ def multinomial_with_replacement(
     rv += 0.0001
     rv = tl.where(rv > 0.9999, 0.9999, rv)
 
-    cdf_ptr += tl.program_id(1) * K
+    cdf_ptr += tle.program_id(1) * K
     start = tl.zeros((NBLOCK,), dtype=tl.int32)
     end = tl.zeros((NBLOCK,), dtype=tl.int32) + K - 1
     steps = tl.math.log2(K.to(tl.float32)).to(tl.int32) + 1

--- a/src/flag_gems/ops/mv.py
+++ b/src/flag_gems/ops/mv.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
@@ -32,7 +33,7 @@ def mv_kernel(
     BLOCK_N: tl.constexpr,
     BLOCK_M: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     offset_n = pid * BLOCK_N + tl.arange(0, BLOCK_N)[:, None]
     offset_m = tl.arange(0, BLOCK_M)[None, :]
     n_mask = offset_n < N

--- a/src/flag_gems/ops/nonzero.py
+++ b/src/flag_gems/ops/nonzero.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
@@ -28,7 +29,7 @@ def nonzero_kernel(
     ndim: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
 
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offset < n_elements

--- a/src/flag_gems/ops/ones.py
+++ b/src/flag_gems/ops/ones.py
@@ -6,6 +6,8 @@ import triton.language as tl
 
 from flag_gems.utils.shape_utils import volume
 
+from ..utils import triton_lang_extension as tle
+
 
 @triton.jit
 def ones_kernel(
@@ -13,7 +15,7 @@ def ones_kernel(
     n_elements,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(axis=0)
+    pid = tle.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
     offsets = block_start + tl.arange(0, BLOCK_SIZE)
     mask = offsets < n_elements

--- a/src/flag_gems/ops/pad.py
+++ b/src/flag_gems/ops/pad.py
@@ -68,6 +68,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("from triton import language as tl")
     code.newline()
     code.writeline("from flag_gems.utils.libentry import libentry")
+    code.writeline("from flag_gems.utils import triton_lang_extension as tle")
     code.writeline("from flag_gems.utils.type_utils import type_promotion")
     code.newline()
     code.newline()
@@ -271,7 +272,7 @@ def generate_pad_kernel(
     code.writeline("):")
 
     with code.indent():
-        code.writeline("pid = tl.program_id(0)")
+        code.writeline("pid = tle.program_id(0)")
         code.writeline("block_offset = pid * BLOCK_SIZE")
         code.writeline("offset = block_offset + tl.arange(0, BLOCK_SIZE)")
         code.newline()

--- a/src/flag_gems/ops/prod.py
+++ b/src/flag_gems/ops/prod.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 @triton.jit
@@ -21,7 +22,7 @@ def prod_kernel_mid(
     M,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     inp_ptrs = inp + offset
     mask = offset < M
@@ -93,8 +94,8 @@ def prod_kernel(
     BLOCK_N: tl.constexpr,
 ):
     # set offset
-    pid_m = tl.program_id(0)
-    pid_k = tl.program_id(1)
+    pid_m = tle.program_id(0)
+    pid_k = tle.program_id(1)
     m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
     n_offset = tl.arange(0, BLOCK_N)
     offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k

--- a/src/flag_gems/ops/rand.py
+++ b/src/flag_gems/ops/rand.py
@@ -7,6 +7,8 @@ import triton.language as tl
 from flag_gems.utils.random_utils import philox_cuda_seed_offset, uint_to_uniform_float
 from flag_gems.utils.shape_utils import volume
 
+from ..utils import triton_lang_extension as tle
+
 
 def heur_block(args):
     if args["N"] <= 512:
@@ -42,7 +44,7 @@ def rand_kernel(
     philox_offset = philox_offset.to(tl.int64)
     c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
-    i4 = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    i4 = tle.program_id(0) * BLOCK + tl.arange(0, BLOCK)
     c0 += i4
     _O = c0 * 0
     r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, _O, _O)
@@ -50,7 +52,7 @@ def rand_kernel(
     r1 = uint_to_uniform_float(r1)
     r2 = uint_to_uniform_float(r2)
     r3 = uint_to_uniform_float(r3)
-    off_0 = tl.program_id(0) * BLOCK * 4 + tl.arange(0, BLOCK)
+    off_0 = tle.program_id(0) * BLOCK * 4 + tl.arange(0, BLOCK)
     off_1 = off_0 + BLOCK
     off_2 = off_1 + BLOCK
     off_3 = off_2 + BLOCK

--- a/src/flag_gems/ops/randn.py
+++ b/src/flag_gems/ops/randn.py
@@ -7,6 +7,8 @@ import triton.language as tl
 from flag_gems.utils.random_utils import philox_cuda_seed_offset, uint_to_uniform_float
 from flag_gems.utils.shape_utils import volume
 
+from ..utils import triton_lang_extension as tle
+
 try:
     pair_uniform_to_normal = tl.pair_uniform_to_normal
 except AttributeError:
@@ -54,7 +56,7 @@ def randn_kernel(
     philox_offset = philox_offset.to(tl.int64)
     c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
-    i4 = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    i4 = tle.program_id(0) * BLOCK + tl.arange(0, BLOCK)
     c0 += i4
     _O = c0 * 0
     r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, _O, _O)
@@ -64,7 +66,7 @@ def randn_kernel(
     r3 = uint_to_uniform_float(r3)
     n0, n1 = pair_uniform_to_normal(r0, r1)
     n2, n3 = pair_uniform_to_normal(r2, r3)
-    off_0 = tl.program_id(0) * BLOCK * 4 + tl.arange(0, BLOCK)
+    off_0 = tle.program_id(0) * BLOCK * 4 + tl.arange(0, BLOCK)
     off_1 = off_0 + BLOCK
     off_2 = off_1 + BLOCK
     off_3 = off_2 + BLOCK

--- a/src/flag_gems/ops/repeat.py
+++ b/src/flag_gems/ops/repeat.py
@@ -58,6 +58,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("from flag_gems.utils.shape_utils import volume")
     code.writeline("from flag_gems.utils.libentry import libentry")
     code.writeline("from flag_gems.utils.type_utils import type_promotion")
+    code.writeline("from flag_gems.utils import triton_lang_extension as tle")
     code.newline()
     code.newline()
     return code
@@ -275,11 +276,11 @@ def generate_repeat_kernel(
     with code.indent():
         # get pid
         code.writeline("# task id & masking")
-        pid_stmt = "pid = tl.program_id(0)"
+        pid_stmt = "pid = tle.program_id(0)"
         code.writeline(pid_stmt)
         function_ns.create_name("pid")
 
-        code.writeline("num_ctas = tl.num_programs(0)")
+        code.writeline("num_ctas = tle.num_programs(0)")
         function_ns.create_name("num_ctas")
 
         # get tid (a.k.a task id)

--- a/src/flag_gems/ops/repeat_interleave.py
+++ b/src/flag_gems/ops/repeat_interleave.py
@@ -4,6 +4,7 @@ import torch
 import triton
 from triton import language as tl
 
+from ..utils import triton_lang_extension as tle
 from ..utils.pointwise_dynamic import pointwise_dynamic
 from ..utils.shape_utils import c_contiguous_stride
 from ..utils.tensor_wrapper import StridedBuffer
@@ -63,7 +64,7 @@ def repeat_interleave_self_int(inp, repeats, dim=None, *, output_size=None):
 def repeat_interleave_tensor_kernel(
     repeats_ptr, cumsum_ptr, out_ptr, size, BLOCK_SIZE: tl.constexpr
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     mask = pid < size
     cumsum = tl.load(cumsum_ptr + pid, mask, other=0)
     repeats = tl.load(repeats_ptr + pid, mask, other=0)

--- a/src/flag_gems/ops/rms_norm.py
+++ b/src/flag_gems/ops/rms_norm.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
@@ -22,7 +23,7 @@ def rms_norm_kernel(
     eps,  # epsilon to avoid division by zero
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     Y += pid * y_stride_r
     X += pid * x_stride_r
 

--- a/src/flag_gems/ops/scatter.py
+++ b/src/flag_gems/ops/scatter.py
@@ -15,6 +15,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("import triton.language as tl")
     code.newline()
     code.writeline("from flag_gems.utils import libentry")
+    code.writeline("from flag_gems.utils import triton_lang_extension as tle")
     code.newline()
     code.newline()
     return code
@@ -92,8 +93,8 @@ def generate_scatter_kernel(
 
     # Kernel Code
     with code.indent():
-        code.writeline("pid_x = tl.program_id(0)")
-        code.writeline("pid_y = tl.program_id(1)")
+        code.writeline("pid_x = tle.program_id(0)")
+        code.writeline("pid_y = tle.program_id(1)")
         code.writeline(
             "rows_offsets = pid_x * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]"
         )

--- a/src/flag_gems/ops/select_scatter.py
+++ b/src/flag_gems/ops/select_scatter.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry, offsetCalculator, restride_dim
+from ..utils import triton_lang_extension as tle
 
 
 def cfggen():
@@ -30,7 +31,7 @@ def select_scatter_kernel(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     rows_offsets = pid * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     rows_mask = rows_offsets < M
 

--- a/src/flag_gems/ops/slice_scatter.py
+++ b/src/flag_gems/ops/slice_scatter.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry, offsetCalculator, restride_dim
+from ..utils import triton_lang_extension as tle
 
 
 def cfggen():
@@ -28,7 +29,7 @@ def slice_scatter_kernel(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     rows_offsets = pid * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     rows_mask = rows_offsets < M
 
@@ -179,8 +180,8 @@ def scatter_by_row_kernel(
     step,
     BLOCK: tl.constexpr,
 ):
-    pidx = tl.program_id(0)
-    pidy = tl.program_id(1)
+    pidx = tle.program_id(0)
+    pidy = tle.program_id(1)
 
     am_idx = pidx // N1
     an_idx = pidx % N1
@@ -282,8 +283,8 @@ def scatter_3d_mid_kernel(
     # Each cta processes one [1, NBLOCK, KBLOCK] chunk for input and output
     # The src chunk size is dynamically determined
 
-    pidx = tl.program_id(0)
-    pidy = tl.program_id(1)
+    pidx = tle.program_id(0)
+    pidy = tle.program_id(1)
 
     am_idx = pidx
     an_idx = pidy * NBLOCK
@@ -365,8 +366,8 @@ def scatter_2d_inner_kernel(
     R: tl.constexpr,
     C: tl.constexpr,
 ):
-    i0 = tl.program_id(0) * R
-    j0 = tl.program_id(1) * C
+    i0 = tle.program_id(0) * R
+    j0 = tle.program_id(1) * C
     ii = i0 + tl.arange(0, R)[:, None]
     jj = j0 + tl.arange(0, C)[None, :]
 
@@ -426,8 +427,8 @@ def scatter_2d_outer_kernel(
     NROW: tl.constexpr,
     NCOL: tl.constexpr,
 ):
-    pidx = tl.program_id(0)
-    pidy = tl.program_id(1)
+    pidx = tle.program_id(0)
+    pidy = tle.program_id(1)
 
     row_idx = pidx * NROW
     col_idx = pidy * NCOL

--- a/src/flag_gems/ops/softmax.py
+++ b/src/flag_gems/ops/softmax.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 MAX_TILE_K = 8192
 NUM_SMS = torch.cuda.get_device_properties(
@@ -62,8 +63,8 @@ def softmax_kernel_non_inner(
     TILE_K: tl.constexpr,
     ONE_TILE_PER_CTA: tl.constexpr,
 ):
-    pid_k = tl.program_id(1)
-    pid_m = tl.program_id(0)
+    pid_k = tle.program_id(1)
+    pid_m = tle.program_id(0)
 
     k_offsets = pid_k * TILE_K + tl.arange(0, TILE_K)
 
@@ -154,7 +155,7 @@ def softmax_kernel_inner(
     TILE_N: tl.constexpr,
     ONE_TILE_PER_CTA: tl.constexpr,
 ):
-    pid_m = tl.program_id(0)
+    pid_m = tle.program_id(0)
     if ONE_TILE_PER_CTA:
         n_offsets = tl.arange(0, TILE_N)
         offset = pid_m * N + n_offsets
@@ -254,8 +255,8 @@ def softmax_backward_kernel_non_inner(
     TILE_K: tl.constexpr,
     ONE_TILE_PER_CTA: tl.constexpr,
 ):
-    pid_m = tl.program_id(0)
-    pid_k = tl.program_id(1)
+    pid_m = tle.program_id(0)
+    pid_k = tle.program_id(1)
     offsets_k = pid_k * TILE_K + tl.arange(0, TILE_K)
 
     if ONE_TILE_PER_CTA:
@@ -325,7 +326,7 @@ def softmax_backward_kernel_inner(
     TILE_N: tl.constexpr,
     ONE_TILE_PER_CTA: tl.constexpr,
 ):
-    pid_m = tl.program_id(0)
+    pid_m = tle.program_id(0)
     m_offsets = pid_m * TILE_M + tl.arange(0, TILE_M)
     if ONE_TILE_PER_CTA:
         n_offsets = tl.arange(0, TILE_N)

--- a/src/flag_gems/ops/sum.py
+++ b/src/flag_gems/ops/sum.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from ..utils import dim_compress, libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
@@ -23,7 +24,7 @@ def sum_kernel_1(
     else:
         cdtype = inp.dtype.element_ty
 
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     inp_ptrs = inp + offset
     mask = offset < M
@@ -79,7 +80,7 @@ def sum_kernel(
         cdtype = inp.dtype.element_ty
 
     # Map the program id to the row of inp it should compute.
-    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    pid = tle.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     inp = inp + pid * N
     out = out + pid
     row_mask = pid < M

--- a/src/flag_gems/ops/tile.py
+++ b/src/flag_gems/ops/tile.py
@@ -58,6 +58,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("from flag_gems.utils.shape_utils import volume")
     code.writeline("from flag_gems.utils.libentry import libentry")
     code.writeline("from flag_gems.utils.type_utils import type_promotion")
+    code.writeline("from flag_gems.utils import triton_lang_extension as tle")
     code.newline()
     code.newline()
     return code
@@ -275,11 +276,11 @@ def generate_tile_kernel(
     with code.indent():
         # get pid
         code.writeline("# task id & masking")
-        pid_stmt = "pid = tl.program_id(0)"
+        pid_stmt = "pid = tle.program_id(0)"
         code.writeline(pid_stmt)
         function_ns.create_name("pid")
 
-        code.writeline("num_ctas = tl.num_programs(0)")
+        code.writeline("num_ctas = tle.num_programs(0)")
         function_ns.create_name("num_ctas")
 
         # get tid (a.k.a task id)

--- a/src/flag_gems/ops/topk.py
+++ b/src/flag_gems/ops/topk.py
@@ -8,6 +8,7 @@ import triton.language.core as core
 from triton.language.standard import _log2, zeros_like
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 _MIN_FLOAT32_VAL: tl.constexpr = torch.finfo(torch.float32).min
 _MAX_FLOAT32_VAL: tl.constexpr = torch.finfo(torch.float32).max
@@ -52,9 +53,9 @@ def topk_stage1_kernel(
     CHUNK_SIZE: tl.constexpr,
     DESCENDING: tl.constexpr,
 ):
-    cur_batch = tl.program_id(0)
-    cur_chunk_idx = tl.program_id(1)
-    chunk_num = tl.num_programs(1)
+    cur_batch = tle.program_id(0)
+    cur_chunk_idx = tle.program_id(1)
+    chunk_num = tle.num_programs(1)
 
     y_ptr += cur_batch * chunk_num * k + cur_chunk_idx * k
     index_ptr += cur_batch * chunk_num * k + cur_chunk_idx * k
@@ -215,7 +216,7 @@ def topk_stage2_kernel(
     BLOCK_SIZE: tl.constexpr,
     DESCENDING: tl.constexpr,
 ):
-    cur_batch = tl.program_id(0)
+    cur_batch = tle.program_id(0)
     chunk_x += cur_batch * N
     chunk_index += cur_batch * N
     y_ptr += cur_batch * k

--- a/src/flag_gems/ops/triu.py
+++ b/src/flag_gems/ops/triu.py
@@ -6,7 +6,6 @@ import triton.language as tl
 
 from ..utils import libentry
 from ..utils import triton_lang_extension as tle
-from ..utils.shape_utils import can_use_int32_index
 
 
 def cfggen():
@@ -38,11 +37,8 @@ def triu_kernel(
     diagonal,
     M_BLOCK_SIZE: tl.constexpr,
     N_BLOCK_SIZE: tl.constexpr,
-    INT64_INDEX: tl.constexpr = False,
 ):
     pid = tle.program_id(0)
-    if INT64_INDEX:
-        pid = pid.to(tl.int64)
     row = pid * M_BLOCK_SIZE + tl.arange(0, M_BLOCK_SIZE)[:, None]
     m_mask = row < M
     X += row * N
@@ -70,13 +66,9 @@ def triu_batch_kernel(
     diagonal,
     BATCH_BLOCK_SIZE: tl.constexpr,
     MN_BLOCK_SIZE: tl.constexpr,
-    INT64_INDEX: tl.constexpr = False,
 ):
     batch_id = tle.program_id(0)
     mn_id = tle.program_id(1)
-    if INT64_INDEX:
-        batch_id = batch_id.to(tl.int64)
-        mn_id = mn_id.to(tl.int64)
     row = batch_id * BATCH_BLOCK_SIZE + tl.arange(0, BATCH_BLOCK_SIZE)[:, None]
     batch_mask = row < batch
     X += row * MN
@@ -100,12 +92,11 @@ def triu(A, diagonal=0):
     A = A.contiguous()
     out = torch.empty_like(A)
     assert len(A.shape) > 1, "Input tensor must have at least 2 dimensions"
-    use_int64_index = not can_use_int32_index(A)
     M, N = A.shape[-2:]
     with torch.cuda.device(A.device):
         if len(A.shape) == 2:
             grid = lambda meta: (triton.cdiv(M, meta["M_BLOCK_SIZE"]),)
-            triu_kernel[grid](A, out, M, N, diagonal, INT64_INDEX=use_int64_index)
+            triu_kernel[grid](A, out, M, N, diagonal)
         else:
             batch = int(torch.numel(A) / M / N)
             B = A.view(batch, -1)
@@ -114,7 +105,12 @@ def triu(A, diagonal=0):
                 triton.cdiv(M * N, meta["MN_BLOCK_SIZE"]),
             )
             triu_batch_kernel[grid](
-                B, out, batch, M * N, N, diagonal, INT64_INDEX=use_int64_index
+                B,
+                out,
+                batch,
+                M * N,
+                N,
+                diagonal,
             )
             out = out.view(A.shape)
     return out

--- a/src/flag_gems/ops/triu.py
+++ b/src/flag_gems/ops/triu.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 from ..utils.shape_utils import can_use_int32_index
 
 
@@ -39,7 +40,7 @@ def triu_kernel(
     N_BLOCK_SIZE: tl.constexpr,
     INT64_INDEX: tl.constexpr = False,
 ):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     if INT64_INDEX:
         pid = pid.to(tl.int64)
     row = pid * M_BLOCK_SIZE + tl.arange(0, M_BLOCK_SIZE)[:, None]
@@ -71,8 +72,8 @@ def triu_batch_kernel(
     MN_BLOCK_SIZE: tl.constexpr,
     INT64_INDEX: tl.constexpr = False,
 ):
-    batch_id = tl.program_id(0)
-    mn_id = tl.program_id(1)
+    batch_id = tle.program_id(0)
+    mn_id = tle.program_id(1)
     if INT64_INDEX:
         batch_id = batch_id.to(tl.int64)
         mn_id = mn_id.to(tl.int64)

--- a/src/flag_gems/ops/uniform.py
+++ b/src/flag_gems/ops/uniform.py
@@ -7,6 +7,8 @@ import triton.language as tl
 from flag_gems.utils.random_utils import philox_cuda_seed_offset, uint_to_uniform_float
 from flag_gems.utils.shape_utils import volume
 
+from ..utils import triton_lang_extension as tle
+
 
 def heur_block(args):
     if args["N"] <= 512:
@@ -44,7 +46,7 @@ def uniform_kernel(
     philox_offset = philox_offset.to(tl.int64)
     c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
-    i4 = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    i4 = tle.program_id(0) * BLOCK + tl.arange(0, BLOCK)
     c0 += i4
     _O = c0 * 0
     r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, _O, _O)
@@ -52,7 +54,7 @@ def uniform_kernel(
     r1 = uint_to_uniform_float(r1) * (to - from_) + from_
     r2 = uint_to_uniform_float(r2) * (to - from_) + from_
     r3 = uint_to_uniform_float(r3) * (to - from_) + from_
-    off_0 = tl.program_id(0) * BLOCK * 4 + tl.arange(0, BLOCK)
+    off_0 = tle.program_id(0) * BLOCK * 4 + tl.arange(0, BLOCK)
     off_1 = off_0 + BLOCK
     off_2 = off_1 + BLOCK
     off_3 = off_2 + BLOCK

--- a/src/flag_gems/ops/unique.py
+++ b/src/flag_gems/ops/unique.py
@@ -4,6 +4,8 @@ import triton.language as tl
 
 from flag_gems.utils.libentry import libentry
 
+from ..utils import triton_lang_extension as tle
+
 
 @libentry()
 @triton.jit
@@ -87,8 +89,8 @@ def output_counts_flat_kernel(
     tiles_per_cta: int,
     tile_size: tl.constexpr,
 ):
-    pid = tl.program_id(0)
-    ctas_num = tl.num_programs(0)
+    pid = tle.program_id(0)
+    ctas_num = tle.num_programs(0)
     # grid-stride-loop style kernel
     for j in range(0, tiles_per_cta):
         global_pid = pid + j * ctas_num
@@ -148,8 +150,8 @@ def quick_output_flat_kernel(
     tiles_per_cta: int,
     tile_size: tl.constexpr,
 ):
-    pid = tl.program_id(0)
-    ctas_num = tl.num_programs(0)
+    pid = tle.program_id(0)
+    ctas_num = tle.num_programs(0)
     # grid-stride-loop style kernel
     for j in range(0, tiles_per_cta):
         global_pid = pid + j * ctas_num
@@ -227,8 +229,8 @@ def local_quick_unique_flat_kernel(
     tile_size: tl.constexpr,
     return_counts: tl.constexpr,
 ):
-    pid = tl.program_id(0)
-    ctas_num = tl.num_programs(0)
+    pid = tle.program_id(0)
+    ctas_num = tle.num_programs(0)
     # grid-stride-loop style kernel
     for j in range(0, tiles_per_cta):
         global_pid = pid + j * ctas_num
@@ -315,8 +317,8 @@ def global_quick_unique_flat_kernel(
     one_tile_per_cta: tl.constexpr,
     return_counts: tl.constexpr,
 ):
-    pid = tl.program_id(0)
-    ctas_num = tl.num_programs(0)
+    pid = tle.program_id(0)
+    ctas_num = tle.num_programs(0)
     if one_tile_per_cta:  # monolitic kernel style
         global_quick_unique_flat_impl(
             pid,
@@ -484,8 +486,8 @@ def local_ne_flat_kernel(
     tiles_per_cta: int,
     tile_size: tl.constexpr,
 ):
-    pid = tl.program_id(0)
-    ctas_num = tl.num_programs(0)
+    pid = tle.program_id(0)
+    ctas_num = tle.num_programs(0)
     # grid-stride-loop style kernel
     for j in range(0, tiles_per_cta):
         global_pid = pid + j * ctas_num
@@ -588,8 +590,8 @@ def global_cumsum_flat_kernel(
     one_tile_per_cta: tl.constexpr,
     return_counts: tl.constexpr,
 ):
-    pid = tl.program_id(0)
-    ctas_num = tl.num_programs(0)
+    pid = tle.program_id(0)
+    ctas_num = tle.num_programs(0)
     if one_tile_per_cta:  # monolitic kernel style
         global_cumsum_flat_impl(
             pid,

--- a/src/flag_gems/ops/upsample_bicubic2d_aa.py
+++ b/src/flag_gems/ops/upsample_bicubic2d_aa.py
@@ -5,6 +5,8 @@ import torch
 import triton
 import triton.language as tl
 
+from ..utils import triton_lang_extension as tle
+
 
 def configs():
     block = [(bx, by) for bx in (512, 256, 128, 64) for by in (2, 1)]
@@ -38,8 +40,8 @@ def upsample_bicubic2d_aa_kernel(
     BLOCK_X: tl.constexpr,
     BLOCK_Y: tl.constexpr,
 ):
-    pid_x = tl.program_id(axis=0)
-    pid_y = tl.program_id(axis=1)
+    pid_x = tle.program_id(axis=0)
+    pid_y = tle.program_id(axis=1)
     ow = (pid_x * BLOCK_X + tl.arange(0, BLOCK_X)) % OW
     oh = (pid_y * BLOCK_Y + tl.arange(0, BLOCK_Y)) % OH
 
@@ -389,8 +391,8 @@ def general_interpolate_bicubic2d_aa_kernel(
     BLOCK_X: tl.constexpr,
     BLOCK_Y: tl.constexpr,
 ):
-    pid_x = tl.program_id(axis=0)
-    pid_y = tl.program_id(axis=1)
+    pid_x = tle.program_id(axis=0)
+    pid_y = tle.program_id(axis=1)
     ow = (pid_x * BLOCK_X + tl.arange(0, BLOCK_X)) % OW
     oh = (pid_y * BLOCK_Y + tl.arange(0, BLOCK_Y)) % OH
 

--- a/src/flag_gems/ops/upsample_nearest2d.py
+++ b/src/flag_gems/ops/upsample_nearest2d.py
@@ -5,6 +5,8 @@ import torch
 import triton
 import triton.language as tl
 
+from ..utils import triton_lang_extension as tle
+
 
 def configs():
     block = [1024, 2048]
@@ -37,7 +39,7 @@ def upsample_nearest2d_kernel(
     SAME_H: tl.constexpr,
     SAME_W: tl.constexpr,
 ):
-    pid = tl.program_id(axis=0)
+    pid = tle.program_id(axis=0)
     idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     ow = idx % OW
     oh = idx // OW % OH

--- a/src/flag_gems/ops/var_mean.py
+++ b/src/flag_gems/ops/var_mean.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import dim_compress, libentry
+from ..utils import triton_lang_extension as tle
 
 
 def cfggen():
@@ -45,7 +46,7 @@ def var_mean_welford_kernel(
     BLOCK_N: tl.constexpr,
 ):
     # Map the program id to the row of X it should compute.
-    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    pid = tle.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     X = X + pid * N
     Var = Var + pid
     Mean = Mean + pid
@@ -88,7 +89,7 @@ def var_mean_kernel_1(
     BLOCK_N: tl.constexpr,
 ):
     # Map the program id to the row of X it should compute.
-    pid = tl.program_id(0)
+    pid = tle.program_id(0)
     offset = pid * BLOCK_N + tl.arange(0, BLOCK_N)
 
     X = X + offset

--- a/src/flag_gems/ops/vector_norm.py
+++ b/src/flag_gems/ops/vector_norm.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from ..utils import dim_compress, libentry
+from ..utils import triton_lang_extension as tle
 
 try:
     from triton.language.extra.cuda.libdevice import pow
@@ -28,7 +29,7 @@ def cfggen():
 @triton.autotune(configs=cfggen(), key=["M", "N"])
 @triton.jit
 def l2_norm_kernel(X, Out, M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
-    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    pid = tle.program_id(0).to(tl.int64) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     X = X + pid * N
     Out = Out + pid
     row_mask = pid < M
@@ -50,7 +51,7 @@ def l2_norm_kernel(X, Out, M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
 @libentry()
 @triton.jit
 def l2_norm_kernel_1(X, Mid, M, BLOCK_SIZE: tl.constexpr):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0).to(tl.int64)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     X = X + offset
     Mid = Mid + pid
@@ -76,7 +77,7 @@ def l2_norm_kernel_2(Mid, Out, MID_SIZE, BLOCK_MID: tl.constexpr):
 @triton.autotune(configs=cfggen(), key=["M", "N"])
 @triton.jit
 def max_norm_kernel(X, Out, M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
-    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    pid = tle.program_id(0).to(tl.int64) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     X = X + pid * N
     Out = Out + pid
     row_mask = pid < M
@@ -98,7 +99,7 @@ def max_norm_kernel(X, Out, M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
 @libentry()
 @triton.jit
 def max_norm_kernel_1(X, Mid, M, BLOCK_SIZE: tl.constexpr):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0).to(tl.int64)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     X = X + offset
     Mid = Mid + pid
@@ -124,7 +125,7 @@ def max_norm_kernel_2(Mid, Out, MID_SIZE, BLOCK_MID: tl.constexpr):
 @triton.autotune(configs=cfggen(), key=["M", "N"])
 @triton.jit
 def min_norm_kernel(X, Out, M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
-    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    pid = tle.program_id(0).to(tl.int64) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     X = X + pid * N
     Out = Out + pid
     row_mask = pid < M
@@ -146,7 +147,7 @@ def min_norm_kernel(X, Out, M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
 @libentry()
 @triton.jit
 def min_norm_kernel_1(X, Mid, M, BLOCK_SIZE: tl.constexpr):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0).to(tl.int64)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     X = X + offset
     Mid = Mid + pid
@@ -172,7 +173,7 @@ def min_norm_kernel_2(Mid, Out, MID_SIZE, BLOCK_MID: tl.constexpr):
 @triton.autotune(configs=cfggen(), key=["M", "N"])
 @triton.jit
 def l0_norm_kernel(X, Out, M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
-    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    pid = tle.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     X = X + pid * N
     Out = Out + pid
     row_mask = pid < M
@@ -193,7 +194,7 @@ def l0_norm_kernel(X, Out, M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
 @libentry()
 @triton.jit
 def l0_norm_kernel_1(X, Mid, M, BLOCK_SIZE: tl.constexpr):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0).to(tl.int64)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     X = X + offset
     Mid = Mid + pid
@@ -220,7 +221,7 @@ def l0_norm_kernel_2(Mid, Out, MID_SIZE, BLOCK_MID: tl.constexpr):
 @triton.autotune(configs=cfggen(), key=["M", "N"])
 @triton.jit(do_not_specialize=["ord"])
 def v_norm_kernel(X, Out, M, N, ord, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
-    pid = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    pid = tle.program_id(0).to(tl.int64) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     X = X + pid * N
     Out = Out + pid
     row_mask = pid < M
@@ -241,7 +242,7 @@ def v_norm_kernel(X, Out, M, N, ord, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexp
 @libentry()
 @triton.jit(do_not_specialize=["ord"])
 def l1_norm_kernel_1(X, Mid, ord, M, BLOCK_SIZE: tl.constexpr):
-    pid = tl.program_id(0)
+    pid = tle.program_id(0).to(tl.int64)
     offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     X = X + offset
     Mid = Mid + pid

--- a/src/flag_gems/ops/vector_norm.py
+++ b/src/flag_gems/ops/vector_norm.py
@@ -274,7 +274,7 @@ def vector_norm(x, ord=2, dim=None, keepdim=False, dtype=None):
         raise NotImplementedError(f"vector_norm not implemented for {dtype}")
 
     with torch.cuda.device(x.device):
-        if dim is None or len(dim) == x.ndim:
+        if (not dim) or len(dim) == x.ndim:
             dim = list(range(x.ndim))
             shape = [1] * x.ndim
             x = dim_compress(x, dim)

--- a/src/flag_gems/ops/vstack.py
+++ b/src/flag_gems/ops/vstack.py
@@ -5,6 +5,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 @libentry()
@@ -38,8 +39,8 @@ def vstack_kernel(
     max_tile_elems,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid_x = tl.program_id(axis=0)
-    tensor_idx = tl.program_id(axis=1)
+    pid_x = tle.program_id(axis=0)
+    tensor_idx = tle.program_id(axis=1)
     col_idx = tl.arange(0, BLOCK_SIZE)
 
     intensor_ptr = tl.where(tensor_idx == 0, itensor_ptr0, itensor_ptr1)

--- a/src/flag_gems/ops/weightnorm.py
+++ b/src/flag_gems/ops/weightnorm.py
@@ -6,6 +6,7 @@ import triton
 import triton.language as tl
 
 from ..utils import libentry
+from ..utils import triton_lang_extension as tle
 
 
 def cfggen_first():
@@ -62,7 +63,7 @@ def weight_norm_kernel_last(
     BLOCK_COL_SIZE: tl.constexpr,
 ):
     tx = tl.arange(0, BLOCK_COL_SIZE)[:, None]
-    bx = tl.program_id(axis=0) * BLOCK_COL_SIZE
+    bx = tle.program_id(axis=0) * BLOCK_COL_SIZE
     col_offset = bx + tx
     col_mask = col_offset < N
 
@@ -102,7 +103,7 @@ def weight_norm_kernel_first(
     BLOCK_COL_SIZE: tl.constexpr,
 ):
     ty = tl.arange(0, BLOCK_ROW_SIZE)[:, None]
-    by = tl.program_id(axis=0) * BLOCK_ROW_SIZE
+    by = tle.program_id(axis=0) * BLOCK_ROW_SIZE
     row_offset = by + ty
     row_mask = row_offset < M
 
@@ -144,7 +145,7 @@ def weight_norm_bwd_kernel_last(
     BLOCK_COL_SIZE: tl.constexpr,
 ):
     tx = tl.arange(0, BLOCK_COL_SIZE)[:, None]
-    bx = tl.program_id(axis=0) * BLOCK_COL_SIZE
+    bx = tle.program_id(axis=0) * BLOCK_COL_SIZE
     col_offset = tx + bx
     col_mask = col_offset < N
 
@@ -194,7 +195,7 @@ def weight_norm_bwd_kernel_first(
     BLOCK_COL_SIZE: tl.constexpr,
 ):
     ty = tl.arange(0, BLOCK_ROW_SIZE)[:, None]
-    by = tl.program_id(axis=0) * BLOCK_ROW_SIZE
+    by = tle.program_id(axis=0) * BLOCK_ROW_SIZE
     row_offset = by + ty
     row_mask = row_offset < M
 
@@ -241,7 +242,7 @@ def norm_kernel(
     BLOCK_COL_SIZE: tl.constexpr,
 ):
     tid_m = tl.arange(0, BLOCK_ROW_SIZE)[:, None]
-    pid = tl.program_id(axis=0) * BLOCK_ROW_SIZE
+    pid = tle.program_id(axis=0) * BLOCK_ROW_SIZE
     row_offset = pid + tid_m
     row_mask = row_offset < v_shape1
 
@@ -279,7 +280,7 @@ def norm_bwd_kernel(
     BLOCK_COL_SIZE: tl.constexpr,
 ):
     tid_m = tl.arange(0, BLOCK_ROW_SIZE)[:, None]
-    pid = tl.program_id(axis=0) * BLOCK_ROW_SIZE
+    pid = tle.program_id(axis=0) * BLOCK_ROW_SIZE
     row_offset = pid + tid_m
     row_mask = row_offset < v_shape1
 

--- a/src/flag_gems/ops/zeros.py
+++ b/src/flag_gems/ops/zeros.py
@@ -6,6 +6,8 @@ import triton.language as tl
 
 from flag_gems.utils.shape_utils import volume
 
+from ..utils import triton_lang_extension as tle
+
 
 @triton.jit
 def zeros_kernel(
@@ -13,7 +15,7 @@ def zeros_kernel(
     n_elements,
     BLOCK_SIZE: tl.constexpr,
 ):
-    pid = tl.program_id(axis=0)  # We use a 1D launch grid so axis is 0.
+    pid = tle.program_id(axis=0)  # We use a 1D launch grid so axis is 0.
     block_start = pid * BLOCK_SIZE
     offsets = block_start + tl.arange(0, BLOCK_SIZE)
     mask = offsets < n_elements

--- a/src/flag_gems/utils/pointwise_dynamic.py
+++ b/src/flag_gems/utils/pointwise_dynamic.py
@@ -612,7 +612,7 @@ class KernelGenerator:
             return code
 
         with code.indent():
-            code.writeline("pid = tl.program_id(0)")
+            code.writeline("pid = tle.program_id(0)")
             self.gen_num_tiles(code)
             # monolitic kernel: one_tile_per_cta, it may requires a very large grid to compute
             code.writeline("if one_tile_per_cta: # monolitic kernel style")
@@ -638,7 +638,7 @@ class KernelGenerator:
             return code
 
         with code.indent():
-            code.writeline("pid = tl.program_id(0)")
+            code.writeline("pid = tle.program_id(0)")
             self.gen_num_tiles(code)
             # monolitic kernel: one_tile_per_cta, it may requires a very large grid to compute
             code.writeline("if one_tile_per_cta: # monolitic kernel style")
@@ -731,7 +731,7 @@ class KernelGenerator:
             return code
 
         with code.indent():
-            code.writeline("pid = tl.program_id(0)")
+            code.writeline("pid = tle.program_id(0)")
             # code.writeline("num_ctas = tl.num_programs(0)")
             # monolitic kernel: one_tile_per_cta, it may requires a very large grid to compute
             code.writeline("if one_tile_per_cta: # monolitic kernel style")

--- a/src/flag_gems/utils/pointwise_dynamic.py
+++ b/src/flag_gems/utils/pointwise_dynamic.py
@@ -1048,6 +1048,7 @@ class ModuleGenerator:
         code.writeline(")")
         code.writeline("from flag_gems.utils.tensor_wrapper import StridedBuffer")
         code.writeline("from flag_gems.utils.libentry import libentry")
+        code.writeline("from flag_gems.utils import triton_lang_extension as tle")
         code.newline()
         code.newline()
         return code

--- a/src/flag_gems/utils/pointwise_dynamic.py
+++ b/src/flag_gems/utils/pointwise_dynamic.py
@@ -467,7 +467,10 @@ class KernelGenerator:
         # cta_offsets
         code.writeline("# tile offsets")
         for i in range(ndim):
-            code.writeline(f"offset{i} = tile_id{i} * tile_size{i}")
+            # Or else: AssertionError: Block pointers only support 32 bit
+            # `offsets/block_shape`, add a `.to(tl.int32)` or use regular indexing
+            # for 64 bit support
+            code.writeline(f"offset{i} = (tile_id{i} * tile_size{i}).to(tl.int32)")
 
         # loads
         code.writeline("# loads")
@@ -517,7 +520,7 @@ class KernelGenerator:
             )
 
     def gen_body_gsl_with_bptr(self, code):
-        code.writeline("num_ctas = tl.num_programs(0)")
+        code.writeline("num_ctas = tle.num_programs(0)")
         code.writeline("for j in range(0, tiles_per_cta):")
         with code.indent():
             code.writeline("tile_id = pid + j * num_ctas")
@@ -593,7 +596,7 @@ class KernelGenerator:
             )
 
     def gen_body_gsl_without_bptr(self, code):
-        code.writeline("num_ctas = tl.num_programs(0)")
+        code.writeline("num_ctas = tle.num_programs(0)")
         code.writeline("for j in range(0, tiles_per_cta):")
         with code.indent():
             code.writeline("tile_id = pid + j * num_ctas")
@@ -712,7 +715,7 @@ class KernelGenerator:
             )
 
     def gen_body_gsl_1d_tile(self, code):
-        code.writeline("num_ctas = tl.num_programs(0)")
+        code.writeline("num_ctas = tle.num_programs(0)")
         code.writeline("for j in range(0, tiles_per_cta):")
         with code.indent():
             code.writeline("tile_id = pid + j * num_ctas")
@@ -732,7 +735,7 @@ class KernelGenerator:
 
         with code.indent():
             code.writeline("pid = tle.program_id(0)")
-            # code.writeline("num_ctas = tl.num_programs(0)")
+            # code.writeline("num_ctas = te.num_programs(0)")
             # monolitic kernel: one_tile_per_cta, it may requires a very large grid to compute
             code.writeline("if one_tile_per_cta: # monolitic kernel style")
             with code.indent():

--- a/src/flag_gems/utils/shape_utils.py
+++ b/src/flag_gems/utils/shape_utils.py
@@ -6,6 +6,8 @@ import torch
 import triton
 import triton.language as tl
 
+from ..utils import triton_lang_extension as tle
+
 Shape = Tuple[int]
 Stride = Tuple[int]
 MultiIndex = Tuple[int]
@@ -252,8 +254,8 @@ def add_on_kernel(
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
-    pid_x = tl.program_id(axis=0)
-    pid_y = tl.program_id(axis=1)
+    pid_x = tle.program_id(axis=0)
+    pid_y = tle.program_id(axis=1)
     rows_offset = pid_x * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
     rows_mask = rows_offset < M
 

--- a/src/flag_gems/utils/triton_lang_extension.py
+++ b/src/flag_gems/utils/triton_lang_extension.py
@@ -1,0 +1,28 @@
+"""
+Triton device functions.
+
+Custom triton device functions that we need to use.
+
+NOTE:
+Do not try to add triton builtin-style functions(functions with an ir builder in its
+arguments) here. We only define device-functions(triton.jit decorated functions with
+return statement) here.
+
+These functions can be used in kernel progamming and are not bound to any grid.
+"""
+import triton
+from triton import language as tl
+
+
+@triton.jit
+def program_id(
+    axis: int,
+) -> tl.tensor:
+    return tl.program_id(axis).to(tl.int64)
+
+
+@triton.jit
+def num_programs(
+    axis: int,
+) -> tl.tensor:
+    return tl.num_programs(axis).to(tl.int64)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Other

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
add program_id & num_programs that returns tensor in tl.int64 to avoid integer overflow

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
Offset calculating and indexing is triton is usually done in int32 if not coded carefully. For example:

```python
offset1 = pid1 * TILE_SIZE1 + tl.arange(0, TILE_SIZE1)
offsets = offset1 * stride1 + offset2 * stride2 + ...
x = tl.load(ptr + offsets)
```

It is possible that `offsets` exceeds the limit of int32 and overflows into some very large negative number, and that `ptr+ offsets` points to some illegal memory addresses.

Since most indexing code begins at `tl.program_id` and `tl.num_programs`, if we make them `int64`, consecutive indexing code would be in `int64`, thus avoids overflow.

It is also possible to avoid this by writing indexing code carefully

```python
x = tl.load(ptr + offset1 * stride1 + offset2 * stride2 + ...)
```

instead of

```python
x = tl.load(ptr + (offset1 * stride1 + offset2 * stride2 + ...))
```

But rewriting a lot of indexing code is tedious, so we add a module to collect some utility triton.jitted fucntions to do this.

Import the module by
`from flag_gems.utils import triton_lang_extension as tle`
and use `tle.program_id` and `tle.num_programs` instead of `tl.program_id` and `tl.num_programs` will work.