### PR TITLE
add .venv to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ bin-release/
 __pycache__/
 .vscode/
 
+# Python venv directory
+.venv
+
 # Distribution files
 build/
 *.egg-info/


### PR DESCRIPTION
### PR Category
Other

### Type of Change
Other

### Description
Add `.venv` to `.gitignore` so python-venv related files won't be added to the git wrongly.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
