### PR TITLE
Refactor `skip_rms_norm` to `fused_add_rms_norm` with in-place multi-output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ For more details, please refer to [c++ extensions](docs/build_flaggems_with_c_ex
 - support BLAS operators: mv, outer
 - support pointwise operators: bitwise_and, bitwise_not, bitwise_or, cos, clamp, eq, ge, gt, isinf, isnan, le, lt, ne, neg, or, sin, tanh, sigmoid
 - support reduction operators: all, any, amax, argmax, max, min, prod, sum, var_mean, vector_norm, cross_entropy_loss, group_norm, log_softmax, rms_norm
-- support fused operators: skip_rms_norm, skip_layer_norm, gelu_and_mul, silu_and_mul, apply_rotary_position_embedding
+- support fused operators: fused_add_rms_norm, skip_layer_norm, gelu_and_mul, silu_and_mul, apply_rotary_position_embedding
 
 ### v2.1
 - support Tensor operators: where, arange, repeat, masked_fill, tile, unique, index_select, masked_select, ones, ones_like, zeros, zeros_like, full, full_like, flip, pad

--- a/README_cn.md
+++ b/README_cn.md
@@ -39,7 +39,7 @@ FlagGems 可以作为纯 Python 包安装，也可以作为带有 C++ 扩展的�
 - 支持BLAS类算子: mv, outer
 - 支持pointwise类算子: bitwise_and, bitwise_not, bitwise_or, cos, clamp, eq, ge, gt, isinf, isnan, le, lt, ne, neg, or, sin, tanh, sigmoid
 - 支持reduction类算子: all, any, amax, argmax, max, min, prod, sum, var_mean, vector_norm, cross_entropy_loss, group_norm, log_softmax, rms_norm
-- 支持融合算子: skip_rms_norm, skip_layer_norm, gelu_and_mul, silu_and_mul, apply_rotary_position_embedding
+- 支持融合算子: fused_add_rms_norm, skip_layer_norm, gelu_and_mul, silu_and_mul, apply_rotary_position_embedding
 
 ### v2.1
 - 支持Tensor类算子：where, arange, repeat, masked_fill, tile, unique, index_select, masked_select, ones, ones_like, zeros, zeros_like, full, full_like, flip, pad

--- a/benchmark/test_fused_perf.py
+++ b/benchmark/test_fused_perf.py
@@ -69,9 +69,9 @@ def test_perf_skip_layernorm():
     bench.run()
 
 
-@pytest.mark.skip_rmsnorm
-def test_perf_skip_rmsnorm():
-    def skip_rmsnorm_input_fn(shape, dtype, device):
+@pytest.mark.fused_add_rms_norm
+def test_perf_fused_add_rms_norm():
+    def fused_add_rms_norm_input_fn(shape, dtype, device):
         inp = torch.randn(shape, dtype=dtype, device=device)
         residual = torch.randn(shape, dtype=dtype, device=device)
         layer_shape = (shape[-1],)
@@ -84,11 +84,11 @@ def test_perf_skip_rmsnorm():
         hidden_states = x * torch.rsqrt(variance + eps)
         return weight * hidden_states
 
-    gems_op = flag_gems.skip_rms_norm
+    gems_op = flag_gems.fused_add_rms_norm
 
     bench = GenericBenchmarkExcluse1D(
-        input_fn=skip_rmsnorm_input_fn,
-        op_name="skip_rmsnorm",
+        input_fn=fused_add_rms_norm_input_fn,
+        op_name="fused_add_rms_norm",
         torch_op=torch_op,
         dtypes=FLOAT_DTYPES,
     )

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,7 +36,7 @@ For more details, please refer to [c++ extensions](build_flaggems_with_c_extensi
 - support BLAS operators: mv, outer
 - support pointwise operators: bitwise_and, bitwise_not, bitwise_or, cos, clamp, eq, ge, gt, isinf, isnan, le, lt, ne, neg, or, sin, tanh, sigmoid
 - support reduction operators: all, any, amax, argmax, max, min, prod, sum, var_mean, vector_norm, cross_entropy_loss, group_norm, log_softmax, rms_norm
-- support fused operators: skip_rms_norm, skip_layer_norm, gelu_and_mul, silu_and_mul, apply_rotary_position_embedding
+- support fused operators: fused_add_rms_norm, skip_layer_norm, gelu_and_mul, silu_and_mul, apply_rotary_position_embedding
 
 ### v2.1
 - support Tensor operators: where, arange, repeat, masked_fill, tile, unique, index_select, masked_select, ones, ones_like, zeros, zeros_like, full, full_like, flip, pad

--- a/docs/operator_list.md
+++ b/docs/operator_list.md
@@ -141,7 +141,7 @@
 
 ## v4.0
 - rms_norm
-- skip_rms_norm
+- fused_add_rms_norm
 - skip_layer_norm
 - gelu_and_mul
 - silu_and_mul

--- a/modules_tests/module_test_util.py
+++ b/modules_tests/module_test_util.py
@@ -1,0 +1,21 @@
+import importlib
+
+import torch
+from packaging import version
+
+
+def has_c_extension() -> bool:
+    try:
+        import flag_gems.ext_ops  # noqa: F401
+
+        return True
+    except ImportError:
+        return False
+
+
+def is_torch_version_ge(min_ver: str) -> bool:
+    return version.parse(torch.__version__) >= version.parse(min_ver)
+
+
+def has_vllm() -> bool:
+    return importlib.util.find_spec("vllm") is not None

--- a/modules_tests/test_gems_normalization.py
+++ b/modules_tests/test_gems_normalization.py
@@ -1,23 +1,14 @@
-import importlib
-
 import numpy as np
 import pytest
 import torch
-from packaging import version
 
 import flag_gems
 from flag_gems.modules import GemsRMSNorm
 from flag_gems.testing import assert_close
 
+from .module_test_util import has_c_extension, has_vllm, is_torch_version_ge
+
 device = flag_gems.device
-
-
-def is_torch_version_ge(min_ver: str) -> bool:
-    return version.parse(torch.__version__) >= version.parse(min_ver)
-
-
-def has_vllm() -> bool:
-    return importlib.util.find_spec("vllm") is not None
 
 
 # TODO(flaggems): Current implementation only supports 2D input tensors and a 1D `normalized_shape` (given as int).
@@ -62,11 +53,12 @@ def test_gems_rmsnorm(shape, dtype):
     else:
         pytest.skip("Skipping vLLM RMSNorm comparison: vLLM not installed")
 
-    torch.library.opcheck(
-        torch.ops.flag_gems.rms_norm,
-        (inp, target.weight.data, target.eps),
-        test_utils=("test_schema", "test_autograd_registration"),
-    )
+    if has_c_extension():
+        torch.library.opcheck(
+            torch.ops.flag_gems.rms_norm,
+            (inp, target.weight.data, target.eps),
+            test_utils=("test_schema", "test_autograd_registration"),
+        )
 
 
 @pytest.mark.parametrize("shape", [(4, 64), (8, 128), (1024, 1024)])
@@ -119,8 +111,9 @@ def test_gems_rmsnorm_with_residual(shape, dtype):
     else:
         pytest.skip("Skipping vLLM RMSNorm comparison: vLLM not installed")
 
-    torch.library.opcheck(
-        torch.ops.flag_gems.fused_add_rms_norm,
-        (inp, residual, target.weight.data, target.eps),
-        test_utils=("test_schema", "test_autograd_registration"),
-    )
+    if has_c_extension():
+        torch.library.opcheck(
+            torch.ops.flag_gems.fused_add_rms_norm,
+            (inp, residual, target.weight.data, target.eps),
+            test_utils=("test_schema", "test_autograd_registration"),
+        )

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -1,4 +1,5 @@
 from .cross_entropy_loss import cross_entropy_loss
+from .fused_add_rms_norm import fused_add_rms_norm
 from .gelu_and_mul import gelu_and_mul
 from .instance_norm import instance_norm
 from .outer import outer
@@ -6,13 +7,12 @@ from .reshape_and_cache import reshape_and_cache
 from .rotary_embedding import apply_rotary_pos_emb
 from .silu_and_mul import silu_and_mul
 from .skip_layernorm import skip_layer_norm
-from .skip_rms_norm import skip_rms_norm
 from .weight_norm import weight_norm
 
 __all__ = [
     "apply_rotary_pos_emb",
     "skip_layer_norm",
-    "skip_rms_norm",
+    "fused_add_rms_norm",
     "silu_and_mul",
     "gelu_and_mul",
     "cross_entropy_loss",

--- a/src/flag_gems/fused/fused_add_rms_norm.py
+++ b/src/flag_gems/fused/fused_add_rms_norm.py
@@ -1,7 +1,6 @@
 import logging
 import math
 
-import torch
 import triton
 import triton.language as tl
 
@@ -14,13 +13,10 @@ logger = logging.getLogger(__name__)
 
 @libentry()
 @triton.jit(do_not_specialize=["eps"])
-def skip_rms_norm_kernel(
-    Y,  # pointer to the output
+def fused_add_rms_norm_kernel(
     X,  # pointer to the input
     R,  # pointer to the residual
     W,  # pointer to the weights
-    y_stride_r,
-    y_stride_c,
     x_stride_r,  # how much to increase the pointer when moving by 1 row
     x_stride_c,  # how much to increase the pointer when moving by 1 col
     r_stride_r,  # how much to increase the pointer when moving by 1 row
@@ -30,7 +26,6 @@ def skip_rms_norm_kernel(
     BLOCK_SIZE: tl.constexpr,
 ):
     pid = tle.program_id(0)
-    Y += pid * y_stride_r
     X += pid * x_stride_r
     R += pid * r_stride_r
 
@@ -40,35 +35,36 @@ def skip_rms_norm_kernel(
     r = tl.load(R + cols * r_stride_c, mask, other=0.0).to(tl.float32)
 
     x += r
+    # write back to residual
+    tl.store(R + cols * r_stride_c, x, mask=mask)
 
     var = tl.sum(x * x / N, axis=0)
     rrms = 1 / tl.sqrt(var + eps)
 
     w = tl.load(W + tl.arange(0, BLOCK_SIZE), mask=mask, other=0.0)
-    y = (x * rrms).to(Y.dtype.element_ty) * w
-    tl.store(Y + cols * y_stride_c, y, mask=mask)
+    y = (x * rrms).to(X.dtype.element_ty) * w
+    # write back to input
+    tl.store(X + cols * x_stride_c, y, mask=mask)
 
 
-class SkipRmsNorm(torch.autograd.Function):
-    @staticmethod
-    def forward(ctx, x, residual, normalized_shape, weight, eps=1e-5):
-        logger.debug("GEMS LAYERNORM FORWARD")
-        dim = x.ndim - len(normalized_shape)
-        M = math.prod(x.shape[:dim])
-        N = math.prod(normalized_shape)
+def fused_add_rms_norm(x, residual, normalized_shape, weight, eps=1e-5):
+    """
+    This function performs fused residual addition and RMS normalization **in-place**.
+    Both `x` and `residual` tensors will be modified. Use with caution if these tensors
+    are reused elsewhere or require gradients.
+    """
+    logger.debug("GEMS FUSED_ADD_RMS_NORM FORWARD")
+    dim = x.ndim - len(normalized_shape)
+    M = math.prod(x.shape[:dim])
+    N = math.prod(normalized_shape)
 
-        BLOCK_SIZE = triton.next_power_of_2(N)
-        x = x.contiguous()
-        residual = residual.contiguous()
-        weight = weight.contiguous()
-        y = torch.empty_like(x)
+    BLOCK_SIZE = triton.next_power_of_2(N)
+    x = x.contiguous()
+    residual = residual.contiguous()
+    weight = weight.contiguous()
 
-        with torch_device_fn.device(x.device):
-            skip_rms_norm_kernel[M,](
-                y, x, residual, weight, N, 1, N, 1, N, 1, N, eps, BLOCK_SIZE
-            )
-        return y
-
-
-def skip_rms_norm(x, residual, normalized_shape, weight, eps=1e-5):
-    return SkipRmsNorm.apply(x, residual, normalized_shape, weight, eps)
+    with torch_device_fn.device(x.device):
+        fused_add_rms_norm_kernel[M,](
+            x, residual, weight, N, 1, N, 1, N, eps, BLOCK_SIZE
+        )
+    return x, residual

--- a/src/flag_gems/modules/normalization.py
+++ b/src/flag_gems/modules/normalization.py
@@ -30,7 +30,6 @@ try:
 except ImportError:
     has_c_extension = False
 
-
 __all__ = [
     "gems_rms_forward",
     "GemsRMSNorm",
@@ -47,10 +46,8 @@ def gems_rms_forward(
             torch.ops.flag_gems.fused_add_rms_norm(x, residual, weight, eps)
             return x, residual
         else:
-            residual = x + residual
-            return (
-                flag_gems.rms_norm(residual, list(weight.size()), weight, eps),
-                residual,
+            return flag_gems.fused_add_rms_norm(
+                x, residual, list(weight.size()), weight, eps
             )
     else:
         logger.debug("GEMS CUSTOM RMS_NORM")

--- a/src/flag_gems/runtime/backend/_cambricon/fused/__init__.py
+++ b/src/flag_gems/runtime/backend/_cambricon/fused/__init__.py
@@ -1,11 +1,11 @@
+from .fused_add_rms_norm import fused_add_rms_norm
 from .gelu_and_mul import gelu_and_mul
 from .silu_and_mul import silu_and_mul
 from .skip_layernorm import skip_layer_norm
-from .skip_rms_norm import skip_rms_norm
 
 __all__ = [
     "skip_layer_norm",
-    "skip_rms_norm",
+    "fused_add_rms_norm",
     "silu_and_mul",
     "gelu_and_mul",
 ]

--- a/src/flag_gems/runtime/backend/_kunlunxin/fused/__init__.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/fused/__init__.py
@@ -1,17 +1,17 @@
 from .cross_entropy_loss import cross_entropy_loss
+from .fused_add_rms_norm import fused_add_rms_norm
 from .gelu_and_mul import gelu_and_mul
 from .instance_norm import instance_norm
 from .outer import outer
 from .rotary_embedding import apply_rotary_pos_emb
 from .silu_and_mul import silu_and_mul
 from .skip_layernorm import skip_layer_norm
-from .skip_rms_norm import skip_rms_norm
 from .weight_norm import weight_norm
 
 __all__ = [
     "apply_rotary_pos_emb",
     "skip_layer_norm",
-    "skip_rms_norm",
+    "fused_add_rms_norm",
     "silu_and_mul",
     "gelu_and_mul",
     "cross_entropy_loss",

--- a/src/flag_gems/runtime/backend/_kunlunxin/fused/fused_add_rms_norm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/fused/fused_add_rms_norm.py
@@ -2,7 +2,6 @@ import builtins
 import logging
 import math
 
-import torch
 import triton
 import triton.language as tl
 
@@ -15,13 +14,10 @@ logger = logging.getLogger(__name__)
 
 @libentry()
 @triton.jit(do_not_specialize=["eps"])
-def skip_rms_norm_kernel(
-    Y,  # pointer to the output
+def fused_add_rms_norm_kernel(
     X,  # pointer to the input
     R,  # pointer to the residual
     W,  # pointer to the weights
-    y_stride_r,
-    y_stride_c,
     x_stride_r,  # how much to increase the pointer when moving by 1 row
     x_stride_c,  # how much to increase the pointer when moving by 1 col
     r_stride_r,  # how much to increase the pointer when moving by 1 row
@@ -31,7 +27,6 @@ def skip_rms_norm_kernel(
     BLOCK_SIZE: tl.constexpr,
 ):
     pid = tle.program_id(0)
-    Y += pid * y_stride_r
     X += pid * x_stride_r
     R += pid * r_stride_r
 
@@ -41,24 +36,24 @@ def skip_rms_norm_kernel(
     r = tl.load(R + cols * r_stride_c, mask, other=0.0).to(tl.float32)
 
     x += r
+    # write back to residual
+    tl.store(R + cols * r_stride_c, x, mask=mask)
 
     var = tl.sum(x * x / N, axis=0)
     rrms = 1 / tl.sqrt(var + eps)
 
     w = tl.load(W + tl.arange(0, BLOCK_SIZE), mask=mask, other=0.0)
-    y = (x * rrms).to(Y.dtype.element_ty) * w
-    tl.store(Y + cols * y_stride_c, y, mask=mask)
+    y = (x * rrms).to(X.dtype.element_ty) * w
+    # write back to input
+    tl.store(X + cols * x_stride_c, y, mask=mask)
 
 
 @libentry()
 @triton.jit(do_not_specialize=["eps"])
-def skip_rms_norm_kernel_tile(
-    Y,  # pointer to the output
+def fused_add_rms_norm_kernel_tile(
     X,  # pointer to the input
     R,  # pointer to the residual
-    W,  # pointer to the weights
-    y_stride_r,
-    y_stride_c,
+    W,  # pointer to the weight
     x_stride_r,  # how much to increase the pointer when moving by 1 row
     x_stride_c,  # how much to increase the pointer when moving by 1 col
     r_stride_r,  # how much to increase the pointer when moving by 1 row
@@ -68,16 +63,8 @@ def skip_rms_norm_kernel_tile(
     BLOCK_SIZE: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    Y += pid * y_stride_r
     X += pid * x_stride_r
     R += pid * r_stride_r
-
-    mask = tl.arange(0, BLOCK_SIZE) < N
-    cols = tl.arange(0, BLOCK_SIZE)
-    x = tl.load(X + cols * x_stride_c, mask, other=0.0).to(tl.float32)
-    r = tl.load(R + cols * r_stride_c, mask, other=0.0).to(tl.float32)
-
-    x += r
 
     # var = tl.sum(x * x / N, axis=0)
     # rrms = 1 / tl.sqrt(var + eps)
@@ -104,37 +91,37 @@ def skip_rms_norm_kernel_tile(
         r = tl.load(R + cols, mask, other=0.0).to(tl.float32)
         x += r
         w = tl.load(W + cols, mask, other=0.0)
-        y = (x * rrms).to(Y.dtype.element_ty) * w
-        tl.store(Y + cols * y_stride_c, y, mask=mask)
+        y = (x * rrms).to(X.dtype.element_ty) * w
+        # write back to residual and input
+        tl.store(R + cols * r_stride_c, x, mask=mask)
+        tl.store(X + cols * x_stride_c, y, mask=mask)
 
 
-class SkipRmsNorm(torch.autograd.Function):
-    @staticmethod
-    def forward(ctx, x, residual, normalized_shape, weight, eps=1e-5):
-        logger.debug("GEMS LAYERNORM FORWARD")
-        dim = x.ndim - len(normalized_shape)
-        M = math.prod(x.shape[:dim])
-        N = math.prod(normalized_shape)
+def fused_add_rms_norm(x, residual, normalized_shape, weight, eps=1e-5):
+    """
+    This function performs fused residual addition and RMS normalization **in-place**.
+    Both `x` and `residual` tensors will be modified. Use with caution if these tensors
+    are reused elsewhere or require gradients.
+    """
+    logger.debug("GEMS FUSED_ADD_RMS_NORM FORWARD")
+    dim = x.ndim - len(normalized_shape)
+    M = math.prod(x.shape[:dim])
+    N = math.prod(normalized_shape)
 
-        BLOCK_SIZE = builtins.min(
-            64 * 128, triton.next_power_of_2(N)
-        )  # core_num * buffer_size_limit
-        x = x.contiguous()
-        residual = residual.contiguous()
-        weight = weight.contiguous()
-        y = torch.empty_like(x)
+    BLOCK_SIZE = builtins.min(
+        64 * 128, triton.next_power_of_2(N)
+    )  # core_num * buffer_size_limit
+    x = x.contiguous()
+    residual = residual.contiguous()
+    weight = weight.contiguous()
 
-        with torch_device_fn.device(x.device):
-            if N > 64 * 128:
-                skip_rms_norm_kernel_tile[M,](
-                    y, x, residual, weight, N, 1, N, 1, N, 1, N, eps, BLOCK_SIZE
-                )
-            else:
-                skip_rms_norm_kernel[M,](
-                    y, x, residual, weight, N, 1, N, 1, N, 1, N, eps, BLOCK_SIZE
-                )
-        return y
-
-
-def skip_rms_norm(x, residual, normalized_shape, weight, eps=1e-5):
-    return SkipRmsNorm.apply(x, residual, normalized_shape, weight, eps)
+    with torch_device_fn.device(x.device):
+        if N > 64 * 128:
+            fused_add_rms_norm_kernel_tile[M,](
+                x, residual, weight, N, 1, N, 1, N, eps, BLOCK_SIZE
+            )
+        else:
+            fused_add_rms_norm_kernel[M,](
+                x, residual, weight, N, 1, N, 1, N, eps, BLOCK_SIZE
+            )
+    return x, residual

--- a/src/flag_gems/runtime/backend/_nvidia/fused/__init__.py
+++ b/src/flag_gems/runtime/backend/_nvidia/fused/__init__.py
@@ -1,5 +1,5 @@
-from .skip_rms_norm import skip_rms_norm
+from .fused_add_rms_norm import fused_add_rms_norm
 
 __all__ = [
-    "skip_rms_norm",
+    "fused_add_rms_norm",
 ]

--- a/src/flag_gems/runtime/backend/_nvidia/fused/fused_add_rms_norm.py
+++ b/src/flag_gems/runtime/backend/_nvidia/fused/fused_add_rms_norm.py
@@ -1,7 +1,6 @@
 import logging
 import math
 
-import torch
 import triton
 import triton.language as tl
 
@@ -14,13 +13,10 @@ logger = logging.getLogger(__name__)
 
 @libentry()
 @triton.jit(do_not_specialize=["eps"])
-def skip_rms_norm_kernel(
-    Y,  # pointer to the output
+def fused_add_rms_norm_kernel(
     X,  # pointer to the input
     R,  # pointer to the residual
     W,  # pointer to the weights
-    y_stride_r,
-    y_stride_c,
     x_stride_r,  # how much to increase the pointer when moving by 1 row
     x_stride_c,  # how much to increase the pointer when moving by 1 col
     r_stride_r,  # how much to increase the pointer when moving by 1 row
@@ -30,7 +26,6 @@ def skip_rms_norm_kernel(
     BLOCK_SIZE: tl.constexpr,
 ):
     pid = tle.program_id(0)
-    Y += pid * y_stride_r
     X += pid * x_stride_r
     R += pid * r_stride_r
 
@@ -40,36 +35,33 @@ def skip_rms_norm_kernel(
     r = tl.load(R + cols * r_stride_c, mask, other=0.0).to(tl.float32)
 
     x += r
+    # write back to residual
+    tl.store(R + cols * r_stride_c, x, mask=mask)
 
     var = tl.sum(x * x / N, axis=0)
     rrms = 1 / tl.sqrt(var + eps)
 
     w = tl.load(W + tl.arange(0, BLOCK_SIZE), mask=mask, other=0.0)
-    y = (x * rrms).to(Y.dtype.element_ty) * w
-    tl.store(Y + cols * y_stride_c, y, mask=mask)
+    y = (x * rrms).to(X.dtype.element_ty) * w
+    # write back to input
+    tl.store(X + cols * x_stride_c, y, mask=mask)
 
 
-class SkipRmsNorm(torch.autograd.Function):
-    @staticmethod
-    def forward(ctx, x, residual, normalized_shape, weight, eps=1e-5):
-        logger.debug("GEMS LAYERNORM FORWARD")
-        dim = x.ndim - len(normalized_shape)
-        M = math.prod(x.shape[:dim])
-        N = math.prod(normalized_shape)
+def fused_add_rms_norm(x, residual, normalized_shape, weight, eps=1e-5):
+    print(
+        "\n .......test for mutibackend specific fused op fused_add_rms_norm ........\n"
+    )
+    dim = x.ndim - len(normalized_shape)
+    M = math.prod(x.shape[:dim])
+    N = math.prod(normalized_shape)
 
-        BLOCK_SIZE = triton.next_power_of_2(N)
-        x = x.contiguous()
-        residual = residual.contiguous()
-        weight = weight.contiguous()
-        y = torch.empty_like(x)
+    BLOCK_SIZE = triton.next_power_of_2(N)
+    x = x.contiguous()
+    residual = residual.contiguous()
+    weight = weight.contiguous()
 
-        with torch_device_fn.device(x.device):
-            skip_rms_norm_kernel[M,](
-                y, x, residual, weight, N, 1, N, 1, N, 1, N, eps, BLOCK_SIZE
-            )
-        return y
-
-
-def skip_rms_norm(x, residual, normalized_shape, weight, eps=1e-5):
-    print("\n .......test for mutibackend specific fused op skip_rms_norm ........\n")
-    return SkipRmsNorm.apply(x, residual, normalized_shape, weight, eps)
+    with torch_device_fn.device(x.device):
+        fused_add_rms_norm_kernel[M,](
+            x, residual, weight, N, 1, N, 1, N, eps, BLOCK_SIZE
+        )
+    return x, residual


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

This PR includes the following changes:

1. Renamed `skip_rms_norm` to `fused_add_rms_norm` across the codebase:
   - Operator name updated in README.
   - Benchmark and test entries updated accordingly.

2. Rewrote the kernel implementation:
   - Changed from a single-output design to a two-output, in-place version that modifies both `x` and `residual`.

3. Updated backend support:
   - Synced the implementation for both **Cambricon** and **Kunlunxin** backends to reflect the new kernel interface.

4. Modified module logic:
   - Adjusted how the module invokes `fused_add_rms_norm` to accommodate the new in-place behavior and output structure.

5. Removed the `autograd.Function` registration:
   - This avoids issues during backward pass and simplifies integration with frameworks that assume standard autograd behavior.

These changes improve clarity, memory efficiency, and backend consistency, while also resolving issues related to autograd integration.


### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
