### PR TITLE
update hstack

### DIFF
--- a/src/flag_gems/ops/hstack.py
+++ b/src/flag_gems/ops/hstack.py
@@ -1,20 +1,78 @@
-import itertools
 import logging
 from typing import List, Tuple, Union
 
 import torch
 import triton
-
-from flag_gems.utils import pointwise_dynamic
-from flag_gems.utils.tensor_wrapper import StridedBuffer
+import triton.language as tl
 
 logger = logging.getLogger(__name__)
 
 
-@pointwise_dynamic(is_tensor=[True], promotion_methods=[(0, "DEFAULT")])
 @triton.jit
-def copy_func(x):
-    return x
+def hstack_copy_func_kernel_4(
+    out_ptr,
+    in_ptr_a,
+    in_ptr_b,
+    in_ptr_c,
+    in_ptr_d,
+    dim_size_in_a,
+    dim_size_in_b,
+    dim_size_in_c,
+    dim_size_in_d,
+    dim_size_out,
+    dim_prod_post,
+    dim_offset_a,
+    dim_offset_b,
+    dim_offset_c,
+    dim_offset_d,
+    total_elements_a,
+    total_elements_b,
+    total_elements_c,
+    total_elements_d,
+    BLOCK_X: tl.constexpr,
+):
+    pid_x = tl.program_id(0)
+    pid_y = tl.program_id(1)
+
+    if pid_y == 0:
+        in_ptr = in_ptr_a
+        dim_size_in = dim_size_in_a
+        dim_offset = dim_offset_a
+        total_elements = total_elements_a
+    elif pid_y == 1:
+        in_ptr = in_ptr_b
+        dim_size_in = dim_size_in_b
+        dim_offset = dim_offset_b
+        total_elements = total_elements_b
+    elif pid_y == 2:
+        in_ptr = in_ptr_c
+        dim_size_in = dim_size_in_c
+        dim_offset = dim_offset_c
+        total_elements = total_elements_c
+    else:
+        in_ptr = in_ptr_d
+        dim_size_in = dim_size_in_d
+        dim_offset = dim_offset_d
+        total_elements = total_elements_d
+
+    block_start = pid_x * BLOCK_X
+    offsets = tl.arange(0, BLOCK_X)
+    mask = block_start + offsets < total_elements
+
+    idx = block_start + offsets
+
+    pre_idx = idx // (dim_size_in * dim_prod_post)
+    dim_idx = (idx // dim_prod_post) % dim_size_in
+    post_idx = idx % dim_prod_post
+
+    out_idx = (
+        pre_idx * dim_size_out * dim_prod_post
+        + (dim_idx + dim_offset) * dim_prod_post
+        + post_idx
+    )
+
+    data = tl.load(in_ptr + idx, mask=mask)
+    tl.store(out_ptr + out_idx, data, mask=mask)
 
 
 def hstack(
@@ -55,19 +113,93 @@ def hstack(
                         for tensor number {tensor_num + 1} in the list."
                 )
 
+    inp_shapes = [list(_.shape) for _ in tensors]
+    inp0_shape = inp_shapes[0]
+    dtype, device = tensors[0].dtype, tensors[0].device
     out_shape[dim] = sum(s[dim] for s in inp_shapes)
+    out = torch.empty(out_shape, dtype=dtype, device=device)
 
-    out0 = torch.empty(out_shape, dtype=tensors[0].dtype, device=tensors[0].device)
-    out0_strides = out0.stride()
-    out0_offsets = list(
-        itertools.accumulate(
-            [s[dim] * out0_strides[dim] for s in inp_shapes[:-1]], initial=0
+    dim_prod_post = 1
+    for s in inp0_shape[dim:]:
+        dim_prod_post *= s
+    BLOCK = 1024
+    dim_offset = 0
+    i = 0
+    while i < len(tensors):
+        tensors_in_batch = tensors[i : i + 4]
+        num_tensors_in_batch = len(tensors_in_batch)
+
+        args = []
+        total_elements_list = []
+        current_dim_offset = dim_offset
+
+        for j in range(4):
+            if j < num_tensors_in_batch:
+                tensor = tensors_in_batch[j].contiguous()
+                shape = tensor.shape
+                total_elements = tensor.numel()
+                dim_size_in = shape[dim]
+
+                args.extend([tensor, dim_size_in, current_dim_offset, total_elements])
+                total_elements_list.append(total_elements)
+                current_dim_offset += dim_size_in
+            else:
+                # Add placeholders for unused tensor slots
+                args.extend([tensors_in_batch[0], 0, 0, 0])
+                total_elements_list.append(0)
+
+        dim_size_out = out_shape[dim]
+        dim_prod_post = 1
+        for d in range(dim + 1, tensors[0].ndim):
+            dim_prod_post *= tensors[0].shape[d]
+
+        grid_y = num_tensors_in_batch
+        max_elements_in_batch = max(total_elements_list) if total_elements_list else 0
+        grid = (triton.cdiv(max_elements_in_batch, BLOCK), grid_y)
+
+        (
+            tensor_a,
+            dim_size_in_a,
+            dim_offset_a,
+            total_elements_a,
+            tensor_b,
+            dim_size_in_b,
+            dim_offset_b,
+            total_elements_b,
+            tensor_c,
+            dim_size_in_c,
+            dim_offset_c,
+            total_elements_c,
+            tensor_d,
+            dim_size_in_d,
+            dim_offset_d,
+            total_elements_d,
+        ) = args
+
+        hstack_copy_func_kernel_4[grid](
+            out,
+            tensor_a,
+            tensor_b,
+            tensor_c,
+            tensor_d,
+            dim_size_in_a,
+            dim_size_in_b,
+            dim_size_in_c,
+            dim_size_in_d,
+            dim_size_out,
+            dim_prod_post,
+            dim_offset_a,
+            dim_offset_b,
+            dim_offset_c,
+            dim_offset_d,
+            total_elements_a,
+            total_elements_b,
+            total_elements_c,
+            total_elements_d,
+            BLOCK_X=BLOCK,
         )
-    )
 
-    for a, out0_offset in zip(tensors, out0_offsets):
-        in_view = StridedBuffer(a, a.shape, a.stride())
-        out_view = StridedBuffer(out0, a.shape, out0.stride(), offset=out0_offset)
-        copy_func.instantiate(a.ndim)(in_view, out0=out_view)
+        dim_offset = current_dim_offset
+        i += num_tensors_in_batch
 
-    return out0
+    return out


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
```
benchmark/test_tensor_concat_perf.py 
Operator: hstack  Performance Test (dtype=torch.float16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.019616            0.005952               3.296          [[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]]
SUCCESS               0.007072            0.006336               1.116          [[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]]
SUCCESS               0.008352            0.007360               1.135          [[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]]
SUCCESS               0.009536            0.008352               1.142          [[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]]
SUCCESS               0.011776            0.010560               1.115          [[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]]
SUCCESS               0.006656            0.006016               1.106          [[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]]
SUCCESS               0.006944            0.006176               1.124          [[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]]
SUCCESS               0.009344            0.008480               1.102          [[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]]
SUCCESS               0.006560            0.005984               1.096          [[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]]
SUCCESS               0.007232            0.006336               1.141          [[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]]


Operator: hstack  Performance Test (dtype=torch.float32, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.006848            0.005984               1.144          [[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]]
SUCCESS               0.007328            0.006624               1.106          [[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]]
SUCCESS               0.009312            0.008384               1.111          [[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]]
SUCCESS               0.011424            0.010352               1.104          [[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]]
SUCCESS               0.015712            0.014880               1.056          [[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]]
SUCCESS               0.006880            0.006656               1.034          [[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]]
SUCCESS               0.007072            0.006304               1.122          [[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]]
SUCCESS               0.011520            0.010464               1.101          [[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]]
SUCCESS               0.006752            0.005984               1.128          [[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]]
SUCCESS               0.007712            0.006688               1.153          [[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]]


Operator: hstack  Performance Test (dtype=torch.bfloat16, mode=cuda,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.006592            0.005984               1.102          [[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]]
SUCCESS               0.007264            0.006336               1.146          [[torch.Size([256, 256]), torch.Size([256, 256]), torch.Size([256, 256])]]
SUCCESS               0.008256            0.007424               1.112          [[torch.Size([512, 512]), torch.Size([512, 512]), torch.Size([512, 512])]]
SUCCESS               0.009440            0.008352               1.130          [[torch.Size([512, 1024]), torch.Size([512, 1024]), torch.Size([512, 1024])]]
SUCCESS               0.011584            0.010720               1.081          [[torch.Size([512, 2048]), torch.Size([512, 2048]), torch.Size([512, 2048])]]
SUCCESS               0.006656            0.006016               1.106          [[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]]
SUCCESS               0.006976            0.006208               1.124          [[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]]
SUCCESS               0.009472            0.008352               1.134          [[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]]
SUCCESS               0.006752            0.005984               1.128          [[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]]
SUCCESS               0.007232            0.006336               1.141          [[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]]
```