### PR TITLE
Fix addmm op bug

### DIFF
--- a/tests/test_blas_ops.py
+++ b/tests/test_blas_ops.py
@@ -28,7 +28,7 @@ FLOAT_DTYPES = [torch.float32] if QUICK_MODE else FLOAT_DTYPES
 def test_accuracy_addmm(M, N, K, scalar, dtype):
     mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
     mat2 = torch.randn((K, N), dtype=dtype, device=flag_gems.device)
-    bias = torch.randn((N,), dtype=dtype, device=flag_gems.device)
+    bias = torch.randn((M, N), dtype=dtype, device=flag_gems.device)
     ref_mat1 = to_reference(mat1, True)
     ref_mat2 = to_reference(mat2, True)
     ref_bias = to_reference(bias, True)

--- a/tests/test_blas_ops.py
+++ b/tests/test_blas_ops.py
@@ -28,18 +28,27 @@ FLOAT_DTYPES = [torch.float32] if QUICK_MODE else FLOAT_DTYPES
 def test_accuracy_addmm(M, N, K, scalar, dtype):
     mat1 = torch.randn((M, K), dtype=dtype, device=flag_gems.device)
     mat2 = torch.randn((K, N), dtype=dtype, device=flag_gems.device)
-    bias = torch.randn((M, N), dtype=dtype, device=flag_gems.device)
+    bias1 = torch.randn((N,), dtype=dtype, device=flag_gems.device)
     ref_mat1 = to_reference(mat1, True)
     ref_mat2 = to_reference(mat2, True)
-    ref_bias = to_reference(bias, True)
+    ref_bias1 = to_reference(bias1, True)
 
     alpha = beta = scalar
 
-    ref_out = torch.addmm(ref_bias, ref_mat1, ref_mat2, alpha=alpha, beta=beta)
+    ref_out1 = torch.addmm(ref_bias1, ref_mat1, ref_mat2, alpha=alpha, beta=beta)
     with flag_gems.use_gems():
-        res_out = torch.addmm(bias, mat1, mat2, alpha=alpha, beta=beta)
+        res_out1 = torch.addmm(bias1, mat1, mat2, alpha=alpha, beta=beta)
 
-    gems_assert_close(res_out, ref_out, dtype, reduce_dim=K)
+    gems_assert_close(res_out1, ref_out1, dtype, reduce_dim=K)
+
+    bias2 = torch.randn((M, N), dtype=dtype, device=flag_gems.device)
+    ref_bias2 = to_reference(bias2, True)
+
+    ref_out2 = torch.addmm(ref_bias2, ref_mat1, ref_mat2, alpha=alpha, beta=beta)
+    with flag_gems.use_gems():
+        res_out2 = torch.addmm(bias2, mat1, mat2, alpha=alpha, beta=beta)
+
+    gems_assert_close(res_out2, ref_out2, dtype, reduce_dim=K)
 
 
 @pytest.mark.bmm


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
[ Operator ]

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
[ Bug Fix ]

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
The first argument of `torch.addmm` op is the `bias` matrix, the shape of which should be broadcastable with the output shape. But the implementation of `flag_gems.addmm` only takes the row of `bias` into consideration. e.g. When the shape of `bias` is `(m x n)`, the result is incorrect.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.
