### PR TITLE
Fix: logger conflict by import vllm

### DIFF
--- a/benchmark/performance_utils.py
+++ b/benchmark/performance_utils.py
@@ -52,8 +52,7 @@ def SkipVersion(module_name, skip_pattern):
         raise ValueError("Cannot parse version number from skip_pattern.")
 
     try:
-        module = importlib.import_module(module_name)
-        version = module.__version__
+        version = importlib.metadata.version(module_name)
         major, minor = map(int, version.split(".")[:2])
     except Exception:
         raise ImportError(f"Cannot determine version of module: {module_name}")

--- a/benchmark/test_attention_perf.py
+++ b/benchmark/test_attention_perf.py
@@ -294,6 +294,9 @@ class FlashAttnVarlenBenchmark(Benchmark):
 @pytest.mark.skipif(flag_gems.vendor_name == "cambricon", reason="TypeError")
 @pytest.mark.flash_attn_varlen_func
 def test_perf_flash_attn_varlen_func():
+    import os
+
+    os.environ["VLLM_CONFIGURE_LOGGING"] = "0"
     from vllm.vllm_flash_attn.flash_attn_interface import flash_attn_varlen_func
 
     bench = FlashAttnVarlenBenchmark(


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Benchmark 
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix 
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
The bug was import by flash_attn_varlen_func benchmark. 
flash_attn_varlen_func test will try to import vllm, and then all pytest logger config will be changed by unknown reason.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
