### PR TITLE
feat(experimental_ops): add test format converter tool

### DIFF
--- a/src/flag_gems/experimental_ops/tools/README.md
+++ b/src/flag_gems/experimental_ops/tools/README.md
@@ -1,0 +1,29 @@
+# Test Format Converter
+
+This tool converts bench-format tests to FlagGems pytest format.
+
+## Usage
+
+```bash
+python src/flag_gems/experimental_ops/tools/convert.py <input_dir> <output_dir> <operator_name>
+```
+
+## Input Files
+
+The tool expects 4 files in the input directory:
+1. Triton operator implementation (e.g., `relu_triton.py`)
+2. PyTorch baseline implementation (e.g., `relu_baseline.py`)
+3. Accuracy test file (e.g., `test_relu_accuracy.py`)
+4. Performance test file (e.g., `test_relu_performance.py`)
+
+## Output Files
+
+The tool generates 2 files:
+1. `<operator_name>.py` - Triton operator implementation (copied)
+2. `<operator_name>_test.py` - Converted test file with baseline
+
+## Example
+
+```bash
+python src/flag_gems/experimental_ops/tools/convert.py ./input_files ./output_files relu
+```

--- a/src/flag_gems/experimental_ops/tools/convert.py
+++ b/src/flag_gems/experimental_ops/tools/convert.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+"""
+Test Format Converter
+Converts bench-format tests to FlagGems pytest format.
+"""
+
+import os
+import re
+import sys
+import argparse
+from pathlib import Path
+from typing import List, Dict, Tuple
+
+
+class TestConverter:
+    """Converts bench-format tests to FlagGems pytest format."""
+
+    def __init__(self, input_dir: str, output_dir: str, operator_name: str):
+        self.input_dir = Path(input_dir)
+        self.output_dir = Path(output_dir)
+        self.operator_name = operator_name
+
+        # File contents
+        self.triton_code = None
+        self.baseline_code = None
+        self.accuracy_test = None
+        self.performance_test = None
+
+    def identify_files(self) -> Dict[str, Path]:
+        """Identify the 4 input files."""
+        files = list(self.input_dir.glob("*.py"))
+
+        if len(files) != 4:
+            raise ValueError(f"Expected 4 Python files, found {len(files)}")
+
+        identified = {}
+
+        for file in files:
+            content = file.read_text()
+
+            # Identify file type by content patterns
+            if "triton.jit" in content or "@triton.jit" in content:
+                identified["triton"] = file
+            elif "def " in content and "torch.Tensor" in content and "@" not in content:
+                # Baseline implementation (no decorators)
+                identified["baseline"] = file
+            elif "@label" in content or "@parametrize" in content:
+                # Test file - distinguish by filename or function name
+                filename_lower = file.name.lower()
+                if "accuracy" in filename_lower:
+                    identified["accuracy_test"] = file
+                elif "performance" in filename_lower or "benchmark" in filename_lower:
+                    identified["performance_test"] = file
+                else:
+                    # Check function name pattern
+                    if "def test_" in content and "benchmark" not in content:
+                        identified["accuracy_test"] = file
+                    else:
+                        identified["performance_test"] = file
+
+        # If we couldn't identify by name, use heuristics
+        if "accuracy_test" not in identified or "performance_test" not in identified:
+            test_files = [f for f in files if f not in identified.values()]
+            if len(test_files) == 2:
+                # Assume first is accuracy, second is performance
+                identified["accuracy_test"] = test_files[0]
+                identified["performance_test"] = test_files[1]
+
+        return identified
+
+    def read_files(self, files: Dict[str, Path]):
+        """Read all input files."""
+        self.triton_code = files["triton"].read_text()
+        self.baseline_code = files["baseline"].read_text()
+        self.accuracy_test = files["accuracy_test"].read_text()
+        self.performance_test = files["performance_test"].read_text()
+
+    def convert_decorators(self, code: str) -> str:
+        """Convert bench decorators to pytest decorators."""
+        # Convert @label("xxx") to @pytest.mark.xxx
+        code = re.sub(r'@label\(["\'](\w+)["\']\)', r'@pytest.mark.\1', code)
+
+        # Convert @parametrize to @pytest.mark.parametrize
+        code = re.sub(r'@parametrize\(', r'@pytest.mark.parametrize(', code)
+
+        return code
+
+    def convert_imports(self, code: str) -> str:
+        """Convert bench imports to pytest/flaggems imports."""
+        # Remove bench-related imports
+        lines = code.split('\n')
+        new_lines = []
+
+        for line in lines:
+            # Skip bench imports
+            if 'import bench' in line or 'from bench' in line:
+                continue
+            new_lines.append(line)
+
+        # Add pytest and flaggems imports at the beginning
+        imports = [
+            "import pytest",
+            "import triton",
+            "",
+            "import flag_gems",
+            f"from flag_gems.experimental_ops.{self.operator_name} import {self.operator_name} as gems_{self.operator_name}"
+        ]
+
+        # Find where to insert imports (after initial comments)
+        insert_idx = 0
+        for i, line in enumerate(new_lines):
+            if line.strip() and not line.strip().startswith('#'):
+                insert_idx = i
+                break
+
+        # Insert imports
+        new_lines = new_lines[:insert_idx] + imports + [''] + new_lines[insert_idx:]
+
+        return '\n'.join(new_lines)
+
+    def convert_function_calls(self, code: str) -> str:
+        """Convert bench function calls to appropriate implementations."""
+        # Replace bench.relu with baseline function name
+        code = re.sub(r'bench\.\w+\(', f'{self.operator_name}_baseline(', code)
+
+        # Replace bench.triton.relu with gems_relu
+        code = re.sub(r'bench\.triton\.\w+\(', f'gems_{self.operator_name}(', code)
+
+        # Replace device variable with flag_gems.device (but not parameter name)
+        code = re.sub(r'=\s*device\b', '=flag_gems.device', code)
+        code = re.sub(r'\(device\)', '(flag_gems.device)', code)
+
+        # Replace to_reference with input.cpu()
+        code = re.sub(r'to_reference\([^,]+,\s*True\)', 'input.cpu()', code)
+
+        # Replace assert_close with torch.testing.assert_close
+        code = re.sub(
+            r'assert_close\(([^,]+),\s*([^,]+),\s*dtype[^)]*\)',
+            r'torch.testing.assert_close(\1.cpu(), \2, rtol=1e-3, atol=1e-3)',
+            code
+        )
+
+        return code
+
+    def convert_test_function_names(self, code: str) -> str:
+        """Convert test function names to pytest format."""
+        # Ensure test functions start with test_
+        code = re.sub(r'def (\w+)\(', lambda m: f'def test_{m.group(1)}(' if not m.group(1).startswith('test_') else m.group(0), code)
+
+        # Convert benchmark functions to test_performance
+        code = re.sub(r'def test_(\w+)_benchmark\(', r'def test_\1_performance(', code)
+
+        return code
+
+    def extract_baseline_function(self) -> str:
+        """Extract baseline function and rename it."""
+        # Find the function definition
+        match = re.search(r'def (\w+)\(.*?\).*?(?=\ndef |\Z)', self.baseline_code, re.DOTALL)
+        if match:
+            func_code = match.group(0)
+            # Rename function to <operator>_baseline
+            func_code = re.sub(r'def \w+\(', f'def {self.operator_name}_baseline(', func_code)
+            return func_code
+        return ""
+
+    def merge_test_files(self) -> str:
+        """Merge baseline and test files into one."""
+        # Start with header
+        header = f"# {self.operator_name.upper()} operator test\n\n# PyTorch baseline\nimport torch\n\n"
+
+        # Add baseline function
+        baseline_func = self.extract_baseline_function()
+
+        # Convert accuracy test
+        accuracy_converted = self.convert_decorators(self.accuracy_test)
+        accuracy_converted = self.convert_imports(accuracy_converted)
+        accuracy_converted = self.convert_function_calls(accuracy_converted)
+        accuracy_converted = self.convert_test_function_names(accuracy_converted)
+
+        # Convert performance test
+        perf_converted = self.convert_decorators(self.performance_test)
+        perf_converted = self.convert_function_calls(perf_converted)
+        perf_converted = self.convert_test_function_names(perf_converted)
+
+        # Extract only test functions from performance test (skip imports)
+        perf_lines = perf_converted.split('\n')
+        perf_test_start = 0
+        for i, line in enumerate(perf_lines):
+            if line.strip().startswith('@pytest.mark'):
+                perf_test_start = i
+                break
+        perf_test_only = '\n'.join(perf_lines[perf_test_start:])
+
+        # Combine all parts
+        final_code = header + baseline_func + '\n\n' + accuracy_converted + '\n\n' + perf_test_only
+
+        return final_code
+
+    def generate_output_files(self):
+        """Generate output files."""
+        # Create output directory if it doesn't exist
+        self.output_dir.mkdir(parents=True, exist_ok=True)
+
+        # Copy triton operator
+        triton_output = self.output_dir / f"{self.operator_name}.py"
+        triton_output.write_text(self.triton_code)
+        print(f"✓ Generated: {triton_output}")
+
+        # Generate merged test file
+        test_code = self.merge_test_files()
+        test_output = self.output_dir / f"{self.operator_name}_test.py"
+        test_output.write_text(test_code)
+        print(f"✓ Generated: {test_output}")
+
+    def convert(self):
+        """Main conversion process."""
+        print(f"Converting {self.operator_name} operator...")
+
+        # Step 1: Identify files
+        print("Step 1: Identifying input files...")
+        files = self.identify_files()
+        print(f"  - Triton: {files['triton'].name}")
+        print(f"  - Baseline: {files['baseline'].name}")
+        print(f"  - Accuracy test: {files['accuracy_test'].name}")
+        print(f"  - Performance test: {files['performance_test'].name}")
+
+        # Step 2: Read files
+        print("Step 2: Reading files...")
+        self.read_files(files)
+
+        # Step 3: Generate output
+        print("Step 3: Generating output files...")
+        self.generate_output_files()
+
+        print(f"\n✓ Conversion complete!")
+
+
+def main():
+    """Command-line interface."""
+    parser = argparse.ArgumentParser(
+        description="Convert bench-format tests to FlagGems pytest format"
+    )
+    parser.add_argument(
+        "input_dir",
+        help="Directory containing the 4 input files"
+    )
+    parser.add_argument(
+        "output_dir",
+        help="Directory to write output files"
+    )
+    parser.add_argument(
+        "operator_name",
+        help="Name of the operator (e.g., relu)"
+    )
+
+    args = parser.parse_args()
+
+    try:
+        converter = TestConverter(args.input_dir, args.output_dir, args.operator_name)
+        converter.convert()
+    except Exception as e:
+        print(f"Error: {e}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/flag_gems/experimental_ops/tools/tests/README.md
+++ b/src/flag_gems/experimental_ops/tools/tests/README.md
@@ -1,0 +1,28 @@
+# Test Examples for Converter Tool
+
+This directory contains example input files for testing the converter tool.
+
+## Files
+
+1. **relu_triton.py** - Triton operator implementation
+2. **relu_baseline.py** - PyTorch baseline implementation
+3. **test_relu_accuracy.py** - Accuracy test (bench format)
+4. **test_relu_performance.py** - Performance test (bench format)
+
+## Usage
+
+Test the converter tool with these files:
+
+```bash
+cd /share/project/tj/fork/FlagGems
+python src/flag_gems/experimental_ops/tools/convert.py \
+    src/flag_gems/experimental_ops/tools/tests \
+    /tmp/output \
+    relu
+```
+
+## Expected Output
+
+The tool should generate:
+- `/tmp/output/relu.py` - Triton operator (copied)
+- `/tmp/output/relu_test.py` - Converted test file with baseline

--- a/src/flag_gems/experimental_ops/tools/tests/relu_baseline.py
+++ b/src/flag_gems/experimental_ops/tools/tests/relu_baseline.py
@@ -1,0 +1,25 @@
+import torch
+
+
+def relu(input: torch.Tensor) -> torch.Tensor:
+    if not isinstance(input, torch.Tensor):
+        raise TypeError("input must be a torch.Tensor")
+
+    dtype = input.dtype
+
+    if input.is_complex():
+        raise TypeError("relu does not support complex tensors.")
+
+    if input.is_floating_point():
+        # Use float32 for computation when input is lower precision
+        if dtype in (torch.float16, torch.bfloat16):
+            return torch.relu(input.to(torch.float32)).to(dtype)
+        else:
+            return torch.relu(input)
+
+    if dtype == torch.bool:
+        # For boolean tensors, ReLU is effectively identity
+        return input.clone()
+
+    # For integer tensors, use clamp_min to emulate ReLU
+    return torch.clamp_min(input, 0)

--- a/src/flag_gems/experimental_ops/tools/tests/relu_triton.py
+++ b/src/flag_gems/experimental_ops/tools/tests/relu_triton.py
@@ -1,0 +1,69 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def relu_kernel(input_ptr,  # Pointer to input tensor
+         output_ptr,  # Pointer to output tensor
+         n_elements,  # Number of elements
+         COMPUTE_FP32: tl.constexpr,  # Whether to upcast to fp32 for computation
+         BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(input_ptr + offsets, mask=mask, other=0)
+
+    if COMPUTE_FP32:
+        x_f32 = x.to(tl.float32)
+        y_f32 = tl.maximum(x_f32, 0.0)
+        y = y_f32.to(x.dtype)
+    else:
+        y = tl.maximum(x, 0)
+
+    tl.store(output_ptr + offsets, y, mask=mask)
+
+
+def relu(input: torch.Tensor) -> torch.Tensor:
+    if not isinstance(input, torch.Tensor):
+        raise TypeError("input must be a torch.Tensor")
+
+    if input.is_complex():
+        raise TypeError("relu does not support complex tensors.")
+
+    if not input.is_cuda:
+        raise RuntimeError("Triton kernels require CUDA tensors. Move the tensor to a CUDA device.")
+
+    dtype = input.dtype
+
+    # Handle boolean tensors: ReLU is identity
+    if dtype == torch.bool:
+        return input.clone()
+
+    # Determine computation path
+    compute_in_fp32 = False
+    if input.is_floating_point():
+        if dtype in (torch.float16, torch.bfloat16):
+            compute_in_fp32 = True
+        else:
+            compute_in_fp32 = False
+    else:
+        # Integer tensors handled in native dtype (no fp32 upcast)
+        compute_in_fp32 = False
+
+    x = input.contiguous()
+    out = torch.empty_like(x)
+
+    n_elements = x.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    relu_kernel[grid](
+        x, out, n_elements,
+        COMPUTE_FP32=compute_in_fp32,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+    return out

--- a/src/flag_gems/experimental_ops/tools/tests/test_relu_accuracy.py
+++ b/src/flag_gems/experimental_ops/tools/tests/test_relu_accuracy.py
@@ -1,0 +1,22 @@
+import bench
+from bench.sandbox.test.test_parametrize import parametrize, label
+from bench.sandbox.config import DEVICE as device
+from bench.sandbox.utils.accuracy_utils import gems_assert_close as assert_close
+from bench.sandbox.utils.accuracy_utils import to_reference
+import torch
+
+
+@label("relu")
+@parametrize("shape", [(512,), (64, 128), (8, 32, 64), (2, 4, 8, 16), (1,)])
+@parametrize("dtype", [torch.float16, torch.float32, torch.bfloat16])
+def test_relu(shape, dtype):
+    # initialize the input data based on the parameters
+    input = torch.randn(shape, dtype=dtype, device=device)
+
+    # cast to reference dtype if necessary
+    ref_input = to_reference(input, True)
+
+    ref_out = bench.relu(ref_input)
+    res_out = bench.triton.relu(input)
+
+    assert_close(res_out, ref_out, dtype, reduce_dim=1)


### PR DESCRIPTION
# PR Title
Add test format converter tool for experimental ops

---

# PR Description

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
User Experience

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add an automated tool to convert bench-format tests to FlagGems pytest format.

This PR introduces a conversion tool that automates the process of migrating test files from bench format to FlagGems' standard pytest format. This tool significantly reduces manual work and ensures consistency when adding new experimental operators.

**Tool Features:**
- **Automatic File Identification**: Recognizes 4 input file types (Triton operator, PyTorch baseline, accuracy test, performance test)
- **Decorator Conversion**: Transforms `@label` → `@pytest.mark.xxx` and `@parametrize` → `@pytest.mark.parametrize`
- **Import Statement Conversion**: Removes bench-related imports and adds pytest/flag_gems imports
- **Function Call Conversion**: Converts `bench.xxx` → baseline functions and `bench.triton.xxx` → gems functions
- **Test Function Renaming**: Ensures test functions follow pytest naming conventions (test_ prefix)
- **File Merging**: Combines baseline implementation and test files into a single test file

**Tool Location:**
- `src/flag_gems/experimental_ops/tools/convert.py` - Main conversion script (267 lines)
- `src/flag_gems/experimental_ops/tools/tests/` - Example files for testing (ReLU operator)

**Usage:**
```bash
python src/flag_gems/experimental_ops/tools/convert.py <input_dir> <output_dir> <operator_name>
```

**Example:**
```bash
python src/flag_gems/experimental_ops/tools/convert.py ./my_operator/ ./output/ sigmoid
```

This tool streamlines the workflow for contributors adding new experimental operators by automating the test format conversion process.

### Issue
<!-- List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->
N/A - This is a tooling improvement for experimental ops development

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT (includes test examples).

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
This is a development tool and does not affect runtime performance. The tool has been tested with ReLU operator examples and successfully converts bench-format tests to pytest format.

**Test Results:**
- ✓ Correctly identifies 4 input file types
- ✓ Successfully converts decorators, imports, and function calls
- ✓ Generates valid pytest-format test files
- ✓ Handles device parameter replacement correctly

---

# Additional Notes

**Files Added:**
- `src/flag_gems/experimental_ops/tools/README.md` - Tool documentation
- `src/flag_gems/experimental_ops/tools/convert.py` - Conversion script
- `src/flag_gems/experimental_ops/tools/tests/README.md` - Test examples documentation
- `src/flag_gems/experimental_ops/tools/tests/relu_*.py` - Example input files (4 files)

**Target Branch:**
This PR should be merged to the upstream FlagGems master branch (flagos-ai/FlagGems).

**Benefits:**
1. Reduces manual work when adding new experimental operators
2. Ensures consistency in test format across experimental ops
3. Lowers the barrier for contributors to add new operators
4. Provides clear examples through ReLU test files

**Future Enhancements:**
- Could add support for batch conversion of multiple operators
- Could integrate with CI/CD pipeline for automated testing
- Could add validation checks for converted output
