### PR TITLE
Gather bwd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ bin-release/
 # Other files and folders
 .settings/
 __pycache__/
+.vscode/
 
 # Distribution files
 build/

--- a/benchmark/test_select_and_slice_perf.py
+++ b/benchmark/test_select_and_slice_perf.py
@@ -6,15 +6,21 @@ import torch
 from flag_gems.utils import shape_utils
 
 from .attri_util import FLOAT_DTYPES
-from .performance_utils import GenericBenchmark, generate_tensor_input
+from .performance_utils import GenericBenchmark2DOnly, generate_tensor_input
 
 
-class TensorSelectBenchmark(GenericBenchmark):
+class TensorSelectBenchmark(GenericBenchmark2DOnly):
     def set_more_metrics(self):
         return ["gbps"]
 
     def set_more_shapes(self):
-        return super().set_more_shapes()
+        shapes = super().set_more_shapes()
+        return [
+            # this filter is for scatter
+            shape
+            for shape in shapes
+            if len(shape) == 2 and shape[0] > 16 and shape[1] > 16
+        ]
 
 
 def index_select_input_fn(shape, cur_dtype, device):
@@ -81,37 +87,21 @@ def test_generic_reduction_benchmark(op_name, torch_op, input_fn, gbps_fn, dtype
 
 
 def gather_scatter_gbps(bench_fn_args, latency):
-    index = bench_fn_args[2]
-    io_amount = sum([shape_utils.size_in_bytes(item) for item in [index, index]])
+    inp, dim, index = bench_fn_args[:3]
+    data_shape = list(inp.shape)
+    data_shape[dim] = index.shape[dim]
+    data = torch.empty(data_shape, dtype=inp.dtype, device=inp.device)
+    io_amount = sum([shape_utils.size_in_bytes(item) for item in [index, data, data]])
     return io_amount * 1e-9 / (latency * 1e-3)
 
 
 @pytest.mark.scatter
 def test_perf_scatter():
     def scatter_input_fn(shape, dtype, device):
-        batch, size = shape
-        src_shape = [batch // 16, size // 16]
-        inp = torch.randn(shape, dtype=dtype, device=device)
+        input_gen = gather_input_fn(shape, dtype, device)
+        inp, dim, index = next(input_gen)
+        src_shape = list(size + 16 for size in index.shape)
         src = torch.randn(src_shape, dtype=dtype, device=device)
-
-        dim = random.choice([0, 1])
-        size_dim = min(src_shape[dim], shape[dim])
-
-        index_shape = [
-            random.randint(1, min(src_shape[0], shape[0])),
-            random.randint(1, min(src_shape[1], shape[1])),
-        ]
-        index = torch.empty(tuple(index_shape), dtype=torch.long, device=device)
-
-        m, n = index_shape
-
-        index_size_dim = index_shape[dim]
-        # make unique indices
-        for i in range(1 if dim == 0 else m):
-            for j in range(1 if dim == 1 else n):
-                ii = [i, j]
-                ii[dim] = slice(0, index.size(dim) + 1)
-                index[tuple(ii)] = torch.randperm(size_dim)[0:index_size_dim]
 
         yield inp, dim, index, src
 
@@ -128,13 +118,11 @@ def test_perf_scatter():
 def gather_input_fn(shape, dtype, device):
     inp = torch.randn(shape, dtype=dtype, device=device)
 
-    dim = random.choice([0, 1])
+    dim = random.randint(0, len(shape) - 1)
     size_dim = shape[dim]
-    index_shape = [
-        random.randint(1, shape[0]),
-        random.randint(1, shape[1]),
-    ]
-    index = torch.empty(tuple(index_shape), dtype=torch.long, device=device)
+    index_shape = list(shape)
+    index_shape[dim] = random.randint(1, shape[dim])
+    index = torch.empty(index_shape, dtype=torch.long, device=device)
 
     m, n = index_shape
 
@@ -174,6 +162,7 @@ def test_perf_gather_backward():
         op_name="gather_backward",
         torch_op=torch.gather,
         input_fn=gather_input_fn,
+        get_gbps=gather_scatter_gbps,
         dtypes=FLOAT_DTYPES,
         is_backward=True,
     )

--- a/benchmark/test_select_and_slice_perf.py
+++ b/benchmark/test_select_and_slice_perf.py
@@ -125,31 +125,32 @@ def test_perf_scatter():
     bench.run()
 
 
+def gather_input_fn(shape, dtype, device):
+    inp = torch.randn(shape, dtype=dtype, device=device)
+
+    dim = random.choice([0, 1])
+    size_dim = shape[dim]
+    index_shape = [
+        random.randint(1, shape[0]),
+        random.randint(1, shape[1]),
+    ]
+    index = torch.empty(tuple(index_shape), dtype=torch.long, device=device)
+
+    m, n = index_shape
+
+    index_size_dim = index_shape[dim]
+    # make unique indices
+    for i in range(1 if dim == 0 else m):
+        for j in range(1 if dim == 1 else n):
+            ii = [i, j]
+            ii[dim] = slice(0, index.size(dim) + 1)
+            index[tuple(ii)] = torch.randperm(size_dim)[0:index_size_dim]
+
+    yield inp, dim, index
+
+
 @pytest.mark.gather
 def test_perf_gather():
-    def gather_input_fn(shape, dtype, device):
-        inp = torch.randn(shape, dtype=dtype, device=device)
-
-        dim = random.choice([0, 1])
-        size_dim = shape[dim]
-        index_shape = [
-            random.randint(1, shape[0]),
-            random.randint(1, shape[1]),
-        ]
-        index = torch.empty(tuple(index_shape), dtype=torch.long, device=device)
-
-        m, n = index_shape
-
-        index_size_dim = index_shape[dim]
-        # make unique indices
-        for i in range(1 if dim == 0 else m):
-            for j in range(1 if dim == 1 else n):
-                ii = [i, j]
-                ii[dim] = slice(0, index.size(dim) + 1)
-                index[tuple(ii)] = torch.randperm(size_dim)[0:index_size_dim]
-
-        yield inp, dim, index
-
     bench = TensorSelectBenchmark(
         op_name="gather",
         torch_op=torch.gather,
@@ -165,6 +166,18 @@ def slice_scatter_gbps(bench_fn_args, latency):
     src = bench_fn_args[1]
     io_amount = sum([shape_utils.size_in_bytes(item) for item in [inp, src, src]])
     return io_amount * 1e-9 / (latency * 1e-3)
+
+
+@pytest.mark.gather_backward
+def test_perf_gather_backward():
+    bench = TensorSelectBenchmark(
+        op_name="gather_backward",
+        torch_op=torch.gather,
+        input_fn=gather_input_fn,
+        dtypes=FLOAT_DTYPES,
+        is_backward=True,
+    )
+    bench.run()
 
 
 @pytest.mark.slice_scatter

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -163,6 +163,7 @@ def enable(lib=aten_lib, unused=None, registrar=registrar):
             ("scatter.src", scatter, Autograd.disable),
             ("scatter.reduce", scatter, Autograd.disable),
             ("gather", gather, Autograd.disable),
+            ("gather_backward", gather_backward, Autograd.disable),
             ("isclose", isclose, Autograd.disable),
             ("allclose", allclose, Autograd.disable),
             ("fill.Scalar", fill_scalar, Autograd.disable),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -39,7 +39,7 @@ from .fill import fill_scalar, fill_tensor
 from .flip import flip
 from .full import full
 from .full_like import full_like
-from .gather import gather
+from .gather import gather, gather_backward
 from .ge import ge, ge_scalar
 from .gelu import gelu
 from .groupnorm import group_norm
@@ -176,6 +176,7 @@ __all__ = [
     "fill_tensor",
     "exponential_",
     "gather",
+    "gather_backward",
     "flip",
     "ones_like",
     "full_like",

--- a/src/flag_gems/ops/gather.py
+++ b/src/flag_gems/ops/gather.py
@@ -259,5 +259,6 @@ def gather(inp, dim, index, out=None, sparse_grad=False):
 
 
 def gather_backward(grad, self, dim, index, sparse_grad):
+    logging.debug("GEMS GATHER BACKWARD")
     result = torch.zeros_like(self)
     return scatter(result, dim, index, grad, reduce="add")

--- a/src/flag_gems/ops/gather.py
+++ b/src/flag_gems/ops/gather.py
@@ -9,7 +9,7 @@ from flag_gems.utils.code_cache import code_cache_dir
 from flag_gems.utils.code_utils import IndentedBuffer, NameSpace
 from flag_gems.utils.shape_utils import restride_dim
 
-from .scatter import scatter
+from .scatter import scatter_
 
 
 def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
@@ -260,5 +260,5 @@ def gather(inp, dim, index, out=None, sparse_grad=False):
 
 def gather_backward(grad, self, dim, index, sparse_grad):
     logging.debug("GEMS GATHER BACKWARD")
-    result = torch.zeros_like(self)
-    return scatter(result, dim, index, grad, reduce="add")
+    result = grad.new_zeros(self.shape)
+    return scatter_(result, dim, index, grad, reduce="add")

--- a/src/flag_gems/ops/gather.py
+++ b/src/flag_gems/ops/gather.py
@@ -9,6 +9,8 @@ from flag_gems.utils.code_cache import code_cache_dir
 from flag_gems.utils.code_utils import IndentedBuffer, NameSpace
 from flag_gems.utils.shape_utils import restride_dim
 
+from .scatter import scatter
+
 
 def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("import torch")
@@ -254,3 +256,8 @@ def gather(inp, dim, index, out=None, sparse_grad=False):
 
     _gather_func(inp_strided, out, index, dim, stride_dim, M, N)
     return out
+
+
+def gather_backward(grad, self, dim, index, sparse_grad):
+    result = torch.zeros_like(self)
+    return scatter(result, dim, index, grad, reduce="add")

--- a/src/flag_gems/ops/scatter.py
+++ b/src/flag_gems/ops/scatter.py
@@ -7,6 +7,7 @@ import torch
 
 from flag_gems.utils.code_cache import code_cache_dir
 from flag_gems.utils.code_utils import IndentedBuffer, NameSpace
+from flag_gems.utils.shape_utils import restride_dim
 
 
 def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
@@ -16,7 +17,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.newline()
     code.writeline("from flag_gems.utils import libentry")
     code.writeline("from flag_gems import runtime")
-    code.writeline("from flag_gems.utils import triton_lang_extension as tle")
+    # code.writeline("from flag_gems.utils import triton_lang_extension as tle")
     code.newline()
     code.newline()
     return code
@@ -32,15 +33,36 @@ def generate_scatter_kernel(
 
     # the autotune function
 
+    code.writeline("def heur_block(args):")
+    with code.indent():
+        code.writeline("return 256")
+    code.newline()
+    code.newline()
+
+    code.writeline("def loop_count(args):")
+    with code.indent():
+        code.writeline("return 4")
     code.newline()
     code.newline()
 
     # the decorators
     code.writeline("@libentry()")
+    code.writeline("@triton.heuristics(")
+    with code.indent():
+        code.writeline("{")
+        with code.indent():
+            code.writeline('"BLOCK": heur_block,')
+            code.writeline('"LOOP": loop_count,')
+        code.writeline("}")
+    code.writeline(")")
+    inp_stride_vars = ",".join(f"'inp_stride_{i}'" for i in range(rank))
+    index_stride_vars = ",".join(f"'index_stride_{i}'" for i in range(rank))
+    src_stride_vars = ",".join(f"'src_stride_{i}'" for i in range(rank))
+    shape_vars = ",".join(f"'shape_{i}'" for i in range(rank))
     code.writeline(
-        '@triton.autotune(configs=runtime.get_triton_config("scatter"), key=["M", "N"], restore_value=["inp"])'
+        f"@triton.jit(do_not_specialize=['N','stride_dim','inp_size_dim',"
+        f"{inp_stride_vars},{index_stride_vars},{src_stride_vars},{shape_vars}])"
     )
-    code.writeline("@triton.jit")
 
     # signature
     code.writeline(f"def {kernel_name}(")
@@ -67,74 +89,99 @@ def generate_scatter_kernel(
             code.writeline(f"{stride_args}, # stride for index")
 
             for i in range(rank):
-                function_ns.create_name(f"index_shape_{i}")
-            shape_args = ", ".join(f"index_shape_{i}: int" for i in range(rank))
-            code.writeline(f"{shape_args}, # shape for index")
+                function_ns.create_name(f"src_stride_{i}")
+            stride_args = ", ".join(f"src_stride_{i}: int" for i in range(rank))
+            code.writeline(f"{stride_args}, # stride for src")
 
-            code.writeline("dim,")
+            for i in range(rank):
+                function_ns.create_name(f"shape_{i}")
+            shape_args = ", ".join(f"shape_{i}: int" for i in range(rank))
+            code.writeline(f"{shape_args}, # shape")
+            code.writeline("inp_size_dim,")
             code.writeline("stride_dim,")
-            code.writeline("M,")
             code.writeline("N,")
             # reduce options
             code.writeline("IS_ADD: tl.constexpr,")
             code.writeline("IS_MUL: tl.constexpr,")
-            code.writeline("BLOCK_M: tl.constexpr,")
-            code.writeline("BLOCK_N: tl.constexpr,")
+            code.writeline("BLOCK: tl.constexpr,")
+            code.writeline("LOOP: tl.constexpr,")
+            code.writeline("INT32_OFFSET: tl.constexpr")
 
     code.writeline("):")
 
     # Kernel Code
     with code.indent():
-        code.writeline("pid_x = tle.program_id(0)")
-        code.writeline("pid_y = tle.program_id(1)")
-        code.writeline(
-            "rows_offsets = pid_x * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]"
-        )
-        code.writeline(
-            "cols_offsets = pid_y * BLOCK_N + tl.arange(0, BLOCK_N)[None, :]"
-        )
-        code.writeline("rows_mask = rows_offsets < M")
-        code.writeline("cols_mask = cols_offsets < N")
-
-        code.writeline("offsets = (rows_offsets * N + cols_offsets).to(tl.int64)")
-        code.writeline("mask = rows_mask & cols_mask")
+        code.writeline("pid = tl.program_id(0)")
+        code.writeline("if not INT32_OFFSET:")
+        with code.indent():
+            code.writeline("pid = pid.to(tl.int64)")
+        code.writeline("offsets = pid * LOOP * BLOCK + tl.arange(0, BLOCK)")
 
         #   1. Calculate inp_offsets and idx_offsets
-        code.writeline("inp_offsets = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.int64)")
-        code.writeline("idx_offsets = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.int64)")
-        code.writeline("cur_idx = rows_offsets * N + cols_offsets")
-
-        #   2. snippets
-        for i in range(rank):
-            code.writeline(f"mod = cur_idx % index_shape_{i}")
-            code.writeline(f"inp_offsets += mod * inp_stride_{i}")
-            code.writeline(f"idx_offsets += mod * index_stride_{i}")
-            if i != (rank - 1):
-                code.writeline(f"cur_idx = cur_idx // index_shape_{i}")
-
-        #   3. Use offsets to scatter
-        code.writeline(
-            "cur_src = tl.load(src_strided + idx_offsets, mask=mask, other=0)"
-        )
-        code.writeline("cur_index = tl.load(index + idx_offsets, mask=mask, other=0)")
-        code.writeline("inp_offsets += cur_index * stride_dim")
-
-        code.newline()
-        code.writeline("if IS_ADD: ")
+        code.writeline("for loop_iter in range(LOOP):")
         with code.indent():
-            code.writeline("cur_inp = tl.load(inp + inp_offsets, mask=mask, other=0)")
-            code.writeline("res = cur_inp + cur_src")
-            code.writeline("tl.store(out + inp_offsets, res, mask=mask)")
+            code.writeline("mask = offsets < N")
+            code.writeline("cur_idx = offsets")
+            code.writeline("if INT32_OFFSET:")
+            with code.indent():
+                code.writeline("inp_offsets = tl.zeros((BLOCK, ), dtype=tl.int32)")
+                code.writeline("idx_offsets = tl.zeros((BLOCK, ), dtype=tl.int32)")
+                code.writeline("src_offsets = tl.zeros((BLOCK, ), dtype=tl.int32)")
+            code.writeline("else:")
+            with code.indent():
+                code.writeline("inp_offsets = tl.zeros((BLOCK, ), dtype=tl.int64)")
+                code.writeline("idx_offsets = tl.zeros((BLOCK, ), dtype=tl.int64)")
+                code.writeline("src_offsets = tl.zeros((BLOCK, ), dtype=tl.int64)")
+            for i in range(rank)[::-1]:
+                code.writeline("if INT32_OFFSET:")
+                with code.indent():
+                    code.writeline(f"shape_{i} = shape_{i}.to(tl.int32)")
+                    code.writeline(f"inp_stride_{i} = inp_stride_{i}.to(tl.int32)")
+                    code.writeline(f"index_stride_{i} = index_stride_{i}.to(tl.int32)")
+                    code.writeline(f"src_stride_{i} = src_stride_{i}.to(tl.int32)")
+                code.writeline(f"mod = cur_idx % shape_{i}")
+                code.writeline(f"inp_offsets += mod * inp_stride_{i}")
+                code.writeline(f"idx_offsets += mod * index_stride_{i}")
+                code.writeline(f"src_offsets += mod * src_stride_{i}")
+                if i != 0:
+                    code.writeline(f"cur_idx = cur_idx // shape_{i}")
 
-        code.writeline("elif IS_MUL: ")
-        with code.indent():
-            code.writeline("cur_inp = tl.load(inp + inp_offsets, mask=mask, other=0)")
-            code.writeline("res = cur_inp * cur_src")
-            code.writeline("tl.store(out + inp_offsets, res, mask=mask)")
+            #   2. Use offsets to scatter
+            code.writeline(
+                "cur_src = tl.load(src_strided + src_offsets, mask=mask, other=0)"
+            )
+            code.writeline(
+                "cur_index = tl.load(index + idx_offsets, mask=mask, other=0)"
+            )
+            code.writeline("if INT32_OFFSET:")
+            with code.indent():
+                code.writeline("cur_index = cur_index.to(tl.int32)")
+                code.writeline("stride_dim = stride_dim.to(tl.int32)")
 
-        code.writeline("else: ")
-        with code.indent():
-            code.writeline("tl.store(out + inp_offsets, cur_src, mask=mask)")
+            code.writeline("dim_offsets = cur_index * stride_dim")
+            code.writeline("inp_offsets += dim_offsets")
+            code.newline()
+            code.writeline("if IS_ADD: ")
+            with code.indent():
+                code.writeline(
+                    "cur_inp = tl.load(inp + inp_offsets, mask=mask, other=0)"
+                )
+                code.writeline("res = cur_inp + cur_src")
+                code.writeline("tl.store(out + inp_offsets, res, mask=mask)")
+
+            code.writeline("elif IS_MUL: ")
+            with code.indent():
+                code.writeline(
+                    "cur_inp = tl.load(inp + inp_offsets, mask=mask, other=0)"
+                )
+                code.writeline("res = cur_inp * cur_src")
+                code.writeline("tl.store(out + inp_offsets, res, mask=mask)")
+
+            code.writeline("else: ")
+            with code.indent():
+                code.writeline("tl.store(out + inp_offsets, cur_src, mask=mask)")
+
+            code.writeline("offsets += BLOCK")
 
     code.newline()
     code.newline()
@@ -149,10 +196,11 @@ def parameter_for_wrapper() -> str:
     parameters.append("index")
     parameters.append("inp")
     parameters.append("out")
-    parameters.append("dim")
-    parameters.append("M")
+    parameters.append("dim_size")
+    parameters.append("dim_stride")
     parameters.append("N")
-    parameters.append("reduce")
+    parameters.append("reduce: tl.constexpr=None")
+    parameters.append("int32_offset: tl.constexpr=None")
 
     return ", ".join(parameters)
 
@@ -170,18 +218,19 @@ def generate_destination_passing_wrapper(
     with code.indent():
         code.writeline("inp_strides = list(inp.stride())")
         code.writeline("index_strides = index.stride()")
+        code.writeline("src_strides = src_strided.stride()")
         code.writeline("index_shapes = list(index.shape)")
-        code.writeline("stride_dim = inp_strides[dim]")
-        code.writeline("inp_strides[dim] = 0")
+        code.writeline("inp_size_dim = dim_size")
+        code.writeline("stride_dim = dim_stride")
 
         code.writeline('IS_ADD = reduce == "add"')
         code.writeline('IS_MUL = reduce == "multiply"')
+        code.writeline("int32_offset = int32_offset or True")
 
         # kernel launch
         code.writeline("grid = lambda meta: (")
         with code.indent():
-            code.writeline('triton.cdiv(M, meta["BLOCK_M"]),')
-            code.writeline('triton.cdiv(N, meta["BLOCK_N"])')
+            code.writeline('triton.cdiv(N, meta["BLOCK"] * meta["LOOP"]), ')
         code.writeline(")")
 
         kernel_launch: str = f"{kernel_name}[grid]("
@@ -196,16 +245,19 @@ def generate_destination_passing_wrapper(
                 s = ", ".join(f"index_strides[{i}]" for i in range(rank))
                 code.writeline(f"{s},")
 
+                s = ", ".join(f"src_strides[{i}]" for i in range(rank))
+                code.writeline(f"{s},")
+
                 s = ", ".join(f"index_shapes[{i}]" for i in range(rank))
                 code.writeline(f"{s},")
 
-                code.writeline("dim,")
+                code.writeline("inp_size_dim,")
                 code.writeline("stride_dim,")
-                code.writeline("M,")
                 code.writeline("N,")
                 # reduce options
                 code.writeline("IS_ADD,")
                 code.writeline("IS_MUL,")
+                code.writeline("INT32_OFFSET=int32_offset,")
         code.writeline(")")
         code.writeline("return out")
 
@@ -275,31 +327,51 @@ _scatter_func = ScatterFunction()
 
 def scatter(inp, dim, index, src, reduce=None):
     logging.debug("GEMS SCATTER")
-    inp = inp.contiguous()
-    index = index.contiguous()
-    src = src.contiguous()
     out = inp.clone()
 
-    src_strided = src.as_strided(index.shape, src.stride()).contiguous()
-    # plain_idx = torch.arange(0, index.numel(), device=inp.device).reshape(index.shape)
-    N = list(index.shape)[index.ndim - 1]
-    M = index.numel() // N
+    src_strided = src.as_strided(index.shape, src.stride())
+    inp_restrided = restride_dim(inp, dim, index.shape)
+    dim_size = inp.size(dim)
+    dim_stride = inp.stride(dim)
+    N = index.numel()
 
-    _scatter_func(src_strided, index, inp, out, dim, M, N, reduce)
+    int32_size_dim = lambda x: x.stride(dim) * x.size(dim) < 2**32
+    use_int32_offset = all(map(int32_size_dim, (inp, index, src)))
+    _scatter_func(
+        src_strided,
+        index,
+        inp_restrided,
+        out,
+        dim_size,
+        dim_stride,
+        N,
+        reduce,
+        int32_offset=use_int32_offset,
+    )
     return out
 
 
 def scatter_(inp, dim, index, src, reduce=None):
     logging.debug("GEMS SCATTER_")
-    inp = inp.contiguous()
-    index = index.contiguous()
-    src = src.contiguous()
     out = inp
 
-    src_strided = src.as_strided(index.shape, src.stride()).contiguous()
-    # plain_idx = torch.arange(0, index.numel(), device=inp.device).reshape(index.shape)
-    N = list(index.shape)[index.ndim - 1]
-    M = index.numel() // N
+    src_restrided = src.as_strided(index.shape, src.stride())
+    inp_restrided = restride_dim(inp, dim, index.shape)
+    dim_size = inp.size(dim)
+    dim_stride = inp.stride(dim)
+    N = index.numel()
 
-    _scatter_func(src_strided, index, inp, out, dim, M, N, reduce)
+    int32_size_dim = lambda x: x.stride(dim) * x.size(dim) < 2**32
+    use_int32_offset = all(map(int32_size_dim, (inp, index, src)))
+    _scatter_func(
+        src_restrided,
+        index,
+        inp_restrided,
+        out,
+        dim_size,
+        dim_stride,
+        N,
+        reduce,
+        int32_offset=use_int32_offset,
+    )
     return inp

--- a/src/flag_gems/ops/scatter.py
+++ b/src/flag_gems/ops/scatter.py
@@ -38,7 +38,7 @@ def generate_scatter_kernel(
     # the decorators
     code.writeline("@libentry()")
     code.writeline(
-        '@triton.autotune(configs=runtime.get_tuned_config("scatter"), key=["M", "N"])'
+        '@triton.autotune(configs=runtime.get_triton_config("scatter"), key=["M", "N"], restore_value=["inp"])'
     )
     code.writeline("@triton.jit")
 
@@ -302,4 +302,4 @@ def scatter_(inp, dim, index, src, reduce=None):
     M = index.numel() // N
 
     _scatter_func(src_strided, index, inp, out, dim, M, N, reduce)
-    return out
+    return inp

--- a/src/flag_gems/ops/scatter.py
+++ b/src/flag_gems/ops/scatter.py
@@ -334,6 +334,11 @@ def scatter(inp, dim, index, src, reduce=None):
     logging.debug("GEMS SCATTER")
     out = inp.clone()
 
+    if reduce is not None:
+        assert inp.dtype not in (
+            torch.bfloat16,
+        ), "Unsupported operation: reduce scatter bfloat tensors."
+
     if has_internal_overlapping(out):
         out = out.contiguous()
 
@@ -363,6 +368,11 @@ def scatter(inp, dim, index, src, reduce=None):
 def scatter_(inp, dim, index, src, reduce=None):
     logging.debug("GEMS SCATTER_")
     out = inp
+
+    if reduce is not None:
+        assert inp.dtype not in (
+            torch.bfloat16,
+        ), "Unsupported operation: reduce scatter bfloat tensors."
 
     assert not has_internal_overlapping(
         out

--- a/src/flag_gems/ops/scatter.py
+++ b/src/flag_gems/ops/scatter.py
@@ -287,3 +287,19 @@ def scatter(inp, dim, index, src, reduce=None):
 
     _scatter_func(src_strided, index, inp, out, dim, M, N, reduce)
     return out
+
+
+def scatter_(inp, dim, index, src, reduce=None):
+    logging.debug("GEMS SCATTER_")
+    inp = inp.contiguous()
+    index = index.contiguous()
+    src = src.contiguous()
+    out = inp
+
+    src_strided = src.as_strided(index.shape, src.stride()).contiguous()
+    # plain_idx = torch.arange(0, index.numel(), device=inp.device).reshape(index.shape)
+    N = list(index.shape)[index.ndim - 1]
+    M = index.numel() // N
+
+    _scatter_func(src_strided, index, inp, out, dim, M, N, reduce)
+    return out

--- a/src/flag_gems/ops/scatter.py
+++ b/src/flag_gems/ops/scatter.py
@@ -35,7 +35,7 @@ def generate_scatter_kernel(
 
     code.writeline("def heur_block(args):")
     with code.indent():
-        code.writeline("return 256")
+        code.writeline("return 128")
     code.newline()
     code.newline()
 
@@ -118,7 +118,7 @@ def generate_scatter_kernel(
         code.writeline("offsets = pid * LOOP * BLOCK + tl.arange(0, BLOCK)")
 
         #   1. Calculate inp_offsets and idx_offsets
-        code.writeline("for loop_iter in range(LOOP):")
+        code.writeline("for loop_iter in tl.static_range(LOOP):")
         with code.indent():
             code.writeline("mask = offsets < N")
             code.writeline("cur_idx = offsets")
@@ -164,7 +164,6 @@ def generate_scatter_kernel(
             code.writeline("if IS_ADD: ")
             with code.indent():
                 code.writeline("tl.atomic_add(out + inp_offsets, cur_src, mask=mask)")
-
             code.writeline("elif IS_MUL: ")
             with code.indent():
                 code.writeline("stop = tl.where(mask, 0, 1).to(tl.int1)")

--- a/src/flag_gems/ops/scatter.py
+++ b/src/flag_gems/ops/scatter.py
@@ -163,7 +163,9 @@ def generate_scatter_kernel(
             code.newline()
             code.writeline("if IS_ADD: ")
             with code.indent():
-                code.writeline("tl.atomic_add(out + inp_offsets, cur_src, mask=mask)")
+                code.writeline(
+                    "tl.atomic_add(out + inp_offsets, cur_src, mask=mask, sem='relaxed')"
+                )
             code.writeline("elif IS_MUL: ")
             with code.indent():
                 code.writeline("stop = tl.where(mask, 0, 1).to(tl.int1)")
@@ -176,7 +178,7 @@ def generate_scatter_kernel(
                     )
                     code.writeline("res = tl.where(stop, cur_inp, cur_inp * cur_src)")
                     code.writeline(
-                        "cas_res = tl.atomic_cas(out + inp_offsets, cur_inp, res)"
+                        "cas_res = tl.atomic_cas(out + inp_offsets, cur_inp, res, sem='relaxed')"
                     )
                     code.writeline("stop |= cur_inp == cas_res")
                     code.writeline("block_stop = tl.sum(stop.to(tl.int32)) == BLOCK")

--- a/src/flag_gems/ops/select_scatter.py
+++ b/src/flag_gems/ops/select_scatter.py
@@ -3,7 +3,7 @@ import logging
 import torch
 
 from ..ops.copy import copy
-from ..utils.shape_utils import MemOverlap, has_internal_overlapping
+from ..utils.shape_utils import has_internal_overlapping
 
 
 def select_scatter(inp, src, dim, index):
@@ -19,7 +19,7 @@ def select_scatter(inp, src, dim, index):
         list(src.shape) == valid_shape
     ), "Expected src to have a size equal to the slice of self"
 
-    if has_internal_overlapping(inp) == MemOverlap.Yes:
+    if has_internal_overlapping(inp):
         out = torch.empty(inp.size(), dtype=inp.dtype, device=inp.device)
     else:
         out = torch.empty_strided(

--- a/src/flag_gems/ops/slice_scatter.py
+++ b/src/flag_gems/ops/slice_scatter.py
@@ -4,7 +4,7 @@ import torch
 import triton
 
 from ..ops.copy import copy
-from ..utils.shape_utils import MemOverlap, has_internal_overlapping
+from ..utils.shape_utils import has_internal_overlapping
 
 
 def slice_scatter(inp, src, dim=0, start=None, end=None, step=1):
@@ -25,7 +25,7 @@ def slice_scatter(inp, src, dim=0, start=None, end=None, step=1):
         list(src.shape) == valid_shape
     ), "Expected src to have a size equal to the slice of self"
 
-    if has_internal_overlapping(inp) == MemOverlap.Yes:
+    if has_internal_overlapping(inp):
         out = torch.empty(inp.size(), dtype=inp.dtype, device=inp.device)
     else:
         out = torch.empty_strided(

--- a/src/flag_gems/utils/shape_utils.py
+++ b/src/flag_gems/utils/shape_utils.py
@@ -1,4 +1,3 @@
-import enum
 import functools
 import operator
 from typing import Iterable, Sequence, Tuple
@@ -226,21 +225,15 @@ def can_use_int32_index(a):
     return True
 
 
-class MemOverlap(enum.Enum):
-    No = 0
-    Yes = 1
-    TooHard = 2
-
-
 def has_internal_overlapping(x: torch.Tensor):
     if x.is_contiguous():
-        return MemOverlap.No
+        return False
     if torch.ops.aten.is_non_overlapping_and_dense(x):
-        return MemOverlap.No
+        return False
     for size, stride in zip(x.size(), x.stride()):
         if size > 1 and stride == 0:
-            return MemOverlap.Yes
-    return MemOverlap.TooHard
+            return True
+    return True
 
 
 def restride_dim(src, dim, shape, step=0, storage_offset=None):

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -422,7 +422,7 @@ def test_accuracy_scatter_src(src_shape, inp_shape, dim, dtype):
     "inp_shape", [(64, 16, 8)] if QUICK_MODE else [(512, 128, 32), (1024, 64, 16)]
 )
 @pytest.mark.parametrize("dim", [0, 1, 2])
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
 def test_accuracy_scatter_add(src_shape, inp_shape, dim, dtype):
     inp = torch.randn(inp_shape, dtype=dtype, device=flag_gems.device)
     src = torch.randn(src_shape, dtype=dtype, device=flag_gems.device)
@@ -466,7 +466,7 @@ def test_accuracy_scatter_add(src_shape, inp_shape, dim, dtype):
     "inp_shape", [(64, 16, 8)] if QUICK_MODE else [(512, 128, 32), (1024, 64, 16)]
 )
 @pytest.mark.parametrize("dim", [0, 1, 2])
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
 def test_accuracy_scatter_mul(src_shape, inp_shape, dim, dtype):
     inp = torch.randn(inp_shape, dtype=dtype, device=flag_gems.device)
     src = torch.randn(src_shape, dtype=dtype, device=flag_gems.device)

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -544,6 +544,9 @@ def test_accuracy_gather(inp_shape, dim, dtype):
 
     gems_assert_equal(res_out, ref_out)
 
+    if dtype in (torch.bfloat16,):
+        return
+
     out_grad = torch.randn_like(res_out)
     ref_grad = to_reference(out_grad)
 

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -510,7 +510,9 @@ def test_accuracy_scatter_mul(src_shape, inp_shape, dim, dtype):
 @pytest.mark.parametrize("dim", [0, 1, 2])
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_accuracy_gather(inp_shape, dim, dtype):
-    inp = torch.randn(inp_shape, dtype=dtype, device=flag_gems.device)
+    inp = torch.randn(
+        inp_shape, dtype=dtype, device=flag_gems.device, requires_grad=True
+    )
     size_dim = inp_shape[dim]
 
     import random
@@ -541,6 +543,15 @@ def test_accuracy_gather(inp_shape, dim, dtype):
         res_out = torch.gather(inp, dim, index)
 
     gems_assert_equal(res_out, ref_out)
+
+    out_grad = torch.randn_like(res_out)
+    ref_grad = to_reference(out_grad)
+
+    (ref_in_grad,) = torch.autograd.grad(ref_out, ref_inp, ref_grad)
+    with flag_gems.use_gems():
+        (res_in_grad,) = torch.autograd.grad(res_out, inp, out_grad)
+    res_in_grad = to_reference(res_in_grad)
+    gems_assert_equal(res_in_grad, ref_in_grad)
 
 
 @pytest.mark.select_scatter


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator


### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Performance Optimization 

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Refactored scatter and gather backward for better performance.  Changes are:
- Use 1d grid of 256 sized blocks, each unrolling 4 times
- Restride inp, index and src to have the same size
- Scatter add/multiply are now using tl atomics 
- Update benchmarks

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

![image](https://github.com/user-attachments/assets/d3290175-47a2-4fa4-a599-fd325d7a55cb)
![image](https://github.com/user-attachments/assets/2601b87f-3e2c-4300-990c-3d9024d321f9)

