### PR TITLE
[Refactor]: Replace direct calls to torch.cuda with torch_device_fn

### DIFF
--- a/src/flag_gems/fused/flash_mla.py
+++ b/src/flag_gems/fused/flash_mla.py
@@ -183,7 +183,7 @@ def flash_mla(
 
     o = torch.empty([b * s_q, h_q, dv], dtype=q.dtype, device=device)
 
-    major, _ = torch.cuda.get_device_capability(device)
+    major, _ = torch_device_fn.get_device_capability(device)
     if major == 9:
         BLOCK_H = 64
         num_stages = 3

--- a/src/flag_gems/ops/get_scheduler_metadata.py
+++ b/src/flag_gems/ops/get_scheduler_metadata.py
@@ -6,6 +6,8 @@ import torch
 import triton
 import triton.language as tl
 
+from flag_gems.runtime import torch_device_fn
+
 logger = logging.getLogger(__name__)
 
 
@@ -100,7 +102,7 @@ def get_optimal_block_mn(
     varlen_and_split=False,
     append_kv=False,
 ):
-    arch_cap = torch.cuda.get_device_capability(device)
+    arch_cap = torch_device_fn.get_device_capability(device)
     arch = arch_cap[0] * 10 + arch_cap[1]
     sm86_or_89 = arch == 86 or arch == 89
 
@@ -469,9 +471,11 @@ def get_scheduler_metadata(
         effective_window_left >= 0 or effective_window_right >= 0
     ) and not final_is_causal
 
-    arch_cap = torch.cuda.get_device_capability(device)
+    arch_cap = torch_device_fn.get_device_capability(device)
     arch = arch_cap[0] * 10 + arch_cap[1]
-    num_sm = torch.cuda.get_device_properties(device).multi_processor_count - sm_margin
+    num_sm = (
+        torch_device_fn.get_device_properties(device).multi_processor_count - sm_margin
+    )
 
     softcap = 1.0 if has_softcap else 0.0
 


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator 
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Refactor 
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Some vendors do not support explicit calls to torch.cuda. Use torch_device_fn to replace torch.cuda in order to reduce cases of backend-specific custom operators.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
