### PR TITLE
[test] relax the accuracy condition of log op

### DIFF
--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -786,12 +786,12 @@ def test_accuracy_logical_not(shape, dtype):
 def test_accuracy_log(shape, dtype):
     inp = torch.rand(shape, dtype=dtype, device=flag_gems.device)
 
-    ref_inp = to_reference(inp)
+    ref_inp = to_reference(inp, True)
     ref_out = torch.log(ref_inp)
     with flag_gems.use_gems():
         res_out = torch.log(inp)
 
-    gems_assert_equal(res_out, ref_out)
+    gems_assert_close(res_out, ref_out, dtype)
 
 
 @pytest.mark.fill_


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
OP Test
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Other
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
asserting results equal is not appropriate for cpu mode.
this pr sets reference input tensor as higher precision and only requires output tensors to be close.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
