### PR TITLE
udpate stack

### DIFF
--- a/src/flag_gems/ops/stack.py
+++ b/src/flag_gems/ops/stack.py
@@ -1,20 +1,76 @@
-import itertools
 import logging
 from typing import List, Tuple, Union
 
 import torch
 import triton
-
-from flag_gems.utils import pointwise_dynamic
-from flag_gems.utils.tensor_wrapper import StridedBuffer
+import triton.language as tl
 
 logger = logging.getLogger(__name__)
 
 
-@pointwise_dynamic(is_tensor=[True], promotion_methods=[(0, "DEFAULT")])
 @triton.jit
-def copy_func(x):
-    return x
+def stack_copy_func_kernel_4(
+    out_ptr,
+    in_ptr_a,
+    in_ptr_b,
+    in_ptr_c,
+    in_ptr_d,
+    dim_size_in_a,
+    dim_size_in_b,
+    dim_size_in_c,
+    dim_size_in_d,
+    dim_size_out,
+    dim_prod_post,
+    dim_offset_a,
+    dim_offset_b,
+    dim_offset_c,
+    dim_offset_d,
+    total_elements_a,
+    total_elements_b,
+    total_elements_c,
+    total_elements_d,
+    BLOCK_X: tl.constexpr,
+):
+    pid_x = tl.program_id(0)
+    pid_y = tl.program_id(1)
+
+    if pid_y == 0:
+        in_ptr = in_ptr_a
+        dim_size_in = dim_size_in_a
+        dim_offset = dim_offset_a
+        total_elements = total_elements_a
+    elif pid_y == 1:
+        in_ptr = in_ptr_b
+        dim_size_in = dim_size_in_b
+        dim_offset = dim_offset_b
+        total_elements = total_elements_b
+    elif pid_y == 2:
+        in_ptr = in_ptr_c
+        dim_size_in = dim_size_in_c
+        dim_offset = dim_offset_c
+        total_elements = total_elements_c
+    else:
+        in_ptr = in_ptr_d
+        dim_size_in = dim_size_in_d
+        dim_offset = dim_offset_d
+        total_elements = total_elements_d
+
+    block_start = pid_x * BLOCK_X
+    offsets = tl.arange(0, BLOCK_X)
+    mask = block_start + offsets < total_elements
+
+    idx = block_start + offsets
+
+    pre_idx = idx // (dim_size_in * dim_prod_post)
+    post_idx = idx % dim_prod_post
+    pre_idx = idx // dim_prod_post
+
+    out_idx = (
+        pre_idx * dim_size_out * dim_prod_post + dim_offset * dim_prod_post + post_idx
+    )
+
+    data = tl.load(in_ptr + idx, mask=mask)
+    tl.store(out_ptr + out_idx, data, mask=mask)
 
 
 def stack(
@@ -42,18 +98,80 @@ def stack(
     if dim < 0:
         dim = dim + len(inp0_shape) + 1
 
-    in0_shape = inp0_shape[:dim] + [1] + inp0_shape[dim:]
+    dtype, device = tensors[0].dtype, tensors[0].device
     out_shape = inp0_shape[:dim] + [len(tensors)] + inp0_shape[dim:]
-    out0 = torch.empty(out_shape, dtype=tensors[0].dtype, device=tensors[0].device)
-    out0_strides = out0.stride()
-    out0_offsets = list(
-        itertools.accumulate([out0_strides[dim] for _ in inp_shapes[:-1]], initial=0)
-    )
+    out = torch.empty(out_shape, dtype=dtype, device=device)
 
-    for a, out0_offset in zip(tensors, out0_offsets):
-        a = a.reshape(in0_shape)
-        in_view = StridedBuffer(a, in0_shape, a.stride())
-        out_view = StridedBuffer(out0, in0_shape, out0.stride(), offset=out0_offset)
-        copy_func.instantiate(a.ndim)(in_view, out0=out_view)
+    dim_prod_post = 1
+    for s in inp0_shape[dim:]:
+        dim_prod_post *= s
 
-    return out0
+    BLOCK = 1024
+    i = 0
+    while i < len(tensors):
+        tensors_in_batch = tensors[i : i + 4]
+        num_tensors_in_batch = len(tensors_in_batch)
+
+        args = []
+        total_elements_list = []
+
+        for j in range(4):
+            if j < num_tensors_in_batch:
+                tensor = tensors_in_batch[j].contiguous()
+                total_elements = tensor.numel()
+                args.extend([tensor, 1, i + j, total_elements])
+                total_elements_list.append(total_elements)
+            else:
+                args.extend([tensors_in_batch[0], 0, 0, 0])
+                total_elements_list.append(0)
+
+        dim_size_out = len(tensors)
+
+        grid_y = num_tensors_in_batch
+        max_elements_in_batch = tensors[0].numel() if total_elements_list else 0
+        grid = (triton.cdiv(max_elements_in_batch, BLOCK), grid_y)
+
+        (
+            tensor_a,
+            dim_size_in_a,
+            dim_offset_a,
+            total_elements_a,
+            tensor_b,
+            dim_size_in_b,
+            dim_offset_b,
+            total_elements_b,
+            tensor_c,
+            dim_size_in_c,
+            dim_offset_c,
+            total_elements_c,
+            tensor_d,
+            dim_size_in_d,
+            dim_offset_d,
+            total_elements_d,
+        ) = args
+
+        stack_copy_func_kernel_4[grid](
+            out,
+            tensor_a,
+            tensor_b,
+            tensor_c,
+            tensor_d,
+            dim_size_in_a,
+            dim_size_in_b,
+            dim_size_in_c,
+            dim_size_in_d,
+            dim_size_out,
+            dim_prod_post,
+            dim_offset_a,
+            dim_offset_b,
+            dim_offset_c,
+            dim_offset_d,
+            total_elements_a,
+            total_elements_b,
+            total_elements_c,
+            total_elements_d,
+            BLOCK_X=BLOCK,
+        )
+        i += num_tensors_in_batch
+
+    return out


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
```
benchmark/test_tensor_concat_perf.py 
Operator: stack  Performance Test (dtype=torch.float16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.006784            0.005920               1.146          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': 0})
SUCCESS               0.006688            0.006080               1.100          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': -1})
SUCCESS               0.007360            0.006432               1.144          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': 0})
SUCCESS               0.007456            0.006496               1.148          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': -1})
SUCCESS               0.008640            0.007360               1.174          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': 0})
SUCCESS               0.012128            0.007904               1.534          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': -1})
SUCCESS               0.009568            0.008384               1.141          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': 0})
SUCCESS               0.016576            0.009696               1.710          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': -1})
SUCCESS               0.011552            0.010432               1.107          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': 0})
SUCCESS               0.027328            0.013792               1.981          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': -1})
SUCCESS               0.006624            0.005920               1.119          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': 0})
SUCCESS               0.006688            0.006048               1.106          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': -1})
SUCCESS               0.007200            0.006240               1.154          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': 0})
SUCCESS               0.007008            0.006400               1.095          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': -1})
SUCCESS               0.009536            0.008480               1.125          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': 0})
SUCCESS               0.016544            0.009728               1.701          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': -1})
SUCCESS               0.006624            0.006048               1.095          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': 0})
SUCCESS               0.006944            0.006112               1.136          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': -1})
SUCCESS               0.007136            0.006432               1.109          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': 0})
SUCCESS               0.007808            0.006496               1.202          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': -1})


Operator: stack  Performance Test (dtype=torch.float32, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.006912            0.006080               1.137          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': 0})
SUCCESS               0.007104            0.006272               1.133          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': -1})
SUCCESS               0.007360            0.006656               1.106          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': 0})
SUCCESS               0.007680            0.006944               1.106          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': -1})
SUCCESS               0.009376            0.008512               1.102          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': 0})
SUCCESS               0.012704            0.009856               1.289          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': -1})
SUCCESS               0.011424            0.010368               1.102          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': 0})
SUCCESS               0.020576            0.013728               1.499          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': -1})
SUCCESS               0.015840            0.014688               1.078          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': 0})
SUCCESS               0.041040            0.026976               1.521          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': -1})
SUCCESS               0.006848            0.006048               1.132          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': 0})
SUCCESS               0.007072            0.006240               1.133          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': -1})
SUCCESS               0.007328            0.006432               1.139          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': 0})
SUCCESS               0.007520            0.006624               1.135          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': -1})
SUCCESS               0.011616            0.010480               1.108          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': 0})
SUCCESS               0.022848            0.015328               1.491          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': -1})
SUCCESS               0.006816            0.006080               1.121          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': 0})
SUCCESS               0.006944            0.006240               1.113          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': -1})
SUCCESS               0.007584            0.006624               1.145          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': 0})
SUCCESS               0.007968            0.006848               1.164          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': -1})


Operator: stack  Performance Test (dtype=torch.bfloat16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.006656            0.006048               1.101          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': 0})
SUCCESS               0.006720            0.006112               1.099          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': -1})
SUCCESS               0.007360            0.006432               1.144          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': 0})
SUCCESS               0.007264            0.006528               1.113          ([[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]], {'dim': -1})
SUCCESS               0.008480            0.007456               1.137          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': 0})
SUCCESS               0.012064            0.007840               1.539          ([[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]], {'dim': -1})
SUCCESS               0.009568            0.008384               1.141          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': 0})
SUCCESS               0.016864            0.009728               1.734          ([[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]], {'dim': -1})
SUCCESS               0.011808            0.010752               1.098          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': 0})
SUCCESS               0.028480            0.016288               1.749          ([[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]], {'dim': -1})
SUCCESS               0.006816            0.005920               1.151          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': 0})
SUCCESS               0.006688            0.006048               1.106          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': -1})
SUCCESS               0.006944            0.006240               1.113          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': 0})
SUCCESS               0.007008            0.006272               1.117          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': -1})
SUCCESS               0.009600            0.008288               1.158          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': 0})
SUCCESS               0.016736            0.009728               1.720          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': -1})
SUCCESS               0.006848            0.005952               1.151          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': 0})
SUCCESS               0.006944            0.006080               1.142          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': -1})
SUCCESS               0.007104            0.006432               1.104          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': 0})
SUCCESS               0.007776            0.006464               1.203          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': -1})
```