### PR TITLE
[New Feature] Update muti_backend_framework

### DIFF
--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -12,6 +12,7 @@ device = runtime.device.name
 aten_lib = torch.library.Library("aten", "IMPL")
 registrar = Register
 current_work_registrar = None
+runtime.replace_customized_ops(globals())
 
 
 def enable(lib=aten_lib, unused=None, registrar=registrar):

--- a/src/flag_gems/runtime/__init__.py
+++ b/src/flag_gems/runtime/__init__.py
@@ -35,11 +35,4 @@ def replace_customized_ops(_globals):
                 error.customized_op_replace_error(e)
 
 
-__all__ = [
-    "commom_utils",
-    "backend",
-    "device",
-    "get_tuned_config",
-    "get_heuristic_config",
-    "replace_customized_ops",
-]
+__all__ = ["*"]

--- a/src/flag_gems/runtime/__init__.py
+++ b/src/flag_gems/runtime/__init__.py
@@ -27,12 +27,12 @@ def get_heuristic_config(op_name):
 
 def replace_customized_ops(_globals):
     if device.vendor != commom_utils.vendors.NVIDIA:
-        customized_op_infos = backend.get_curent_device_extend_op(device.vendor_name)
-        for fn_name, fn in customized_op_infos:
-            try:
+        customized_op_infos = backend.get_current_device_extend_op(device.vendor_name)
+        try:
+            for fn_name, fn in customized_op_infos:
                 _globals[fn_name] = fn
-            except RuntimeError as e:
-                error.customized_op_replace_error(e)
+        except RuntimeError as e:
+            error.customized_op_replace_error(e)
 
 
 __all__ = ["*"]

--- a/src/flag_gems/runtime/__init__.py
+++ b/src/flag_gems/runtime/__init__.py
@@ -1,4 +1,4 @@
-from . import backend, commom_utils
+from . import backend, commom_utils, error
 from .backend.device import DeviceDetector
 from .configloader import ConfigLoader
 
@@ -23,6 +23,18 @@ def get_tuned_config(op_name):
 
 def get_heuristic_config(op_name):
     return config_loader.heuristics_config[op_name]
+
+
+def replace_customized_ops(_globals):
+    if device.vendor != commom_utils.vendors.NVIDIA:
+        customized_op_infos = backend.get_curent_device_extend_op()
+        for single_op_info in customized_op_infos:
+            op_fun = single_op_info[1]
+            op_fun_name = op_fun.__name__
+            try:
+                _globals[op_fun_name] = op_fun
+            except RuntimeError as e:
+                error.customized_op_replace_error(e)
 
 
 __all__ = [

--- a/src/flag_gems/runtime/__init__.py
+++ b/src/flag_gems/runtime/__init__.py
@@ -27,12 +27,10 @@ def get_heuristic_config(op_name):
 
 def replace_customized_ops(_globals):
     if device.vendor != commom_utils.vendors.NVIDIA:
-        customized_op_infos = backend.get_curent_device_extend_op()
-        for single_op_info in customized_op_infos:
-            op_fun = single_op_info[1]
-            op_fun_name = op_fun.__name__
+        customized_op_infos = backend.get_curent_device_extend_op(device.vendor_name)
+        for fn_name, fn in customized_op_infos:
             try:
-                _globals[op_fun_name] = op_fun
+                _globals[fn_name] = fn
             except RuntimeError as e:
                 error.customized_op_replace_error(e)
 
@@ -43,4 +41,5 @@ __all__ = [
     "device",
     "get_tuned_config",
     "get_heuristic_config",
+    "replace_customized_ops",
 ]

--- a/src/flag_gems/runtime/backend/README.md
+++ b/src/flag_gems/runtime/backend/README.md
@@ -41,27 +41,8 @@ You should configure  `triton.autotune` params in `FlagGems/src/flag_gems/runtim
 ##### step 2.4  `ops`
 The `ops` directory is where `vendor-customized operator` implementations are stored. For instance, if you want to create a custom `add operation`, you should place the implementation in `ops/add.py`. Following that, you should configure ops/__init__.py accordingly.
 ```python
-from backend_utils import Autograd
+from .add import add
+from .gelu import gelu
 
-from . import add, gelu
-
-def get_specific_ops():
-    return (
-        ("add.Tensor", add.add, Autograd.disable),
-        ("gelu", gelu.gelu, Autograd.enable),
-    )
-
-
-def get_unused_ops():
-    return ("cumsum", "cos")
+__all__= ["add", "gelu"]
 ```
-- The `get_specific_ops` function is designed to retrieve vendor-customized operators. If this feature is not required, the function can return an `empty tuple: ()`. An item such as `"add.Tensor"`, `add.add`, `Autograd.disable` is used to describe operator registration details.
-
-
-    - `"add.Tensor"` denotes the name of the Aten operation you wish to replace.
-
-    - `add.add` represents the implementation of the add operator using Triton.
-
-    - `Autograd.enable/Autograd.disable` indicates whether the operator supports backward computation (gradient calculation) or not.
-
-- The `get_unused_ops()` function is intended to obtain a list of operations that vendors prefer users not to utilize. If this functionality is not needed, the function can also return an `empty tuple: ()`. An item such as `"cumsum"`  is a string type represents the name of op you don't want users to use it.

--- a/src/flag_gems/runtime/backend/__init__.py
+++ b/src/flag_gems/runtime/backend/__init__.py
@@ -134,7 +134,7 @@ def get_vendor_infos():
     return infos
 
 
-def get_curent_device_extend_op(vendor_name=None):
+def get_current_device_extend_op(vendor_name=None):
     import_vendor_extra_lib(vendor_name)
     global ops_module, fused_module, customized_ops
     if customized_ops is not None:

--- a/src/flag_gems/runtime/backend/__init__.py
+++ b/src/flag_gems/runtime/backend/__init__.py
@@ -1,6 +1,7 @@
 import ast
 import functools
 import importlib
+import inspect
 import os
 import sys
 
@@ -12,7 +13,28 @@ device_name = None
 torch_device_object = None
 torch_device_fn_device = None
 tl_extra_backend_module = None
+ops_module = None
+fused_module = None
+heuristic_config_module = None
+vendor_extra_lib_imported = False
 device_fn_cache = {}
+customized_ops = None
+
+
+def import_vendor_extra_lib(vendor_name=None):
+    global vendor_extra_lib_imported
+    if vendor_extra_lib_imported is True:
+        return
+    global ops_module, fused_module, heuristic_config_module
+    try:
+        ops_module = importlib.import_module(f"_{vendor_name}.ops")
+    except RuntimeError:
+        pass
+    try:
+        fused_module = importlib.import_module(f"_{vendor_name}.fused")
+    except RuntimeError:
+        pass
+    vendor_extra_lib_imported = True
 
 
 def get_codegen_result(code, result_key):
@@ -113,23 +135,35 @@ def get_vendor_infos():
 
 
 def get_curent_device_extend_op(vendor_name=None):
-    global vendor_module
-    get_vendor_module(vendor_name)
-    vendor_module.OpLoader()
-    return vendor_module.specific_ops
+    import_vendor_extra_lib(vendor_name)
+    global ops_module, fused_module, customized_ops
+    if customized_ops is not None:
+        return customized_ops
+    customized_ops = []
+    if ops_module is not None:
+        ops = inspect.getmembers(ops_module, inspect.isfunction)
+        customized_ops += ops
+    if fused_module is not None:
+        fused_ops = inspect.getmembers(fused_module, inspect.isfunction)
+        customized_ops += fused_ops
+    return customized_ops
 
 
 def get_curent_device_unused_op(vendor_name=None):
     global vendor_module
     get_vendor_module(vendor_name)
-    vendor_module.OpLoader()
-    return list(vendor_module.unused_ops)
+    return list(vendor_module.CUSTOMIZED_UNUSED_OPS)
 
 
 def get_heuristic_config(vendor_name=None):
-    global vendor_module
-    get_vendor_module(vendor_name)
-    return vendor_module.HEURISTICS_CONFIGS
+    # import_vendor_extra_lib(vendor_name)
+    global heuristic_config_module
+    heuristic_config_module = importlib.import_module(
+        f"_{vendor_name}.heuristics_config_utils"
+    )
+    if hasattr(heuristic_config_module, "HEURISTICS_CONFIGS"):
+        return heuristic_config_module.HEURISTICS_CONFIGS
+    return None
 
 
 def get_tune_config(vendor_name=None):

--- a/src/flag_gems/runtime/backend/_iluvatar/__init__.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/__init__.py
@@ -1,22 +1,9 @@
 from backend_utils import VendorInfoBase  # noqa: E402
 
-from .heuristics_config_utils import HEURISTICS_CONFIGS
-
-global specific_ops, unused_ops
-specific_ops = None
-unused_ops = None
 vendor_info = VendorInfoBase(
     vendor_name="iluvatar", device_name="cuda", device_query_cmd="ixsmi"
 )
 
+CUSTOMIZED_UNUSED_OPS = ("randperm", "topk", "sort", "multinomial")
 
-def OpLoader():
-    global specific_ops, unused_ops
-    if specific_ops is None:
-        from . import ops  # noqa: F403
-
-        specific_ops = ops.get_specific_ops()
-        unused_ops = ops.get_unused_ops()
-
-
-__all__ = ["HEURISTICS_CONFIGS", "vendor_info", "OpLoader"]
+__all__ = ["*"]

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/__init__.py
@@ -1,19 +1,4 @@
-from backend_utils import Autograd
+from .bmm import bmm
+from .mm import mm
 
-from . import bmm, mm
-
-
-def get_specific_ops():
-    return (
-        ("mm", mm.mm, Autograd.disable),
-        ("bmm", bmm.bmm, Autograd.disable),
-    )
-
-
-def get_unused_ops():
-    # The following operations are marked as unused because the
-    # triton.language.core.reshape function is not supported in Triton 2.1.
-    return ("randperm", "topk", "sort", "multinomial")
-
-
-__all__ = ["get_specific_ops", "get_unused_ops"]
+__all__ = ["bmm", "mm"]

--- a/src/flag_gems/runtime/backend/_metax/__init__.py
+++ b/src/flag_gems/runtime/backend/_metax/__init__.py
@@ -1,20 +1,7 @@
 from backend_utils import VendorInfoBase  # noqa: E402
 
-from .heuristics_config_utils import HEURISTICS_CONFIGS
-
-global specific_ops, unused_ops
 vendor_info = VendorInfoBase(
     vendor_name="metax", device_name="cuda", device_query_cmd="mx-smi"
 )
 
-
-def OpLoader():
-    global specific_ops, unused_ops
-    # if specific_ops is None:
-    from . import ops  # noqa: F403
-
-    specific_ops = ops.get_specific_ops()
-    unused_ops = ops.get_unused_ops()
-
-
-__all__ = ["HEURISTICS_CONFIGS", "vendor_info", "OpLoader"]
+__all__ = ["vendor_info"]

--- a/src/flag_gems/runtime/backend/_metax/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/__init__.py
@@ -1,55 +1,39 @@
-from flag_gems.runtime.commom_utils import Autograd
+from .arange import arange, arange_start
+from .exponential_ import exponential_
+from .fill import fill_scalar, fill_tensor
+from .full import full
+from .full_like import full_like
+from .groupnorm import group_norm
+from .isin import isin
+from .log_softmax import log_softmax
+from .min import min, min_dim
+from .ones import ones
+from .outer import outer
+from .prod import prod, prod_dim
+from .sigmoid import sigmoid
+from .tanh import tanh
+from .unique import unique
+from .zeros import zeros
 
-from . import (
-    arange,
-    exponential_,
-    fill,
-    full,
-    full_like,
-    groupnorm,
-    isin,
-    log_softmax,
-    min,
-    ones,
-    outer,
-    prod,
-    sigmoid,
-    tanh,
-    unique,
-    zeros,
-)
-
-
-def get_specific_ops():
-    return (
-        ("arange.start_step", arange.arange_start, Autograd.disable),
-        ("arange.start", arange.arange_start, Autograd.disable),
-        ("arange", arange.arange, Autograd.disable),
-        ("exponential_", exponential_.exponential_, Autograd.disable),
-        ("fill.Scalar", fill.fill_scalar, Autograd.disable),
-        ("fill.Tensor", fill.fill_tensor, Autograd.disable),
-        ("full_like", full_like.full_like, Autograd.disable),
-        ("full", full.full, Autograd.disable),
-        ("native_group_norm", groupnorm.group_norm, Autograd.enable),
-        ("isin.Tensor_Tensor", isin.isin, Autograd.disable),
-        ("isin.Scalar_Tensor", isin.isin, Autograd.disable),
-        ("isin.Tensor_Scalar", isin.isin, Autograd.disable),
-        ("log_softmax.int", log_softmax.log_softmax, Autograd.enable),
-        ("min", min.min, Autograd.disable),
-        ("min.dim", min.min_dim, Autograd.disable),
-        ("ones", ones.ones, Autograd.disable),
-        ("prod", prod.prod, Autograd.disable),
-        ("prod.dim_int", prod.prod_dim, Autograd.disable),
-        ("sigmoid", sigmoid.sigmoid, Autograd.enable),
-        ("tanh", tanh.tanh, Autograd.enable),
-        ("_unique2", unique._unique2, Autograd.disable),
-        ("zeros", zeros.zeros, Autograd.disable),
-        ("outer", outer.outer, Autograd.enable),
-    )
-
-
-def get_unused_ops():
-    return ()
-
-
-__all__ = ["get_specific_ops", "get_unused_ops"]
+__all__ = [
+    "arange",
+    "arange_start",
+    "exponential_",
+    "fill_scalar",
+    "fill_tensor",
+    "full",
+    "full_like",
+    "group_norm",
+    "isin",
+    "log_softmax",
+    "min_dim",
+    "min",
+    "ones",
+    "outer",
+    "prod",
+    "prod_dim",
+    "sigmoid",
+    "tanh",
+    "unique",
+    "zeros",
+]

--- a/src/flag_gems/runtime/backend/_nvidia/__init__.py
+++ b/src/flag_gems/runtime/backend/_nvidia/__init__.py
@@ -1,22 +1,10 @@
 from backend_utils import VendorInfoBase  # noqa: E402
 
-from .heuristics_config_utils import HEURISTICS_CONFIGS
-
-global specific_ops, unused_ops
-specific_ops = None
-unused_ops = None
 vendor_info = VendorInfoBase(
     vendor_name="nvidia", device_name="cuda", device_query_cmd="nvidia-smi"
 )
 
-
-def OpLoader():
-    global specific_ops, unused_ops
-    if specific_ops is None:
-        from . import ops  # noqa: F403
-
-        specific_ops = ops.get_specific_ops()
-        unused_ops = ops.get_unused_ops()
+CUSTOMIZED_UNUSED_OPS = ("cumsum", "cos", "add")
 
 
-__all__ = ["HEURISTICS_CONFIGS", "vendor_info", "OpLoader"]
+__all__ = ["HEURISTICS_CONFIGS", "CUSTOMIZED_UNUSED_OPS", "vendor_info"]

--- a/src/flag_gems/runtime/backend/_nvidia/__init__.py
+++ b/src/flag_gems/runtime/backend/_nvidia/__init__.py
@@ -7,4 +7,4 @@ vendor_info = VendorInfoBase(
 CUSTOMIZED_UNUSED_OPS = ("cumsum", "cos", "add")
 
 
-__all__ = ["HEURISTICS_CONFIGS", "CUSTOMIZED_UNUSED_OPS", "vendor_info"]
+__all__ = ["*"]

--- a/src/flag_gems/runtime/backend/_nvidia/fused/__init__.py
+++ b/src/flag_gems/runtime/backend/_nvidia/fused/__init__.py
@@ -1,0 +1,5 @@
+from .skip_rms_norm import skip_rms_norm
+
+__all__ = [
+    "skip_rms_norm",
+]

--- a/src/flag_gems/runtime/backend/_nvidia/fused/skip_rms_norm.py
+++ b/src/flag_gems/runtime/backend/_nvidia/fused/skip_rms_norm.py
@@ -1,0 +1,73 @@
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+
+
+@libentry()
+@triton.jit(do_not_specialize=["eps"])
+def skip_rms_norm_kernel(
+    Y,  # pointer to the output
+    X,  # pointer to the input
+    R,  # pointer to the residual
+    W,  # pointer to the weights
+    y_stride_r,
+    y_stride_c,
+    x_stride_r,  # how much to increase the pointer when moving by 1 row
+    x_stride_c,  # how much to increase the pointer when moving by 1 col
+    r_stride_r,  # how much to increase the pointer when moving by 1 row
+    r_stride_c,  # how much to increase the pointer when moving by 1 col
+    N,  # number of columns in X
+    eps,  # epsilon to avoid division by zero
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tle.program_id(0)
+    Y += pid * y_stride_r
+    X += pid * x_stride_r
+    R += pid * r_stride_r
+
+    mask = tl.arange(0, BLOCK_SIZE) < N
+    cols = tl.arange(0, BLOCK_SIZE)
+    x = tl.load(X + cols * x_stride_c, mask, other=0.0).to(tl.float32)
+    r = tl.load(R + cols * r_stride_c, mask, other=0.0).to(tl.float32)
+
+    x += r
+
+    var = tl.sum(x * x / N, axis=0)
+    rrms = 1 / tl.sqrt(var + eps)
+
+    w = tl.load(W + tl.arange(0, BLOCK_SIZE), mask=mask, other=0.0)
+    y = (x * rrms).to(Y.dtype.element_ty) * w
+    tl.store(Y + cols * y_stride_c, y, mask=mask)
+
+
+class SkipRmsNorm(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, residual, normalized_shape, weight, eps=1e-5):
+        logging.debug("GEMS LAYERNORM FORWARD")
+        dim = x.ndim - len(normalized_shape)
+        M = math.prod(x.shape[:dim])
+        N = math.prod(normalized_shape)
+
+        BLOCK_SIZE = triton.next_power_of_2(N)
+        x = x.contiguous()
+        residual = residual.contiguous()
+        weight = weight.contiguous()
+        y = torch.empty_like(x)
+
+        with torch_device_fn.device(x.device):
+            skip_rms_norm_kernel[M,](
+                y, x, residual, weight, N, 1, N, 1, N, 1, N, eps, BLOCK_SIZE
+            )
+        return y
+
+
+def skip_rms_norm(x, residual, normalized_shape, weight, eps=1e-5):
+    print("\n .......test for mutibackend specific fused op skip_rms_norm ........\n")
+    return SkipRmsNorm.apply(x, residual, normalized_shape, weight, eps)

--- a/src/flag_gems/runtime/backend/_nvidia/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_nvidia/ops/__init__.py
@@ -1,17 +1,4 @@
-from backend_utils import Autograd
+from .add import add
+from .gelu import gelu
 
-from . import add, gelu
-
-
-def get_specific_ops():
-    return (
-        ("add.Tensor", add.add, Autograd.disable),
-        ("gelu", gelu.gelu, Autograd.enable),
-    )
-
-
-def get_unused_ops():
-    return ("cumsum", "cos")
-
-
-__all__ = ["get_specific_ops", "get_unused_ops"]
+__all__ = ["add", "gelu"]

--- a/src/flag_gems/runtime/configloader.py
+++ b/src/flag_gems/runtime/configloader.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 
 import triton
 
@@ -22,6 +23,11 @@ class ConfigLoader(object):
             # and is reserved from being an attr for vendor customizability
             self.primitive_yaml_config = self.get_vendor_tune_config()
             self.heuristics_config = self.get_vendor_heuristics_config()
+            if self.heuristics_config is None:
+                vendorname = self.device.vendor_name
+                warnings.warn(
+                    f"The {vendorname} configuration of heuristics_config is None"
+                )
             # gen_key is an identifier that indicates whether the current config needs to be generated automatically
             self.gen_key = "gen"
             # loaded_triton_config is wrapped in triton.Config according to primitive_yaml_config

--- a/src/flag_gems/runtime/error.py
+++ b/src/flag_gems/runtime/error.py
@@ -13,3 +13,9 @@ def register_error(e):
     raise RuntimeError(
         e, "An error was encountered while registering the triton operator."
     )
+
+
+def customized_op_replace_error(e):
+    raise RuntimeError(
+        e, "An exception occurred while replacing the customization operator."
+    )

--- a/src/flag_gems/runtime/register.py
+++ b/src/flag_gems/runtime/register.py
@@ -16,10 +16,9 @@ class Register:
         self.reg_key = self.device.name.upper()
         self.reg_bac_key = "Autograd" + self.reg_key
         self.all_ops = []
-        self.vendor_extend_configs = self.get_vendor_extend_op()
         self.vendor_unused_ops_list = self.get_vendor_unused_op()
         self.unused_ops = user_unused_ops_list + self.vendor_unused_ops_list
-        self.config = config + self.vendor_extend_configs
+        self.config = config
         self.config_filter()
         self.for_each()
 
@@ -28,21 +27,12 @@ class Register:
             item for item in self.config if item[1].__name__ not in self.unused_ops
         ]
 
-    def get_vendor_extend_op(self):
-        if self.device.vendor != commom_utils.vendors.NVIDIA:
-            return backend.get_curent_device_extend_op(self.device.vendor_name)
-        return ()
-
     def get_vendor_unused_op(self):
         if self.device.vendor != commom_utils.vendors.NVIDIA:
             return backend.get_curent_device_unused_op(self.device.vendor_name)
         return []
 
     def register_impl(self, key, fn, has_backward):
-        if self.device.vendor != commom_utils.vendors.NVIDIA:
-            if key in self.extend_configs_dict:
-                single_item = self.extend_configs_dict[key]
-                _, fn, has_backward = single_item
         if has_backward is commom_utils.Autograd.enable:
             device_key = self.reg_bac_key
         else:
@@ -51,13 +41,9 @@ class Register:
         self.lib.impl(key, fn, device_key)
 
     def for_each(self):
-        self.extend_configs_dict = {}
-        for item in self.vendor_extend_configs:
-            self.extend_configs_dict[item[0]] = item
         try:
             for key, func, has_backward in self.config:
-                if key not in self.unused_ops and key not in self.all_ops:
-                    self.register_impl(key, func, has_backward)
+                self.register_impl(key, func, has_backward)
         except Exception as e:
             error.register_error(e)
 


### PR DESCRIPTION
### PR Category
Other

### Type of Change
New Feature 

### Description
1.Support for vendor-customized fused-operators

2.Supports the usage mode of users similar to `flag_gems.op_name`,such as:
```python
import flag_gems
flag_gems.add()
flag_gems.skip_rms_norm()
```
3.Simplify vendor access: after the update, users only need to import operators in the `vendor/ops/__init__.py` directory. for example:
```python
from .add import add
from .gelu import gelu

__all__ = ["add", "gelu"]
```
and vendor only need to provide `vendor_info` and `CUSTOMIZED_UNUSED_OPS` in `vendor/__init__.py`.for example:

```python
from backend_utils import VendorInfoBase  # noqa: E402

vendor_info = VendorInfoBase(
    vendor_name="nvidia", device_name="cuda", device_query_cmd="nvidia-smi"
)

CUSTOMIZED_UNUSED_OPS = ("cumsum", "cos", "add")


__all__ = ["*"]


```
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
