### PR TITLE
write to tmp file & replace, avoid writing a module per process in PointwiseDynamic

### DIFF
--- a/src/flag_gems/ops/gather.py
+++ b/src/flag_gems/ops/gather.py
@@ -3,11 +3,10 @@ import logging
 import os
 from typing import Any, Callable, Mapping, Tuple
 
-import filelock
 import torch
 
 from flag_gems.utils.code_cache import code_cache_dir
-from flag_gems.utils.code_utils import IndentedBuffer
+from flag_gems.utils.code_utils import IndentedBuffer, write_atomic
 from flag_gems.utils.shape_utils import restride_dim
 
 from .scatter import scatter_
@@ -159,14 +158,8 @@ class GatherFunction:
             )
 
             file_name = f"gather_rank_{key}.py"
-            lock_name = f"{file_name}.lock"
             file_path = code_cache_dir() / file_name
-            lock_path = code_cache_dir() / lock_name
-
-            with filelock.FileLock(lock_path):
-                if not os.path.exists(file_path):
-                    with open(file_path, "wt", encoding="utf-8") as f:
-                        f.write(code.getvalue())
+            write_atomic(file_path, code.getvalue())
 
             # load
             spec = importlib.util.spec_from_file_location(

--- a/src/flag_gems/ops/index_put.py
+++ b/src/flag_gems/ops/index_put.py
@@ -3,6 +3,7 @@ import logging
 import os
 from typing import Any, Callable, List, Mapping, Tuple
 
+import filelock
 import torch
 
 from flag_gems.utils.code_cache import code_cache_dir
@@ -223,14 +224,19 @@ class IndexPutFunction:
                 "_index_put_jit_function",
                 code,
             )
-            file_name = f"index_put_{key}_pid_{self.pid}.py"
+            file_name = f"index_put_{key}.py"
 
-            with open(code_cache_dir() / file_name, "wt", encoding="utf-8") as f:
-                f.write(code.getvalue())
+            lock_name = f"{file_name}.lock"
+            lock_path = code_cache_dir() / lock_name
+            file_path = code_cache_dir() / file_name
+            with filelock.FileLock(lock_path):
+                if not os.path.exists(file_path):
+                    with open(file_path, "wt", encoding="utf-8") as f:
+                        f.write(code.getvalue())
 
             spec = importlib.util.spec_from_file_location(
-                f"_gen_module_rank_{key}_pid_{self.pid}",
-                f.name,
+                f"_gen_module_rank_{key}",
+                file_path,
             )
 
             m = importlib.util.module_from_spec(spec)

--- a/src/flag_gems/ops/pad.py
+++ b/src/flag_gems/ops/pad.py
@@ -3,11 +3,10 @@ import logging
 import os
 from typing import Any, Callable, List, Mapping, Tuple
 
-import filelock
 import torch
 
 from flag_gems.utils.code_cache import code_cache_dir
-from flag_gems.utils.code_utils import IndentedBuffer
+from flag_gems.utils.code_utils import IndentedBuffer, write_atomic
 
 
 # --------------------------- padding wrapper genration -----------------------------------
@@ -411,13 +410,8 @@ class PadFunction:
             )
 
             file_name = f"constant_pad_rank_{key}.py"
-            lock_name = f"{file_name}.lock"
-            lock_path = code_cache_dir() / lock_name
             file_path = code_cache_dir() / file_name
-            with filelock.FileLock(lock_path):
-                if not os.path.exists(file_path):
-                    with open(file_path, "wt", encoding="utf-8") as f:
-                        f.write(code.getvalue())
+            write_atomic(file_path, code.getvalue())
 
             # load
             spec = importlib.util.spec_from_file_location(

--- a/src/flag_gems/ops/pad.py
+++ b/src/flag_gems/ops/pad.py
@@ -3,6 +3,7 @@ import logging
 import os
 from typing import Any, Callable, List, Mapping, Tuple
 
+import filelock
 import torch
 
 from flag_gems.utils.code_cache import code_cache_dir
@@ -409,15 +410,19 @@ class PadFunction:
                 code,
             )
 
-            file_name = f"constant_pad_rank_{key}_pid_{self.pid}.py"
-
-            with open(code_cache_dir() / file_name, "wt", encoding="utf-8") as f:
-                f.write(code.getvalue())
+            file_name = f"constant_pad_rank_{key}.py"
+            lock_name = f"{file_name}.lock"
+            lock_path = code_cache_dir() / lock_name
+            file_path = code_cache_dir() / file_name
+            with filelock.FileLock(lock_path):
+                if not os.path.exists(file_path):
+                    with open(file_path, "wt", encoding="utf-8") as f:
+                        f.write(code.getvalue())
 
             # load
             spec = importlib.util.spec_from_file_location(
-                f"_gen_module_rank_{key}_pid_{self.pid}",
-                f.name,
+                f"_gen_module_rank_{key}",
+                file_path,
             )
 
             m = importlib.util.module_from_spec(spec)

--- a/src/flag_gems/ops/repeat.py
+++ b/src/flag_gems/ops/repeat.py
@@ -3,11 +3,10 @@ import logging
 import os
 from typing import Callable, List, Mapping
 
-import filelock
 import torch
 
 from flag_gems.utils.code_cache import code_cache_dir
-from flag_gems.utils.code_utils import IndentedBuffer
+from flag_gems.utils.code_utils import IndentedBuffer, write_atomic
 
 
 # --------------------------- repeat wrapper genration -----------------------------------
@@ -410,13 +409,8 @@ class RepeatFunction:
             )
 
             file_name = f"repeat_rank_{key}.py"
-            lock_name = f"{file_name}.lock"
-            lock_path = code_cache_dir() / lock_name
             file_path = code_cache_dir() / file_name
-            with filelock.FileLock(lock_path):
-                if not os.path.exists(file_path):
-                    with open(file_path, "wt", encoding="utf-8") as f:
-                        f.write(code.getvalue())
+            write_atomic(file_path, code.getvalue())
 
             # load
             spec = importlib.util.spec_from_file_location(

--- a/src/flag_gems/ops/scatter.py
+++ b/src/flag_gems/ops/scatter.py
@@ -3,6 +3,7 @@ import logging
 import os
 from typing import Any, Callable, List, Mapping, Tuple
 
+import filelock
 import torch
 
 from flag_gems.utils.code_cache import code_cache_dir
@@ -295,15 +296,19 @@ class ScatterFunction:
                 code,
             )
 
-            file_name = f"scatter_rank_{key}_pid_{self.pid}.py"
-
-            with open(code_cache_dir() / file_name, "wt", encoding="utf-8") as f:
-                f.write(code.getvalue())
+            file_name = f"scatter_rank_{key}.py"
+            lock_name = f"{file_name}.lock"
+            lock_path = code_cache_dir() / lock_name
+            file_path = code_cache_dir() / file_name
+            with filelock.FileLock(lock_path):
+                if not os.path.exists(file_path):
+                    with open(file_path, "wt", encoding="utf-8") as f:
+                        f.write(code.getvalue())
 
             # load
             spec = importlib.util.spec_from_file_location(
-                f"_gen_module_rank_{key}_pid_{self.pid}",
-                f.name,
+                f"_gen_module_rank_{key}",
+                file_path,
             )
 
             m = importlib.util.module_from_spec(spec)

--- a/src/flag_gems/ops/scatter.py
+++ b/src/flag_gems/ops/scatter.py
@@ -3,11 +3,10 @@ import logging
 import os
 from typing import Any, Callable, List, Mapping, Tuple
 
-import filelock
 import torch
 
 from flag_gems.utils.code_cache import code_cache_dir
-from flag_gems.utils.code_utils import IndentedBuffer
+from flag_gems.utils.code_utils import IndentedBuffer, write_atomic
 from flag_gems.utils.shape_utils import has_internal_overlapping, restride_dim
 
 
@@ -297,13 +296,8 @@ class ScatterFunction:
             )
 
             file_name = f"scatter_rank_{key}.py"
-            lock_name = f"{file_name}.lock"
-            lock_path = code_cache_dir() / lock_name
             file_path = code_cache_dir() / file_name
-            with filelock.FileLock(lock_path):
-                if not os.path.exists(file_path):
-                    with open(file_path, "wt", encoding="utf-8") as f:
-                        f.write(code.getvalue())
+            write_atomic(file_path, code.getvalue())
 
             # load
             spec = importlib.util.spec_from_file_location(

--- a/src/flag_gems/ops/tile.py
+++ b/src/flag_gems/ops/tile.py
@@ -3,6 +3,7 @@ import logging
 import os
 from typing import Callable, List, Mapping
 
+import filelock
 import torch
 
 from flag_gems.utils.code_cache import code_cache_dir
@@ -408,15 +409,19 @@ class TileFunction:
                 code,
             )
 
-            file_name = f"tile_rank_{key}_pid_{self.pid}.py"
-
-            with open(code_cache_dir() / file_name, "wt", encoding="utf-8") as f:
-                f.write(code.getvalue())
+            file_name = f"tile_rank_{key}.py"
+            lock_name = f"{file_name}.lock"
+            lock_path = code_cache_dir() / lock_name
+            file_path = code_cache_dir() / file_name
+            with filelock.FileLock(lock_path):
+                if not os.path.exists(file_path):
+                    with open(file_path, "wt", encoding="utf-8") as f:
+                        f.write(code.getvalue())
 
             # load
             spec = importlib.util.spec_from_file_location(
-                f"_gen_module_rank_{key}_pid_{self.pid}",
-                f.name,
+                f"_gen_module_rank_{key}",
+                file_path,
             )
 
             m = importlib.util.module_from_spec(spec)

--- a/src/flag_gems/ops/tile.py
+++ b/src/flag_gems/ops/tile.py
@@ -3,11 +3,10 @@ import logging
 import os
 from typing import Callable, List, Mapping
 
-import filelock
 import torch
 
 from flag_gems.utils.code_cache import code_cache_dir
-from flag_gems.utils.code_utils import IndentedBuffer
+from flag_gems.utils.code_utils import IndentedBuffer, write_atomic
 
 
 # --------------------------- tile wrapper genration -----------------------------------
@@ -410,13 +409,8 @@ class TileFunction:
             )
 
             file_name = f"tile_rank_{key}.py"
-            lock_name = f"{file_name}.lock"
-            lock_path = code_cache_dir() / lock_name
             file_path = code_cache_dir() / file_name
-            with filelock.FileLock(lock_path):
-                if not os.path.exists(file_path):
-                    with open(file_path, "wt", encoding="utf-8") as f:
-                        f.write(code.getvalue())
+            write_atomic(file_path, code.getvalue())
 
             # load
             spec = importlib.util.spec_from_file_location(

--- a/src/flag_gems/utils/code_utils.py
+++ b/src/flag_gems/utils/code_utils.py
@@ -59,9 +59,13 @@
 import builtins
 import contextlib
 import keyword
+import os
 import re
+import threading
+import uuid
 from collections import defaultdict
 from io import StringIO
+from pathlib import Path
 from typing import Dict, Set
 
 
@@ -178,3 +182,20 @@ class NameSpace:
             return True
 
         return False
+
+
+def write_atomic(
+    path_: str,
+    content: str,
+    make_dirs: bool = False,
+    encoding: str = "utf-8",
+) -> None:
+    path = Path(path_)
+    if make_dirs:
+        path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = (
+        path.parent / f".{os.getpid()}.{threading.get_ident()}.{uuid.uuid4().hex}.tmp"
+    )
+    with tmp_path.open("wt", encoding=encoding) as f:
+        f.write(content)
+    tmp_path.replace(path)

--- a/tests/test_pointwise_dynamic.py
+++ b/tests/test_pointwise_dynamic.py
@@ -927,16 +927,16 @@ def test_dynamic_function_with_multiprocess(use_block_pointer):
     shape = [128]
     alpha = 2.0
     ctx = multiprocessing.get_context("spawn")
-    executor = concurrent.futures.ProcessPoolExecutor(max_workers=8, mp_context=ctx)
-    inputs = [torch.randn(shape, device=flag_gems.device) for _ in range(32)]
-    expected_outs = [item * alpha for item in inputs]
-    outs = []
-    for item in inputs:
-        out_future = executor.submit(
-            f_for_concurrency_test, item, alpha, use_block_pointer
-        )
-        outs.append(out_future)
-    outs = [item.result() for item in outs]
+    with concurrent.futures.ProcessPoolExecutor(max_workers=8, mp_context=ctx) as executor:
+        inputs = [torch.randn(shape, device=flag_gems.device) for _ in range(32)]
+        expected_outs = [item * alpha for item in inputs]
+        outs = []
+        for item in inputs:
+            out_future = executor.submit(
+                f_for_concurrency_test, item, alpha, use_block_pointer
+            )
+            outs.append(out_future)
+        outs = [item.result() for item in outs]
 
-    for out, expected_out in zip(outs, expected_outs):
-        torch.testing.assert_close(out, expected_out)
+        for out, expected_out in zip(outs, expected_outs):
+            torch.testing.assert_close(out, expected_out)

--- a/tests/test_pointwise_dynamic.py
+++ b/tests/test_pointwise_dynamic.py
@@ -907,16 +907,16 @@ def f_for_concurrency_test(x, alpha, use_block_pointer):
 def test_dynamic_function_with_multithread(use_block_pointer):
     shape = [128]
     alpha = 2.0
-    executor = concurrent.futures.ThreadPoolExecutor(max_workers=8)
-    inputs = [torch.randn(shape, device=flag_gems.device) for _ in range(32)]
-    expected_outs = [item * alpha for item in inputs]
-    outs = []
-    for item in inputs:
-        out_future = executor.submit(
-            f_for_concurrency_test, item, alpha, use_block_pointer
-        )
-        outs.append(out_future)
-    outs = [item.result() for item in outs]
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as executor:
+        inputs = [torch.randn(shape, device=flag_gems.device) for _ in range(32)]
+        expected_outs = [item * alpha for item in inputs]
+        outs = []
+        for item in inputs:
+            out_future = executor.submit(
+                f_for_concurrency_test, item, alpha, use_block_pointer
+            )
+            outs.append(out_future)
+        outs = [item.result() for item in outs]
 
     for out, expected_out in zip(outs, expected_outs):
         torch.testing.assert_close(out, expected_out)

--- a/tests/test_pointwise_dynamic.py
+++ b/tests/test_pointwise_dynamic.py
@@ -1,3 +1,6 @@
+import concurrent.futures
+import multiprocessing
+
 import pytest
 import torch
 import triton
@@ -874,3 +877,66 @@ def test_dynamic_function_zero_sized_task_binary(use_1d_tile, use_block_pointer)
     y = torch.randn_like(x)
     out = f(x, y)
     torch.testing.assert_close(out, x * 2.0 + y)
+
+
+def f_for_concurrency_test(x, alpha, use_block_pointer):
+    config = CodeGenConfig(
+        max_tile_size=1024,
+        max_grid_size=MAX_GRID_SIZES,
+        max_num_warps_per_cta=32,
+        prefer_block_pointer=use_block_pointer,
+        prefer_1d_tile=False,
+    )
+
+    @pointwise_dynamic(
+        num_inputs=3,
+        is_tensor=[True, True, False],
+        promotion_methods=[(0, 1, "DEFAULT")],
+        config=config,
+    )
+    @triton.jit
+    def axpy(x, y, alpha):
+        return alpha * x + y
+
+    y = torch.zeros_like(x)
+    out = axpy(x, y, alpha)
+    return out
+
+
+@pytest.mark.parametrize("use_block_pointer", USE_BLOCK_POINTER)
+def test_dynamic_function_with_multithread(use_block_pointer):
+    shape = [128]
+    alpha = 2.0
+    executor = concurrent.futures.ThreadPoolExecutor(max_workers=8)
+    inputs = [torch.randn(shape, device=flag_gems.device) for _ in range(32)]
+    expected_outs = [item * alpha for item in inputs]
+    outs = []
+    for item in inputs:
+        out_future = executor.submit(
+            f_for_concurrency_test, item, alpha, use_block_pointer
+        )
+        outs.append(out_future)
+    outs = [item.result() for item in outs]
+
+    for out, expected_out in zip(outs, expected_outs):
+        torch.testing.assert_close(out, expected_out)
+
+
+@pytest.mark.parametrize("use_block_pointer", USE_BLOCK_POINTER)
+def test_dynamic_function_with_multiprocess(use_block_pointer):
+    shape = [128]
+    alpha = 2.0
+    ctx = multiprocessing.get_context("spawn")
+    executor = concurrent.futures.ProcessPoolExecutor(max_workers=8, mp_context=ctx)
+    inputs = [torch.randn(shape, device=flag_gems.device) for _ in range(32)]
+    expected_outs = [item * alpha for item in inputs]
+    outs = []
+    for item in inputs:
+        out_future = executor.submit(
+            f_for_concurrency_test, item, alpha, use_block_pointer
+        )
+        outs.append(out_future)
+    outs = [item.result() for item in outs]
+
+    for out, expected_out in zip(outs, expected_outs):
+        torch.testing.assert_close(out, expected_out)

--- a/tests/test_pointwise_dynamic.py
+++ b/tests/test_pointwise_dynamic.py
@@ -927,7 +927,9 @@ def test_dynamic_function_with_multiprocess(use_block_pointer):
     shape = [128]
     alpha = 2.0
     ctx = multiprocessing.get_context("spawn")
-    with concurrent.futures.ProcessPoolExecutor(max_workers=8, mp_context=ctx) as executor:
+    with concurrent.futures.ProcessPoolExecutor(
+        max_workers=8, mp_context=ctx
+    ) as executor:
         inputs = [torch.randn(shape, device=flag_gems.device) for _ in range(32)]
         expected_outs = [item * alpha for item in inputs]
         outs = []


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Other

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Other

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
1. use filelock to avoid writing a module per process in PointwiseDynamiccFunction, 
2. add tests for multiprocessing & multithreading

Previously, PointwiseDynamic woule generate module for pointwise functions with the process id as suffix in filename to avoid conflicts in file-writing. It has 2 drawbacks: filenames with pid prevent file reuse between different runs, it generate duplicated files with different names, which is redundant.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
