### PR TITLE
[Operator] Fix full & full_like op

### DIFF
--- a/src/flag_gems/ops/full.py
+++ b/src/flag_gems/ops/full.py
@@ -4,35 +4,75 @@ import torch
 import triton
 import triton.language as tl
 
-from flag_gems.utils.shape_utils import volume
-
 from ..utils import triton_lang_extension as tle
+from ..utils.shape_utils import volume
 
 
-@triton.jit(do_not_specialize=["fill_value"])
+@triton.jit(do_not_specialize=["fill_value_or_ptr"])
 def full_kernel(
     output_ptr,
     n_elements,
-    fill_value,
+    fill_value_or_ptr,
+    FILL_VALUE_IS_PTR: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
 ):
     pid = tle.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
     offsets = block_start + tl.arange(0, BLOCK_SIZE)
     mask = offsets < n_elements
+    if FILL_VALUE_IS_PTR:
+        fill_value = tl.load(fill_value_or_ptr)
+    else:
+        fill_value = fill_value_or_ptr
     tl.store(output_ptr + offsets, fill_value, mask=mask)
+
+
+ALL_INT_DTYPES = (torch.int8, torch.int16, torch.int32, torch.int64)
+ALL_FLOAT_DTYPES = (torch.bfloat16, torch.float16, torch.float32, torch.float64)
+
+
+def check_dtype(fill_value, dtype, device):
+    if isinstance(fill_value, bool):
+        if dtype != torch.bool:
+            fill_value = int(fill_value)
+    elif (
+        dtype in ALL_INT_DTYPES
+        and (fill_value < torch.iinfo(dtype).min or fill_value > torch.iinfo(dtype).max)
+    ) or (
+        dtype in ALL_FLOAT_DTYPES
+        and (fill_value < torch.finfo(dtype).min or fill_value > torch.finfo(dtype).max)
+    ):
+        raise RuntimeError(
+            f"value cannot be converted to type {dtype} without overflow"
+        )
+    if dtype in ALL_FLOAT_DTYPES:
+        fill_value = torch.tensor(fill_value, dtype=dtype, device=device)
+    return fill_value
 
 
 def full(size, fill_value, *, dtype=None, layout=None, device=None, pin_memory=None):
     logging.debug("GEMS FULL")
-    if dtype is None:
-        dtype = torch.get_default_dtype()
     if device is None:
-        device = torch.device("cuda")
+        device = torch.device("cpu")
+    if dtype is None:
+        if isinstance(fill_value, bool):
+            dtype = torch.bool
+        elif isinstance(fill_value, int):
+            dtype = torch.int64
+        else:
+            dtype = torch.get_default_dtype()
+    else:
+        fill_value = check_dtype(fill_value, dtype, device)
 
     out = torch.empty(size, device=device, dtype=dtype)
     N = volume(size)
     grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE"]),)
     with torch.cuda.device(device):
-        full_kernel[grid_fn](out, N, fill_value, BLOCK_SIZE=1024)
+        full_kernel[grid_fn](
+            out,
+            N,
+            fill_value,
+            FILL_VALUE_IS_PTR=isinstance(fill_value, torch.Tensor),
+            BLOCK_SIZE=1024,
+        )
     return out

--- a/src/flag_gems/ops/full_like.py
+++ b/src/flag_gems/ops/full_like.py
@@ -3,7 +3,7 @@ import logging
 import torch
 import triton
 
-from .full import full_kernel
+from .full import check_dtype, full_kernel
 
 
 def full_like(
@@ -21,9 +21,16 @@ def full_like(
         device = x.device
     if dtype is None:
         dtype = x.dtype
+    fill_value = check_dtype(fill_value, dtype, device)
     out = torch.empty_like(x, device=device, dtype=dtype)
     N = x.numel()
     grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE"]),)
     with torch.cuda.device(x.device):
-        full_kernel[grid_fn](out, N, fill_value, BLOCK_SIZE=1024)
+        full_kernel[grid_fn](
+            out,
+            N,
+            fill_value,
+            FILL_VALUE_IS_PTR=isinstance(fill_value, torch.Tensor),
+            BLOCK_SIZE=1024,
+        )
     return out

--- a/src/flag_gems/ops/ones.py
+++ b/src/flag_gems/ops/ones.py
@@ -4,9 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
-from flag_gems.utils.shape_utils import volume
-
 from ..utils import triton_lang_extension as tle
+from ..utils.shape_utils import volume
 
 
 @triton.jit

--- a/src/flag_gems/ops/zeros.py
+++ b/src/flag_gems/ops/zeros.py
@@ -4,9 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
-from flag_gems.utils.shape_utils import volume
-
 from ..utils import triton_lang_extension as tle
+from ..utils.shape_utils import volume
 
 
 @triton.jit


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description
1. When dtype is not provided, dtype should be set according to fill_value.
2. When dtype is provided, fill_value should be check for overflow.
3. If dtype is not bool and fill_value is bool, fill_value should be converted to int.
4. If dtype is float, the truncation of fill_value should be noted.
5. The default device should be "cpu".

### Issue

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

