### PR TITLE
fix fatals when 'max_seqlen_q' is 'numpy.int32'

### DIFF
--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -584,10 +584,10 @@ def flash_attn_varlen_func(
     assert fa_version == 2, "Only FA2 is implemented."
 
     max_seqlen_q = (
-        max_seqlen_q.item() if isinstance(max_seqlen_q, torch.Tensor) else max_seqlen_q
+        max_seqlen_q.item() if hasattr(max_seqlen_q, "item") else max_seqlen_q
     )
     max_seqlen_k = (
-        max_seqlen_k.item() if isinstance(max_seqlen_k, torch.Tensor) else max_seqlen_k
+        max_seqlen_k.item() if hasattr(max_seqlen_k, "item") else max_seqlen_k
     )
 
     out, q, k, v, softmax_lse, *_ = mha_varlan_fwd(


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
`max_seqlen_q` could be `np.int32`, but it only checks whether it's `torch.Tensor` now.

### Issue
PR #781, #789

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
