### PR TITLE
Add concat_and_cache_mla kernel and corresponding tests

### DIFF
--- a/src/flag_gems/fused/concat_and_cache_mla.py
+++ b/src/flag_gems/fused/concat_and_cache_mla.py
@@ -1,0 +1,171 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+#from ..utils import libentry
+
+
+logger = logging.getLogger(__name__)
+
+# enum Fp8KVCacheDataType
+FP8_KV_CACHE_DATA_TYPE_AUTO    = tl.constexpr(0)
+FP8_KV_CACHE_DATA_TYPE_FP8E4M3 = tl.constexpr(1)
+FP8_KV_CACHE_DATA_TYPE_FP8E5M2 = tl.constexpr(2)
+
+
+#@libentry()
+@triton.jit
+def concat_and_cache_mla_kernel(
+    ###### pointers #####
+    kv_c_ptr,         # in,  [num_tokens, kv_lora_rank]
+    k_pe_ptr,         # in,  [num_tokens, pe_dim]
+    kv_cache_ptr,     # out, [num_blocks, block_size, kv_lora_rank + pe_dim]
+    slot_mapping_ptr, # in,  [num_tokens]
+    ###### strides #####
+    block_stride,
+    entry_stride,
+    kv_c_stride,
+    k_pe_stride,
+    ###### dims #####
+    kv_lora_rank,
+    pe_dim,
+    block_size,       # kv cache block size
+    scale_ptr,
+    ###### data type #####
+    kv_dtype: tl.constexpr,   # one of Fp8KVCacheDataType
+    BLOCK_SIZE: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    slot_idx = tl.load(slot_mapping_ptr + token_idx)
+    
+    # Skip padded tokens
+    if slot_idx < 0:
+        return
+    
+    # Calculate cache position
+    block_id = slot_idx // block_size
+    block_offset = slot_idx % block_size
+    cache_base = block_id * block_stride + block_offset * entry_stride
+    
+    # Preload scale if needed
+    if kv_dtype != FP8_KV_CACHE_DATA_TYPE_AUTO:
+        scale_val = tl.load(scale_ptr)
+    
+    # Process kv_c section
+    for i in range(0, kv_lora_rank, BLOCK_SIZE):
+        idx = i + tl.arange(0, BLOCK_SIZE)
+        mask = idx < kv_lora_rank
+        
+        src_ptr = kv_c_ptr + token_idx * kv_c_stride + idx
+        dst_ptr = kv_cache_ptr + cache_base + idx
+        
+        val = tl.load(src_ptr, mask=mask, other=0)
+        
+        if kv_dtype != FP8_KV_CACHE_DATA_TYPE_AUTO:
+            if kv_dtype == FP8_KV_CACHE_DATA_TYPE_FP8E4M3:
+                val = (val / scale_val).to(tl.float8e4nv)
+            elif kv_dtype == FP8_KV_CACHE_DATA_TYPE_FP8E5M2:
+                val = (val / scale_val).to(tl.float8e5)
+            val = val.to(tl.uint8, bitcast=True)
+        tl.store(dst_ptr, val, mask=mask)
+    
+    # Process k_pe section
+    for j in range(0, pe_dim, BLOCK_SIZE):
+        idx = j + tl.arange(0, BLOCK_SIZE)
+        mask = idx < pe_dim
+        
+        src_ptr = k_pe_ptr + token_idx * k_pe_stride + idx
+        dst_ptr = kv_cache_ptr + cache_base + kv_lora_rank + idx
+        
+        val = tl.load(src_ptr, mask=mask, other=0)
+        
+        if kv_dtype != FP8_KV_CACHE_DATA_TYPE_AUTO:
+            if kv_dtype == FP8_KV_CACHE_DATA_TYPE_FP8E4M3:
+                val = (val / scale_val).to(tl.float8e4nv)
+            elif kv_dtype == FP8_KV_CACHE_DATA_TYPE_FP8E5M2:
+                val = (val / scale_val).to(tl.float8e5)
+            val = val.to(tl.uint8, bitcast=True)
+        tl.store(dst_ptr, val, mask=mask)
+
+class ConcatAndCacheMla(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx,
+                kv_c: torch.Tensor,
+                k_pe: torch.Tensor,
+                kv_cache: torch.Tensor,
+                slot_mapping: torch.Tensor,
+                kv_cache_dtype: str,
+                scale: torch.Tensor):
+        print("args: kv_c: ", kv_c.shape, "k_pe: ", k_pe.shape,
+              "kv_cache: ", kv_cache.shape, "slot_mapping: ", slot_mapping.shape,
+              "kv_cache_dtype: ", kv_cache_dtype, "scale: ", scale.shape)
+        print("kv_c type: ", kv_c.dtype, "k_pe type: ", k_pe.dtype, "kv_cache type: ", kv_cache.dtype, )
+        if kv_cache_dtype != "auto" and kv_cache.dtype != torch.uint8:
+            raise ValueError("For FP8 kv_cache must be uint8 dtype")
+        if kv_cache_dtype == "auto" and kv_cache.dtype != kv_c.dtype:
+            raise ValueError("For auto mode kv_cache must match input dtype")
+        
+        # Map string dtype to internal constants
+        kv_dtype_map = {
+            "auto": FP8_KV_CACHE_DATA_TYPE_AUTO,
+            "fp8": FP8_KV_CACHE_DATA_TYPE_FP8E4M3,
+            "fp8e4m3": FP8_KV_CACHE_DATA_TYPE_FP8E4M3,
+            "fp8e5m2": FP8_KV_CACHE_DATA_TYPE_FP8E5M2,
+        }
+        kv_dtype = kv_dtype_map.get(kv_cache_dtype)
+        if kv_dtype is None:
+            raise ValueError(f"Unsupported kv_cache_dtype: {kv_cache_dtype}")
+        kv_dtype = int(kv_dtype) # tl.constexpr->int
+
+        kv_lora_rank = kv_c.size(1)
+        pe_dim = k_pe.size(1)
+        num_tokens = slot_mapping.size(0)
+        
+        # make sure `scale` is a scalar tensor
+        if scale.numel() != 1:
+            scale = scale.view(1)
+
+        # make sure all tensors are on the same device
+        device = kv_c.device
+        k_pe = k_pe.to(device)
+        kv_cache = kv_cache.to(device)
+        slot_mapping = slot_mapping.to(device)
+        scale = scale.to(device)
+
+        # configure kernel launch
+        grid = (num_tokens,)
+        BLOCK_SIZE = min(kv_lora_rank, 512)
+        
+        assert kv_cache.dim() == 3, "kv_cache must be a 3D tensor"
+        assert kv_cache.size(2) == kv_lora_rank + pe_dim, \
+            "kv_cache's last dimension must match kv_lora_rank + pe_dim"
+        with torch.cuda.device(device):
+            concat_and_cache_mla_kernel[grid](
+                kv_c, k_pe, kv_cache, slot_mapping,
+                kv_cache.stride(0),  # block_stride
+                kv_cache.stride(1),  # entry_stride
+                kv_c.stride(0),      # kv_c_stride
+                k_pe.stride(0),      # k_pe_stride
+                kv_lora_rank,
+                pe_dim,
+                kv_cache.size(1),    # kv cache block_size
+                scale,
+                kv_dtype=kv_dtype,
+                BLOCK_SIZE=BLOCK_SIZE,
+            )
+        return kv_cache
+
+def concat_and_cache_mla(
+    kv_c: torch.Tensor,
+    k_pe: torch.Tensor,
+    kv_cache: torch.Tensor,
+    slot_mapping: torch.Tensor,
+    kv_cache_dtype: str,
+    scale: torch.Tensor,
+) -> None:
+    logger.debug("GEMS CONCAT_AND_CACHE_MLA")
+    return ConcatAndCacheMla.apply(
+        kv_c, k_pe, kv_cache, slot_mapping, kv_cache_dtype, scale
+    )

--- a/tests/test_concat_and_cache_mla.py
+++ b/tests/test_concat_and_cache_mla.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+import os
+import sys
+
+# TODO: change this
+sys.path.append(os.path.abspath(os.path.expanduser("~/workspace")))
+
+import random
+
+import pytest
+import torch
+
+# TODO: remove vllm dependencies
+from vllm.tests.kernels.utils import DEFAULT_OPCHECK_TEST_UTILS, opcheck
+from vllm import _custom_ops as ops
+from vllm.platforms import current_platform
+
+import flag_gems
+
+
+COPYING_DIRECTION = [('cuda', 'cpu'), ('cuda', 'cuda'), ('cpu', 'cuda')]
+DTYPES = [torch.half, torch.bfloat16, torch.float]
+NUM_TOKENS = [42]  # Arbitrary values for testing
+NUM_LAYERS = [1]  # Arbitrary values for testing
+NUM_HEADS = [8]  # Arbitrary values for testing
+HEAD_SIZES = [64, 80, 120, 256]
+BLOCK_SIZES = [8, 16, 32]
+CACHE_LAYOUTS = ["NHD", "HND"]
+
+# Parameters for MLA tests.
+KV_LORA_RANKS = [512]
+QK_ROPE_HEAD_DIMS = [64]
+NUM_TOKENS_MLA = [42]
+BLOCK_SIZES_MLA = [16]
+NUM_BLOCKS_MLA = [8]
+
+# Arbitrary values for testing
+# don't make it too large. e.g. [1024, 36000] will OOM
+NUM_BLOCKS = [1024, 10000]
+
+NUM_MAPPINGS = [256]  # Arbitrary values for testing
+SEEDS = [0]
+CUDA_DEVICES = [
+    # TODO: also check with multiple GPUs
+    #f"cuda:0"
+    f"cuda:{i}" for i in range(1 if torch.cuda.device_count() == 1 else 2)
+]
+
+# We assume fp8 is always enabled for testing.
+KV_CACHE_DTYPE = ["auto", "fp8"]
+
+
+def _create_mla_cache(
+    num_blocks: int,
+    block_size: int,
+    entry_size: int,
+    dtype: torch.dtype,
+    kv_cache_dtype: str,
+    device: str,
+) -> torch.Tensor:
+    cache_dtype = torch.uint8 if kv_cache_dtype == "fp8" else dtype
+    return torch.zeros(num_blocks,
+                       block_size,
+                       entry_size,
+                       dtype=cache_dtype,
+                       device=device)
+
+@pytest.mark.parametrize("kv_lora_rank", KV_LORA_RANKS)
+@pytest.mark.parametrize("qk_rope_head_dim", QK_ROPE_HEAD_DIMS)
+@pytest.mark.parametrize("num_tokens", NUM_TOKENS_MLA)
+@pytest.mark.parametrize("block_size", BLOCK_SIZES_MLA)
+@pytest.mark.parametrize("num_blocks", NUM_BLOCKS_MLA)
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("seed", SEEDS)
+@pytest.mark.parametrize("device", CUDA_DEVICES)
+@pytest.mark.parametrize("kv_cache_dtype", KV_CACHE_DTYPE)
+@torch.inference_mode()
+def test_concat_and_cache_mla(
+    kv_lora_rank: int,
+    qk_rope_head_dim: int,
+    num_tokens: int,
+    block_size: int,
+    num_blocks: int,
+    dtype: torch.dtype,
+    seed: int,
+    device: str,
+    kv_cache_dtype: str,
+) -> None:
+    current_platform.seed_everything(seed)
+    torch.set_default_device(device)
+
+    total_slots = num_blocks * block_size
+    slot_mapping_lst = random.sample(range(total_slots), num_tokens)
+    slot_mapping = torch.tensor(slot_mapping_lst,
+                                dtype=torch.long,
+                                device=device)
+
+    kv_c = torch.randn(num_tokens, kv_lora_rank, dtype=dtype, device=device)
+    k_pe = torch.randn(num_tokens,
+                       qk_rope_head_dim,
+                       dtype=dtype,
+                       device=device)
+    entry_size = kv_lora_rank + qk_rope_head_dim
+
+    scale = torch.tensor(0.1, dtype=torch.float32, device=device)
+    kv_cache = _create_mla_cache(num_blocks, block_size, entry_size, dtype,
+                                 kv_cache_dtype, device)
+    ref_temp = torch.zeros(*kv_cache.shape, dtype=dtype, device=device)
+
+    for i in range(num_tokens):
+        slot = slot_mapping[i].item()
+        block_idx = slot // block_size
+        block_offset = slot % block_size
+        ref_temp[block_idx, block_offset, :kv_lora_rank] = kv_c[i]
+        ref_temp[block_idx, block_offset, kv_lora_rank:] = k_pe[i]
+
+    if kv_cache_dtype == "fp8":
+        ref_kv_cache = torch.empty_like(ref_temp, dtype=kv_cache.dtype)
+        ops.convert_fp8(ref_kv_cache,
+                        ref_temp,
+                        scale.item(),
+                        kv_dtype=kv_cache_dtype)
+    else:
+        ref_kv_cache = ref_temp
+
+    # compare FlagGems and vLLM's implementations
+    BACKEND = 'gems'
+    if BACKEND == "gems":
+        from flag_gems.fused.concat_and_cache_mla import concat_and_cache_mla
+        concat_and_cache_mla(kv_c, k_pe, kv_cache, slot_mapping,
+                                 kv_cache_dtype, scale)
+        
+    else:
+        opcheck(
+            torch.ops._C_cache_ops.concat_and_cache_mla,
+            (kv_c, k_pe, kv_cache, slot_mapping, kv_cache_dtype, scale),
+            test_utils=DEFAULT_OPCHECK_TEST_UTILS,
+        )
+
+        ops.concat_and_cache_mla(kv_c, k_pe, kv_cache, slot_mapping,
+                                 kv_cache_dtype, scale)
+
+    if kv_cache_dtype == "fp8":
+        result_temp = torch.empty_like(kv_cache, dtype=torch.float16)
+        ops.convert_fp8(result_temp,
+                        kv_cache.contiguous(),
+                        scale.item(),
+                        kv_dtype=kv_cache_dtype)
+        expected_temp = torch.empty_like(ref_kv_cache, dtype=torch.float16)
+        ops.convert_fp8(expected_temp,
+                        ref_kv_cache,
+                        scale.item(),
+                        kv_dtype=kv_cache_dtype)
+        torch.testing.assert_close(result_temp,
+                                   expected_temp,
+                                   atol=0.001,
+                                   rtol=0.1)
+    else:
+        torch.testing.assert_close(kv_cache, ref_kv_cache)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator | OP Test

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add `concat_and_cache_mla`, which is adopted from vLLM CUDA implementation: https://github.com/vllm-project/vllm/blob/main/csrc/cache_kernels.cu#L308-L350

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->
1. Not passing all the tests due to precision errors when Fp8KvCache is set.
<img width="1140" alt="image" src="https://github.com/user-attachments/assets/e579578b-5022-4c3e-8d7e-2cac60b296c1" />
2. test code depends on vLLM. 

My steps to build vLLM, torch, etc.:
```bash
conda create -n latest python==3.11
conda activate latest

conda install pip -y

pip config set global.index-url https://mirrors.aliyun.com/pypi/simple/
pip install torch==2.6.0+cu124 torchvision==0.21.0+cu124 torchaudio==2.6.0+cu124 -f https://mirrors.aliyun.com/pytorch-wheels/cu124/

pip install 'numpy<2' #降级numpy
# pip install triton==2.2.0
pip install triton==3.3.0
pip install transformers==4.40.2

cd FlagGems
pip install .

pip install triton==3.3.0

cd vllm
python use_existing_torch.py
pip install -r requirements/build.txt
pip install --no-build-isolation -e . -v
pip install pytest
```
Structure: ~/workspace/vllm, ~/workspace/FlagGems

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
