### PR TITLE
Fix addmm cpp wrapper

### DIFF
--- a/include/flag_gems/operators.h
+++ b/include/flag_gems/operators.h
@@ -23,8 +23,8 @@ void fused_add_rms_norm(at::Tensor &input,
 at::Tensor addmm(const at::Tensor &self,
                  const at::Tensor &mat1,
                  const at::Tensor &mat2,
-                 const at::Scalar &beta = 1.0,
-                 const at::Scalar &alpha = 1.0);
+                 const at::Scalar &beta = 1,
+                 const at::Scalar &alpha = 1);
 at::Tensor nonzero(const at::Tensor &inp);
 // Rotary embedding
 void rotary_embedding_inplace(at::Tensor &q,

--- a/lib/addmm.cpp
+++ b/lib/addmm.cpp
@@ -22,8 +22,8 @@ at::Tensor addmm(const at::Tensor &self,
   at::Tensor mat2_c = mat2.contiguous();
   at::Tensor out = at::empty({mat1_sizes[0], mat2_sizes[1]}, mat1.options());
   at::Tensor self_c = self.broadcast_to(out.sizes()).contiguous();
-  double alpha_val = alpha.toDouble();
-  double beta_val = beta.toDouble();
+  float alpha_val = alpha.to<float>();
+  float beta_val = beta.to<float>();
 
   const TritonJITFunction &f =
       TritonJITFunction::getInstance(std::string(utils::get_triton_src_path() / "addmm.py"), "addmm_kernel");

--- a/src/flag_gems/csrc/cstub.cpp
+++ b/src/flag_gems/csrc/cstub.cpp
@@ -15,6 +15,7 @@ PYBIND11_MODULE(c_operators, m) {
   m.def("rotary_embedding", &flag_gems::rotary_embedding);
   m.def("rotary_embedding_inplace", &flag_gems::rotary_embedding_inplace);
   m.def("bmm", &flag_gems::bmm);
+  m.def("addmm", &flag_gems::addmm);
 }
 
 namespace flag_gems {


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Other

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Cast `c10::Scalar` alpha and beta to float instead of double before calling `TritonJITFunction`. Passing in doubles to triton causes compile error.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
