### PR TITLE
【github setting】Add CODEOWNERS to enforce review for critical directories & code_scan setting

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,16 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @global-owner1 and @global-owner2 will be requested for
+# review when someone opens a pull request.
+
+/src/flag_gems/*      @kiddyjinjin   @0x45f
+/src/flag_gems/runtime/backend/*
+
+/tests/*             @kiddyjinjin   @0x45f
+/modules_tests/*     @kiddyjinjin   @0x45f
+/benchmark/*         @kiddyjinjin   @0x45f
+
+
+/lib/*                 @zhangpeiyang1  @huangyiqun
+/ctests/*              @zhangpeiyang1  @huangyiqun
+/include/*             @zhangpeiyang1  @huangyiqun

--- a/.github/workflows/code_scan.yaml
+++ b/.github/workflows/code_scan.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   scan-code-and-report:
     runs-on: scan
+    if: ${{ github.repository == 'Flagopen/FlagGems' }}
     concurrency:
       group: scan-code-and-report-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Other

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Other

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
This PR adds a CODEOWNERS file to better manage review responsibilities as PR volume increases.

Critical directories (e.g. `/src/flag_gems`,` tests`, `benchmarks`, and `libs`) are now protected by designated code owners, while `runtime/backend` is intentionally excluded to keep iteration flexible.

This helps clarify ownership and ensures appropriate review without slowing down development.



