### PR TITLE
[Muti backend] add iluvatar backend

### DIFF
--- a/examples/model_bert_test.py
+++ b/examples/model_bert_test.py
@@ -32,7 +32,7 @@ def test_accuracy_bert(prompt, dtype):
     with flag_gems.use_gems():
         with torch.no_grad():
             res_outputs = res_model(**res_inputs).last_hidden_state
-    res_outputs = res_outputs.to("cpu")
+
     maxdiff = torch.max(torch.abs(ref_outputs - res_outputs))
     succeed = True
     if (

--- a/examples/model_bert_test.py
+++ b/examples/model_bert_test.py
@@ -32,7 +32,7 @@ def test_accuracy_bert(prompt, dtype):
     with flag_gems.use_gems():
         with torch.no_grad():
             res_outputs = res_model(**res_inputs).last_hidden_state
-
+    res_outputs = res_outputs.to("cpu")
     maxdiff = torch.max(torch.abs(ref_outputs - res_outputs))
     succeed = True
     if (

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -127,6 +127,8 @@ def early_config_prune(configs, nargs, **kwargs):
     key=["KV_CTX", "HEAD_DIM"],
     prune_configs_by={
         "early_config_prune": early_config_prune,
+        "perf_model": None,
+        "top_k": 1.0,
     },
 )
 @triton.jit

--- a/src/flag_gems/ops/topk.py
+++ b/src/flag_gems/ops/topk.py
@@ -5,7 +5,7 @@ import torch
 import triton
 import triton.language as tl
 import triton.language.core as core
-from triton.language.standard import _log2, zeros_like
+from triton.language.standard import zeros_like
 
 from ..runtime import torch_device_fn
 from ..utils import libentry
@@ -23,6 +23,15 @@ _MIN_INT32_VAL: tl.constexpr = torch.iinfo(torch.int32).min
 _MAX_INT32_VAL: tl.constexpr = torch.iinfo(torch.int32).max
 _MIN_INT64_VAL: tl.constexpr = torch.iinfo(torch.int64).min
 _MAX_INT64_VAL: tl.constexpr = torch.iinfo(torch.int64).max
+
+
+def _log2(i: core.constexpr):
+    log2 = 0
+    n = i.value
+    while n > 1:
+        n >>= 1
+        log2 += 1
+    return core.constexpr(log2)
 
 
 @triton.jit

--- a/src/flag_gems/ops/topk.py
+++ b/src/flag_gems/ops/topk.py
@@ -5,7 +5,7 @@ import torch
 import triton
 import triton.language as tl
 import triton.language.core as core
-from triton.language.standard import zeros_like
+from triton.language.standard import _log2, zeros_like
 
 from ..runtime import torch_device_fn
 from ..utils import libentry
@@ -23,15 +23,6 @@ _MIN_INT32_VAL: tl.constexpr = torch.iinfo(torch.int32).min
 _MAX_INT32_VAL: tl.constexpr = torch.iinfo(torch.int32).max
 _MIN_INT64_VAL: tl.constexpr = torch.iinfo(torch.int64).min
 _MAX_INT64_VAL: tl.constexpr = torch.iinfo(torch.int64).max
-
-
-def _log2(i: core.constexpr):
-    log2 = 0
-    n = i.value
-    while n > 1:
-        n >>= 1
-        log2 += 1
-    return core.constexpr(log2)
 
 
 @triton.jit

--- a/src/flag_gems/ops/topk.py
+++ b/src/flag_gems/ops/topk.py
@@ -5,7 +5,13 @@ import torch
 import triton
 import triton.language as tl
 import triton.language.core as core
-from triton.language.standard import _log2, zeros_like
+
+try:
+    # TODO: Triton 2.1 does not implement _log2.
+    # Remove the try-catch block once all vendors upgrade to a newer version of Triton.
+    from triton.language.standard import _log2, zeros_like
+except ImportError:
+    pass
 
 from ..runtime import torch_device_fn
 from ..utils import libentry

--- a/src/flag_gems/ops/upsample_bicubic2d_aa.py
+++ b/src/flag_gems/ops/upsample_bicubic2d_aa.py
@@ -390,8 +390,14 @@ def general_interpolate_bicubic2d_aa_kernel(
     ow = (pid_x * BLOCK_X + tl.arange(0, BLOCK_X)) % OW
     oh = (pid_y * BLOCK_Y + tl.arange(0, BLOCK_Y)) % OH
 
-    support_w = 2 * reciprocal_scale_w if (reciprocal_scale_w >= 1.0) else 2.0
-    support_h = 2 * reciprocal_scale_h if (reciprocal_scale_h >= 1.0) else 2.0
+    if reciprocal_scale_w >= 1.0:
+        support_w = 2 * reciprocal_scale_w
+    else:
+        support_w = 2.0
+    if reciprocal_scale_h >= 1.0:
+        support_h = 2 * reciprocal_scale_h
+    else:
+        support_h = 2.0
 
     interpolate_w = (support_w + 0.5).to(tl.int32) * 2 + 1
     interpolate_h = (support_h + 0.5).to(tl.int32) * 2 + 1
@@ -408,8 +414,14 @@ def general_interpolate_bicubic2d_aa_kernel(
         tl.int32
     )
 
-    invscale_w = 1.0 / reciprocal_scale_w if (reciprocal_scale_w >= 1.0) else 1.0
-    invscale_h = 1.0 / reciprocal_scale_h if (reciprocal_scale_h >= 1.0) else 1.0
+    if reciprocal_scale_w >= 1.0:
+        invscale_w = 1.0 / reciprocal_scale_w
+    else:
+        invscale_w = 1.0
+    if reciprocal_scale_h >= 1.0:
+        invscale_h = 1.0 / reciprocal_scale_h
+    else:
+        invscale_h = 1.0
     start_minus_center_w = span_start_w - center_w
     start_minus_center_h = span_start_h - center_h
 

--- a/src/flag_gems/runtime/backend/_iluvatar/__init__.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/__init__.py
@@ -1,0 +1,22 @@
+from backend_utils import VendorInfoBase  # noqa: E402
+
+from .heuristics_config_utils import HEURISTICS_CONFIGS
+
+global specific_ops, unused_ops
+specific_ops = None
+unused_ops = None
+vendor_info = VendorInfoBase(
+    vendor_name="iluvatar", device_name="cuda", device_query_cmd="ixsmi"
+)
+
+
+def OpLoader():
+    global specific_ops, unused_ops
+    if specific_ops is None:
+        from . import ops  # noqa: F403
+
+        specific_ops = ops.get_specific_ops()
+        unused_ops = ops.get_unused_ops()
+
+
+__all__ = ["HEURISTICS_CONFIGS", "vendor_info", "OpLoader"]

--- a/src/flag_gems/runtime/backend/_iluvatar/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/heuristics_config_utils.py
@@ -1,0 +1,265 @@
+import torch
+import triton
+
+
+def argmax_heur_block_m(args):
+    return 4 if args["M"] < 4096 else 8
+
+
+def argmax_heur_block_n(args):
+    return min(4096, triton.next_power_of_2(args["N"]))
+
+
+def bmm_heur_divisible_m(args):
+    return args["M"] % args["BLOCK_M"] == 0
+
+
+def bmm_heur_divisible_n(args):
+    return args["N"] % args["BLOCK_N"] == 0
+
+
+def bmm_heur_divisible_k(args):
+    return args["K"] % args["BLOCK_K"] == 0
+
+
+def dropout_heur_block(args):
+    if args["N"] <= 512:
+        return 512
+    else:
+        return 1024
+
+
+def dropout_heur_num_warps(args):
+    if args["N"] <= 512:
+        return 4
+    elif args["N"] <= 1024:
+        return 8
+    else:
+        return 16
+
+
+def exponential_heur_block(args):
+    if args["N"] <= 512:
+        return 512
+    else:
+        return 1024
+
+
+def exponential_heur_num_warps(args):
+    if args["N"] <= 512:
+        return 4
+    elif args["N"] <= 1024:
+        return 8
+    else:
+        return 16
+
+
+def gather_heur_block_m(args):
+    return min(4, triton.next_power_of_2(triton.cdiv(args["N"], 2048)))
+
+
+def gather_heur_block_n(args):
+    return min(2048, triton.next_power_of_2(args["N"]))
+
+
+def index_select_heur_block_m(args):
+    return min(4, triton.next_power_of_2(triton.cdiv(256, args["N"])))
+
+
+def index_select_heur_block_n(args):
+    m = min(triton.next_power_of_2(triton.cdiv(args["N"], 16)), 512)
+    return max(m, 16)
+
+
+def mm_heur_even_k(args):
+    return args["K"] % (args["BLOCK_K"] * args["SPLIT_K"]) == 0
+
+
+def rand_heur_block(args):
+    if args["N"] <= 512:
+        return 512
+    else:
+        return 1024
+
+
+def rand_heur_num_warps(args):
+    if args["N"] <= 512:
+        return 4
+    elif args["N"] <= 1024:
+        return 8
+    else:
+        return 16
+
+
+def randn_heur_block(args):
+    if args["N"] <= 512:
+        return 512
+    else:
+        return 1024
+
+
+def randn_heur_num_warps(args):
+    if args["N"] <= 512:
+        return 4
+    elif args["N"] <= 1024:
+        return 8
+    else:
+        return 16
+
+
+def softmax_heur_tile_k(args):
+    MAX_TILE_K = 8192
+    NUM_SMS = torch.cuda.get_device_properties(
+        torch.cuda.current_device()
+    ).multi_processor_count
+    tile_k = 1
+    upper_bound = min(args["K"], MAX_TILE_K)
+    while tile_k <= upper_bound:
+        num_blocks = args["M"] * triton.cdiv(args["K"], tile_k)
+        num_waves = num_blocks / NUM_SMS
+        if (num_waves > 1) and (tile_k * 2 <= upper_bound):
+            tile_k *= 2
+        else:
+            break
+    return tile_k
+
+
+def softmax_heur_tile_n_non_inner(args):
+    return triton.cdiv(8192, args["TILE_K"])
+
+
+def softmax_heur_one_tile_per_cta(args):
+    return args["TILE_N"] >= args["N"]
+
+
+def softmax_heur_num_warps_non_inner(args):
+    tile_size = args["TILE_N"] * args["TILE_K"]
+    if tile_size < 2048:
+        return 4
+    elif tile_size < 4096:
+        return 8
+    else:
+        return 16
+
+
+def softmax_heur_tile_n_inner(args):
+    if args["N"] <= (32 * 1024):
+        return triton.next_power_of_2(args["N"])
+    else:
+        return 4096
+
+
+def softmax_heur_num_warps_inner(args):
+    tile_size = args["TILE_N"]
+    if tile_size < 2048:
+        return 4
+    elif tile_size < 4096:
+        return 8
+    else:
+        return 16
+
+
+def softmax_heur_tile_n_bwd_non_inner(args):
+    return max(1, 1024 // args["TILE_K"])
+
+
+def softmax_heru_tile_m(args):
+    return max(1, 1024 // args["TILE_N"])
+
+
+def uniform_heur_block(args):
+    if args["N"] <= 512:
+        return 512
+    else:
+        return 1024
+
+
+def uniform_heur_num_warps(args):
+    if args["N"] <= 512:
+        return 4
+    elif args["N"] <= 1024:
+        return 8
+    else:
+        return 16
+
+
+def var_mean_heur_block_n(args):
+    return triton.next_power_of_2(args["BLOCK_NUM"])
+
+
+def upsample_nearest2d_SAME_H(args):
+    return args["OH"] == args["IH"]
+
+
+def upsample_nearest2d_SAME_W(args):
+    return args["OW"] == args["IW"]
+
+
+HEURISTICS_CONFIGS = {
+    "argmax": {
+        "BLOCK_M": argmax_heur_block_m,
+        "BLOCK_N": argmax_heur_block_n,
+    },
+    "bmm": {
+        "DIVISIBLE_M": bmm_heur_divisible_m,
+        "DIVISIBLE_N": bmm_heur_divisible_n,
+        "DIVISIBLE_K": bmm_heur_divisible_k,
+    },
+    "dropout": {
+        "BLOCK": dropout_heur_block,
+        "num_warps": dropout_heur_num_warps,
+    },
+    "exponential_": {
+        "BLOCK": exponential_heur_block,
+        "num_warps": exponential_heur_num_warps,
+    },
+    "gather": {
+        "BLOCK_M": gather_heur_block_m,
+        "BLOCK_N": gather_heur_block_n,
+    },
+    "index_select": {
+        "BLOCK_M": index_select_heur_block_m,
+        "BLOCK_N": index_select_heur_block_n,
+    },
+    "mm": {
+        "EVEN_K": mm_heur_even_k,
+    },
+    "rand": {
+        "BLOCK": rand_heur_block,
+        "num_warps": rand_heur_num_warps,
+    },
+    "randn": {
+        "BLOCK": randn_heur_block,
+        "num_warps": randn_heur_num_warps,
+    },
+    "softmax_non_inner": {
+        "TILE_K": softmax_heur_tile_k,
+        "TILE_N": softmax_heur_tile_n_non_inner,
+        "ONE_TILE_PER_CTA": softmax_heur_one_tile_per_cta,
+        "num_warps": softmax_heur_num_warps_non_inner,
+    },
+    "softmax_inner": {
+        "TILE_N": softmax_heur_tile_n_inner,
+        "ONE_TILE_PER_CTA": softmax_heur_one_tile_per_cta,
+        "num_warps": softmax_heur_num_warps_inner,
+    },
+    "softmax_backward_non_inner": {
+        "TILE_N": softmax_heur_tile_n_bwd_non_inner,
+        "ONE_TILE_PER_CTA": softmax_heur_one_tile_per_cta,
+    },
+    "softmax_backward_inner": {
+        "TILE_M": softmax_heru_tile_m,
+        "ONE_TILE_PER_CTA": softmax_heur_one_tile_per_cta,
+    },
+    "uniform": {
+        "BLOCK": uniform_heur_block,
+        "num_warps": uniform_heur_num_warps,
+    },
+    "upsample_nearest2d": {
+        "SAME_H": upsample_nearest2d_SAME_H,
+        "SAME_W": upsample_nearest2d_SAME_W,
+    },
+    "var_mean": {
+        "BLOCK_N": var_mean_heur_block_n,
+    },
+}

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/__init__.py
@@ -1,0 +1,17 @@
+from backend_utils import Autograd
+
+from . import bmm, mm
+
+
+def get_specific_ops():
+    return (
+        ("mm", mm.mm, Autograd.enable),
+        ("bmm", bmm.bmm, Autograd.enable),
+    )
+
+
+def get_unused_ops():
+    return ()
+
+
+__all__ = ["get_specific_ops", "get_unused_ops"]

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/__init__.py
@@ -5,13 +5,15 @@ from . import bmm, mm
 
 def get_specific_ops():
     return (
-        ("mm", mm.mm, Autograd.enable),
-        ("bmm", bmm.bmm, Autograd.enable),
+        ("mm", mm.mm, Autograd.disable),
+        ("bmm", bmm.bmm, Autograd.disable),
     )
 
 
 def get_unused_ops():
-    return ()
+    # The following operations are marked as unused because the
+    # triton.language.core.reshape function is not supported in Triton 2.1.
+    return ("randperm", "topk", "sort", "multinomial")
 
 
 __all__ = ["get_specific_ops", "get_unused_ops"]

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/bmm.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/bmm.py
@@ -6,7 +6,6 @@ import triton.language as tl
 from triton.ops.matmul_perf_model import early_config_prune, estimate_matmul_time
 
 from flag_gems import runtime
-from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry
 from flag_gems.utils import triton_lang_extension as tle
 
@@ -135,6 +134,6 @@ def bmm(A, B):
         triton.cdiv(meta["N"], meta["BLOCK_N"]),
         batch,
     )
-    with torch_device_fn.device(A.device):
+    with torch.cuda.device(A.device):
         bmm_kernel[grid_fn](A, B, out, M, N, K)
     return out

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/bmm.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/bmm.py
@@ -1,0 +1,140 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+from triton.ops.matmul_perf_model import early_config_prune, estimate_matmul_time
+
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("bmm"),
+    key=["M", "N", "K"],
+    prune_configs_by={
+        "early_config_prune": early_config_prune,
+        "perf_model": estimate_matmul_time,
+        "top_k": 10,
+    },
+)
+@triton.heuristics(runtime.get_heuristic_config("bmm"))
+@triton.jit
+def bmm_kernel(
+    A,
+    B,
+    C,
+    M,
+    N,
+    K,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+    DIVISIBLE_M: tl.constexpr,
+    DIVISIBLE_N: tl.constexpr,
+    DIVISIBLE_K: tl.constexpr,
+):
+    # batch offsets
+    pid_b = tle.program_id(2)
+    A += pid_b * M * K
+    B += pid_b * K * N
+    C += pid_b * M * N
+
+    pidx = tle.program_id(0)
+    pidy = tle.program_id(1)
+
+    if GROUP_M == 1:
+        pid_m, pid_n = pidx, pidy
+    else:
+        # reorder CTAs
+        gridx = tle.num_programs(0)
+        gridy = tle.num_programs(1)
+        pid = pidx + pidy * gridx
+
+        num_CTA_per_group = gridy * GROUP_M
+
+        group_id = pid // num_CTA_per_group
+        inner_group_id = pid % num_CTA_per_group
+        GROUP_SIZE = tl.where(
+            (group_id * GROUP_M + GROUP_M) > gridx, gridx % GROUP_M, GROUP_M
+        )
+        pid_m = group_id * GROUP_M + inner_group_id % GROUP_SIZE
+        pid_n = inner_group_id // GROUP_SIZE
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    offs_k = tl.arange(0, BLOCK_K)
+
+    if not DIVISIBLE_M:
+        mask_m = offs_m < M
+    if not DIVISIBLE_N:
+        mask_n = offs_n < N
+
+    a_ptrs = A + offs_m[:, None] * K + offs_k[None, :]
+    b_ptrs = B + offs_k[:, None] * N + offs_n[None, :]
+    o_ptrs = C + offs_m[:, None] * N + offs_n[None, :]
+
+    num_iters = tl.cdiv(K, BLOCK_K)
+    o = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for _ in range(num_iters):
+        if DIVISIBLE_K:
+            if DIVISIBLE_M:
+                mask_a = None
+            else:
+                mask_a = mask_m[:, None]
+            if DIVISIBLE_N:
+                mask_b = None
+            else:
+                mask_b = mask_n[None, :]
+        else:
+            mask_k = offs_k < K
+            if DIVISIBLE_M:
+                mask_a = mask_k[None, :]
+            else:
+                mask_a = mask_m[:, None] & mask_k[None, :]
+            if DIVISIBLE_N:
+                mask_b = mask_k[:, None]
+            else:
+                mask_b = mask_k[:, None] & mask_n[None, :]
+
+        a = tl.load(a_ptrs, mask_a)
+        b = tl.load(b_ptrs, mask_b)
+
+        offs_k += BLOCK_K
+        a_ptrs += BLOCK_K
+        b_ptrs += BLOCK_K * N
+
+        o += tl.dot(a, b, allow_tf32=False)
+
+    if DIVISIBLE_M and DIVISIBLE_N:
+        mask_c = None
+    elif DIVISIBLE_M and not DIVISIBLE_N:
+        mask_c = mask_n[None, :]
+    elif not DIVISIBLE_M and DIVISIBLE_N:
+        mask_c = mask_m[:, None]
+    else:
+        mask_c = mask_m[:, None] & mask_n[None, :]
+    tl.store(o_ptrs, o, mask_c)
+
+
+def bmm(A, B):
+    logging.debug("GEMS BMM")
+    batch, M, K = A.shape
+    _, _, N = B.shape
+    A = A.contiguous()
+    B = B.contiguous()
+    out = torch.empty((batch, M, N), dtype=A.dtype, device=A.device)
+
+    grid_fn = lambda meta: (
+        triton.cdiv(meta["M"], meta["BLOCK_M"]),
+        triton.cdiv(meta["N"], meta["BLOCK_N"]),
+        batch,
+    )
+    with torch_device_fn.device(A.device):
+        bmm_kernel[grid_fn](A, B, out, M, N, K)
+    return out

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/mm.py
@@ -6,7 +6,6 @@ import triton.language as tl
 from triton.ops.matmul_perf_model import early_config_prune, estimate_matmul_time
 
 from flag_gems import runtime
-from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry
 from flag_gems.utils import triton_lang_extension as tle
 
@@ -131,7 +130,7 @@ def mm(a, b):
         triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
         META["SPLIT_K"],
     )
-    with torch_device_fn.device(a.device):
+    with torch.cuda.device(a.device):
         mm_kernel[grid](
             a,
             b,

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/mm.py
@@ -1,0 +1,151 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+from triton.ops.matmul_perf_model import early_config_prune, estimate_matmul_time
+
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("mm"),
+    key=["M", "N", "K"],
+    prune_configs_by={
+        "early_config_prune": early_config_prune,
+        "perf_model": estimate_matmul_time,
+        "top_k": 10,
+    },
+)
+@triton.heuristics(runtime.get_heuristic_config("mm"))
+@triton.jit
+def mm_kernel(
+    A,
+    B,
+    C,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    dot_out_dtype: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+    EVEN_K: tl.constexpr,
+):
+    # matrix multiplication
+    pid = tle.program_id(0)
+    pid_z = tle.program_id(1)
+    grid_m = tl.cdiv(M, BLOCK_M)
+    grid_n = tl.cdiv(N, BLOCK_N)
+    # re-order program ID for better L2 performance
+    width = GROUP_M * grid_n
+    group_id = pid // width
+    group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (pid % group_size)
+    pid_n = (pid % width) // (group_size)
+    # do matrix multiplication
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
+    rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+    rk = pid_z * BLOCK_K + tl.arange(0, BLOCK_K)
+    # pointers
+    A = A + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
+    B = B + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=dot_out_dtype)
+    for k in range(0, tl.cdiv(K, BLOCK_K * SPLIT_K)):
+        if EVEN_K:
+            a = tl.load(A)
+            b = tl.load(B)
+        else:
+            k_remaining = K - k * (BLOCK_K * SPLIT_K)
+            _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)
+            a = tl.load(A, mask=rk[None, :] < k_remaining, other=_0)
+            b = tl.load(B, mask=rk[:, None] < k_remaining, other=_0)
+        if a.dtype != b.dtype:
+            a = a.to(C.dtype.element_ty)
+            b = b.to(C.dtype.element_ty)
+        acc += tl.dot(a, b, out_dtype=dot_out_dtype, allow_tf32=False)
+        A += BLOCK_K * SPLIT_K * stride_ak
+        B += BLOCK_K * SPLIT_K * stride_bk
+    acc = acc.to(C.dtype.element_ty)
+    # rematerialize rm and rn to save registers
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    C = C + (rm[:, None] * stride_cm + rn[None, :] * stride_cn)
+    mask = (rm < M)[:, None] & (rn < N)[None, :]
+    # handles write-back with reduction-splitting
+    if SPLIT_K == 1:
+        tl.store(C, acc, mask=mask)
+    else:
+        tl.atomic_add(C, acc, mask=mask)
+
+
+_ordered_datatypes = [torch.float16, torch.bfloat16, torch.float32]
+
+
+def get_higher_dtype(a, b):
+    if a is b:
+        return a
+
+    assert a in _ordered_datatypes
+    assert b in _ordered_datatypes
+
+    for d in _ordered_datatypes:
+        if a is d:
+            return b
+        if b is d:
+            return a
+
+
+def mm(a, b):
+    logging.debug("GEMS MM")
+    device = a.device
+    # handle non-contiguous inputs if necessary
+    if a.stride(0) > 1 and a.stride(1) > 1:
+        a = a.contiguous()
+    if b.stride(0) > 1 and b.stride(1) > 1:
+        b = b.contiguous()
+    # checks constraints
+    assert a.shape[1] == b.shape[0], "incompatible dimensions"
+    M, K = a.shape
+    _, N = b.shape
+    # allocates output
+    c_dtype = get_higher_dtype(a.dtype, b.dtype)
+    c = torch.empty((M, N), device=device, dtype=c_dtype)
+    dot_out_dtype = tl.float32
+    # launch kernel
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+        META["SPLIT_K"],
+    )
+    with torch_device_fn.device(a.device):
+        mm_kernel[grid](
+            a,
+            b,
+            c,
+            M,
+            N,
+            K,
+            a.stride(0),
+            a.stride(1),
+            b.stride(0),
+            b.stride(1),
+            c.stride(0),
+            c.stride(1),
+            dot_out_dtype=dot_out_dtype,
+            GROUP_M=8,
+        )
+    return c

--- a/src/flag_gems/runtime/backend/_iluvatar/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_iluvatar/tune_configs.yaml
@@ -1,0 +1,3232 @@
+attention:
+- gen: true
+  param_map:
+    META:
+      BLOCK_M: block_m
+      BLOCK_N: block_n
+      PRE_LOAD_V: pre_load_v
+    num_warps: warps
+    num_stages: stages
+  block_m:
+  - 64
+  - 128
+  block_n:
+  - 32
+  - 64
+  - 128
+  pre_load_v:
+  - true
+  - false
+  warps:
+  - 4
+  - 8
+  stages:
+  - 1
+  - 2
+  - 3
+bmm:
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 4
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 32
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 64
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 128
+    GROUP_M: 1
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 128
+    GROUP_M: 2
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+argmax:
+- META:
+    BLOCK_M: 8
+  num_warps: 8
+- META:
+    BLOCK_M: 16
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+  num_warps: 8
+log_softmax:
+- META:
+    BLOCK_M: 8
+    BLOCK_N: 256
+  num_warps: 8
+- META:
+    BLOCK_M: 16
+    BLOCK_N: 512
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 512
+  num_warps: 8
+mm:
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 32
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 64
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 128
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 256
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 32
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 64
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 128
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 256
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 32
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 32
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 32
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 32
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 32
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 32
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 32
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 32
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 64
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 128
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 128
+    BLOCK_N: 256
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 32
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 32
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 32
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 32
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 32
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 32
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 32
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 32
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 64
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 128
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 32
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 64
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 128
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_M: 256
+    BLOCK_N: 256
+    BLOCK_K: 256
+    SPLIT_K: 1
+  num_stages: 2
+  num_warps: 16
+softmax_non_inner:
+- META:
+    TILE_K: 32
+- META:
+    TILE_K: 64
+- META:
+    TILE_K: 128
+- META:
+    TILE_K: 256
+- META:
+    TILE_K: 1024
+softmax_inner:
+- META:
+    TILE_N: 32
+- META:
+    TILE_N: 64
+- META:
+    TILE_N: 128
+- META:
+    TILE_N: 256
+- META:
+    TILE_N: 1024
+test_libentry:
+- META:
+    TILE_N: 32
+- META:
+    TILE_N: 64
+- META:
+    TILE_N: 128
+- META:
+    TILE_N: 256
+- META:
+    TILE_N: 512
+- META:
+    TILE_N: 1024
+min:
+- META:
+    BLOCK_M: 8
+    BLOCK_N: 256
+  num_warps: 8
+- META:
+    BLOCK_M: 16
+    BLOCK_N: 512
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 512
+  num_warps: 8
+prod:
+- META:
+    BLOCK_M: 8
+    BLOCK_N: 256
+  num_warps: 8
+- META:
+    BLOCK_M: 16
+    BLOCK_N: 512
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 512
+  num_warps: 8
+max:
+- META:
+    BLOCK_M: 8
+    BLOCK_N: 256
+  num_warps: 8
+- META:
+    BLOCK_M: 16
+    BLOCK_N: 512
+  num_warps: 8
+- META:
+    BLOCK_M: 32
+    BLOCK_N: 512
+  num_warps: 8
+addmm:
+- META:
+    BLOCK_SIZE_M: 32
+    BLOCK_SIZE_N: 32
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_SIZE_M: 32
+    BLOCK_SIZE_N: 64
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_SIZE_M: 32
+    BLOCK_SIZE_N: 128
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 32
+    BLOCK_SIZE_N: 256
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 32
+    BLOCK_SIZE_N: 32
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_SIZE_M: 32
+    BLOCK_SIZE_N: 64
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_SIZE_M: 32
+    BLOCK_SIZE_N: 128
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 32
+    BLOCK_SIZE_N: 256
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 32
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 64
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 128
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 256
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 32
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 64
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 4
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 128
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 256
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 64
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 64
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 64
+    BLOCK_SIZE_K: 128
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 128
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 128
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 128
+    BLOCK_SIZE_K: 128
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 256
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 256
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 64
+    BLOCK_SIZE_N: 256
+    BLOCK_SIZE_K: 128
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 128
+    BLOCK_SIZE_N: 64
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 128
+    BLOCK_SIZE_N: 64
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 128
+    BLOCK_SIZE_N: 64
+    BLOCK_SIZE_K: 128
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 128
+    BLOCK_SIZE_N: 128
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 128
+    BLOCK_SIZE_N: 128
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 128
+    BLOCK_SIZE_N: 128
+    BLOCK_SIZE_K: 128
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 128
+    BLOCK_SIZE_N: 256
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 128
+    BLOCK_SIZE_N: 256
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 128
+    BLOCK_SIZE_N: 256
+    BLOCK_SIZE_K: 128
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 256
+    BLOCK_SIZE_N: 64
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 256
+    BLOCK_SIZE_N: 64
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 256
+    BLOCK_SIZE_N: 64
+    BLOCK_SIZE_K: 128
+  num_stages: 1
+  num_warps: 8
+- META:
+    BLOCK_SIZE_M: 256
+    BLOCK_SIZE_N: 128
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 256
+    BLOCK_SIZE_N: 128
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 256
+    BLOCK_SIZE_N: 128
+    BLOCK_SIZE_K: 128
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 256
+    BLOCK_SIZE_N: 256
+    BLOCK_SIZE_K: 32
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 256
+    BLOCK_SIZE_N: 256
+    BLOCK_SIZE_K: 64
+  num_stages: 1
+  num_warps: 16
+- META:
+    BLOCK_SIZE_M: 256
+    BLOCK_SIZE_N: 256
+    BLOCK_SIZE_K: 128
+  num_stages: 1
+  num_warps: 16
+cross_entropy_loss:
+- META:
+    BLOCK_C: 256
+    BLOCK_D: 1
+  num_warps: 4
+- META:
+    BLOCK_C: 256
+    BLOCK_D: 4
+  num_warps: 4
+- META:
+    BLOCK_C: 256
+    BLOCK_D: 16
+  num_warps: 4
+- META:
+    BLOCK_C: 512
+    BLOCK_D: 1
+  num_warps: 4
+- META:
+    BLOCK_C: 512
+    BLOCK_D: 4
+  num_warps: 4
+- META:
+    BLOCK_C: 512
+    BLOCK_D: 16
+  num_warps: 4
+- META:
+    BLOCK_C: 1024
+    BLOCK_D: 1
+  num_warps: 4
+- META:
+    BLOCK_C: 1024
+    BLOCK_D: 4
+  num_warps: 4
+- META:
+    BLOCK_C: 1024
+    BLOCK_D: 16
+  num_warps: 4
+masked_fill:
+- gen: true
+  param_map:
+    META:
+      BLOCK_SIZE: block_n
+    num_warps: warps
+  block_n:
+  - 1024
+  - 2048
+  - 4096
+  warps:
+  - 4
+  - 8
+  - 16
+all:
+- gen: true
+  param_map:
+    META:
+      BLOCK_M: block_m
+      BLOCK_N: block_n
+    num_warps: 4
+  block_m:
+  - 1
+  - 2
+  - 4
+  - 8
+  block_n:
+  - 1024
+amax:
+- gen: true
+  param_map:
+    META:
+      BLOCK_M: block_m
+      BLOCK_N: block_n
+    num_warps: 4
+  block_m:
+  - 1
+  - 2
+  - 4
+  - 8
+  block_n:
+  - 1024
+any:
+- gen: true
+  param_map:
+    META:
+      BLOCK_M: block_m
+      BLOCK_N: block_n
+    num_warps: 4
+  block_m:
+  - 1
+  - 2
+  - 4
+  - 8
+  block_n:
+  - 1024
+index_select:
+- gen: true
+  param_map:
+    META:
+      BLOCK_M: block_m
+      BLOCK_N: block_n
+    num_warps: 4
+  block_m:
+  - 1
+  - 2
+  - 4
+  block_n:
+  - 1024
+  - 2048
+  - 4096
+layer_norm_persistent:
+- gen: true
+  param_map:
+    META: {}
+    num_warps: warps
+  warps:
+  - 4
+  - 8
+  - 16
+layer_norm_loop:
+- gen: true
+  param_map:
+    META:
+      TILE_N: tile_n
+    num_warps: warps
+  warps:
+  - 4
+  - 8
+  - 16
+  tile_n:
+  - 1024
+  - 2048
+  - 4096
+  - 8192
+layer_norm_backward:
+- gen: true
+  param_map:
+    META:
+      BLOCK_ROW_SIZE: block_r
+      BLOCK_COL_SIZE: 2048
+    num_warps: warps
+  warps:
+  - 4
+  - 8
+  - 16
+  block_r:
+  - 1
+  - 2
+  - 4
+  - 8
+weight_bias_backward:
+- gen: true
+  param_map:
+    META:
+      BLOCK_ROW_SIZE: 2048
+      BLOCK_COL_SIZE: block_c
+    num_warps: warps
+  warps:
+  - 4
+  - 8
+  - 16
+  block_c:
+  - 1
+  - 2
+  - 4
+  - 8
+masked_select:
+- gen: true
+  param_map:
+    META:
+      BLOCK_SIZE: blocks
+    num_warps: warps
+  warps:
+  - 4
+  - 8
+  - 16
+  - 32
+  blocks:
+  - 256
+  - 512
+  - 1024
+  - 2048
+  - 4096
+mean:
+- gen: true
+  param_map:
+    META:
+      BLOCK_M: block_m
+      BLOCK_N: 1024
+    num_warps: 4
+  block_m:
+  - 1
+  - 2
+  - 4
+  - 8
+
+instancenorm:
+- gen: true
+  param_map:
+    META: {}
+    num_warps: warps
+  warps:
+  - 4
+  - 8
+  - 16
+
+instance_norm_loop:
+- gen: true
+  param_map:
+    META:
+      TILE_N: tile_n
+    num_warps: warps
+  warps:
+    - 4
+    - 8
+    - 16
+  tile_n:
+    - 1024
+    - 2048
+    - 4096
+    - 8192
+instance_norm_backward:
+- gen : true
+  param_map:
+    META:
+      BLOCK_ROW_SIZE: block_m
+      BLOCK_COL_SIZE: 2048
+    num_warps: warps
+  warps:
+    - 4
+    - 8
+    - 16
+  block_m:
+    - 1
+    - 2
+    - 4
+    - 8
+
+instance_norm_weight_bias_backward:
+- gen : true
+  param_map:
+    META:
+      BLOCK_BATCH_SIZE: block_m
+      BLOCK_COL_SIZE: 2048
+    num_warps: warps
+  warps:
+    - 4
+    - 8
+    - 16
+  block_m:
+    - 1
+    - 2
+    - 4
+    - 8
+
+count_nonzero:
+- gen : true
+  param_map:
+    META:
+      BLOCK_SIZE: block_m
+    num_warps: 4
+  block_m:
+    - 1024
+    - 2048
+    - 4096
+cross_entropy_loss_sum_and_scale:
+- gen : true
+  param_map:
+    META:
+      BLOCK_N: block_n
+  block_n:
+  - 64
+  - 256
+  - 1024
+
+upsample_nearest2d:
+- gen : true
+  param_map:
+    META:
+      BLOCK_SIZE: block_n
+    num_warps: warps
+  block_n: [1024, 2048]
+  warps: [4, 8]
+
+upsample_bicubic2d_aa:
+- gen : true
+  param_map:
+    META:
+      BLOCK_X: block_x
+      BLOCK_Y: block_y
+    num_warps: warps
+  block_x: [512, 256, 128, 64]
+  block_y: [2, 1]
+  warps: [4, 8]
+
+mv:
+- gen: true
+  param_map:
+    META:
+      BLOCK_M: block_m
+      BLOCK_N: block_n
+    num_warps: warps
+    num_stages: stages
+  warps:
+  - 4
+  - 8
+  block_m:
+  - 1
+  - 32
+  - 64
+  - 128
+  block_n:
+  - 1
+  - 2
+  - 4
+  - 8
+  stages:
+  - 3
+  - 4
+nonzero:
+- gen: true
+  param_map:
+    META:
+      BLOCK_SIZE: blocks
+    num_warps: warps
+    num_stages: 4
+  warps:
+  - 4
+  - 8
+  - 16
+  - 32
+  blocks:
+  - 256
+  - 512
+  - 1024
+  - 2048
+  - 4096
+  - 8192
+randperm:
+- gen: true
+  param_map:
+    META: {}
+    num_warps: warps
+  warps:
+  - 4
+  - 8
+  - 16
+select_scatter:
+- gen: true
+  param_map:
+    META:
+      BLOCK_M: block_m
+      BLOCK_N: 1024
+    num_warps: 4
+  block_m:
+  - 1
+  - 2
+  - 4
+  - 8
+select_scatter_inner:
+- META:
+    R: 1
+    C: 512
+  num_warps: 4
+- META:
+    R: 32
+    C: 32
+  num_warps: 4
+- META:
+    R: 64
+    C: 64
+  num_warps: 4
+- META:
+    R: 4
+    C: 512
+  num_warps: 4
+- META:
+    R: 16
+    C: 128
+  num_warps: 4
+softmax:
+- META:
+    TILE_K: 32
+- META:
+    TILE_K: 64
+- META:
+    TILE_K: 128
+- META:
+    TILE_K: 256
+- META:
+    TILE_K: 512
+- META:
+    TILE_K: 1024
+vstack:
+- gen: true
+  param_map:
+    META:
+      BLOCK_SIZE: blocks
+    num_warps: warps
+  warps:
+  - 4
+  - 8
+  - 16
+  - 32
+  blocks:
+  - 512
+  - 1024
+  - 2048
+  - 4096
+gather:
+- gen: true
+  param_map:
+    META:
+      BLOCK_M: block_m
+      BLOCK_N: block_n
+    num_warps: 4
+  block_m:
+  - 1
+  - 2
+  - 4
+  - 8
+  block_n:
+  - 256
+  - 512
+  - 1024
+  - 2048
+scatter:
+- gen: true
+  param_map:
+    META:
+      BLOCK_M: block_m
+      BLOCK_N: block_n
+    num_warps: 4
+  block_m:
+  - 1
+  - 2
+  - 4
+  - 8
+  block_n:
+  - 256
+  - 512
+  - 1024
+  - 2048
+sum:
+- gen: true
+  param_map:
+    META:
+      BLOCK_M: block_m
+      BLOCK_N: 1024
+    num_warps: 4
+  block_m:
+  - 1
+  - 2
+  - 4
+  - 8
+triu:
+- gen: true
+  param_map:
+    META:
+      M_BLOCK_SIZE: 1
+      N_BLOCK_SIZE: 2048
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+triu_batch:
+- gen: true
+  param_map:
+    META:
+      BATCH_BLOCK_SIZE: 1
+      MN_BLOCK_SIZE: 512
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+weight_norm_kernel_last:
+- gen: true
+  param_map:
+    META:
+      BLOCK_ROW_SIZE: block_m
+      BLOCK_COL_SIZE: block_n
+    num_warps: warps
+  warps:
+  - 4
+  - 8
+  - 16
+  block_m:
+  - 512
+  - 1024
+  - 2048
+  block_n:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 32
+weight_norm_kernel_first:
+- gen: true
+  param_map:
+    META:
+      BLOCK_ROW_SIZE: block_m
+      BLOCK_COL_SIZE: block_n
+    num_warps: warps
+  warps:
+  - 4
+  - 8
+  - 16
+  block_m:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 32
+  block_n:
+  - 512
+  - 1024
+  - 2048
+weight_norm_kernel:
+- gen: true
+  param_map:
+    META:
+      BLOCK_ROW_SIZE: block_m
+      BLOCK_COL_SIZE: block_n
+    num_warps: warps
+  warps:
+  - 4
+  - 8
+  - 16
+  block_m:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 32
+  block_n:
+  - 256
+  - 512
+  - 1024
+  - 2048
+vector_norm:
+- gen: true
+  param_map:
+    META:
+      BLOCK_M: block_m
+      BLOCK_N: 1024
+    num_warps: 4
+  block_m:
+  - 1
+  - 2
+  - 4
+  - 8
+var_mean:
+- gen: true
+  param_map:
+    META:
+      BLOCK_M: block_m
+      BLOCK_N: block_n
+    num_warps: warps
+  block_m:
+  - 1
+  - 2
+  - 4
+  - 8
+  block_n:
+  - 1024
+  - 2048
+  warps:
+  - 4
+  - 8
+  - 16

--- a/src/flag_gems/runtime/backend/device.py
+++ b/src/flag_gems/runtime/backend/device.py
@@ -61,6 +61,7 @@ class DeviceDetector(object):
         cmd = {
             "cambricon": "mlu",
             "mthreads": "musa",
+            "iluvatar": "corex",
         }
         for vendor_name, flag in cmd.items():
             if hasattr(torch, flag):

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -193,9 +193,10 @@ def test_accuracy_cumsum(shape, dtype):
     dim = 1 if shape == REDUCTION_SHAPES[-1] else -1
     if dtype in INT_DTYPES:
         inp = torch.randint(-3, 3, shape, device=flag_gems.device).to(dtype)
+        ref_inp = to_reference(inp)
     else:
         inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
-    ref_inp = to_reference(inp, True)
+        ref_inp = to_reference(inp, True)
 
     ref_out = torch.cumsum(ref_inp, dim=dim)
     with flag_gems.use_gems():


### PR DESCRIPTION
### PR Category
Other

### Type of Change
New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
* examples/model_bert_test.py: use cpu reference rather fp64 cuda
* src/flag_gems/ops/upsample_bicubic2d_aa.py: triton 2.1 not support tenary if 
* src/flag_gems/ops/topk.py: triton 2.1 not implement _log2
* src/flag_gems/ops/attention.py: triton 2.1 do not provide default args for prune_configs_by
* tests/accuracy_utils.py: avoid use fp64
* tests/test_reduction_ops.py: no need upcast for int? we meet problem comparing res:  0(int32) with 0.0(float64).
*  src/flag_gems/runtime/backend/_iluvatar: add our backend

I don not use libtuner in mm, since somehow lose sime args, maybe we merge the PR, and then fix the problem
![image](https://github.com/user-attachments/assets/eb790415-d2c0-4fad-846b-835c50e588d2)


I almost push all the needed fix, except the 
* in libentry.py we use api in triton 2.1 https://github.com/FlagOpen/FlagGems/commit/248785cd66e75dd425bf7351d10ade2dbffadb36
* and in setup.py we lower the requirements of triton and torch to 
```
    install_requires=[
        f"{triton_package_name}>=2.1.0",
        "torch>=2.1.1",
        "PyYAML",
    ],
```

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
