### PR TITLE
Fix a Setup error

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -102,7 +102,7 @@ setup(
     package_dir={"": "src"},
     include_package_data=True,  # To include non-Python files, e.g., README
     package_data={
-        "flag_gems.runtime": ["**/*.yaml"],
+        "flag_gems.runtime": ["*/**/*.yaml"],
     },
     setup_requires=["setuptools"],
 )


### PR DESCRIPTION
### PR Category
User Experience

### Type of Change
Bug Fix

### Description
When I tried to install it with pip from Github with `pip install git+https://github.com/FlagOpen/FlagGems.git`, and then use it in my project, it reports an error `FileNotFoundError: [Errno 2] No such file or directory: '**/.venv/lib/python3.10/site-packages/flag_gems/runtime/backend/_nvidia/tune_configs.yaml'`. It's due to the Yaml files are not packaged correctly during building. Now I reset the package searching patterns, and it works. You can try it with `pip install git+https://github.com/sgjzfzzf/FlagGems.git`.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
