### PR TITLE
Add logical_xor gems op

### DIFF
--- a/benchmark/test_binary_pointwise_perf.py
+++ b/benchmark/test_binary_pointwise_perf.py
@@ -52,6 +52,7 @@ class BinaryPointwiseBenchmark(Benchmark):
             ("rsub", torch.rsub, FLOAT_DTYPES),
             ("logical_or", torch.logical_or, INT_DTYPES + BOOL_DTYPES),
             ("logical_and", torch.logical_and, INT_DTYPES + BOOL_DTYPES),
+            ("logical_xor", torch.logical_xor, INT_DTYPES + BOOL_DTYPES),
             # Comparison operations
             ("eq", torch.eq, FLOAT_DTYPES),
             ("ge", torch.ge, FLOAT_DTYPES),

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -196,6 +196,7 @@ def enable(lib=aten_lib, unused=None):
             ("count_nonzero", count_nonzero, Autograd.disable),
             ("logical_or", logical_or, Autograd.disable),
             ("logical_and", logical_and, Autograd.disable),
+            ("logical_xor", logical_xor, Autograd.disable),
             ("logical_not", logical_not, Autograd.disable),
         ),
         user_unused_ops_list=unused,

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -56,6 +56,7 @@ from .log_softmax import log_softmax
 from .logical_and import logical_and
 from .logical_not import logical_not
 from .logical_or import logical_or
+from .logical_xor import logical_xor
 from .lt import lt, lt_scalar
 from .masked_fill import masked_fill, masked_fill_
 from .masked_select import masked_select
@@ -275,5 +276,6 @@ __all__ = [
     "repeat_interleave_self_tensor",
     "logical_or",
     "logical_and",
+    "logical_xor",
     "logical_not",
 ]

--- a/src/flag_gems/ops/logical_xor.py
+++ b/src/flag_gems/ops/logical_xor.py
@@ -1,0 +1,17 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from ..utils import pointwise_dynamic
+
+
+@pointwise_dynamic(promotion_methods=[(0, 1, "ALWAYS_BOOL")])
+@triton.jit
+def logical_xor_func(x, y):
+    return x.to(tl.int1) ^ y.to(tl.int1)
+
+
+def logical_xor(A, B):
+    logging.debug("GEMS LOGICAL_XOR")
+    return logical_xor_func(A, B)

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -1253,3 +1253,26 @@ def test_accuracy_logical_and(shape, dtype):
         res_out = torch.logical_and(inp1, inp2)
 
     gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.logical_xor
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", ALL_FLOAT_DTYPES + ALL_INT_DTYPES + BOOL_TYPES)
+def test_accuracy_logical_xor(shape, dtype):
+    if dtype in ALL_FLOAT_DTYPES:
+        inp1 = torch.randn(shape, dtype=dtype, device="cuda")
+        inp2 = torch.randn(shape, dtype=dtype, device="cuda")
+    elif dtype in ALL_INT_DTYPES:
+        inp1 = torch.randint(-1000, 1000, shape, dtype=dtype, device="cuda")
+        inp2 = torch.randint(-1000, 1000, shape, dtype=dtype, device="cuda")
+    elif dtype in BOOL_TYPES:
+        inp1 = torch.randint(0, 2, shape, dtype=dtype, device="cuda")
+        inp2 = torch.randint(0, 2, shape, dtype=dtype, device="cuda")
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.logical_xor(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.logical_xor(inp1, inp2)
+
+    gems_assert_equal(res_out, ref_out)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add logical_xor gems op
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
A100-40G
```
Operator: logical_xor  Performance Test (dtype=torch.int16, mode=cuda,level=comprehensive)
Size         Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS         Size Detail
------------------------------------------------------------------------------------------------------------------------
SUCCESS               3.848320            3.928992               0.979               0.547          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.006752            0.006784               0.995               0.001          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.080096            0.079104               1.013               0.424          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.079840            0.079712               1.002               0.421          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               3.850336            3.928928               0.980               0.547          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.006496            0.006496               1.000               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.008032            0.007360               1.091               0.004          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.008480            0.008320               1.019               0.063          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.026752            0.025696               1.041               0.326          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.259456            0.258752               1.003               0.519          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.008032            0.006784               1.184               0.001          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.007296            0.007264               1.004               0.018          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.012512            0.012416               1.008               0.169          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.079296            0.079904               0.992               0.420          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               0.976768            0.980000               0.997               0.548          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]


Operator: logical_xor  Performance Test (dtype=torch.int32, mode=cuda,level=comprehensive)
Size         Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS         Size Detail
------------------------------------------------------------------------------------------------------------------------
SUCCESS               6.796256            6.823008               0.996               0.315          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.007392            0.007392               1.000               0.001          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.127680            0.127616               1.001               0.263          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.128576            0.128544               1.000               0.261          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               6.796416            6.823200               0.996               0.315          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.006528            0.006528               1.000               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.007392            0.007488               0.987               0.004          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.009696            0.010240               0.947               0.051          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.043648            0.043776               0.997               0.192          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.445760            0.443360               1.005               0.303          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.007296            0.007008               1.041               0.001          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.008128            0.008064               1.008               0.016          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.016192            0.016160               1.002               0.130          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.127776            0.127744               1.000               0.263          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               1.715008            1.714016               1.001               0.313          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]


Operator: logical_xor  Performance Test (dtype=torch.bool, mode=cuda,level=comprehensive)
Size         Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS         Size Detail
------------------------------------------------------------------------------------------------------------------------
SUCCESS               2.402816            2.511200               0.957               0.855          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.006784            0.006784               1.000               0.001          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.049952            0.050880               0.982               0.659          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.049024            0.048800               1.005               0.688          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               2.405120            2.503168               0.961               0.858          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.006784            0.006816               0.995               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.006976            0.008032               0.869               0.004          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.008448            0.008832               0.957               0.059          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.017824            0.018240               0.977               0.460          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.164096            0.163200               1.005               0.822          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.007200            0.006784               1.061               0.001          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.007616            0.007584               1.004               0.017          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.010176            0.010560               0.964               0.199          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.051040            0.050848               1.004               0.660          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               0.611904            0.608800               1.005               0.882          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]

```