### PR TITLE
[benchmark] skip angle for musa

### DIFF
--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -40,15 +40,15 @@ class UnaryPointwiseBenchmark(Benchmark):
 forward_operations = [
     ("abs", torch.abs, FLOAT_DTYPES),
     *(
-        [
+        []
+        if flag_gems.device == "musa"  # angle is not supported on musa
+        else [
             (
                 "angle",
                 torch.angle,
                 COMPLEX_DTYPES + [torch.float32] + INT_DTYPES + BOOL_DTYPES,
             )
         ]
-        if flag_gems.device == "musa"  # angle is not supported on musa
-        else []
     ),
     ("erf", torch.erf, FLOAT_DTYPES),
     ("exp", torch.exp, FLOAT_DTYPES),


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Benchmark
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
musa mis-skipped benchmark of angle on all other devices. this pr fixed it.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
