### PR TITLE
fixbugs: pytest argument error in test_named_ops.py

### DIFF
--- a/tests/test_named_ops.py
+++ b/tests/test_named_ops.py
@@ -223,7 +223,7 @@ if __name__ == "__main__":
             for op, uts in collection.items():
                 for ut in uts:
                     cmd = f"{file_name}::{ut}"
-                    result = pytest.main(["-s", cmd, "--device", device])
+                    result = pytest.main(["-s", cmd, "--ref", device])
         print("final_result: ", final_result)
         exit(final_result)
 


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
OP Test
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
When use `--all` argumemt in  `FlagGems/tests/test_named_ops.py` , the main function will pass the `-- device` parameter to other test files. and the correct way is to pass `--ref`.
### Issue
https://github.com/FlagOpen/FlagGems/issues/601
<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
