### PR TITLE
[LibTuner] Update default parameters of LibTuner

### DIFF
--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -148,13 +148,19 @@ class LibTuner(triton.runtime.Autotuner):
         pre_hook=None,
         post_hook=None,
         prune_configs_by: Optional[Dict] = None,
-        warmup=25,
-        rep=100,
+        warmup=None,
+        rep=None,
         use_cuda_graph=False,
         do_bench=None,
         strategy=None,
         share=None,
     ):
+        # NOTE(zhengyang): See discussion in https://github.com/triton-lang/triton/pull/4496
+        if major_version == 2 or (major_version == 3 and minor_version <= 1):
+            if warmup is None:
+                warmup = 25
+            if rep is None:
+                rep = 100
         if major_version == 2:
             super().__init__(
                 fn,


### PR DESCRIPTION
### PR Category
LibTuner

### Type of Change
New Feature

### Description
Update default parameters of LibTuner to adapt to versions after Triton 3.1
This makes the autotuner device-agnostic. Instead of having to know about the existence of e.g. do_bench_cudagraph, it can let the callers decide which backend-specific benchmarking function to use.
See discussion in https://github.com/triton-lang/triton/pull/4496

### Issue

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

