### PR TITLE
[Iluvatar] fix sin/cos, FA

### DIFF
--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -63,14 +63,8 @@ forward_operations = [
     ("log_sigmoid", torch.nn.functional.logsigmoid, FLOAT_DTYPES),
     ("silu", torch.nn.functional.silu, FLOAT_DTYPES),
     # Trigonometric operations
-    *(
-        []
-        if vendor_name == "iluvatar"  # FIXME(iluvatar): large shapes not support now.
-        else [
-            ("cos", torch.cos, FLOAT_DTYPES),
-            ("sin", torch.sin, FLOAT_DTYPES),
-        ]
-    ),
+    ("cos", torch.cos, FLOAT_DTYPES),
+    ("sin", torch.sin, FLOAT_DTYPES),
     ("tanh", torch.tanh, FLOAT_DTYPES),
     # Bitwise operations
     ("bitwise_not", torch.bitwise_not, INT_DTYPES),

--- a/src/flag_gems/ops/flash_api.py
+++ b/src/flag_gems/ops/flash_api.py
@@ -508,6 +508,9 @@ def mha_varlan_fwd(
             block_size,  # block_size,
         )
 
+        if flag_gems.vendor_name == "iluvatar":
+            params.k_ptr = k.view(k.shape[0], k.shape[1], -1)
+            params.v_ptr = v.view(v.shape[0], v.shape[1], -1)
         logger.debug("kernel: flash_varlen_fwd")
         grid = lambda args: (
             triton.cdiv(max_seqlen_q, args["BLOCK_M"]),

--- a/src/flag_gems/runtime/backend/_iluvatar/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/heuristics_config_utils.py
@@ -309,15 +309,15 @@ HEURISTICS_CONFIGS = {
     "vdot": {
         "BLOCK_SIZE": vdot_heur_block_size,
     },
-    "mha_varlen_fwd": {
-        "BLOCK_M": lambda args: 32,
-        "BLOCK_N": lambda args: 16,
+    "mha_varlen_prefill": {
+        "BLOCK_M": lambda args: 64,
+        "BLOCK_N": lambda args: 32,
         "num_warps": lambda args: 4,
         "num_stages": lambda args: 3,
     },
     "mha_varlen_decode": {
-        "BLOCK_M": lambda args: 16,
-        "BLOCK_N": lambda args: 64,
+        "BLOCK_M": lambda args: 32,
+        "BLOCK_N": lambda args: 16,
         "num_warps": lambda args: 4,
         "num_stages": lambda args: 3,
     },


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
1. Enable performance tests for `sin` and `cos`.

2. Fix flash_attention_varlen: 1)  compress the last two dimensions for Iluvatar to ensure correct stride handling for async-cp like https://github.com/FlagOpen/FlagGems/pull/783 . 2) refactor to remove unnecessary convert_layout. On Iluvatar, this acts as a workaround to fix an accuracy issue.
On all vendors, this change is expected to improve performance.
<img width="2594" height="429" alt="image" src="https://github.com/user-attachments/assets/db774fd6-4702-4f4a-b4f9-34c91deab6ce" />
<img width="2532" height="395" alt="image" src="https://github.com/user-attachments/assets/c29d3d6e-fe18-4076-851e-721954f4eff6" />
<img width="2536" height="444" alt="image" src="https://github.com/user-attachments/assets/c3eb89de-2e3a-4b63-8fc9-74ce7cd79e19" />

3. fix `test_sdpa_legacy`: Iluvatar SDPA CPU backend has known issues, use math backend instead.

4. fix `test_flash_fwd_nonsquare_qk` and `test_flash_fwd_swa`: CUDA FlashAttention on Iluvatar uses a different optimized implementation, which causes LSE to differ from original implementation on math.

5. `test_flash_fwd_dropout`: Verified it passes on NV A100 with Triton, so the test is enabled.
### Issue





<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
