### PR TITLE
Fix: diff dtype in cat, hstack, stack

### DIFF
--- a/src/flag_gems/ops/cat.py
+++ b/src/flag_gems/ops/cat.py
@@ -110,7 +110,6 @@ def cat(
     dtype = dtypes[0]
     for dt in dtypes[1:]:
         dtype = torch.promote_types(dtype, dt)
-
     # Convert all tensors to the common dtype if needed
     A = [t.to(dtype) if t.dtype != dtype else t for t in A]
 

--- a/src/flag_gems/ops/hstack.py
+++ b/src/flag_gems/ops/hstack.py
@@ -121,7 +121,6 @@ def hstack(
     dtype = dtypes[0]
     for dt in dtypes[1:]:
         dtype = torch.promote_types(dtype, dt)
-
     # Convert all tensors to the common dtype if needed
     tensors = [t.to(dtype) if t.dtype != dtype else t for t in tensors]
     device = tensors[0].device

--- a/src/flag_gems/ops/stack.py
+++ b/src/flag_gems/ops/stack.py
@@ -103,13 +103,11 @@ def stack(
     dtype = dtypes[0]
     for dt in dtypes[1:]:
         dtype = torch.promote_types(dtype, dt)
-
+    # Convert all tensors to the result dtype if needed
+    tensors = [t.to(dtype) if t.dtype != dtype else t for t in tensors]
     device = tensors[0].device
     out_shape = inp0_shape[:dim] + [len(tensors)] + inp0_shape[dim:]
     out = torch.empty(out_shape, dtype=dtype, device=device)
-
-    # Convert all tensors to the result dtype if needed
-    tensors = [t.to(dtype) if t.dtype != dtype else t for t in tensors]
 
     dim_prod_post = 1
     for s in inp0_shape[dim:]:


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator 
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
gems.cat can not handle different tensor data type in python wrapper.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
