### PR TITLE
[Metax] fix accuracy error of scatter in metax

### DIFF
--- a/src/flag_gems/ops/scatter.py
+++ b/src/flag_gems/ops/scatter.py
@@ -17,6 +17,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.newline()
     code.writeline("from flag_gems.utils import libentry")
     code.writeline("from flag_gems import runtime")
+    code.writeline("import flag_gems")
     # code.writeline("from flag_gems.utils import triton_lang_extension as tle")
     code.newline()
     code.newline()
@@ -35,6 +36,9 @@ def generate_scatter_kernel(
 
     code.writeline("def heur_block(args):")
     with code.indent():
+        code.writeline("if(flag_gems.vendor_name=='metax'):")
+        with code.indent():
+            code.writeline("return 256")
         code.writeline("return 128")
     code.newline()
     code.newline()

--- a/src/flag_gems/runtime/backend/_metax/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_metax/tune_configs.yaml
@@ -22,8 +22,7 @@ attention:
   - 8
   stages:
   - 1
-  - 2
-  - 3
+
 bmm:
 - META:
     TILE_M: 32


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operater

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
We found that scatter with `heur_block=128 ` will calculate wrong answer, so need to change it to 256 while running in metax backend
