### PR TITLE
MTHREADS: adjust method for skipping unsupported ops

### DIFF
--- a/benchmark/test_binary_pointwise_perf.py
+++ b/benchmark/test_binary_pointwise_perf.py
@@ -49,12 +49,14 @@ class BinaryPointwiseBenchmark(Benchmark):
             ("mul", torch.mul, FLOAT_DTYPES),
             ("pow", torch.pow, FLOAT_DTYPES),
             ("sub", torch.sub, FLOAT_DTYPES),
-            ("floor_divide", torch.floor_divide, INT_DTYPES)
-            if flag_gems.device != "musa"
-            else (),
-            ("remainder", torch.remainder, INT_DTYPES)
-            if flag_gems.device != "musa"
-            else (),
+            *(
+                [
+                    ("floor_divide", torch.floor_divide, INT_DTYPES),
+                    ("remainder", torch.remainder, INT_DTYPES),
+                ]
+                if flag_gems.device != "musa"
+                else []
+            ),
             ("rsub", torch.rsub, FLOAT_DTYPES),
             ("logical_or", torch.logical_or, INT_DTYPES + BOOL_DTYPES),
             ("logical_and", torch.logical_and, INT_DTYPES + BOOL_DTYPES),

--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -50,9 +50,15 @@ class UnaryReductionBenchmark(Benchmark):
 
 
 forward_operations = [
-    ("all", torch.all, FLOAT_DTYPES) if flag_gems.device != "musa" else (),
+    *(
+        [
+            ("all", torch.all, FLOAT_DTYPES),
+            ("any", torch.any, FLOAT_DTYPES),
+        ]
+        if flag_gems.device != "musa"
+        else []
+    ),
     ("amax", torch.amax, FLOAT_DTYPES),
-    ("any", torch.any, FLOAT_DTYPES) if flag_gems.device != "musa" else (),
     ("argmax", torch.argmax, FLOAT_DTYPES),
     ("argmin", torch.argmin, FLOAT_DTYPES),
     ("max", torch.max, FLOAT_DTYPES),

--- a/benchmark/test_select_and_slice_perf.py
+++ b/benchmark/test_select_and_slice_perf.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 import torch
 
+import flag_gems
 from flag_gems.utils import shape_utils
 
 from .attri_util import FLOAT_DTYPES
@@ -287,17 +288,19 @@ def gen_indices(input_shape, indices_shape, accumulate):
         index = np.random.choice(
             np.arange(input_shape[i]), size=shape, replace=accumulate
         )
-        indices.append(torch.tensor(index, device="cuda"))
+        indices.append(torch.tensor(index, device=flag_gems.device))
     return indices
 
 
 def index_put_input_fn(accumulate):
     def inner(shapes, dtype, device):
         input_shape, indices_shape, values_shape = shapes
-        inp = torch.randn(input_shape, dtype=dtype, device="cuda", requires_grad=False)
+        inp = torch.randn(
+            input_shape, dtype=dtype, device=flag_gems.device, requires_grad=False
+        )
         indices = gen_indices(input_shape, indices_shape, accumulate)
         values = torch.randn(
-            values_shape, dtype=dtype, device="cuda", requires_grad=False
+            values_shape, dtype=dtype, device=flag_gems.device, requires_grad=False
         )
         yield inp, indices, values, accumulate
 

--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -42,12 +42,14 @@ special_operations = [
     # Sorting Operations
     ("topk", torch.topk, FLOAT_DTYPES, topk_input_fn),
     # Complex Operations
-    ("resolve_neg", torch.resolve_neg, [torch.cfloat], resolve_neg_input_fn)
-    if flag_gems.device != "musa"
-    else (),
-    ("resolve_conj", torch.resolve_conj, [torch.cfloat], resolve_conj_input_fn)
-    if flag_gems.device != "musa"
-    else (),
+    *(
+        [
+            ("resolve_neg", torch.resolve_neg, [torch.cfloat], resolve_neg_input_fn),
+            ("resolve_conj", torch.resolve_conj, [torch.cfloat], resolve_conj_input_fn),
+        ]
+        if flag_gems.device != "musa"
+        else []
+    ),
 ]
 
 


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
op tests

### Description
- adjust the method for skipping unsupported ops with musa backend
- Change the device type of tensor in index_put benchmark test for multi-backends

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
