### PR TITLE
[Test] upcast cfloat to complex128 as reference

### DIFF
--- a/tests/accuracy_utils.py
+++ b/tests/accuracy_utils.py
@@ -131,7 +131,10 @@ def to_reference(inp, upcast=False):
     if TO_CPU:
         ref_inp = ref_inp.to("cpu")
     if upcast:
-        ref_inp = ref_inp.to(torch.float64)
+        if ref_inp.is_complex():
+            ref_inp = ref_inp.to(torch.complex128)
+        else:
+            ref_inp = ref_inp.to(torch.float64)
     return ref_inp
 
 

--- a/tests/test_blas_ops.py
+++ b/tests/test_blas_ops.py
@@ -138,8 +138,8 @@ def test_accuracy_vdot(M, is_conj, dtype, stride):
     if inp2_is_conj:
         inp2 = inp2.conj()
 
-    ref_inp1 = to_reference(inp1, False)
-    ref_inp2 = to_reference(inp2, False)
+    ref_inp1 = to_reference(inp1, True)
+    ref_inp2 = to_reference(inp2, True)
 
     with flag_gems.use_gems():
         res_out = torch.vdot(inp1, inp2)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
OP Test
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
there exists slight error between result and reference of operator vdot while ref option is set as cpu.
here I upcast reference input to higher precision and specify torch.complex128 as the corresponding data type for torch.cfloat.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
