### PR TITLE
[BENCHMARK] Fix wrong reference of device_name in benchmarks

### DIFF
--- a/benchmark/test_binary_pointwise_perf.py
+++ b/benchmark/test_binary_pointwise_perf.py
@@ -50,10 +50,10 @@ class BinaryPointwiseBenchmark(Benchmark):
             ("pow", torch.pow, FLOAT_DTYPES),
             ("sub", torch.sub, FLOAT_DTYPES),
             ("floor_divide", torch.floor_divide, INT_DTYPES)
-            if flag_gems.device_name != "musa"
+            if flag_gems.runtime.backend.device_name != "musa"
             else (),
             ("remainder", torch.remainder, INT_DTYPES)
-            if flag_gems.device_name != "musa"
+            if flag_gems.runtime.backend.device_name != "musa"
             else (),
             ("rsub", torch.rsub, FLOAT_DTYPES),
             ("logical_or", torch.logical_or, INT_DTYPES + BOOL_DTYPES),

--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -50,9 +50,9 @@ class UnaryReductionBenchmark(Benchmark):
 
 
 forward_operations = [
-    ("all", torch.all, FLOAT_DTYPES) if flag_gems.device_name != "musa" else (),
+    ("all", torch.all, FLOAT_DTYPES) if flag_gems.runtime.backend.device_name != "musa" else (),
     ("amax", torch.amax, FLOAT_DTYPES),
-    ("any", torch.any, FLOAT_DTYPES) if flag_gems.device_name != "musa" else (),
+    ("any", torch.any, FLOAT_DTYPES) if flag_gems.runtime.backend.device_name != "musa" else (),
     ("argmax", torch.argmax, FLOAT_DTYPES),
     ("argmin", torch.argmin, FLOAT_DTYPES),
     ("max", torch.max, FLOAT_DTYPES),

--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -43,10 +43,10 @@ special_operations = [
     ("topk", torch.topk, FLOAT_DTYPES, topk_input_fn),
     # Complex Operations
     ("resolve_neg", torch.resolve_neg, [torch.cfloat], resolve_neg_input_fn)
-    if flag_gems.device_name != "musa"
+    if flag_gems.runtime.backend.device_name != "musa"
     else (),
     ("resolve_conj", torch.resolve_conj, [torch.cfloat], resolve_conj_input_fn)
-    if flag_gems.device_name != "musa"
+    if flag_gems.runtime.backend.device_name != "musa"
     else (),
 ]
 


### PR DESCRIPTION
* 'flag_gems.device_name' does not exist.
* 'flag_gems.runtime.backend.device_name' is used instead.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
