### PR TITLE
【PerfXLab】Optimize Randn and randn_like

### DIFF
--- a/src/flag_gems/ops/randn.py
+++ b/src/flag_gems/ops/randn.py
@@ -50,7 +50,7 @@ def pair_uniform_to_normal_fast(u1, u2):
     u1 = tl.maximum(1.0e-7, u1)
     theta = 6.283185307179586 * u2
     r = tl.sqrt(-2.0 * tl.log(u1))
-    sin_t, cos_t = high_precision_fast_sin_cos(theta)  # 注意顺序
+    sin_t, cos_t = high_precision_fast_sin_cos(theta)
     return r * cos_t, r * sin_t
 
 

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -26,7 +26,6 @@ from .accuracy_utils import (
     unsqueeze_tensor,
     unsqueeze_tuple,
 )
-from .conftest import TO_CPU
 
 
 @pytest.mark.abs


### PR DESCRIPTION
PR Category
 [ Operator] 

Type of Change
[Performance Optimization]

Description
optimize randn and randn_like

Issue

Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

Performance
t_tensor_constructor_perf.py::test_tensor_constructor_benchmark[randn-randn-generic_constructor_input_fn]
Operator: randn  Performance Test (dtype=torch.float16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.290912            1.666816               1.374          {'size': [1073741824], 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.043616            0.032896               1.326          {'size': [4096, 4096], 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.043712            0.033920               1.289          {'size': [64, 512, 512], 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               2.274112            1.653408               1.375          {'size': [1024, 1024, 1024], 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.005664            0.005632               1.006          {'size': [64, 64], 'dtype': torch.float16, 'device': 'cuda'}


Operator: randn  Performance Test (dtype=torch.float32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.276512            1.713344               1.329          {'size': [1073741824], 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.043392            0.032320               1.343          {'size': [4096, 4096], 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.043136            0.032384               1.332          {'size': [64, 512, 512], 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               2.259264            1.687392               1.339          {'size': [1024, 1024, 1024], 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.005856            0.005408               1.083          {'size': [64, 64], 'dtype': torch.float32, 'device': 'cuda'}


Operator: randn  Performance Test (dtype=torch.bfloat16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.273152            1.642272               1.384          {'size': [1073741824], 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.043584            0.032256               1.351          {'size': [4096, 4096], 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.043712            0.032128               1.361          {'size': [64, 512, 512], 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               2.274240            1.641728               1.385          {'size': [1024, 1024, 1024], 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.005856            0.005408               1.083          {'size': [64, 64], 'dtype': torch.bfloat16, 'device': 'cuda'}



test_tensor_constructor_perf.py::test_tensor_constructor_benchmark[randn_like-randn_like-unary_input_fn]
Operator: randn_like  Performance Test (dtype=torch.float16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.291104            1.667392               1.374          [torch.Size([1073741824])]
SUCCESS               0.044384            0.033152               1.339          [torch.Size([4096, 4096])]
SUCCESS               0.044160            0.032896               1.342          [torch.Size([64, 512, 512])]
SUCCESS               2.273856            1.654624               1.374          [torch.Size([1024, 1024, 1024])]
SUCCESS               0.005536            0.005344               1.036          [torch.Size([64, 64])]


Operator: randn_like  Performance Test (dtype=torch.float32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.260832            1.700096               1.330          [torch.Size([1073741824])]
SUCCESS               0.043168            0.032480               1.329          [torch.Size([4096, 4096])]
SUCCESS               0.043360            0.032480               1.335          [torch.Size([64, 512, 512])]
SUCCESS               2.260352            1.700224               1.329          [torch.Size([1024, 1024, 1024])]
SUCCESS               0.005696            0.005344               1.066          [torch.Size([64, 64])]


Operator: randn_like  Performance Test (dtype=torch.bfloat16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.275488            1.642208               1.386          [torch.Size([1073741824])]
SUCCESS               0.043552            0.032192               1.353          [torch.Size([4096, 4096])]
SUCCESS               0.043360            0.032160               1.348          [torch.Size([64, 512, 512])]
SUCCESS               2.275040            1.642432               1.385          [torch.Size([1024, 1024, 1024])]
SUCCESS               0.005536            0.005344               1.036          [torch.Size([64, 64])]
