### PR TITLE
use CUstream to launch kernel instead c10::cuda::CUDAStream in cpp warper

### DIFF
--- a/docs/ctest_in_flaggems.md
+++ b/docs/ctest_in_flaggems.md
@@ -1,6 +1,6 @@
 # C++ Tests in FlagGems
 
-If you build FlagGems with C extensions with `BUILD_CTESTS` cmake option `ON`, you can run the ctest in the dir `FlagGems/build/cpython-3xx` with command:
+If you build FlagGems with C extensions with `FLAGGEMS_BUILD_CTESTS` cmake option `ON`, you can run the ctest in the dir `FlagGems/build/cpython-3xx` with command:
 
 ```bash
 ctest .

--- a/lib/add.cpp
+++ b/lib/add.cpp
@@ -33,7 +33,7 @@ at::Tensor add_tensor(const at::Tensor &a_, const at::Tensor &b_) {
   c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
   c10::DeviceGuard guard(out.device());
   CUstream raw_stream = static_cast<CUstream>(stream.stream());
-  f(stream, num_blocks, 1, 1, num_warps, num_stages, a, b, out, n, tile_size);
+  f(raw_stream, num_blocks, 1, 1, num_warps, num_stages, a, b, out, n, tile_size);
   return out;
 }
 }  // namespace flag_gems

--- a/lib/argmax.cpp
+++ b/lib/argmax.cpp
@@ -37,8 +37,8 @@ at::Tensor argmax(const at::Tensor &self, std::optional<int64_t> dim, bool keepd
 
     c10::DeviceGuard guard(self.device());
     c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-
-    f1(stream,
+    CUstream raw_stream = static_cast<CUstream>(stream.stream());
+    f1(raw_stream,
        mid_size,
        1,
        1,
@@ -50,7 +50,7 @@ at::Tensor argmax(const at::Tensor &self, std::optional<int64_t> dim, bool keepd
        M,
        block_size);
 
-    f2(stream,
+    f2(raw_stream,
        1,
        1,
        1,

--- a/lib/argmax.cpp
+++ b/lib/argmax.cpp
@@ -105,8 +105,9 @@ at::Tensor argmax(const at::Tensor &self, std::optional<int64_t> dim, bool keepd
 
   c10::DeviceGuard guard(self.device());
   c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
+  CUstream raw_stream = static_cast<CUstream>(stream.stream());
 
-  f(stream, grid_x, grid_y, 1, num_warps, num_stages, contiguous_self, out, M, N, K, tile_m, tile_n);
+  f(raw_stream, grid_x, grid_y, 1, num_warps, num_stages, contiguous_self, out, M, N, K, tile_m, tile_n);
 
   return out;
 }

--- a/lib/contiguous.cpp
+++ b/lib/contiguous.cpp
@@ -33,7 +33,7 @@ at::Tensor contiguous(const at::Tensor &self, at::MemoryFormat memory_format) {
   c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
   c10::DeviceGuard guard(out.device());
   CUstream raw_stream = static_cast<CUstream>(stream.stream());
-  f(stream,
+  f(raw_stream,
     num_blocks,
     1,
     1,

--- a/lib/fill.cpp
+++ b/lib/fill.cpp
@@ -20,8 +20,8 @@ at::Tensor fill_scalar(const at::Tensor& input, const c10::Scalar& value) {
 
   c10::DeviceGuard guard(out.device());
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
-
-  fill_kernel(stream, grid_x, 1, 1, 4, 0, out, value, numel, BLOCK_SIZE);
+  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  fill_kernel(raw_stream, grid_x, 1, 1, 4, 0, out, value, numel, BLOCK_SIZE);
 
   return out;
 }
@@ -41,8 +41,8 @@ at::Tensor fill_tensor(const at::Tensor& input, const at::Tensor& value) {
 
   c10::DeviceGuard guard(out.device());
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
-
-  fill_kernel(stream, grid_x, 1, 1, 4, 0, out, value, numel, BLOCK_SIZE);
+  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  fill_kernel(raw_stream, grid_x, 1, 1, 4, 0, out, value, numel, BLOCK_SIZE);
 
   return out;
 }
@@ -60,8 +60,8 @@ at::Tensor& fill_scalar_(at::Tensor& input, const c10::Scalar& value) {
 
   c10::DeviceGuard guard(input.device());
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
-
-  fill_kernel(stream, grid_x, 1, 1, 4, 0, input, value, numel, BLOCK_SIZE);
+  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  fill_kernel(raw_stream, grid_x, 1, 1, 4, 0, input, value, numel, BLOCK_SIZE);
   return input;
 }
 
@@ -79,8 +79,8 @@ at::Tensor& fill_tensor_(at::Tensor& input, const at::Tensor& value) {
 
   c10::DeviceGuard guard(input.device());
   cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
-
-  fill_kernel(stream, grid_x, 1, 1, 4, 0, input, value, numel, BLOCK_SIZE);
+  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  fill_kernel(raw_stream, grid_x, 1, 1, 4, 0, input, value, numel, BLOCK_SIZE);
   return input;
 }
 

--- a/lib/fill.cpp
+++ b/lib/fill.cpp
@@ -19,7 +19,7 @@ at::Tensor fill_scalar(const at::Tensor& input, const c10::Scalar& value) {
                                      "fill_scalar_kernel");
 
   c10::DeviceGuard guard(out.device());
-  cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
+  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
   CUstream raw_stream = static_cast<CUstream>(stream.stream());
   fill_kernel(raw_stream, grid_x, 1, 1, 4, 0, out, value, numel, BLOCK_SIZE);
 
@@ -40,7 +40,7 @@ at::Tensor fill_tensor(const at::Tensor& input, const at::Tensor& value) {
                                      "fill_tensor_kernel");
 
   c10::DeviceGuard guard(out.device());
-  cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
+  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
   CUstream raw_stream = static_cast<CUstream>(stream.stream());
   fill_kernel(raw_stream, grid_x, 1, 1, 4, 0, out, value, numel, BLOCK_SIZE);
 
@@ -59,7 +59,7 @@ at::Tensor& fill_scalar_(at::Tensor& input, const c10::Scalar& value) {
                                      "fill_scalar_kernel");
 
   c10::DeviceGuard guard(input.device());
-  cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
+  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
   CUstream raw_stream = static_cast<CUstream>(stream.stream());
   fill_kernel(raw_stream, grid_x, 1, 1, 4, 0, input, value, numel, BLOCK_SIZE);
   return input;
@@ -78,7 +78,7 @@ at::Tensor& fill_tensor_(at::Tensor& input, const at::Tensor& value) {
                                      "fill_tensor_kernel");
 
   c10::DeviceGuard guard(input.device());
-  cudaStream_t stream = c10::cuda::getCurrentCUDAStream();
+  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
   CUstream raw_stream = static_cast<CUstream>(stream.stream());
   fill_kernel(raw_stream, grid_x, 1, 1, 4, 0, input, value, numel, BLOCK_SIZE);
   return input;

--- a/lib/max.cpp
+++ b/lib/max.cpp
@@ -73,7 +73,7 @@ using namespace triton_jit;
   c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
   CUstream raw_stream = static_cast<CUstream>(stream.stream());
 
-  f(stream,
+  f(raw_stream,
     num_blocks,
     1,
     1,
@@ -115,9 +115,9 @@ at::Tensor max(const at::Tensor &self) {
   c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
   CUstream raw_stream = static_cast<CUstream>(stream.stream());
   // def max_kernel_1(inp,mid,M,BLOCK_SIZE: tl.constexpr)
-  max_kernel_1(stream, mid_size, 1, 1, num_warps, num_stages, self, mid, M, block_size);
+  max_kernel_1(raw_stream, mid_size, 1, 1, num_warps, num_stages, self, mid, M, block_size);
   // def max_kernel_2(mid, out, mid_size, BLOCK_MID: tl.constexpr):
-  max_kernel_2(stream, 1, 1, 1, num_warps, num_stages, mid, out, mid_size, block_mid);
+  max_kernel_2(raw_stream, 1, 1, 1, num_warps, num_stages, mid, out, mid_size, block_mid);
   return out;
 }
 }  // namespace flag_gems

--- a/lib/sum.cpp
+++ b/lib/sum.cpp
@@ -86,7 +86,7 @@ at::Tensor sum_dim(const at::Tensor &self,
   c10::DeviceGuard guard(out.device());
   c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
   CUstream raw_stream = static_cast<CUstream>(stream.stream());
-  f(stream,
+  f(raw_stream,
     num_blocks,
     1,
     1,

--- a/lib/zeros.cpp
+++ b/lib/zeros.cpp
@@ -46,7 +46,7 @@ at::Tensor zeros(at::IntArrayRef size,
   c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
   CUstream raw_stream = static_cast<CUstream>(stream.stream());
 
-  f(stream,
+  f(raw_stream,
     num_blocks,
     /* grid_y = */ 1,
     /* grid_z = */ 1,


### PR DESCRIPTION
### PR Category
Other

### Type of Change
Other

### Description

use `CUstream`

```c++
  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
  CUstream  raw_stream = static_cast<CUstream>(stream.stream());

  f(raw_stream, grid_x, grid_y, 1, num_warps, num_stages, ...);
```

instead of `c10::cuda::CUDAStream` 

```c++
  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
  CUstream  raw_stream = static_cast<CUstream>(stream.stream());

  f(stream, grid_x, grid_y, 1, num_warps, num_stages, ...);
```


### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
