### PR TITLE
remove num_warps=4 in kernel signature to compatible with triton 2.1

### DIFF
--- a/src/flag_gems/ops/instancenorm.py
+++ b/src/flag_gems/ops/instancenorm.py
@@ -280,7 +280,6 @@ def update_running_stats_kernel(
     eps,
     BLOCK_BATCH_SIZE: tl.constexpr = 1,
     BLOCK_CHANNEL_SIZE: tl.constexpr = 2048,
-    num_warps=4,
 ):
     cid = tl.program_id(0) * BLOCK_CHANNEL_SIZE + tl.arange(0, BLOCK_CHANNEL_SIZE)
     col_mask = cid < C


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
![9B184880-15AE-4409-89BB-F348B4C2C088](https://github.com/user-attachments/assets/e7b57b90-0a04-46ef-9a4e-c519b529e6dc)
triton 2.1 do not support num_warps in kernel signature


### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
