### PR TITLE
[enflame] fix stride mismatch int flash_attention_forward test

### DIFF
--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -1065,7 +1065,7 @@ def flash_attention_forward(
     else:
         non_null_window_right = -1
 
-    out = torch.empty_like(query)
+    out = torch.empty(query.shape, device=query.device, dtype=query.dtype)
     if cumulative_sequence_length_q is not None:
         out, q, k, v, lse, philox_seed, philox_offset, p = mha_varlan_fwd(
             query,

--- a/tests/test_attention_ops.py
+++ b/tests/test_attention_ops.py
@@ -192,6 +192,7 @@ def attention_ref(
     else:
         attention_drop = attention
     output = torch.einsum("bhts,bshd->bthd", attention_drop, v * dropout_scaling)
+    output = output.contiguous()
     if query_padding_mask is not None:
         output.masked_fill_((~query_padding_mask)[:, :, None, None], 0.0)
     return output.to(dtype=dtype_og), attention.to(dtype=dtype_og)
@@ -662,7 +663,7 @@ def test_flash_fwd_gqa_alibi_softcap(
 @pytest.mark.flash_attention_forward
 @pytest.mark.parametrize(
     ["batch", "num_head", "num_head_k", "q_seq_len", "kv_seq_len"],
-    [(1, 4, 1, 1, 1024), (4, 4, 4, 1, 519)],
+    [(1, 4, 1, 1, 1024), (4, 4, 4, 1, 519), (1, 4, 1, 2, 16)],
 )
 @pytest.mark.parametrize("head_size", [128, 192])
 @pytest.mark.parametrize("is_causal", [False, True])


### PR DESCRIPTION
    detail log:
    test_attention_ops.py::attention_ref

       output = torch.einsum("bhts,bshd->bthd", attention_drop, drop_v)
       if query_padding_mask is not None:
            output.masked_fill_((~query_padding_mask)[:, :, None, None], 0.0)
        log:output.shape torch.Size([1, 2, 4, 128])
        log:output.stride (256, 128, 256, 1)
        output = output.contiguous() --need contiguous
        log:output.shape torch.Size([1, 2, 4, 128])
        log:output.stride (1024, 512, 128, 1)
    flag_gems/ops/attention.py::flash_attention_forward
        query = transpose(1, 2) got a temp layout
        log:out torch.Size([1, 4, 2, 128])
        log:out.stride (1024, 128, 512, 1)
        log:out.is_contiguous() False
        out = out.contiguous()
        log:out.contiguous() torch.Size([1, 4, 2, 128])
        log:out.contiguous().stride (1024, 128, 512, 1)
        log:out.contiguous().is_contiguous() False

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
