### PR TITLE
fix online softmax where there are inf's in the input

### DIFF
--- a/src/flag_gems/ops/softmax.py
+++ b/src/flag_gems/ops/softmax.py
@@ -90,8 +90,8 @@ def softmax_kernel_non_inner(
             mask = (n_offsets[:, None] < N) & (k_offsets < K)
             inp = tl.load(input_ptr + offsets, mask=mask, other=-float("inf"))
             m_new = tl.maximum(m, inp)
-            alpha = tl.exp(m - m_new)
-            z = z * alpha + tl.exp(inp - m_new)
+            all_neg_inf = m_new == float("-inf")
+            z = tl.where(all_neg_inf, z, z * tl.exp(m - m_new) + tl.exp(inp - m_new))
             m = m_new
 
         m_reduced = tl.max(m, 0)  # (TILE_K,)

--- a/src/flag_gems/ops/softmax.py
+++ b/src/flag_gems/ops/softmax.py
@@ -43,6 +43,7 @@ def heur_num_warps_non_inner(args):
         return 16
 
 
+@libentry()
 @triton.heuristics(
     {
         "TILE_K": heur_tile_k,
@@ -138,6 +139,7 @@ def heur_num_warps_inner(args):
         return 16
 
 
+@libentry()
 @triton.heuristics(
     {
         "TILE_N": heur_tile_n_inner,


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Fix online softmax where there are inf's in the input. Since online softmax algorithm is used in loop-style softmax-kernel.

The update rule for m & z is(note that we use a binary combine & reduce in epilogue style):

```python
m = tl.full([TILE_N], value=float("-inf"), dtype=tl.float32)
z = tl.full([TILE_N], value=0.0, dtype=tl.float32)
for ...:
  inp = tl.load(input_ptr + n_offsets)
  m_new = tl.maximum(m, inp)
  z = z * tl.exp(m - m_new) + tl.exp(inp - m_new))
  m = m_new
```

It is possible that the new_new is still `-inf`, thus `m - m_new` and `inp - m_new` are nan. To fix this, we need to skip those `-inf`s, they contribute nothing to the normalizer z.

Here is the fix.

```python
all_neg_inf = m_new == float("-inf")
z = tl.where(all_neg_inf, z, z * tl.exp(m - m_new) + tl.exp(inp - m_new))
m = m_new
```

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
