### PR TITLE
[BUG] set upcast=True for reference of max_pool2d_backward

### DIFF
--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -1212,7 +1212,7 @@ def test_accuracy_max_pool2d_backward(
     shape, kernel_size, stride, padding, dilation, ceil_mode, dtype
 ):
     inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
-    ref_inp = to_reference(inp)
+    ref_inp = to_reference(inp, upcast=True)
     ref_out, _ = torch.nn.functional.max_pool2d_with_indices(
         ref_inp,
         kernel_size=kernel_size,
@@ -1221,10 +1221,7 @@ def test_accuracy_max_pool2d_backward(
         dilation=dilation,
         ceil_mode=ceil_mode,
     )
-    out_grad = torch.randn_like(ref_out, device=flag_gems.device)
-    ref_grad = to_reference(out_grad)
-    (ref_in_grad,) = torch.autograd.grad(ref_out, ref_inp, ref_grad)
-    _, res_indices = flag_gems.max_pool2d_with_indices(
+    res_out, res_indices = flag_gems.max_pool2d_with_indices(
         inp,
         kernel_size=kernel_size,
         stride=stride,
@@ -1232,6 +1229,9 @@ def test_accuracy_max_pool2d_backward(
         dilation=dilation,
         ceil_mode=ceil_mode,
     )
+    out_grad = torch.randn_like(res_out, device=flag_gems.device)
+    ref_grad = to_reference(out_grad, upcast=True)
+    (ref_in_grad,) = torch.autograd.grad(ref_out, ref_inp, ref_grad)
     res_in_grad = flag_gems.max_pool2d_backward(
         out_grad,
         inp,


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
<img width="1115" height="581" alt="image" src="https://github.com/user-attachments/assets/71b58eac-71dd-4114-903a-ad2160bb0f60" />

`pytest tests/test_reduction_ops.py::test_accuracy_max_pool2d_backward[dtype0-shape0-3-2-1-1-False]  --ref cpu`  failed on NV-A100 triton3.1 (passed using triton3.2). Upcast cpu reference to fix it. 

By the way, I suggest use `--ref cpu` for CI. for now, we use `--cpu --mode quick`, and missed some bugs when use `--ref cpu`

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
