### PR TITLE
Avoid relative imports

### DIFF
--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -1,14 +1,14 @@
-from .concat_and_cache_mla import concat_and_cache_mla
-from .cross_entropy_loss import cross_entropy_loss
-from .fused_add_rms_norm import fused_add_rms_norm
-from .gelu_and_mul import gelu_and_mul
-from .instance_norm import instance_norm
-from .outer import outer
-from .reshape_and_cache import reshape_and_cache
-from .rotary_embedding import apply_rotary_pos_emb
-from .silu_and_mul import silu_and_mul
-from .skip_layernorm import skip_layer_norm
-from .weight_norm import weight_norm
+from flag_gems.fused.concat_and_cache_mla import concat_and_cache_mla
+from flag_gems.fused.cross_entropy_loss import cross_entropy_loss
+from flag_gems.fused.fused_add_rms_norm import fused_add_rms_norm
+from flag_gems.fused.gelu_and_mul import gelu_and_mul
+from flag_gems.fused.instance_norm import instance_norm
+from flag_gems.fused.outer import outer
+from flag_gems.fused.reshape_and_cache import reshape_and_cache
+from flag_gems.fused.rotary_embedding import apply_rotary_pos_emb
+from flag_gems.fused.silu_and_mul import silu_and_mul
+from flag_gems.fused.skip_layernorm import skip_layer_norm
+from flag_gems.fused.weight_norm import weight_norm
 
 __all__ = [
     "apply_rotary_pos_emb",

--- a/src/flag_gems/fused/concat_and_cache_mla.py
+++ b/src/flag_gems/fused/concat_and_cache_mla.py
@@ -4,7 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
-from ..utils import libentry
+from flag_gems.utils import libentry
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/fused/cross_entropy_loss.py
+++ b/src/flag_gems/fused/cross_entropy_loss.py
@@ -5,10 +5,10 @@ import triton
 import triton.language as tl
 from torch.nn import _reduction as _Reduction
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/fused/fused_add_rms_norm.py
+++ b/src/flag_gems/fused/fused_add_rms_norm.py
@@ -4,9 +4,9 @@ import math
 import triton
 import triton.language as tl
 
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/fused/gelu_and_mul.py
+++ b/src/flag_gems/fused/gelu_and_mul.py
@@ -4,7 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic, tl_extra_shim
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
 
 erf = tl_extra_shim.erf
 pow = tl_extra_shim.pow

--- a/src/flag_gems/fused/instance_norm.py
+++ b/src/flag_gems/fused/instance_norm.py
@@ -6,10 +6,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils.type_utils import get_accumulator_dtype
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils.type_utils import get_accumulator_dtype
 
 logger = logging.getLogger(__name__)
 Tensor = torch.Tensor

--- a/src/flag_gems/fused/outer.py
+++ b/src/flag_gems/fused/outer.py
@@ -2,7 +2,7 @@ import logging
 
 import torch
 
-from ..ops import mul, mv
+from flag_gems.ops import mul, mv
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/fused/reshape_and_cache.py
+++ b/src/flag_gems/fused/reshape_and_cache.py
@@ -3,8 +3,8 @@ import logging
 import triton
 import triton.language as tl
 
-from ..runtime import torch_device_fn
-from ..utils import libentry
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/fused/rotary_embedding.py
+++ b/src/flag_gems/fused/rotary_embedding.py
@@ -5,9 +5,9 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/fused/silu_and_mul.py
+++ b/src/flag_gems/fused/silu_and_mul.py
@@ -4,7 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/fused/skip_layernorm.py
+++ b/src/flag_gems/fused/skip_layernorm.py
@@ -5,9 +5,9 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/fused/weight_norm.py
+++ b/src/flag_gems/fused/weight_norm.py
@@ -5,11 +5,11 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..ops import weight_norm_interface, weight_norm_interface_backward
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.ops import weight_norm_interface, weight_norm_interface_backward
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -1,50 +1,50 @@
-from .abs import abs, abs_
-from .add import add, add_
-from .addmm import addmm
-from .all import all, all_dim, all_dims
-from .amax import amax
-from .angle import angle
-from .any import any, any_dim, any_dims
-from .arange import arange, arange_start
-from .argmax import argmax
-from .argmin import argmin
-from .attention import (
+from flag_gems.ops.abs import abs, abs_
+from flag_gems.ops.add import add, add_
+from flag_gems.ops.addmm import addmm
+from flag_gems.ops.all import all, all_dim, all_dims
+from flag_gems.ops.amax import amax
+from flag_gems.ops.angle import angle
+from flag_gems.ops.any import any, any_dim, any_dims
+from flag_gems.ops.arange import arange, arange_start
+from flag_gems.ops.argmax import argmax
+from flag_gems.ops.argmin import argmin
+from flag_gems.ops.attention import (
     flash_attention_forward,
     flash_attn_varlen_func,
     scaled_dot_product_attention,
 )
-from .batch_norm import batch_norm, batch_norm_backward
-from .bitwise_and import (
+from flag_gems.ops.batch_norm import batch_norm, batch_norm_backward
+from flag_gems.ops.bitwise_and import (
     bitwise_and_scalar,
     bitwise_and_scalar_,
     bitwise_and_scalar_tensor,
     bitwise_and_tensor,
     bitwise_and_tensor_,
 )
-from .bitwise_not import bitwise_not, bitwise_not_
-from .bitwise_or import (
+from flag_gems.ops.bitwise_not import bitwise_not, bitwise_not_
+from flag_gems.ops.bitwise_or import (
     bitwise_or_scalar,
     bitwise_or_scalar_,
     bitwise_or_scalar_tensor,
     bitwise_or_tensor,
     bitwise_or_tensor_,
 )
-from .bmm import bmm
-from .cat import cat
-from .clamp import clamp, clamp_, clamp_tensor, clamp_tensor_
-from .contiguous import contiguous
-from .conv1d import conv1d
-from .conv2d import conv2d
-from .conv_depthwise2d import _conv_depthwise2d
-from .cos import cos, cos_
-from .count_nonzero import count_nonzero
-from .cummax import cummax
-from .cummin import cummin
-from .cumsum import cumsum, cumsum_out, normed_cumsum
-from .diag import diag
-from .diag_embed import diag_embed
-from .diagonal import diagonal_backward
-from .div import (
+from flag_gems.ops.bmm import bmm
+from flag_gems.ops.cat import cat
+from flag_gems.ops.clamp import clamp, clamp_, clamp_tensor, clamp_tensor_
+from flag_gems.ops.contiguous import contiguous
+from flag_gems.ops.conv1d import conv1d
+from flag_gems.ops.conv2d import conv2d
+from flag_gems.ops.conv_depthwise2d import _conv_depthwise2d
+from flag_gems.ops.cos import cos, cos_
+from flag_gems.ops.count_nonzero import count_nonzero
+from flag_gems.ops.cummax import cummax
+from flag_gems.ops.cummin import cummin
+from flag_gems.ops.cumsum import cumsum, cumsum_out, normed_cumsum
+from flag_gems.ops.diag import diag
+from flag_gems.ops.diag_embed import diag_embed
+from flag_gems.ops.diagonal import diagonal_backward
+from flag_gems.ops.div import (
     div_mode,
     div_mode_,
     floor_divide,
@@ -54,131 +54,143 @@ from .div import (
     true_divide,
     true_divide_,
 )
-from .dot import dot
-from .dropout import dropout, dropout_backward
-from .elu import elu
-from .embedding import embedding, embedding_backward
-from .eq import eq, eq_scalar
-from .erf import erf, erf_
-from .exp import exp, exp_
-from .exponential_ import exponential_
-from .eye import eye
-from .eye_m import eye_m
-from .fill import fill_scalar, fill_scalar_, fill_tensor, fill_tensor_
-from .flip import flip
-from .full import full
-from .full_like import full_like
-from .gather import gather, gather_backward
-from .ge import ge, ge_scalar
-from .gelu import gelu, gelu_, gelu_backward
-from .glu import glu
-from .groupnorm import group_norm, group_norm_backward
-from .gt import gt, gt_scalar
-from .hstack import hstack
-from .index import index
-from .index_add import index_add
-from .index_put import index_put, index_put_
-from .index_select import index_select
-from .isclose import allclose, isclose
-from .isfinite import isfinite
-from .isin import isin
-from .isinf import isinf
-from .isnan import isnan
-from .kron import kron
-from .layernorm import layer_norm, layer_norm_backward
-from .le import le, le_scalar
-from .lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tensor_
-from .linspace import linspace
-from .log import log
-from .log_sigmoid import log_sigmoid
-from .log_softmax import log_softmax, log_softmax_backward
-from .logical_and import logical_and
-from .logical_not import logical_not
-from .logical_or import logical_or
-from .logical_xor import logical_xor
-from .lt import lt, lt_scalar
-from .masked_fill import masked_fill, masked_fill_
-from .masked_select import masked_select
-from .max import max, max_dim
-from .maximum import maximum
-from .mean import mean, mean_dim
-from .min import min, min_dim
-from .minimum import minimum
-from .mm import mm, mm_out
-from .mse_loss import mse_loss
-from .mul import mul, mul_
-from .multinomial import multinomial
-from .mv import mv
-from .nan_to_num import nan_to_num
-from .ne import ne, ne_scalar
-from .neg import neg, neg_
-from .nllloss import (
+from flag_gems.ops.dot import dot
+from flag_gems.ops.dropout import dropout, dropout_backward
+from flag_gems.ops.elu import elu
+from flag_gems.ops.embedding import embedding, embedding_backward
+from flag_gems.ops.eq import eq, eq_scalar
+from flag_gems.ops.erf import erf, erf_
+from flag_gems.ops.exp import exp, exp_
+from flag_gems.ops.exponential_ import exponential_
+from flag_gems.ops.eye import eye
+from flag_gems.ops.eye_m import eye_m
+from flag_gems.ops.fill import fill_scalar, fill_scalar_, fill_tensor, fill_tensor_
+from flag_gems.ops.flip import flip
+from flag_gems.ops.full import full
+from flag_gems.ops.full_like import full_like
+from flag_gems.ops.gather import gather, gather_backward
+from flag_gems.ops.ge import ge, ge_scalar
+from flag_gems.ops.gelu import gelu, gelu_, gelu_backward
+from flag_gems.ops.glu import glu
+from flag_gems.ops.groupnorm import group_norm, group_norm_backward
+from flag_gems.ops.gt import gt, gt_scalar
+from flag_gems.ops.hstack import hstack
+from flag_gems.ops.index import index
+from flag_gems.ops.index_add import index_add
+from flag_gems.ops.index_put import index_put, index_put_
+from flag_gems.ops.index_select import index_select
+from flag_gems.ops.isclose import allclose, isclose
+from flag_gems.ops.isfinite import isfinite
+from flag_gems.ops.isin import isin
+from flag_gems.ops.isinf import isinf
+from flag_gems.ops.isnan import isnan
+from flag_gems.ops.kron import kron
+from flag_gems.ops.layernorm import layer_norm, layer_norm_backward
+from flag_gems.ops.le import le, le_scalar
+from flag_gems.ops.lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tensor_
+from flag_gems.ops.linspace import linspace
+from flag_gems.ops.log import log
+from flag_gems.ops.log_sigmoid import log_sigmoid
+from flag_gems.ops.log_softmax import log_softmax, log_softmax_backward
+from flag_gems.ops.logical_and import logical_and
+from flag_gems.ops.logical_not import logical_not
+from flag_gems.ops.logical_or import logical_or
+from flag_gems.ops.logical_xor import logical_xor
+from flag_gems.ops.lt import lt, lt_scalar
+from flag_gems.ops.masked_fill import masked_fill, masked_fill_
+from flag_gems.ops.masked_select import masked_select
+from flag_gems.ops.max import max, max_dim
+from flag_gems.ops.maximum import maximum
+from flag_gems.ops.mean import mean, mean_dim
+from flag_gems.ops.min import min, min_dim
+from flag_gems.ops.minimum import minimum
+from flag_gems.ops.mm import mm, mm_out
+from flag_gems.ops.mse_loss import mse_loss
+from flag_gems.ops.mul import mul, mul_
+from flag_gems.ops.multinomial import multinomial
+from flag_gems.ops.mv import mv
+from flag_gems.ops.nan_to_num import nan_to_num
+from flag_gems.ops.ne import ne, ne_scalar
+from flag_gems.ops.neg import neg, neg_
+from flag_gems.ops.nllloss import (
     nll_loss2d_backward,
     nll_loss2d_forward,
     nll_loss_backward,
     nll_loss_forward,
 )
-from .nonzero import nonzero
-from .normal import normal_float_tensor, normal_tensor_float, normal_tensor_tensor
-from .ones import ones
-from .ones_like import ones_like
-from .pad import constant_pad_nd, pad
-from .polar import polar
-from .pow import (
+from flag_gems.ops.nonzero import nonzero
+from flag_gems.ops.normal import (
+    normal_float_tensor,
+    normal_tensor_float,
+    normal_tensor_tensor,
+)
+from flag_gems.ops.ones import ones
+from flag_gems.ops.ones_like import ones_like
+from flag_gems.ops.pad import constant_pad_nd, pad
+from flag_gems.ops.polar import polar
+from flag_gems.ops.pow import (
     pow_scalar,
     pow_tensor_scalar,
     pow_tensor_scalar_,
     pow_tensor_tensor,
     pow_tensor_tensor_,
 )
-from .prod import prod, prod_dim
-from .quantile import quantile
-from .rand import rand
-from .rand_like import rand_like
-from .randn import randn
-from .randn_like import randn_like
-from .randperm import randperm
-from .reciprocal import reciprocal, reciprocal_
-from .relu import relu, relu_
-from .repeat import repeat
-from .repeat_interleave import (
+from flag_gems.ops.prod import prod, prod_dim
+from flag_gems.ops.quantile import quantile
+from flag_gems.ops.rand import rand
+from flag_gems.ops.rand_like import rand_like
+from flag_gems.ops.randn import randn
+from flag_gems.ops.randn_like import randn_like
+from flag_gems.ops.randperm import randperm
+from flag_gems.ops.reciprocal import reciprocal, reciprocal_
+from flag_gems.ops.relu import relu, relu_
+from flag_gems.ops.repeat import repeat
+from flag_gems.ops.repeat_interleave import (
     repeat_interleave_self_int,
     repeat_interleave_self_tensor,
     repeat_interleave_tensor,
 )
-from .resolve_conj import resolve_conj
-from .resolve_neg import resolve_neg
-from .rms_norm import rms_norm
-from .rsqrt import rsqrt, rsqrt_
-from .scatter import scatter, scatter_
-from .select_scatter import select_scatter
-from .sigmoid import sigmoid, sigmoid_, sigmoid_backward
-from .silu import silu, silu_, silu_backward
-from .sin import sin, sin_
-from .slice_scatter import slice_scatter
-from .softmax import softmax, softmax_backward
-from .sort import sort
-from .stack import stack
-from .sub import sub, sub_
-from .sum import sum, sum_dim, sum_dim_out, sum_out
-from .tanh import tanh, tanh_, tanh_backward
-from .threshold import threshold, threshold_backward
-from .tile import tile
-from .to import to_dtype
-from .topk import topk
-from .triu import triu
-from .uniform import uniform_
-from .unique import _unique2
-from .upsample_bicubic2d_aa import _upsample_bicubic2d_aa
-from .upsample_nearest2d import upsample_nearest2d
-from .var_mean import var_mean
-from .vdot import vdot
-from .vector_norm import vector_norm
-from .vstack import vstack
-from .weightnorm import weight_norm_interface, weight_norm_interface_backward
-from .where import where_scalar_other, where_scalar_self, where_self, where_self_out
-from .zeros import zeros
-from .zeros_like import zeros_like
+from flag_gems.ops.resolve_conj import resolve_conj
+from flag_gems.ops.resolve_neg import resolve_neg
+from flag_gems.ops.rms_norm import rms_norm
+from flag_gems.ops.rsqrt import rsqrt, rsqrt_
+from flag_gems.ops.scatter import scatter, scatter_
+from flag_gems.ops.select_scatter import select_scatter
+from flag_gems.ops.sigmoid import sigmoid, sigmoid_, sigmoid_backward
+from flag_gems.ops.silu import silu, silu_, silu_backward
+from flag_gems.ops.sin import sin, sin_
+from flag_gems.ops.slice_scatter import slice_scatter
+from flag_gems.ops.softmax import softmax, softmax_backward
+from flag_gems.ops.sort import sort
+from flag_gems.ops.stack import stack
+from flag_gems.ops.sub import sub, sub_
+from flag_gems.ops.sum import sum, sum_dim, sum_dim_out, sum_out
+from flag_gems.ops.tanh import tanh, tanh_, tanh_backward
+from flag_gems.ops.threshold import threshold, threshold_backward
+from flag_gems.ops.tile import tile
+from flag_gems.ops.to import to_dtype
+from flag_gems.ops.topk import topk
+from flag_gems.ops.triu import triu
+from flag_gems.ops.uniform import uniform_
+from flag_gems.ops.unique import _unique2
+from flag_gems.ops.upsample_bicubic2d_aa import _upsample_bicubic2d_aa
+from flag_gems.ops.upsample_nearest2d import upsample_nearest2d
+from flag_gems.ops.var_mean import var_mean
+from flag_gems.ops.vdot import vdot
+from flag_gems.ops.vector_norm import vector_norm
+from flag_gems.ops.vstack import vstack
+from flag_gems.ops.weightnorm import (
+    weight_norm_interface,
+    weight_norm_interface_backward,
+)
+from flag_gems.ops.where import (
+    where_scalar_other,
+    where_scalar_self,
+    where_self,
+    where_self_out,
+)
+from flag_gems.ops.zeros import zeros
+from flag_gems.ops.zeros_like import zeros_like
 
 __all__ = [
     "log_sigmoid",

--- a/src/flag_gems/ops/abs.py
+++ b/src/flag_gems/ops/abs.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/add.py
+++ b/src/flag_gems/ops/add.py
@@ -3,7 +3,7 @@ import logging
 import torch
 import triton
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/addmm.py
+++ b/src/flag_gems/ops/addmm.py
@@ -4,10 +4,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import broadcastable_to, libentry, libtuner
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import broadcastable_to, libentry, libtuner
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/all.py
+++ b/src/flag_gems/ops/all.py
@@ -5,10 +5,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import dim_compress, libentry, libtuner
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry, libtuner
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/amax.py
+++ b/src/flag_gems/ops/amax.py
@@ -5,11 +5,11 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import dim_compress, libentry, libtuner
-from ..utils import triton_lang_extension as tle
-from ..utils.limits import get_dtype_min
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry, libtuner
+from flag_gems.utils import triton_lang_extension as tle
+from flag_gems.utils.limits import get_dtype_min
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/angle.py
+++ b/src/flag_gems/ops/angle.py
@@ -5,7 +5,7 @@ import torch
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic, tl_extra_shim
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
 
 atan2 = tl_extra_shim.atan2
 

--- a/src/flag_gems/ops/any.py
+++ b/src/flag_gems/ops/any.py
@@ -5,10 +5,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import dim_compress, libentry, libtuner
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry, libtuner
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/arange.py
+++ b/src/flag_gems/ops/arange.py
@@ -5,9 +5,9 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/argmax.py
+++ b/src/flag_gems/ops/argmax.py
@@ -5,11 +5,11 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
-from ..utils.limits import get_dtype_min
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+from flag_gems.utils.limits import get_dtype_min
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/argmin.py
+++ b/src/flag_gems/ops/argmin.py
@@ -5,11 +5,11 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
-from ..utils.limits import get_dtype_max
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+from flag_gems.utils.limits import get_dtype_max
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -4,11 +4,10 @@ import torch
 import triton
 import triton.language as tl
 
+from flag_gems import runtime
+from flag_gems.ops.flash_api import mha_fwd, mha_varlan_fwd
+from flag_gems.ops.flash_kernel import keep
 from flag_gems.runtime import torch_device_fn
-
-from .. import runtime
-from .flash_api import mha_fwd, mha_varlan_fwd
-from .flash_kernel import keep
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/batch_norm.py
+++ b/src/flag_gems/ops/batch_norm.py
@@ -5,9 +5,9 @@ import triton
 import triton.language as tl
 from torch import Tensor
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import libentry, tl_extra_shim
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, tl_extra_shim
 
 logger = logging.getLogger(__name__)
 rsqrt = tl_extra_shim.rsqrt

--- a/src/flag_gems/ops/bitwise_and.py
+++ b/src/flag_gems/ops/bitwise_and.py
@@ -2,7 +2,7 @@ import logging
 
 import triton
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/bitwise_not.py
+++ b/src/flag_gems/ops/bitwise_not.py
@@ -2,7 +2,7 @@ import logging
 
 import triton
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/bitwise_or.py
+++ b/src/flag_gems/ops/bitwise_or.py
@@ -2,7 +2,7 @@ import logging
 
 import triton
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/bmm.py
+++ b/src/flag_gems/ops/bmm.py
@@ -4,10 +4,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import libentry, libtuner
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, libtuner
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/cat.py
+++ b/src/flag_gems/ops/cat.py
@@ -5,8 +5,8 @@ from typing import List, Tuple, Union
 import torch
 import triton
 
-from ..utils import pointwise_dynamic
-from ..utils.tensor_wrapper import StridedBuffer
+from flag_gems.utils import pointwise_dynamic
+from flag_gems.utils.tensor_wrapper import StridedBuffer
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/clamp.py
+++ b/src/flag_gems/ops/clamp.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/contiguous.py
+++ b/src/flag_gems/ops/contiguous.py
@@ -2,7 +2,7 @@ import logging
 
 import torch
 
-from ..ops.copy import copy
+from flag_gems.ops.copy import copy
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/conv1d.py
+++ b/src/flag_gems/ops/conv1d.py
@@ -1,6 +1,6 @@
 import logging
 
-from .conv2d import conv2d
+from flag_gems.ops.conv2d import conv2d
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/conv2d.py
+++ b/src/flag_gems/ops/conv2d.py
@@ -4,8 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..utils import libentry
+from flag_gems import runtime
+from flag_gems.utils import libentry
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/conv_depthwise2d.py
+++ b/src/flag_gems/ops/conv_depthwise2d.py
@@ -1,6 +1,6 @@
 import logging
 
-from .conv2d import conv2d
+from flag_gems.ops.conv2d import conv2d
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/copy.py
+++ b/src/flag_gems/ops/copy.py
@@ -1,6 +1,6 @@
 import triton
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 
 @pointwise_dynamic(is_tensor=(True,), promotion_methods=[(0, "DEFAULT")])

--- a/src/flag_gems/ops/cos.py
+++ b/src/flag_gems/ops/cos.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/count_nonzero.py
+++ b/src/flag_gems/ops/count_nonzero.py
@@ -4,9 +4,9 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..utils import dim_compress, libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.utils import dim_compress, libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/cummax.py
+++ b/src/flag_gems/ops/cummax.py
@@ -6,10 +6,10 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
-from ..utils.limits import get_dtype_min
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+from flag_gems.utils.limits import get_dtype_min
 
 Tensor = torch.Tensor
 

--- a/src/flag_gems/ops/cummin.py
+++ b/src/flag_gems/ops/cummin.py
@@ -6,10 +6,10 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
-from ..utils.limits import get_dtype_max
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+from flag_gems.utils.limits import get_dtype_max
 
 Tensor = torch.Tensor
 

--- a/src/flag_gems/ops/cumsum.py
+++ b/src/flag_gems/ops/cumsum.py
@@ -5,11 +5,9 @@ import torch
 import triton
 import triton.language as tl
 
-from flag_gems.utils import libentry
-
-from ..runtime import device, torch_device_fn
-from ..utils import get_device_properties
-from ..utils import triton_lang_extension as tle
+from flag_gems.runtime import device, torch_device_fn
+from flag_gems.utils import get_device_properties, libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 device = device.name
 logger = logging.getLogger(__name__)

--- a/src/flag_gems/ops/diag.py
+++ b/src/flag_gems/ops/diag.py
@@ -4,8 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import torch_device_fn
-from ..utils import triton_lang_extension as tle
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/diag_embed.py
+++ b/src/flag_gems/ops/diag_embed.py
@@ -3,7 +3,7 @@ import logging
 import torch
 import triton
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/diagonal.py
+++ b/src/flag_gems/ops/diagonal.py
@@ -3,7 +3,7 @@ import logging
 import torch
 import triton
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/div.py
+++ b/src/flag_gems/ops/div.py
@@ -4,8 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
-from ..utils.triton_lang_extension import div_rn, div_rz, fmod, trunc
+from flag_gems.utils import pointwise_dynamic
+from flag_gems.utils.triton_lang_extension import div_rn, div_rz, fmod, trunc
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/dot.py
+++ b/src/flag_gems/ops/dot.py
@@ -5,9 +5,9 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/dropout.py
+++ b/src/flag_gems/ops/dropout.py
@@ -4,13 +4,12 @@ import torch
 import triton
 import triton.language as tl
 
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
 from flag_gems.utils.random_utils import (
     philox_backend_seed_offset,
     uint_to_uniform_float,
 )
-
-from .. import runtime
-from ..runtime import torch_device_fn
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/elu.py
+++ b/src/flag_gems/ops/elu.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/embedding.py
+++ b/src/flag_gems/ops/embedding.py
@@ -4,9 +4,9 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/eq.py
+++ b/src/flag_gems/ops/eq.py
@@ -3,8 +3,8 @@ import logging
 import triton
 import triton.language as tl
 
-from ..runtime import device
-from ..utils import pointwise_dynamic
+from flag_gems.runtime import device
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 device = device.name

--- a/src/flag_gems/ops/erf.py
+++ b/src/flag_gems/ops/erf.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/exp.py
+++ b/src/flag_gems/ops/exp.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/exponential_.py
+++ b/src/flag_gems/ops/exponential_.py
@@ -4,13 +4,12 @@ import torch
 import triton
 import triton.language as tl
 
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
 from flag_gems.utils.random_utils import (
     philox_backend_seed_offset,
     uint_to_uniform_float,
 )
-
-from .. import runtime
-from ..runtime import torch_device_fn
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/eye.py
+++ b/src/flag_gems/ops/eye.py
@@ -3,8 +3,8 @@ import logging
 import torch
 import triton
 
-from ..runtime import device, torch_device_fn
-from .eye_m import eye_kernel
+from flag_gems.ops.eye_m import eye_kernel
+from flag_gems.runtime import device, torch_device_fn
 
 logger = logging.getLogger(__name__)
 device_ = device

--- a/src/flag_gems/ops/eye_m.py
+++ b/src/flag_gems/ops/eye_m.py
@@ -4,8 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import device, torch_device_fn
-from ..utils import libentry
+from flag_gems.runtime import device, torch_device_fn
+from flag_gems.utils import libentry
 
 logger = logging.getLogger(__name__)
 device_ = device

--- a/src/flag_gems/ops/fill.py
+++ b/src/flag_gems/ops/fill.py
@@ -4,8 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import torch_device_fn
-from ..utils import pointwise_dynamic
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/flash_api.py
+++ b/src/flag_gems/ops/flash_api.py
@@ -5,10 +5,7 @@ import torch
 import triton
 
 import flag_gems
-from flag_gems.runtime import torch_device_fn
-from flag_gems.utils.random_utils import philox_backend_seed_offset
-
-from .flash_kernel import (
+from flag_gems.ops.flash_kernel import (
     block_m_splitkv_heuristic,
     block_n_splitkv_heuristic,
     flash_fwd_kernel,
@@ -16,6 +13,8 @@ from .flash_kernel import (
     flash_fwd_splitkv_kernel,
     flash_varlen_fwd_kernel,
 )
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils.random_utils import philox_backend_seed_offset
 
 logger = logging.getLogger(__name__)
 _debug = False

--- a/src/flag_gems/ops/flash_kernel.py
+++ b/src/flag_gems/ops/flash_kernel.py
@@ -1,8 +1,8 @@
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..utils import libentry, tl_extra_shim
+from flag_gems import runtime
+from flag_gems.utils import libentry, tl_extra_shim
 
 
 @triton.jit

--- a/src/flag_gems/ops/flip.py
+++ b/src/flag_gems/ops/flip.py
@@ -3,8 +3,8 @@ import logging
 import torch
 import triton
 
-from ..utils import pointwise_dynamic
-from ..utils.tensor_wrapper import StridedBuffer
+from flag_gems.utils import pointwise_dynamic
+from flag_gems.utils.tensor_wrapper import StridedBuffer
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/full.py
+++ b/src/flag_gems/ops/full.py
@@ -4,7 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
-from ..utils.pointwise_dynamic import pointwise_dynamic
+from flag_gems.utils.pointwise_dynamic import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/full_like.py
+++ b/src/flag_gems/ops/full_like.py
@@ -2,7 +2,7 @@ import logging
 
 import torch
 
-from .full import check_dtype, full_func, full_func_scalar
+from flag_gems.ops.full import check_dtype, full_func, full_func_scalar
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/gather.py
+++ b/src/flag_gems/ops/gather.py
@@ -5,11 +5,10 @@ from typing import Any, Callable, Mapping, Tuple
 
 import torch
 
+from flag_gems.ops.scatter import scatter_
 from flag_gems.utils.code_cache import code_cache_dir
 from flag_gems.utils.code_utils import IndentedBuffer, write_atomic
 from flag_gems.utils.shape_utils import restride_dim
-
-from .scatter import scatter_
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/ge.py
+++ b/src/flag_gems/ops/ge.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/gelu.py
+++ b/src/flag_gems/ops/gelu.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic, tl_extra_shim
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
 
 erf = tl_extra_shim.erf
 exp = tl_extra_shim.exp

--- a/src/flag_gems/ops/glu.py
+++ b/src/flag_gems/ops/glu.py
@@ -4,7 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic, tl_extra_shim
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
 
 logger = logging.getLogger(__name__)
 exp = tl_extra_shim.exp

--- a/src/flag_gems/ops/groupnorm.py
+++ b/src/flag_gems/ops/groupnorm.py
@@ -4,9 +4,9 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import torch_device_fn
-from ..utils import libentry, tl_extra_shim
-from ..utils import triton_lang_extension as tle
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, tl_extra_shim
+from flag_gems.utils import triton_lang_extension as tle
 
 rsqrt = tl_extra_shim.rsqrt
 logger = logging.getLogger(__name__)

--- a/src/flag_gems/ops/gt.py
+++ b/src/flag_gems/ops/gt.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/hstack.py
+++ b/src/flag_gems/ops/hstack.py
@@ -5,8 +5,8 @@ from typing import List, Tuple, Union
 import torch
 import triton
 
-from ..utils import pointwise_dynamic
-from ..utils.tensor_wrapper import StridedBuffer
+from flag_gems.utils import pointwise_dynamic
+from flag_gems.utils.tensor_wrapper import StridedBuffer
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/index.py
+++ b/src/flag_gems/ops/index.py
@@ -5,10 +5,9 @@ from typing import Any, Callable, List, Mapping, Tuple
 
 import torch
 
+from flag_gems.ops.gather import gather
 from flag_gems.utils.code_cache import code_cache_dir
 from flag_gems.utils.code_utils import IndentedBuffer, write_atomic
-
-from .gather import gather
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/index_select.py
+++ b/src/flag_gems/ops/index_select.py
@@ -4,9 +4,9 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..utils import dim_compress, libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.utils import dim_compress, libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/isclose.py
+++ b/src/flag_gems/ops/isclose.py
@@ -4,8 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic, tl_extra_shim
-from .all import all
+from flag_gems.ops.all import all
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
 
 try:
     _isfinited = tl_extra_shim.isfinited

--- a/src/flag_gems/ops/isfinite.py
+++ b/src/flag_gems/ops/isfinite.py
@@ -4,7 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic, tl_extra_shim
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
 
 try:
     _isfinited = tl_extra_shim.isfinited

--- a/src/flag_gems/ops/isin.py
+++ b/src/flag_gems/ops/isin.py
@@ -5,13 +5,12 @@ import torch
 import triton
 import triton.language as tl
 
+from flag_gems.ops.all import reduce_all
+from flag_gems.ops.any import reduce_any
+from flag_gems.ops.unique import _unique2
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import triton_lang_extension as tle
 from flag_gems.utils.libentry import libentry
-
-from ..runtime import torch_device_fn
-from ..utils import triton_lang_extension as tle
-from .all import reduce_all
-from .any import reduce_any
-from .unique import _unique2
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/isinf.py
+++ b/src/flag_gems/ops/isinf.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic, tl_extra_shim
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
 
 _isinf = tl_extra_shim.isinf
 

--- a/src/flag_gems/ops/isnan.py
+++ b/src/flag_gems/ops/isnan.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic, tl_extra_shim
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
 
 _isnan = tl_extra_shim.isnan
 

--- a/src/flag_gems/ops/kron.py
+++ b/src/flag_gems/ops/kron.py
@@ -5,9 +5,9 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/layernorm.py
+++ b/src/flag_gems/ops/layernorm.py
@@ -5,10 +5,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/le.py
+++ b/src/flag_gems/ops/le.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/lerp.py
+++ b/src/flag_gems/ops/lerp.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/linspace.py
+++ b/src/flag_gems/ops/linspace.py
@@ -4,8 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/log.py
+++ b/src/flag_gems/ops/log.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/log_sigmoid.py
+++ b/src/flag_gems/ops/log_sigmoid.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/log_softmax.py
+++ b/src/flag_gems/ops/log_softmax.py
@@ -4,10 +4,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/logical_and.py
+++ b/src/flag_gems/ops/logical_and.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/logical_not.py
+++ b/src/flag_gems/ops/logical_not.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/logical_or.py
+++ b/src/flag_gems/ops/logical_or.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/logical_xor.py
+++ b/src/flag_gems/ops/logical_xor.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/lt.py
+++ b/src/flag_gems/ops/lt.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/masked_fill.py
+++ b/src/flag_gems/ops/masked_fill.py
@@ -4,7 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
-from ..utils import broadcastable_to, pointwise_dynamic
+from flag_gems.utils import broadcastable_to, pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/masked_select.py
+++ b/src/flag_gems/ops/masked_select.py
@@ -4,10 +4,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import broadcastable, libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import broadcastable, libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/max.py
+++ b/src/flag_gems/ops/max.py
@@ -6,11 +6,11 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import dim_compress, libentry, libtuner
-from ..utils import triton_lang_extension as tle
-from ..utils.limits import get_dtype_min
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry, libtuner
+from flag_gems.utils import triton_lang_extension as tle
+from flag_gems.utils.limits import get_dtype_min
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/maximum.py
+++ b/src/flag_gems/ops/maximum.py
@@ -3,8 +3,8 @@ import logging
 import triton
 import triton.language as tl
 
-from ..runtime import device
-from ..utils import pointwise_dynamic
+from flag_gems.runtime import device
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 device = device.name

--- a/src/flag_gems/ops/mean.py
+++ b/src/flag_gems/ops/mean.py
@@ -5,10 +5,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import dim_compress, libentry, libtuner
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry, libtuner
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/min.py
+++ b/src/flag_gems/ops/min.py
@@ -6,11 +6,11 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import dim_compress, libentry, libtuner
-from ..utils import triton_lang_extension as tle
-from ..utils.limits import get_dtype_max
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry, libtuner
+from flag_gems.utils import triton_lang_extension as tle
+from flag_gems.utils.limits import get_dtype_max
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/minimum.py
+++ b/src/flag_gems/ops/minimum.py
@@ -3,8 +3,8 @@ import logging
 import triton
 import triton.language as tl
 
-from ..runtime import device
-from ..utils import pointwise_dynamic
+from flag_gems.runtime import device
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 device = device.name

--- a/src/flag_gems/ops/mm.py
+++ b/src/flag_gems/ops/mm.py
@@ -4,10 +4,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import libentry, libtuner
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, libtuner
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/mse_loss.py
+++ b/src/flag_gems/ops/mse_loss.py
@@ -6,9 +6,9 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import torch_device_fn
-from ..utils import libentry, pointwise_dynamic
-from ..utils import triton_lang_extension as tle
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, pointwise_dynamic
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/mul.py
+++ b/src/flag_gems/ops/mul.py
@@ -3,7 +3,7 @@ import logging
 import torch
 import triton
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/multinomial.py
+++ b/src/flag_gems/ops/multinomial.py
@@ -4,6 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
+from flag_gems.ops import normed_cumsum
 from flag_gems.utils import libentry
 from flag_gems.utils.random_utils import philox_backend_seed_offset, uniform
 
@@ -72,8 +73,6 @@ def multinomial(prob, n_samples, with_replacement=False, *, gen=None):
         else:
             vals, indices = torch.topk(s, n_samples, dim=-1)
             return indices.to(torch.int64)
-
-    from flag_gems.ops import normed_cumsum
 
     cum_prob = normed_cumsum(prob, dim=-1)
 

--- a/src/flag_gems/ops/mv.py
+++ b/src/flag_gems/ops/mv.py
@@ -4,10 +4,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/nan_to_num.py
+++ b/src/flag_gems/ops/nan_to_num.py
@@ -4,7 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic, tl_extra_shim
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
 
 _isnan = tl_extra_shim.isnan
 

--- a/src/flag_gems/ops/ne.py
+++ b/src/flag_gems/ops/ne.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/neg.py
+++ b/src/flag_gems/ops/neg.py
@@ -2,7 +2,7 @@ import logging
 
 import triton
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/nllloss.py
+++ b/src/flag_gems/ops/nllloss.py
@@ -4,8 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import torch_device_fn
-from ..utils import libentry
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/nonzero.py
+++ b/src/flag_gems/ops/nonzero.py
@@ -4,10 +4,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/normal.py
+++ b/src/flag_gems/ops/normal.py
@@ -3,11 +3,11 @@ import logging
 import torch
 import triton
 
-from ..runtime import torch_device_fn
-from ..utils import pointwise_dynamic
-from ..utils.random_utils import philox_backend_seed_offset
-from ..utils.shape_utils import broadcast_shapes, volume
-from .randn import randn_kernel
+from flag_gems.ops.randn import randn_kernel
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import pointwise_dynamic
+from flag_gems.utils.random_utils import philox_backend_seed_offset
+from flag_gems.utils.shape_utils import broadcast_shapes, volume
 
 logger = logging.getLogger(__name__)
 UNROLL = 4

--- a/src/flag_gems/ops/ones.py
+++ b/src/flag_gems/ops/ones.py
@@ -4,10 +4,10 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import device, torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
-from ..utils.shape_utils import volume
+from flag_gems.runtime import device, torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+from flag_gems.utils.shape_utils import volume
 
 device_ = device
 logger = logging.getLogger(__name__)

--- a/src/flag_gems/ops/ones_like.py
+++ b/src/flag_gems/ops/ones_like.py
@@ -3,8 +3,8 @@ import logging
 import torch
 import triton
 
-from ..runtime import torch_device_fn
-from .ones import ones_kernel
+from flag_gems.ops.ones import ones_kernel
+from flag_gems.runtime import torch_device_fn
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/polar.py
+++ b/src/flag_gems/ops/polar.py
@@ -4,7 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/pow.py
+++ b/src/flag_gems/ops/pow.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic, tl_extra_shim
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
 
 _pow = tl_extra_shim.pow
 logger = logging.getLogger(__name__)

--- a/src/flag_gems/ops/prod.py
+++ b/src/flag_gems/ops/prod.py
@@ -5,10 +5,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import dim_compress, libentry, libtuner
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry, libtuner
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/quantile.py
+++ b/src/flag_gems/ops/quantile.py
@@ -5,9 +5,9 @@ import triton
 import triton.language as tl
 from torch import Tensor
 
-from ..runtime import torch_device_fn
-from ..utils import dim_compress, libentry, tl_extra_shim
-from ..utils import triton_lang_extension as tle
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry, tl_extra_shim
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/rand.py
+++ b/src/flag_gems/ops/rand.py
@@ -4,14 +4,13 @@ import torch
 import triton
 import triton.language as tl
 
+from flag_gems import runtime
+from flag_gems.runtime import device, torch_device_fn
 from flag_gems.utils.random_utils import (
     philox_backend_seed_offset,
     uint_to_uniform_float,
 )
 from flag_gems.utils.shape_utils import volume
-
-from .. import runtime
-from ..runtime import device, torch_device_fn
 
 logger = logging.getLogger(__name__)
 device_ = device

--- a/src/flag_gems/ops/rand_like.py
+++ b/src/flag_gems/ops/rand_like.py
@@ -4,9 +4,8 @@ import torch
 import triton
 
 from flag_gems.ops.rand import rand_kernel
+from flag_gems.runtime import torch_device_fn
 from flag_gems.utils.random_utils import philox_backend_seed_offset
-
-from ..runtime import torch_device_fn
 
 logger = logging.getLogger(__name__)
 UNROLL = 4

--- a/src/flag_gems/ops/randn.py
+++ b/src/flag_gems/ops/randn.py
@@ -4,14 +4,13 @@ import torch
 import triton
 import triton.language as tl
 
+from flag_gems import runtime
+from flag_gems.runtime import device, torch_device_fn
 from flag_gems.utils.random_utils import (
     philox_backend_seed_offset,
     uint_to_uniform_float,
 )
 from flag_gems.utils.shape_utils import volume
-
-from .. import runtime
-from ..runtime import device, torch_device_fn
 
 try:
     pair_uniform_to_normal = tl.pair_uniform_to_normal

--- a/src/flag_gems/ops/randn_like.py
+++ b/src/flag_gems/ops/randn_like.py
@@ -4,9 +4,8 @@ import torch
 import triton
 
 from flag_gems.ops.randn import randn_kernel
+from flag_gems.runtime import torch_device_fn
 from flag_gems.utils.random_utils import philox_backend_seed_offset
-
-from ..runtime import torch_device_fn
 
 logger = logging.getLogger(__name__)
 UNROLL = 4

--- a/src/flag_gems/ops/randperm.py
+++ b/src/flag_gems/ops/randperm.py
@@ -4,12 +4,11 @@ import torch
 import triton
 import triton.language as tl
 
+from flag_gems import runtime
+from flag_gems.ops.topk import argsort
+from flag_gems.runtime import device, torch_device_fn
+from flag_gems.utils import libentry
 from flag_gems.utils.random_utils import philox_backend_seed_offset
-
-from .. import runtime
-from ..runtime import device, torch_device_fn
-from ..utils import libentry
-from .topk import argsort
 
 logger = logging.getLogger(__name__)
 device_ = device

--- a/src/flag_gems/ops/reciprocal.py
+++ b/src/flag_gems/ops/reciprocal.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/relu.py
+++ b/src/flag_gems/ops/relu.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/repeat_interleave.py
+++ b/src/flag_gems/ops/repeat_interleave.py
@@ -4,10 +4,10 @@ import torch
 import triton
 from triton import language as tl
 
-from ..utils import triton_lang_extension as tle
-from ..utils.pointwise_dynamic import pointwise_dynamic
-from ..utils.shape_utils import c_contiguous_stride
-from ..utils.tensor_wrapper import StridedBuffer
+from flag_gems.utils import triton_lang_extension as tle
+from flag_gems.utils.pointwise_dynamic import pointwise_dynamic
+from flag_gems.utils.shape_utils import c_contiguous_stride
+from flag_gems.utils.tensor_wrapper import StridedBuffer
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/rms_norm.py
+++ b/src/flag_gems/ops/rms_norm.py
@@ -5,9 +5,9 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/rsqrt.py
+++ b/src/flag_gems/ops/rsqrt.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/select_scatter.py
+++ b/src/flag_gems/ops/select_scatter.py
@@ -2,8 +2,8 @@ import logging
 
 import torch
 
-from ..ops.copy import copy
-from ..utils.shape_utils import MemOverlap, has_internal_overlapping
+from flag_gems.ops.copy import copy
+from flag_gems.utils.shape_utils import MemOverlap, has_internal_overlapping
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/sigmoid.py
+++ b/src/flag_gems/ops/sigmoid.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic, tl_extra_shim
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
 
 logger = logging.getLogger(__name__)
 exp2 = tl_extra_shim.exp2

--- a/src/flag_gems/ops/silu.py
+++ b/src/flag_gems/ops/silu.py
@@ -3,8 +3,8 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
-from ..utils.triton_lang_extension import div_rn
+from flag_gems.utils import pointwise_dynamic
+from flag_gems.utils.triton_lang_extension import div_rn
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/sin.py
+++ b/src/flag_gems/ops/sin.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/slice_scatter.py
+++ b/src/flag_gems/ops/slice_scatter.py
@@ -3,8 +3,8 @@ import logging
 import torch
 import triton
 
-from ..ops.copy import copy
-from ..utils.shape_utils import MemOverlap, has_internal_overlapping
+from flag_gems.ops.copy import copy
+from flag_gems.utils.shape_utils import MemOverlap, has_internal_overlapping
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/softmax.py
+++ b/src/flag_gems/ops/softmax.py
@@ -4,10 +4,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/sort.py
+++ b/src/flag_gems/ops/sort.py
@@ -11,18 +11,26 @@ from .topk import _get_finfo_val, _get_iinfo_val, argsort
 logger = logging.getLogger(__name__)
 
 
+def unwrap_if_constexpr(o):
+    return o.value if isinstance(o, tl.constexpr) else o
+
+
 @tl.constexpr
-def get_int_t(num_bits, signed) -> tl.dtype:
+def get_int_t(num_bits: tl.constexpr, signed: tl.constexpr) -> tl.dtype:
+    num_bits = unwrap_if_constexpr(num_bits)
+    signed = unwrap_if_constexpr(signed)
     return tl.core.get_int_dtype(num_bits, signed)
 
 
 @tl.constexpr
-def one_zeros(num_bits) -> int:
+def one_zeros(num_bits: tl.constexpr) -> int:
+    num_bits = unwrap_if_constexpr(num_bits)
     return 1 << (num_bits - 1)
 
 
 @tl.constexpr
-def zero_ones(num_bits) -> int:
+def zero_ones(num_bits: tl.constexpr) -> int:
+    num_bits = unwrap_if_constexpr(num_bits)
     return (1 << (num_bits - 1)) - 1
 
 

--- a/src/flag_gems/ops/sort.py
+++ b/src/flag_gems/ops/sort.py
@@ -12,17 +12,17 @@ logger = logging.getLogger(__name__)
 
 
 @tl.constexpr
-def get_int_t(num_bits: tl.constexpr, signed: tl.constexpr) -> tl.dtype:
+def get_int_t(num_bits, signed) -> tl.dtype:
     return tl.core.get_int_dtype(num_bits, signed)
 
 
 @tl.constexpr
-def one_zeros(num_bits: tl.constexpr) -> int:
+def one_zeros(num_bits) -> int:
     return 1 << (num_bits - 1)
 
 
 @tl.constexpr
-def zero_ones(num_bits: tl.constexpr) -> int:
+def zero_ones(num_bits) -> int:
     return (1 << (num_bits - 1)) - 1
 
 

--- a/src/flag_gems/ops/sort.py
+++ b/src/flag_gems/ops/sort.py
@@ -3,7 +3,6 @@ import logging
 import torch
 import triton
 import triton.language as tl
-from triton.language.core import _unwrap_if_constexpr
 
 from ..runtime import torch_device_fn
 from ..utils import libentry
@@ -14,20 +13,16 @@ logger = logging.getLogger(__name__)
 
 @tl.constexpr
 def get_int_t(num_bits: tl.constexpr, signed: tl.constexpr) -> tl.dtype:
-    num_bits = _unwrap_if_constexpr(num_bits)
-    signed = _unwrap_if_constexpr(signed)
     return tl.core.get_int_dtype(num_bits, signed)
 
 
 @tl.constexpr
 def one_zeros(num_bits: tl.constexpr) -> int:
-    num_bits = _unwrap_if_constexpr(num_bits)
     return 1 << (num_bits - 1)
 
 
 @tl.constexpr
 def zero_ones(num_bits: tl.constexpr) -> int:
-    num_bits = _unwrap_if_constexpr(num_bits)
     return (1 << (num_bits - 1)) - 1
 
 

--- a/src/flag_gems/ops/sort.py
+++ b/src/flag_gems/ops/sort.py
@@ -4,9 +4,9 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from .topk import _get_finfo_val, _get_iinfo_val, argsort
+from flag_gems.ops.topk import _get_finfo_val, _get_iinfo_val, argsort
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/stack.py
+++ b/src/flag_gems/ops/stack.py
@@ -5,8 +5,8 @@ from typing import List, Tuple, Union
 import torch
 import triton
 
-from ..utils import pointwise_dynamic
-from ..utils.tensor_wrapper import StridedBuffer
+from flag_gems.utils import pointwise_dynamic
+from flag_gems.utils.tensor_wrapper import StridedBuffer
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/sub.py
+++ b/src/flag_gems/ops/sub.py
@@ -3,7 +3,7 @@ import logging
 import torch
 import triton
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/sum.py
+++ b/src/flag_gems/ops/sum.py
@@ -5,10 +5,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import dim_compress, libentry, libtuner
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry, libtuner
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/tanh.py
+++ b/src/flag_gems/ops/tanh.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic, tl_extra_shim
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
 
 pow = tl_extra_shim.pow
 _tanh = tl_extra_shim.tanh

--- a/src/flag_gems/ops/threshold.py
+++ b/src/flag_gems/ops/threshold.py
@@ -3,7 +3,7 @@ import logging
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/to.py
+++ b/src/flag_gems/ops/to.py
@@ -3,7 +3,7 @@ import logging
 import torch
 import triton
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/topk.py
+++ b/src/flag_gems/ops/topk.py
@@ -13,10 +13,10 @@ try:
 except ImportError:
     pass
 
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
-from ..utils.limits import get_dtype_max, get_dtype_min
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+from flag_gems.utils.limits import get_dtype_max, get_dtype_min
 
 logger = logging.getLogger(__name__)
 _MIN_FLOAT32_VAL = tl.constexpr(torch.finfo(torch.float32).min)

--- a/src/flag_gems/ops/triu.py
+++ b/src/flag_gems/ops/triu.py
@@ -4,10 +4,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/uniform.py
+++ b/src/flag_gems/ops/uniform.py
@@ -3,14 +3,13 @@ import logging
 import triton
 import triton.language as tl
 
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
 from flag_gems.utils.random_utils import (
     philox_backend_seed_offset,
     uint_to_uniform_float,
 )
 from flag_gems.utils.shape_utils import volume
-
-from .. import runtime
-from ..runtime import torch_device_fn
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/unique.py
+++ b/src/flag_gems/ops/unique.py
@@ -2,10 +2,9 @@ import torch
 import triton
 import triton.language as tl
 
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import triton_lang_extension as tle
 from flag_gems.utils.libentry import libentry
-
-from ..runtime import torch_device_fn
-from ..utils import triton_lang_extension as tle
 
 
 @libentry()

--- a/src/flag_gems/ops/upsample_bicubic2d_aa.py
+++ b/src/flag_gems/ops/upsample_bicubic2d_aa.py
@@ -5,9 +5,9 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import device, torch_device_fn
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import device, torch_device_fn
+from flag_gems.utils import triton_lang_extension as tle
 
 device = device.name
 

--- a/src/flag_gems/ops/upsample_nearest2d.py
+++ b/src/flag_gems/ops/upsample_nearest2d.py
@@ -5,9 +5,9 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import device, torch_device_fn
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import device, torch_device_fn
+from flag_gems.utils import triton_lang_extension as tle
 
 device = device.name
 logger = logging.getLogger(__name__)

--- a/src/flag_gems/ops/var_mean.py
+++ b/src/flag_gems/ops/var_mean.py
@@ -4,10 +4,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import dim_compress, libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/vdot.py
+++ b/src/flag_gems/ops/vdot.py
@@ -5,8 +5,8 @@ import triton
 import triton.language as tl
 from torch import Tensor
 
-from .. import runtime
-from ..utils import libentry
+from flag_gems import runtime
+from flag_gems.utils import libentry
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/vector_norm.py
+++ b/src/flag_gems/ops/vector_norm.py
@@ -5,10 +5,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import dim_compress, libentry, tl_extra_shim
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry, tl_extra_shim
+from flag_gems.utils import triton_lang_extension as tle
 
 pow = tl_extra_shim.pow
 logger = logging.getLogger(__name__)

--- a/src/flag_gems/ops/vstack.py
+++ b/src/flag_gems/ops/vstack.py
@@ -4,10 +4,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import libentry
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/weightnorm.py
+++ b/src/flag_gems/ops/weightnorm.py
@@ -5,10 +5,10 @@ import torch
 import triton
 import triton.language as tl
 
-from .. import runtime
-from ..runtime import torch_device_fn
-from ..utils import libentry, tl_extra_shim
-from ..utils import triton_lang_extension as tle
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, tl_extra_shim
+from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/where.py
+++ b/src/flag_gems/ops/where.py
@@ -4,7 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
-from ..utils import pointwise_dynamic
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/ops/zeros.py
+++ b/src/flag_gems/ops/zeros.py
@@ -4,9 +4,9 @@ import torch
 import triton
 import triton.language as tl
 
-from ..runtime import device, torch_device_fn
-from ..utils import triton_lang_extension as tle
-from ..utils.shape_utils import volume
+from flag_gems.runtime import device, torch_device_fn
+from flag_gems.utils import triton_lang_extension as tle
+from flag_gems.utils.shape_utils import volume
 
 device_ = device
 logger = logging.getLogger(__name__)

--- a/src/flag_gems/ops/zeros_like.py
+++ b/src/flag_gems/ops/zeros_like.py
@@ -3,8 +3,8 @@ import logging
 import torch
 import triton
 
-from ..runtime import torch_device_fn
-from .zeros import zeros_kernel
+from flag_gems.ops.zeros import zeros_kernel
+from flag_gems.runtime import torch_device_fn
 
 logger = logging.getLogger(__name__)
 

--- a/src/flag_gems/testing/__init__.py
+++ b/src/flag_gems/testing/__init__.py
@@ -1,6 +1,6 @@
 import torch
 
-from .. import runtime
+from flag_gems import runtime
 
 if runtime.device.vendor_name == "kunlunxin":
     RESOLUTION = {

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -12,8 +12,9 @@ from typing import Dict, Optional
 
 import triton
 
-from .. import runtime
-from ..runtime import torch_device_fn
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+
 from .code_cache import config_cache_dir
 
 logger = logging.getLogger(__name__)

--- a/src/flag_gems/utils/random_utils.py
+++ b/src/flag_gems/utils/random_utils.py
@@ -3,8 +3,7 @@ import triton
 import triton.language as tl
 
 import flag_gems
-
-from ..runtime import torch_device_fn
+from flag_gems.runtime import torch_device_fn
 
 try:
     uint_to_uniform_float = tl.uint_to_uniform_float

--- a/src/flag_gems/utils/triton_driver_helper.py
+++ b/src/flag_gems/utils/triton_driver_helper.py
@@ -1,5 +1,5 @@
 try:
-    from ..runtime import torch_device_fn
+    from flag_gems.runtime import torch_device_fn
 
     get_device_properties = torch_device_fn.get_device_properties
 except AttributeError:


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Refactor

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Avoid relative imports in python files that contain triton jit functions to allow importing those files as top-level files.

Relative imports make it difficult for files to be run as scripts or imported as top-level. But in triton jit c++ runtime, we need to import the python file as a top-level for triton jit functions defined in standalone scripts to be used.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
