### PR TITLE
[bug fix]replace trace with diagonal + sum for unsupported dtypes on CPU

### DIFF
--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -875,10 +875,14 @@ def test_accuracy_trace(shape, dtype):
         inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
 
     ref_inp = to_reference(inp)
-    if dtype == torch.bool and ref_inp.device.type == "cpu":
-        pytest.skip("skipping bool on CPU reference.")
-
-    ref_out = torch.trace(ref_inp)
+    if ref_inp.device.type == "cpu" and dtype in [
+        torch.half,
+        torch.bfloat16,
+        torch.bool,
+    ]:
+        ref_out = torch.sum(torch.diagonal(ref_inp))
+    else:
+        ref_out = torch.trace(ref_inp)
     with flag_gems.use_gems():
         res_out = torch.trace(inp)
 


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
OP Test

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
This PR fixes the correctness test failure of the `trace` operator on CPU
for unsupported dtypes (`Half`, `BFloat16`, and `Bool`).

