### PR TITLE
Add logical_and gems op

### DIFF
--- a/benchmark/test_binary_pointwise_perf.py
+++ b/benchmark/test_binary_pointwise_perf.py
@@ -51,6 +51,7 @@ class BinaryPointwiseBenchmark(Benchmark):
             ("remainder", torch.remainder, INT_DTYPES),
             ("rsub", torch.rsub, FLOAT_DTYPES),
             ("logical_or", torch.logical_or, INT_DTYPES + BOOL_DTYPES),
+            ("logical_and", torch.logical_and, INT_DTYPES + BOOL_DTYPES),
             # Comparison operations
             ("eq", torch.eq, FLOAT_DTYPES),
             ("ge", torch.ge, FLOAT_DTYPES),

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -193,6 +193,7 @@ def enable(lib=aten_lib, unused=None):
             ("diag_embed", diag_embed, Autograd.disable),
             ("diagonal_backward", diagonal_backward, Autograd.disable),
             ("logical_or", logical_or, Autograd.disable),
+            ("logical_and", logical_and, Autograd.disable),
             ("logical_not", logical_not, Autograd.disable),
         ),
         user_unused_ops_list=unused,

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -52,6 +52,7 @@ from .isnan import isnan
 from .layernorm import layer_norm
 from .le import le, le_scalar
 from .log_softmax import log_softmax
+from .logical_and import logical_and
 from .logical_not import logical_not
 from .logical_or import logical_or
 from .lt import lt, lt_scalar
@@ -270,5 +271,6 @@ __all__ = [
     "_conv_depthwise2d",
     "repeat_interleave_self_tensor",
     "logical_or",
+    "logical_and",
     "logical_not",
 ]

--- a/src/flag_gems/ops/logical_and.py
+++ b/src/flag_gems/ops/logical_and.py
@@ -1,0 +1,17 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from ..utils import pointwise_dynamic
+
+
+@pointwise_dynamic(promotion_methods=[(0, 1, "ALWAYS_BOOL")])
+@triton.jit
+def logical_and_func(x, y):
+    return x.to(tl.int1).logical_and(y.to(tl.int1))
+
+
+def logical_and(A, B):
+    logging.debug("GEMS LOGICAL_AND")
+    return logical_and_func(A, B)

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -1230,3 +1230,26 @@ def test_accuracy_logical_or(shape, dtype):
         res_out = torch.logical_or(inp1, inp2)
 
     gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.logical_and
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", ALL_FLOAT_DTYPES + ALL_INT_DTYPES + BOOL_TYPES)
+def test_accuracy_logical_and(shape, dtype):
+    if dtype in ALL_FLOAT_DTYPES:
+        inp1 = torch.randn(shape, dtype=dtype, device="cuda")
+        inp2 = torch.randn(shape, dtype=dtype, device="cuda")
+    elif dtype in ALL_INT_DTYPES:
+        inp1 = torch.randint(-1000, 1000, shape, dtype=dtype, device="cuda")
+        inp2 = torch.randint(-1000, 1000, shape, dtype=dtype, device="cuda")
+    elif dtype in BOOL_TYPES:
+        inp1 = torch.randint(0, 2, shape, dtype=dtype, device="cuda")
+        inp2 = torch.randint(0, 2, shape, dtype=dtype, device="cuda")
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.logical_and(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.logical_and(inp1, inp2)
+
+    gems_assert_equal(res_out, ref_out)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add logical_and gems op
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
A100-40G
```
Operator: logical_and  Performance Test (dtype=torch.int16, mode=cuda,level=comprehensive)
Size         Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS         Size Detail
------------------------------------------------------------------------------------------------------------------------
SUCCESS               3.849536            3.926912               0.980               0.547          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.007168            0.006816               1.052               0.001          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.079296            0.079104               1.002               0.424          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.079904            0.078976               1.012               0.425          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               3.850144            3.927872               0.980               0.547          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.007488            0.006528               1.147               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.007360            0.008000               0.920               0.004          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.008384            0.008896               0.942               0.059          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.025824            0.026656               0.969               0.315          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.258720            0.258752               1.000               0.519          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.007264            0.007360               0.987               0.001          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.007616            0.007328               1.039               0.018          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.013408            0.013280               1.010               0.158          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.079296            0.079040               1.003               0.425          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               0.976800            0.980096               0.997               0.548          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]


Operator: logical_and  Performance Test (dtype=torch.int32, mode=cuda,level=comprehensive)
Size         Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS         Size Detail
------------------------------------------------------------------------------------------------------------------------
SUCCESS               6.795744            6.823136               0.996               0.315          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.006816            0.006816               1.000               0.001          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.128384            0.128480               0.999               0.261          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.128544            0.128480               1.000               0.261          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               6.795616            6.823584               0.996               0.315          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.006816            0.007744               0.880               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.007040            0.007424               0.948               0.004          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.009696            0.010208               0.950               0.051          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.043104            0.043584               0.989               0.192          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.445664            0.443424               1.005               0.303          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.006816            0.006816               1.000               0.001          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.007584            0.007584               1.000               0.017          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.016256            0.017056               0.953               0.123          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.128544            0.128608               1.000               0.261          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               1.715552            1.713088               1.001               0.313          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]


Operator: logical_and  Performance Test (dtype=torch.bool, mode=cuda,level=comprehensive)
Size         Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS         Size Detail
------------------------------------------------------------------------------------------------------------------------
SUCCESS               2.401920            2.509344               0.957               0.856          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.006816            0.006816               1.000               0.001          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.051040            0.050880               1.003               0.659          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.048992            0.049824               0.983               0.673          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               2.405952            2.504064               0.961               0.858          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.006880            0.006880               1.000               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.006816            0.006816               1.000               0.005          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.007840            0.008192               0.957               0.064          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.017760            0.018528               0.959               0.453          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.163392            0.163328               1.000               0.822          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.006816            0.007328               0.930               0.001          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.007072            0.007072               1.000               0.019          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.010208            0.010752               0.949               0.195          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.049984            0.050976               0.981               0.658          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               0.611616            0.608992               1.004               0.882          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]

```