### PR TITLE
[UTILS] Change get_device_properties api

### DIFF
--- a/src/flag_gems/ops/cumsum.py
+++ b/src/flag_gems/ops/cumsum.py
@@ -8,7 +8,8 @@ import triton.language as tl
 from flag_gems.utils import libentry
 
 from ..runtime import device, torch_device_fn
-from ..utils import triton_lang_extension as tle
+from ..utils import get_device_properties
+from ..utils import sriton_lang_extension as tle
 
 device = device.name
 logger = logging.getLogger(__name__)
@@ -391,7 +392,7 @@ def normed_cumsum(inp, dim=-1):
     out = torch.empty_like(inp)
     with torch_device_fn.device(inp.device.index):
         # Pass one, scan a (batch, n_tiles * TILE) sized block within each cta
-        num_sms = torch_device_fn.get_device_properties(device).multi_processor_count
+        num_sms = get_device_properties(device).multi_processor_count
         TILE = 2048
         # Each row is split into n_chunks of chunks where each chunk is compised of
         # n_tiles of tiles. Different chunks are assigned to different ctas.

--- a/src/flag_gems/ops/cumsum.py
+++ b/src/flag_gems/ops/cumsum.py
@@ -9,7 +9,7 @@ from flag_gems.utils import libentry
 
 from ..runtime import device, torch_device_fn
 from ..utils import get_device_properties
-from ..utils import sriton_lang_extension as tle
+from ..utils import triton_lang_extension as tle
 
 device = device.name
 logger = logging.getLogger(__name__)

--- a/src/flag_gems/utils/__init__.py
+++ b/src/flag_gems/utils/__init__.py
@@ -19,5 +19,6 @@ __all__ = [
     "offsetCalculator",
     "broadcastable_to",
     "broadcastable",
+    "get_device_properties",
     "tl_extra_shim",
 ]

--- a/src/flag_gems/utils/__init__.py
+++ b/src/flag_gems/utils/__init__.py
@@ -7,6 +7,7 @@ from .shape_utils import (
     offsetCalculator,
     restride_dim,
 )
+from .triton_driver_helper import get_device_properties
 from .triton_lang_helper import tl_extra_shim
 
 __all__ = [

--- a/src/flag_gems/utils/triton_driver_helper.py
+++ b/src/flag_gems/utils/triton_driver_helper.py
@@ -1,0 +1,8 @@
+try:
+    from ..runtime import torch_device_fn
+
+    get_device_properties = torch_device_fn.get_device_properties
+except ImportError:
+    import triton
+
+    get_device_properties = triton.runtime.driver.active.utils.get_device_properties

--- a/src/flag_gems/utils/triton_lang_helper.py
+++ b/src/flag_gems/utils/triton_lang_helper.py
@@ -1,5 +1,3 @@
-import triton
-
 from ..runtime import backend
 from ..runtime.backend.device import DeviceDetector
 
@@ -12,13 +10,13 @@ from ..runtime.backend.device import DeviceDetector
 
 device = DeviceDetector()
 backend.set_torch_backend_device_fn(device.vendor_name)
-tl_extra_shim = None
-if tl_extra_shim is None:
+try:
+    backend.set_tl_extra_backend_module(device.vendor_name)
+    tl_extra_shim = backend.get_tl_extra_backend_module()
+except ImportError:
+    import triton
+
     try:
-        backend.set_tl_extra_backend_module(device.vendor_name)
-        tl_extra_shim = backend.get_tl_extra_backend_module()
+        tl_extra_shim = triton.language.math
     except ImportError:
-        try:
-            tl_extra_shim = triton.language.math
-        except ImportError:
-            tl_extra_shim = triton.language.libdevice
+        tl_extra_shim = triton.language.libdevice

--- a/tests/test_pointwise_dynamic.py
+++ b/tests/test_pointwise_dynamic.py
@@ -6,7 +6,6 @@ import torch
 import triton
 
 import flag_gems
-from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import get_device_properties
 from flag_gems.utils.pointwise_dynamic import (
     CodeGenConfig,

--- a/tests/test_pointwise_dynamic.py
+++ b/tests/test_pointwise_dynamic.py
@@ -7,6 +7,7 @@ import triton
 
 import flag_gems
 from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import get_device_properties
 from flag_gems.utils.pointwise_dynamic import (
     CodeGenConfig,
     FunctionSchema,
@@ -781,7 +782,7 @@ def test_dynamic_function_gsl(use_block_pointer):
 
 
 @pytest.mark.skipif(
-    torch_device_fn.get_device_properties(0).total_memory < (80 * 1024**3),
+    get_device_properties(0).total_memory < (80 * 1024**3),
     reason="This test requires a lot of memory.",
 )
 @pytest.mark.parametrize("use_block_pointer", USE_BLOCK_POINTER)


### PR DESCRIPTION
### PR Category
UTILS

### Type of Change
New Feature

### Description
If ```torch_device_fn.get_device_properties``` is not supported, use ```triton.runtime.driver.active.utils.get_device_properties```

### Issue


### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

