### PR TITLE
Add to.dtype op

### DIFF
--- a/benchmark/performance_utils.py
+++ b/benchmark/performance_utils.py
@@ -323,6 +323,7 @@ class Benchmark:
                 or isinstance(item, (int, float))
                 or item is None
                 or isinstance(item, (list, tuple))
+                or isinstance(item, torch.dtype)
             ):
                 args.append(item)
             elif isinstance(item, dict):

--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -125,3 +125,20 @@ def test_general_unary_pointwise_backward_perf(op_name, torch_op, dtypes):
         is_backward=True,
     )
     bench.run()
+
+
+class ToDtypeBenchmark(UnaryPointwiseBenchmark):
+    def get_input_iter(self, cur_dtype) -> Generator:
+        for shape in self.shapes:
+            inp = torch.randn(shape, dtype=torch.float32, device=self.device)
+            yield inp, cur_dtype
+
+
+@pytest.mark.to_dtype
+def test_to_dtype_perf():
+    bench = ToDtypeBenchmark(
+        op_name="to_dtype",
+        torch_op=torch.Tensor.to,
+        dtypes=[torch.float16, torch.bfloat16, torch.float64],
+    )
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -315,6 +315,7 @@ def enable(
             ("log_sigmoid", log_sigmoid, Autograd.disable),
             ("vdot", vdot, Autograd.disable),
             ("mse_loss", mse_loss, Autograd.disable),
+            ("to.dtype", to_dtype, Autograd.disable),
         ),
         user_unused_ops_list=[] if unused is None else unused,
         lib=lib,

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -154,6 +154,7 @@ from .sum import sum, sum_dim
 from .tanh import tanh, tanh_, tanh_backward
 from .threshold import threshold, threshold_backward
 from .tile import tile
+from .to import to_dtype
 from .topk import topk
 from .triu import triu
 from .uniform import uniform_
@@ -391,4 +392,5 @@ __all__ = [
     "vdot",
     "mse_loss",
     "log",
+    "to_dtype",
 ]

--- a/src/flag_gems/ops/to.py
+++ b/src/flag_gems/ops/to.py
@@ -1,0 +1,27 @@
+import logging
+
+import torch
+import triton
+
+from ..utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(
+    is_tensor=[
+        True,
+    ],
+    promotion_methods=[(0, "DEFAULT")],
+)
+@triton.jit
+def to_dtype_func(x):
+    return x
+
+
+def to_dtype(x, dtype, non_blocking=False, copy=False, memory_format=None):
+    logger.debug("GEMS TO.DTYPE")
+    if not copy and x.dtype == dtype:
+        return x
+    out = torch.empty_like(x, dtype=dtype, memory_format=memory_format)
+    return to_dtype_func(x, out0=out)

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -864,3 +864,15 @@ def test_accuracy_fill_(value, shape, dtype):
         x.fill_(value_tensor)
 
     gems_assert_equal(x, ref_x)
+
+
+@pytest.mark.to_dtype
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", ALL_FLOAT_DTYPES + ALL_INT_DTYPES)
+def test_accuracy_to_dtype(shape, dtype):
+    x = torch.randn(shape, dtype=torch.float32, device=flag_gems.device)
+    ref_x = to_reference(x)
+    ref_out = ref_x.to(dtype)
+    with flag_gems.use_gems():
+        out = x.to(dtype)
+    gems_assert_equal(out, ref_out)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add to.dtype op
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
```
benchmark/test_unary_pointwise_perf.py 
Operator: to_dtype  Performance Test (dtype=torch.float16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               4.774944            4.700352               1.016               0.228          [torch.Size([1073741824]), torch.float16]
SUCCESS               0.007744            0.007712               1.004               0.001          [torch.Size([64, 64]), torch.float16]
SUCCESS               0.085920            0.086528               0.993               0.194          [torch.Size([4096, 4096]), torch.float16]
SUCCESS               0.086560            0.086528               1.000               0.194          [torch.Size([64, 512, 512]), torch.float16]
SUCCESS               4.768864            4.698432               1.015               0.229          [torch.Size([1024, 1024, 1024]), torch.float16]
SUCCESS               0.007552            0.007584               0.996               0.000          [torch.Size([1024, 1]), torch.float16]
SUCCESS               0.007136            0.007104               1.005               0.002          [torch.Size([1024, 16]), torch.float16]
SUCCESS               0.009312            0.010080               0.924               0.026          [torch.Size([1024, 256]), torch.float16]
SUCCESS               0.028352            0.028384               0.999               0.148          [torch.Size([1024, 4096]), torch.float16]
SUCCESS               0.307264            0.303488               1.012               0.221          [torch.Size([1024, 65536]), torch.float16]
SUCCESS               0.007904            0.006944               1.138               0.001          [torch.Size([64, 64, 1]), torch.float16]
SUCCESS               0.008352            0.008128               1.028               0.008          [torch.Size([64, 64, 16]), torch.float16]
SUCCESS               0.012512            0.013312               0.940               0.079          [torch.Size([64, 64, 256]), torch.float16]
SUCCESS               0.085888            0.085920               1.000               0.195          [torch.Size([64, 64, 4096]), torch.float16]


Operator: to_dtype  Performance Test (dtype=torch.bfloat16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               4.773504            4.700128               1.016               0.228          [torch.Size([1073741824]), torch.bfloat16]
SUCCESS               0.007712            0.006912               1.116               0.001          [torch.Size([64, 64]), torch.bfloat16]
SUCCESS               0.086624            0.085920               1.008               0.195          [torch.Size([4096, 4096]), torch.bfloat16]
SUCCESS               0.086496            0.085856               1.007               0.195          [torch.Size([64, 512, 512]), torch.bfloat16]
SUCCESS               4.771744            4.700928               1.015               0.228          [torch.Size([1024, 1024, 1024]), torch.bfloat16]
SUCCESS               0.006560            0.006560               1.000               0.000          [torch.Size([1024, 1]), torch.bfloat16]
SUCCESS               0.007136            0.008064               0.885               0.002          [torch.Size([1024, 16]), torch.bfloat16]
SUCCESS               0.009344            0.009888               0.945               0.027          [torch.Size([1024, 256]), torch.bfloat16]
SUCCESS               0.027456            0.027488               0.999               0.153          [torch.Size([1024, 4096]), torch.bfloat16]
SUCCESS               0.306496            0.304320               1.007               0.221          [torch.Size([1024, 65536]), torch.bfloat16]
SUCCESS               0.006944            0.007968               0.871               0.001          [torch.Size([64, 64, 1]), torch.bfloat16]
SUCCESS               0.007424            0.007424               1.000               0.009          [torch.Size([64, 64, 16]), torch.bfloat16]
SUCCESS               0.012512            0.013408               0.933               0.078          [torch.Size([64, 64, 256]), torch.bfloat16]
SUCCESS               0.086592            0.086656               0.999               0.194          [torch.Size([64, 64, 4096]), torch.bfloat16]


Operator: to_dtype  Performance Test (dtype=torch.float64, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               9.896576           10.201888               0.970               0.105          [torch.Size([1073741824]), torch.float64]
SUCCESS               0.010304            0.007904               1.304               0.001          [torch.Size([64, 64]), torch.float64]
SUCCESS               0.163872            0.164032               0.999               0.102          [torch.Size([4096, 4096]), torch.float64]
SUCCESS               0.164608            0.164032               1.004               0.102          [torch.Size([64, 512, 512]), torch.float64]
SUCCESS               9.896224           10.205056               0.970               0.105          [torch.Size([1024, 1024, 1024]), torch.float64]
SUCCESS               0.009568            0.007392               1.294               0.000          [torch.Size([1024, 1]), torch.float64]
SUCCESS               0.010208            0.007200               1.418               0.002          [torch.Size([1024, 16]), torch.float64]
SUCCESS               0.011008            0.009120               1.207               0.029          [torch.Size([1024, 256]), torch.float64]
SUCCESS               0.048160            0.045504               1.058               0.092          [torch.Size([1024, 4096]), torch.float64]
SUCCESS               0.626144            0.639392               0.979               0.105          [torch.Size([1024, 65536]), torch.float64]
SUCCESS               0.010368            0.007072               1.466               0.001          [torch.Size([64, 64, 1]), torch.float64]
SUCCESS               0.010016            0.007584               1.321               0.009          [torch.Size([64, 64, 16]), torch.float64]
SUCCESS               0.017696            0.015296               1.157               0.069          [torch.Size([64, 64, 256]), torch.float64]
SUCCESS               0.164576            0.164704               0.999               0.102          [torch.Size([64, 64, 4096]), torch.float64]
```