### PR TITLE
[Ascend] remove uncleaned split_k

### DIFF
--- a/src/flag_gems/runtime/backend/_ascend/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_ascend/heuristics_config_utils.py
@@ -83,7 +83,7 @@ def index_select_heur_block_n(args):
 
 
 def mm_heur_even_k(args):
-    return args["K"] % (args["BLOCK_K"] * args["SPLIT_K"]) == 0
+    return args["K"] % args["BLOCK_K"] == 0
 
 
 def rand_heur_block(args):

--- a/src/flag_gems/runtime/backend/_ascend/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/mm.py
@@ -36,7 +36,6 @@ def mm_kernel(
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
     GROUP_M: tl.constexpr,
-    SPLIT_K: tl.constexpr,
     EVEN_K: tl.constexpr,
 ):
     # matrix multiplication
@@ -121,7 +120,6 @@ def mm(a, b):
     # launch kernel
     grid = lambda META: (
         triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
-        META["SPLIT_K"],
     )
     with torch_device_fn.device(a.device):
         mm_kernel[grid](


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

Some `split_k` are not removed correctly in ascend implementations, which might lead to unexpected failure. Now this PR cleans them.
