### PR TITLE
fix fatals when 'max_seqlen_q' is int

### DIFF
--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -583,6 +583,13 @@ def flash_attn_varlen_func(
 
     assert fa_version == 2, "Only FA2 is implemented."
 
+    max_seqlen_q = (
+        max_seqlen_q.item() if isinstance(max_seqlen_q, torch.Tensor) else max_seqlen_q
+    )
+    max_seqlen_k = (
+        max_seqlen_k.item() if isinstance(max_seqlen_k, torch.Tensor) else max_seqlen_k
+    )
+
     out, q, k, v, softmax_lse, *_ = mha_varlan_fwd(
         q,
         k,

--- a/src/flag_gems/patches/patch_vllm_all.py
+++ b/src/flag_gems/patches/patch_vllm_all.py
@@ -221,7 +221,7 @@ def custom_gems_flash_attention_impl_forwad(
             cu_seqlens_q=cu_seqlens_q,
             max_seqlen_q=max_seqlen_q,
             seqused_k=seqused_k,
-            max_seqlen_k=max_seqlen_k.item(),
+            max_seqlen_k=max_seqlen_k,
             softmax_scale=self.scale,
             causal=True,
             alibi_slopes=self.alibi_slopes,


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
`custom_gems_flash_attention_impl_forwad` will fail if `max_seqlen_q` is a int instead of `torch.Tensor`. This PR adds logic to check whether it's a `torch.Tensor` and if so it will call `item` method, otherwise it will pass the value directly.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

Introduced by PR #781.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
