### PR TITLE
fix fill op pybind11 binding

### DIFF
--- a/src/flag_gems/csrc/cstub.cpp
+++ b/src/flag_gems/csrc/cstub.cpp
@@ -15,12 +15,6 @@ PYBIND11_MODULE(c_operators, m) {
   m.def("rotary_embedding", &flag_gems::rotary_embedding);
   m.def("rotary_embedding_inplace", &flag_gems::rotary_embedding_inplace);
   m.def("bmm", &flag_gems::bmm);
-  m.def("addmm", &flag_gems::addmm);
-
-  m.def("fill_scalar", &flag_gems::fill_scalar);
-  m.def("fill_tensor", &flag_gems::fill_tensor);
-  m.def("fill_scalar_", &flag_gems::fill_scalar_);
-  m.def("fill_tensor_", &flag_gems::fill_tensor_);
 }
 
 namespace flag_gems {

--- a/src/flag_gems/csrc/cstub.cpp
+++ b/src/flag_gems/csrc/cstub.cpp
@@ -17,10 +17,10 @@ PYBIND11_MODULE(c_operators, m) {
   m.def("bmm", &flag_gems::bmm);
   m.def("addmm", &flag_gems::addmm);
 
-  m.impl("fill_scalar", &flag_gems::fill_scalar);
-  m.impl("fill_tensor", &flag_gems::fill_tensor);
-  m.impl("fill_scalar_", &flag_gems::fill_scalar_);
-  m.impl("fill_tensor_", &flag_gems::fill_tensor_);
+  m.def("fill_scalar", &flag_gems::fill_scalar);
+  m.def("fill_tensor", &flag_gems::fill_tensor);
+  m.def("fill_scalar_", &flag_gems::fill_scalar_);
+  m.def("fill_tensor_", &flag_gems::fill_tensor_);
 }
 
 namespace flag_gems {


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Remove the pybind11 binding for fill and addmm since they have c10::Scalar parameter, while `c10::Scalar` does not have a fully functional type caster. The `load` method of it is a dummy placeholder which raises error.

For more details, please refer to torch/csrc/utils/pybind.cpp



### Issue
#809 
<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
