### PR TITLE
add hash key for code in libtuner

### DIFF
--- a/src/flag_gems/ops/all.py
+++ b/src/flag_gems/ops/all.py
@@ -26,7 +26,6 @@ def reduce_all(a, b):
 @libtuner(
     configs=runtime.get_tuned_config("naive_reduction"),
     key=["M", "N"],
-    share="naive_reduction",
 )
 @triton.jit
 def all_kernel_dim(

--- a/src/flag_gems/ops/amax.py
+++ b/src/flag_gems/ops/amax.py
@@ -50,7 +50,6 @@ def amax_kernel_2(mid, out, mid_size, BLOCK_MID: tl.constexpr):
 @libtuner(
     configs=runtime.get_tuned_config("naive_reduction"),
     key=["M", "N"],
-    share="naive_reduction",
 )
 @triton.jit
 def amax_kernel(

--- a/src/flag_gems/ops/any.py
+++ b/src/flag_gems/ops/any.py
@@ -26,7 +26,6 @@ def reduce_any(a, b):
 @libtuner(
     configs=runtime.get_tuned_config("naive_reduction"),
     key=["M", "N"],
-    share="naive_reduction",
 )
 @triton.jit
 def any_kernel_dim(

--- a/src/flag_gems/ops/max.py
+++ b/src/flag_gems/ops/max.py
@@ -54,7 +54,6 @@ def heur_block_n(args):
 @libtuner(
     configs=runtime.get_tuned_config("naive_reduction"),
     key=["M", "N"],
-    share="naive_reduction",
 )
 @triton.jit
 def max_kernel(

--- a/src/flag_gems/ops/mean.py
+++ b/src/flag_gems/ops/mean.py
@@ -64,7 +64,6 @@ def mean(inp, *, dtype=None):
 @libtuner(
     configs=runtime.get_tuned_config("naive_reduction"),
     key=["M", "N"],
-    share="naive_reduction",
 )
 @triton.jit
 def mean_dim_kernel(X, Mean, M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):

--- a/src/flag_gems/ops/min.py
+++ b/src/flag_gems/ops/min.py
@@ -54,7 +54,6 @@ def heur_block_n(args):
 @libtuner(
     configs=runtime.get_tuned_config("naive_reduction"),
     key=["M", "N"],
-    share="naive_reduction",
 )
 @triton.jit
 def min_kernel(

--- a/src/flag_gems/ops/prod.py
+++ b/src/flag_gems/ops/prod.py
@@ -74,7 +74,6 @@ def heur_block_n(args):
 @libtuner(
     configs=runtime.get_tuned_config("naive_reduction"),
     key=["M", "N"],
-    share="naive_reduction",
 )
 @triton.jit
 def prod_kernel(

--- a/src/flag_gems/ops/sum.py
+++ b/src/flag_gems/ops/sum.py
@@ -61,7 +61,6 @@ def sum_kernel_2(mid, out, mid_size, BLOCK_MID: tl.constexpr):
 @libtuner(
     configs=runtime.get_tuned_config("naive_reduction"),
     key=["M", "N"],
-    share="naive_reduction",
 )
 @triton.jit
 def sum_kernel(

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -1,4 +1,5 @@
 import builtins
+import hashlib
 import inspect
 import logging
 import math
@@ -30,6 +31,19 @@ ATTRS = {
 }
 version = triton.__version__.split(".")
 major_version, minor_version = eval(version[0]), eval(version[1])
+
+
+def get_kernel_hash(func, configs):
+    if hasattr(func, "fn"):
+        original_func = func.fn
+    else:
+        original_func = func
+
+    source_code = inspect.getsource(original_func)
+    config_strs = [str(config) for config in configs]
+    combined_content = f"{source_code}{config_strs}"
+    return hashlib.md5(combined_content.encode("utf-8")).hexdigest()[:8]
+
 
 if major_version == 2:
 
@@ -199,9 +213,19 @@ class LibTuner(triton.runtime.Autotuner):
         self.keys = key
         self.strategy = strategy
         self.share = share
-        self.cache = libcache[share] if share else libcache[self.__name__]
+        self.kernel_hash = get_kernel_hash(self.base_fn, self.configs)
+        # Use table name with hash instead of hash in key
+        self.table_name = (
+            f"{share}_{self.kernel_hash}"
+            if share
+            else f"{self.__name__}_{self.kernel_hash}"
+        )
+        self.cache = libcache[self.table_name]
         if strategy:
             assert len(self.strategy) == len(self.keys), "Invalid number of strategies"
+        self.base_fn = fn
+        while not inspect.isfunction(self.base_fn):
+            self.base_fn = self.base_fn.fn
 
     def get_key(self, args):
         if self.strategy is None:

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -215,17 +215,10 @@ class LibTuner(triton.runtime.Autotuner):
         self.share = share
         self.kernel_hash = get_kernel_hash(self.base_fn, self.configs)
         # Use table name with hash instead of hash in key
-        self.table_name = (
-            f"{share}_{self.kernel_hash}"
-            if share
-            else f"{self.__name__}_{self.kernel_hash}"
-        )
+        self.table_name = f"{self.__name__}_{self.kernel_hash}"
         self.cache = libcache[self.table_name]
         if strategy:
             assert len(self.strategy) == len(self.keys), "Invalid number of strategies"
-        self.base_fn = fn
-        while not inspect.isfunction(self.base_fn):
-            self.base_fn = self.base_fn.fn
 
     def get_key(self, args):
         if self.strategy is None:

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -171,7 +171,6 @@ class LibTuner(triton.runtime.Autotuner):
         use_cuda_graph=False,
         do_bench=None,
         strategy=None,
-        share=None,
     ):
         # NOTE(zhengyang): See discussion in https://github.com/triton-lang/triton/pull/4496
         if major_version == 2 or (major_version == 3 and minor_version <= 1):
@@ -212,7 +211,6 @@ class LibTuner(triton.runtime.Autotuner):
         self.__name__ = self.base_fn.__name__
         self.keys = key
         self.strategy = strategy
-        self.share = share
         self.kernel_hash = get_kernel_hash(self.base_fn, self.configs)
         # Use table name with hash instead of hash in key
         self.table_name = f"{self.__name__}_{self.kernel_hash}"
@@ -296,7 +294,6 @@ def libtuner(
     use_cuda_graph=False,
     do_bench=None,
     strategy=None,
-    share=None,
 ):
     """
     Decorator for triton library autotuner.
@@ -318,7 +315,6 @@ def libtuner(
             use_cuda_graph=use_cuda_graph,
             do_bench=do_bench,
             strategy=strategy,
-            share=share,
         )
 
     return decorator


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
libtuner
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
The current libtuner lacks a field representing the code, which may result in enabling outdated cache after modifying the code. To address this issue, this PR has added the md5 value of the source code as the hash key.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
add test UT in `test_libbentry.py` 
```
pytest -s /workspace/FlagGems/tests/test_libentry.py::test_hash_generation 
=============================================================== test session starts ================================================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.9.0, hypothesis-6.130.8, flakefinder-1.1.0, rerunfailures-15.1, shard-0.1.2, xdist-3.6.1, xdoctest-1.0.2, typeguard-4.3.0
collected 1 item                                                                                                                                   
Running 1 items in this shard

tests/test_libentry.py .

================================================================= warnings summary =================================================================
../../usr/local/lib/python3.12/dist-packages/triton/runtime/autotuner.py:105: 11 warnings
tests/test_libentry.py: 3 warnings
  /usr/local/lib/python3.12/dist-packages/triton/runtime/autotuner.py:105: DeprecationWarning: warmup, rep, and use_cuda_graph parameters are deprecated. See https://github.com/triton-lang/triton/pull/4496 for details.
    warnings.warn(("warmup, rep, and use_cuda_graph parameters are deprecated. See "

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
========================================================== 1 passed, 14 warnings in 0.10s ==========================================================
```