### PR TITLE
update op of cat

### DIFF
--- a/src/flag_gems/ops/cat.py
+++ b/src/flag_gems/ops/cat.py
@@ -43,6 +43,7 @@ def copy_func_kernel(
 def cat(
     A: Union[Tuple[torch.Tensor, ...], List[torch.Tensor]], dim: int = 0
 ) -> torch.Tensor:
+    logger.debug("GEMS CAT")
     if len(A) == 0:
         raise RuntimeError("torch.cat(): expected a non-empty list of Tensors")
     if len(A) == 1:

--- a/src/flag_gems/ops/cat.py
+++ b/src/flag_gems/ops/cat.py
@@ -9,38 +9,6 @@ logger = logging.getLogger(__name__)
 
 
 @triton.jit
-def copy_func_kernel(
-    out_ptr,
-    in_ptr,
-    dim_size_in,
-    dim_size_out,
-    dim_prod_post,
-    dim_offset,
-    total_elements,
-    BLOCK: tl.constexpr,
-):
-    pid = tl.program_id(0)
-    block_start = pid * BLOCK
-    offsets = tl.arange(0, BLOCK)
-    mask = block_start + offsets < total_elements
-
-    idx = block_start + offsets
-
-    pre_idx = idx // (dim_size_in * dim_prod_post)
-    dim_idx = (idx // dim_prod_post) % dim_size_in
-    post_idx = idx % dim_prod_post
-
-    out_idx = (
-        pre_idx * dim_size_out * dim_prod_post
-        + (dim_idx + dim_offset) * dim_prod_post
-        + post_idx
-    )
-
-    data = tl.load(in_ptr + idx, mask=mask)
-    tl.store(out_ptr + out_idx, data, mask=mask)
-
-
-@triton.jit
 def cat_copy_func_kernel_4(
     out_ptr,
     in_ptr_a,

--- a/src/flag_gems/ops/cat.py
+++ b/src/flag_gems/ops/cat.py
@@ -41,7 +41,7 @@ def copy_func_kernel(
 
 
 @triton.jit
-def copy_func_kernel_4(
+def cat_copy_func_kernel_4(
     out_ptr,
     in_ptr_a,
     in_ptr_b,
@@ -198,7 +198,7 @@ def cat(
             total_elements_d,
         ) = args
 
-        copy_func_kernel_4[grid](
+        cat_copy_func_kernel_4[grid](
             out,
             tensor_a,
             tensor_b,

--- a/src/flag_gems/ops/cat.py
+++ b/src/flag_gems/ops/cat.py
@@ -40,6 +40,73 @@ def copy_func_kernel(
     tl.store(out_ptr + out_idx, data, mask=mask)
 
 
+@triton.jit
+def copy_func_kernel_4(
+    out_ptr,
+    in_ptr_a,
+    in_ptr_b,
+    in_ptr_c,
+    in_ptr_d,
+    dim_size_in_a,
+    dim_size_in_b,
+    dim_size_in_c,
+    dim_size_in_d,
+    dim_size_out,
+    dim_prod_post,
+    dim_offset_a,
+    dim_offset_b,
+    dim_offset_c,
+    dim_offset_d,
+    total_elements_a,
+    total_elements_b,
+    total_elements_c,
+    total_elements_d,
+    BLOCK_X: tl.constexpr,
+):
+    pid_x = tl.program_id(0)
+    pid_y = tl.program_id(1)
+
+    if pid_y == 0:
+        in_ptr = in_ptr_a
+        dim_size_in = dim_size_in_a
+        dim_offset = dim_offset_a
+        total_elements = total_elements_a
+    elif pid_y == 1:
+        in_ptr = in_ptr_b
+        dim_size_in = dim_size_in_b
+        dim_offset = dim_offset_b
+        total_elements = total_elements_b
+    elif pid_y == 2:
+        in_ptr = in_ptr_c
+        dim_size_in = dim_size_in_c
+        dim_offset = dim_offset_c
+        total_elements = total_elements_c
+    else:
+        in_ptr = in_ptr_d
+        dim_size_in = dim_size_in_d
+        dim_offset = dim_offset_d
+        total_elements = total_elements_d
+
+    block_start = pid_x * BLOCK_X
+    offsets = tl.arange(0, BLOCK_X)
+    mask = block_start + offsets < total_elements
+
+    idx = block_start + offsets
+
+    pre_idx = idx // (dim_size_in * dim_prod_post)
+    dim_idx = (idx // dim_prod_post) % dim_size_in
+    post_idx = idx % dim_prod_post
+
+    out_idx = (
+        pre_idx * dim_size_out * dim_prod_post
+        + (dim_idx + dim_offset) * dim_prod_post
+        + post_idx
+    )
+
+    data = tl.load(in_ptr + idx, mask=mask)
+    tl.store(out_ptr + out_idx, data, mask=mask)
+
+
 def cat(
     A: Union[Tuple[torch.Tensor, ...], List[torch.Tensor]], dim: int = 0
 ) -> torch.Tensor:
@@ -50,10 +117,9 @@ def cat(
         return A[0]
 
     assert dim >= -A[0].ndim and dim < A[0].ndim, f"Invalid dim: {dim}"
-    # Convert negative dim to positive
-    dim = dim % A[0].ndim
+    dim %= A[0].ndim
 
-    # Same rank check
+    # Validation checks
     inp_shapes = [list(_.shape) for _ in A]
     inp0_shape = inp_shapes[0]
     for s in inp_shapes[1:]:
@@ -61,23 +127,17 @@ def cat(
             raise RuntimeError(
                 f"Tensors must have same number of dimensions: got {len(inp0_shape)} and {len(s)}"
             )
-    # Same size check
     for tensor_idx, inp_shape in enumerate(inp_shapes):
         for idx, (common_length, length) in enumerate(zip(inp0_shape, inp_shape)):
-            if idx == dim:
-                continue
-            elif length != common_length:
+            if idx != dim and length != common_length:
                 raise RuntimeError(
                     f"Sizes of tensors must match except in dimension {dim}. "
                     f"Expected size {common_length} but got size {length} for tensor number "
                     f"{tensor_idx} in the list"
                 )
 
-    dtype = A[0].dtype
-    device = A[0].device
-    ndims = A[0].ndim
+    dtype, device = A[0].dtype, A[0].device
     shapes = [t.shape for t in A]
-
     cat_dim_sizes = [s[dim] for s in shapes]
     out_shape = list(shapes[0])
     out_shape[dim] = sum(cat_dim_sizes)
@@ -86,31 +146,82 @@ def cat(
     BLOCK = 1024
     dim_offset = 0
 
-    for i, tensor in enumerate(A):
-        tensor_shape = tensor.shape
+    i = 0
+    while i < len(A):
+        tensors_in_batch = A[i : i + 4]
+        num_tensors_in_batch = len(tensors_in_batch)
 
-        dim_size_in = tensor_shape[dim]
+        args = []
+        total_elements_list = []
+        current_dim_offset = dim_offset
+
+        for j in range(4):
+            if j < num_tensors_in_batch:
+                tensor = tensors_in_batch[j].contiguous()
+                shape = tensor.shape
+                total_elements = tensor.numel()
+                dim_size_in = shape[dim]
+
+                args.extend([tensor, dim_size_in, current_dim_offset, total_elements])
+                total_elements_list.append(total_elements)
+                current_dim_offset += dim_size_in
+            else:
+                # Add placeholders for unused tensor slots
+                args.extend([tensors_in_batch[0], 0, 0, 0])
+                total_elements_list.append(0)
+
         dim_size_out = out_shape[dim]
-
         dim_prod_post = 1
-        for d in range(dim + 1, ndims):
-            dim_prod_post *= tensor_shape[d]
+        for d in range(dim + 1, A[0].ndim):
+            dim_prod_post *= A[0].shape[d]
 
-        total_elements = tensor.numel()
+        grid_y = num_tensors_in_batch
+        max_elements_in_batch = max(total_elements_list) if total_elements_list else 0
+        grid = (triton.cdiv(max_elements_in_batch, BLOCK), grid_y)
 
-        grid = lambda meta: (triton.cdiv(total_elements, BLOCK),)
+        (
+            tensor_a,
+            dim_size_in_a,
+            dim_offset_a,
+            total_elements_a,
+            tensor_b,
+            dim_size_in_b,
+            dim_offset_b,
+            total_elements_b,
+            tensor_c,
+            dim_size_in_c,
+            dim_offset_c,
+            total_elements_c,
+            tensor_d,
+            dim_size_in_d,
+            dim_offset_d,
+            total_elements_d,
+        ) = args
 
-        copy_func_kernel[grid](
+        copy_func_kernel_4[grid](
             out,
-            tensor,
-            dim_size_in,
+            tensor_a,
+            tensor_b,
+            tensor_c,
+            tensor_d,
+            dim_size_in_a,
+            dim_size_in_b,
+            dim_size_in_c,
+            dim_size_in_d,
             dim_size_out,
             dim_prod_post,
-            dim_offset,
-            total_elements,
-            BLOCK=BLOCK,
+            dim_offset_a,
+            dim_offset_b,
+            dim_offset_c,
+            dim_offset_d,
+            total_elements_a,
+            total_elements_b,
+            total_elements_c,
+            total_elements_d,
+            BLOCK_X=BLOCK,
         )
 
-        dim_offset += dim_size_in
+        dim_offset = current_dim_offset
+        i += num_tensors_in_batch
 
     return out

--- a/src/flag_gems/ops/cat.py
+++ b/src/flag_gems/ops/cat.py
@@ -119,7 +119,7 @@ def cat(
     assert dim >= -A[0].ndim and dim < A[0].ndim, f"Invalid dim: {dim}"
     dim %= A[0].ndim
 
-    # Validation checks
+    # Same rank check
     inp_shapes = [list(_.shape) for _ in A]
     inp0_shape = inp_shapes[0]
     for s in inp_shapes[1:]:


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
```
benchmark/test_tensor_concat_perf.py 
Operator: cat  Performance Test (dtype=torch.float16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.006832            0.005984               1.142          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': 0})
SUCCESS               0.006656            0.005952               1.118          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': -1})
SUCCESS               0.007136            0.006464               1.104          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': 0})
SUCCESS               0.007168            0.006464               1.109          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': -1})
SUCCESS               0.012192            0.007360               1.657          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': 0})
SUCCESS               0.008352            0.007360               1.135          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': -1})
SUCCESS               0.009344            0.008448               1.106          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': 0})
SUCCESS               0.009376            0.008384               1.118          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': -1})
SUCCESS               0.011488            0.010496               1.095          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': 0})
SUCCESS               0.011616            0.010624               1.093          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': -1})
SUCCESS               0.006816            0.006304               1.081          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': 0})
SUCCESS               0.006880            0.006080               1.132          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': -1})
SUCCESS               0.006976            0.006240               1.118          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': 0})
SUCCESS               0.007200            0.006240               1.154          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': -1})
SUCCESS               0.009344            0.008480               1.102          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': 0})
SUCCESS               0.009376            0.008448               1.110          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': -1})
SUCCESS               0.006816            0.005984               1.139          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': 0})
SUCCESS               0.006656            0.006112               1.089          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': -1})
SUCCESS               0.007104            0.006400               1.110          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': 0})
SUCCESS               0.007168            0.006592               1.087          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': -1})


Operator: cat  Performance Test (dtype=torch.float32, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.006880            0.006144               1.120          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': 0})
SUCCESS               0.006912            0.006080               1.137          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': -1})
SUCCESS               0.007392            0.006816               1.085          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': 0})
SUCCESS               0.007584            0.006688               1.134          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': -1})
SUCCESS               0.009152            0.008640               1.059          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': 0})
SUCCESS               0.009344            0.008448               1.106          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': -1})
SUCCESS               0.011360            0.010528               1.079          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': 0})
SUCCESS               0.011264            0.010336               1.090          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': -1})
SUCCESS               0.017792            0.014912               1.193          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': 0})
SUCCESS               0.015840            0.014880               1.065          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': -1})
SUCCESS               0.006848            0.006944               0.986          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': 0})
SUCCESS               0.006688            0.006720               0.995          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': -1})
SUCCESS               0.007104            0.006464               1.099          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': 0})
SUCCESS               0.007296            0.006368               1.146          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': -1})
SUCCESS               0.011360            0.010720               1.060          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': 0})
SUCCESS               0.011360            0.010464               1.086          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': -1})
SUCCESS               0.006752            0.006080               1.111          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': 0})
SUCCESS               0.006816            0.006752               1.009          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': -1})
SUCCESS               0.007808            0.006816               1.146          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': 0})
SUCCESS               0.007968            0.006880               1.158          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': -1})


Operator: cat  Performance Test (dtype=torch.bfloat16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.006656            0.005952               1.118          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': 0})
SUCCESS               0.006656            0.005984               1.112          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': -1})
SUCCESS               0.007136            0.006400               1.115          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': 0})
SUCCESS               0.007104            0.006400               1.110          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': -1})
SUCCESS               0.008448            0.007488               1.128          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': 0})
SUCCESS               0.008448            0.007488               1.128          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': -1})
SUCCESS               0.009568            0.008416               1.137          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': 0})
SUCCESS               0.009504            0.008384               1.134          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': -1})
SUCCESS               0.011776            0.010752               1.095          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': 0})
SUCCESS               0.011808            0.010752               1.098          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': -1})
SUCCESS               0.006816            0.006272               1.087          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': 0})
SUCCESS               0.006880            0.006080               1.132          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': -1})
SUCCESS               0.007168            0.006240               1.149          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': 0})
SUCCESS               0.007008            0.006240               1.123          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': -1})
SUCCESS               0.009568            0.008416               1.137          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': 0})
SUCCESS               0.009504            0.008352               1.138          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': -1})
SUCCESS               0.006784            0.006048               1.122          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': 0})
SUCCESS               0.006656            0.006208               1.072          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': -1})
SUCCESS               0.007104            0.006400               1.110          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': 0})
SUCCESS               0.007392            0.006592               1.121          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': -1})


Operator: cat  Performance Test (dtype=torch.int16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.006656            0.005984               1.112          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': 0})
SUCCESS               0.006656            0.006016               1.106          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': -1})
SUCCESS               0.007296            0.006400               1.140          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': 0})
SUCCESS               0.007296            0.006400               1.140          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': -1})
SUCCESS               0.008480            0.007456               1.137          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': 0})
SUCCESS               0.008448            0.007456               1.133          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': -1})
SUCCESS               0.009536            0.008416               1.133          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': 0})
SUCCESS               0.009280            0.008352               1.111          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': -1})
SUCCESS               0.011744            0.010752               1.092          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': 0})
SUCCESS               0.011584            0.010720               1.081          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': -1})
SUCCESS               0.006624            0.006336               1.045          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': 0})
SUCCESS               0.006656            0.006048               1.101          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': -1})
SUCCESS               0.007136            0.006208               1.149          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': 0})
SUCCESS               0.007200            0.006208               1.160          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': -1})
SUCCESS               0.009568            0.008384               1.141          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': 0})
SUCCESS               0.009472            0.008352               1.134          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': -1})
SUCCESS               0.006656            0.006016               1.106          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': 0})
SUCCESS               0.006656            0.030208               0.220          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': -1})
SUCCESS               0.007520            0.006368               1.181          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': 0})
SUCCESS               0.007168            0.006592               1.087          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': -1})


Operator: cat  Performance Test (dtype=torch.int32, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.006880            0.006176               1.114          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': 0})
SUCCESS               0.006656            0.006080               1.095          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': -1})
SUCCESS               0.007584            0.006784               1.118          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': 0})
SUCCESS               0.007584            0.006688               1.134          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': -1})
SUCCESS               0.009088            0.008512               1.068          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': 0})
SUCCESS               0.009248            0.008320               1.112          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': -1})
SUCCESS               0.011584            0.010688               1.084          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': 0})
SUCCESS               0.011552            0.010464               1.104          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': -1})
SUCCESS               0.015552            0.014816               1.050          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': 0})
SUCCESS               0.015968            0.014944               1.069          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': -1})
SUCCESS               0.006656            0.006944               0.959          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': 0})
SUCCESS               0.006688            0.006688               1.000          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': -1})
SUCCESS               0.007136            0.006464               1.104          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': 0})
SUCCESS               0.007104            0.006368               1.116          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': -1})
SUCCESS               0.011360            0.010688               1.063          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': 0})
SUCCESS               0.011552            0.010496               1.101          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': -1})
SUCCESS               0.006976            0.006176               1.130          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': 0})
SUCCESS               0.007040            0.006720               1.048          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': -1})
SUCCESS               0.007584            0.006816               1.113          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': 0})
SUCCESS               0.007744            0.006944               1.115          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': -1})
```