### PR TITLE
optimize gelu_backward/glu_backward

### DIFF
--- a/src/flag_gems/utils/pointwise_dynamic.py
+++ b/src/flag_gems/utils/pointwise_dynamic.py
@@ -21,7 +21,7 @@ from flag_gems.utils.shape_utils import (
 )
 from flag_gems.utils.tensor_wrapper import StridedBuffer
 from flag_gems.utils.type_utils import ELEMENTWISE_TYPE_PROMOTION_KIND, type_promotion
-
+from flag_gems.runtime import torch_device_fn
 
 # ------------------ Operation Description ---------------------------
 def _type_name(type) -> str:
@@ -822,15 +822,25 @@ class WrapperGenerator:
             with code.indent():
                 self.gen_return(code)
             max_tile_size = self.config.max_tile_size
-            code.writeline(
-                f"tile_sizes = heuristics_for_tile_size({max_tile_size}, *shape)"
-            )
+
+            capability = torch_device_fn.get_device_capability(torch_device_fn.current_device())
+            if self.name.find("fill_scalar") != -1 and capability[0] >= 9:
+                code.writeline("tile_sizes = tuple([64])")
+            else:
+                code.writeline(
+                    f"tile_sizes = heuristics_for_tile_size({max_tile_size}, *shape)"
+                )
+
             code.writeline("tile_size = math.prod(tile_sizes)")
             code.writeline(
                 "num_tiles = math.prod(triton.cdiv(size, tile_size) for size, tile_size in zip(shape, tile_sizes))"
             )
-            max_grid_size0 = self.config.max_grid_size[0]
-            code.writeline(f"num_ctas = min({max_grid_size0}, num_tiles)")
+
+            if capability[0] >= 9:
+                code.writeline("num_ctas = num_tiles")
+            else:
+                max_grid_size0 = self.config.max_grid_size[0]
+                code.writeline(f"num_ctas = min({max_grid_size0}, num_tiles)")
 
             code.writeline("tiles_per_cta = triton.cdiv(num_tiles, num_ctas)")
             code.writeline("num_warps = heuristics_for_num_warps(tile_size)")
@@ -850,13 +860,23 @@ class WrapperGenerator:
             with code.indent():
                 self.gen_return(code)
             max_tile_size = self.config.max_tile_size
-            code.writeline(
-                f"tile_sizes = heuristics_for_tile_size({max_tile_size}, num_tasks)"
-            )
+
+            capability = torch_device_fn.get_device_capability(torch_device_fn.current_device())
+            if self.name.find("fill_scalar") != -1 and capability[0] >= 9:
+                code.writeline("tile_sizes = tuple([64])")
+            else:
+                code.writeline(
+                    f"tile_sizes = heuristics_for_tile_size({max_tile_size}, num_tasks)"
+                )
+
             code.writeline("tile_size = tile_sizes[0]")
             code.writeline("num_tiles = triton.cdiv(num_tasks, tile_size)")
-            max_grid_size0 = self.config.max_grid_size[0]
-            code.writeline(f"num_ctas = min({max_grid_size0}, num_tiles)")
+
+            if capability[0] >= 9:
+                code.writeline("num_ctas = num_tiles")
+            else:
+                max_grid_size0 = self.config.max_grid_size[0]
+                code.writeline(f"num_ctas = min({max_grid_size0}, num_tiles)")
 
             code.writeline("tiles_per_cta = triton.cdiv(num_tiles, num_ctas)")
             code.writeline("num_warps = heuristics_for_num_warps(tile_size)")


### PR DESCRIPTION
### PR Category
[Operator]

### Type of Change
[ Performance Optimization]

### Description
optimize gelu_backward/glu_backward performance on h100

### Issue

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
Gelu_backward:
test_unary_pointwise_perf.py::test_general_unary_pointwise_backward_perf[gelu-gelu-dtypes0] 
Operator: gelu_backward  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)

Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------

SUCCESS               0.008512            0.008256               1.031               0.127          [torch.Size([1048576])]
SUCCESS               0.006272            0.006304               0.995               0.001          [torch.Size([64, 64])]
SUCCESS               0.086720            0.045888               1.890               0.366          [torch.Size([4096, 4096])]
SUCCESS               0.045984            0.046016               0.999               0.365          [torch.Size([64, 512, 512])]
SUCCESS               0.722752            0.619552               1.167               0.433          [torch.Size([256, 1024, 1024])]
SUCCESS               0.050336            0.006208               8.108               0.000          [torch.Size([1024, 1])]
SUCCESS               0.058752            0.006432               9.134               0.003          [torch.Size([1024, 16])]
SUCCESS               0.007808            0.006912               1.130               0.038          [torch.Size([1024, 256])]
SUCCESS               0.016416            0.016448               0.998               0.255          [torch.Size([1024, 4096])]
SUCCESS               0.153280            0.163360               0.938               0.411          [torch.Size([1024, 65536])]
SUCCESS               0.074464            0.006144              12.120               0.001          [torch.Size([64, 64, 1])]
SUCCESS               0.088032            0.006656              13.226               0.010          [torch.Size([64, 64, 16])]
SUCCESS               0.019040            0.008576               2.220               0.122          [torch.Size([64, 64, 256])]
SUCCESS               0.063424            0.046272               1.371               0.363          [torch.Size([64, 64, 4096])]


Operator: gelu_backward  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)

Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------

SUCCESS               0.058432            0.010560               5.533               0.099          [torch.Size([1048576])]
SUCCESS               0.042784            0.006432               6.652               0.001          [torch.Size([64, 64])]
SUCCESS               0.073504            0.072832               1.009               0.230          [torch.Size([4096, 4096])]
SUCCESS               0.073536            0.073184               1.005               0.229          [torch.Size([64, 512, 512])]
SUCCESS               1.040288            1.041312               0.999               0.258          [torch.Size([256, 1024, 1024])]
SUCCESS               0.006464            0.006304               1.025               0.000          [torch.Size([1024, 1])]
SUCCESS               0.006656            0.006368               1.045               0.003          [torch.Size([1024, 16])]
SUCCESS               0.023328            0.007296               3.197               0.036          [torch.Size([1024, 256])]
SUCCESS               0.054240            0.023968               2.263               0.175          [torch.Size([1024, 4096])]
SUCCESS               0.266720            0.266048               1.003               0.252          [torch.Size([1024, 65536])]
SUCCESS               0.046432            0.006048               7.677               0.001          [torch.Size([64, 64, 1])]
SUCCESS               0.006624            0.006464               1.025               0.010          [torch.Size([64, 64, 16])]
SUCCESS               0.073568            0.010208               7.207               0.103          [torch.Size([64, 64, 256])]
SUCCESS               0.072832            0.072608               1.003               0.231          [torch.Size([64, 64, 4096])]


Operator: gelu_backward  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)

Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------

SUCCESS               0.064896            0.008416               7.711               0.125          [torch.Size([1048576])]
SUCCESS               0.039648            0.005984               6.626               0.001          [torch.Size([64, 64])]
SUCCESS               0.077760            0.046976               1.655               0.357          [torch.Size([4096, 4096])]
SUCCESS               0.044704            0.047040               0.950               0.357          [torch.Size([64, 512, 512])]
SUCCESS               0.725376            0.643392               1.127               0.417          [torch.Size([256, 1024, 1024])]
SUCCESS               0.073760            0.005856              12.596               0.000          [torch.Size([1024, 1])]
SUCCESS               0.006016            0.005856               1.027               0.003          [torch.Size([1024, 16])]
SUCCESS               0.048096            0.006592               7.296               0.040          [torch.Size([1024, 256])]
SUCCESS               0.016160            0.016544               0.977               0.254          [torch.Size([1024, 4096])]
SUCCESS               0.155328            0.170432               0.911               0.394          [torch.Size([1024, 65536])]
SUCCESS               0.048320            0.005856               8.251               0.001          [torch.Size([64, 64, 1])]
SUCCESS               0.072480            0.006304              11.497               0.010          [torch.Size([64, 64, 16])]
SUCCESS               0.008288            0.008384               0.989               0.125          [torch.Size([64, 64, 256])]
SUCCESS               0.050528            0.047136               1.072               0.356          [torch.Size([64, 64, 4096])]


Glu_backward:
test_unary_pointwise_perf.py::test_glu_backward_perf 
Operator: glu_backward  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)

Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------

SUCCESS               2.265696            1.746016               1.298               0.615          [torch.Size([1073741824])]
SUCCESS               0.006240            0.005600               1.114               0.001          [torch.Size([64, 64])]
SUCCESS               0.044640            0.034592               1.290               0.485          [torch.Size([4096, 4096])]
SUCCESS               0.044576            0.034624               1.287               0.485          [torch.Size([64, 512, 512])]
SUCCESS               2.314592            2.511744               0.922               0.427          [torch.Size([1024, 1024, 1024])]
SUCCESS               0.006048            0.005536               1.092               0.000          [torch.Size([1024, 2])]
SUCCESS               0.006304            0.005728               1.101               0.006          [torch.Size([1024, 32])]
SUCCESS               0.007872            0.007136               1.103               0.073          [torch.Size([1024, 512])]
SUCCESS               0.062848            0.020992               2.994               0.400          [torch.Size([1024, 8192])]
SUCCESS               0.299584            0.224320               1.336               0.598          [torch.Size([1024, 131072])]
SUCCESS               0.007776            0.006016               1.293               0.001          [torch.Size([64, 64, 2])]
SUCCESS               0.012352            0.006272               1.969               0.021          [torch.Size([64, 64, 32])]
SUCCESS               0.011328            0.009920               1.142               0.211          [torch.Size([64, 64, 512])]
SUCCESS               0.081344            0.086112               0.945               0.390          [torch.Size([64, 64, 8192])]


Operator: glu_backward  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)

Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------

SUCCESS               3.958080            3.492096               1.133               0.307          [torch.Size([1073741824])]
SUCCESS               0.006816            0.005792               1.177               0.001          [torch.Size([64, 64])]
SUCCESS               0.071552            0.061696               1.160               0.272          [torch.Size([4096, 4096])]
SUCCESS               0.071488            0.061920               1.155               0.271          [torch.Size([64, 512, 512])]
SUCCESS               3.940704            3.490464               1.129               0.308          [torch.Size([1024, 1024, 1024])]
SUCCESS               0.006528            0.005600               1.166               0.000          [torch.Size([1024, 2])]
SUCCESS               0.006944            0.005952               1.167               0.006          [torch.Size([1024, 32])]
SUCCESS               0.008640            0.008064               1.071               0.065          [torch.Size([1024, 512])]
SUCCESS               0.040320            0.034368               1.173               0.244          [torch.Size([1024, 8192])]
SUCCESS               0.501632            0.442144               1.135               0.304          [torch.Size([1024, 131072])]
SUCCESS               0.006752            0.006304               1.071               0.001          [torch.Size([64, 64, 2])]
SUCCESS               0.007232            0.006304               1.147               0.021          [torch.Size([64, 64, 32])]
SUCCESS               0.018336            0.013312               1.377               0.158          [torch.Size([64, 64, 512])]
SUCCESS               0.132512            0.116736               1.135               0.287          [torch.Size([64, 64, 8192])]


Operator: glu_backward  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)

Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------

SUCCESS               2.276160            1.751072               1.300               0.613          [torch.Size([1073741824])]
SUCCESS               0.006432            0.005632               1.142               0.001          [torch.Size([64, 64])]
SUCCESS               0.044704            0.034464               1.297               0.487          [torch.Size([4096, 4096])]
SUCCESS               0.044576            0.034624               1.287               0.485          [torch.Size([64, 512, 512])]
SUCCESS               2.316768            2.526944               0.917               0.425          [torch.Size([1024, 1024, 1024])]
SUCCESS               0.006240            0.005632               1.108               0.000          [torch.Size([1024, 2])]
SUCCESS               0.006496            0.005760               1.128               0.006          [torch.Size([1024, 32])]
SUCCESS               0.007904            0.007136               1.108               0.073          [torch.Size([1024, 512])]
SUCCESS               0.026432            0.020992               1.259               0.400          [torch.Size([1024, 8192])]
SUCCESS               0.299456            0.224288               1.335               0.598          [torch.Size([1024, 131072])]
SUCCESS               0.045504            0.005984               7.604               0.001          [torch.Size([64, 64, 2])]
SUCCESS               0.006944            0.006304               1.102               0.021          [torch.Size([64, 64, 32])]
SUCCESS               0.011360            0.010016               1.134               0.209          [torch.Size([64, 64, 512])]
SUCCESS               0.081632            0.086112               0.948               0.390          [torch.Size([64, 64, 8192])]
