### PR TITLE
【bug fix】fix repeat_interleave bug & remove redundant clone() for inplace operators

### DIFF
--- a/benchmark/performance_utils.py
+++ b/benchmark/performance_utils.py
@@ -262,12 +262,7 @@ class Benchmark:
         self.gems_op = gems_op
 
     def get_latency(self, op, *args, **kwargs):
-        if self.is_inplace:
-            fn = lambda: op(
-                *[x.clone() if torch.is_tensor(x) else x for x in args], **kwargs
-            )
-        else:
-            fn = lambda: op(*args, **kwargs)
+        fn = lambda: op(*args, **kwargs)
         if self.is_backward:
             out = fn()
             dout = torch.randn_like(out)

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -1004,7 +1004,7 @@ def test_accuracy_repeat_interleave_self_int(shape, dim, dtype):
 
     ref_out = torch.repeat_interleave(ref_inp, repeats, dim)
     with flag_gems.use_gems():
-        res_out = torch.repeat_interleave(ref_inp, repeats, dim)
+        res_out = torch.repeat_interleave(inp, repeats, dim)
     gems_assert_equal(res_out, ref_out)
 
 
@@ -1019,7 +1019,7 @@ def test_accuracy_repeat_interleave_self_int_non_contiguous(shape, dim, dtype):
 
     ref_out = torch.repeat_interleave(ref_inp, repeats, dim)
     with flag_gems.use_gems():
-        res_out = torch.repeat_interleave(ref_inp, repeats, dim)
+        res_out = torch.repeat_interleave(inp, repeats, dim)
     gems_assert_equal(res_out, ref_out)
 
 


### PR DESCRIPTION
…ators

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
OP Test &  Benchmark

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
The current benchmark logic introduces an extra` clone() `for all tensor inputs before each benchmark run.
While this helps isolate inputs, it also brings additional overhead for inplace operators, which can noticeably affect benchmark results and does not reflect real execution behavior.

This PR removes the extra `clone() `in the benchmark path, so inplace operators are now benchmarked without the additional tensor` copy` overhead.

#### Known limitation
This change also introduces a known caveat:
Since the input tensor is no longer cloned before each run,
the output from the previous iteration may be reused as the input of the next one.
For numerically sensitive operators, this may make the benchmark results less strict or less stable.
At the moment, this trade-off is accepted to avoid the more significant distortion caused by the unconditional `clone() `overhead.

#### Future work

A more robust solution could be:
- selectively cloning inputs only for operators that require strict input isolation, or
- resetting inputs in a more lightweight and operator-aware manner.

This can be improved in a follow-up PR.
Suggestions or alternative approaches are very welcome — feel free to comment or submit improvements if you have better ideas.

### Issue
<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
