### PR TITLE
test cummin ops with nan value

### DIFF
--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -304,6 +304,37 @@ def test_accuracy_cummin(shape, dtype):
     gems_assert_equal(res_out.indices, ref_out.indices)
 
 
+@pytest.mark.cummin
+@pytest.mark.parametrize("shape", CUMMIN_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("nan_ratio", [0.1, 0.3, 0.5])
+def test_accuracy_cummin_with_nan(shape, dtype, nan_ratio):
+    """Test cummin with NaN values at different ratios"""
+    dim = 1 if shape == REDUCTION_SHAPES[-1] else -1
+
+    # Create tensor with some NaN values
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    # Randomly set some values to NaN
+    total_elements = inp.numel()
+    nan_count = int(total_elements * nan_ratio)
+    nan_indices = torch.randperm(total_elements)[:nan_count]
+    flat_inp = inp.flatten()
+    flat_inp[nan_indices] = float("nan")
+    inp = flat_inp.view(shape)
+
+    ref_inp = to_reference(inp, True)
+
+    ref_out = torch.cummin(ref_inp, dim=dim)
+    with flag_gems.use_gems():
+        res_out = torch.cummin(inp, dim=dim)
+
+    gems_assert_close(
+        res_out.values, ref_out.values, dtype, reduce_dim=shape[dim], equal_nan=True
+    )
+    gems_assert_equal(res_out.indices, ref_out.indices)
+
+
 CUMMAX_SHAPES = (
     [(2, 32)] if QUICK_MODE else REDUCTION_SHAPES + [(2637,), (16, 1025, 255)]
 )
@@ -329,6 +360,37 @@ def test_accuracy_cummax(shape, dtype):
     with flag_gems.use_gems():
         res_out = torch.cummax(inp, dim=dim)
     gems_assert_close(res_out.values, ref_out.values, dtype, reduce_dim=shape[dim])
+    gems_assert_equal(res_out.indices, ref_out.indices)
+
+
+@pytest.mark.cummax
+@pytest.mark.parametrize("shape", CUMMAX_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("nan_ratio", [0.1, 0.3, 0.5])
+def test_accuracy_cummax_with_nan(shape, dtype, nan_ratio):
+    """Test cummax with NaN values at different ratios"""
+    dim = 1 if shape == REDUCTION_SHAPES[-1] else -1
+
+    # Create tensor with some NaN values
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    # Randomly set some values to NaN
+    total_elements = inp.numel()
+    nan_count = int(total_elements * nan_ratio)
+    nan_indices = torch.randperm(total_elements)[:nan_count]
+    flat_inp = inp.flatten()
+    flat_inp[nan_indices] = float("nan")
+    inp = flat_inp.view(shape)
+
+    ref_inp = to_reference(inp, True)
+
+    ref_out = torch.cummax(ref_inp, dim=dim)
+    with flag_gems.use_gems():
+        res_out = torch.cummax(inp, dim=dim)
+
+    gems_assert_close(
+        res_out.values, ref_out.values, dtype, reduce_dim=shape[dim], equal_nan=True
+    )
     gems_assert_equal(res_out.indices, ref_out.indices)
 
 


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
OP Test
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix 
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
I have notice that in `FlagGems/src/flag_gems/utils/triton_lang_extension.py` , the func will deal with value of nan:
```
@triton.jit
def minimum_with_index_tie_break_right(a_value, a_index, b_value, b_index):
    mask = a_value < b_value
    equal = a_value == b_value
    if is_floating(a_value):
        a_isnan = a_value != a_value
        b_isnan = b_value != b_value
        mask |= a_isnan and not b_isnan
        # Consider NaNs as equal
        equal |= a_isnan and b_isnan

    # Prefer highest index if values are equal
    mask |= equal & (a_index > b_index)
    return tl.where(mask, a_value, b_value), tl.where(mask, a_index, b_index)
```
And our current testing code did not detect this situation.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
