### PR TITLE
Add linspace op

### DIFF
--- a/benchmark/test_tensor_constructor_perf.py
+++ b/benchmark/test_tensor_constructor_perf.py
@@ -1,4 +1,5 @@
 import math
+import random
 
 import pytest
 import torch
@@ -56,6 +57,18 @@ def arange_input_fn(shape, dtype, device):
         },
 
 
+def linspace_input_fn(shape, dtype, device):
+    limit = torch.finfo(dtype).max - 1
+    num = int(min(limit, math.prod(shape)))
+    yield {
+        "start": 0,
+        "end": num,
+        "steps": random.randint(1, num),
+        "dtype": dtype,
+        "device": device,
+    },
+
+
 # Define operations and their corresponding input functions
 tensor_constructor_operations = [
     # generic tensor constructor
@@ -75,6 +88,8 @@ tensor_constructor_operations = [
     ("full_like", torch.full_like, full_like_input_fn),
     # arange
     ("arange", torch.arange, arange_input_fn),
+    # linspace
+    ("linspace", torch.linspace, linspace_input_fn),
 ]
 
 

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -103,6 +103,7 @@ def enable(lib=aten_lib, unused=None, registrar=registrar):
             ("zeros_like", zeros_like, Autograd.disable),
             ("ones_like", ones_like, Autograd.disable),
             ("full_like", full_like, Autograd.disable),
+            ("linspace", linspace, Autograd.disable),
             ("resolve_neg", resolve_neg, Autograd.disable),
             ("resolve_conj", resolve_conj, Autograd.disable),
             ("normal.Tensor_float", normal_tensor_float, Autograd.disable),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -58,6 +58,7 @@ from .isinf import isinf
 from .isnan import isnan
 from .layernorm import layer_norm
 from .le import le, le_scalar
+from .linspace import linspace
 from .log_sigmoid import log_sigmoid
 from .log_softmax import log_softmax
 from .logical_and import logical_and
@@ -181,6 +182,7 @@ __all__ = [
     "zeros",
     "ones",
     "full",
+    "linspace",
     "native_dropout",
     "erf",
     "embedding",

--- a/src/flag_gems/ops/linspace.py
+++ b/src/flag_gems/ops/linspace.py
@@ -1,0 +1,66 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from ..utils import libentry
+from ..utils import triton_lang_extension as tle
+
+
+@libentry()
+@triton.jit
+def linspace_kernel(
+    out_ptr,
+    start,
+    mid,
+    end,
+    step_size,
+    steps,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tle.program_id(0)
+    idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = idx < steps
+    fw_mask = idx < mid
+    fw_values = start + (step_size * idx)
+    bd_values = end - step_size * (steps - idx - 1)
+
+    out_val = tl.where(fw_mask, fw_values, bd_values)
+    tl.store(out_ptr + idx, out_val, mask=mask)
+
+
+def linspace(
+    start,
+    end,
+    steps,
+    *,
+    out=None,
+    dtype=None,
+    layout=torch.strided,
+    device=None,
+    requires_grad=False,
+    pin_memory=False
+) -> torch.Tensor:
+    logging.debug("GEMS LINSPACE")
+    assert steps >= 1, "steps must be >= 1"
+
+    mid = steps / 2
+    if steps == 1:
+        step_size = 0.0
+    else:
+        step_size = (float(end) - float(start)) / (steps - 1)
+
+    if out is None:
+        out = torch.empty(
+            steps,
+            dtype=dtype,
+            layout=layout,
+            device=device,
+            pin_memory=pin_memory,
+            requires_grad=requires_grad,
+        )
+    BLOCK_SIZE = 128
+    grid = (triton.cdiv(steps, BLOCK_SIZE),)
+    linspace_kernel[grid](out, start, mid, end, step_size, steps, BLOCK_SIZE=BLOCK_SIZE)
+    return out

--- a/src/flag_gems/ops/linspace.py
+++ b/src/flag_gems/ops/linspace.py
@@ -58,6 +58,10 @@ def linspace(
     if steps == 1:
         return torch.fill(out, start)
     else:
+        if isinstance(start, torch.Tensor):
+            start = start.item()
+        if isinstance(end, torch.Tensor):
+            end = end.item()
         mid = steps // 2
         step_size = (float(end) - float(start)) / (steps - 1)
         BLOCK_SIZE = 128

--- a/src/flag_gems/ops/linspace.py
+++ b/src/flag_gems/ops/linspace.py
@@ -12,6 +12,7 @@ from ..utils import triton_lang_extension as tle
 @triton.jit
 def linspace_kernel(
     out_ptr,
+    out_stride0,
     start,
     mid,
     end,
@@ -27,7 +28,7 @@ def linspace_kernel(
     bd_values = end - step_size * (steps - idx - 1)
 
     out_val = tl.where(fw_mask, fw_values, bd_values)
-    tl.store(out_ptr + idx, out_val, mask=mask)
+    tl.store(out_ptr + idx * out_stride0, out_val, mask=mask)
 
 
 def linspace(
@@ -45,12 +46,6 @@ def linspace(
     logging.debug("GEMS LINSPACE")
     assert steps >= 1, "steps must be >= 1"
 
-    mid = steps // 2
-    if steps == 1:
-        step_size = 0.0
-    else:
-        step_size = (float(end) - float(start)) / (steps - 1)
-
     if out is None:
         out = torch.empty(
             steps,
@@ -60,7 +55,14 @@ def linspace(
             pin_memory=pin_memory,
             requires_grad=requires_grad,
         )
-    BLOCK_SIZE = 128
-    grid = (triton.cdiv(steps, BLOCK_SIZE),)
-    linspace_kernel[grid](out, start, mid, end, step_size, steps, BLOCK_SIZE=BLOCK_SIZE)
-    return out
+    if steps == 1:
+        return torch.fill(out, start)
+    else:
+        mid = steps // 2
+        step_size = (float(end) - float(start)) / (steps - 1)
+        BLOCK_SIZE = 128
+        grid = (triton.cdiv(steps, BLOCK_SIZE),)
+        linspace_kernel[grid](
+            out, out.stride(0), start, mid, end, step_size, steps, BLOCK_SIZE=BLOCK_SIZE
+        )
+        return out

--- a/src/flag_gems/ops/linspace.py
+++ b/src/flag_gems/ops/linspace.py
@@ -45,7 +45,7 @@ def linspace(
     logging.debug("GEMS LINSPACE")
     assert steps >= 1, "steps must be >= 1"
 
-    mid = steps / 2
+    mid = steps // 2
     if steps == 1:
         step_size = 0.0
     else:

--- a/src/flag_gems/ops/linspace.py
+++ b/src/flag_gems/ops/linspace.py
@@ -32,29 +32,18 @@ def linspace_kernel(
 
 
 def linspace(
-    start,
-    end,
-    steps,
-    *,
-    out=None,
-    dtype=None,
-    layout=torch.strided,
-    device=None,
-    requires_grad=False,
-    pin_memory=False
+    start, end, steps, *, dtype=None, layout=None, device=None, pin_memory=None
 ) -> torch.Tensor:
     logging.debug("GEMS LINSPACE")
     assert steps >= 1, "steps must be >= 1"
 
-    if out is None:
-        out = torch.empty(
-            steps,
-            dtype=dtype,
-            layout=layout,
-            device=device,
-            pin_memory=pin_memory,
-            requires_grad=requires_grad,
-        )
+    out = torch.empty(
+        steps,
+        dtype=dtype,
+        layout=layout,
+        device=device,
+        pin_memory=pin_memory,
+    )
     if steps == 1:
         return torch.fill(out, start)
     else:

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -547,11 +547,9 @@ def test_linspace(start, end, steps, dtype, device, pin_memory):
         start,
         end,
         steps,
-        out=None,
         dtype=dtype,
         layout=None,
         device=device,
-        requires_grad=False,
         pin_memory=pin_memory,
     )
     with flag_gems.use_gems():
@@ -559,11 +557,9 @@ def test_linspace(start, end, steps, dtype, device, pin_memory):
             start,
             end,
             steps,
-            out=None,
             dtype=dtype,
             layout=None,
             device=device,
-            requires_grad=False,
             pin_memory=pin_memory,
         )
     if dtype in [torch.float16, torch.bfloat16]:

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -533,6 +533,45 @@ def test_arange(start, step, end, dtype, device, pin_memory):
     gems_assert_equal(res_out, ref_out)
 
 
+@pytest.mark.linspace
+@pytest.mark.parametrize("start", [0, 2, 4])
+@pytest.mark.parametrize("end", [1024, 2048, 4096])
+@pytest.mark.parametrize("steps", [1, 257, 513])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES + ALL_INT_DTYPES + [None])
+@pytest.mark.parametrize("device", [device, None])
+@pytest.mark.parametrize("pin_memory", [False, None])
+def test_linspace(start, end, steps, dtype, device, pin_memory):
+    if TO_CPU:
+        return
+    ref_out = torch.linspace(
+        start,
+        end,
+        steps,
+        out=None,
+        dtype=dtype,
+        layout=None,
+        device=device,
+        requires_grad=False,
+        pin_memory=pin_memory,
+    )
+    with flag_gems.use_gems():
+        res_out = torch.linspace(
+            start,
+            end,
+            steps,
+            out=None,
+            dtype=dtype,
+            layout=None,
+            device=device,
+            requires_grad=False,
+            pin_memory=pin_memory,
+        )
+    if dtype in [torch.float16, torch.bfloat16]:
+        gems_assert_close(res_out, ref_out, dtype=dtype)
+    else:
+        gems_assert_equal(res_out, ref_out)
+
+
 @pytest.mark.skipif(flag_gems.device == "musa", reason="AssertionError")
 @pytest.mark.skipif(flag_gems.vendor_name == "kunlunxin", reason="RESULT TODOFIX")
 @pytest.mark.isin

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -535,8 +535,8 @@ def test_arange(start, step, end, dtype, device, pin_memory):
 
 @pytest.mark.linspace
 @pytest.mark.parametrize("start", [0, 2, 4])
-@pytest.mark.parametrize("end", [1024, 2048, 4096])
-@pytest.mark.parametrize("steps", [1, 257, 513])
+@pytest.mark.parametrize("end", [256, 2048, 4096])
+@pytest.mark.parametrize("steps", [1, 256, 512])
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES + ALL_INT_DTYPES + [None])
 @pytest.mark.parametrize("device", [device, None])
 @pytest.mark.parametrize("pin_memory", [False, None])


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add linspace op
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

```
benchmark/test_tensor_constructor_perf.py 
Operator: linspace  Performance Test (dtype=torch.float16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007744            0.007424               1.043          {'start': 0, 'end': 65503, 'steps': 11930, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.007712            0.006176               1.249          {'start': 0, 'end': 4096, 'steps': 3598, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.006752            0.006528               1.034          {'start': 0, 'end': 65503, 'steps': 3165, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.006688            0.006976               0.959          {'start': 0, 'end': 65503, 'steps': 24547, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.006784            0.006656               1.019          {'start': 0, 'end': 65503, 'steps': 7776, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.007392            0.007648               0.967          {'start': 0, 'end': 65503, 'steps': 48606, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.007392            0.006176               1.197          {'start': 0, 'end': 10000, 'steps': 541, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.007168            0.007008               1.023          {'start': 0, 'end': 65503, 'steps': 62128, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.007264            0.007616               0.954          {'start': 0, 'end': 65503, 'steps': 30535, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.006432            0.006176               1.041          {'start': 0, 'end': 10000, 'steps': 7891, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.007360            0.007616               0.966          {'start': 0, 'end': 65503, 'steps': 39451, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.006912            0.006656               1.038          {'start': 0, 'end': 65503, 'steps': 54982, 'dtype': torch.float16, 'device': 'cuda'}


Operator: linspace  Performance Test (dtype=torch.float32, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              11.912832            5.959104               1.999          {'start': 0, 'end': 1073741824, 'steps': 1028344234, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.006176            0.006176               1.000          {'start': 0, 'end': 4096, 'steps': 1975, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.018048            0.012000               1.504          {'start': 0, 'end': 16777216, 'steps': 981161, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.038336            0.022112               1.734          {'start': 0, 'end': 16777216, 'steps': 2767021, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               6.853696            3.430368               1.998          {'start': 0, 'end': 1073741824, 'steps': 591429131, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               2.992288            1.499456               1.996          {'start': 0, 'end': 268435456, 'steps': 257972581, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.006752            0.006528               1.034          {'start': 0, 'end': 10000, 'steps': 561, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.015200            0.011104               1.369          {'start': 0, 'end': 2560000, 'steps': 766165, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               2.924992            1.465472               1.996          {'start': 0, 'end': 655360000, 'steps': 252165756, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.006784            0.007392               0.918          {'start': 0, 'end': 10000, 'steps': 6251, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.011712            0.009184               1.275          {'start': 0, 'end': 2560000, 'steps': 440106, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.064672            0.035264               1.834          {'start': 0, 'end': 655360000, 'steps': 5076269, 'dtype': torch.float32, 'device': 'cuda'}


Operator: linspace  Performance Test (dtype=torch.bfloat16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.653472            0.329152               1.985          {'start': 0, 'end': 1073741824, 'steps': 55846449, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.006720            0.006176               1.088          {'start': 0, 'end': 4096, 'steps': 3087, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.153792            0.079296               1.939          {'start': 0, 'end': 16777216, 'steps': 12677224, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.124928            0.065760               1.900          {'start': 0, 'end': 16777216, 'steps': 10274023, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               5.398432            2.702464               1.998          {'start': 0, 'end': 1073741824, 'steps': 465792052, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               2.240704            1.123712               1.994          {'start': 0, 'end': 268435456, 'steps': 193058198, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.006432            0.006784               0.948          {'start': 0, 'end': 10000, 'steps': 9974, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.019904            0.013536               1.470          {'start': 0, 'end': 2560000, 'steps': 1178752, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               5.961792            2.984256               1.998          {'start': 0, 'end': 655360000, 'steps': 514488235, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.006432            0.006752               0.953          {'start': 0, 'end': 10000, 'steps': 5423, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.029824            0.017984               1.658          {'start': 0, 'end': 2560000, 'steps': 2017588, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               4.037504            2.022432               1.996          {'start': 0, 'end': 655360000, 'steps': 348277461, 'dtype': torch.bfloat16, 'device': 'cuda'}
```