### PR TITLE
[bugfix] replace tle with tl for operators using philox

### DIFF
--- a/src/flag_gems/ops/dropout.py
+++ b/src/flag_gems/ops/dropout.py
@@ -6,8 +6,6 @@ import triton.language as tl
 
 from flag_gems.utils.random_utils import philox_cuda_seed_offset, uint_to_uniform_float
 
-from ..utils import triton_lang_extension as tle
-
 
 def heur_block(args):
     if args["N"] <= 512:
@@ -46,7 +44,7 @@ def dropout_forward_kernel(
     philox_offset = philox_offset.to(tl.int64)
     c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
-    i4 = tle.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    i4 = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
     c0 += i4
     _O = c0 * 0
     r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, _O, _O)
@@ -61,7 +59,7 @@ def dropout_forward_kernel(
     mask3 = r3 > p
     p = 1.0 / (1.0 - p)
 
-    off_0 = tle.program_id(0) * BLOCK * UNROLL + tl.arange(0, BLOCK)
+    off_0 = tl.program_id(0) * BLOCK * UNROLL + tl.arange(0, BLOCK)
     off_1 = off_0 + BLOCK
     off_2 = off_1 + BLOCK
     off_3 = off_2 + BLOCK
@@ -103,7 +101,7 @@ def dropout_backward_kernel(
     philox_offset = philox_offset.to(tl.int64)
     c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
-    i4 = tle.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    i4 = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
     c0 += i4
     _O = c0 * 0
     r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, _O, _O)
@@ -116,7 +114,7 @@ def dropout_backward_kernel(
     mask1 = r1 > p
     mask2 = r2 > p
     mask3 = r3 > p
-    off_0 = tle.program_id(0) * BLOCK * UNROLL + tl.arange(0, BLOCK)
+    off_0 = tl.program_id(0) * BLOCK * UNROLL + tl.arange(0, BLOCK)
     off_1 = off_0 + BLOCK
     off_2 = off_1 + BLOCK
     off_3 = off_2 + BLOCK

--- a/src/flag_gems/ops/exponential_.py
+++ b/src/flag_gems/ops/exponential_.py
@@ -6,8 +6,6 @@ import triton.language as tl
 
 from flag_gems.utils.random_utils import philox_cuda_seed_offset, uint_to_uniform_float
 
-from ..utils import triton_lang_extension as tle
-
 
 def heur_block(args):
     if args["N"] <= 512:
@@ -46,7 +44,7 @@ def fused_exponential_kernel(
     philox_offset = philox_offset.to(tl.int64)
     c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
-    i4 = tle.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    i4 = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
     c0 += i4
     _O = c0 * 0
     r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, _O, _O)
@@ -56,7 +54,7 @@ def fused_exponential_kernel(
         y0 = transform_exponential(d0, lambd, eps)
         y1 = transform_exponential(d1, lambd, eps)
         UNROLL = 2
-        start = tle.program_id(0).to(tl.uint64) * BLOCK * UNROLL
+        start = tl.program_id(0).to(tl.uint64) * BLOCK * UNROLL
         off_0 = start + tl.arange(0, BLOCK)
         off_1 = off_0 + BLOCK
         tl.store(out_ptr + off_0, y0, mask=off_0 < N, eviction_policy="evict_first")
@@ -71,7 +69,7 @@ def fused_exponential_kernel(
         y2 = transform_exponential(f2, lambd, eps)
         y3 = transform_exponential(f3, lambd, eps)
         UNROLL = 4
-        start = tle.program_id(0).to(tl.uint64) * BLOCK * UNROLL
+        start = tl.program_id(0).to(tl.uint64) * BLOCK * UNROLL
         off_0 = start + tl.arange(0, BLOCK)
         off_1 = off_0 + BLOCK
         off_2 = off_1 + BLOCK

--- a/src/flag_gems/ops/ones.py
+++ b/src/flag_gems/ops/ones.py
@@ -6,9 +6,11 @@ import triton.language as tl
 
 from flag_gems.utils.shape_utils import volume
 
+from ..utils import libentry
 from ..utils import triton_lang_extension as tle
 
 
+@libentry()
 @triton.jit
 def ones_kernel(
     output_ptr,
@@ -31,7 +33,8 @@ def ones(size, *, dtype=None, layout=None, device=None, pin_memory=None):
 
     out = torch.empty(size, device=device, dtype=dtype)
     N = volume(size)
-    grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE"]),)
+    BLOCK_SIZE = 1024
+    grid = (triton.cdiv(N, BLOCK_SIZE),)
     with torch.cuda.device(device):
-        ones_kernel[grid_fn](out, N, BLOCK_SIZE=1024)
+        ones_kernel[grid](out, N, BLOCK_SIZE)
     return out

--- a/src/flag_gems/ops/rand.py
+++ b/src/flag_gems/ops/rand.py
@@ -7,8 +7,6 @@ import triton.language as tl
 from flag_gems.utils.random_utils import philox_cuda_seed_offset, uint_to_uniform_float
 from flag_gems.utils.shape_utils import volume
 
-from ..utils import triton_lang_extension as tle
-
 
 def heur_block(args):
     if args["N"] <= 512:
@@ -44,7 +42,7 @@ def rand_kernel(
     philox_offset = philox_offset.to(tl.int64)
     c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
-    i4 = tle.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    i4 = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
     c0 += i4
     _O = c0 * 0
     r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, _O, _O)
@@ -52,7 +50,7 @@ def rand_kernel(
     r1 = uint_to_uniform_float(r1)
     r2 = uint_to_uniform_float(r2)
     r3 = uint_to_uniform_float(r3)
-    off_0 = tle.program_id(0) * BLOCK * 4 + tl.arange(0, BLOCK)
+    off_0 = tl.program_id(0) * BLOCK * 4 + tl.arange(0, BLOCK)
     off_1 = off_0 + BLOCK
     off_2 = off_1 + BLOCK
     off_3 = off_2 + BLOCK

--- a/src/flag_gems/ops/randn.py
+++ b/src/flag_gems/ops/randn.py
@@ -7,8 +7,6 @@ import triton.language as tl
 from flag_gems.utils.random_utils import philox_cuda_seed_offset, uint_to_uniform_float
 from flag_gems.utils.shape_utils import volume
 
-from ..utils import triton_lang_extension as tle
-
 try:
     pair_uniform_to_normal = tl.pair_uniform_to_normal
 except AttributeError:
@@ -56,7 +54,7 @@ def randn_kernel(
     philox_offset = philox_offset.to(tl.int64)
     c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
-    i4 = tle.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    i4 = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
     c0 += i4
     _O = c0 * 0
     r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, _O, _O)
@@ -66,7 +64,7 @@ def randn_kernel(
     r3 = uint_to_uniform_float(r3)
     n0, n1 = pair_uniform_to_normal(r0, r1)
     n2, n3 = pair_uniform_to_normal(r2, r3)
-    off_0 = tle.program_id(0) * BLOCK * 4 + tl.arange(0, BLOCK)
+    off_0 = tl.program_id(0) * BLOCK * 4 + tl.arange(0, BLOCK)
     off_1 = off_0 + BLOCK
     off_2 = off_1 + BLOCK
     off_3 = off_2 + BLOCK

--- a/src/flag_gems/ops/randperm.py
+++ b/src/flag_gems/ops/randperm.py
@@ -7,7 +7,6 @@ import triton.language as tl
 from flag_gems.utils.random_utils import philox_cuda_seed_offset
 
 from ..utils import libentry
-from ..utils import triton_lang_extension as tle
 from .topk import argsort
 
 _MIN_INT8_VAL: tl.constexpr = torch.iinfo(torch.int8).min
@@ -69,7 +68,7 @@ def bitonic_sortbykey_kernel(
     BLOCK_SIZE: tl.constexpr,
     DESCENDING: tl.constexpr,
 ):
-    cur_batch = tle.program_id(0)
+    cur_batch = tl.program_id(0)
     chunk_x += cur_batch * N
     chunk_index += cur_batch * N
     index_ptr += cur_batch * N
@@ -126,9 +125,9 @@ def digit_hist_kernel(
     bins_segment,
     BLOCK_SIZE: tl.constexpr,
 ):
-    bin_segid = tle.program_id(1)
-    pid0 = tle.program_id(0)
-    grid0 = tle.num_programs(0)
+    bin_segid = tl.program_id(1)
+    pid0 = tl.program_id(0)
+    grid0 = tl.num_programs(0)
 
     key_offset = pid0.to(tl.int64) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     key_mask = key_offset < n_elements
@@ -181,7 +180,7 @@ def radix_sortbykey_scatter_kernel(
     LOOKBACK_KIND_MASK = LOOKBACK_PARTIAL_MASK | LOOKBACK_GLOBAL_MASK
     LOOKBACK_VALUE_MASK = ~LOOKBACK_KIND_MASK
 
-    pid0 = tle.program_id(0)
+    pid0 = tl.program_id(0)
     portion_id_i64 = portion_id
     portion_id_i64 = portion_id_i64.to(tl.int64)
     key_offset = (
@@ -197,8 +196,8 @@ def radix_sortbykey_scatter_kernel(
     ikey_data = radix_type_convert(key_data)
     key_digit = (ikey_data >> bit_offset) & bit_mask
 
-    blk_bin_start = tle.program_id(1) * bins_segment
-    last_block = tle.program_id(0) == tle.num_programs(0) - 1
+    blk_bin_start = tl.program_id(1) * bins_segment
+    last_block = tl.program_id(0) == tl.num_programs(0) - 1
     for s in range(bins_segment):
         bin_id = s + blk_bin_start
         key_digit_mask = (key_digit == bin_id) & key_mask
@@ -260,7 +259,7 @@ def radix_sortbykey_scatter_kernel(
 def duplicate_keys_shuffle_kernel(
     value_in, n_elements, philox_seed, philox_offset, BLOCK_SIZE: tl.constexpr
 ):
-    pid0 = tle.program_id(0)
+    pid0 = tl.program_id(0)
     offset_range = tl.arange(0, BLOCK_SIZE)
     value_offset = pid0.to(tl.int64) * BLOCK_SIZE + offset_range
     value_mask = value_offset < n_elements
@@ -270,7 +269,7 @@ def duplicate_keys_shuffle_kernel(
     philox_offset = philox_offset.to(tl.int64)
     c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
-    i4 = tle.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    i4 = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     c0 += i4
     _O = c0 * 0
     r0, _, _, _ = tl.philox(philox_seed, c0, c1, _O, _O)

--- a/src/flag_gems/ops/uniform.py
+++ b/src/flag_gems/ops/uniform.py
@@ -7,8 +7,6 @@ import triton.language as tl
 from flag_gems.utils.random_utils import philox_cuda_seed_offset, uint_to_uniform_float
 from flag_gems.utils.shape_utils import volume
 
-from ..utils import triton_lang_extension as tle
-
 
 def heur_block(args):
     if args["N"] <= 512:
@@ -46,7 +44,7 @@ def uniform_kernel(
     philox_offset = philox_offset.to(tl.int64)
     c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
-    i4 = tle.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    i4 = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
     c0 += i4
     _O = c0 * 0
     r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, _O, _O)
@@ -54,7 +52,7 @@ def uniform_kernel(
     r1 = uint_to_uniform_float(r1) * (to - from_) + from_
     r2 = uint_to_uniform_float(r2) * (to - from_) + from_
     r3 = uint_to_uniform_float(r3) * (to - from_) + from_
-    off_0 = tle.program_id(0) * BLOCK * 4 + tl.arange(0, BLOCK)
+    off_0 = tl.program_id(0) * BLOCK * 4 + tl.arange(0, BLOCK)
     off_1 = off_0 + BLOCK
     off_2 = off_1 + BLOCK
     off_3 = off_2 + BLOCK

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -122,7 +122,11 @@ class LibEntry(triton.KernelInterface):
                         raise RuntimeError("Invalid Runtime Function")
                     fn = fn.fn
                 for p in self.jit_function.params:
-                    if p.is_constexpr and p.name not in constexprs:
+                    if (
+                        p.is_constexpr
+                        and p.name not in constexprs
+                        and (p.default is not inspect._empty)
+                    ):
                         constexprs[p.name] = p.default
                 cache[entry_key] = (kernel, constexprs)
             return kernel, constexprs


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
remove tle for those operators using philox.
uniform function doesn't support int64 as offset temporarily.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
