### PR TITLE
Support Multi-DB-Backends for LibCache

### DIFF
--- a/docs/libcache_db_backend.md
+++ b/docs/libcache_db_backend.md
@@ -1,0 +1,32 @@
+# LibCache DataBase Backend Setup
+
+`LibCache` provides a dispatch mechanism for the database used to store benchmark results. The dependency library is `sqlalchemy`, so please make sure it's available in the working environment.
+
+The way to select corresponding backend is to set the environment variable `FLAGGEMS_DB_URL`.
+
+## SQLite3
+
+The default backend available is `SQLite3`. Please make sure the relative library `sqlite3` is already installed. If you want to store the db file in an assigned place, please set the environment variable as
+```bash
+export FLAGGEMS_DB_URL=sqlite:///${db_path}
+```
+If you want use it as a memory library, or don't want to remain or reuse caches in your current environment, you could set the environment as
+```bash
+export FLAGGEMS_DB_URL=sqlite:///:memory:
+```
+The cache would be only stored in the memory, and when the connection is broken, the database would be lost.
+
+## PostgreSQL
+
+As an embed database, `SQLite3` doesn't support multi-writers at the same time, which could be common in some cases. So we also support the users to select `PostgreSQL` as the backend. Different from the embed database, it requires the setup it before using. You could refer to the [document](https://documentation.ubuntu.com/server/how-to/databases/install-postgresql/) on how to set it up. Or you could use a remote database to allow several `FlagGems` instances to connect to it at the same time and share benchmark results in this way.
+
+After creating your own database, you could use the following url to set the environment variable
+```bash
+export FLAGGEMS_DB_URL=postgresql+psycopg:///${user}:${password}@${host}:${port}/${db}
+```
+If the database in on your local machine, and your current role could allow you to access it directly, you can use the following environment variable
+```bash
+export FLAGGEMS_DB_URL=postgresql+psycopg:///${db}
+```
+
+Before using it, please make sure the related dependency `psycopg` is installed on your machine.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,6 +27,7 @@ dependencies = [
     "pybind11",
     "PyYAML",
     "packaging",
+    "sqlalchemy",
 ]
 
 [project.optional-dependencies]

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -6,14 +6,24 @@ import logging
 import math
 import multiprocessing
 import os
-import sqlite3
-import threading
 import time
 from abc import abstractmethod
 from collections import OrderedDict
 from functools import cached_property
 from itertools import starmap
-from typing import Any, Callable, Dict, Iterator, List, Optional, Tuple, Type, Union
+from pathlib import Path
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    Final,
+    Iterator,
+    List,
+    Optional,
+    Tuple,
+    Type,
+    Union,
+)
 
 import torch
 import triton
@@ -22,6 +32,7 @@ from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
 from flag_gems.runtime.backend import vendor_module
 from flag_gems.utils.code_cache import config_cache_dir
+from flag_gems.utils.models import PersistantModel, SQLPersistantModel
 
 logger = logging.getLogger(__name__)
 
@@ -54,60 +65,16 @@ if major_version == 2:
 
     setattr(triton.Config, "all_kwargs", all_kwargs)
 
-FLAGGEMS_ENABLE_DISK_CACHE = os.getenv("FLAGGEMS_ENABLE_DISK_CACHE", "1") == "1"
-
-
-class Connections(object):
-    def __init__(self, cache_path: str, *args, **kwargs) -> Connections:
-        super().__init__(*args, **kwargs)
-        self.cache_path: str = cache_path
-        self.lock = multiprocessing.Lock()
-        self.conns: Dict[int, sqlite3.Connection] = {}
-
-    def __del__(self):
-        for conn in self.conns.values():
-            conn.close()
-
-    @property
-    def curr_conn(self) -> sqlite3.Connection:
-        with self.lock:
-            tid: int = threading.get_ident()
-            conn: Optional[sqlite3.Connection] = self.conns.get(tid)
-            if conn is None:
-                conn = sqlite3.connect(self.cache_path)
-                self.conns[tid] = conn
-            return conn
+FLAGGEMS_DB_URL = os.getenv("FLAGGEMS_DB_URL", None)
 
 
 class Cache(object):
-    def __init__(self, table_name: str, conns: Connections, *args, **kwargs) -> Cache:
+    def __init__(
+        self, table_name: str, model: PersistantModel, *args, **kwargs
+    ) -> Cache:
         super().__init__(*args, **kwargs)
-        self.table_name: str = table_name
-        self.conns: Connections = conns
-        self.py2sql: Dict[type, str] = {
-            bool: "BOOLEAN",
-            int: "INTEGER",
-            float: "DOUBLE",
-            str: "VARCHAR(16)",  # it often stores string values like 'torch.float16', so 16 would be long enough
-        }
-
-    @staticmethod
-    def build_key_dict(key: Tuple[Union[int, float, str], ...]) -> Dict[str, Any]:
-        return {
-            f"key_{k}": v for k, v in enumerate(key) if isinstance(v, (int, float, str))
-        }
-
-    @staticmethod
-    def build_config_dict(config: triton.Config) -> Dict[str, Any]:
-        return {
-            k: v
-            for k, v in config.all_kwargs().items()
-            if isinstance(v, (int, float, str))
-        }
-
-    @property
-    def conn(self) -> sqlite3.Connection:
-        return self.conns.curr_conn
+        self.table_name: Final[str] = table_name
+        self.model: Final[PersistantModel] = model
 
 
 class ConfigCache(Cache):
@@ -116,24 +83,9 @@ class ConfigCache(Cache):
     """
 
     def __init__(
-        self, table_name: str, conns: Connections, *args, **kwargs
+        self, table_name: str, model: PersistantModel, *args, **kwargs
     ) -> ConfigCache:
-        super().__init__(table_name, conns, *args, **kwargs)
-        self.config_signature: inspect.Signature = inspect.signature(triton.Config)
-        self.dict_cache: Dict[
-            Tuple[Union[int, float, str], ...], triton.Config
-        ] = {}  # this dict is used to cache some results in the memory
-        self.lock = multiprocessing.Lock()
-        self.names: List[str] = [
-            name
-            for _, name, _, _, _, _ in self.conn.execute(
-                f"PRAGMA table_info({self.table_name});"
-            ).fetchall()
-        ]
-        self.create_sql: Optional[
-            str
-        ] = None  # if the corresponding sql instruction is None, meaning the table is not ready, we need to flush it
-        self.insert_sql: Optional[str] = None
+        super().__init__(table_name, model, *args, **kwargs)
 
     def __contains__(self, key: Tuple[Union[int, float, str], ...]) -> bool:
         return self.get(key) is not None
@@ -141,143 +93,57 @@ class ConfigCache(Cache):
     def __getitem__(self, key: Tuple[Union[int, float, str], ...]) -> triton.Config:
         ret: Optional[triton.Config] = self.get(key)
         if ret is None:
-            raise KeyError(key)
-        else:
-            return ret
+            raise KeyError(f"Key {key} not found in ConfigCache.")
+        return ret
 
     def __setitem__(
         self, key: Tuple[Union[int, float, str], ...], config: triton.Config
-    ):
+    ) -> None:
         self.set(key, config)
 
-    @property
-    def knames(self) -> Iterator[str]:
-        return filter(
-            lambda name: name.startswith("key_"), self.names
-        )  # if the column name starts with "key_", it should be a key defined by the libtuner
-
-    @property
-    def cnames(self) -> Iterator[str]:
-        return filter(
-            lambda name: not name.startswith("key_"), self.names
-        )  # otherwise, it should be a parameter in the config
-
-    @property
-    def select_sql(self) -> Optional[str]:
-        if self.names:
-            return "SELECT {} FROM {} WHERE {};".format(
-                ", ".join(self.cnames),
-                self.table_name,
-                " AND ".join(map(lambda kname: f"{kname}=?", self.knames)),
-            )
-        else:
-            return None
-
     def get(self, key: Tuple[Union[int, float, str], ...]) -> Optional[triton.Config]:
-        with self.lock:
-            ret = self.dict_cache.get(key)
-            if ret is not None or self.select_sql is None:
-                # if the key is already in the dict cache, we can return it directly
-                # or if `select_sql` is not ready yet, which means the table is not ready yet, we can return None
-                return ret
-            rets = self.conn.execute(self.select_sql, key).fetchall()
-            if not rets:
-                return None
-            [ret] = rets
-            kwargs: Dict[str, Any] = {}
-            numargs: Dict[str, int] = {}
-            for k, v in zip(self.cnames, ret):
-                if k in self.config_signature.parameters:
-                    numargs[k] = v
-                else:
-                    kwargs[k] = v
-            ret = triton.Config(kwargs, **numargs)
-            self.dict_cache[key] = ret
-            return ret
+        return self.model.get_config(self.table_name, key)
 
-    def set(self, key: Tuple[Union[int, float, str], ...], config: triton.Config):
-        with self.lock:
-            key_queries: Dict[str, Any] = self.build_key_dict(key)
-            config_queries: Dict[str, Any] = self.build_config_dict(config)
-            queries: Dict[str, Any] = key_queries | config_queries
-            if self.create_sql is None:
-                self.create_sql = "CREATE TABLE IF NOT EXISTS {} ({});".format(
-                    self.table_name,
-                    ",\n".join(
-                        [f"{k} {self.py2sql[type(v)]}" for k, v in queries.items()]
-                        + ["PRIMARY KEY ({})".format(", ".join(key_queries.keys()))]
-                    ),
-                )
-                self.conn.execute(self.create_sql)
-            if not self.names:
-                self.names = queries
-            if self.insert_sql is None:
-                self.insert_sql = "INSERT OR REPLACE INTO {} VALUES ({});".format(
-                    self.table_name, ", ".join("?" for _ in queries.values())
-                )
-            self.conn.execute(self.insert_sql, [*queries.values()])
-        self.conn.commit()
+    def set(
+        self, key: Tuple[Union[int, float, str], ...], config: triton.Config
+    ) -> None:
+        return self.model.put_config(self.table_name, key, config)
 
 
 class BenchmarkCache(Cache):
     def __init__(
         self,
         table_name: str,
+        model: PersistantModel,
         key: Tuple[Union[int, float, str], ...],
-        conns: Connections,
         *args,
         **kwargs,
     ) -> BenchmarkCache:
         """
         `BenchmarkCache` is used to store the benchmark results for the pair of the specific key and configuration.
         """
-        super().__init__(table_name, conns, *args, **kwargs)
-        self.key: Tuple[Union[int, float, str], ...] = key
-        self.lock = multiprocessing.Lock()
-        self.create_sql: Optional[str] = None
-        self.select_sql: Optional[str] = None
-        self.insert_sql: Optional[str] = None
+        super().__init__(table_name, model, *args, **kwargs)
+        self.key: Final[Tuple[Union[int, float, str], ...]] = key
 
-    def __getitem__(self, config: triton.Config) -> Optional[List[float]]:
-        with self.lock:
-            queries: Dict[str, Union[int, float, str]] = self.build_query(config)
-            if self.select_sql is None:
-                where: str = " AND ".join(f"{k} = ?" for k in queries.keys())
-                self.select_sql = (
-                    f"SELECT p50, p20, p80 FROM {self.table_name} WHERE {where};"
-                )
-            ret = self.conn.execute(self.select_sql, [*queries.values()]).fetchone()
-            if isinstance(ret, tuple):
-                ret = [*ret]
-            return ret
+    def __contains__(self, config: triton.Config) -> bool:
+        return self.model.get_benchmark(self.key, config) is not None
 
-    def __setitem__(self, config: triton.Config, benchmark: List[float]) -> None:
-        with self.lock:
-            queries: Dict[str, Union[int, float, str]] = self.build_query(config)
-            values: List[str] = [*queries.values(), *benchmark]
-            if not self.insert_sql:
-                self.insert_sql = "INSERT OR REPLACE INTO {} VALUES ({});".format(
-                    self.table_name, ", ".join("?" for _ in values)
-                )
-            self.conn.execute(self.insert_sql, values)
-        self.conn.commit()
-
-    def build_query(self, config: triton.Config) -> Dict[str, Any]:
-        queries: Dict[str, Any] = self.build_key_dict(
-            self.key
-        ) | self.build_config_dict(config)
-        if self.create_sql is None:
-            self.create_sql = "CREATE TABLE IF NOT EXISTS {} ({});".format(
-                self.table_name,
-                ",\n".join(
-                    [f"{k} {self.py2sql[type(v)]}" for k, v in queries.items()]
-                    + [f"p{n} DOUBLE" for n in [50, 20, 80]]
-                    + ["PRIMARY KEY ({})".format(", ".join(queries.keys()))]
-                ),
+    def __getitem__(self, config: triton.Config) -> Tuple[float]:
+        ret: Optional[Tuple[float, float, float]] = self.get(config)
+        if ret is None:
+            raise KeyError(
+                f"Config {config} not found in BenchmarkCache for key {self.key}."
             )
-            self.conn.execute(self.create_sql)
-            self.conn.commit()
-        return queries
+        return ret
+
+    def __setitem__(self, config: triton.Config, benchmark: Tuple[float]) -> None:
+        return self.set(config, benchmark)
+
+    def get(self, config: triton.Config) -> Optional[Tuple[float, float, float]]:
+        return self.model.get_benchmark(self.table_name, self.key, config)
+
+    def set(self, config: triton.Config, benchmark: Tuple[float, float, float]) -> None:
+        return self.model.put_benchmark(self.table_name, self.key, config, benchmark)
 
 
 class LibCache(object):
@@ -288,29 +154,25 @@ class LibCache(object):
             cls._instance = super(LibCache, cls).__new__(cls)
         return cls._instance
 
-    def __init__(self, enable_disk_cache: bool):
+    def __init__(self, db_url: Optional[str] = None):
         self.global_cache: Dict = {}
         self.volumn: Dict = {}
-        cache_file_name = (
-            f"TunedConfig_{torch.cuda.get_device_name().replace(' ', '_')}_triton_{major_version}_{minor_version}.db"
-            if vendor_module.vendor_info.vendor_name == "nvidia"
-            else f"TunedConfig_{vendor_module.vendor_info.vendor_name}_triton_{major_version}_{minor_version}.db"
-        )
-        self.cache_path = (
-            (config_cache_dir() / cache_file_name) if enable_disk_cache else ":memory:"
-        )
-        self.bench_lock = multiprocessing.Lock()
-        self.config_lock = multiprocessing.Lock()
-        self.conns: Connections = Connections(self.cache_path)
+        if db_url is None:
+            device_name: str = torch.cuda.get_device_name().replace(" ", "_")
+            cache_file_name: str = (
+                f"TunedConfig_{device_name}_triton_{major_version}_{minor_version}.db"
+                if vendor_module.vendor_info.vendor_name == "nvidia"
+                else f"TunedConfig_{vendor_module.vendor_info.vendor_name}_triton_{major_version}_{minor_version}.db"
+            )
+            cache_path: Path = config_cache_dir() / cache_file_name
+            self.db_url: str = f"sqlite:///{cache_path}"
+        else:
+            self.db_url: str = db_url
         self.config_cache_pool: Dict[str, ConfigCache] = {}
         self.benchmark_cache_pool: Dict[
             Tuple[str, Tuple[Union[int, float, str], ...]], BenchmarkCache
         ] = {}
-
-    def __post_init__(self):
-        with sqlite3.connect(self.cache_path) as conn:
-            conn.execute("PRAGMA journal=WAL;")
-            conn.commit()
+        self.model: PersistantModel = SQLPersistantModel(self.db_url)
 
     def __getitem__(
         self, key: Union[str, Tuple[Union[int, float, str], ...]]
@@ -325,23 +187,21 @@ class LibCache(object):
     def get_benchmark(
         self, table: str, key: Tuple[Union[int, float, str], ...]
     ) -> BenchmarkCache:
-        with self.bench_lock:
-            ret = self.benchmark_cache_pool.get((table, key))
-            if ret is None:
-                ret = BenchmarkCache(table, key, self.conns)
-                self.benchmark_cache_pool[(table, key)] = ret
+        ret = self.benchmark_cache_pool.get((table, key))
+        if ret is None:
+            ret = BenchmarkCache(table, self.model, key)
+            self.benchmark_cache_pool[(table, key)] = ret
         return ret
 
     def get_config(self, table: str) -> ConfigCache:
-        with self.config_lock:
-            ret = self.config_cache_pool.get(table)
-            if ret is None:
-                ret = ConfigCache(table, self.conns)
-                self.config_cache_pool[table] = ret
+        ret = self.config_cache_pool.get(table)
+        if ret is None:
+            ret = ConfigCache(table, self.model)
+            self.config_cache_pool[table] = ret
         return ret
 
 
-libcache = LibCache(FLAGGEMS_ENABLE_DISK_CACHE)
+libcache = LibCache(FLAGGEMS_DB_URL)
 
 
 class LibTuner(triton.runtime.Autotuner):
@@ -427,23 +287,23 @@ class LibTuner(triton.runtime.Autotuner):
         self.cache: BenchmarkCache = libcache[self.config_table_name]
 
     @cached_property
-    def cache_key(self):
+    def cache_key(self) -> str:
         jit_fn = self.fn
         while not isinstance(jit_fn, triton.runtime.JITFunction):
             jit_fn = jit_fn.fn
         return jit_fn.cache_key
 
     @cached_property
-    def kernel_hash(self):
+    def kernel_hash(self) -> str:
         return hashlib.md5(
             f"{self.cache_key}{self.configs_hash}".encode("utf-8")
-        ).hexdigest()
+        ).hexdigest()[:32]
 
     @cached_property
-    def configs_hash(self):
+    def configs_hash(self) -> str:
         return hashlib.md5(
             ",".join(map(lambda config: str(config), self.configs)).encode("utf-8")
-        ).hexdigest()
+        ).hexdigest()[:32]
 
     def get_key(self, args):
         if self.strategy is None:
@@ -562,11 +422,11 @@ class LibTuner(triton.runtime.Autotuner):
                 bench_start = time.time()
 
                 def bench(config: triton.Config) -> List[float]:
-                    ret = cache[config]
+                    ret = cache.get(config)
                     if ret is None:
                         ret = self._bench(*args, config=config, **kwargs)
-                        cache[config] = ret
-                    return ret
+                        cache[config] = tuple(ret)
+                    return list(ret)
 
                 best_config, timings = self.policy(
                     bench,

--- a/src/flag_gems/utils/models/__init__.py
+++ b/src/flag_gems/utils/models/__init__.py
@@ -1,0 +1,4 @@
+from .model import PersistantModel
+from .sql import SQLPersistantModel
+
+__all__ = ["PersistantModel", "SQLPersistantModel"]

--- a/src/flag_gems/utils/models/model.py
+++ b/src/flag_gems/utils/models/model.py
@@ -1,0 +1,92 @@
+import inspect
+from abc import abstractmethod
+from typing import Dict, Final, Optional, Sequence, Tuple, Union, overload
+
+import triton
+
+
+class PersistantModel(object):
+    signature: Final[inspect.Signature] = inspect.signature(triton.Config)
+
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    @staticmethod
+    def parse_config(config: triton.Config) -> Dict[str, Union[int, float, str]]:
+        return {
+            k: v
+            for k, v in config.all_kwargs().items()
+            if isinstance(v, (int, float, str))
+        }
+
+    @abstractmethod
+    def get_config(
+        self, name: str, key: Sequence[Union[bool, int, float, str]]
+    ) -> Optional[triton.Config]:
+        ...
+
+    @abstractmethod
+    def get_benchmark(
+        self,
+        name: str,
+        keys: Sequence[Union[bool, int, float, str]],
+        config: triton.Config,
+    ) -> Optional[Tuple[float, float, float]]:
+        ...
+
+    @overload
+    def put_config(
+        self,
+        name: str,
+        keys: Sequence[Union[bool, int, float, str]],
+        config: triton.Config,
+    ) -> None:
+        ...
+
+    @overload
+    def put_config(
+        self,
+        name: str,
+        keys: Sequence[Union[bool, int, float, str]],
+        config: Dict[str, Union[bool, int, float, str]],
+    ) -> None:
+        ...
+
+    @abstractmethod
+    def put_config(
+        self,
+        name: str,
+        keys: Sequence[Union[bool, int, float, str]],
+        config: Union[triton.Config, Dict[str, Union[bool, int, float, str]]],
+    ) -> None:
+        ...
+
+    @overload
+    def put_benchmark(
+        self,
+        name: str,
+        keys: Sequence[Union[bool, int, float, str]],
+        config: triton.Config,
+        benchmark: Tuple[float, float, float],
+    ) -> None:
+        ...
+
+    @overload
+    def put_benchmark(
+        self,
+        name: str,
+        keys: Sequence[Union[bool, int, float, str]],
+        config: Dict[str, Union[bool, int, float, str]],
+        benchmark: Tuple[float, float, float],
+    ) -> None:
+        ...
+
+    @abstractmethod
+    def put_benchmark(
+        self,
+        name: str,
+        keys: Sequence[Union[bool, int, float, str]],
+        config: Union[triton.Config, Dict[str, Union[bool, int, float, str]]],
+        benchmark: Tuple[float, float, float],
+    ) -> None:
+        ...

--- a/src/flag_gems/utils/models/session.py
+++ b/src/flag_gems/utils/models/session.py
@@ -1,0 +1,15 @@
+import sqlalchemy.exc
+import sqlalchemy.orm
+from typing_extensions import override
+
+
+class RollbackSession(sqlalchemy.orm.Session):
+    def __init__(self, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+
+    @override
+    def commit(self) -> None:
+        try:
+            super().commit()
+        except sqlalchemy.exc.IntegrityError:
+            self.rollback()

--- a/src/flag_gems/utils/models/sql.py
+++ b/src/flag_gems/utils/models/sql.py
@@ -1,0 +1,208 @@
+from itertools import chain
+from typing import Any, Callable, Dict, Final, Mapping, Optional, Sequence, Tuple, Union
+
+import sqlalchemy
+import sqlalchemy.ext.automap
+import sqlalchemy.orm
+import triton
+from typing_extensions import override
+
+from .model import PersistantModel
+from .session import RollbackSession
+
+
+class Base(sqlalchemy.orm.DeclarativeBase):
+    ...
+
+
+class SQLPersistantModel(PersistantModel):
+    def __init__(self, db_url: str, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.engine: Final[sqlalchemy.engine.Engine] = sqlalchemy.create_engine(db_url)
+        self.sql_model_pool: Dict[str, type[Base]] = {}
+
+    @staticmethod
+    def build_sql_model_by_py(
+        name: str,
+        keys: Mapping[str, Union[Any, type]],
+        values: Mapping[str, Union[Any, type]] = {},
+    ) -> type[Base]:
+        annotations: Dict[str, type] = {
+            k: sqlalchemy.orm.Mapped[v if isinstance(v, type) else type(v)]
+            for k, v in chain(keys.items(), values.items())
+        }
+        cols: Dict[str, sqlalchemy.orm.MappedColumn] = {
+            k: sqlalchemy.orm.mapped_column(primary_key=True) for k in keys.keys()
+        } | {k: sqlalchemy.orm.mapped_column(primary_key=False) for k in values.keys()}
+        ModelCls: type[Base] = type(
+            name,
+            (Base,),
+            {
+                "__annotations__": annotations,
+                "__tablename__": name,
+                **cols,
+            },
+        )
+        return ModelCls
+
+    @staticmethod
+    def build_sql_model_by_db(
+        name: str,
+        engine: sqlalchemy.engine.Engine,
+    ) -> Optional[type[Base]]:
+        AutoBase: sqlalchemy.ext.automap.AutomapBase = (
+            sqlalchemy.ext.automap.automap_base(Base)
+        )
+        AutoBase.prepare(engine)
+        ModelCls: Optional[type[Base]] = AutoBase.classes.get(name)
+        return ModelCls
+
+    @staticmethod
+    def get_key_dict(
+        keys: Sequence[Union[bool, int, float, str]],
+    ) -> Dict[str, Union[bool, int, float, str]]:
+        return {f"key_{i}": v for i, v in enumerate(keys)}
+
+    @staticmethod
+    def get_config_dict(
+        config: triton.Config,
+    ) -> Dict[str, Union[bool, int, float, str]]:
+        return {
+            k: v
+            for k, v in config.all_kwargs().items()
+            if isinstance(v, (int, float, str))
+        }
+
+    def get_sql_model(
+        self,
+        name: str,
+        keys: Mapping[str, Union[Any, type]] = {},
+        values: Mapping[str, Union[Any, type]] = {},
+    ) -> Callable[[str, Optional[Mapping[str, type]]], Optional[type[Base]]]:
+        ModelCls: Optional[type[Base]] = self.sql_model_pool.get(name)
+        if ModelCls is not None:
+            return ModelCls
+        ModelCls: Optional[type[Base]] = SQLPersistantModel.build_sql_model_by_db(
+            name, self.engine
+        )
+        if ModelCls is not None:
+            self.sql_model_pool[name] = ModelCls
+            return ModelCls
+        if not keys or not values:
+            return None
+        ModelCls: type[Base] = SQLPersistantModel.build_sql_model_by_py(
+            name, keys, values
+        )
+        with self.engine.begin() as conn:
+            conn.execute(
+                sqlalchemy.schema.CreateTable(ModelCls.__table__, if_not_exists=True)
+            )
+        self.sql_model_pool[name] = ModelCls
+        return ModelCls
+
+    @override
+    def get_config(
+        self, name: str, keys: Sequence[Union[bool, int, float, str]]
+    ) -> Optional[triton.Config]:
+        key_dict: Dict[
+            str, Union[bool, int, float, str]
+        ] = SQLPersistantModel.get_key_dict(keys)
+        ConfigCls: Optional[type[Base]] = self.get_sql_model(name, key_dict)
+        if ConfigCls is None:
+            return None
+        with RollbackSession(self.engine) as session:
+            obj: Optional[Base] = session.get(
+                ConfigCls,
+                key_dict,
+            )
+            if obj is None:
+                return None
+            obj_dict: Dict[str, Union[bool, int, float, str]] = {
+                k.key: getattr(obj, k.key)
+                for k in sqlalchemy.inspect(obj).mapper.columns
+                if k.key not in key_dict
+            }
+            kwargs: Dict[str, Union[bool, int, float, str]] = {
+                k: v for k, v in obj_dict.items() if k not in self.signature.parameters
+            }
+            config_dict: Dict[str, int] = {
+                k: v for k, v in obj_dict.items() if k in self.signature.parameters
+            }
+            return triton.Config(kwargs, **config_dict)
+
+    @override
+    def get_benchmark(
+        self,
+        name: str,
+        keys: Sequence[Union[bool, int, float, str]],
+        config: triton.Config,
+    ) -> Optional[Tuple[float, float, float]]:
+        key_dict: Dict[str, Union[bool, int, float, str]] = {
+            **SQLPersistantModel.get_key_dict(keys),
+            **SQLPersistantModel.get_config_dict(config),
+        }
+        BenchmarkCls: Optional[type[Base]] = self.get_sql_model(name, key_dict)
+        if BenchmarkCls is None:
+            return None
+        with RollbackSession(self.engine) as session:
+            obj: Optional[Base] = session.get(
+                BenchmarkCls,
+                key_dict,
+            )
+            if obj is None:
+                return None
+            p50: float = obj.p50
+            p20: float = obj.p20
+            p80: float = obj.p80
+            return (p50, p20, p80)
+
+    def put_config(
+        self,
+        name: str,
+        keys: Sequence[Union[bool, int, float, str]],
+        config: Union[triton.Config, Dict[str, Union[bool, int, float, str]]],
+    ) -> None:
+        if isinstance(config, triton.Config):
+            config: Dict[
+                str, Union[bool, int, float, str]
+            ] = SQLPersistantModel.get_config_dict(config)
+        key_dict: Dict[
+            str, Union[bool, int, float, str]
+        ] = SQLPersistantModel.get_key_dict(keys)
+        ConfigCls: Optional[type[Base]] = self.get_sql_model(
+            name,
+            {k: type(v) for k, v in key_dict.items()},
+            {k: type(v) for k, v in config.items()},
+        )
+        if ConfigCls is not None:
+            with RollbackSession(self.engine) as session:
+                obj: Base = ConfigCls(**key_dict, **config)
+                session.merge(obj)
+                session.commit()
+
+    def put_benchmark(
+        self,
+        name: str,
+        keys: Sequence[Union[bool, int, float, str]],
+        config: Union[triton.Config, Dict[str, Union[bool, int, float, str]]],
+        benchmark: Tuple[float, float, float],
+    ) -> None:
+        key_dict: Dict[
+            str, Union[bool, int, float, str]
+        ] = SQLPersistantModel.get_key_dict(keys)
+        if isinstance(config, triton.Config):
+            config: Dict[
+                str, Union[bool, int, float, str]
+            ] = SQLPersistantModel.get_config_dict(config)
+        p50, p20, p80 = benchmark
+        benchmark: Dict[str, float] = {"p50": p50, "p20": p20, "p80": p80}
+        BenchmarkCls: Optional[type[Base]] = self.get_sql_model(
+            name,
+            key_dict | config,
+            benchmark,
+        )
+        if BenchmarkCls is not None:
+            with RollbackSession(self.engine) as session:
+                obj: Base = BenchmarkCls(**key_dict, **config, **benchmark)
+                session.merge(obj)
+                session.commit()


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Other

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
This PR supports multi-sql-backends for `libcache`. It's powered by `sqlalchemy`. The previous SQL backend is sqlite3, which doesn't support multi-writers at the same time, and may lead to some writing conflicts in the multi-workers cases. By introducing PostgreSQL as an available option for `libcache`, which supports several writings at the same time, it could solve the problem.

The details are recored in the document `docs/libcache_db_backend.md`. Please refer to it for more details.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
