### PR TITLE
[Benchmark] support profiling wrapper cpu time cost

### DIFF
--- a/benchmark/attri_util.py
+++ b/benchmark/attri_util.py
@@ -138,6 +138,12 @@ def get_recommended_shapes(
     return _shapes_sort(DEFAULT_SHAPES)
 
 
+class BenchMode(Enum):
+    KERNEL = "kernel"
+    OPERATOR = "operator"
+    WRAPPER = "wrapper"
+
+
 class BenchLevel(Enum):
     COMPREHENSIVE = "comprehensive"
     CORE = "core"

--- a/benchmark/conftest.py
+++ b/benchmark/conftest.py
@@ -14,6 +14,7 @@ from benchmark.attri_util import (
     FLOAT_DTYPES,
     INT_DTYPES,
     BenchLevel,
+    BenchMode,
     OperationAttribute,
     get_recommended_shapes,
 )
@@ -25,7 +26,7 @@ vendor_name = flag_gems.vendor_name
 
 class BenchConfig:
     def __init__(self):
-        self.cpu_mode = False
+        self.mode = BenchMode.KERNEL
         self.bench_level = BenchLevel.COMPREHENSIVE
         self.warm_up = DEFAULT_WARMUP_COUNT
         self.repetition = DEFAULT_ITER_COUNT
@@ -50,12 +51,12 @@ def pytest_addoption(parser):
             "--mode" if vendor_name != "kunlunxin" else "--fg_mode"
         ),  # TODO: fix pytest-* common --mode args
         action="store",
-        default=device,
+        default="kernel",
         required=False,
-        choices=[device, "cpu"],
+        choices=["kernel", "operator", "wrapper"],
         help=(
-            "Specify how to measure latency, "
-            f"'cpu' for CPU-side measurement or {device} for GPU-side measurement."
+            "Specify how to measure latency, 'kernel' for device kernel, ",
+            "'operator' for end2end operator or 'wrapper' for runtime wrapper.",
         ),
     )
 
@@ -132,7 +133,7 @@ def pytest_addoption(parser):
 def pytest_configure(config):
     global Config  # noqa: F824
     mode_value = config.getoption("--mode")
-    Config.cpu_mode = mode_value == "cpu"
+    Config.mode = BenchMode(mode_value)
 
     Config.query = config.getoption("--query")
 


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Benchmark
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
set new choices 'kernel', 'operator' and 'wrapper' for option mode.
'kernel' mode: get the latency of triton kernel on accelerator
'operator' mode: get the latency of gems operator from end to end on cpu
'wrapper' mode: get the latency of gems operator implemented by python or cpp
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
