### PR TITLE
Fix test_perf_upsample_bicubic2d_aa

### DIFF
--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -290,7 +290,7 @@ def test_perf_upsample_bicubic2d_aa():
             "align_corners": False,
             "scales_h": None,
             "scales_w": None,
-        }
+        },
 
     if vendor_name == "cambricon":
         dtypes = [torch.float32]


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
E                   Failed: _upsample_bicubic2d_aa() received an invalid combination of arguments - got (), but expected one of:
E                    * (Tensor input, tuple of ints output_size, bool align_corners, tuple of floats scale_factors)
E                    * (Tensor input, tuple of ints output_size, bool align_corners, float scales_h = None, float scales_w = None, *, Tensor out = None)

This PR https://github.com/flagos-ai/FlagGems/pull/1096 delete the comma.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
