### PR TITLE
fix test_fused_perf in benchmark

### DIFF
--- a/benchmark/summary_for_plot.py
+++ b/benchmark/summary_for_plot.py
@@ -102,7 +102,7 @@ def parse_log(log_file_path: str) -> List[BenchmarkResult]:
         log_lines = [
             line
             for line in file.read().strip().split("\n")
-            if line.startswith("[INFO]")
+            if line.startswith("[INFO] {")
         ]
 
     benchmark_results = []

--- a/benchmark/test_fused_perf.py
+++ b/benchmark/test_fused_perf.py
@@ -1,3 +1,4 @@
+import os
 from typing import Optional
 
 import pytest
@@ -235,13 +236,13 @@ class TopKSoftmaxBenchmark(Benchmark):
 )
 @pytest.mark.skipif(vendor_name == "metax", reason="TODOFIX")
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="RESULT TODOFIX")
-@pytest.mark.skipif(vendor_name == "iluvatar", reason="RESULT TODOFIX")
 @pytest.mark.skipif(vendor_name == "mthreads", reason="RESULT TODOFIX")
 @pytest.mark.skipif(vendor_name == "hygon", reason="RuntimeError")
 @pytest.mark.skipif(flag_gems.vendor_name == "cambricon", reason="TypeError")
 @pytest.mark.topk_softmax
 def test_perf_topk_softmax():
     try:
+        os.environ["VLLM_CONFIGURE_LOGGING"] = "0"
         from vllm._custom_ops import topk_softmax as vllm_topk_softmax
     except (ImportError, AttributeError) as e:
         pytest.skip(f"Skipped due to missing vLLM topk_softmax: {e}")


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
1. Enable test_perf_topk_softmax on Iluvatar backend

2. Fix missing logs caused when vllm is imported, same as https://github.com/flagos-ai/FlagGems/pull/838

3. Fix JSON parsing failure when VLLM emits non-JSON [INFO] logs
`[INFO] Automatically detected platform cuda.`

reproduce on NV-A100:  

```python
$ pytest test_fused_perf.py -m topk_softmax --level core --record log
$ cat result_test_fused_perf-m_topk_softmax--level_core--record_log.log
[INFO] Automatically detected platform cuda.
[INFO] {"op_name": "topk_softmax", "dtype": "torch.float32", "mode": "kernel", "level": "core", "result": [{"legacy_shape": null, "shape_detail": [[256, 16], [256, 16], [256, 16], [256, 128]], "latency_base": 0.016383999958634377, "latency": 0.016383999958634377, "gbps_base": null, "gbps": null, "speedup": 1.0, "accuracy": null, "tflops": null, "utilization": null, "compared_speedup": null, "error_msg": null}, {"legacy_shape": null, "shape_detail": [[1024, 32], [1024, 32], [1024, 32], [1024, 256]], "latency_base": 0.025599999353289604, "latency": 0.03788800165057182, "gbps_base": null, "gbps": null, "speedup": 0.6756756291712006, "accuracy": null, "tflops": null, "utilization": null, "compared_speedup": null, "error_msg": null}, {"legacy_shape": null, "shape_detail": [[4096, 8], [4096, 8], [4096, 8], [4096, 64]], "latency_base": 0.013311999849975109, "latency": 0.014336000196635723, "gbps_base": null, "gbps": null, "speedup": 0.9285714053700335, "accuracy": null, "tflops": null, "utilization": null, "compared_speedup": null, "error_msg": null}, {"legacy_shape": null, "shape_detail": [[8192, 8], [8192, 8], [8192, 8], [8192, 128]], "latency_base": 0.027648000046610832, "latency": 0.026623999699950218, "gbps_base": null, "gbps": null, "speedup": 1.0384615519156022, "accuracy": null, "tflops": null, "utilization": null, "compared_speedup": null, "error_msg": null}, {"legacy_shape": null, "shape_detail": [[16384, 8], [16384, 8], [16384, 8], [16384, 256]], "latency_base": 0.053247999399900436, "latency": 0.08089599758386612, "gbps_base": null, "gbps": null, "speedup": 0.6582278603425024, "accuracy": null, "tflops": null, "utilization": null, "compared_speedup": null, "error_msg": null}]}

$ python3 summary_for_plot.py result_test_fused_perf-m_topk_softmax--level_core--record_log.log 
Traceback (most recent call last):
  File "FlagGems/benchmark/summary_for_plot.py", line 320, in <module>
    main(args.log_file_path)
  File "FlagGems/benchmark/summary_for_plot.py", line 300, in main
    result = parse_log(log_file_path)
  File "FlagGems/benchmark/summary_for_plot.py", line 112, in parse_log
    data = json.loads(json_str)
  File "/usr/lib/python3.10/json/__init__.py", line 346, in loads
    return _default_decoder.decode(s)
  File "/usr/lib/python3.10/json/decoder.py", line 337, in decode
    obj, end = self.raw_decode(s, idx=_w(s, 0).end())
  File "/usr/lib/python3.10/json/decoder.py", line 355, in raw_decode
    raise JSONDecodeError("Expecting value", s, err.value) from None
json.decoder.JSONDecodeError: Expecting value: line 1 column 1 (char 0)
```

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
