### PR TITLE
add one-sweep radix sort

### DIFF
--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -118,7 +118,7 @@ def test_perf_unique():
 def test_perf_sort():
     class SortBenchmark(GenericBenchmark2DOnly):
         def set_more_shapes(self):
-            return [(1024, 1), (1024, 512)]
+            return [(1024, 1), (1024, 512), (16, 128 * 1024), (8, 256 * 1024)]
 
     def sort_input_fn(shape, dtype, device):
         inp = generate_tensor_input(shape, dtype, device)
@@ -128,7 +128,7 @@ def test_perf_sort():
         input_fn=sort_input_fn,
         op_name="sort",
         torch_op=torch.sort,
-        dtypes=INT_DTYPES + FLOAT_DTYPES,
+        dtypes=BOOL_DTYPES + INT_DTYPES + FLOAT_DTYPES,
     )
     bench.run()
 

--- a/src/flag_gems/ops/sort.py
+++ b/src/flag_gems/ops/sort.py
@@ -231,7 +231,8 @@ def sweep(
 
 
 def radix_sort(arr, k_bits=8, descending=False):
-    m, n = arr.shape
+    n = arr.shape[-1]
+    m = arr.numel() // n
     assert n < (1 << 30), "we have not implemented 2**30 per launch"
     dtype = arr.dtype
     num_bits = 1 if dtype == torch.bool else (arr.itemsize * 8)
@@ -269,7 +270,7 @@ def radix_sort(arr, k_bits=8, descending=False):
         arr_in = torch.clone(arr)
         indices_in = (
             torch.arange(0, n, dtype=torch.int64, device=arr_in.device)
-            .broadcast_to((m, n))
+            .broadcast_to(arr.shape)
             .contiguous()
         )
         arr_out = torch.empty_like(arr)

--- a/src/flag_gems/ops/sort.py
+++ b/src/flag_gems/ops/sort.py
@@ -1,5 +1,4 @@
 import logging
-import math
 
 import torch
 import triton
@@ -10,6 +9,325 @@ from ..utils import libentry
 from .topk import _get_finfo_val, _get_iinfo_val, argsort
 
 logger = logging.getLogger(__name__)
+
+# NOTE(chenfeiyu): In Triton 3.3+, callable constexpr is *finally* allowed
+# which allows us to call some function which does not return tl.tensor
+# Althought it still has some usability issues
+# Yes, it is *possible* to decorate a function with constexpr, looks like c++
+# constexpr function? You could be next!
+
+
+@tl.constexpr
+def get_int_t(num_bits, signed):
+    return tl.core.get_int_dtype(num_bits, signed)
+
+
+@tl.constexpr
+def one_zeros(num_bits):
+    return tl.constexpr(1) << (num_bits - 1)
+
+
+@tl.constexpr
+def zero_ones(num_bits):
+    return (tl.constexpr(1) << (num_bits - 1)) - 1
+
+
+@triton.jit
+def uint_to_uint(x, descending: tl.constexpr = False):
+    out = ~x if descending else x
+    return out
+
+
+@triton.jit
+def int_to_uint(x, descending: tl.constexpr = False):
+    num_bits: tl.constexpr = x.dtype.primitive_bitwidth
+    udtype = get_int_t(num_bits, False)
+    ux = tl.cast(x, udtype, bitcast=True)
+    if descending:
+        # 0111111....1
+        bit_mask: tl.constexpr = zero_ones(num_bits)
+        out = ux ^ bit_mask
+    else:
+        # 1000000...0
+        sign_bit_mask: tl.constexpr = one_zeros(num_bits)
+        out = ux ^ sign_bit_mask
+    return out
+
+
+@triton.jit
+def floating_to_uint(x, descending: tl.constexpr = False):
+    num_bits: tl.constexpr = x.dtype.primitive_bitwidth
+    sdtype = get_int_t(num_bits, True)
+    udtype = get_int_t(num_bits, False)
+    sx = x.to(sdtype, bitcast=True)
+    ux = x.to(udtype, bitcast=True)
+
+    sign_bit_mask: tl.constexpr = one_zeros(num_bits)
+    mask = sign_bit_mask | (sx >> (num_bits - 1)).to(udtype, bitcast=True)
+    # 1000000000...0 for positive
+    # 1111111111...1 for negative
+
+    if descending:
+        out = ux ^ (~mask)
+    else:
+        out = ux ^ mask
+    return out.to(udtype, bitcast=True)
+
+
+@triton.jit
+def convert_to_uint_preverse_order(x: tl.tensor, descending: tl.constexpr = False):
+    if x.dtype.is_floating():
+        out = floating_to_uint(x, descending)
+    elif x.dtype.is_int_signed():
+        out = int_to_uint(x, descending)
+    elif x.dtype.is_int_unsigned():
+        out = uint_to_uint(x, descending)
+    return out
+
+
+@triton.jit
+def compute_global_hist(
+    arr_ptr,
+    out_ptr,
+    num_passes,
+    n,
+    tiles_n_per_cta,
+    TILE_N: tl.constexpr,
+    TILE_R: tl.constexpr,
+    num_bits_per_pass: tl.constexpr,
+    descending: tl.constexpr,
+):
+    # arr_ptr: (m, N)
+    # out_ptr: (m, n_passes, r), where r = 2 ** k_bits is the number of bins
+    pid_n = tl.program_id(1)
+    pid_m = tl.program_id(0)
+
+    r: tl.constexpr = 2**num_bits_per_pass
+    bfe_mask: tl.constexpr = (1 << num_bits_per_pass) - 1  # a.k.a. 2 ** k_bits - 1
+    CTA_TILE_N: tl.constexpr = TILE_N * tiles_n_per_cta
+    cta_n_start = CTA_TILE_N * pid_n
+    cta_n_end = tl.minimum(cta_n_start + CTA_TILE_N, n)
+
+    for p in range(0, num_passes):  # parallel
+        bit_offset = p * num_bits_per_pass
+        for r_start in range(0, r, TILE_R):  # parallel
+            bin_indices = r_start + tl.arange(0, TILE_R)
+            acc = tl.zeros((TILE_R, TILE_N), dtype=tl.int64)
+            for n_start in range(cta_n_start, cta_n_end, TILE_N):  # sequantial
+                n_offsets = n_start + tl.arange(0, TILE_N)  # (TILE_N, )
+                mask = n_offsets < cta_n_end
+                arr = tl.load(arr_ptr + pid_m * n + n_offsets, mask=mask)
+                arr = convert_to_uint_preverse_order(arr, descending)
+                key = (arr >> bit_offset) & bfe_mask  # (TILE_N, )
+                matches = tl.where(
+                    mask, (bin_indices[:, None] == key), False
+                )  # (TILE_R, TILE_N)
+                acc += matches
+            local_sum = tl.sum(acc, axis=1)
+            tl.atomic_add(
+                out_ptr + pid_m * num_passes * r + p * r + bin_indices,
+                local_sum,
+                sem="relaxed",
+            )
+
+
+@triton.jit
+def sweep(
+    arr_ptr,
+    associate_arr_ptr,
+    excumsum_bins_ptr,
+    out_ptr,
+    associate_out_ptr,  # outputs
+    flag_ptr,
+    aggregate_ptr,
+    inclusive_prefix_ptr,  # status
+    n_passes,
+    pass_id,
+    bit_offset,
+    N,
+    OUT_N,
+    TILE_N: tl.constexpr,
+    TILE_R: tl.constexpr,
+    k_bits: tl.constexpr,
+    descending: tl.constexpr,
+):
+    # r: num_bins = 2 ** k_bits
+    # OUT_N: grid_n = cdiv(N, )
+
+    # arr_ptr: (m, N)
+    # out_ptr: (m, N)
+    # excumsum_bins_ptr: (m, n_passes, r)
+    # flag_ptr: (m, r, OUT_N)
+    # aggregate_ptr: (m, r, OUT_N)
+    # inclusive_prefix_ptr: (m, r, OUT_N)
+    # grid: (m, grid_r, grid_n)
+
+    # load data
+    pid_n = tl.program_id(1)  # TODO: use a global counter to avoid dead-lock
+    pid_r = tl.program_id(2)
+    pid_m = tl.program_id(0)
+
+    # initialize flag to zero-local sum is not ready
+    r: tl.constexpr = 2**k_bits
+    bfe_mask: tl.constexpr = (1 << k_bits) - 1  # a.k.a. 2 ** k_bits - 1
+    cta_r_start = pid_r * TILE_R
+    cta_r_end = tl.minimum(cta_r_start + TILE_R, r)
+
+    # write flags for (TILE_R,) once
+    bins = cta_r_start + tl.arange(0, TILE_R)
+    flag_offsets_ = pid_m * (r * OUT_N) + bins * OUT_N + pid_n  # (TILE_R, )
+    tl.atomic_xchg(flag_ptr + flag_offsets_, 0, sem="release")
+
+    # cumsum for a bin_index
+    n_offsets = pid_n * TILE_N + tl.arange(0, TILE_N)  # (TILE_N, )
+    mask = n_offsets < N
+    arr = tl.load(arr_ptr + pid_m * N + n_offsets, mask=mask)
+    arr_u = convert_to_uint_preverse_order(arr, descending)
+    key = (arr_u >> bit_offset) & bfe_mask  # (TILE_N, )
+    # since triton can only use scalar as condition, loop by bin_index
+    for bin_index in tl.range(cta_r_start, cta_r_end, num_stages=2):
+        matches = tl.where(mask, key == bin_index, False)  # (TILE_N, )
+
+        # cta level cumsum per bin
+        local_sum = tl.sum(matches, axis=0)  # scalar
+        state_offset = pid_m * (r * OUT_N) + bin_index * OUT_N + pid_n
+        flag_offset = pid_m * (r * OUT_N) + bin_index * OUT_N + pid_n
+        tl.store(aggregate_ptr + state_offset, local_sum)
+        tl.atomic_xchg(flag_ptr + flag_offset, 1, sem="release")
+
+        # decoupled lookback
+        exclusive_prefix = tl.zeros((), dtype=tl.int64)
+        i_lookback = pid_n - 1
+        while i_lookback >= 0:
+            state_offset_i = pid_m * (r * OUT_N) + bin_index * OUT_N + i_lookback
+            flag_offset_i = pid_m * (r * OUT_N) + bin_index * OUT_N + i_lookback
+            flag = tl.atomic_add(flag_ptr + flag_offset_i, 0, sem="acquire")
+            while flag == 0:
+                flag = tl.atomic_add(flag_ptr + flag_offset_i, 0, sem="acquire")
+            if flag == 1:
+                this_aggregate = tl.load(aggregate_ptr + state_offset_i)
+                exclusive_prefix += this_aggregate
+                i_lookback -= 1
+            else:  # flag == 2
+                inclusive_prefix = tl.load(inclusive_prefix_ptr + state_offset_i)
+                exclusive_prefix += inclusive_prefix
+                i_lookback = -1  # go back to -1 to break to loop
+        tl.store(inclusive_prefix_ptr + state_offset, exclusive_prefix + local_sum)
+        tl.atomic_xchg(flag_ptr + flag_offset, 2, sem="release")
+
+        local_ex_cumsum = (
+            tl.cumsum(matches.to(tl.int64), axis=0) - matches
+        )  # (TILE_N, )
+        ex_cumsum_in_bin = (
+            exclusive_prefix + local_ex_cumsum
+        )  # global ex_cumsum_in_bin (TILE_N, )
+
+        # ex_cumsum_bins (m, n_passes, r)
+        ex_cumsum_bins = tl.load(
+            excumsum_bins_ptr + pid_m * (n_passes * r) + pass_id * r + bin_index
+        )  # scalar
+        pos = ex_cumsum_bins + ex_cumsum_in_bin  # (TILE_N, )
+        # tl.static_print(pos.shape)
+        # tl.static_print(arr.shape)
+        # tl.static_print(matches.shape)
+        tl.store(out_ptr + pid_m * N + pos, arr, mask=matches)
+        if associate_arr_ptr is not None:
+            associate_arr = tl.load(
+                associate_arr_ptr + pid_m * N + n_offsets, mask=mask
+            )
+            tl.store(associate_out_ptr + pid_m * N + pos, associate_arr, mask=matches)
+
+        # tl.store(out_ptr + pid_m * N + n_offsets, pos, mask=matches)
+
+
+# radix sort a contiguous matrix along the last dimension
+# TODO(chenfeiyu): implement inplace radix sort when sorting dimension size is smaller
+def radix_sort(arr, k_bits=8, descending=False):
+    m, n = arr.shape
+    dtype = arr.dtype
+    num_bits = 1 if dtype == torch.bool else (arr.itemsize * 8)
+
+    TILE_N = 1024
+    tiles_n_per_cta = 8
+    CTA_TILE_N = tiles_n_per_cta * TILE_N
+
+    num_bins = 2**k_bits
+    n_passes = triton.cdiv(num_bits, k_bits)
+    TILE_R = 16
+
+    with torch_device_fn.device(arr.device):
+        grid_n = triton.cdiv(n, CTA_TILE_N)
+        grid_for_global_hist = (m, grid_n, 1)
+
+        global_hist = torch.zeros(
+            (m, n_passes, num_bins), device=arr.device, dtype=torch.int64
+        )
+        compute_global_hist[grid_for_global_hist](
+            arr,
+            global_hist,
+            n_passes,
+            n,
+            tiles_n_per_cta,
+            TILE_N,
+            TILE_R,
+            k_bits,
+            descending,
+        )
+        ex_cumsum_bins = torch.cumsum(global_hist, -1) - global_hist
+
+        # sort
+        arr_in = torch.clone(arr)
+        indices_in = (
+            torch.arange(0, n, dtype=torch.int64, device=arr_in.device)
+            .broadcast_to((m, n))
+            .contiguous()
+        )
+        arr_out = torch.empty_like(arr)
+        indices_out = torch.empty_like(indices_in)
+
+        TILE_R = 8
+        grid_r = triton.cdiv(num_bins, TILE_R)
+        TILE_N = 2048
+        grid_n = triton.cdiv(n, TILE_N)
+        grid_for_sweep = (
+            m,
+            grid_n,
+            grid_r,
+        )
+
+        flag = torch.empty((m, num_bins, grid_n), device=arr.device, dtype=torch.int64)
+        aggregate = torch.empty(
+            (m, num_bins, grid_n), device=arr.device, dtype=torch.int64
+        )
+        inclusive_prefix = torch.empty(
+            (m, num_bins, grid_n), device=arr.device, dtype=torch.int64
+        )
+
+        for i in range(0, n_passes):
+            bit_offset = i * k_bits
+            sweep[grid_for_sweep](
+                arr_in,
+                indices_in,
+                ex_cumsum_bins,
+                arr_out,
+                indices_out,
+                flag,
+                aggregate,
+                inclusive_prefix,
+                n_passes,
+                i,
+                bit_offset,
+                n,
+                grid_n,
+                TILE_N,
+                TILE_R,
+                k_bits,
+                descending,
+            )
+            arr_in, arr_out = arr_out, arr_in
+            indices_in, indices_out = indices_out, indices_in
+
+    return arr_in, indices_in
 
 
 @libentry()
@@ -51,9 +369,6 @@ def sort(inp, dim=-1, descending=False):
     sort_elem_cnt = inp.shape[dim]
     if sort_elem_cnt == 1:
         return inp, torch.zeros_like(inp, dtype=torch.int64)
-    elif sort_elem_cnt > 512:  # TODO: Optimize implementation for large cases.
-        return torch.sort(inp, stable=False, dim=dim, descending=descending)
-    block_size = triton.next_power_of_2(sort_elem_cnt)
 
     if dim < 0:
         dim = dim + inp.ndim
@@ -61,22 +376,10 @@ def sort(inp, dim=-1, descending=False):
         inp = torch.movedim(inp, dim, -1).contiguous()
     else:
         inp = inp.contiguous()
-    batch_size = math.prod(inp.shape) // sort_elem_cnt
 
-    out = torch.empty_like(inp)
-    out_index = torch.empty_like(inp, dtype=torch.int64)
-
-    with torch_device_fn.device(inp.device):
-        sort_kernel[batch_size,](
-            inp,
-            out,
-            out_index,
-            N=sort_elem_cnt,
-            BLOCK_SIZE=block_size,
-            DESCENDING=descending,
-            IS_FLOAT=inp.is_floating_point(),
-            num_warps=4,
-        )
+    dtype = inp.dtype
+    num_bits_per_pass = 1 if dtype == torch.bool else 4
+    out, out_index = radix_sort(inp, num_bits_per_pass, descending)
 
     if dim != inp.ndim - 1:
         out = torch.movedim(out, -1, dim)

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -1117,7 +1117,7 @@ def test_accuracy_diagonal_backward(shape, dtype, dim1, dim2, offset):
     "hiddensize", [1, 256, 2048, 9333, 65536, 32768, 128 * 1024, 256 * 1024]
 )
 @pytest.mark.parametrize("descending", [True, False])
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES + INT_DTYPES + BOOL_TYPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES + INT_DTYPES)
 @pytest.mark.parametrize("dim", [0, -1])
 def test_sort(batch_size, hiddensize, descending, dtype, dim):
     if dtype in BOOL_TYPES:

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -1113,44 +1113,35 @@ def test_accuracy_diagonal_backward(shape, dtype, dim1, dim2, offset):
 @pytest.mark.skipif(flag_gems.vendor_name == "kunlunxin", reason="RESULT TODOFIX")
 @pytest.mark.sort
 @pytest.mark.parametrize("batch_size", [4, 8])
-@pytest.mark.parametrize("hiddensize", [1, 256, 2048, 9333, 65536])
+@pytest.mark.parametrize(
+    "hiddensize", [1, 256, 2048, 9333, 65536, 32768, 128 * 1024, 256 * 1024]
+)
 @pytest.mark.parametrize("descending", [True, False])
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES + INT_DTYPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES + INT_DTYPES + BOOL_TYPES)
 @pytest.mark.parametrize("dim", [0, -1])
 def test_sort(batch_size, hiddensize, descending, dtype, dim):
-    if dtype in FLOAT_DTYPES:
-        x = torch.empty((hiddensize,), dtype=dtype, device=flag_gems.device)
-        tmp = torch.tensor(0, dtype=dtype)
-        inf = torch.tensor(float("inf"), dtype=dtype)
-        for i in range(0, hiddensize):
-            x[i] = tmp.item()
-            tmp = torch.nextafter(tmp, inf)
-            if tmp.item() == inf.item():
-                hiddensize = i
-                x = x[:hiddensize]
-                break
+    if dtype in BOOL_TYPES:
+        y = torch.randint(
+            0, 2, (batch_size, hiddensize), dtype=dtype, device=flag_gems.device
+        )
+    elif dtype in ALL_INT_DTYPES:
+        min_v, max_v = torch.iinfo(dtype).min, torch.iinfo(dtype).max
+        y = torch.randint(
+            min_v, max_v, (batch_size, hiddensize), dtype=dtype, device=flag_gems.device
+        )
     else:
-        if flag_gems.device == "musa" and dtype == torch.int16:
-            # arange short type on torch of mthreads not supported yet.
-            x = torch.arange(hiddensize, dtype=torch.int32, device=flag_gems.device).to(
-                dtype
-            )
-        else:
-            x = torch.arange(hiddensize, dtype=dtype, device=flag_gems.device)
-    y = torch.empty((batch_size, hiddensize), dtype=dtype, device=flag_gems.device)
+        y = torch.randn((batch_size, hiddensize), dtype=dtype, device=flag_gems.device)
 
-    # Each row use different shuffled index.
-    col_indices = torch.randperm(x.size(0))
-    for bsz in range(batch_size):
-        col_indices = torch.randperm(x.size(0))
-        y[bsz, :] = x[col_indices]
-    if dim == 0:
-        y = torch.movedim(y, dim, -1)
     ref_y = to_reference(y)
-    ref_value, ref_index = torch.sort(ref_y, dim=dim, descending=descending)
+    # we only implement stable sort, non-stable sort is undefined
+    ref_value, ref_index = torch.sort(
+        ref_y, dim=dim, stable=True, descending=descending
+    )
 
     with flag_gems.use_gems():
-        res_value, res_index = torch.sort(y, dim=dim, descending=descending)
+        res_value, res_index = torch.sort(
+            y, dim=dim, stable=True, descending=descending
+        )
 
     gems_assert_close(res_value, ref_value, dtype)
     gems_assert_equal(res_index, ref_index)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

Implement OneSweep Radix sort, which supports parallel sorting along sorting dimension.

Not implemented features:
- pack status & flag 
- reduce the status to 32-bit(2bits for flag & 30bits for status)
- inplace radix sort for small sorting dimension size


Features that cannot be implemented in triton
- parallell lookback

Since we have not optimize it to triton's extreme, it sorts faster with 4bits per pass than 8bits per pass.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
I optimize for large sorting dimension size. The performance for smaller sorting dimension size is bad.
And the overall performance is not good enough, we can leave it for the future.

```text
test_special_perf.py
Operator: sort  Performance Test (dtype=torch.bool, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.013312            0.317440               0.042          ([torch.Size([64, 64])], {'dim': -1, 'descending': False})
SUCCESS               0.021504            0.296960               0.072          ([torch.Size([256, 256])], {'dim': -1, 'descending': False})
SUCCESS               0.054272            0.321408               0.169          ([torch.Size([1024, 1024])], {'dim': -1, 'descending': False})
SUCCESS               0.599040            0.723968               0.827          ([torch.Size([4096, 4096])], {'dim': -1, 'descending': False})
SUCCESS               3.890176            2.832384               1.373          ([torch.Size([1024, 65536])], {'dim': -1, 'descending': False})
SUCCESS               0.009216            0.003072               3.000          ([torch.Size([1024, 1])], {'dim': -1, 'descending': False})
SUCCESS               0.036864            0.323584               0.114          ([torch.Size([1024, 512])], {'dim': -1, 'descending': False})
SUCCESS               0.280288            0.325632               0.861          ([torch.Size([16, 131072])], {'dim': -1, 'descending': False})
SUCCESS               0.280576            0.327680               0.856          ([torch.Size([8, 262144])], {'dim': -1, 'descending': False})


Operator: sort  Performance Test (dtype=torch.int16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.013312            0.508928               0.026          ([torch.Size([64, 64])], {'dim': -1, 'descending': False})
SUCCESS               0.025600            0.533504               0.048          ([torch.Size([256, 256])], {'dim': -1, 'descending': False})
SUCCESS               0.069632            1.240064               0.056          ([torch.Size([1024, 1024])], {'dim': -1, 'descending': False})
SUCCESS               0.829440           10.799104               0.077          ([torch.Size([4096, 4096])], {'dim': -1, 'descending': False})
SUCCESS               7.143424           43.453442               0.164          ([torch.Size([1024, 65536])], {'dim': -1, 'descending': False})
SUCCESS               0.009216            0.003072               3.000          ([torch.Size([1024, 1])], {'dim': -1, 'descending': False})
SUCCESS               0.050176            1.191936               0.042          ([torch.Size([1024, 512])], {'dim': -1, 'descending': False})
SUCCESS               0.497664            1.447936               0.344          ([torch.Size([16, 131072])], {'dim': -1, 'descending': False})
SUCCESS               0.494592            1.453056               0.340          ([torch.Size([8, 262144])], {'dim': -1, 'descending': False})


Operator: sort  Performance Test (dtype=torch.int32, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.015200            0.765952               0.020          ([torch.Size([64, 64])], {'dim': -1, 'descending': False})
SUCCESS               0.030720            0.792256               0.039          ([torch.Size([256, 256])], {'dim': -1, 'descending': False})
SUCCESS               0.108544            2.109440               0.051          ([torch.Size([1024, 1024])], {'dim': -1, 'descending': False})
SUCCESS               1.342464           18.485249               0.073          ([torch.Size([4096, 4096])], {'dim': -1, 'descending': False})
SUCCESS              16.647167           73.274368               0.227          ([torch.Size([1024, 65536])], {'dim': -1, 'descending': False})
SUCCESS               0.009216            0.003072               3.000          ([torch.Size([1024, 1])], {'dim': -1, 'descending': False})
SUCCESS               0.076800            2.040832               0.038          ([torch.Size([1024, 512])], {'dim': -1, 'descending': False})
SUCCESS               0.526336            2.435072               0.216          ([torch.Size([16, 131072])], {'dim': -1, 'descending': False})
SUCCESS               0.524288            2.463744               0.213          ([torch.Size([8, 262144])], {'dim': -1, 'descending': False})


Operator: sort  Performance Test (dtype=torch.float16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.013312            0.505632               0.026          ([torch.Size([64, 64])], {'dim': -1, 'descending': False})
SUCCESS               0.026624            0.534528               0.050          ([torch.Size([256, 256])], {'dim': -1, 'descending': False})
SUCCESS               0.071680            1.255424               0.057          ([torch.Size([1024, 1024])], {'dim': -1, 'descending': False})
SUCCESS               0.859136           10.972160               0.078          ([torch.Size([4096, 4096])], {'dim': -1, 'descending': False})
SUCCESS               6.976512           44.102657               0.158          ([torch.Size([1024, 65536])], {'dim': -1, 'descending': False})
SUCCESS               0.009216            0.003072               3.000          ([torch.Size([1024, 1])], {'dim': -1, 'descending': False})
SUCCESS               0.051328            1.210368               0.042          ([torch.Size([1024, 512])], {'dim': -1, 'descending': False})
SUCCESS               0.509952            1.460160               0.349          ([torch.Size([16, 131072])], {'dim': -1, 'descending': False})
SUCCESS               0.506880            1.475584               0.344          ([torch.Size([8, 262144])], {'dim': -1, 'descending': False})


Operator: sort  Performance Test (dtype=torch.float32, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.015360            0.773120               0.020          ([torch.Size([64, 64])], {'dim': -1, 'descending': False})
SUCCESS               0.034816            0.788480               0.044          ([torch.Size([256, 256])], {'dim': -1, 'descending': False})
SUCCESS               0.109440            2.148352               0.051          ([torch.Size([1024, 1024])], {'dim': -1, 'descending': False})
SUCCESS               1.357824           18.668545               0.073          ([torch.Size([4096, 4096])], {'dim': -1, 'descending': False})
SUCCESS              16.316416           74.265602               0.220          ([torch.Size([1024, 65536])], {'dim': -1, 'descending': False})
SUCCESS               0.009216            0.003072               3.000          ([torch.Size([1024, 1])], {'dim': -1, 'descending': False})
SUCCESS               0.077824            2.079744               0.037          ([torch.Size([1024, 512])], {'dim': -1, 'descending': False})
SUCCESS               0.526336            2.464768               0.214          ([torch.Size([16, 131072])], {'dim': -1, 'descending': False})
SUCCESS               0.524288            2.489344               0.211          ([torch.Size([8, 262144])], {'dim': -1, 'descending': False})


Operator: sort  Performance Test (dtype=torch.bfloat16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.013312            0.506880               0.026          ([torch.Size([64, 64])], {'dim': -1, 'descending': False})
SUCCESS               0.026624            0.533504               0.050          ([torch.Size([256, 256])], {'dim': -1, 'descending': False})
SUCCESS               0.071680            1.263616               0.057          ([torch.Size([1024, 1024])], {'dim': -1, 'descending': False})
SUCCESS               0.851968           11.056128               0.077          ([torch.Size([4096, 4096])], {'dim': -1, 'descending': False})
SUCCESS               6.852608           44.112896               0.155          ([torch.Size([1024, 65536])], {'dim': -1, 'descending': False})
SUCCESS               0.009216            0.003072               3.000          ([torch.Size([1024, 1])], {'dim': -1, 'descending': False})
SUCCESS               0.052224            1.210368               0.043          ([torch.Size([1024, 512])], {'dim': -1, 'descending': False})
SUCCESS               0.506880            1.458176               0.348          ([torch.Size([16, 131072])], {'dim': -1, 'descending': False})
SUCCESS               0.502784            1.485824               0.338          ([torch.Size([8, 262144])], {'dim': -1, 'descending': False})
```
