### PR TITLE
feat(experimental_ops): add ReLU as demo case

### DIFF
--- a/src/flag_gems/experimental_ops/relu.py
+++ b/src/flag_gems/experimental_ops/relu.py
@@ -4,11 +4,13 @@ import triton.language as tl
 
 
 @triton.jit
-def relu_kernel(input_ptr,  # Pointer to input tensor
-         output_ptr,  # Pointer to output tensor
-         n_elements,  # Number of elements
-         COMPUTE_FP32: tl.constexpr,  # Whether to upcast to fp32 for computation
-         BLOCK_SIZE: tl.constexpr):
+def relu_kernel(
+    input_ptr,  # Pointer to input tensor
+    output_ptr,  # Pointer to output tensor
+    n_elements,  # Number of elements
+    COMPUTE_FP32: tl.constexpr,  # Whether to upcast to fp32 for computation
+    BLOCK_SIZE: tl.constexpr,
+):
     pid = tl.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
     offsets = block_start + tl.arange(0, BLOCK_SIZE)
@@ -34,7 +36,9 @@ def relu(input: torch.Tensor) -> torch.Tensor:
         raise TypeError("relu does not support complex tensors.")
 
     if not input.is_cuda:
-        raise RuntimeError("Triton kernels require CUDA tensors. Move the tensor to a CUDA device.")
+        raise RuntimeError(
+            "Triton kernels require CUDA tensors. Move the tensor to a CUDA device."
+        )
 
     dtype = input.dtype
 
@@ -61,7 +65,9 @@ def relu(input: torch.Tensor) -> torch.Tensor:
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
 
     relu_kernel[grid](
-        x, out, n_elements,
+        x,
+        out,
+        n_elements,
         COMPUTE_FP32=compute_in_fp32,
         BLOCK_SIZE=BLOCK_SIZE,
     )


### PR DESCRIPTION
# PR Title
Add ReLU as demo case for experimental ops

---

# PR Description

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
User Experience

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add a demo case for Experimental ops: ReLU operator

This PR adds ReLU as a clean demo example for the experimental ops framework, demonstrating:
- Triton kernel implementation with proper dtype handling (fp16/bf16 upcast to fp32)
- Comprehensive test suite following FlagGems pytest standards
- PyTorch baseline implementation for accuracy comparison
- Performance benchmarking using triton.testing.do_bench

**Key Features:**
- **ReLU Implementation** (`relu.py`):
  - Triton kernel with configurable fp32 computation for lower precision types
  - Proper error handling for complex tensors and CUDA requirement checks
  - Support for various dtypes including bool and integer types

- **Test Suite** (`relu_test.py`):
  - Accuracy tests with parametrized shapes and dtypes
  - Performance benchmarks comparing against PyTorch baseline
  - Follows FlagGems experimental ops testing conventions

This serves as a reference implementation for contributors adding new experimental operators.

### Issue
<!-- List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->
N/A - This is a demo PR for experimental ops framework

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
Performance benchmarking is included in the test suite using `triton.testing.do_bench`.
The tests compare FlagGems ReLU implementation against PyTorch baseline across multiple shapes and dtypes.

**Accuracy and Performance Results:**
正确性测试: 15/15
| Speedup | dtype | shape | PyTorch (ms) | Triton (ms) |
|---------|-------|-------|--------------|-------------|
| 2.221 | float16 | [512] | 17.696 | 7.968 |
| 1.926 | float16 | [64, 128] | 15.072 | 7.824 |
| 2.121 | float16 | [8, 32, 64] | 15.200 | 7.168 |
| 1.865 | float16 | [2, 4, 8, 16] | 14.144 | 7.584 |
| 1.889 | float16 | [1] | 12.576 | 6.656 |
| 0.991 | float32 | [512] | 7.168 | 7.232 |
| 1.055 | float32 | [64, 128] | 8.000 | 7.584 |
| 1.004 | float32 | [8, 32, 64] | 7.200 | 7.168 |
| 0.962 | float32 | [2, 4, 8, 16] | 7.296 | 7.584 |
| 1.038 | float32 | [1] | 6.912 | 6.656 |
| 2.173 | bfloat16 | [512] | 14.464 | 6.656 |
| 2.199 | bfloat16 | [64, 128] | 15.200 | 6.912 |
| 2.125 | bfloat16 | [8, 32, 64] | 16.832 | 7.920 |
| 2.286 | bfloat16 | [2, 4, 8, 16] | 15.584 | 6.816 |
| 1.888 | bfloat16 | [1] | 12.624 | 6.688 |
| **1.716** | **Average** | **—** | **12.398** | **7.228** |

**Key Observations:**
- **float16/bfloat16**: Achieves ~2x speedup due to fp32 upcast optimization
- **float32**: Performance is comparable to PyTorch baseline (~1x)
- **Overall Average**: 1.72x speedup across all test cases
---

# Additional Notes

**Files Added:**
- `src/flag_gems/experimental_ops/relu.py` - ReLU operator implementation
- `src/flag_gems/experimental_ops/exp_tests/relu_test.py` - Test suite

**Target Branch:**
This PR should be merged to the upstream FlagGems master branch (flagos-ai/FlagGems).

**How to Test:**
```bash
# Run accuracy tests
pytest src/flag_gems/experimental_ops/exp_tests/relu_test.py::test_relu_accuracy -v

# Run performance tests
pytest src/flag_gems/experimental_ops/exp_tests/relu_test.py::test_relu_performance -v
```
