### PR TITLE
use loop kernel for min, max, prod, log_softmax to allow larger reduction size

### DIFF
--- a/src/flag_gems/ops/log_softmax.py
+++ b/src/flag_gems/ops/log_softmax.py
@@ -10,22 +10,8 @@ from ..utils import libentry
 from ..utils import triton_lang_extension as tle
 
 
-def heur_block_n(args):
-    return triton.next_power_of_2(args["N"])
-
-
-def heur_num_warps(args):
-    if args["N"] <= 1024:
-        return 4
-    elif args["N"] <= 2048:
-        return 8
-    else:
-        return 16
-
-
 @libentry()
 @triton.autotune(configs=runtime.get_triton_config("log_softmax"), key=["M", "N"])
-@triton.heuristics({"num_warps": heur_num_warps})
 @triton.jit
 def log_softmax_kernel(
     output_ptr,
@@ -70,7 +56,6 @@ def log_softmax_kernel(
 
 @libentry()
 @triton.autotune(configs=runtime.get_triton_config("log_softmax"), key=["M", "N"])
-@triton.heuristics({"num_warps": heur_num_warps})
 @triton.jit
 def log_softmax_backward_kernel(
     out_ptr,

--- a/src/flag_gems/ops/log_softmax.py
+++ b/src/flag_gems/ops/log_softmax.py
@@ -24,19 +24,8 @@ def heur_num_warps(args):
 
 
 @libentry()
-@triton.autotune(
-    configs=runtime.get_triton_config("log_softmax"),
-    key=[
-        "M",
-        "N",
-    ],
-)
-@triton.heuristics(
-    {
-        "BLOCK_N": heur_block_n,
-        "num_warps": heur_num_warps,
-    }
-)
+@triton.autotune(configs=runtime.get_triton_config("log_softmax"), key=["M", "N"])
+@triton.heuristics({"num_warps": heur_num_warps})
 @triton.jit
 def log_softmax_kernel(
     output_ptr,
@@ -50,33 +39,38 @@ def log_softmax_kernel(
     pid_m = tle.program_id(0)
     pid_k = tle.program_id(1)
     m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    n_offset = tl.arange(0, BLOCK_N)
-    offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
-    mask = m_offset[:, None] < M and n_offset[None, :] < N
-    input_ptrs = input_ptr + offset
-    inp = tl.load(input_ptrs, mask=mask, other=-float("inf")).to(tl.float32)
-    row_minus_max = inp - tl.max(inp, axis=1)[:, None]
-    numerator = tl.exp(row_minus_max)
-    denominator = tl.sum(numerator, axis=1)[:, None]
-    softmax_output = tl.log(numerator / denominator)
-    output_ptrs = output_ptr + offset
-    tl.store(output_ptrs, softmax_output, mask=mask)
+
+    # TODO(chenfeiyu): consider float64 add add a utility function to get accumulator type
+    m = tl.full([BLOCK_M, BLOCK_N], value=float("-inf"), dtype=tl.float32)
+    z = tl.full([BLOCK_M, BLOCK_N], value=0.0, dtype=tl.float32)
+    for start_n in range(0, N, BLOCK_N):
+        n_offset = start_n + tl.arange(0, BLOCK_N)
+        offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
+        mask = m_offset[:, None] < M and n_offset[None, :] < N
+        input_ptrs = input_ptr + offset
+        inp = tl.load(input_ptrs, mask=mask, other=-float("inf")).to(tl.float32)
+        m_new = tl.maximum(inp, m)
+        all_neg_inf = m_new == float("-inf")
+        z = tl.where(all_neg_inf, z, z * tl.exp(m - m_new) + tl.exp(inp - m_new))
+        m = m_new
+
+    m_reduced = tl.max(m, 1)
+    z = tl.sum(z * tl.exp(m - m_reduced[:, None]), 1)
+    m = m_reduced
+
+    for start_n in range(0, N, BLOCK_N):
+        n_offset = start_n + tl.arange(0, BLOCK_N)
+        offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
+        mask = m_offset[:, None] < M and n_offset[None, :] < N
+        input_ptrs = input_ptr + offset
+        inp = tl.load(input_ptrs, mask=mask, other=-float("inf")).to(tl.float32)
+        o = inp - m[:, None] - tl.log(z[:, None])
+        tl.store(output_ptr + offset, o, mask=mask)
 
 
 @libentry()
-@triton.autotune(
-    configs=runtime.get_triton_config("log_softmax"),
-    key=[
-        "M",
-        "N",
-    ],
-)
-@triton.heuristics(
-    {
-        "BLOCK_N": heur_block_n,
-        "num_warps": heur_num_warps,
-    }
-)
+@triton.autotune(configs=runtime.get_triton_config("log_softmax"), key=["M", "N"])
+@triton.heuristics({"num_warps": heur_num_warps})
 @triton.jit
 def log_softmax_backward_kernel(
     out_ptr,
@@ -91,20 +85,28 @@ def log_softmax_backward_kernel(
     pid_m = tle.program_id(0)
     pid_k = tle.program_id(1)
     m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    n_offset = tl.arange(0, BLOCK_N)
 
-    offsets = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
-    mask = m_offset[:, None] < M and n_offset[None, :] < N
-    out_ptrs = out_ptr + offsets
-    out = tl.load(out_ptrs, mask=mask).to(tl.float32)
-    out_grad_ptrs = out_grad_ptr + offsets
-    out_grad = tl.load(out_grad_ptrs, mask=mask).to(tl.float32)
+    scale = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for start_n in range(0, N, BLOCK_N):
+        n_offset = start_n + tl.arange(0, BLOCK_N)
+        offsets = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
+        mask = m_offset[:, None] < M and n_offset[None, :] < N
+        out_grad_ptrs = out_grad_ptr + offsets
+        out_grad = tl.load(out_grad_ptrs, mask=mask).to(tl.float32)
+        scale += out_grad
+    scale = tl.sum(scale, 1)
 
-    scale = tl.sum(out_grad, 1)
-    in_grad = out_grad - tl.exp(out.to(tl.float32)) * scale[:, None]
-
-    in_grad_ptrs = in_grad_ptr + offsets
-    tl.store(in_grad_ptrs, in_grad, mask=mask)
+    for start_n in range(0, N, BLOCK_N):
+        n_offset = start_n + tl.arange(0, BLOCK_N)
+        offsets = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
+        mask = m_offset[:, None] < M and n_offset[None, :] < N
+        out_ptrs = out_ptr + offsets
+        out = tl.load(out_ptrs, mask=mask).to(tl.float32)
+        out_grad_ptrs = out_grad_ptr + offsets
+        out_grad = tl.load(out_grad_ptrs, mask=mask).to(tl.float32)
+        in_grad = out_grad - tl.exp(out) * scale[:, None]
+        in_grad_ptrs = in_grad_ptr + offsets
+        tl.store(in_grad_ptrs, in_grad, mask=mask)
 
 
 class LogSoftmax(torch.autograd.Function):

--- a/src/flag_gems/ops/max.py
+++ b/src/flag_gems/ops/max.py
@@ -77,9 +77,7 @@ def max_kernel(
         mask = m_offset[:, None] < M and n_offset[None, :] < N
         inp_ptrs = inp + offset
         inp_vals = tl.load(inp_ptrs, mask=mask, other=-float("inf"))
-        max_value, max_index = tl.max(
-            inp_vals, axis=1, return_indices=True, return_indices_tie_break_left=True
-        )
+        max_value, max_index = tl.max(inp_vals, axis=1, return_indices=True)
         update_mask = max_value > result_value
         result_value = tl.where(update_mask, max_value, result_value)
         result_index = tl.where(update_mask, i + max_index, result_index)

--- a/src/flag_gems/ops/max.py
+++ b/src/flag_gems/ops/max.py
@@ -77,7 +77,9 @@ def max_kernel(
         mask = m_offset[:, None] < M and n_offset[None, :] < N
         inp_ptrs = inp + offset
         inp_vals = tl.load(inp_ptrs, mask=mask, other=-float("inf"))
-        max_value, max_index = tl.max(inp_vals, axis=1, return_indices=True)
+        max_value, max_index = tl.max(
+            inp_vals, axis=1, return_indices=True, return_indices_tie_break_left=True
+        )
         update_mask = max_value > result_value
         result_value = tl.where(update_mask, max_value, result_value)
         result_index = tl.where(update_mask, i + max_index, result_index)

--- a/src/flag_gems/ops/min.py
+++ b/src/flag_gems/ops/min.py
@@ -53,11 +53,6 @@ def heur_block_n(args):
         "N",
     ],
 )
-@triton.heuristics(
-    {
-        "BLOCK_N": heur_block_n,
-    }
-)
 @triton.jit
 def min_kernel(
     inp,
@@ -73,21 +68,30 @@ def min_kernel(
     pid_m = tle.program_id(0)
     pid_k = tle.program_id(1)
     m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    n_offset = tl.arange(0, BLOCK_N)
-    offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
-    offset_index = m_offset * K + pid_k
-    # set mask
-    mask1 = m_offset < M
-    mask = m_offset[:, None] < M and n_offset[None, :] < N
-    inp_ptrs = inp + offset
-    inp_vals = tl.load(inp_ptrs, mask=mask, other=float("inf")).to(tl.float32)
-    result_value, result_index = tl.min(inp_vals, axis=1, return_indices=True)
 
+    min_values = tl.full([BLOCK_M], dtype=tl.float32, value=float("inf"))
+    argmin_values = tl.full([BLOCK_M], dtype=tl.int64, value=0)
+    for start_n in range(0, N, BLOCK_N):
+        n_offset = start_n + tl.arange(0, BLOCK_N)
+        offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
+        mask = m_offset[:, None] < M and n_offset[None, :] < N
+        inp_ptrs = inp + offset
+        inp_vals = tl.load(inp_ptrs, mask=mask, other=float("inf"))
+        local_min, local_argmin = tl.min(
+            inp_vals, 1, return_indices=True, return_indices_tie_break_left=True
+        )
+        # if return indices is not supported, call a tl.argmax in addition
+        # local_argmin = tl.argmin(inp_vals, 1)
+        update = local_min < min_values
+        min_values = tl.where(update, local_min, min_values)
+        argmin_values = tl.where(update, start_n + local_argmin, argmin_values)
+
+    offset_index = m_offset * K + pid_k
     out_value_ptrs = out_value + offset_index
     out_index_ptrs = out_index + offset_index
-
-    tl.store(out_value_ptrs, result_value, mask=mask1)
-    tl.store(out_index_ptrs, result_index, mask=mask1)
+    mask1 = m_offset < M
+    tl.store(out_value_ptrs, min_values, mask=mask1)
+    tl.store(out_index_ptrs, argmin_values, mask=mask1)
 
 
 def min(inp):

--- a/src/flag_gems/ops/min.py
+++ b/src/flag_gems/ops/min.py
@@ -77,9 +77,7 @@ def min_kernel(
         mask = m_offset[:, None] < M and n_offset[None, :] < N
         inp_ptrs = inp + offset
         inp_vals = tl.load(inp_ptrs, mask=mask, other=float("inf"))
-        local_min, local_argmin = tl.min(
-            inp_vals, 1, return_indices=True, return_indices_tie_break_left=True
-        )
+        local_min, local_argmin = tl.min(inp_vals, 1, return_indices=True)
         # if return indices is not supported, call a tl.argmax in addition
         # local_argmin = tl.argmin(inp_vals, 1)
         update = local_min < min_values

--- a/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
@@ -95,13 +95,17 @@ argmax:
   num_warps: 8
 log_softmax:
 - META:
-    BLOCK_M: 1
-- META:
-    BLOCK_M: 2
-- META:
-    BLOCK_M: 4
-- META:
     BLOCK_M: 8
+    BLOCK_N: 256
+  num_warps: 8
+- META:
+    BLOCK_M: 16
+    BLOCK_N: 512
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 512
+  num_warps: 8
 mm:
 - META:
     BLOCK_M: 128
@@ -260,22 +264,28 @@ test_libentry:
 min:
 - META:
     BLOCK_M: 8
+    BLOCK_N: 256
   num_warps: 8
 - META:
     BLOCK_M: 16
+    BLOCK_N: 512
   num_warps: 8
 - META:
     BLOCK_M: 32
+    BLOCK_N: 512
   num_warps: 8
 prod:
 - META:
     BLOCK_M: 8
+    BLOCK_N: 256
   num_warps: 8
 - META:
     BLOCK_M: 16
+    BLOCK_N: 512
   num_warps: 8
 - META:
     BLOCK_M: 32
+    BLOCK_N: 512
   num_warps: 8
 max:
 - META:

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -274,7 +274,7 @@ def test_accuracy_count_nonzero(shape, dtype):
 
 
 @pytest.mark.log_softmax
-@pytest.mark.parametrize("shape", REDUCTION_SMALL_SHAPES)
+@pytest.mark.parametrize("shape", REDUCTION_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_accuracy_log_softmax(shape, dtype):
     dim = 1


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Use loop kernel for min, max, prod, log_softmax to allow larger reduction size.

We leave persistent/loop(stream)/split algorithms and better strategy to support different layouts for further optimization.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
