### PR TITLE
fix:remove extra 'D' from FLAGGEMS_USE_EXTERNAL_TRITON_JIT in CMAKE_ARGS

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -82,7 +82,7 @@ Editable installation with external TritonJIT
 ```shell
 pip install -U scikit-build-core ninja cmake pybind11
 
-CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DDFLAGGEMS_USE_EXTERNAL_TRITON_JIT=ON -DTritonJIT_ROOT=<install path of triton-jit>" \
+CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_USE_EXTERNAL_TRITON_JIT=ON -DTritonJIT_ROOT=<install path of triton-jit>" \
 pip install --no-build-isolation -v -e .
 ```
 


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Docs

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Documentation Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
remove extra 'D' from FLAGGEMS_USE_EXTERNAL_TRITON_JIT in CMAKE_ARGS

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
