### PR TITLE
Add model-based benchmarking support and Qwen2.5 op shape config

### DIFF
--- a/benchmark/attri_util.py
+++ b/benchmark/attri_util.py
@@ -31,7 +31,7 @@ DEFAULT_SHAPES = [
 
 def model_shapes():
     # batch sizes * seq lengths
-    BS = [2**i for i in range(0, 9, 2)]
+    BS = [1, 2, 3, 4, 8, 98, 256, 8192]
     # attn: wqkv, wo; ffn: w13, w2
     NK = [
         # extract from llama3-8b

--- a/benchmark/attri_util.py
+++ b/benchmark/attri_util.py
@@ -29,26 +29,30 @@ DEFAULT_SHAPES = [
 ]
 
 
-# This function is adapted from: https://github.com/pytorch-labs/tritonbench/blob/main/tritonbench/utils/triton_op.py
-def llama_shapes():
+def model_shapes():
     # batch sizes * seq lengths
-    BS = [2**i for i in range(0, 17)]
+    BS = [2**i for i in range(0, 9, 2)]
     # attn: wqkv, wo; ffn: w13, w2
-    KN = [
-        (4096, 12288),
+    NK = [
+        # extract from llama3-8b
+        (1024, 4096),
+        (128256, 4096),
+        (14336, 4096),
+        (4096, 14336),
         (4096, 4096),
-        (4096, 22016),
-        (11008, 4096),
-        (8192, 1280),
-        (1024, 8192),
-        (8192, 7168),
-        (3584, 8192),
-        (16384, 2304),
-        (2048, 16384),
-        (16384, 13312),
-        (6656, 16384),
+        (6144, 4096),
+        (28672, 4096),
+        # extract from qwen2.5-7b
+        (3584, 3584),
+        (18944, 3584),
+        (3584, 18944),
+        (152064, 3584),
+        (37888, 3584),
+        (512, 3584),
+        (4608, 3584),
     ]
-    return [(bs, n, k, None) for bs, (k, n) in itertools.product(BS, KN)]
+
+    return [(4, bs, n, k) for bs, (n, k) in itertools.product(BS, NK)]
 
 
 @dataclass

--- a/benchmark/benchmark_for_models.py
+++ b/benchmark/benchmark_for_models.py
@@ -1,0 +1,62 @@
+import argparse
+import subprocess
+
+import yaml
+
+
+def load_shape_file(path):
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
+
+
+def build_markers(shape_data):
+    return list({op_name for op_name, shapes in shape_data.items() if shapes})
+
+
+def run_benchmark_command(markers_str, shape_file, args):
+    cmd = [
+        "pytest",
+        "-m",
+        markers_str,
+        "-s",
+        "--level",
+        "core",
+        "--record",
+        "log",
+        "--shape_file",
+        shape_file,
+    ]
+    if args.extra_args:
+        cmd += args.extra_args.split()
+
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    print("stdout:", result.stdout)
+    print("stderr:", result.stderr)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Run benchmark for given operators list and corresponding shapes."
+    )
+    parser.add_argument(
+        "--shape-file",
+        type=str,
+        default="shapes.yaml",
+        help="Path to the shape file (default: shapes.yaml)",
+    )
+    parser.add_argument(
+        "--extra-args",
+        type=str,
+        default="",
+        help="Extra args to pass to pytest (e.g., '--tb=short')",
+    )
+    args = parser.parse_args()
+
+    shape_data = load_shape_file(args.shape_file)
+    markers = build_markers(shape_data)
+    if not markers:
+        print(f"[Warning] No markers found in {args.shape_file}, skip benchmarking.")
+        exit(0)
+
+    markers_str = " or ".join(markers)
+    run_benchmark_command(markers_str, args.shape_file, args)

--- a/benchmark/conftest.py
+++ b/benchmark/conftest.py
@@ -6,9 +6,7 @@ import pytest
 import torch
 
 import flag_gems
-from flag_gems.runtime import torch_device_fn
-
-from .attri_util import (
+from benchmark.attri_util import (
     ALL_AVAILABLE_METRICS,
     BOOL_DTYPES,
     DEFAULT_ITER_COUNT,
@@ -19,6 +17,7 @@ from .attri_util import (
     OperationAttribute,
     get_recommended_shapes,
 )
+from flag_gems.runtime import torch_device_fn
 
 device = flag_gems.device
 vendor_name = flag_gems.vendor_name

--- a/benchmark/core_shapes.yaml
+++ b/benchmark/core_shapes.yaml
@@ -1,11 +1,3 @@
-outer:
-  shapes:
-    - [384, 384]
-    - [1024, 1024]
-    - [4096, 4096]
-    - [8192, 8192]
-    - [10240, 10240] #from perf
-
 single_dim_shapes: &single_dim_shapes
   shapes:
     - [64]
@@ -55,12 +47,20 @@ quantile:
 
 BlasBenchmark:
   shapes:
+    - [2, 384, 384, 384]
     - [2, 4096, 4096, 4096]
-    - [16, 384, 384, 384]
     - [16, 1024, 1024, 1024]
     - [16, 2048, 2048, 2048]
     - [16, 4096, 4096, 4096]
-  shape_desc: "B, M, N, K" # shapes are defined as (B, M, N, K)
+  shape_desc: "B, M, N, K"   # shapes are defined as (B, M, N, K)
+
+MvAndOuterBenchmark:
+  shapes:
+    - [384, 384]
+    - [1024, 1024]
+    - [4096, 4096]
+    - [8192, 8192]
+    - [10240, 10240]  #from perf
 
 # NORM shapes can be either 3D or 4D:
 # - 3D shapes are represented as [batch_size, channels, hidden_size]

--- a/benchmark/models_shapes/qwen25.yaml
+++ b/benchmark/models_shapes/qwen25.yaml
@@ -1,0 +1,114 @@
+fill_:
+  shapes:
+    - [67108864]
+    - [8, 16, 75]
+    - [256, 16, 75]
+    - [8]
+    - [256]
+    - [0, 3584]
+
+mm:  # batch size from  1 to 8192, and B stride is always column major # [B stride]: (1, 3584)
+  shapes:
+    - [1, 1, 152064, 3584]
+    - [1, 2, 152064, 3584]
+    - [1, 3, 152064, 3584]
+    - [1, 5, 152064, 3584]
+    - [1, 6, 152064, 3584]
+    - [1, 7, 152064, 3584]
+    - [1, 8, 152064, 3584]
+    - [1, 256, 152064, 3584]
+    # batch size = 8
+    - [1, 8, 3584, 18944]
+    - [1, 8, 3584, 3584]
+    - [1, 8, 37888, 3584]
+    # batch size = 98
+    - [1, 98, 3584, 18944]
+    - [1, 98, 3584, 3584]
+    - [1, 98, 37888, 3584]
+    # batch size = 256
+    - [1, 256, 3584, 18944]
+    - [1, 256, 3584, 3584]
+    - [1, 256, 37888, 3584]
+    # batch size = 8192
+    - [1, 8192, 3584, 18944]
+    - [1, 8192, 3584, 3584]
+    - [1, 8192, 37888, 3584]
+  shape_desc: "B, M, N, K" # shapes are defined as (B, M, N, K)
+
+
+addmm:  #  B stride is always column major # [B stride]: (1, 3584)
+  shapes:
+    - [1, 4, 4608, 3584]
+    - [1, 6, 4608, 3584]
+    - [1, 7, 4608, 3584]
+    - [1, 8, 4608, 3584]
+    - [1, 16, 4608, 3584]
+    - [1, 32, 4608, 3584]
+    - [1, 64, 4608, 3584]
+    - [1, 68, 4608, 3584]
+    - [1, 98, 4608, 3584]
+    - [1, 113, 4608, 3584]
+    - [1, 256, 4608, 3584]
+    - [1, 8192, 4608, 3584]
+  shape_desc: "B, M, N, K" # shapes are defined as (B, M, N, K)
+
+fused_add_rms_norm:
+  shapes:
+    - [4, 3584]
+    - [8, 3584]
+    - [16, 3584]
+    - [32, 3584]
+    - [64, 3584]
+    - [113, 3584]
+    - [256, 3584]
+    - [8192, 3584]
+
+sort:
+  shapes:
+    - [4, 152064]
+
+
+# TODO: to be added
+# silu_and_mul:  # need broadcast
+#   shapes:
+#     - [22, 18944]  # with [22, 37888]
+#     - [22, 37888]
+
+# contiguous:
+# rotary_embedding:
+#   shapes:
+#     - []
+# to:
+#   shapes:
+#     - [4]
+#     - [4, 1]
+#     - [4, 152064]
+#     - [4, 152]
+
+# div: true_divide_ & true_divi
+# sub:
+# softmax:
+# masked_fill:
+# argmax:
+# scatter:
+# rms_norm:
+# le:
+# index:
+# exponential_:
+# embedding:
+# cumsum:
+# resolve_neg:
+# resolve_conj:
+# ones:
+# zeros:
+# full:
+# lt:（scalar and lt）
+# where:
+# mul:
+# gather:
+# arange:
+# sin:
+# reciprocal:
+# pow
+# cos:
+# cat:

--- a/benchmark/test_attention_perf.py
+++ b/benchmark/test_attention_perf.py
@@ -6,8 +6,12 @@ import torch
 import triton
 
 import flag_gems
-
-from .performance_utils import Benchmark, GenericBenchmark, SkipVersion, vendor_name
+from benchmark.performance_utils import (
+    Benchmark,
+    GenericBenchmark,
+    SkipVersion,
+    vendor_name,
+)
 
 
 class AttentionBenchmark(GenericBenchmark):

--- a/benchmark/test_binary_pointwise_perf.py
+++ b/benchmark/test_binary_pointwise_perf.py
@@ -4,9 +4,8 @@ import pytest
 import torch
 
 import flag_gems
-
-from .attri_util import BOOL_DTYPES, DEFAULT_METRICS, FLOAT_DTYPES, INT_DTYPES
-from .performance_utils import Benchmark, generate_tensor_input
+from benchmark.attri_util import BOOL_DTYPES, DEFAULT_METRICS, FLOAT_DTYPES, INT_DTYPES
+from benchmark.performance_utils import Benchmark, generate_tensor_input
 
 
 class BinaryPointwiseBenchmark(Benchmark):

--- a/benchmark/test_blas_perf.py
+++ b/benchmark/test_blas_perf.py
@@ -4,16 +4,15 @@ import pytest
 import torch
 
 import flag_gems
-
-from .attri_util import (
+from benchmark.attri_util import (
     COMPLEX_DTYPES,
     DEFAULT_METRICS,
     FLOAT_DTYPES,
     BenchLevel,
     model_shapes,
 )
-from .conftest import Config
-from .performance_utils import Benchmark, GenericBenchmark2DOnly, vendor_name
+from benchmark.conftest import Config
+from benchmark.performance_utils import Benchmark, GenericBenchmark2DOnly, vendor_name
 
 
 class BlasBenchmark(Benchmark):

--- a/benchmark/test_blas_perf.py
+++ b/benchmark/test_blas_perf.py
@@ -1,4 +1,3 @@
-import itertools
 from typing import Generator
 
 import pytest
@@ -11,10 +10,10 @@ from .attri_util import (
     DEFAULT_METRICS,
     FLOAT_DTYPES,
     BenchLevel,
-    llama_shapes,
+    model_shapes,
 )
 from .conftest import Config
-from .performance_utils import Benchmark, vendor_name
+from .performance_utils import Benchmark, GenericBenchmark2DOnly, vendor_name
 
 
 class BlasBenchmark(Benchmark):
@@ -30,31 +29,23 @@ class BlasBenchmark(Benchmark):
 
     def get_input_iter(self, cur_dtype) -> Generator:
         for b, m, n, k in self.shapes:
-            yield from self.input_fn(b, m, n, k, cur_dtype, self.device)
-        # llama shapes
+            yield from self.input_fn(b, m, n, k, cur_dtype, self.device, False)
+
         if Config.bench_level == BenchLevel.COMPREHENSIVE:
-            for m, n, k, _ in llama_shapes():
-                yield from self.input_fn(1, m, n, k, cur_dtype, self.device)
+            for b, m, n, k in self.shapes:
+                yield from self.input_fn(b, m, n, k, cur_dtype, self.device, True)
 
     def set_more_shapes(self):
-        split_k_shapes = [
-            (1, m, m, k)
-            for m in [16 * i for i in range(1, 5)]
-            for k in [4096 * i for i in range(1, 9)]
+        large_k_shapes = [
+            (8, 1848, 1536, 151936),
+            (8, 1848, 1536, 128256),
+            (8, 1848, 1536, 152064),
         ]
-        # 'mv' operations only involve M and N dimensions.
-        # Shapes with large K values are not suitable for these two operations.
-        if self.op_name not in ["mv"]:
-            # B=1 or 4, M= 13, N= 2 , K=2^6..2^15
-            large_k_shapes = list(
-                itertools.product([1, 4], [13], [2], [2**i for i in range(6, 15)])
-            )
-            return large_k_shapes + split_k_shapes
-        return split_k_shapes
+
+        model_shaps = model_shapes()
+        return large_k_shapes + model_shaps
 
     def get_tflops(self, op, *args, **kwargs):
-        """This method is currently not really implemented and serves as a placeholder.
-        A proper implementation will be developed in the future."""
         total_flops = 0
         # shape(m,k)(k,n)
         # total_flops mxnx2k
@@ -62,13 +53,12 @@ class BlasBenchmark(Benchmark):
             total_flops = args[0].shape[0] * args[0].shape[1] * args[1].shape[1] * 2
         # shape(m,n)(n,p)
         # total_flops mxpx(2n+1)
-        if self.op_name == "addmm":
+        elif self.op_name == "addmm":
             total_flops = (
                 args[0].shape[0] * args[1].shape[1] * (args[1].shape[0] * 2 + 1)
             )
-        # shape(b,n,m), (b,m,p)
         # total_flops bxnxpx2m
-        if self.op_name == "bmm":
+        elif self.op_name == "bmm":
             total_flops = (
                 args[0].shape[0]
                 * args[0].shape[1]
@@ -76,37 +66,38 @@ class BlasBenchmark(Benchmark):
                 * 2
                 * args[0].shape[2]
             )
-        # shape(n,m)(m,)
-        # total_flops n*2m
-        if self.op_name == "mv":
-            total_flops = args[0].shape[0] * 2 * args[0].shape[1]
-
         return total_flops
 
 
-def addmm_input_fn(b, m, n, k, cur_dtype, device):
+def addmm_input_fn(b, m, n, k, cur_dtype, device, b_column_major):
     inp1 = torch.randn([m, k], dtype=cur_dtype, device=device)
-    inp2 = torch.randn([k, n], dtype=cur_dtype, device=device)
     bias = torch.randn([m, n], dtype=cur_dtype, device=device)
-    yield bias, inp1, inp2,
+    if b_column_major:
+        inp2 = torch.randn([n, k], dtype=cur_dtype, device=device)
+        yield bias, inp1, inp2.t(),
+    else:
+        inp2 = torch.randn([k, n], dtype=cur_dtype, device=device)
+        yield bias, inp1, inp2,
 
 
-def bmm_input_fn(b, m, n, k, cur_dtype, device):
+def bmm_input_fn(b, m, n, k, cur_dtype, device, b_column_major):
     inp1 = torch.randn([b, m, k], dtype=cur_dtype, device=device)
-    inp2 = torch.randn([b, k, n], dtype=cur_dtype, device=device)
-    yield inp1, inp2
+    if b_column_major:
+        inp2 = torch.randn([b, n, k], dtype=cur_dtype, device=device)
+        yield inp1, inp2.transpose(1, 2)
+    else:
+        inp2 = torch.randn([b, k, n], dtype=cur_dtype, device=device)
+        yield inp1, inp2
 
 
-def mm_input_fn(b, m, n, k, cur_dtype, device):
+def mm_input_fn(b, m, n, k, cur_dtype, device, b_column_major):
     inp1 = torch.randn([m, k], dtype=cur_dtype, device=device)
-    inp2 = torch.randn([k, n], dtype=cur_dtype, device=device)
-    yield inp1, inp2
-
-
-def mv_input_fn(b, m, n, k, cur_dtype, device):
-    inp1 = torch.randn([m, n], dtype=cur_dtype, device=device)
-    inp2 = torch.randn([n], dtype=cur_dtype, device=device)
-    yield inp1, inp2
+    if b_column_major:
+        inp2 = torch.randn([n, k], dtype=cur_dtype, device=device)
+        yield inp1, inp2.t()
+    else:
+        inp2 = torch.randn([k, n], dtype=cur_dtype, device=device)
+        yield inp1, inp2
 
 
 @pytest.mark.parametrize(
@@ -130,12 +121,6 @@ def mv_input_fn(b, m, n, k, cur_dtype, device):
             mm_input_fn,
             marks=pytest.mark.mm,
         ),
-        pytest.param(
-            "mv",
-            torch.Tensor.mv,
-            mv_input_fn,
-            marks=pytest.mark.mv,
-        ),
     ],
 )
 @pytest.mark.skipif(
@@ -149,9 +134,9 @@ def test_blas_benchmark(op_name, torch_op, input_fn):
     bench.run()
 
 
-class OuterBenchmark(BlasBenchmark):
+class MvAndOuterBenchmark(GenericBenchmark2DOnly):
     """
-    benchmark for outer
+    Benchmark for MV and Outer operations
     """
 
     def set_more_shapes(self):
@@ -162,20 +147,42 @@ class OuterBenchmark(BlasBenchmark):
             yield from self.input_fn(m, n, cur_dtype, self.device)
 
 
-@pytest.mark.outer
-def test_outer_benchmark():
-    def outer_input_fn(m, n, cur_dtype, device):
-        inp1 = torch.randn([m], dtype=cur_dtype, device=device)
-        inp2 = torch.randn([n], dtype=cur_dtype, device=device)
-        yield inp1, inp2
+def mv_input_fn(m, n, cur_dtype, device):
+    inp1 = torch.randn([m, n], dtype=cur_dtype, device=device)
+    inp2 = torch.randn([n], dtype=cur_dtype, device=device)
+    yield inp1, inp2
 
-    bench = OuterBenchmark(
-        input_fn=outer_input_fn,
-        op_name="outer",
-        torch_op=torch.Tensor.outer,
+
+def outer_input_fn(m, n, cur_dtype, device):
+    inp1 = torch.randn([m], dtype=cur_dtype, device=device)
+    inp2 = torch.randn([n], dtype=cur_dtype, device=device)
+    yield inp1, inp2
+
+
+@pytest.mark.parametrize(
+    "op_name, torch_op, input_fn",
+    [
+        pytest.param(
+            "mv",
+            torch.Tensor.mv,
+            mv_input_fn,
+            marks=pytest.mark.mv,
+        ),
+        pytest.param(
+            "outer",
+            torch.Tensor.outer,
+            outer_input_fn,
+            marks=pytest.mark.outer,
+        ),
+    ],
+)
+def test_mv_and_outer_benchmark(op_name, torch_op, input_fn):
+    bench = MvAndOuterBenchmark(
+        input_fn=input_fn,
+        op_name=op_name,
+        torch_op=torch_op,
         dtypes=FLOAT_DTYPES,
     )
-    bench.set_gems(flag_gems.outer)
     bench.run()
 
 

--- a/benchmark/test_distribution_perf.py
+++ b/benchmark/test_distribution_perf.py
@@ -1,8 +1,8 @@
 import pytest
 import torch
 
-from .attri_util import FLOAT_DTYPES
-from .performance_utils import GenericBenchmark, unary_input_fn
+from benchmark.attri_util import FLOAT_DTYPES
+from benchmark.performance_utils import GenericBenchmark, unary_input_fn
 
 
 def normal_input_fn(shape, cur_dtype, device):

--- a/benchmark/test_fused_perf.py
+++ b/benchmark/test_fused_perf.py
@@ -4,9 +4,8 @@ import pytest
 import torch
 
 import flag_gems
-
-from .attri_util import FLOAT_DTYPES
-from .performance_utils import (
+from benchmark.attri_util import FLOAT_DTYPES
+from benchmark.performance_utils import (
     GenericBenchmark,
     GenericBenchmarkExcluse1D,
     binary_input_fn,

--- a/benchmark/test_generic_pointwise_perf.py
+++ b/benchmark/test_generic_pointwise_perf.py
@@ -1,9 +1,9 @@
 import pytest
 import torch
 
-from .attri_util import FLOAT_DTYPES, INT_DTYPES
-from .conftest import BenchLevel, Config
-from .performance_utils import (
+from benchmark.attri_util import FLOAT_DTYPES, INT_DTYPES
+from benchmark.conftest import BenchLevel, Config
+from benchmark.performance_utils import (
     GenericBenchmark,
     GenericBenchmarkExcluse1D,
     generate_tensor_input,

--- a/benchmark/test_norm_perf.py
+++ b/benchmark/test_norm_perf.py
@@ -2,9 +2,8 @@ import pytest
 import torch
 
 import flag_gems
-
-from .attri_util import FLOAT_DTYPES, BenchLevel
-from .performance_utils import (
+from benchmark.attri_util import FLOAT_DTYPES, BenchLevel
+from benchmark.performance_utils import (
     Config,
     GenericBenchmark,
     GenericBenchmark2DOnly,

--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -5,10 +5,8 @@ import pytest
 import torch
 
 import flag_gems
-from flag_gems.utils import shape_utils
-
-from .attri_util import BOOL_DTYPES, FLOAT_DTYPES, INT_DTYPES, BenchLevel
-from .performance_utils import (
+from benchmark.attri_util import BOOL_DTYPES, FLOAT_DTYPES, INT_DTYPES, BenchLevel
+from benchmark.performance_utils import (
     Benchmark,
     Config,
     GenericBenchmark,
@@ -17,6 +15,7 @@ from .performance_utils import (
     unary_input_fn,
     vendor_name,
 )
+from flag_gems.utils import shape_utils
 
 
 class UnaryReductionBenchmark(Benchmark):

--- a/benchmark/test_select_and_slice_perf.py
+++ b/benchmark/test_select_and_slice_perf.py
@@ -5,15 +5,14 @@ import pytest
 import torch
 
 import flag_gems
-from flag_gems.utils import shape_utils
-
-from .attri_util import FLOAT_DTYPES
-from .performance_utils import (
+from benchmark.attri_util import FLOAT_DTYPES
+from benchmark.performance_utils import (
     GenericBenchmark,
     GenericBenchmark2DOnly,
     generate_tensor_input,
     vendor_name,
 )
+from flag_gems.utils import shape_utils
 
 
 class TensorSelectBenchmark(GenericBenchmark2DOnly):

--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -4,9 +4,8 @@ import pytest
 import torch
 
 import flag_gems
-
-from .attri_util import BOOL_DTYPES, FLOAT_DTYPES, INT_DTYPES, BenchLevel
-from .performance_utils import (
+from benchmark.attri_util import BOOL_DTYPES, FLOAT_DTYPES, INT_DTYPES, BenchLevel
+from benchmark.performance_utils import (
     Config,
     GenericBenchmark,
     GenericBenchmark2DOnly,

--- a/benchmark/test_tensor_concat_perf.py
+++ b/benchmark/test_tensor_concat_perf.py
@@ -3,8 +3,8 @@ from typing import Generator
 import pytest
 import torch
 
-from .attri_util import FLOAT_DTYPES, INT_DTYPES, BenchLevel
-from .performance_utils import (
+from benchmark.attri_util import FLOAT_DTYPES, INT_DTYPES, BenchLevel
+from benchmark.performance_utils import (
     Benchmark,
     Config,
     GenericBenchmark,

--- a/benchmark/test_tensor_constructor_perf.py
+++ b/benchmark/test_tensor_constructor_perf.py
@@ -5,9 +5,8 @@ import pytest
 import torch
 
 import flag_gems
-
-from .attri_util import BenchLevel
-from .performance_utils import (
+from benchmark.attri_util import BenchLevel
+from benchmark.performance_utils import (
     Config,
     GenericBenchmark,
     generate_tensor_input,

--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -4,15 +4,14 @@ import pytest
 import torch
 
 import flag_gems
-
-from .attri_util import (
+from benchmark.attri_util import (
     BOOL_DTYPES,
     COMPLEX_DTYPES,
     DEFAULT_METRICS,
     FLOAT_DTYPES,
     INT_DTYPES,
 )
-from .performance_utils import Benchmark, generate_tensor_input, vendor_name
+from benchmark.performance_utils import Benchmark, generate_tensor_input, vendor_name
 
 fp64_is_supported = flag_gems.runtime.device.support_fp64
 

--- a/src/flag_gems/ops/mm.py
+++ b/src/flag_gems/ops/mm.py
@@ -9,19 +9,6 @@ from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry, libtuner
 from flag_gems.utils import triton_lang_extension as tle
 
-try:
-    device_id = torch_device_fn.current_device()
-except AttributeError:
-    device_id = 0
-
-try:
-    L2_CACHE_SIZE = torch_device_fn.get_device_properties(device_id).L2_cache_size
-    SM_COUNT = torch_device_fn.get_device_properties(device_id).multi_processor_count
-except AttributeError:
-    L2_CACHE_SIZE = 40 * 1024 * 1024  # 40MB in bytes
-    SM_COUNT = 82  # nvidia 3090
-CACHE_USAGE_THRESHOLD = 0.7
-
 logger = logging.getLogger(__name__)
 
 
@@ -31,406 +18,14 @@ def prev_multiple_of(a, b):
     return tl.cdiv(a, b) * b - b
 
 
-@triton.jit()
-def swizzle_tile(
-    tile_id,
-    M,
-    N,
-    K,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-    BLOCK_K: tl.constexpr,
-    GROUP_M: tl.constexpr,
-):
-    grid_m = tl.cdiv(M, BLOCK_M)
-    grid_n = tl.cdiv(N, BLOCK_N)
-    # re-order program ID for better L2 performance
-    width = GROUP_M * grid_n
-    group_id = tile_id // width
-    group_size = tl.minimum(grid_m - group_id * GROUP_M, GROUP_M)
-    pid_m = group_id * GROUP_M + (tile_id % group_size)
-    pid_n = (tile_id % width) // group_size
-    return pid_m, pid_n
-
-
-@libentry()
-@triton.heuristics(
-    {
-        "EVEN_K": lambda args: args["K"] % (args["BLOCK_K"]) == 0,
-    }
-)
-@triton.jit
-def first_wave(
-    A,
-    B,
-    C,
-    M,
-    N,
-    K,
-    locks,
-    stride_am,
-    stride_ak,
-    stride_bk,
-    stride_bn,
-    stride_cm,
-    stride_cn,
-    total_full_tiles_streamk,
-    total_partial_tiles_streamk,
-    iters_per_tile,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-    BLOCK_K: tl.constexpr,
-    GROUP_M: tl.constexpr,
-    EVEN_K: tl.constexpr,
-):
-    pid = tl.program_id(0)  # pid range from 0 to sm_count
-    start_iter = pid * total_full_tiles_streamk + tl.minimum(
-        pid, total_partial_tiles_streamk
-    )
-    last_iter = (pid + 1) * total_full_tiles_streamk + tl.minimum(
-        pid + 1, total_partial_tiles_streamk
-    )
-    while start_iter < last_iter:
-        remain_iters = start_iter % iters_per_tile
-        # Iterate over the K axis. Recalculate end_iter as M/N may change during the iteration.
-        end_iter = tl.minimum(start_iter + (iters_per_tile - remain_iters), last_iter)
-
-        tile_id = start_iter // iters_per_tile
-
-        pid_m, pid_n = swizzle_tile(
-            tile_id, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M
-        )
-
-        rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-        rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-        rk = tl.arange(0, BLOCK_K)
-
-        ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
-        rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
-
-        # pointers
-        A_ptr = (
-            A
-            + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
-            + BLOCK_K * stride_ak * remain_iters
-        )
-        B_ptr = (
-            B
-            + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)
-            + BLOCK_K * stride_bk * remain_iters
-        )
-        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-
-        for current_iter in range(start_iter, end_iter):
-            if EVEN_K:
-                a = tl.load(A_ptr)
-                b = tl.load(B_ptr)
-            else:
-                k_mask = (current_iter % iters_per_tile) * BLOCK_K + rk < K
-                _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)
-                a = tl.load(A_ptr, mask=k_mask[None, :], other=_0)
-                b = tl.load(B_ptr, mask=k_mask[:, None], other=_0)
-            acc += tl.dot(a, b, out_dtype=tl.float32, allow_tf32=False)
-            A_ptr += BLOCK_K * stride_ak
-            B_ptr += BLOCK_K * stride_bk
-        # last iteration of the tile always happens before its start on another SM
-        if end_iter % iters_per_tile == 0:
-            C_ptr = C + (
-                rm[:, None] * stride_cm + rn[None, :] * stride_cn
-            )  # compute inside the if/else to avoid spilling!
-            mask = (rm < M)[:, None] & (rn < N)[None, :]
-            tl.store(C_ptr, acc, mask=mask)
-            if remain_iters != 0:  # only if tile has been partially processed
-                tl.atomic_xchg(locks + tile_id, 1)
-        else:
-            while tl.atomic_cas(locks + tile_id, 1, 1) != 1:
-                pass
-            C_ptr = C + (
-                rm[:, None] * stride_cm + rn[None, :] * stride_cn
-            )  # compute inside the if/else to avoid spilling!
-            mask = (rm < M)[:, None] & (rn < N)[None, :]
-            tl.atomic_add(C_ptr, acc, mask=mask, sem="relaxed")
-        start_iter = end_iter
-
-
-@libentry()
-@triton.heuristics(
-    {
-        "EVEN_K": lambda args: args["K"] % (args["BLOCK_K"]) == 0,
-    }
-)
-@triton.jit
-def classic_tiles_mm(
-    A,
-    B,
-    C,
-    M,
-    N,
-    K,
-    stride_am,
-    stride_ak,
-    stride_bk,
-    stride_bn,
-    stride_cm,
-    stride_cn,
-    total_tiles_streamk,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-    BLOCK_K: tl.constexpr,
-    GROUP_M: tl.constexpr,
-    EVEN_K: tl.constexpr,
-):
-    # first wave has done more tiles than there are SMs, we adjust pid
-    tile_id = tl.program_id(0) + total_tiles_streamk
-    pid_m, pid_n = swizzle_tile(tile_id, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M)
-
-    # do matrix multiplication
-    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    rk = tl.arange(0, BLOCK_K)
-    # pointers
-    ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
-    rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
-
-    A = A + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
-    B = B + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)
-    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_K)):
-        if EVEN_K:
-            a = tl.load(A)
-            b = tl.load(B)
-        else:
-            k_remaining = K - k * BLOCK_K
-            _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)
-            a = tl.load(A, mask=rk[None, :] < k_remaining, other=_0)
-            b = tl.load(B, mask=rk[:, None] < k_remaining, other=_0)
-        acc += tl.dot(a, b, out_dtype=tl.float32, allow_tf32=False)
-        A += BLOCK_K * stride_ak
-        B += BLOCK_K * stride_bk
-    acc = acc.to(C.dtype.element_ty)
-    # rematerialize rm and rn to save registers
-    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    C = C + (rm[:, None] * stride_cm + rn[None, :] * stride_cn)
-    mask = (rm < M)[:, None] & (rn < N)[None, :]
-    tl.store(C, acc, mask=mask)
-
-
-@libentry()
-@libtuner(
-    configs=runtime.get_tuned_config("mm_iobound") + runtime.get_tuned_config("mm"),
-    key=["M", "N", "K", "stride_am", "stride_bk"],
-)
-@triton.heuristics(
-    {
-        "EVEN_K": lambda args: args["K"] % (args["BLOCK_K"]) == 0,
-    }
-)
-@triton.jit
-def mm_kernel_with_grouped_k(
-    A,
-    B,
-    C,  # [Split_K, M, N]
-    M,
-    N,
-    K,
-    stride_am,
-    stride_ak,
-    stride_bk,
-    stride_bn,
-    stride_cb,
-    stride_cm,
-    stride_cn,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-    BLOCK_K: tl.constexpr,
-    SPLIT_K: tl.constexpr,  # Number of split-K groups
-    GROUP_K_LENGTH: tl.constexpr,
-    EVEN_K: tl.constexpr,
-):
-    pid = tl.program_id(0)
-    assert GROUP_K_LENGTH % BLOCK_K == 0, "GROUP_K_LENGTH must be divisible by BLOCK_K"
-
-    num_blocks_m = tl.cdiv(M, BLOCK_M)
-    total_num_m = num_blocks_m * SPLIT_K
-
-    pid_n = pid // total_num_m
-    odd_column = pid_n % 2
-    pid_m_normal = pid % total_num_m
-    # this is a line-one implementation for the following code:
-    #     if odd_column:
-    #         pid_m_for_c = (total_num_m - 1) - pid_m_normal
-    #     else:
-    #         pid_m_for_c = pid_m_normal
-    pid_m_for_c = (1 - odd_column) * pid_m_normal + odd_column * (
-        total_num_m - 1 - pid_m_normal
-    )
-
-    pid_m = pid_m_for_c % num_blocks_m
-    pid_k = pid_m_for_c // num_blocks_m
-
-    # Calculate K_LENGTH based on pid_k
-    group_k_length = min(K - pid_k * GROUP_K_LENGTH, GROUP_K_LENGTH)
-
-    # matrix multiplication
-    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    k_start = pid_k * GROUP_K_LENGTH
-    offs_k = k_start + tl.arange(0, BLOCK_K)
-
-    offs_am = tl.max_contiguous(tl.multiple_of(offs_m % M, BLOCK_M), BLOCK_M)
-    offs_bn = tl.max_contiguous(tl.multiple_of(offs_n % N, BLOCK_N), BLOCK_N)
-
-    # pointers
-    A_ptr = A + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
-    B_ptr = B + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
-
-    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-
-    for k in range(0, tl.cdiv(group_k_length, BLOCK_K)):
-        if EVEN_K:
-            a = tl.load(A_ptr)
-            b = tl.load(B_ptr)
-        else:
-            k_remaining = k_start + group_k_length - k * BLOCK_K
-            a = tl.load(A_ptr, mask=offs_k[None, :] < k_remaining, other=0.0)
-            b = tl.load(B_ptr, mask=offs_k[:, None] < k_remaining, other=0.0)
-        if a.dtype != b.dtype:
-            a = a.to(C.dtype.element_ty)
-            b = b.to(C.dtype.element_ty)
-        acc += tl.dot(a, b, out_dtype=tl.float32, allow_tf32=False)
-        A_ptr += BLOCK_K * stride_ak
-        B_ptr += BLOCK_K * stride_bk
-    acc = acc.to(C.dtype.element_ty)
-
-    # Store results
-    offs_cb = pid_k * stride_cb
-    offs_cm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    offs_cn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-
-    C_ptr = C + offs_cb + (offs_cm[:, None] * stride_cm + offs_cn[None, :] * stride_cn)
-    mask = (offs_cm < M)[:, None] & (offs_cn < N)[None, :]
-
-    tl.store(C_ptr, acc, mask=mask)
-
-
-@libentry()
-@triton.autotune(configs=runtime.get_tuned_config("sum"), key=["M", "N"])
-@triton.jit
-def group_merge_kernel(
-    SRC,  # [SPLIT_K, M, N] 3D Tensor
-    DST,  # [M, N]
-    SPLIT_K,
-    M,
-    N,
-    stride_k,
-    stride_m,
-    stride_n,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-):
-    offs_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
-    offs_n = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
-
-    mask_m = offs_m < M
-    mask_n = offs_n < N
-
-    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-
-    for k in range(SPLIT_K):
-        src_ptr = (
-            SRC + k * stride_k + offs_m[:, None] * stride_m + offs_n[None, :] * stride_n
-        )
-        sub_matrix = tl.load(src_ptr, mask=mask_m[:, None] & mask_n[None, :], other=0.0)
-
-        acc += sub_matrix
-    acc = acc.to(DST.dtype.element_ty)
-    dst_ptr = DST + offs_m[:, None] * stride_m + offs_n[None, :] * stride_n
-    tl.store(dst_ptr, acc, mask=mask_m[:, None] & mask_n[None, :])
-
-
-@libentry()
-@libtuner(
-    configs=runtime.get_tuned_config("mm_iobound"),
-    # Add 'stride_am' and 'stride_bk' to trigger autotune for tensors with the same shape but different strides.
-    key=["M", "N", "K", "stride_am", "stride_bk"],
-)
-@triton.heuristics(
-    {
-        "EVEN_K": lambda args: args["K"] % (args["BLOCK_K"]) == 0,
-    }
-)
-@triton.jit
-def mm_kernel_iobound(
-    A,
-    B,
-    C,
-    M,
-    N,
-    K,
-    stride_am,
-    stride_ak,
-    stride_bk,
-    stride_bn,
-    stride_cm,
-    stride_cn,
-    BLOCK_M: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-    BLOCK_K: tl.constexpr,
-    EVEN_K: tl.constexpr,
-):
-    # column major tile
-    pid = tle.program_id(0)
-    grid_m = tl.cdiv(M, BLOCK_M)
-    pid_m = pid % grid_m
-    pid_n = pid // grid_m
-
-    # do matrix multiplication
-    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    rk = tl.arange(0, BLOCK_K)
-
-    ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
-    rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
-
-    A = A + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
-    B = B + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)
-
-    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_K)):
-        if EVEN_K:
-            a = tl.load(A)
-            b = tl.load(B)
-        else:
-            k_remaining = K - k * BLOCK_K
-            _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)
-            a = tl.load(A, mask=rk[None, :] < k_remaining, other=_0)
-            b = tl.load(B, mask=rk[:, None] < k_remaining, other=_0)
-        if a.dtype != b.dtype:
-            a = a.to(C.dtype.element_ty)
-            b = b.to(C.dtype.element_ty)
-        acc += tl.dot(a, b, out_dtype=tl.float32, allow_tf32=False)
-        A += BLOCK_K * stride_ak
-        B += BLOCK_K * stride_bk
-    acc = acc.to(C.dtype.element_ty)
-    # rematerialize rm and rn to save registers
-    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
-    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
-    C = C + (rm[:, None] * stride_cm + rn[None, :] * stride_cn)
-    mask = (rm < M)[:, None] & (rn < N)[None, :]
-    # handles write-back with reduction-splitting
-    tl.store(C, acc, mask=mask)
-
-
 @libentry()
 @libtuner(
     configs=runtime.get_tuned_config("mm"),
-    # Add 'stride_am' and 'stride_bk' to trigger autotune for tensors with the same shape but different strides.
-    key=["M", "N", "K", "stride_am", "stride_bk"],
-    strategy=["log", "log", "log", None, None],
+    key=["M", "N", "K"],
+    strategy=["log", "log", "log"],
 )
 @triton.jit
-def mm_kernel_general(
+def mm_kernel(
     A,
     B,
     C,
@@ -516,160 +111,27 @@ def get_higher_dtype(a, b):
             return a
 
 
-def streamk_mm(a, b, c, M, N, K, c_dtype, sm_count=108):
-    # TODO: profile to different settings for different chip
-    if b.stride(0) == 1:
-        BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 128
-        num_stages = 3
-        num_warps = 8
-    else:
-        BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 64
-        num_stages = 3
-        num_warps = 16
-
-    GROUP_M = 8
-    number_blocks_m = triton.cdiv(M, BLOCK_M)
-    number_blocks_n = triton.cdiv(N, BLOCK_N)
-
-    total_tiles = number_blocks_m * number_blocks_n
-    iters_per_tile = triton.cdiv(K, BLOCK_K)
-    tiles_per_wave = sm_count
-
-    # tiles that would executed in the last wave in general situation.
-    # and this is the tiles that we are going to adopt streamk)
-    total_tiles_streamk = total_tiles % tiles_per_wave
-    # mini wave
-    total_iters_streamk = total_tiles_streamk * iters_per_tile
-    total_full_tiles_streamk = total_iters_streamk // tiles_per_wave
-    total_partial_tiles_streamk = total_iters_streamk % tiles_per_wave
-
-    locks = torch.zeros((total_tiles_streamk,), device=a.device, dtype=torch.int32)
-
-    with torch_device_fn.device(a.device):
-        first_wave[(tiles_per_wave,)](
-            a,
-            b,
-            c,
-            M,
-            N,
-            K,
-            locks,
-            a.stride(0),
-            a.stride(1),
-            b.stride(0),
-            b.stride(1),
-            c.stride(0),
-            c.stride(1),
-            total_full_tiles_streamk=total_full_tiles_streamk,
-            total_partial_tiles_streamk=total_partial_tiles_streamk,
-            iters_per_tile=iters_per_tile,
-            BLOCK_M=BLOCK_M,
-            BLOCK_N=BLOCK_N,
-            BLOCK_K=BLOCK_K,
-            GROUP_M=GROUP_M,
-            num_stages=num_stages,
-            num_warps=num_warps,
-        )
-
-        classic_tiles_mm[(total_tiles - total_tiles_streamk,)](
-            a,
-            b,
-            c,
-            M,
-            N,
-            K,
-            a.stride(0),
-            a.stride(1),
-            b.stride(0),
-            b.stride(1),
-            c.stride(0),
-            c.stride(1),
-            total_tiles_streamk=total_tiles_streamk,
-            BLOCK_M=BLOCK_M,
-            BLOCK_N=BLOCK_N,
-            BLOCK_K=BLOCK_K,
-            GROUP_M=GROUP_M,
-            num_stages=num_stages,
-            num_warps=num_warps,
-        )
-    return c
-
-
-def splitk_mm(a, b, c, M, N, K, c_dtype):
-    GROUP_K_LENGTH = 1024
-    SPLIT_K = triton.cdiv(K, GROUP_K_LENGTH)
-    # TODO: float32 or c_dtype
-    multi_c = torch.empty((SPLIT_K, M, N), device=a.device, dtype=c_dtype)
-    # 1st kernel: compute partial results
-    grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]) * SPLIT_K,
-    )
-    grid2 = lambda META: (
-        triton.cdiv(M, META["BLOCK_M"]),
-        triton.cdiv(N, META["BLOCK_N"]),
-    )
-    with torch_device_fn.device(a.device):
-        mm_kernel_with_grouped_k[grid](
-            a,
-            b,
-            multi_c,
-            M,
-            N,
-            K,
-            a.stride(0),
-            a.stride(1),
-            b.stride(0),
-            b.stride(1),
-            multi_c.stride(0),
-            multi_c.stride(1),
-            multi_c.stride(2),
-            SPLIT_K=SPLIT_K,
-            GROUP_K_LENGTH=GROUP_K_LENGTH,
-        )
-        # return torch.sum(multi_c, dim=0)
-        # 2nd kernel: merge partial results
-        group_merge_kernel[grid2](
-            multi_c,
-            c,
-            SPLIT_K,
-            M,
-            N,
-            multi_c.stride(0),
-            multi_c.stride(1),
-            multi_c.stride(2)
-        )
-    return c
-
-
-def iobound_mm(a, b, c, M, N, K):
+def mm(a, b):
+    logger.debug("GEMS MM")
+    device = a.device
+    # handle non-contiguous inputs if necessary
+    if a.stride(0) > 1 and a.stride(1) > 1:
+        a = a.contiguous()
+    if b.stride(0) > 1 and b.stride(1) > 1:
+        b = b.contiguous()
+    # checks constraints
+    assert a.shape[1] == b.shape[0], "incompatible dimensions"
+    M, K = a.shape
+    _, N = b.shape
+    # allocates output
+    c_dtype = get_higher_dtype(a.dtype, b.dtype)
+    c = torch.empty((M, N), device=device, dtype=c_dtype)
     # launch kernel
     grid = lambda META: (
         triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
     )
     with torch_device_fn.device(a.device):
-        mm_kernel_iobound[grid](
-            a,
-            b,
-            c,
-            M,
-            N,
-            K,
-            a.stride(0),
-            a.stride(1),
-            b.stride(0),
-            b.stride(1),
-            c.stride(0),
-            c.stride(1)
-        )
-    return c
-
-
-def general_mm(a, b, c, M, N, K):
-    grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
-    )
-    with torch_device_fn.device(a.device):
-        mm_kernel_general[grid](
+        mm_kernel[grid](
             a,
             b,
             c,
@@ -687,59 +149,6 @@ def general_mm(a, b, c, M, N, K):
     return c
 
 
-def mini_mm_scenario(a, b, l2_cache_size=40 * 1024 * 1024, cache_usage_threshold=0.8):
-    return (
-        a.shape[0] <= 256
-        and (a.numel() * a.element_size() + b.shape[0] * b.element_size())
-        < l2_cache_size * cache_usage_threshold
-    )
-
-
-def streamk_scenario(a, b, M, N, K):
-    # TODO: this my change sometime according to the realbenchmark result
-    # Currently, the best configuration for streamk has only been tested on A100(capability[0] > 7).
-    # The optimal settings for other devices need to be determined through real testing.
-    capability = torch_device_fn.get_device_capability(device_id)
-    return (
-        capability[0] > 7
-        and a.dtype in [torch.float16]
-        and b.dtype in [torch.float16]
-        and M > 1024
-        and N > 1024
-        and K > M * 10
-    )
-
-
-def two_stages_splitk_mm_scenario(M, N, K):
-    return (M < 32 or N < 32) and (K > M * 10 or K > N * 10)
-
-
-def mm(a, b):
-    logger.debug("GEMS MM")
-    device = a.device
-    # handle non-contiguous inputs if necessary
-    if a.stride(0) > 1 and a.stride(1) > 1:
-        a = a.contiguous()
-    if b.stride(0) > 1 and b.stride(1) > 1:
-        b = b.contiguous()
-    # checks constraints
-    assert a.shape[1] == b.shape[0], "incompatible dimensions"
-    M, K = a.shape
-    _, N = b.shape
-    # allocates output
-    c_dtype = get_higher_dtype(a.dtype, b.dtype)
-    c = torch.empty((M, N), device=device, dtype=c_dtype)
-
-    if mini_mm_scenario(a, b, L2_CACHE_SIZE, CACHE_USAGE_THRESHOLD):
-        return iobound_mm(a, b, c, M, N, K)
-    elif streamk_scenario(a, b, M, N, K):
-        return streamk_mm(a, b, c, M, N, K, c_dtype, sm_count=SM_COUNT)
-    elif two_stages_splitk_mm_scenario(M, N, K):
-        return splitk_mm(a, b, c, M, N, K, c_dtype)
-    else:
-        return general_mm(a, b, c, M, N, K)
-
-
 def mm_out(a, b, *, out):
     logger.debug("GEMS MM_OUT")
     # handle non-contiguous inputs if necessary
@@ -752,14 +161,26 @@ def mm_out(a, b, *, out):
     M, K = a.shape
     _, N = b.shape
     # allocates output
-    c_dtype = out.dtype
     c = out
     # launch kernel
-    if mini_mm_scenario(a, b, L2_CACHE_SIZE, CACHE_USAGE_THRESHOLD):
-        return iobound_mm(a, b, c, M, N, K)
-    elif streamk_scenario(a, b, M, N, K):
-        return streamk_mm(a, b, c, M, N, K, c_dtype, sm_count=SM_COUNT)
-    elif two_stages_splitk_mm_scenario(M, N, K):
-        return splitk_mm(a, b, c, M, N, K, c_dtype)
-    else:
-        return general_mm(a, b, c, M, N, K)
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+        META["SPLIT_K"],
+    )
+    with torch_device_fn.device(a.device):
+        mm_kernel[grid](
+            a,
+            b,
+            c,
+            M,
+            N,
+            K,
+            a.stride(0),
+            a.stride(1),
+            b.stride(0),
+            b.stride(1),
+            c.stride(0),
+            c.stride(1),
+            GROUP_M=8,
+        )
+    return c

--- a/src/flag_gems/ops/mm.py
+++ b/src/flag_gems/ops/mm.py
@@ -9,6 +9,19 @@ from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry, libtuner
 from flag_gems.utils import triton_lang_extension as tle
 
+try:
+    device_id = torch_device_fn.current_device()
+except AttributeError:
+    device_id = 0
+
+try:
+    L2_CACHE_SIZE = torch_device_fn.get_device_properties(device_id).L2_cache_size
+    SM_COUNT = torch_device_fn.get_device_properties(device_id).multi_processor_count
+except AttributeError:
+    L2_CACHE_SIZE = 40 * 1024 * 1024  # 40MB in bytes
+    SM_COUNT = 82  # nvidia 3090
+CACHE_USAGE_THRESHOLD = 0.7
+
 logger = logging.getLogger(__name__)
 
 
@@ -18,14 +31,406 @@ def prev_multiple_of(a, b):
     return tl.cdiv(a, b) * b - b
 
 
+@triton.jit()
+def swizzle_tile(
+    tile_id,
+    M,
+    N,
+    K,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+):
+    grid_m = tl.cdiv(M, BLOCK_M)
+    grid_n = tl.cdiv(N, BLOCK_N)
+    # re-order program ID for better L2 performance
+    width = GROUP_M * grid_n
+    group_id = tile_id // width
+    group_size = tl.minimum(grid_m - group_id * GROUP_M, GROUP_M)
+    pid_m = group_id * GROUP_M + (tile_id % group_size)
+    pid_n = (tile_id % width) // group_size
+    return pid_m, pid_n
+
+
+@libentry()
+@triton.heuristics(
+    {
+        "EVEN_K": lambda args: args["K"] % (args["BLOCK_K"]) == 0,
+    }
+)
+@triton.jit
+def first_wave(
+    A,
+    B,
+    C,
+    M,
+    N,
+    K,
+    locks,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    total_full_tiles_streamk,
+    total_partial_tiles_streamk,
+    iters_per_tile,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    EVEN_K: tl.constexpr,
+):
+    pid = tl.program_id(0)  # pid range from 0 to sm_count
+    start_iter = pid * total_full_tiles_streamk + tl.minimum(
+        pid, total_partial_tiles_streamk
+    )
+    last_iter = (pid + 1) * total_full_tiles_streamk + tl.minimum(
+        pid + 1, total_partial_tiles_streamk
+    )
+    while start_iter < last_iter:
+        remain_iters = start_iter % iters_per_tile
+        # Iterate over the K axis. Recalculate end_iter as M/N may change during the iteration.
+        end_iter = tl.minimum(start_iter + (iters_per_tile - remain_iters), last_iter)
+
+        tile_id = start_iter // iters_per_tile
+
+        pid_m, pid_n = swizzle_tile(
+            tile_id, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M
+        )
+
+        rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+        rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+        rk = tl.arange(0, BLOCK_K)
+
+        ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
+        rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+
+        # pointers
+        A_ptr = (
+            A
+            + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
+            + BLOCK_K * stride_ak * remain_iters
+        )
+        B_ptr = (
+            B
+            + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)
+            + BLOCK_K * stride_bk * remain_iters
+        )
+        acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+        for current_iter in range(start_iter, end_iter):
+            if EVEN_K:
+                a = tl.load(A_ptr)
+                b = tl.load(B_ptr)
+            else:
+                k_mask = (current_iter % iters_per_tile) * BLOCK_K + rk < K
+                _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)
+                a = tl.load(A_ptr, mask=k_mask[None, :], other=_0)
+                b = tl.load(B_ptr, mask=k_mask[:, None], other=_0)
+            acc += tl.dot(a, b, out_dtype=tl.float32, allow_tf32=False)
+            A_ptr += BLOCK_K * stride_ak
+            B_ptr += BLOCK_K * stride_bk
+        # last iteration of the tile always happens before its start on another SM
+        if end_iter % iters_per_tile == 0:
+            C_ptr = C + (
+                rm[:, None] * stride_cm + rn[None, :] * stride_cn
+            )  # compute inside the if/else to avoid spilling!
+            mask = (rm < M)[:, None] & (rn < N)[None, :]
+            tl.store(C_ptr, acc, mask=mask)
+            if remain_iters != 0:  # only if tile has been partially processed
+                tl.atomic_xchg(locks + tile_id, 1)
+        else:
+            while tl.atomic_cas(locks + tile_id, 1, 1) != 1:
+                pass
+            C_ptr = C + (
+                rm[:, None] * stride_cm + rn[None, :] * stride_cn
+            )  # compute inside the if/else to avoid spilling!
+            mask = (rm < M)[:, None] & (rn < N)[None, :]
+            tl.atomic_add(C_ptr, acc, mask=mask, sem="relaxed")
+        start_iter = end_iter
+
+
+@libentry()
+@triton.heuristics(
+    {
+        "EVEN_K": lambda args: args["K"] % (args["BLOCK_K"]) == 0,
+    }
+)
+@triton.jit
+def classic_tiles_mm(
+    A,
+    B,
+    C,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    total_tiles_streamk,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+    EVEN_K: tl.constexpr,
+):
+    # first wave has done more tiles than there are SMs, we adjust pid
+    tile_id = tl.program_id(0) + total_tiles_streamk
+    pid_m, pid_n = swizzle_tile(tile_id, M, N, K, BLOCK_M, BLOCK_N, BLOCK_K, GROUP_M)
+
+    # do matrix multiplication
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    rk = tl.arange(0, BLOCK_K)
+    # pointers
+    ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
+    rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+
+    A = A + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
+    B = B + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_K)):
+        if EVEN_K:
+            a = tl.load(A)
+            b = tl.load(B)
+        else:
+            k_remaining = K - k * BLOCK_K
+            _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)
+            a = tl.load(A, mask=rk[None, :] < k_remaining, other=_0)
+            b = tl.load(B, mask=rk[:, None] < k_remaining, other=_0)
+        acc += tl.dot(a, b, out_dtype=tl.float32, allow_tf32=False)
+        A += BLOCK_K * stride_ak
+        B += BLOCK_K * stride_bk
+    acc = acc.to(C.dtype.element_ty)
+    # rematerialize rm and rn to save registers
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    C = C + (rm[:, None] * stride_cm + rn[None, :] * stride_cn)
+    mask = (rm < M)[:, None] & (rn < N)[None, :]
+    tl.store(C, acc, mask=mask)
+
+
+@libentry()
+@libtuner(
+    configs=runtime.get_tuned_config("mm_iobound") + runtime.get_tuned_config("mm"),
+    key=["M", "N", "K", "stride_am", "stride_bk"],
+)
+@triton.heuristics(
+    {
+        "EVEN_K": lambda args: args["K"] % (args["BLOCK_K"]) == 0,
+    }
+)
+@triton.jit
+def mm_kernel_with_grouped_k(
+    A,
+    B,
+    C,  # [Split_K, M, N]
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cb,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    SPLIT_K: tl.constexpr,  # Number of split-K groups
+    GROUP_K_LENGTH: tl.constexpr,
+    EVEN_K: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    assert GROUP_K_LENGTH % BLOCK_K == 0, "GROUP_K_LENGTH must be divisible by BLOCK_K"
+
+    num_blocks_m = tl.cdiv(M, BLOCK_M)
+    total_num_m = num_blocks_m * SPLIT_K
+
+    pid_n = pid // total_num_m
+    odd_column = pid_n % 2
+    pid_m_normal = pid % total_num_m
+    # this is a line-one implementation for the following code:
+    #     if odd_column:
+    #         pid_m_for_c = (total_num_m - 1) - pid_m_normal
+    #     else:
+    #         pid_m_for_c = pid_m_normal
+    pid_m_for_c = (1 - odd_column) * pid_m_normal + odd_column * (
+        total_num_m - 1 - pid_m_normal
+    )
+
+    pid_m = pid_m_for_c % num_blocks_m
+    pid_k = pid_m_for_c // num_blocks_m
+
+    # Calculate K_LENGTH based on pid_k
+    group_k_length = min(K - pid_k * GROUP_K_LENGTH, GROUP_K_LENGTH)
+
+    # matrix multiplication
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    k_start = pid_k * GROUP_K_LENGTH
+    offs_k = k_start + tl.arange(0, BLOCK_K)
+
+    offs_am = tl.max_contiguous(tl.multiple_of(offs_m % M, BLOCK_M), BLOCK_M)
+    offs_bn = tl.max_contiguous(tl.multiple_of(offs_n % N, BLOCK_N), BLOCK_N)
+
+    # pointers
+    A_ptr = A + (offs_am[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    B_ptr = B + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for k in range(0, tl.cdiv(group_k_length, BLOCK_K)):
+        if EVEN_K:
+            a = tl.load(A_ptr)
+            b = tl.load(B_ptr)
+        else:
+            k_remaining = k_start + group_k_length - k * BLOCK_K
+            a = tl.load(A_ptr, mask=offs_k[None, :] < k_remaining, other=0.0)
+            b = tl.load(B_ptr, mask=offs_k[:, None] < k_remaining, other=0.0)
+        if a.dtype != b.dtype:
+            a = a.to(C.dtype.element_ty)
+            b = b.to(C.dtype.element_ty)
+        acc += tl.dot(a, b, out_dtype=tl.float32, allow_tf32=False)
+        A_ptr += BLOCK_K * stride_ak
+        B_ptr += BLOCK_K * stride_bk
+    acc = acc.to(C.dtype.element_ty)
+
+    # Store results
+    offs_cb = pid_k * stride_cb
+    offs_cm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_cn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    C_ptr = C + offs_cb + (offs_cm[:, None] * stride_cm + offs_cn[None, :] * stride_cn)
+    mask = (offs_cm < M)[:, None] & (offs_cn < N)[None, :]
+
+    tl.store(C_ptr, acc, mask=mask)
+
+
+@libentry()
+@triton.autotune(configs=runtime.get_tuned_config("sum"), key=["M", "N"])
+@triton.jit
+def group_merge_kernel(
+    SRC,  # [SPLIT_K, M, N] 3D Tensor
+    DST,  # [M, N]
+    SPLIT_K,
+    M,
+    N,
+    stride_k,
+    stride_m,
+    stride_n,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    offs_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask_m = offs_m < M
+    mask_n = offs_n < N
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+
+    for k in range(SPLIT_K):
+        src_ptr = (
+            SRC + k * stride_k + offs_m[:, None] * stride_m + offs_n[None, :] * stride_n
+        )
+        sub_matrix = tl.load(src_ptr, mask=mask_m[:, None] & mask_n[None, :], other=0.0)
+
+        acc += sub_matrix
+    acc = acc.to(DST.dtype.element_ty)
+    dst_ptr = DST + offs_m[:, None] * stride_m + offs_n[None, :] * stride_n
+    tl.store(dst_ptr, acc, mask=mask_m[:, None] & mask_n[None, :])
+
+
+@libentry()
+@libtuner(
+    configs=runtime.get_tuned_config("mm_iobound"),
+    # Add 'stride_am' and 'stride_bk' to trigger autotune for tensors with the same shape but different strides.
+    key=["M", "N", "K", "stride_am", "stride_bk"],
+)
+@triton.heuristics(
+    {
+        "EVEN_K": lambda args: args["K"] % (args["BLOCK_K"]) == 0,
+    }
+)
+@triton.jit
+def mm_kernel_iobound(
+    A,
+    B,
+    C,
+    M,
+    N,
+    K,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    EVEN_K: tl.constexpr,
+):
+    # column major tile
+    pid = tle.program_id(0)
+    grid_m = tl.cdiv(M, BLOCK_M)
+    pid_m = pid % grid_m
+    pid_n = pid // grid_m
+
+    # do matrix multiplication
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    rk = tl.arange(0, BLOCK_K)
+
+    ram = tl.max_contiguous(tl.multiple_of(rm % M, BLOCK_M), BLOCK_M)
+    rbn = tl.max_contiguous(tl.multiple_of(rn % N, BLOCK_N), BLOCK_N)
+
+    A = A + (ram[:, None] * stride_am + rk[None, :] * stride_ak)
+    B = B + (rk[:, None] * stride_bk + rbn[None, :] * stride_bn)
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k in range(0, tl.cdiv(K, BLOCK_K)):
+        if EVEN_K:
+            a = tl.load(A)
+            b = tl.load(B)
+        else:
+            k_remaining = K - k * BLOCK_K
+            _0 = tl.zeros((1, 1), dtype=C.dtype.element_ty)
+            a = tl.load(A, mask=rk[None, :] < k_remaining, other=_0)
+            b = tl.load(B, mask=rk[:, None] < k_remaining, other=_0)
+        if a.dtype != b.dtype:
+            a = a.to(C.dtype.element_ty)
+            b = b.to(C.dtype.element_ty)
+        acc += tl.dot(a, b, out_dtype=tl.float32, allow_tf32=False)
+        A += BLOCK_K * stride_ak
+        B += BLOCK_K * stride_bk
+    acc = acc.to(C.dtype.element_ty)
+    # rematerialize rm and rn to save registers
+    rm = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    rn = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    C = C + (rm[:, None] * stride_cm + rn[None, :] * stride_cn)
+    mask = (rm < M)[:, None] & (rn < N)[None, :]
+    # handles write-back with reduction-splitting
+    tl.store(C, acc, mask=mask)
+
+
 @libentry()
 @libtuner(
     configs=runtime.get_tuned_config("mm"),
-    key=["M", "N", "K"],
-    strategy=["log", "log", "log"],
+    # Add 'stride_am' and 'stride_bk' to trigger autotune for tensors with the same shape but different strides.
+    key=["M", "N", "K", "stride_am", "stride_bk"],
+    strategy=["log", "log", "log", None, None],
 )
 @triton.jit
-def mm_kernel(
+def mm_kernel_general(
     A,
     B,
     C,
@@ -111,6 +516,204 @@ def get_higher_dtype(a, b):
             return a
 
 
+def streamk_mm(a, b, c, M, N, K, c_dtype, sm_count=108):
+    # TODO: profile to different settings for different chip
+    if b.stride(0) == 1:
+        BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 128
+        num_stages = 3
+        num_warps = 8
+    else:
+        BLOCK_M, BLOCK_N, BLOCK_K = 128, 128, 64
+        num_stages = 3
+        num_warps = 16
+
+    GROUP_M = 8
+    number_blocks_m = triton.cdiv(M, BLOCK_M)
+    number_blocks_n = triton.cdiv(N, BLOCK_N)
+
+    total_tiles = number_blocks_m * number_blocks_n
+    iters_per_tile = triton.cdiv(K, BLOCK_K)
+    tiles_per_wave = sm_count
+
+    # tiles that would executed in the last wave in general situation.
+    # and this is the tiles that we are going to adopt streamk)
+    total_tiles_streamk = total_tiles % tiles_per_wave
+    # mini wave
+    total_iters_streamk = total_tiles_streamk * iters_per_tile
+    total_full_tiles_streamk = total_iters_streamk // tiles_per_wave
+    total_partial_tiles_streamk = total_iters_streamk % tiles_per_wave
+
+    locks = torch.zeros((total_tiles_streamk,), device=a.device, dtype=torch.int32)
+
+    with torch_device_fn.device(a.device):
+        first_wave[(tiles_per_wave,)](
+            a,
+            b,
+            c,
+            M,
+            N,
+            K,
+            locks,
+            a.stride(0),
+            a.stride(1),
+            b.stride(0),
+            b.stride(1),
+            c.stride(0),
+            c.stride(1),
+            total_full_tiles_streamk=total_full_tiles_streamk,
+            total_partial_tiles_streamk=total_partial_tiles_streamk,
+            iters_per_tile=iters_per_tile,
+            BLOCK_M=BLOCK_M,
+            BLOCK_N=BLOCK_N,
+            BLOCK_K=BLOCK_K,
+            GROUP_M=GROUP_M,
+            num_stages=num_stages,
+            num_warps=num_warps,
+        )
+
+        classic_tiles_mm[(total_tiles - total_tiles_streamk,)](
+            a,
+            b,
+            c,
+            M,
+            N,
+            K,
+            a.stride(0),
+            a.stride(1),
+            b.stride(0),
+            b.stride(1),
+            c.stride(0),
+            c.stride(1),
+            total_tiles_streamk=total_tiles_streamk,
+            BLOCK_M=BLOCK_M,
+            BLOCK_N=BLOCK_N,
+            BLOCK_K=BLOCK_K,
+            GROUP_M=GROUP_M,
+            num_stages=num_stages,
+            num_warps=num_warps,
+        )
+    return c
+
+
+def splitk_mm(a, b, c, M, N, K, c_dtype):
+    GROUP_K_LENGTH = 1024
+    SPLIT_K = triton.cdiv(K, GROUP_K_LENGTH)
+    # TODO: float32 or c_dtype
+    multi_c = torch.empty((SPLIT_K, M, N), device=a.device, dtype=c_dtype)
+    # 1st kernel: compute partial results
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]) * SPLIT_K,
+    )
+    grid2 = lambda META: (
+        triton.cdiv(M, META["BLOCK_M"]),
+        triton.cdiv(N, META["BLOCK_N"]),
+    )
+    with torch_device_fn.device(a.device):
+        mm_kernel_with_grouped_k[grid](
+            a,
+            b,
+            multi_c,
+            M,
+            N,
+            K,
+            a.stride(0),
+            a.stride(1),
+            b.stride(0),
+            b.stride(1),
+            multi_c.stride(0),
+            multi_c.stride(1),
+            multi_c.stride(2),
+            SPLIT_K=SPLIT_K,
+            GROUP_K_LENGTH=GROUP_K_LENGTH,
+        )
+        # return torch.sum(multi_c, dim=0)
+        # 2nd kernel: merge partial results
+        group_merge_kernel[grid2](
+            multi_c,
+            c,
+            SPLIT_K,
+            M,
+            N,
+            multi_c.stride(0),
+            multi_c.stride(1),
+            multi_c.stride(2)
+        )
+    return c
+
+
+def iobound_mm(a, b, c, M, N, K):
+    # launch kernel
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+    )
+    with torch_device_fn.device(a.device):
+        mm_kernel_iobound[grid](
+            a,
+            b,
+            c,
+            M,
+            N,
+            K,
+            a.stride(0),
+            a.stride(1),
+            b.stride(0),
+            b.stride(1),
+            c.stride(0),
+            c.stride(1)
+        )
+    return c
+
+
+def general_mm(a, b, c, M, N, K):
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+    )
+    with torch_device_fn.device(a.device):
+        mm_kernel_general[grid](
+            a,
+            b,
+            c,
+            M,
+            N,
+            K,
+            a.stride(0),
+            a.stride(1),
+            b.stride(0),
+            b.stride(1),
+            c.stride(0),
+            c.stride(1),
+            GROUP_M=8,
+        )
+    return c
+
+
+def mini_mm_scenario(a, b, l2_cache_size=40 * 1024 * 1024, cache_usage_threshold=0.8):
+    return (
+        a.shape[0] <= 256
+        and (a.numel() * a.element_size() + b.shape[0] * b.element_size())
+        < l2_cache_size * cache_usage_threshold
+    )
+
+
+def streamk_scenario(a, b, M, N, K):
+    # TODO: this my change sometime according to the realbenchmark result
+    # Currently, the best configuration for streamk has only been tested on A100(capability[0] > 7).
+    # The optimal settings for other devices need to be determined through real testing.
+    capability = torch_device_fn.get_device_capability(device_id)
+    return (
+        capability[0] > 7
+        and a.dtype in [torch.float16]
+        and b.dtype in [torch.float16]
+        and M > 1024
+        and N > 1024
+        and K > M * 10
+    )
+
+
+def two_stages_splitk_mm_scenario(M, N, K):
+    return (M < 32 or N < 32) and (K > M * 10 or K > N * 10)
+
+
 def mm(a, b):
     logger.debug("GEMS MM")
     device = a.device
@@ -126,27 +729,15 @@ def mm(a, b):
     # allocates output
     c_dtype = get_higher_dtype(a.dtype, b.dtype)
     c = torch.empty((M, N), device=device, dtype=c_dtype)
-    # launch kernel
-    grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
-    )
-    with torch_device_fn.device(a.device):
-        mm_kernel[grid](
-            a,
-            b,
-            c,
-            M,
-            N,
-            K,
-            a.stride(0),
-            a.stride(1),
-            b.stride(0),
-            b.stride(1),
-            c.stride(0),
-            c.stride(1),
-            GROUP_M=8,
-        )
-    return c
+
+    if mini_mm_scenario(a, b, L2_CACHE_SIZE, CACHE_USAGE_THRESHOLD):
+        return iobound_mm(a, b, c, M, N, K)
+    elif streamk_scenario(a, b, M, N, K):
+        return streamk_mm(a, b, c, M, N, K, c_dtype, sm_count=SM_COUNT)
+    elif two_stages_splitk_mm_scenario(M, N, K):
+        return splitk_mm(a, b, c, M, N, K, c_dtype)
+    else:
+        return general_mm(a, b, c, M, N, K)
 
 
 def mm_out(a, b, *, out):
@@ -161,26 +752,14 @@ def mm_out(a, b, *, out):
     M, K = a.shape
     _, N = b.shape
     # allocates output
+    c_dtype = out.dtype
     c = out
     # launch kernel
-    grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
-        META["SPLIT_K"],
-    )
-    with torch_device_fn.device(a.device):
-        mm_kernel[grid](
-            a,
-            b,
-            c,
-            M,
-            N,
-            K,
-            a.stride(0),
-            a.stride(1),
-            b.stride(0),
-            b.stride(1),
-            c.stride(0),
-            c.stride(1),
-            GROUP_M=8,
-        )
-    return c
+    if mini_mm_scenario(a, b, L2_CACHE_SIZE, CACHE_USAGE_THRESHOLD):
+        return iobound_mm(a, b, c, M, N, K)
+    elif streamk_scenario(a, b, M, N, K):
+        return streamk_mm(a, b, c, M, N, K, c_dtype, sm_count=SM_COUNT)
+    elif two_stages_splitk_mm_scenario(M, N, K):
+        return splitk_mm(a, b, c, M, N, K, c_dtype)
+    else:
+        return general_mm(a, b, c, M, N, K)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

- Updated imports in the benchmark directory to use absolute paths for improved clarity and robustness.

- Added a new script `benchmark_for_models.py` to benchmark all operators and shapes involved in a given model.

- Collected and organized part of the Qwen2.5 operator and shape information into `models_shapes/qwen25.yaml`.

- Updated `mm` benchmark logic to include support for `b_column_major` configurations.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
