### PR TITLE
update flash_varlen_fwd_kernel

### DIFF
--- a/src/flag_gems/ops/flash_kernel.py
+++ b/src/flag_gems/ops/flash_kernel.py
@@ -1082,9 +1082,15 @@ def load_from_kvcache(
     return bK, bV
 
 
-# @libentry()
+@libentry()
 @triton.jit(
     do_not_specialize=[
+        "q_batch_stride",
+        "k_batch_stride",
+        "v_batch_stride",
+        "o_batch_stride",
+        "b",
+        "bk",
         "seqlen_q",
         "seqlen_k",
         "seqlen_q_rounded",
@@ -1118,8 +1124,8 @@ def flash_varlen_fwd_kernel(
     is_seqused_k: tl.constexpr,
     seqused_k_ptr,
     # sizes
-    b: tl.constexpr,
-    bk: tl.constexpr,
+    b,
+    bk,
     h: tl.constexpr,
     hk: tl.constexpr,
     h_hk_ratio: tl.constexpr,


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Refactor

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Update the list of do_not_specialize arguments in `flash_varlen_fwd_kernel` to reduce the chance of recompilation.  As of now the header looks like

```
@triton.jit(
    do_not_specialize=[
        "q_batch_stride",
        "k_batch_stride",
        "v_batch_stride",
        "o_batch_stride",
        "b",
        "bk",
        "seqlen_q",
        "seqlen_k",
        "seqlen_q_rounded",
        "seqlen_k_rounded",
        "total_q",
    ]
)
def flash_varlen_fwd_kernel(
```

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
