### PR TITLE
modify more_shapes for some operators & add get_gbps function for index_add

### DIFF
--- a/benchmark/performance_utils.py
+++ b/benchmark/performance_utils.py
@@ -394,10 +394,10 @@ class GenericBenchmark(Benchmark):
 
     def set_more_shapes(self):
         more_shapes_1d = [
-            (2**28,),
+            (2**20,),
         ]
-        more_shapes_2d = [(10000, 2**i) for i in (0, 8, 16)]
-        more_shapes_3d = [(100, 2**i, 100) for i in (0, 8, 16)]
+        more_shapes_2d = [(10000, 2**i) for i in (0, 8, 15)]
+        more_shapes_3d = [(100, 2**i, 100) for i in (0, 8, 15)]
         return more_shapes_1d + more_shapes_2d + more_shapes_3d
 
     def get_input_iter(self, cur_dtype) -> Generator:

--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -6,7 +6,13 @@ import torch
 
 from flag_gems.utils import shape_utils
 
-from .attri_util import BOOL_DTYPES, FLOAT_DTYPES, INT_DTYPES, BenchLevel
+from .attri_util import (
+    BOOL_DTYPES,
+    DEFAULT_METRICS,
+    FLOAT_DTYPES,
+    INT_DTYPES,
+    BenchLevel,
+)
 from .performance_utils import (
     Benchmark,
     Config,
@@ -18,12 +24,13 @@ from .performance_utils import (
 
 
 class UnaryReductionBenchmark(Benchmark):
+    DEFAULT_METRICS = DEFAULT_METRICS[:] + ["gbps"]
     """
     Base class for benchmarking reduction operations.
     """
 
-    def set_more_metrics(self):
-        return ["gbps"]
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
     def get_gbps(self, args, latency):
         inp = args[0]

--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -123,12 +123,16 @@ def test_perf_sort():
 
 @pytest.mark.multinomial
 def test_multinomial_with_replacement():
+    class MultinomialBenchmark(GenericBenchmark2DOnly):
+        def set_more_shapes(self):
+            return [(1024, 2**i) for i in range(0, 20, 4)]
+
     def multinomial_input_fn(shape, dtype, device):
         dist = torch.rand(shape, dtype=dtype, device=device)
         n_samples = 10000
         yield dist, n_samples, True,
 
-    bench = GenericBenchmark2DOnly(
+    bench = MultinomialBenchmark(
         input_fn=multinomial_input_fn,
         op_name="multinomial",
         torch_op=torch.multinomial,
@@ -305,6 +309,14 @@ def test_perf_conv2d():
 
 @pytest.mark.diag
 def test_perf_diag():
+    class DiagBenchmark(GenericBenchmarkExcluse3D):
+        def set_more_shapes(self):
+            more_shapes_1d = [
+                (2**16,),
+            ]
+            more_shapes_2d = [(10000, 2**i) for i in (0, 8, 15)]
+            return more_shapes_1d + more_shapes_2d
+
     def diag_input_fn(shape, dtype, device):
         input = generate_tensor_input(shape, dtype, device)
         diagonal = random.randint(-4, 4)
@@ -312,7 +324,7 @@ def test_perf_diag():
             "diagonal": diagonal,
         },
 
-    bench = GenericBenchmarkExcluse3D(
+    bench = DiagBenchmark(
         input_fn=diag_input_fn,
         op_name="diag",
         torch_op=torch.diag,

--- a/src/flag_gems/ops/pad.py
+++ b/src/flag_gems/ops/pad.py
@@ -405,7 +405,7 @@ class PadFunction:
                 args,
                 "_wrapper",
                 "_wrapper_out",
-                "_jit_function",
+                "_pad_flaggems_jit_function",
                 code,
             )
 

--- a/src/flag_gems/ops/scatter.py
+++ b/src/flag_gems/ops/scatter.py
@@ -287,7 +287,7 @@ class ScatterFunction:
             code = generate_code(
                 args,
                 "_scatter_wrapper",
-                "_scatter_jit_function",
+                "_scatter_flaggems_jit_function",
                 code,
             )
 


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Other

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

1. Adjusted shapes list in `set_more_shapes` method of `GenericBenchmark.`
2. Added separate `set_more_shapes` methods for `multinomial` and `diag` operators to prevent OOM.
3. Renamed kernel‘s name for `pad` and `scatter` for improved readability.
4. Added `get_gbps` method to `index_add` operator for performance benchmarking.
