### PR TITLE
[METAX] modified op config and skip unsupported op tests

### DIFF
--- a/benchmark/test_attention_perf.py
+++ b/benchmark/test_attention_perf.py
@@ -6,12 +6,8 @@ import torch
 import triton
 
 import flag_gems
-from benchmark.performance_utils import (
-    Benchmark,
-    GenericBenchmark,
-    SkipVersion,
-    vendor_name,
-)
+
+from .performance_utils import Benchmark, GenericBenchmark, SkipVersion, vendor_name
 
 
 class AttentionBenchmark(GenericBenchmark):
@@ -25,6 +21,7 @@ class AttentionBenchmark(GenericBenchmark):
         return None
 
 
+@pytest.mark.skipif(vendor_name == "metax", reason="TODOFIX")
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="RESULT TODOFIX")
 @pytest.mark.skipif(
     flag_gems.device == "musa" or vendor_name == "hygon", reason="RuntimeError"
@@ -76,6 +73,7 @@ class FlashMLABenchmark(GenericBenchmark):
         return None
 
 
+@pytest.mark.skipif(vendor_name == "metax", reason="TODOFIX")
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="RESULT TODOFIX")
 @pytest.mark.skipif(vendor_name == "iluvatar", reason="RESULT TODOFIX")
 @pytest.mark.skipif(

--- a/src/flag_gems/runtime/backend/_metax/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_metax/heuristics_config_utils.py
@@ -357,9 +357,15 @@ HEURISTICS_CONFIGS = {
         "BLOCK_SIZE": zeros_heur_block_size,
         "num_warps": zeros_heur_num_warps,
     },
-    "mha_varlen_fwd": {
-        "BLOCK_M": lambda args: 128,
+    "mha_varlen_prefill": {
+        "BLOCK_M": lambda args: 64,
         "BLOCK_N": lambda args: 32,
+        "num_warps": lambda args: 4,
+        "num_stages": lambda args: 3,
+    },
+    "mha_varlen_decode": {
+        "BLOCK_M": lambda args: 16,
+        "BLOCK_N": lambda args: 16,
         "num_warps": lambda args: 4,
         "num_stages": lambda args: 3,
     },

--- a/tests/test_attention_ops.py
+++ b/tests/test_attention_ops.py
@@ -251,6 +251,7 @@ def gems_flash_fwd(
     return out, lse, seed, offset, debug_softmax
 
 
+@pytest.mark.skipif(flag_gems.vendor_name == "metax", reason="TODOFIX")
 @pytest.mark.skipif(flag_gems.vendor_name == "hygon", reason="RuntimeError")
 @pytest.mark.skipif(flag_gems.device == "musa", reason="RuntimeError")
 @pytest.mark.skipif(flag_gems.vendor_name == "kunlunxin", reason="RESULT TODOFIX")
@@ -318,6 +319,7 @@ def test_sdpa_legacy(
     gems_assert_close(gems_result, torch_result, dtype)
 
 
+@pytest.mark.skipif(flag_gems.vendor_name == "metax", reason="TODOFIX")
 @pytest.mark.skipif(flag_gems.vendor_name == "hygon", reason="RuntimeError")
 @pytest.mark.skipif(flag_gems.device == "musa", reason="RuntimeError")
 @pytest.mark.skipif(flag_gems.vendor_name == "kunlunxin", reason="RESULT TODOFIX")
@@ -348,6 +350,7 @@ def test_sdpa_square_qk_even_mn(
     gems_assert_close(gems_result, torch_result, dtype)
 
 
+@pytest.mark.skipif(flag_gems.vendor_name == "metax", reason="TODOFIX")
 @pytest.mark.skipif(flag_gems.vendor_name == "hygon", reason="RuntimeError")
 @pytest.mark.skipif(flag_gems.device == "musa", reason="RuntimeError")
 @pytest.mark.skipif(flag_gems.vendor_name == "kunlunxin", reason="RESULT TODOFIX")
@@ -376,6 +379,7 @@ def test_sdpa_nonsquare_qk(
     gems_assert_close(gems_result, torch_result, dtype)
 
 
+@pytest.mark.skipif(flag_gems.vendor_name == "metax", reason="TODOFIX")
 @pytest.mark.skipif(TO_CPU, reason="Unsupported in CPU mode")
 @pytest.mark.skipif(flag_gems.vendor_name == "hygon", reason="RuntimeError")
 @pytest.mark.skipif(flag_gems.device == "musa", reason="RuntimeError")
@@ -484,6 +488,7 @@ def test_flash_fwd_gqa_alibi_softcap(
     gems_assert_close(gems_out, torch_out, dtype)
 
 
+@pytest.mark.skipif(flag_gems.vendor_name == "metax", reason="TODOFIX")
 @pytest.mark.skipif(TO_CPU, reason="Unsupported in CPU mode")
 @pytest.mark.skipif(flag_gems.vendor_name == "hygon", reason="RuntimeError")
 @pytest.mark.skipif(flag_gems.device == "musa", reason="RuntimeError")
@@ -558,6 +563,7 @@ def test_flash_splitkv(
     gems_assert_close(gems_out, torch_out, dtype)
 
 
+@pytest.mark.skipif(flag_gems.vendor_name == "metax", reason="TODOFIX")
 @pytest.mark.skipif(TO_CPU, reason="Unsupported in CPU mode")
 @pytest.mark.skipif(torch.__version__ < "2.4", reason="Low Pytorch Version")
 @pytest.mark.skipif(flag_gems.vendor_name == "hygon", reason="RuntimeError")
@@ -1276,6 +1282,7 @@ def test_reshape_and_cache_flash(
         torch.testing.assert_close(value_cache, cloned_value_cache)
 
 
+@pytest.mark.skipif(flag_gems.vendor_name == "metax", reason="TODOFIX")
 @pytest.mark.skipif(flag_gems.vendor_name == "hygon", reason="RuntimeError")
 @pytest.mark.skipif(flag_gems.device == "musa", reason="RuntimeError")
 @pytest.mark.skipif(flag_gems.vendor_name == "kunlunxin", reason="RESULT TODOFIX")


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
OP Test
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
other
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
1. Reduce block size because the size of shared memory in C500 is smaller than A100.
2. Skip op tests that are not supported in C500 now.

