### PR TITLE
【PerfXLab】optimize Vdot

### DIFF
--- a/src/flag_gems/ops/vdot.py
+++ b/src/flag_gems/ops/vdot.py
@@ -64,55 +64,54 @@ def vdot_kernel_complex(
 ):
     pid = tl.program_id(0)
     num_progs = tl.num_programs(0)
-    
+
     grid_stride = num_progs * BLOCK_SIZE
-    
+
     acc_real = tl.zeros([], dtype=tl.float32)
     acc_imag = tl.zeros([], dtype=tl.float32)
-    
 
     for current_start in range(0, n_elements // 2, grid_stride):
-
         complex_idx = current_start + pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
         mask = complex_idx < n_elements // 2
-        
+
         real_offset = complex_idx * 2
-        
+
         inp_real = tl.load(inp_ptr + real_offset * inp_stride, mask=mask, other=0.0)
         inp_imag = tl.load(inp_ptr + real_offset * inp_stride + 1, mask=mask, other=0.0)
-        
-        other_real = tl.load(other_ptr + real_offset * other_stride, mask=mask, other=0.0)
-        other_imag = tl.load(other_ptr + real_offset * other_stride + 1, mask=mask, other=0.0)
-        
+
+        other_real = tl.load(
+            other_ptr + real_offset * other_stride, mask=mask, other=0.0
+        )
+        other_imag = tl.load(
+            other_ptr + real_offset * other_stride + 1, mask=mask, other=0.0
+        )
+
         out_real, out_imag = compute_vdot(
             inp_real, inp_imag, other_real, other_imag, inp_is_conj, other_is_conj
         )
         acc_real += out_real
         acc_imag += out_imag
-    
+
     temp_offset = pid * 2
     tl.store(out_ptr + temp_offset, acc_real)
     tl.store(out_ptr + temp_offset + 1, acc_imag)
 
+
 @libentry()
 @triton.jit()
-def reduce_kernel_complex(
-    input_ptr,
-    out_ptr,
-    n_blocks,
-    BLOCK_SIZE: tl.constexpr
-):
+def reduce_kernel_complex(input_ptr, out_ptr, n_blocks, BLOCK_SIZE: tl.constexpr):
     pid = tl.program_id(0)
     base_offset = tl.arange(0, BLOCK_SIZE)
     mask = base_offset < n_blocks
 
-    inp_real = tl.load(input_ptr+base_offset*2, mask=mask, other=0.0)
-    inp_imag = tl.load(input_ptr+base_offset*2+1,mask=mask, other=0.0)
+    inp_real = tl.load(input_ptr + base_offset * 2, mask=mask, other=0.0)
+    inp_imag = tl.load(input_ptr + base_offset * 2 + 1, mask=mask, other=0.0)
     final_out_real = tl.sum(inp_real)
     final_out_imag = tl.sum(inp_imag)
     if pid == 0:
         tl.store(out_ptr, final_out_real)
-        tl.store(out_ptr+1, final_out_imag)
+        tl.store(out_ptr + 1, final_out_imag)
+
 
 # only support real number
 @libentry()
@@ -130,21 +129,26 @@ def dot_kernel(
     pid = tl.program_id(0)
     num_progs = tl.num_programs(0)
     grid_stride = num_progs * BLOCK_SIZE
-    
+
     acc = tl.zeros([], dtype=tl.float32)
-    
+
     offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    
+
     for current_start in range(0, n_elements, grid_stride):
         cur_offsets = current_start + offsets
         mask = cur_offsets < n_elements
 
-        inp = tl.load(inp_ptr + inp_stride * cur_offsets, mask=mask, other=0.0).to(tl.float32)
-        other = tl.load(other_ptr + other_stride * cur_offsets, mask=mask, other=0.0).to(tl.float32)
+        inp = tl.load(inp_ptr + inp_stride * cur_offsets, mask=mask, other=0.0).to(
+            tl.float32
+        )
+        other = tl.load(
+            other_ptr + other_stride * cur_offsets, mask=mask, other=0.0
+        ).to(tl.float32)
 
         acc += tl.sum(inp * other)
 
     tl.store(out_ptr + pid, acc)
+
 
 @libentry()
 @triton.jit()
@@ -154,15 +158,15 @@ def reduce_kernel(
     n_blocks,
     BLOCK_SIZE: tl.constexpr,
 ):
-
     offset = tl.arange(0, BLOCK_SIZE)
     mask = offset < n_blocks
-    
+
     partial_sums = tl.load(partial_sums_ptr + offset, mask=mask, other=0.0)
     final_sum = tl.sum(partial_sums)
-    
+
     if tl.program_id(0) == 0:
         tl.store(output_ptr, final_sum)
+
 
 @libentry()
 @triton.heuristics(runtime.get_heuristic_config("vdot"))
@@ -185,6 +189,7 @@ def dot_kernel_fp32(
 
     out = tl.sum(inp * other)
     tl.atomic_add(out_ptr, out)
+
 
 def vdot(input: Tensor, other: Tensor):
     logger.debug("GEMS VDOT")
@@ -220,13 +225,17 @@ def vdot(input: Tensor, other: Tensor):
 
         n_elements = inp_real.numel()
         n_complex = inp.numel()
-        
-        block_size = runtime.get_heuristic_config("vdot")["BLOCK_SIZE"]({"n_elements":n_elements})
+
+        block_size = runtime.get_heuristic_config("vdot")["BLOCK_SIZE"](
+            {"n_elements": n_elements}
+        )
         num_blocks = triton.cdiv(n_complex, block_size)
 
         grid_size = min(num_blocks, 1024)
-    
-        partial_real_sums = torch.empty(grid_size, dtype=inp_real.dtype, device=inp.device)
+
+        partial_real_sums = torch.empty(
+            grid_size, dtype=inp_real.dtype, device=inp.device
+        )
         grid = (grid_size,)
         vdot_kernel_complex[grid](
             inp_real,
@@ -237,7 +246,7 @@ def vdot(input: Tensor, other: Tensor):
             other_is_conj=other_is_conj,
             inp_stride=inp_stride,
             other_stride=other_stride,
-            BLOCK_SIZE = block_size,
+            BLOCK_SIZE=block_size,
         )
         output_real = torch.empty(2, dtype=inp_real.dtype, device=inp.device)
         reduce_kernel_complex[(1,)](
@@ -262,8 +271,10 @@ def vdot(input: Tensor, other: Tensor):
         return output
     else:
         n_elements = inp.numel()
-        block_size = runtime.get_heuristic_config("vdot")["BLOCK_SIZE"]({"n_elements":n_elements})
-        
+        block_size = runtime.get_heuristic_config("vdot")["BLOCK_SIZE"](
+            {"n_elements": n_elements}
+        )
+
         num_blocks = triton.cdiv(n_elements, block_size)
         grid_size = min(num_blocks, 1024)
 
@@ -276,12 +287,14 @@ def vdot(input: Tensor, other: Tensor):
             n_elements=n_elements,
             inp_stride=inp_stride,
             other_stride=other_stride,
-            BLOCK_SIZE = block_size,
+            BLOCK_SIZE=block_size,
         )
         output = torch.empty([], dtype=input.dtype, device=inp.device)
         reduce_bs = min(triton.next_power_of_2(grid_size), 1024)
         reduce_kernel[(1,)](
-                partial_sums, output, num_blocks,
-                BLOCK_SIZE=reduce_bs,
+            partial_sums,
+            output,
+            num_blocks,
+            BLOCK_SIZE=reduce_bs,
         )
         return output


### PR DESCRIPTION
### PR Category
[Operator]

### Type of Change
[ Performance Optimization]

### Description
optimize vdot performance on h100

### Issue

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
test_blas_perf.py::test_vdot_benchmark 
Operator: vdot  Performance Test (dtype=torch.complex64, mode=kernel,level=comprehensive)

Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------

SUCCESS               0.008800            0.009056               0.972          [torch.Size([64]), torch.Size([64])]
SUCCESS               0.008832            0.008992               0.982          [torch.Size([1024]), torch.Size([1024])]
SUCCESS               0.009056            0.008928               1.014          [torch.Size([2048]), torch.Size([2048])]
SUCCESS               0.009152            0.009184               0.997          [torch.Size([4096]), torch.Size([4096])]
SUCCESS               0.010784            0.010016               1.077          [torch.Size([65536]), torch.Size([65536])]


Operator: vdot  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)

Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------

SUCCESS               0.008608            0.008160               1.055          [torch.Size([64]), torch.Size([64])]
SUCCESS               0.008192            0.008480               0.966          [torch.Size([1024]), torch.Size([1024])]
SUCCESS               0.008384            0.008480               0.989          [torch.Size([2048]), torch.Size([2048])]
SUCCESS               0.008416            0.008512               0.989          [torch.Size([4096]), torch.Size([4096])]
SUCCESS               0.009536            0.008960               1.064          [torch.Size([65536]), torch.Size([65536])]

Operator: vdot  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)

Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------

SUCCESS               0.008160            0.008096               1.008          [torch.Size([64]), torch.Size([64])]
SUCCESS               0.008160            0.008320               0.981          [torch.Size([1024]), torch.Size([1024])]
SUCCESS               0.008320            0.008448               0.985          [torch.Size([2048]), torch.Size([2048])]
SUCCESS               0.008416            0.008448               0.996          [torch.Size([4096]), torch.Size([4096])]
SUCCESS               0.009600            0.008832               1.087          [torch.Size([65536]), torch.Size([65536])]


Operator: vdot  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)

Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------

SUCCESS               0.008256            0.008160               1.012          [torch.Size([64]), torch.Size([64])]
SUCCESS               0.008192            0.008480               0.966          [torch.Size([1024]), torch.Size([1024])]
SUCCESS               0.008384            0.008480               0.989          [torch.Size([2048]), torch.Size([2048])]
SUCCESS               0.008416            0.008608               0.978          [torch.Size([4096]), torch.Size([4096])]
SUCCESS               0.009536            0.008992               1.060          [torch.Size([65536]), torch.Size([65536])]
