### PR TITLE
add hash key and early stop mechanism for libtuner

### DIFF
--- a/src/flag_gems/ops/mm.py
+++ b/src/flag_gems/ops/mm.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 @libtuner(
     configs=runtime.get_tuned_config("mm"),
     key=["M", "N", "K"],
-    strategy=["log", "log", "log"],
+    strategy=["align32", None, None],
 )
 @triton.heuristics(runtime.get_heuristic_config("mm"))
 @triton.jit

--- a/src/flag_gems/ops/mm.py
+++ b/src/flag_gems/ops/mm.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 @libtuner(
     configs=runtime.get_tuned_config("mm"),
     key=["M", "N", "K"],
-    strategy=["align32", None, None],
+    #    strategy=["align32", None, None],
 )
 @triton.heuristics(runtime.get_heuristic_config("mm"))
 @triton.jit

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -66,6 +66,7 @@ if major_version == 2:
 STRATEGY = {
     None: lambda v: v,
     "log": lambda v: math.ceil(math.log2(v)),
+    "align32": lambda v: (v // 32) * 32,
 }
 
 

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -28,14 +28,16 @@ version = triton.__version__.split(".")
 major_version, minor_version = eval(version[0]), eval(version[1])
 
 
-def get_kernel_hash(func):
+def get_kernel_hash(func, configs):
     if hasattr(func, "fn"):
         original_func = func.fn
     else:
         original_func = func
 
     source_code = inspect.getsource(original_func)
-    return hashlib.md5(source_code.encode("utf-8")).hexdigest()[:8]
+    config_strs = [str(config) for config in configs]
+    combined_content = f"{source_code}{config_strs}"
+    return hashlib.md5(combined_content.encode("utf-8")).hexdigest()[:8]
 
 
 if major_version == 2:
@@ -203,7 +205,7 @@ class LibTuner(triton.runtime.Autotuner):
         self.keys = key
         self.strategy = strategy
         self.share = share
-        self.kernel_hash = get_kernel_hash(self.base_fn)
+        self.kernel_hash = get_kernel_hash(self.base_fn, self.configs)
         # Use table name with hash instead of hash in key
         self.table_name = (
             f"{share}_{self.kernel_hash}"


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Other
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue
The current libtuner lacks a field representing the code, which may result in enabling outdated cache after modifying the code. To address this issue, this PR has added the md5 value of the source code as the hash key.
There is a phenomenon of excessive tuning in the way libtuner searches for the optimal config, which requires excessive computation to improve performance by 1%. Therefore, this PR has added an early stop mechanism.
<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
Test by the following code on H800, Through the following code test, on H800, the first end-to-end tuning time decreased from 11.51 seconds to 8.53 seconds, while the second end-to-end inference time increased from 1.16 seconds to 1.67 seconds.
```
# SPDX-License-Identifier: Apache-2.0
import random
import time

import numpy as np
import torch
from vllm import LLM, SamplingParams

import flag_gems


flag_gems.enable()  # Enable gems for PyTorch (aten) operators
flag_gems.apply_gems_patches_to_vllm(verbose=True)  # Patch vLLM custom ops


def set_seed(seed: int = 42):
    random.seed(seed)
    np.random.seed(seed)
    torch.manual_seed(seed)
    torch.cuda.manual_seed(seed)
    torch.cuda.manual_seed_all(seed)
    torch.backends.cudnn.deterministic = True
    torch.backends.cudnn.benchmark = False


set_seed(42)


# Sample prompts.
prompts = [
    "Hello, my name is",
    "The president of the United States is",
    "The capital of France is",
    "The future of AI is",
]

# Create a sampling params object.
sampling_params = SamplingParams(temperature=0.8, top_p=0.95, max_tokens=120)


def main():
    # Create an LLM.
    llm = LLM(
        model="Qwen/Qwen2.5-7B-Instruct",
        tensor_parallel_size=1,
        max_model_len=1024,
        gpu_memory_utilization=0.5,
        # enforce_eager=True,
    )

    # test time 2 times
    for _ in range(2):
        start_time = time.time()
        # Generate texts from the prompts. The output is a list of RequestOutput
        # objects that contain the prompt, generated text, and other information.
        outputs = llm.generate(prompts, sampling_params)
        end_time = time.time()
        print(f"Time taken for generation: {end_time - start_time:.2f} seconds")



if __name__ == "__main__":
    main()
```
