### PR TITLE
modify: use jitFuntion cache_key instead of source code as hash

### DIFF
--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -214,9 +214,7 @@ class LibTuner(triton.runtime.Autotuner):
             func_hash = jit_fn.cache_key
             config_strs = [str(config) for config in self.configs]
             combined_content = f"{func_hash}{config_strs}"
-            self.kernel_hash = hashlib.md5(
-                combined_content.encode("utf-8")
-            ).hexdigest()[:8]
+            self.kernel_hash = hashlib.md5(combined_content.encode("utf-8")).hexdigest()
         return self.kernel_hash
 
     def get_key(self, args):

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -33,18 +33,6 @@ version = triton.__version__.split(".")
 major_version, minor_version = eval(version[0]), eval(version[1])
 
 
-def get_kernel_hash(func, configs):
-    if hasattr(func, "fn"):
-        original_func = func.fn
-    else:
-        original_func = func
-
-    source_code = inspect.getsource(original_func)
-    config_strs = [str(config) for config in configs]
-    combined_content = f"{source_code}{config_strs}"
-    return hashlib.md5(combined_content.encode("utf-8")).hexdigest()[:8]
-
-
 if major_version == 2:
 
     def all_kwargs(self):
@@ -211,12 +199,22 @@ class LibTuner(triton.runtime.Autotuner):
         self.__name__ = self.base_fn.__name__
         self.keys = key
         self.strategy = strategy
-        self.kernel_hash = get_kernel_hash(self.base_fn, self.configs)
         # Use table name with hash instead of hash in key
+        self.kernel_hash = self.get_kernel_hash
         self.table_name = f"{self.__name__}_{self.kernel_hash}"
         self.cache = libcache[self.table_name]
         if strategy:
             assert len(self.strategy) == len(self.keys), "Invalid number of strategies"
+
+    def get_kernel_hash(self):
+        if self.kernel_hash is None:
+            func_hash = self.fn.cache_key
+            config_strs = [str(config) for config in self.configs]
+            combined_content = f"{func_hash}{config_strs}"
+            self.kernel_hash = hashlib.md5(
+                combined_content.encode("utf-8")
+            ).hexdigest()[:8]
+        return self.kernel_hash
 
     def get_key(self, args):
         if self.strategy is None:

--- a/tests/test_libentry.py
+++ b/tests/test_libentry.py
@@ -237,10 +237,6 @@ def test_threadsafety():
             run_two_threads()
 
 
-@pytest.mark.skipif(
-    flag_gems.vendor_name == "kunlunxin",
-    reason="Test Files for Operators Not Pending Testing",
-)
 def test_hash_generation():
     @libtuner(
         configs=[
@@ -291,10 +287,6 @@ def test_hash_generation():
     assert kernel_a.kernel_hash != kernel_b.kernel_hash
 
 
-@pytest.mark.skipif(
-    flag_gems.vendor_name == "kunlunxin",
-    reason="Test Files for Operators Not Pending Testing",
-)
 def test_hash_changes_when_dependency_modified():
     @triton.jit
     def sub_func(x, y):

--- a/tests/test_libentry.py
+++ b/tests/test_libentry.py
@@ -289,3 +289,70 @@ def test_hash_generation():
 
     assert kernel_a.kernel_hash != kernel_a_copy.kernel_hash
     assert kernel_a.kernel_hash != kernel_b.kernel_hash
+
+
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "kunlunxin",
+    reason="Test Files for Operators Not Pending Testing",
+)
+def test_hash_changes_when_dependency_modified():
+    @triton.jit
+    def sub_func(x, y):
+        return x + y
+
+    @libtuner(
+        configs=[
+            triton.Config({"TILE_N": 32}),
+            triton.Config({"TILE_N": 64}),
+        ],
+        key=["x"],
+    )
+    @triton.jit
+    def main_kernel(x, y):
+        return sub_func(x, y) * 2
+
+    original_hash = main_kernel.kernel_hash
+
+    @triton.jit
+    def sub_func(x, y):  # noqa:F811
+        return x + y + 1
+
+    @libtuner(
+        configs=[
+            triton.Config({"TILE_N": 32}),
+            triton.Config({"TILE_N": 64}),
+        ],
+        key=["x"],
+    )
+    @triton.jit
+    def main_kernel(x, y):
+        return sub_func(x, y) * 2
+
+    modified_hash = main_kernel.kernel_hash
+
+    assert original_hash != modified_hash, (
+        f"Expected different hashes when sub-function changes, "
+        f"but got same hash: {original_hash}"
+    )
+    original_hash = modified_hash
+
+    @triton.jit
+    def sub_func(x, y, z=0):  # noqa:F811
+        return x + y + z
+
+    @libtuner(
+        configs=[
+            triton.Config({"TILE_N": 32}),
+            triton.Config({"TILE_N": 64}),
+        ],
+        key=["x"],
+    )
+    @triton.jit
+    def main_kernel(x, y):
+        return sub_func(x, y) * 2
+
+    modified_hash = main_kernel.kernel_hash
+    assert original_hash != modified_hash, (
+        f"Expected different hashes when sub-function changes, "
+        f"but got same hash: {original_hash}"
+    )


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
libtuner hash value
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Now, the method of hash generation is use source code of kernel function. This will result in changes to the subfunction not being reflected in the hash value. 
So, This PR use jitFuntion cache_key instead of source code as hash.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->