### PR TITLE
[KernelGen] Fix workflow issue: experimental code PR should not trigger normal ops test

### DIFF
--- a/.github/workflows/blas-op-test.yaml
+++ b/.github/workflows/blas-op-test.yaml
@@ -14,19 +14,20 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
-        id: filter
+        id: experimental_ops
         with:
           filters: |
             run_ci:
               - '!src/flag_gems/experimental_ops/**'
+              - '!tests/experimental_ops/**'
 
       - name: Check GPU free
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: tools/gpu_check.sh
 
       - name: BLAS OP
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           echo "current dir: $(pwd)"

--- a/.github/workflows/gems-cpp-extension.yaml
+++ b/.github/workflows/gems-cpp-extension.yaml
@@ -36,20 +36,21 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
-        id: filter
+        id: experimental_ops
         with:
           filters: |
             run_ci:
               - '!src/flag_gems/experimental_ops/**'
+              - '!tests/experimental_ops/**'
 
       - name: Build FlagGems with C-extension
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           SKBUILD_CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON" pip install --no-build-isolation -v -e .
 
       - name: Run FlagGems CTests
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           cd build/cpython-311/ctests

--- a/.github/workflows/gems-experimental-test.yaml
+++ b/.github/workflows/gems-experimental-test.yaml
@@ -5,11 +5,13 @@ on:
     branches: [ "master" ]
     paths:
       - 'src/flag_gems/experimental_ops/**'
+      - 'tests/experimental_ops/**'
+
   pull_request:
     branches: [ "master" ]
     paths:
       - 'src/flag_gems/experimental_ops/**'
-
+      - 'tests/experimental_ops/**'
 env:
   CUDA_VISIBLE_DEVICES: 7
   http_proxy: ${{ secrets.HTTP_PROXY }}
@@ -38,20 +40,41 @@ jobs:
 
           echo "Diffing $BASE_SHA...$HEAD_SHA"
 
-          changed_ops=$(git diff --name-only $BASE_SHA...$HEAD_SHA | grep '^src/flag_gems/experimental_ops/.*\.py$' || true)
+          changed_files=$(git diff --name-only $BASE_SHA...$HEAD_SHA || true)
+          tests_to_run=""
+          missing_tests=""
 
-          tests=""
-          for f in $changed_ops; do
-              base=$(basename "$f" .py)
-              test_file="src/flag_gems/experimental_ops/exp_tests/${base}_test.py"
-              if [ -f "$test_file" ]; then
-                  tests="$tests $test_file"
+          for f in $changed_files; do
+              if [[ $f == src/flag_gems/experimental_ops/*.py ]]; then
+                  if [[ $(basename "$f") == __*__* ]]; then continue; fi
+
+                  base=$(basename "$f" .py)
+                  test_file="tests/experimental_ops/${base}_test.py"
+                  if [ -f "$test_file" ]; then
+                      tests_to_run="$tests_to_run $test_file"
+                  else
+                      missing_tests="$missing_tests $test_file"
+                  fi
+
+              elif [[ $f == tests/experimental_ops/*_test.py ]]; then
+                  if [ -f "$f" ]; then
+                      tests_to_run="$tests_to_run $f"
+                  fi
               fi
           done
 
-          if [ -n "$tests" ]; then
-              echo "Running tests:$tests"
-              run_command pytest -s $tests
+          if [ -n "$missing_tests" ]; then
+              echo "Error: The following operator files were modified, but their corresponding test files are missing:"
+              for m in $missing_tests; do
+                  echo "  - Expected: $m"
+              done
+          fi
+
+          unique_tests=$(echo "$tests_to_run" | tr ' ' '\n' | sort -u | tr '\n' ' ')
+
+          if [ -n "$unique_tests" ]; then
+              echo "Running tests: $unique_tests"
+              run_command pytest -s $unique_tests
           else
-              echo "No relevant ops changes, skipping tests"
+              echo "No relevant changes in ops or tests, skipping."
           fi

--- a/.github/workflows/gems-test-on-hopper.yaml
+++ b/.github/workflows/gems-test-on-hopper.yaml
@@ -46,14 +46,15 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
-        id: filter
+        id: experimental_ops
         with:
           filters: |
             run_ci:
               - '!src/flag_gems/experimental_ops/**'
+              - '!tests/experimental_ops/**'
 
       - name: FlagGems reduction ops on hopper
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           source "/home/zhangzhihui/miniconda3/etc/profile.d/conda.sh"
@@ -64,7 +65,7 @@ jobs:
           run_command pytest -s tests/test_norm_ops.py
 
       - name: FlagGems pointwise ops on hopper
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           source "/home/zhangzhihui/miniconda3/etc/profile.d/conda.sh"
@@ -77,7 +78,7 @@ jobs:
           run_command pytest -s tests/test_tensor_constructor_ops.py
 
       - name: FlagGems blas ops on hopper
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           source "/home/zhangzhihui/miniconda3/etc/profile.d/conda.sh"
@@ -88,7 +89,7 @@ jobs:
           run_command pytest -s tests/test_blas_ops.py
 
       - name: FlagGems special ops on hopper
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           source "/home/zhangzhihui/miniconda3/etc/profile.d/conda.sh"
@@ -98,7 +99,7 @@ jobs:
           run_command pytest -s tests/test_distribution_ops.py
 
       - name: FlagGems convolution ops on hopper
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           source "/home/zhangzhihui/miniconda3/etc/profile.d/conda.sh"
@@ -107,7 +108,7 @@ jobs:
           run_command pytest -s tests/test_convolution_ops.py
 
       - name: FlagGems utils on hopper
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           source "/home/zhangzhihui/miniconda3/etc/profile.d/conda.sh"
@@ -118,7 +119,7 @@ jobs:
           run_command pytest -s tests/test_tensor_wrapper.py
 
       - name: FlagGems examples on hopper
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           source "/home/zhangzhihui/miniconda3/etc/profile.d/conda.sh"

--- a/.github/workflows/gems-test-on-metax.yaml
+++ b/.github/workflows/gems-test-on-metax.yaml
@@ -39,14 +39,15 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
-        id: filter
+        id: experimental_ops
         with:
           filters: |
             run_ci:
               - '!src/flag_gems/experimental_ops/**'
+              - '!tests/experimental_ops/**'
 
       - name: FlagGems reduction ops on metax
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           source tools/run_command.sh
@@ -58,7 +59,7 @@ jobs:
           # GEMS_VENDOR=metax run_command pytest -s tests/test_norm_ops.py
 
       - name: FlagGems pointwise ops on metax
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           ### set private mem out of docker in case OOM
@@ -74,7 +75,7 @@ jobs:
           GEMS_VENDOR=metax run_command pytest -s tests/test_tensor_constructor_ops.py
 
       - name: FlagGems blas ops on metax
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           source tools/run_command.sh
@@ -83,7 +84,7 @@ jobs:
           # GEMS_VENDOR=metax run_command pytest -s tests/test_attention_ops.py
 
       - name: FlagGems special ops on metax
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           source tools/run_command.sh
@@ -92,7 +93,7 @@ jobs:
           GEMS_VENDOR=metax run_command pytest -s tests/test_distribution_ops.py
 
       - name: FlagGems utils on metax
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           source tools/run_command.sh
@@ -101,7 +102,7 @@ jobs:
           GEMS_VENDOR=metax run_command pytest -s tests/test_tensor_wrapper.py
 
       - name: FlagGems examples on metax
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           source tools/run_command.sh

--- a/.github/workflows/model-test.yaml
+++ b/.github/workflows/model-test.yaml
@@ -14,19 +14,20 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
-        id: filter
+        id: experimental_ops
         with:
           filters: |
             run_ci:
               - '!src/flag_gems/experimental_ops/**'
+              - '!tests/experimental_ops/**'
 
       - name: Check GPU free
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: tools/gpu_check.sh
 
       - name: FlagGems examples
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           echo "current dir: $(pwd)"

--- a/.github/workflows/op-test-quick-cpu.yaml
+++ b/.github/workflows/op-test-quick-cpu.yaml
@@ -14,19 +14,20 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
-        id: filter
+        id: experimental_ops
         with:
           filters: |
             run_ci:
               - '!src/flag_gems/experimental_ops/**'
+              - '!tests/experimental_ops/**'
 
       - name: Check GPU free
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: tools/gpu_check.sh
 
       - name: OP Test Quick CPU
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           echo "current dir: $(pwd)"

--- a/.github/workflows/op-utils-test.yaml
+++ b/.github/workflows/op-utils-test.yaml
@@ -14,19 +14,20 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
-        id: filter
+        id: experimental_ops
         with:
           filters: |
             run_ci:
               - '!src/flag_gems/experimental_ops/**'
+              - '!tests/experimental_ops/**'
 
       - name: Check GPU free
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: tools/gpu_check.sh
 
       - name: OP Utils Test
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           echo "current dir: $(pwd)"

--- a/.github/workflows/pointwise-op-test.yaml
+++ b/.github/workflows/pointwise-op-test.yaml
@@ -14,19 +14,20 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
-        id: filter
+        id: experimental_ops
         with:
           filters: |
             run_ci:
               - '!src/flag_gems/experimental_ops/**'
+              - '!tests/experimental_ops/**'
 
       - name: Check GPU free
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: tools/gpu_check.sh
 
       - name: Pointwise OP Test
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           echo "current dir: $(pwd)"

--- a/.github/workflows/python-coverage.yaml
+++ b/.github/workflows/python-coverage.yaml
@@ -84,14 +84,15 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
-        id: filter
+        id: experimental_ops
         with:
           filters: |
             run_ci:
               - '!src/flag_gems/experimental_ops/**'
+              - '!tests/experimental_ops/**'
 
       - name: Get python coverage
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           echo "current dir: $(pwd)"
@@ -107,7 +108,7 @@ jobs:
           bash tools/code_coverage/coverage.sh ${PR_ID}
 
       - name: Report python coverage
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           git config --global --add safe.directory ../FlagGems

--- a/.github/workflows/reduction-op-test.yaml
+++ b/.github/workflows/reduction-op-test.yaml
@@ -14,19 +14,20 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
-        id: filter
+        id: experimental_ops
         with:
           filters: |
             run_ci:
               - '!src/flag_gems/experimental_ops/**'
+              - '!tests/experimental_ops/**'
 
       - name: Check GPU free
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: tools/gpu_check.sh
 
       - name: Reduction Op Test
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           echo "current dir: $(pwd)"

--- a/.github/workflows/special-op-test.yaml
+++ b/.github/workflows/special-op-test.yaml
@@ -14,19 +14,20 @@ jobs:
         uses: actions/checkout@v4
 
       - uses: dorny/paths-filter@v3
-        id: filter
+        id: experimental_ops
         with:
           filters: |
             run_ci:
               - '!src/flag_gems/experimental_ops/**'
+              - '!tests/experimental_ops/**'
 
       - name: Check GPU free
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: tools/gpu_check.sh
 
       - name: Special OP Test
-        if: steps.filter.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.run_ci == 'true'
         shell: bash
         run: |
           echo "current dir: $(pwd)"


### PR DESCRIPTION
### PR Category
CI/CD

### Type of Change
CI/CD

### Description
We have added experimental ops support in FlagGems.

But when there are some ops adding to experimental_ops, required workflows will run.
This would waste time and machines as there is no tests related experimental_ops.

Experimental_ops contains itself CI tests.
So we change logic to skip normal required tests and only run experimental CI test.



### Issue
#1301

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [√] Change is responded to an issue.
- [√] Change is fully covered by a UT.

