### PR TITLE
[muti_backend]support codegen_config specialization

### DIFF
--- a/src/flag_gems/utils/codegen_config_utils.py
+++ b/src/flag_gems/utils/codegen_config_utils.py
@@ -1,0 +1,40 @@
+from dataclasses import dataclass
+from typing import Tuple
+
+import triton
+
+from flag_gems.runtime import device
+from flag_gems.runtime.commom_utils import vendors
+
+
+@dataclass
+class CodeGenConfig:
+    max_tile_size: int
+    max_grid_size: Tuple[int, int, int]
+    max_num_warps_per_cta: int
+
+    prefer_block_pointer: bool
+    prefer_1d_tile: bool
+    # gen_configs: -> configs
+    # prune_config: (as jit function, ) cofigs -> configs
+
+    def __post_init__(self):
+        if self.prefer_1d_tile:
+            self.prefer_block_pointer = False
+
+
+CODEGEN_COFIGS = {
+    vendors.NVIDIA: CodeGenConfig(
+        512,
+        (65536, 65536, 65536),
+        32,
+        True,
+        prefer_1d_tile=int(triton.__version__[0]) < 3,
+    )
+}
+
+
+def get_codegen_config():
+    if device.vendor not in CODEGEN_COFIGS:
+        return CODEGEN_COFIGS.get(vendors.NVIDIA)
+    return CODEGEN_COFIGS.get(device.vendor)


### PR DESCRIPTION
### PR Category
Other

### Type of Change
Other

### Description
1. support codegen_config specialization 
The vendors only needs to config CODEGEN_COFIGS in FlagGems/src/flag_gems/utils/codegen_config_utils.py
```python
CODEGEN_COFIGS = {
    vendors.NVIDIA: CodeGenConfig(
        512,
        (65536, 65536, 65536),
        32,
        True,
        prefer_1d_tile=int(triton.__version__[0]) < 3,
    )
}
```


### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
