### PR TITLE
[benchmark] skip perf test of cummin when triton < 3.0

### DIFF
--- a/benchmark/performance_utils.py
+++ b/benchmark/performance_utils.py
@@ -1,4 +1,5 @@
 import gc
+import importlib
 import logging
 import time
 from typing import Any, Generator, List, Optional, Tuple
@@ -28,6 +29,30 @@ torch_backend_device = flag_gems.runtime.torch_backend_device
 torch_device_fn = flag_gems.runtime.torch_device_fn
 device = flag_gems.device
 torch_backend_device.matmul.allow_tf32 = False
+
+
+def SkipVersion(module_name, skip_pattern):
+    cmp = skip_pattern[0]
+    assert cmp in ("=", "<", ">"), f"Invalid comparison operator: {cmp}"
+    try:
+        M, N = skip_pattern[1:].split(".")
+        M, N = int(M), int(N)
+    except Exception:
+        raise ValueError("Cannot parse version number from skip_pattern.")
+
+    try:
+        module = importlib.import_module(module_name)
+        version = module.__version__
+        major, minor = map(int, version.split(".")[:2])
+    except Exception:
+        raise ImportError(f"Cannot determine version of module: {module_name}")
+
+    if cmp == "=":
+        return major == M and minor == N
+    elif cmp == "<":
+        return (major, minor) < (M, N)
+    else:
+        return (major, minor) > (M, N)
 
 
 class Benchmark:

--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -11,6 +11,7 @@ from .performance_utils import (
     Benchmark,
     Config,
     GenericBenchmark2DOnly,
+    SkipVersion,
     generate_tensor_input,
     unary_input_fn,
 )
@@ -153,7 +154,12 @@ def cumsum_input_fn(shape, cur_dtype, device):
             torch.cummin,
             cumsum_input_fn,
             FLOAT_DTYPES + INT_DTYPES,
-            marks=pytest.mark.cummin,
+            marks=[
+                pytest.mark.cummin,
+                pytest.mark.skipif(
+                    SkipVersion("triton", "<3.0"), reason="triton not supported"
+                ),
+            ],
         ),
     ],
 )


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Benchmark
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Other
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
triton before version 3.0 doesn't support cummin.
mark the parameters of cummin as skipped.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
