### PR TITLE
find libtorch_python and add it as a public dependency for c_operator…

### DIFF
--- a/cmake/FindTorch.cmake
+++ b/cmake/FindTorch.cmake
@@ -10,7 +10,7 @@ endif()
 find_package(Torch CONFIG REQUIRED)
 
 # message(STATUS "TORCH_INSTALL_PREFIX: ${TORCH_INSTALL_PREFIX}")
-# message(STATUS "TORCH_LIBRARIES: ${TORCH_LIBRARIES}")
+message(STATUS "TORCH_LIBRARIES: ${TORCH_LIBRARIES}")
 # get_target_property(TMP_TORCH_LINKED_LIBRARIES torch INTERFACE_LINK_LIBRARIES)
 # message(STATUS "torch linked libraries: ${TMP_TORCH_LINKED_LIBRARIES}")
 
@@ -29,6 +29,17 @@ if (NOT TARGET Torch::Torch)
   target_include_directories(Torch::Torch INTERFACE ${TORCH_INCLUDE_DIRS})
   target_link_libraries(Torch::Torch INTERFACE ${TORCH_LIBRARIES})
   target_compile_options(Torch::Torch INTERFACE ${TORCH_CXX_FLAGS})
+
+  # add torch_python
+  add_library(Torch::Torch_Python INTERFACE IMPORTED)
+  find_library(torch_python_lib
+    NAMES torch_python
+    PATHS "${TORCH_INSTALL_PREFIX}/lib"
+    REQUIRED)
+  message(STATUS "find torch_python lib: ${torch_python_lib}")
+  target_include_directories(Torch::Torch_Python INTERFACE ${TORCH_INCLUDE_DIRS})
+  target_link_libraries(Torch::Torch_Python INTERFACE ${torch_python_lib})
+  target_compile_options(Torch::Torch_Python INTERFACE ${TORCH_CXX_FLAGS})
 endif()
 
 # Since multiple libraries or executables need to link each other, while the torch

--- a/src/flag_gems/csrc/CMakeLists.txt
+++ b/src/flag_gems/csrc/CMakeLists.txt
@@ -1,5 +1,5 @@
 pybind11_add_module(c_operators cstub.cpp)
-target_link_libraries(c_operators PRIVATE operators)
+target_link_libraries(c_operators PUBLIC Torch::Torch_Python PRIVATE operators)
 set_target_properties(c_operators PROPERTIES
   INSTALL_RPATH "${_rpath_portable_origin}/${CMAKE_INSTALL_LIBDIR}")
 

--- a/src/flag_gems/csrc/cstub.cpp
+++ b/src/flag_gems/csrc/cstub.cpp
@@ -1,9 +1,20 @@
 #include <pybind11/pybind11.h>
+#include "torch/python.h"
+
 #include "flag_gems/operators.h"
 
 // TODO: use pytorch's argparse utilities to generate CPython bindings, since it is more efficient than
 // bindings provided by torch library, since it is in a boxed fashion
 PYBIND11_MODULE(c_operators, m) {
+  m.def("sum_dim", &flag_gems::sum_dim);
+  m.def("add_tensor", &flag_gems::add_tensor);
+  m.def("rms_norm", &flag_gems::rms_norm);
+  m.def("fused_add_rms_norm", &flag_gems::fused_add_rms_norm);
+  m.def("nonzero", &flag_gems::nonzero);
+  // Rotary embedding
+  m.def("rotary_embedding", &flag_gems::rotary_embedding);
+  m.def("rotary_embedding_inplace", &flag_gems::rotary_embedding_inplace);
+  m.def("bmm", &flag_gems::bmm);
 }
 
 namespace flag_gems {


### PR DESCRIPTION


### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
User Experience

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Other


### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
1. Find `libtorch_python` and add it as a public dependency for c_operators since we need the type casters to convert between `at::Tensor` and `torch.Tensor`; 
2. Add pybind11 bindings for functions that allow direct calling from Python without informing the dispatcher.

Now the functions can be called directly from Python, with less overhead. For example

```python
In [1]: import torch

In [2]: import flag_gems

In [3]: x = torch.randn(3, 4, device="cuda")

In [4]: y = torch.randn(3, 1, device="cuda")

In [5]: flag_gems.c_operators.add_tensor(x, y)
Out[5]:
tensor([[ 0.3405,  0.1082,  0.5256, -1.4614],
        [-0.1293, -1.3989, -0.5827,  0.2036],
        [-2.1844, -1.4068, -0.8833, -2.4983]], device='cuda:0')
```


### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
