### PR TITLE
Fix: set VLLM_CONFIGURE_LOGGING=0 to solve logger conflict by import vllm

### DIFF
--- a/benchmark/test_attention_perf.py
+++ b/benchmark/test_attention_perf.py
@@ -1,4 +1,5 @@
 import math
+import os
 from typing import Any, List, Optional
 
 import pytest
@@ -290,8 +291,6 @@ class FlashAttnVarlenBenchmark(Benchmark):
 @pytest.mark.skipif(flag_gems.vendor_name == "cambricon", reason="TypeError")
 @pytest.mark.flash_attn_varlen_func
 def test_perf_flash_attn_varlen_func():
-    import os
-
     os.environ["VLLM_CONFIGURE_LOGGING"] = "0"
     from vllm.vllm_flash_attn.flash_attn_interface import flash_attn_varlen_func
 
@@ -326,6 +325,7 @@ class GetSchedulerMetadataBenchmark(GenericBenchmark):
 @pytest.mark.get_scheduler_metadata
 def test_perf_get_scheduler_metadata():
     try:
+        os.environ["VLLM_CONFIGURE_LOGGING"] = "0"
         from vllm.vllm_flash_attn.flash_attn_interface import (
             get_scheduler_metadata as vllm_get_scheduler_metadata,
         )


### PR DESCRIPTION

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
If `flash_attn_varlen_func` is skipped, we need set `os.environ["VLLM_CONFIGURE_LOGGING"] = "0"` again for `test_perf_get_scheduler_metadata`, or `--record log` will not work normally.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
