### PR TITLE
Add requirements_nvidia.txt, Install flagtree by default

### DIFF
--- a/requirements_nvidia.txt
+++ b/requirements_nvidia.txt
@@ -1,0 +1,14 @@
+--index-url https://resource.flagos.net/repository/flagos-pypi-hosted/simple
+--extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
+--trusted-host resource.flagos.net pypi.tuna.tsinghua.edu.cn
+torch>=2.2.0
+packaging
+pybind11
+PyYAML
+sqlalchemy
+setuptools>=64.0
+scikit-build-core>=0.11
+cmake
+ninja
+wheel
+flagtree==0.3.0rc1+3.3


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Feature

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Add the `requirements_nvidia.txt` file to support the default installation of flagtree on machines with an NVIDIA backend.
Add the flagos private source to `requirements_nvidia.txt` to obtain the flagtree wheel package.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
After installing dependencies using `requirements_nvidia.txt`, the pytest for flagtree and flaggems both pass.
![img_v3_02tb_db2497fd-0068-42a7-94fe-e4d9a0b6c0cg](https://github.com/user-attachments/assets/3a7eb22e-91c5-4a42-9fa1-7295d2b2a195)

