### PR TITLE
add argmin (#318)

### DIFF
--- a/OperatorList.md
+++ b/OperatorList.md
@@ -51,6 +51,7 @@
 - tanh
 - amax
 - argmax
+- argmin
 - max
 - min
 - outer

--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -53,6 +53,7 @@ forward_operations = [
     ("amax", torch.amax, FLOAT_DTYPES),
     ("any", torch.any, FLOAT_DTYPES),
     ("argmax", torch.argmax, FLOAT_DTYPES),
+    ("argmin", torch.argmin, FLOAT_DTYPES),
     ("max", torch.max, FLOAT_DTYPES),
     ("mean", torch.mean, FLOAT_DTYPES),
     ("min", torch.min, FLOAT_DTYPES),

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -142,6 +142,7 @@ def enable(lib=aten_lib, unused=None, registrar=registrar):
             ("min.dim", min_dim, Autograd.disable),
             ("amax", amax, Autograd.disable),
             ("argmax", argmax, Autograd.disable),
+            ("argmin", argmin, Autograd.disable),
             ("prod", prod, Autograd.disable),
             ("prod.dim_int", prod_dim, Autograd.disable),
             ("sum", sum, Autograd.disable),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -6,6 +6,7 @@ from .amax import amax
 from .any import any, any_dim, any_dims
 from .arange import arange, arange_start
 from .argmax import argmax
+from .argmin import argmin
 from .attention import scaled_dot_product_attention
 from .bitwise_and import (
     bitwise_and_scalar,
@@ -247,6 +248,7 @@ __all__ = [
     "sum_dim",
     "amax",
     "argmax",
+    "argmin",
     "prod",
     "prod_dim",
     "var_mean",

--- a/src/flag_gems/ops/argmin.py
+++ b/src/flag_gems/ops/argmin.py
@@ -11,12 +11,13 @@ from ..utils import libentry
 from ..utils import triton_lang_extension as tle
 
 torch_dtype_to_tl_dtype_and_max_value = {
-    torch.int16 : (tl.int16, torch.iinfo(torch.int16).max),
-    torch.int32 : (tl.int32, torch.iinfo(torch.int32).max),
-    torch.float16 : (tl.float16, torch.finfo(torch.float16).max),
-    torch.float32 : (tl.float32, torch.finfo(torch.float32).max),
-    torch.bfloat16 : (tl.float32, torch.finfo(torch.float32).max),
+    torch.int16: (tl.int16, torch.iinfo(torch.int16).max),
+    torch.int32: (tl.int32, torch.iinfo(torch.int32).max),
+    torch.float16: (tl.float16, torch.finfo(torch.float16).max),
+    torch.float32: (tl.float32, torch.finfo(torch.float32).max),
+    torch.bfloat16: (tl.float32, torch.finfo(torch.float32).max),
 }
+
 
 @libentry()
 @triton.jit
@@ -58,18 +59,7 @@ def heur_block_n(args):
 
 
 @libentry()
-@triton.autotune(
-    configs=runtime.get_triton_config("argmin"),
-    key=[
-        "M",
-        "N",
-    ],
-)
-@triton.heuristics(
-    {
-        "BLOCK_N": heur_block_n,
-    }
-)
+@triton.heuristics(runtime.get_heuristic_config("argmin"))
 @triton.jit
 def argmin_kernel(
     inp,

--- a/src/flag_gems/ops/argmin.py
+++ b/src/flag_gems/ops/argmin.py
@@ -1,0 +1,176 @@
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from ..utils import libentry
+from ..utils.shape_utils import can_use_int32_index
+
+
+@libentry()
+@triton.jit
+def argmin_kernel_1(
+    inp,
+    mid_value,
+    mid_index,
+    M,
+    BLOCK_SIZE: tl.constexpr,
+    INT64_INDEX: tl.constexpr = False,
+):
+    pid = tl.program_id(0)
+    if INT64_INDEX:
+        pid = pid.to(tl.int64)
+    offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    inp_ptrs = inp + offset
+    mask = offset < M
+    inp_val = tl.load(inp_ptrs, mask=mask, other=float("inf"))
+    min_val, min_index = tl.min(inp_val, axis=0, return_indices=True)
+    min_index = min_index + pid * BLOCK_SIZE
+    mid_value_ptr = mid_value + pid
+    min_index_ptr = mid_index + pid
+    tl.store(mid_value_ptr, min_val)
+    tl.store(min_index_ptr, min_index)
+
+
+@libentry()
+@triton.jit
+def argmin_kernel_2(mid_value, mid_index, out, mid_size, BLOCK_MID: tl.constexpr):
+    offset = tl.arange(0, BLOCK_MID)
+    mid_ptrs = mid_value + offset
+    mask = offset < mid_size
+    mid_val = tl.load(mid_ptrs, mask=mask, other=float("inf"))
+    index_val = tl.argmin(mid_val, axis=0)
+    mid_index_ptrs = mid_index + index_val
+    out_val = tl.load(mid_index_ptrs)
+    tl.store(out, out_val)
+
+
+def heur_block_n(args):
+    return min(4096, triton.next_power_of_2(args["N"]))
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": 8}, num_warps=8),
+        triton.Config({"BLOCK_M": 16}, num_warps=8),
+        triton.Config({"BLOCK_M": 32}, num_warps=8),
+    ],
+    key=[
+        "M",
+        "N",
+    ],
+)
+@triton.heuristics(
+    {
+        "BLOCK_N": heur_block_n,
+    }
+)
+@triton.jit
+def argmin_kernel(
+    inp,
+    out_index,
+    M,
+    N,
+    K,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    INT64_INDEX: tl.constexpr = False,
+):
+    # set offset
+    pid_m = tl.program_id(0)
+    pid_k = tl.program_id(1)
+    if INT64_INDEX:
+        pid_m = pid_m.to(tl.int64)
+        pid_k = pid_k.to(tl.int64)
+    m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+
+    min_values = tl.full([BLOCK_M], dtype=tl.float32, value=float("inf"))
+    argmin_values = tl.full([BLOCK_M], dtype=tl.int64, value=0)
+    for start_n in range(0, N, BLOCK_N):
+        n_offset = start_n + tl.arange(0, BLOCK_N)
+        offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
+        mask = m_offset[:, None] < M and n_offset[None, :] < N
+        inp_ptrs = inp + offset
+        inp_vals = tl.load(inp_ptrs, mask=mask, other=float("inf"))
+        local_min, local_argmin = tl.min(
+            inp_vals, 1, return_indices=True, return_indices_tie_break_left=True
+        )
+        # if return indices is not supported, call a tl.argmin in addition
+        # local_argmin = tl.argmin(inp_vals, 1)
+        update = local_min < min_values
+        min_values = tl.where(update, local_min, min_values)
+        argmin_values = tl.where(update, start_n + local_argmin, argmin_values)
+
+    offset_index = m_offset * K + pid_k
+    out_index_ptrs = out_index + offset_index
+    mask1 = m_offset < M
+    tl.store(out_index_ptrs, argmin_values, mask=mask1)
+
+
+def argmin(inp, dim=None, keepdim=False, *, dtype=None):
+    logging.debug("GEMS argmin")
+    if dim is None:
+        M = inp.numel()
+        if dtype is None:
+            dtype = inp.dtype
+        block_size = triton.next_power_of_2(math.ceil(math.sqrt(M)))
+        mid_size = triton.cdiv(M, block_size)
+        block_mid = triton.next_power_of_2(mid_size)
+        use_int64_index = not can_use_int32_index(inp)
+
+        mid_value = torch.empty((mid_size,), dtype=dtype, device=inp.device)
+        mid_index = torch.empty((mid_size,), dtype=torch.int64, device=inp.device)
+        if keepdim:
+            shape = list(inp.shape)
+            for i in range(0, inp.dim()):
+                shape[i] = 1
+            out = torch.empty(shape, dtype=torch.int64, device=inp.device)
+        else:
+            out = torch.empty([], dtype=torch.int64, device=inp.device)
+
+        with torch.cuda.device(inp.device):
+            argmin_kernel_1[(mid_size, 1, 1)](
+                inp,
+                mid_value,
+                mid_index,
+                M,
+                block_size,
+                INT64_INDEX=use_int64_index,
+            )
+            argmin_kernel_2[(1, 1, 1)](mid_value, mid_index, out, mid_size, block_mid)
+        return out
+    else:
+        assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
+        shape = inp.shape
+        dim = dim % inp.ndim
+        N = shape[dim]
+        M = math.prod(shape[:dim])
+        K = inp.numel() // M // N
+
+        inp = inp.contiguous()
+        use_int64_index = not can_use_int32_index(inp)
+
+        shape_list = list(shape)
+        shape_list[dim] = 1
+        out_index = torch.empty(shape_list, dtype=torch.int64, device=inp.device)
+        if not keepdim:
+            out_index = torch.squeeze(out_index, dim)
+
+        grid = lambda meta: (
+            triton.cdiv(M, meta["BLOCK_M"]),
+            K,
+        )
+        with torch.cuda.device(inp.device):
+            argmin_kernel[grid](
+                inp,
+                out_index,
+                M,
+                N,
+                K,
+                INT64_INDEX=use_int64_index,
+            )
+
+        return out_index

--- a/src/flag_gems/runtime/backend/_nvidia/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_nvidia/heuristics_config_utils.py
@@ -10,6 +10,14 @@ def argmax_heur_block_n(args):
     return min(4096, triton.next_power_of_2(args["N"]))
 
 
+def argmin_heur_block_m(args):
+    return 4 if args["M"] < 4096 else 8
+
+
+def argmin_heur_block_n(args):
+    return min(4096, triton.next_power_of_2(args["N"]))
+
+
 def bmm_heur_divisible_m(args):
     return args["M"] % args["TILE_M"] == 0
 
@@ -199,6 +207,10 @@ HEURISTICS_CONFIGS = {
     "argmax": {
         "BLOCK_M": argmax_heur_block_m,
         "BLOCK_N": argmax_heur_block_n,
+    },
+    "argmin": {
+        "BLOCK_M": argmin_heur_block_m,
+        "BLOCK_N": argmin_heur_block_n,
     },
     "bmm": {
         "DIVISIBLE_M": bmm_heur_divisible_m,

--- a/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
@@ -119,6 +119,16 @@ argmax:
 - META:
     BLOCK_M: 32
   num_warps: 8
+argmin:
+- META:
+    BLOCK_M: 8
+  num_warps: 8
+- META:
+    BLOCK_M: 16
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+  num_warps: 8
 log_softmax:
 - META:
     BLOCK_M: 8

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -95,14 +95,16 @@ def test_accuracy_argmax(shape, dim, keepdim, dtype):
     gems_assert_equal(res_out, ref_out)
 
 
-# TODO: There are some bugs in argmin with large size.
 @pytest.mark.argmin
 @pytest.mark.parametrize("shape", REDUCTION_SMALL_SHAPES)
 @pytest.mark.parametrize("dim", DIM_LIST)
 @pytest.mark.parametrize("keepdim", [True, False])
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES + INT_DTYPES)
 def test_accuracy_argmin(shape, dim, keepdim, dtype):
-    inp = torch.randn(shape, dtype=dtype, device="cuda")
+    if dtype in INT_DTYPES:
+        inp = torch.randint(-1024, 1024, size=shape, device=flag_gems.device).to(dtype)
+    else:
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     ref_inp = to_reference(inp)
 
     ref_out = torch.argmin(ref_inp, dim=dim, keepdim=keepdim)

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -97,7 +97,7 @@ def test_accuracy_argmax(shape, dim, keepdim, dtype):
 
 @pytest.mark.argmin
 @pytest.mark.parametrize("shape", REDUCTION_SMALL_SHAPES)
-@pytest.mark.parametrize("dim", DIM_LIST)
+@pytest.mark.parametrize("dim", DIM_LIST + [None])
 @pytest.mark.parametrize("keepdim", [True, False])
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES + INT_DTYPES)
 def test_accuracy_argmin(shape, dim, keepdim, dtype):

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -95,6 +95,23 @@ def test_accuracy_argmax(shape, dim, keepdim, dtype):
     gems_assert_equal(res_out, ref_out)
 
 
+# TODO: There are some bugs in argmin with large size.
+@pytest.mark.argmin
+@pytest.mark.parametrize("shape", REDUCTION_SMALL_SHAPES)
+@pytest.mark.parametrize("dim", DIM_LIST)
+@pytest.mark.parametrize("keepdim", [True, False])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_argmin(shape, dim, keepdim, dtype):
+    inp = torch.randn(shape, dtype=dtype, device="cuda")
+    ref_inp = to_reference(inp)
+
+    ref_out = torch.argmin(ref_inp, dim=dim, keepdim=keepdim)
+    with flag_gems.use_gems():
+        res_out = torch.argmin(inp, dim=dim, keepdim=keepdim)
+
+    gems_assert_equal(res_out, ref_out)
+
+
 @pytest.mark.CrossEntropyLoss
 @pytest.mark.parametrize("label_smoothing, ignore_index, shape", SMOOTH_IGNORE_SHAPE)
 @pytest.mark.parametrize("reduction", CROSS_ENTROPY_LOSS_REDUCTION)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator, OP Test, Benchmark

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Support argmin, detail see #318 

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->
Resolves #318 
### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
A100 test result:

Operator: argmin  Performance Test (dtype=torch.float16, mode=cuda, level=comprehensive)
Size         Torch Latency (ms)    Gems Latency (ms)         Gems Speedup         Size Detail

------------------------------------------------------------------------------------------
SUCCESS               0.019456            0.013312               1.462          [torch.Size([1048576])]
SUCCESS               0.010240            0.010240               1.000          [torch.Size([64, 64])]
SUCCESS               0.055296            0.043008               1.286          [torch.Size([4096, 4096])]
SUCCESS               0.055296            0.043008               1.286          [torch.Size([64, 512, 512])]
SUCCESS               1.888256            1.249280               1.511          [torch.Size([1024, 1024, 1024])]
SUCCESS               0.007168            0.009216               0.778          [torch.Size([4])]
SUCCESS               0.008192            0.009216               0.889          [torch.Size([1024])]
SUCCESS               1.886208            1.249280               1.510          [torch.Size([1073741824])]
SUCCESS               0.008192            0.009216               0.889          [torch.Size([1024, 1])]
SUCCESS               0.014336            0.010240               1.400          [torch.Size([1024, 16])]
SUCCESS               0.017408            0.010240               1.700          [torch.Size([1024, 256])]
SUCCESS               0.026624            0.018432               1.444          [torch.Size([1024, 4096])]
SUCCESS               0.158720            0.106496               1.490          [torch.Size([1024, 65536])]
SUCCESS               0.009216            0.010240               0.900          [torch.Size([64, 64, 1])]
SUCCESS               0.032768            0.010240               3.200          [torch.Size([64, 64, 16])]
SUCCESS               0.019456            0.012288               1.583          [torch.Size([64, 64, 256])]
SUCCESS               0.055296            0.043008               1.286          [torch.Size([64, 64, 4096])]


Operator: argmin  Performance Test (dtype=torch.float32, mode=cuda, level=comprehensive)
Size         Torch Latency (ms)    Gems Latency (ms)         Gems Speedup         Size Detail

------------------------------------------------------------------------------------------
SUCCESS               0.020480            0.014336               1.429          [torch.Size([1048576])]
SUCCESS               0.010240            0.009216               1.111          [torch.Size([64, 64])]
SUCCESS               0.074752            0.066560               1.123          [torch.Size([4096, 4096])]
SUCCESS               0.074752            0.066560               1.123          [torch.Size([64, 512, 512])]
SUCCESS               2.638848            2.404352               1.098          [torch.Size([1024, 1024, 1024])]
SUCCESS               0.007168            0.009216               0.778          [torch.Size([4])]
SUCCESS               0.008192            0.009216               0.889          [torch.Size([1024])]
SUCCESS               2.638848            2.402304               1.098          [torch.Size([1073741824])]
SUCCESS               0.008192            0.009216               0.889          [torch.Size([1024, 1])]
SUCCESS               0.015360            0.010240               1.500          [torch.Size([1024, 16])]
SUCCESS               0.017408            0.011264               1.545          [torch.Size([1024, 256])]
SUCCESS               0.033792            0.027648               1.222          [torch.Size([1024, 4096])]
SUCCESS               0.214016            0.178176               1.201          [torch.Size([1024, 65536])]
SUCCESS               0.009216            0.009216               1.000          [torch.Size([64, 64, 1])]
SUCCESS               0.033792            0.010240               3.300          [torch.Size([64, 64, 16])]
SUCCESS               0.019456            0.014336               1.357          [torch.Size([64, 64, 256])]
SUCCESS               0.074752            0.066560               1.123          [torch.Size([64, 64, 4096])]


Operator: argmin  Performance Test (dtype=torch.bfloat16, mode=cuda, level=comprehensive)
Size         Torch Latency (ms)    Gems Latency (ms)         Gems Speedup         Size Detail

------------------------------------------------------------------------------------------
SUCCESS               0.019456            0.013312               1.462          [torch.Size([1048576])]
SUCCESS               0.010240            0.010240               1.000          [torch.Size([64, 64])]
SUCCESS               0.056320            0.044032               1.279          [torch.Size([4096, 4096])]
SUCCESS               0.056320            0.044032               1.279          [torch.Size([64, 512, 512])]
SUCCESS               1.954816            1.280000               1.527          [torch.Size([1024, 1024, 1024])]
SUCCESS               0.007168            0.009216               0.778          [torch.Size([4])]
SUCCESS               0.008192            0.009216               0.889          [torch.Size([1024])]
SUCCESS               1.972224            1.277952               1.543          [torch.Size([1073741824])]
SUCCESS               0.008192            0.009216               0.889          [torch.Size([1024, 1])]
SUCCESS               0.014336            0.010240               1.400          [torch.Size([1024, 16])]
SUCCESS               0.017408            0.010240               1.700          [torch.Size([1024, 256])]
SUCCESS               0.026624            0.019456               1.368          [torch.Size([1024, 4096])]
SUCCESS               0.162816            0.106496               1.529          [torch.Size([1024, 65536])]
SUCCESS               0.009216            0.010240               0.900          [torch.Size([64, 64, 1])]
SUCCESS               0.033792            0.010240               3.300          [torch.Size([64, 64, 16])]
SUCCESS               0.019456            0.012288               1.583          [torch.Size([64, 64, 256])]
SUCCESS               0.056320            0.044032               1.279          [torch.Size([64, 64, 4096])]


