### PR TITLE
[bugfix] reorder the computation of weight_norm_backward to pass unit…

### DIFF
--- a/tests/test_norm_ops.py
+++ b/tests/test_norm_ops.py
@@ -484,8 +484,12 @@ def test_accuracy_weightnorm_interface_backward(shape, dtype, dim):
             res_w_grad, res_v, res_g, res_norm, dim
         )
     reduce_size = res_v.numel() // shape[dim]
-    gems_assert_close(res_v_grad, ref_v_grad, dtype, reduce_dim=reduce_size)
-    gems_assert_close(res_g_grad, ref_g_grad, dtype, reduce_dim=reduce_size)
+    gems_assert_close(
+        res_v_grad, ref_v_grad, dtype, reduce_dim=reduce_size, equal_nan=True
+    )
+    gems_assert_close(
+        res_g_grad, ref_g_grad, dtype, reduce_dim=reduce_size, equal_nan=True
+    )
 
 
 @pytest.mark.rms_norm


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
unit test failed on torch.float32.
reorder the computation of reciprocal and power, and keep up with cuda kernel.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
