### PR TITLE
Add contiguous op

### DIFF
--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -402,3 +402,25 @@ def test_perf_kron():
     )
 
     bench.run()
+
+
+@pytest.mark.contiguous
+def test_perf_contiguous():
+    def contiguous_input_fn(shape, dtype, device):
+        if dtype in FLOAT_DTYPES:
+            inp = torch.randn(shape, dtype=dtype, device=device)
+        else:
+            inp = torch.randint(
+                low=-10000, high=10000, size=shape, dtype=dtype, device=device
+            )
+        inp = inp[::2]
+        yield inp,
+
+    bench = GenericBenchmark(
+        input_fn=contiguous_input_fn,
+        op_name="torch.Tensor.contiguous",
+        torch_op=torch.Tensor.contiguous,
+        dtypes=FLOAT_DTYPES,
+    )
+
+    bench.run()

--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -417,7 +417,7 @@ def test_perf_contiguous():
         input_fn=contiguous_input_fn,
         op_name="torch.Tensor.contiguous",
         torch_op=torch.Tensor.contiguous,
-        dtypes=FLOAT_DTYPES,
+        dtypes=FLOAT_DTYPES + INT_DTYPES,
     )
 
     bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -269,6 +269,7 @@ def enable(lib=aten_lib, unused=None, registrar=registrar):
             ("kron", kron, Autograd.disable),
             ("elu", elu, Autograd.disable),
             ("index_put", index_put, Autograd.disable),
+            ("contiguous", contiguous, Autograd.disable),
             ("log_sigmoid", log_sigmoid, Autograd.disable),
             ("vdot", vdot, Autograd.disable),
             ("mse_loss", mse_loss, Autograd.disable),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -27,6 +27,7 @@ from .bitwise_or import (
 from .bmm import bmm
 from .cat import cat
 from .clamp import clamp, clamp_, clamp_tensor, clamp_tensor_
+from .contiguous import contiguous
 from .conv1d import conv1d
 from .conv2d import conv2d
 from .conv_depthwise2d import _conv_depthwise2d
@@ -201,6 +202,7 @@ __all__ = [
     "cos",
     "cos_",
     "count_nonzero",
+    "contiguous",
     "diag",
     "diag_embed",
     "diagonal_backward",

--- a/src/flag_gems/ops/contiguous.py
+++ b/src/flag_gems/ops/contiguous.py
@@ -6,7 +6,7 @@ from ..ops.copy import copy
 
 
 def contiguous(inp, memory_format=torch.contiguous_format):
-    assert memory_format != torch.preserve_format
+    assert memory_format == torch.contiguous_format
     logging.debug("GEMS CONTIGUOUS")
     if inp.is_contiguous(memory_format=memory_format):
         return inp

--- a/src/flag_gems/ops/contiguous.py
+++ b/src/flag_gems/ops/contiguous.py
@@ -1,0 +1,14 @@
+import logging
+
+import torch
+
+from ..ops.copy import copy
+
+
+def contiguous(inp, memory_format=torch.contiguous_format):
+    assert memory_format != torch.preserve_format
+    logging.debug("GEMS CONTIGUOUS")
+    if inp.is_contiguous(memory_format=memory_format):
+        return inp
+    out = torch.empty_like(inp, memory_format=memory_format)
+    return copy(inp, out0=out)

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -1103,7 +1103,7 @@ def test_accuracy_kron(shape, dtype):
 @pytest.mark.parametrize("shape", SPECIAL_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES + ALL_INT_DTYPES)
 def test_accuracy_contiguous(shape, dtype):
-    if shape[0] == 1:
+    if shape[0] <= 2:
         return
     if dtype in FLOAT_DTYPES:
         inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -1097,3 +1097,29 @@ def test_accuracy_kron(shape, dtype):
         res_out = torch.kron(inp1, inp2)
 
     gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.contiguous
+@pytest.mark.parametrize("shape", SPECIAL_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES + ALL_INT_DTYPES)
+def test_accuracy_contiguous(shape, dtype):
+    if shape[0] == 1:
+        return
+    if dtype in FLOAT_DTYPES:
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    else:
+        inp = torch.randint(
+            low=-10000, high=10000, size=shape, dtype=dtype, device=flag_gems.device
+        )
+    inp = inp[::2]
+    gems_assert_equal(inp.is_contiguous(), False)
+
+    ref_inp = to_reference(inp)
+    ref_out = ref_inp.contiguous()
+    with flag_gems.use_gems():
+        res_out = inp.contiguous()
+
+    gems_assert_equal(ref_out.is_contiguous(), True)
+    gems_assert_equal(res_out.is_contiguous(), True)
+    gems_assert_equal(res_out.stride(), ref_out.stride())
+    gems_assert_equal(res_out, ref_out)

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -1112,14 +1112,14 @@ def test_accuracy_contiguous(shape, dtype):
             low=-10000, high=10000, size=shape, dtype=dtype, device=flag_gems.device
         )
     inp = inp[::2]
-    np.testing.assert_equal(inp.is_contiguous(), False)
+    assert inp.is_contiguous() is False
 
     ref_inp = to_reference(inp)
     ref_out = ref_inp.contiguous()
     with flag_gems.use_gems():
         res_out = inp.contiguous()
 
-    np.testing.assert_equal(ref_out.is_contiguous(), True)
-    np.testing.assert_equal(res_out.is_contiguous(), True)
-    np.testing.assert_equal(res_out.stride(), ref_out.stride())
+    assert res_out.is_contiguous() is True
+    assert res_out.is_contiguous() is True
+    assert res_out.stride() == ref_out.stride()
     gems_assert_equal(res_out, ref_out)

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -1112,14 +1112,14 @@ def test_accuracy_contiguous(shape, dtype):
             low=-10000, high=10000, size=shape, dtype=dtype, device=flag_gems.device
         )
     inp = inp[::2]
-    gems_assert_equal(inp.is_contiguous(), False)
+    np.testing.assert_equal(inp.is_contiguous(), False)
 
     ref_inp = to_reference(inp)
     ref_out = ref_inp.contiguous()
     with flag_gems.use_gems():
         res_out = inp.contiguous()
 
-    gems_assert_equal(ref_out.is_contiguous(), True)
-    gems_assert_equal(res_out.is_contiguous(), True)
-    gems_assert_equal(res_out.stride(), ref_out.stride())
+    np.testing.assert_equal(ref_out.is_contiguous(), True)
+    np.testing.assert_equal(res_out.is_contiguous(), True)
+    np.testing.assert_equal(res_out.stride(), ref_out.stride())
     gems_assert_equal(res_out, ref_out)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add contiguous op
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

A100
```
Operator: torch.Tensor.contiguous  Performance Test (dtype=torch.float16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.514880            2.362880               1.064          [torch.Size([536870912])]
SUCCESS               0.009504            0.006944               1.369          [torch.Size([32, 64])]
SUCCESS               0.045408            0.033408               1.359          [torch.Size([2048, 4096])]
SUCCESS               0.045632            0.033696               1.354          [torch.Size([32, 512, 512])]
SUCCESS               2.211552            1.610528               1.373          [torch.Size([512, 1024, 1024])]
SUCCESS               0.641120            0.598848               1.071          [torch.Size([134217728])]
SUCCESS               0.009056            0.007360               1.230          [torch.Size([5000, 1])]
SUCCESS               0.015712            0.012064               1.302          [torch.Size([5000, 256])]
SUCCESS               1.364064            0.977568               1.395          [torch.Size([5000, 65536])]
SUCCESS               0.009056            0.008224               1.101          [torch.Size([50, 1, 100])]
SUCCESS               0.015744            0.012736               1.236          [torch.Size([50, 256, 100])]
SUCCESS               1.352512            1.156416               1.170          [torch.Size([50, 65536, 100])]


Operator: torch.Tensor.contiguous  Performance Test (dtype=torch.float32, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               4.763840            4.698016               1.014          [torch.Size([536870912])]
SUCCESS               0.008000            0.007296               1.096          [torch.Size([32, 64])]
SUCCESS               0.060256            0.058080               1.037          [torch.Size([2048, 4096])]
SUCCESS               0.060672            0.057984               1.046          [torch.Size([32, 512, 512])]
SUCCESS               3.159072            3.136352               1.007          [torch.Size([512, 1024, 1024])]
SUCCESS               1.200832            1.185152               1.013          [torch.Size([134217728])]
SUCCESS               0.008512            0.007520               1.132          [torch.Size([5000, 1])]
SUCCESS               0.017024            0.015520               1.097          [torch.Size([5000, 256])]
SUCCESS               1.946752            1.915968               1.016          [torch.Size([5000, 65536])]
SUCCESS               0.008608            0.006976               1.234          [torch.Size([50, 1, 100])]
SUCCESS               0.016160            0.016672               0.969          [torch.Size([50, 256, 100])]
SUCCESS               1.933280            1.972352               0.980          [torch.Size([50, 65536, 100])]


Operator: torch.Tensor.contiguous  Performance Test (dtype=torch.bfloat16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.515648            2.363072               1.065          [torch.Size([536870912])]
SUCCESS               0.009024            0.006944               1.300          [torch.Size([32, 64])]
SUCCESS               0.045376            0.033376               1.360          [torch.Size([2048, 4096])]
SUCCESS               0.045088            0.033696               1.338          [torch.Size([32, 512, 512])]
SUCCESS               2.211360            1.611328               1.372          [torch.Size([512, 1024, 1024])]
SUCCESS               0.640544            0.598592               1.070          [torch.Size([134217728])]
SUCCESS               0.009600            0.006912               1.389          [torch.Size([5000, 1])]
SUCCESS               0.014976            0.011360               1.318          [torch.Size([5000, 256])]
SUCCESS               1.364736            0.977568               1.396          [torch.Size([5000, 65536])]
SUCCESS               0.009376            0.008416               1.114          [torch.Size([50, 1, 100])]
SUCCESS               0.015040            0.013568               1.108          [torch.Size([50, 256, 100])]
SUCCESS               1.353280            1.156544               1.170          [torch.Size([50, 65536, 100])]


Operator: torch.Tensor.contiguous  Performance Test (dtype=torch.int16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.515648            2.362720               1.065          [torch.Size([536870912])]
SUCCESS               0.009664            0.007296               1.325          [torch.Size([32, 64])]
SUCCESS               0.046400            0.033408               1.389          [torch.Size([2048, 4096])]
SUCCESS               0.045120            0.033664               1.340          [torch.Size([32, 512, 512])]
SUCCESS               2.211040            1.611072               1.372          [torch.Size([512, 1024, 1024])]
SUCCESS               0.640480            0.598592               1.070          [torch.Size([134217728])]
SUCCESS               0.009024            0.007968               1.133          [torch.Size([5000, 1])]
SUCCESS               0.015744            0.011360               1.386          [torch.Size([5000, 256])]
SUCCESS               1.364768            0.977600               1.396          [torch.Size([5000, 65536])]
SUCCESS               0.010272            0.007424               1.384          [torch.Size([50, 1, 100])]
SUCCESS               0.015040            0.013632               1.103          [torch.Size([50, 256, 100])]
SUCCESS               1.352832            1.156480               1.170          [torch.Size([50, 65536, 100])]


Operator: torch.Tensor.contiguous  Performance Test (dtype=torch.int32, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               4.764800            4.700896               1.014          [torch.Size([536870912])]
SUCCESS               0.008000            0.006944               1.152          [torch.Size([32, 64])]
SUCCESS               0.061312            0.058752               1.044          [torch.Size([2048, 4096])]
SUCCESS               0.060576            0.058528               1.035          [torch.Size([32, 512, 512])]
SUCCESS               3.158752            3.136512               1.007          [torch.Size([512, 1024, 1024])]
SUCCESS               1.201056            1.184416               1.014          [torch.Size([134217728])]
SUCCESS               0.008000            0.006944               1.152          [torch.Size([5000, 1])]
SUCCESS               0.017120            0.015584               1.099          [torch.Size([5000, 256])]
SUCCESS               1.946848            1.916192               1.016          [torch.Size([5000, 65536])]
SUCCESS               0.009280            0.008256               1.124          [torch.Size([50, 1, 100])]
SUCCESS               0.016672            0.015744               1.059          [torch.Size([50, 256, 100])]
SUCCESS               1.933088            1.972224               0.980          [torch.Size([50, 65536, 100])]
```