### PR TITLE
Re-implementing gather op

### DIFF
--- a/src/flag_gems/ops/gather.py
+++ b/src/flag_gems/ops/gather.py
@@ -7,7 +7,6 @@ import torch
 
 from flag_gems.utils.code_cache import code_cache_dir
 from flag_gems.utils.code_utils import IndentedBuffer
-from flag_gems.utils.code_utils import IndentedBuffer
 from flag_gems.utils.shape_utils import restride_dim
 
 from .scatter import scatter_

--- a/src/flag_gems/ops/gather.py
+++ b/src/flag_gems/ops/gather.py
@@ -1,12 +1,12 @@
 import importlib
 import logging
 import os
-from typing import Any, Callable, List, Mapping, Tuple
+from typing import Any, Callable, Mapping, Tuple
 
 import torch
 
 from flag_gems.utils.code_cache import code_cache_dir
-from flag_gems.utils.code_utils import IndentedBuffer, NameSpace
+from flag_gems.utils.code_utils import IndentedBuffer
 from flag_gems.utils.shape_utils import restride_dim
 
 from .scatter import scatter_
@@ -34,102 +34,54 @@ def generate_gather_kernel(
     # make the inlined function visible in the context
     code.newline()
 
-    # the decorators
     code.writeline("@libentry()")
-    code.writeline("@triton.heuristics(")
-    with code.indent():
-        code.writeline("runtime.get_heuristic_config('gather')")
-    code.writeline(")")
+    code.writeline("@triton.heuristics({'BLOCK_SIZE_N': lambda args: 512})")
     code.writeline("@triton.jit")
-
-    # signature
     code.writeline(f"def {kernel_name}(")
-    function_ns = NameSpace()
     with code.indent():
-        if rank > 0:
-            code.writeline("inp,")
-            function_ns.create_name("inp")
-            code.writeline("out,")
-            function_ns.create_name("out")
-            code.writeline("index,")
-            function_ns.create_name("index")
-
-            for i in range(rank):
-                function_ns.create_name(f"inp_stride_{i}")
-            stride_args = ", ".join(f"inp_stride_{i}: int" for i in range(rank))
-            code.writeline(f"{stride_args}, # stride for inp")
-
-            for i in range(rank):
-                function_ns.create_name(f"index_stride_{i}")
-            stride_args = ", ".join(f"index_stride_{i}: int" for i in range(rank))
-            code.writeline(f"{stride_args}, # stride for index")
-
-            for i in range(rank):
-                function_ns.create_name(f"index_shape_{i}")
-            shape_args = ", ".join(f"index_shape_{i}: int" for i in range(rank))
-            code.writeline(f"{shape_args}, # shape for index")
-
-            code.writeline("dim,")
-            code.writeline("stride_dim,")
-            code.writeline("M,")
-            code.writeline("N,")
-            code.writeline("BLOCK_M: tl.constexpr,")
-            code.writeline("BLOCK_N: tl.constexpr,")
+        args = [
+            "inp, ",
+            "index, ",
+            "out, ",
+        ]
+        args += [f"inp_shape{i}," for i in range(rank)]
+        args += [f"index_shape{i}, " for i in range(rank)]
+        args += [f"out_shape{i}, " for i in range(rank)]
+        args += [f"inp_stride{i}, " for i in range(rank)]
+        args += [f"index_stride{i}, " for i in range(rank)]
+        args += [f"out_stride{i}, " for i in range(rank)]
+        args += ["dim, ", "dim_stride, ", "N, ", "BLOCK_SIZE_N: tl.constexpr, "]
+        code.writelines(args)
     code.writeline("):")
 
-    # Kernel Code
     with code.indent():
-        code.writeline("pid_x = tle.program_id(0)")
-        code.writeline("pid_y = tle.program_id(1)")
+        code.writeline("pid = tle.program_id(0)")
         code.writeline(
-            "rows_offsets = pid_x * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]"
+            "offset = pid * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)"
         )
-        code.writeline(
-            "cols_offsets = pid_y * BLOCK_N + tl.arange(0, BLOCK_N)[None, :]"
-        )
-        code.writeline("rows_mask = rows_offsets < M")
-        code.writeline("cols_mask = cols_offsets < N")
-
-        code.writeline("offsets = (rows_offsets * N + cols_offsets).to(tl.int64)")
-        code.writeline("mask = rows_mask & cols_mask")
-
-        #   1. Calculate inp_offsets and idx_offsets
-        code.writeline("inp_offsets = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.int64)")
-        code.writeline("idx_offsets = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.int64)")
-        code.writeline("cur_idx = rows_offsets * N + cols_offsets")
-
-        #   2. snippets
-        for i in range(rank):
-            code.writeline(f"mod = cur_idx % index_shape_{i}")
-            code.writeline(f"inp_offsets += mod * inp_stride_{i}")
-            code.writeline(f"idx_offsets += mod * index_stride_{i}")
-            if i != (rank - 1):
-                code.writeline(f"cur_idx //= index_shape_{i}")
-
-        # Use offsets to gather
-        code.writeline("cur_index = tl.load(index + idx_offsets, mask=mask, other=0)")
-        code.writeline("inp_offsets += cur_index * stride_dim")
-        code.writeline("cur_inp = tl.load(inp + inp_offsets, mask=mask, other=0)")
-        code.writeline("tl.store(out + idx_offsets, cur_inp, mask=mask)")
+        code.newline()
+        code.writeline("cur_offset = offset")
+        for i in range(rank - 1, -1, -1):
+            code.writeline(f"index_idx{i} = cur_offset % index_shape{i}")
+            code.writeline(f"cur_offset = cur_offset // index_shape{i}")
+        code.newline()
+        comp = [f"index_idx{i} * index_stride{i}" for i in range(rank)]
+        code.writeline(f"index_offset = {' + '.join(comp)}")
+        code.writeline("mask = offset < N")
+        code.writeline("cur_index = tl.load(index + index_offset, mask=mask, other=0)")
+        code.newline()
+        comp = [f"index_idx{i} * inp_stride{i}" for i in range(rank)]
+        code.writeline(f"inp_offset = {' + '.join(comp)}")
+        code.writeline("inp_offset += cur_index * dim_stride")
+        code.writeline("cur_inp = tl.load(inp + inp_offset, mask=mask, other=0)")
+        code.newline()
+        comp = [f"index_idx{i} * out_stride{i}" for i in range(rank)]
+        code.writeline(f"out_offset = {' + '.join(comp)}")
+        code.writeline("tl.store(out + out_offset, value=cur_inp, mask=mask)")
 
     code.newline()
     code.newline()
     return code
-
-
-def parameter_for_wrapper() -> str:
-    # inp_strided, out, index, dim, stride_dim, M, N
-    parameters: List[str] = []
-
-    parameters.append("inp_strided")
-    parameters.append("out")
-    parameters.append("index")
-    parameters.append("dim")
-    parameters.append("stride_dim")
-    parameters.append("M")
-    parameters.append("N")
-
-    return ", ".join(parameters)
 
 
 def generate_gather_wrapper(
@@ -138,44 +90,38 @@ def generate_gather_wrapper(
     kernel_name: str,
     code: IndentedBuffer,
 ) -> IndentedBuffer:
-    parameters: str = parameter_for_wrapper()
-    wrapper_signature: str = f"def {wrapper_name}({parameters}):"
-    code.writeline(wrapper_signature)
-
+    code.writeline(f"def {wrapper_name}(inp, dim, index, out, dim_stride, N):")
     with code.indent():
-        code.writeline("inp_strides = inp_strided.stride()")
-        code.writeline("index_strides = index.stride()")
-        code.writeline("index_shapes = list(index.shape)")
-
-        # kernel launch
-        code.writeline("grid = lambda meta: (")
+        code.writeline("inp_shape = inp.shape")
+        code.writeline("inp_stride = inp.stride()")
+        code.writeline("index_shape = index.shape")
+        code.writeline("index_stride = index.stride()")
+        code.writeline("out_shape = out.shape")
+        code.writeline("out_stride = out.stride()")
+        code.writeline("grid = lambda meta: (triton.cdiv(N, meta['BLOCK_SIZE_N']), )")
+        code.writeline(f"{kernel_name}[grid](")
         with code.indent():
-            code.writeline('triton.cdiv(M, meta["BLOCK_M"]),')
-            code.writeline('triton.cdiv(N, meta["BLOCK_N"])')
-        code.writeline(")")
-
-        kernel_launch: str = f"{kernel_name}[grid]("
-        code.writeline(kernel_launch)
-
-        with code.indent():
-            code.writeline("inp_strided, out, index, ")
-            if rank > 0:
-                s = ", ".join(f"inp_strides[{i}]" for i in range(rank))
-                code.writeline(f"{s},")
-
-                s = ", ".join(f"index_strides[{i}]" for i in range(rank))
-                code.writeline(f"{s},")
-
-                s = ", ".join(f"index_shapes[{i}]" for i in range(rank))
-                code.writeline(f"{s},")
-
-                code.writeline("dim,")
-                code.writeline("stride_dim,")
-                code.writeline("M,")
-                code.writeline("N,")
+            args = [
+                "inp, ",
+                "index, ",
+                "out, ",
+            ]
+            args += [f"inp_shape[{i}], " for i in range(rank)]
+            args += [f"index_shape[{i}], " for i in range(rank)]
+            args += [f"out_shape[{i}], " for i in range(rank)]
+            args += [f"inp_stride[{i}], " for i in range(rank)]
+            args += [f"index_stride[{i}], " for i in range(rank)]
+            args += [f"out_stride[{i}], " for i in range(rank)]
+            args += [
+                "dim, ",
+                "dim_stride, ",
+                "N, ",
+            ]
+            code.writelines(args)
         code.writeline(")")
         code.writeline("return out")
-
+    code.newline()
+    code.newline()
     return code
 
 
@@ -185,9 +131,7 @@ def generate_code(
     kernel_name: str,
     code: IndentedBuffer,
 ) -> IndentedBuffer:
-    # inputs: inp_strided, out, index, dim, stride_dim, M, N
-    shape = inputs[2].shape
-    rank = len(shape)
+    rank = inputs[0].ndim
 
     code = generate_imports(code)
     code = generate_gather_kernel(rank, kernel_name, code)
@@ -232,9 +176,7 @@ class GatherFunction:
         return overload(*args, **kwargs)
 
     def arg_key(self, *args):
-        tensors = [item for item in args if torch.is_tensor(item)]
-        max_rank = max(item.ndim for item in tensors)
-        return max_rank
+        return args[0].ndim
 
 
 _gather_func = GatherFunction()
@@ -242,19 +184,12 @@ _gather_func = GatherFunction()
 
 def gather(inp, dim, index, out=None, sparse_grad=False):
     logging.debug("GEMS GATHER")
-    inp = inp.contiguous()
-    index = index.contiguous()
     if out is None:
         out = torch.empty_like(index, dtype=inp.dtype, device=inp.device)
-    out = out.contiguous()
-    stride_dim = inp.stride(dim)
-
+    dim_stride = inp.stride(dim)
     inp_strided = restride_dim(inp, dim, index.shape)
-    # plain_idx = torch.arange(0, index.numel(), device=inp.device).reshape(index.shape)
-    N = list(index.shape)[index.ndim - 1]
-    M = index.numel() // N
-
-    _gather_func(inp_strided, out, index, dim, stride_dim, M, N)
+    N = index.numel()
+    _gather_func(inp_strided, dim, index, out, dim_stride, N)
     return out
 
 


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Performance Optimization
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Re-implementing gather op
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
**Before：**
```
Operator: gather  Performance Test (dtype=torch.float16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Torch GBPS            Gems GBPS           Size Detail
-----------------------------------------------------------------------------------------------------------------------------------------
SUCCESS               0.013024            0.011232               1.160               7.548               8.752          [torch.Size([64, 64]), -1, torch.Size([64, 128])]
SUCCESS               0.013184            0.018400               0.717             119.301              85.482          [torch.Size([256, 256]), -1, torch.Size([256, 512])]
SUCCESS               0.032864            0.139904               0.235             765.757             179.879          [torch.Size([1024, 1024]), -1, torch.Size([1024, 2048])]
SUCCESS               0.332608            8.644352               0.038            1210.594              46.580          [torch.Size([4096, 4096]), -1, torch.Size([4096, 8192])]
SUCCESS               1.523776           54.445824               0.028            1056.988              29.582          [torch.Size([1024, 65536]), -1, torch.Size([1024, 131072])]
SUCCESS               0.062144            0.230880               0.269             988.671             266.112          [torch.Size([10000, 256]), -1, torch.Size([10000, 512])]
SUCCESS              14.877792          572.946045               0.026            1057.189              27.452          [torch.Size([10000, 65536]), -1, torch.Size([10000, 131072])]


Operator: gather  Performance Test (dtype=torch.float32, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Torch GBPS            Gems GBPS           Size Detail
-----------------------------------------------------------------------------------------------------------------------------------------
SUCCESS               0.011744            0.008480               1.385              11.161              15.457          [torch.Size([64, 64]), -1, torch.Size([64, 128])]
SUCCESS               0.011616            0.016960               0.685             180.540             123.653          [torch.Size([256, 256]), -1, torch.Size([256, 512])]
SUCCESS               0.038336            0.143840               0.267             875.272             233.276          [torch.Size([1024, 1024]), -1, torch.Size([1024, 2048])]
SUCCESS               0.387040            9.053536               0.043            1387.120              59.300          [torch.Size([4096, 4096]), -1, torch.Size([4096, 8192])]
SUCCESS               1.671840           54.217888               0.031            1284.503              39.608          [torch.Size([1024, 65536]), -1, torch.Size([1024, 131072])]
SUCCESS               0.069696            0.254976               0.273            1175.390             321.285          [torch.Size([10000, 256]), -1, torch.Size([10000, 512])]
SUCCESS              16.339872          569.732117               0.029            1283.457              36.809          [torch.Size([10000, 65536]), -1, torch.Size([10000, 131072])]


Operator: gather  Performance Test (dtype=torch.bfloat16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Torch GBPS            Gems GBPS           Size Detail
-----------------------------------------------------------------------------------------------------------------------------------------
SUCCESS               0.010944            0.008608               1.271               8.982              11.420          [torch.Size([64, 64]), -1, torch.Size([64, 128])]
SUCCESS               0.012384            0.018400               0.673             127.008              85.482          [torch.Size([256, 256]), -1, torch.Size([256, 512])]
SUCCESS               0.033760            0.141472               0.239             745.433             177.886          [torch.Size([1024, 1024]), -1, torch.Size([1024, 2048])]
SUCCESS               0.332864            8.636352               0.039            1209.663              46.623          [torch.Size([4096, 4096]), -1, torch.Size([4096, 8192])]
SUCCESS               1.524480           54.436993               0.028            1056.500              29.587          [torch.Size([1024, 65536]), -1, torch.Size([1024, 131072])]
SUCCESS               0.062240            0.231840               0.268             987.147             265.010          [torch.Size([10000, 256]), -1, torch.Size([10000, 512])]
SUCCESS              14.870400          572.917847               0.026            1057.715              27.454          [torch.Size([10000, 65536]), -1, torch.Size([10000, 131072])]

```


**After：**
```
Operator: gather  Performance Test (dtype=torch.float16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Torch GBPS            Gems GBPS           Size Detail
-----------------------------------------------------------------------------------------------------------------------------------------
SUCCESS               0.013152            0.009536               1.379               7.474              10.309          [torch.Size([64, 64]), -1, torch.Size([64, 128])]
SUCCESS               0.012864            0.009664               1.331             122.269             162.755          [torch.Size([256, 256]), -1, torch.Size([256, 512])]
SUCCESS               0.033632            0.031328               1.074             748.270             803.301          [torch.Size([1024, 1024]), -1, torch.Size([1024, 2048])]
SUCCESS               0.333440            0.307360               1.085            1207.573            1310.038          [torch.Size([4096, 4096]), -1, torch.Size([4096, 8192])]
SUCCESS               1.524736            1.411264               1.080            1056.322            1141.255          [torch.Size([1024, 65536]), -1, torch.Size([1024, 131072])]
SUCCESS               0.062272            0.058784               1.059             986.639            1045.182          [torch.Size([10000, 256]), -1, torch.Size([10000, 512])]
SUCCESS              14.870304           13.689120               1.086            1057.721            1148.988          [torch.Size([10000, 65536]), -1, torch.Size([10000, 131072])]


Operator: gather  Performance Test (dtype=torch.float32, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Torch GBPS            Gems GBPS           Size Detail
-----------------------------------------------------------------------------------------------------------------------------------------
SUCCESS               0.011328            0.008256               1.372              11.571              15.876          [torch.Size([64, 64]), -1, torch.Size([64, 128])]
SUCCESS               0.011776            0.009888               1.191             178.087             212.091          [torch.Size([256, 256]), -1, torch.Size([256, 512])]
SUCCESS               0.039008            0.034944               1.116             860.194             960.234          [torch.Size([1024, 1024]), -1, torch.Size([1024, 2048])]
SUCCESS               0.387648            0.376640               1.029            1384.944            1425.422          [torch.Size([4096, 4096]), -1, torch.Size([4096, 8192])]
SUCCESS               1.672064            1.616960               1.034            1284.331            1328.099          [torch.Size([1024, 65536]), -1, torch.Size([1024, 131072])]
SUCCESS               0.070688            0.066208               1.068            1158.895            1237.313          [torch.Size([10000, 256]), -1, torch.Size([10000, 512])]
SUCCESS              16.339647           15.749472               1.037            1283.474            1331.570          [torch.Size([10000, 65536]), -1, torch.Size([10000, 131072])]


Operator: gather  Performance Test (dtype=torch.bfloat16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Torch GBPS            Gems GBPS           Size Detail
-----------------------------------------------------------------------------------------------------------------------------------------
SUCCESS               0.011936            0.008064               1.480               8.236              12.190          [torch.Size([64, 64]), -1, torch.Size([64, 128])]
SUCCESS               0.012032            0.010720               1.122             130.723             146.722          [torch.Size([256, 256]), -1, torch.Size([256, 512])]
SUCCESS               0.033792            0.030240               1.117             744.727             832.203          [torch.Size([1024, 1024]), -1, torch.Size([1024, 2048])]
SUCCESS               0.332928            0.308128               1.080            1209.430            1306.772          [torch.Size([4096, 4096]), -1, torch.Size([4096, 8192])]
SUCCESS               1.524384            1.409856               1.081            1056.566            1142.395          [torch.Size([1024, 65536]), -1, torch.Size([1024, 131072])]
SUCCESS               0.061504            0.058944               1.043             998.959            1042.345          [torch.Size([10000, 256]), -1, torch.Size([10000, 512])]
SUCCESS              14.872288           13.688032               1.087            1057.580            1149.080          [torch.Size([10000, 65536]), -1, torch.Size([10000, 131072])]
```