### PR TITLE
[operator] group_norm and layer_norm support weight&bias as None

### DIFF
--- a/src/flag_gems/ops/groupnorm.py
+++ b/src/flag_gems/ops/groupnorm.py
@@ -37,8 +37,6 @@ def group_norm_kernel(
 
     wb_offset = group * group_size + group_offset
     wb_mask = wb_offset < C
-    W_ptr = W + wb_offset
-    B_ptr = B + wb_offset
 
     xy_offset = pid * num_elements + group_offset[:, None] * HW + hw_offset[None, :]
     xy_mask = wb_offset[:, None] < C and hw_offset[None, :] < HW
@@ -57,8 +55,14 @@ def group_norm_kernel(
     rstd = rsqrt(var + eps)
     x_hat = x * rstd
 
-    weight = tl.load(W_ptr, mask=wb_mask, other=0.0)[:, None]
-    bias = tl.load(B_ptr, mask=wb_mask, other=0.0)[:, None]
+    if W is None:
+        weight = 1
+    else:
+        weight = tl.load(W + wb_offset, mask=wb_mask, other=0.0)[:, None]
+    if B is None:
+        bias = 0
+    else:
+        bias = tl.load(B + wb_offset, mask=wb_mask, other=0.0)[:, None]
     Y_val = x_hat * weight + bias
 
     tl.store(Y_ptr, Y_val, mask=xy_mask)
@@ -91,7 +95,6 @@ def group_norm_backward_kernel(
     wb_offset = group * group_size + group_offset
 
     wb_mask = wb_offset < C
-    W_ptr = W + wb_offset
 
     xy_offset = pid * num_elements + group_offset[:, None] * HW + hw_offset[None, :]
     xy_mask = wb_offset[:, None] < C and hw_offset[None, :] < HW
@@ -106,7 +109,11 @@ def group_norm_backward_kernel(
     mean = tl.load(Mean_ptr).to(tl.float32)
     dY_val = tl.load(dY_ptr, mask=xy_mask, other=0.0).to(tl.float32)
     X_val = tl.load(X_ptr, mask=xy_mask, other=0.0).to(tl.float32)
-    weight = tl.load(W_ptr, mask=wb_mask, other=0.0).to(tl.float32)[:, None]
+
+    if W is None:
+        weight = 1
+    else:
+        weight = tl.load(W + wb_offset, mask=wb_mask, other=0.0).to(tl.float32)[:, None]
 
     dx_hat = weight * dY_val
 
@@ -145,9 +152,6 @@ def weight_bias_backward_kernel(
     xy_mask = n_offset[:, None] < N and hw_offset[None, :] < HW
     mr_mask = n_offset < N
 
-    dW_ptr = dW + pid
-    dB_ptr = dB + pid
-
     mean_ptr = Mean + group + n_offset * num_groups
     rstd_ptr = Rstd + group + n_offset * num_groups
 
@@ -160,15 +164,17 @@ def weight_bias_backward_kernel(
     mean = tl.load(mean_ptr, mask=mr_mask, other=0.0).to(tl.float32)[:, None]
     rstd = tl.load(rstd_ptr, mask=mr_mask, other=0.0).to(tl.float32)[:, None]
 
-    dB = tl.sum(grad_y)
-    dW = tl.sum((x_f32 - mean) * rstd * grad_y)
-    tl.store(dW_ptr, dW.to(x.dtype))
-    tl.store(dB_ptr, dB.to(x.dtype))
+    if dW is not None:
+        dw = tl.sum((x_f32 - mean) * rstd * grad_y)
+        tl.store(dW + pid, dw.to(x.dtype))
+    if dB is not None:
+        db = tl.sum(grad_y)
+        tl.store(dB + pid, db.to(x.dtype))
 
 
 class GroupNorm(torch.autograd.Function):
     @staticmethod
-    def forward(ctx, x, weight, bias, N, C, HW, num_groups, eps):
+    def forward(ctx, x, N, C, HW, num_groups, weight=None, bias=None, eps=1e-05):
         logging.debug("GEMS GROUPNORM FORWARD")
         group_size = C // num_groups
         x = x.contiguous()
@@ -197,27 +203,26 @@ class GroupNorm(torch.autograd.Function):
                 BLOCK_GROUP_SIZE=triton.next_power_of_2(C // num_groups),
                 BLOCK_HW_SIZE=triton.next_power_of_2(HW),
             )
-        ctx.save_for_backward(x, weight, mean, rstd)
-        ctx.num_groups = num_groups
-        ctx.group_size = group_size
-        ctx.N = N
-        ctx.C = C
-        ctx.HW = HW
+        if x.requires_grad:
+            ctx.save_for_backward(x, weight, bias, mean, rstd)
+            ctx.num_groups = num_groups
+            ctx.group_size = group_size
+            ctx.N = N
+            ctx.C = C
+            ctx.HW = HW
         return y, mean, rstd
 
     @staticmethod
     def backward(ctx, y_grad, mean_grad, rstd_grad):
         logging.debug("GEMS GROUPNORM BACKWARD")
         y_grad = y_grad.contiguous()
-        (x, weight, mean, rstd) = ctx.saved_tensors
+        (x, weight, bias, mean, rstd) = ctx.saved_tensors
         num_groups = ctx.num_groups
         group_size = ctx.group_size
         N = ctx.N
         C = ctx.C
         HW = ctx.HW
         x_grad = torch.empty_like(x)
-        weight_grad = torch.empty_like(weight)
-        bias_grad = torch.empty_like(weight)
         grid = (N * num_groups,)
         with torch_device_fn.device(x.device):
             group_norm_backward_kernel[grid](
@@ -234,23 +239,29 @@ class GroupNorm(torch.autograd.Function):
                 BLOCK_GROUP_SIZE=triton.next_power_of_2(C // num_groups),
                 BLOCK_HW_SIZE=triton.next_power_of_2(HW),
             )
-        weight_bias_backward_kernel[(C, 1, 1)](
-            y_grad,
-            x,
-            mean,
-            rstd,
-            weight_grad,
-            bias_grad,
-            num_groups,
-            group_size,
-            N,
-            C,
-            HW,
-            BLOCK_N=triton.next_power_of_2(N),
-            BLOCK_HW=triton.next_power_of_2(HW),
-        )
-        return x_grad, weight_grad, bias_grad, None, None, None, None, None
+        if weight is None and bias is None:
+            return x_grad, None, None, None, None, None, None, None
+
+        weight_grad = None if weight is None else torch.empty_like(weight)
+        bias_grad = None if bias is None else torch.empty_like(bias)
+        with torch_device_fn.device(x.device):
+            weight_bias_backward_kernel[(C, 1, 1)](
+                y_grad,
+                x,
+                mean,
+                rstd,
+                weight_grad,
+                bias_grad,
+                num_groups,
+                group_size,
+                N,
+                C,
+                HW,
+                BLOCK_N=triton.next_power_of_2(N),
+                BLOCK_HW=triton.next_power_of_2(HW),
+            )
+        return x_grad, None, None, None, None, weight_grad, bias_grad, None
 
 
 def group_norm(x, weight, bias, N, C, HW, num_groups, eps):
-    return GroupNorm.apply(x, weight, bias, N, C, HW, num_groups, eps)
+    return GroupNorm.apply(x, N, C, HW, num_groups, weight, bias, eps)

--- a/src/flag_gems/ops/layernorm.py
+++ b/src/flag_gems/ops/layernorm.py
@@ -54,8 +54,14 @@ def layer_norm_persistent_kernel(
     tl.store(out_mean_ptr + pid, m)
     tl.store(out_rstd_ptr + pid, rstd)
 
-    w = tl.load(weight_ptr + n_offsets, mask=mask)
-    b = tl.load(bias_ptr + n_offsets, mask=mask)
+    if weight_ptr is None:
+        w = 1
+    else:
+        w = tl.load(weight_ptr + n_offsets, mask=mask)
+    if bias_ptr is None:
+        b = 0
+    else:
+        b = tl.load(bias_ptr + n_offsets, mask=mask)
     out = (x - m) * rstd * w + b
 
     tl.store(out_ptr + pid * N + n_offsets, out, mask=mask)
@@ -102,8 +108,14 @@ def layer_norm_persistent_kernel_multiline(
     tl.store(out_mean_ptr + m_offsets, m, mask=m_mask)
     tl.store(out_rstd_ptr + m_offsets, rstd, mask=m_mask)
 
-    w = tl.load(weight_ptr + n_offsets, mask=n_mask)
-    b = tl.load(bias_ptr + n_offsets, mask=n_mask)
+    if weight_ptr is None:
+        w = 1
+    else:
+        w = tl.load(weight_ptr + n_offsets, mask=n_mask)
+    if bias_ptr is None:
+        b = 0
+    else:
+        b = tl.load(bias_ptr + n_offsets, mask=n_mask)
     out = (x - m[:, None]) * rstd[:, None] * w + b
 
     tl.store(out_ptr + m_offsets[:, None] * N + n_offsets, out, mask=mask)
@@ -178,8 +190,14 @@ def layer_norm_loop_kernel(
             other=0.0,
             eviction_policy="evict_first",
         ).to(tl.float32)
-        w = tl.load(weight_ptr + n_offsets, mask=mask)
-        b = tl.load(bias_ptr + n_offsets, mask=mask)
+        if weight_ptr is None:
+            w = 1
+        else:
+            w = tl.load(weight_ptr + n_offsets, mask=mask)
+        if bias_ptr is None:
+            b = 0
+        else:
+            b = tl.load(bias_ptr + n_offsets, mask=mask)
         out = w * (x - m) * rstd + b
         tl.store(out_ptr + pid * N + n_offsets, out, mask=mask)
 
@@ -188,8 +206,14 @@ def layer_norm_loop_kernel(
         x = tl.load(in_ptr + pid * N + n_offsets, eviction_policy="evict_first").to(
             tl.float32
         )
-        w = tl.load(weight_ptr + n_offsets)
-        b = tl.load(bias_ptr + n_offsets)
+        if weight_ptr is None:
+            w = 1
+        else:
+            w = tl.load(weight_ptr + n_offsets)
+        if bias_ptr is None:
+            b = 0
+        else:
+            b = tl.load(bias_ptr + n_offsets)
         out = w * (x - m) * rstd + b
         tl.store(out_ptr + pid * N + n_offsets, out)
 
@@ -234,7 +258,10 @@ def layer_norm_backward_kernel(
         x = tl.load(X + cols[None, :], mask).to(tl.float32)
         x = tl.where(mask, x - mean, 0.0)
         x_hat = x * rstd
-        w = tl.load(W + cols, mask=cols < N).to(tl.float32)
+        if W is None:
+            w = 1
+        else:
+            w = tl.load(W + cols, mask=cols < N).to(tl.float32)
         dx_hat = dy * w
         dx_part2 += dx_hat
         dx_part3 += dx_hat * x_hat
@@ -248,7 +275,10 @@ def layer_norm_backward_kernel(
         mask = row_mask and col_mask
         dy = tl.load(dY + cols[None, :], mask).to(tl.float32)
         x = tl.load(X + cols[None, :], mask).to(tl.float32)
-        w = tl.load(W + cols, mask=cols < N).to(tl.float32)
+        if W is None:
+            w = 1
+        else:
+            w = tl.load(W + cols, mask=cols < N).to(tl.float32)
         x = tl.where(mask, x - mean, 0.0)
         x_hat = x * rstd
         dx_hat = dy * w
@@ -278,8 +308,6 @@ def weight_bias_backward_kernel(
     col_mask = pid < N
     dY += pid
     X += pid
-    dW += pid
-    dB += pid
     accW = tl.zeros([BLOCK_ROW_SIZE, BLOCK_COL_SIZE], dtype=tl.float32)
     accB = tl.zeros([BLOCK_ROW_SIZE, BLOCK_COL_SIZE], dtype=tl.float32)
     for off in range(0, M, BLOCK_ROW_SIZE):
@@ -294,10 +322,12 @@ def weight_bias_backward_kernel(
         x_hat = x * rstd
         accW += dy * x_hat
         accB += dy
-    dw = tl.sum(accW, axis=0)
-    db = tl.sum(accB, axis=0)
-    tl.store(dW, dw[None, :], mask=col_mask)
-    tl.store(dB, db[None, :], mask=col_mask)
+    if dW is not None:
+        dw = tl.sum(accW, axis=0)
+        tl.store(dW + pid, dw[None, :], mask=col_mask)
+    if dB is not None:
+        db = tl.sum(accB, axis=0)
+        tl.store(dB + pid, db[None, :], mask=col_mask)
 
 
 class LayerNorm(torch.autograd.Function):
@@ -310,8 +340,10 @@ class LayerNorm(torch.autograd.Function):
         M = x.numel() // N
 
         x = x.contiguous()
-        weight = weight.contiguous()
-        bias = bias.contiguous()
+        if weight is not None:
+            weight = weight.contiguous()
+        if bias is not None:
+            bias = bias.contiguous()
         y = torch.empty_like(x)
 
         # NOTE: when the input is half-precision(either float16 or bfloat16)
@@ -366,16 +398,17 @@ class LayerNorm(torch.autograd.Function):
                     N,
                     eps,
                 )
-        ctx.save_for_backward(x, weight, mean, rstd)
-        ctx.M = M
-        ctx.N = N
+        if x.requires_grad:
+            ctx.save_for_backward(x, weight, bias, mean, rstd)
+            ctx.M = M
+            ctx.N = N
         return y, mean, rstd
 
     @staticmethod
     def backward(ctx, out_grad, mean_grad, rstd_grad):
         logging.debug("GEMS LAYERNORM BACKWARD")
         out_grad = out_grad.contiguous()
-        (x, weight, mean, rstd) = ctx.saved_tensors
+        (x, weight, bias, mean, rstd) = ctx.saved_tensors
         M = ctx.M
         N = ctx.N
 
@@ -386,14 +419,20 @@ class LayerNorm(torch.autograd.Function):
                 out_grad, x, weight, mean, rstd, in_grad, M, N
             )
 
+        if weight is None and bias is None:
+            return in_grad, None, None, None, None, None
+
+        with torch_device_fn.device(x.device):
             grid = lambda meta: (triton.cdiv(N, meta["BLOCK_COL_SIZE"]), 1, 1)
-            weight_grad = torch.empty_like(weight)
-            bias_grad = torch.empty_like(weight)
+            weight_grad = None if weight is None else torch.empty_like(weight)
+            bias_grad = None if bias is None else torch.empty_like(bias)
             weight_bias_backward_kernel[grid](
                 out_grad, x, mean, rstd, weight_grad, bias_grad, M, N
             )
         return in_grad, None, weight_grad, bias_grad, None, None
 
 
-def layer_norm(x, normalized_shape, weight, bias, eps=1e-5, cudnn_enable=True):
+def layer_norm(
+    x, normalized_shape, weight=None, bias=None, eps=1e-5, cudnn_enable=True
+):
     return LayerNorm.apply(x, normalized_shape, weight, bias, eps, cudnn_enable)

--- a/tests/test_norm_ops.py
+++ b/tests/test_norm_ops.py
@@ -32,18 +32,23 @@ KEEPDIM_DIMS = (
         (1, 64, 32, 32, 64),
     ],
 )
+@pytest.mark.parametrize("wb_none", [False, True])
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_accuracy_groupnorm(N, C, H, W, num_groups, dtype):
+def test_accuracy_groupnorm(N, C, H, W, num_groups, dtype, wb_none):
     HW = H * W
     inp = torch.randn(
         size=(N, C, H, W), dtype=dtype, device=flag_gems.device, requires_grad=True
     )
-    weight = torch.randn(
-        size=(C,), dtype=dtype, device=flag_gems.device, requires_grad=True
-    )
-    bias = torch.randn(
-        size=(C,), dtype=dtype, device=flag_gems.device, requires_grad=True
-    )
+    if wb_none:
+        weight = None
+        bias = None
+    else:
+        weight = torch.randn(
+            size=(C,), dtype=dtype, device=flag_gems.device, requires_grad=True
+        )
+        bias = torch.randn(
+            size=(C,), dtype=dtype, device=flag_gems.device, requires_grad=True
+        )
     eps = 1e-5
 
     ref_inp = to_reference(inp, True)
@@ -68,16 +73,20 @@ def test_accuracy_groupnorm(N, C, H, W, num_groups, dtype):
     out_grad = torch.randn_like(inp)
     ref_grad = to_reference(out_grad, True)
 
-    (ref_in_grad, ref_weight_grad, ref_bias_grad) = torch.autograd.grad(
-        ref_out, (ref_inp, ref_weight, ref_bias), ref_grad
-    )
-    (res_in_grad, res_weight_grad, res_bias_grad) = torch.autograd.grad(
-        res_out, (inp, weight, bias), out_grad
-    )
+    if wb_none:
+        (ref_in_grad,) = torch.autograd.grad(ref_out, ref_inp, ref_grad)
+        (res_in_grad,) = torch.autograd.grad(res_out, inp, out_grad)
+    else:
+        (ref_in_grad, ref_weight_grad, ref_bias_grad) = torch.autograd.grad(
+            ref_out, (ref_inp, ref_weight, ref_bias), ref_grad
+        )
+        (res_in_grad, res_weight_grad, res_bias_grad) = torch.autograd.grad(
+            res_out, (inp, weight, bias), out_grad
+        )
+        gems_assert_close(res_weight_grad, ref_weight_grad, dtype, reduce_dim=N * HW)
+        gems_assert_close(res_bias_grad, ref_bias_grad, dtype, reduce_dim=N * HW)
     group_size = C // num_groups
     gems_assert_close(res_in_grad, ref_in_grad, dtype, reduce_dim=group_size * HW)
-    gems_assert_close(res_weight_grad, ref_weight_grad, dtype, reduce_dim=N * HW)
-    gems_assert_close(res_bias_grad, ref_bias_grad, dtype, reduce_dim=N * HW)
 
 
 @pytest.mark.layer_norm
@@ -94,8 +103,9 @@ def test_accuracy_groupnorm(N, C, H, W, num_groups, dtype):
         (4096, 256),
     ],
 )
+@pytest.mark.parametrize("wb_none", [False, True])
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_accuracy_layernorm(shape, dtype):
+def test_accuracy_layernorm(shape, dtype, wb_none):
     M = shape[0]
     N = shape[1]
     layer_shape = [
@@ -104,12 +114,16 @@ def test_accuracy_layernorm(shape, dtype):
     inp = torch.randn(
         shape[:2], dtype=dtype, device=flag_gems.device, requires_grad=True
     )
-    weight = torch.randn(
-        layer_shape, dtype=dtype, device=flag_gems.device, requires_grad=True
-    )
-    bias = torch.randn(
-        layer_shape, dtype=dtype, device=flag_gems.device, requires_grad=True
-    )
+    if wb_none:
+        weight = None
+        bias = None
+    else:
+        weight = torch.randn(
+            layer_shape, dtype=dtype, device=flag_gems.device, requires_grad=True
+        )
+        bias = torch.randn(
+            layer_shape, dtype=dtype, device=flag_gems.device, requires_grad=True
+        )
     eps = 1e-5
 
     ref_inp = to_reference(inp, True)
@@ -137,15 +151,19 @@ def test_accuracy_layernorm(shape, dtype):
     out_grad = torch.randn_like(inp)
     ref_grad = to_reference(out_grad, True)
 
-    (ref_in_grad, ref_weight_grad, ref_bias_grad) = torch.autograd.grad(
-        ref_out, (ref_inp, ref_weight, ref_bias), ref_grad
-    )
-    (res_in_grad, res_weight_grad, res_bias_grad) = torch.autograd.grad(
-        res_out, (inp, weight, bias), out_grad
-    )
+    if wb_none:
+        (ref_in_grad,) = torch.autograd.grad(ref_out, ref_inp, ref_grad)
+        (res_in_grad,) = torch.autograd.grad(res_out, inp, out_grad)
+    else:
+        (ref_in_grad, ref_weight_grad, ref_bias_grad) = torch.autograd.grad(
+            ref_out, (ref_inp, ref_weight, ref_bias), ref_grad
+        )
+        (res_in_grad, res_weight_grad, res_bias_grad) = torch.autograd.grad(
+            res_out, (inp, weight, bias), out_grad
+        )
+        gems_assert_close(res_weight_grad, ref_weight_grad, dtype, reduce_dim=M)
+        gems_assert_close(res_bias_grad, ref_bias_grad, dtype, reduce_dim=M)
     gems_assert_close(res_in_grad, ref_in_grad, dtype, reduce_dim=N)
-    gems_assert_close(res_weight_grad, ref_weight_grad, dtype, reduce_dim=M)
-    gems_assert_close(res_bias_grad, ref_bias_grad, dtype, reduce_dim=M)
 
 
 @pytest.mark.instance_norm


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
process None pointer in triton kernel and backward function
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->
https://github.com/FlagOpen/FlagGems/issues/323
### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
