### PR TITLE
set FLAGGEMS_SOURCE_DIR at import time

### DIFF
--- a/src/flag_gems/config.py
+++ b/src/flag_gems/config.py
@@ -1,9 +1,13 @@
 import os
 import warnings
+from pathlib import Path
 
 has_c_extension = False
 use_c_extension = False
 aten_patch_list = []
+
+# set FLAGGEMS_SOURCE_DIR for cpp extension to find
+os.environ["FLAGGEMS_SOURCE_DIR"] = str(Path(__file__).parent.resolve())
 
 try:
     from flag_gems import c_operators


### PR DESCRIPTION


### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Other


### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

1. set `FLAGGEMS_SOURCE_DIR` at import time for cpp extension to find the source dir of flag_gems. So it is no longer necessary to set the environment manually when using python package
2. adapt standalone_compile.py to triton 3.4

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
