### PR TITLE
Add 10 operators (group 9)

### DIFF
--- a/src/flag_gems/experimental_ops/selu_.py
+++ b/src/flag_gems/experimental_ops/selu_.py
@@ -30,14 +30,16 @@ def selu_(*args, **kwargs):
     x = None
     if len(args) > 0 and torch.is_tensor(args[0]):
         x = args[0]
-    elif 'input' in kwargs and torch.is_tensor(kwargs['input']):
-        x = kwargs['input']
-    elif 'self' in kwargs and torch.is_tensor(kwargs['self']):
-        x = kwargs['self']
-    elif 'x' in kwargs and torch.is_tensor(kwargs['x']):
-        x = kwargs['x']
+    elif "input" in kwargs and torch.is_tensor(kwargs["input"]):
+        x = kwargs["input"]
+    elif "self" in kwargs and torch.is_tensor(kwargs["self"]):
+        x = kwargs["self"]
+    elif "x" in kwargs and torch.is_tensor(kwargs["x"]):
+        x = kwargs["x"]
     else:
-        raise ValueError("selu_ expects a Tensor as the first argument or under 'input'/'self'/'x' keyword.")
+        raise ValueError(
+            "selu_ expects a Tensor as the first argument or under 'input'/'self'/'x' keyword."
+        )
 
     # Fallback for unsupported cases
     supported_dtypes = {torch.float16, torch.bfloat16, torch.float32}
@@ -50,6 +52,6 @@ def selu_(*args, **kwargs):
         return x
 
     BLOCK_SIZE = 1024
-    grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']),)
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
     selu__kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
     return x

--- a/src/flag_gems/experimental_ops/sgn_.py
+++ b/src/flag_gems/experimental_ops/sgn_.py
@@ -40,14 +40,17 @@ def sgn_(*args, **kwargs):
         raise TypeError("sgn_ expects a single Tensor argument")
 
     # Fallback for unsupported cases
-    unsupported = (
-        (not x.is_cuda)
-        or (not x.is_contiguous())
-        or x.is_complex()
-    )
+    unsupported = (not x.is_cuda) or (not x.is_contiguous()) or x.is_complex()
     supported_dtypes = {
-        torch.float16, torch.float32, torch.float64, torch.bfloat16,
-        torch.int8, torch.int16, torch.int32, torch.int64, torch.uint8
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.bfloat16,
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+        torch.uint8,
     }
     if unsupported or x.dtype not in supported_dtypes:
         return torch.ops.aten.sgn_(x)

--- a/src/flag_gems/experimental_ops/sigmoid.py
+++ b/src/flag_gems/experimental_ops/sigmoid.py
@@ -23,7 +23,9 @@ def _sigmoid_common(x: torch.Tensor, out: torch.Tensor = None):
     if not x.is_cuda:
         raise ValueError("sigmoid: input tensor must be on CUDA device")
     if x.dtype not in (torch.float16, torch.bfloat16, torch.float32):
-        raise NotImplementedError(f"sigmoid: dtype {x.dtype} is not supported (supported: float16, bfloat16, float32)")
+        raise NotImplementedError(
+            f"sigmoid: dtype {x.dtype} is not supported (supported: float16, bfloat16, float32)"
+        )
 
     n_elements = x.numel()
     if out is None:
@@ -34,15 +36,23 @@ def _sigmoid_common(x: torch.Tensor, out: torch.Tensor = None):
         if not out.is_cuda:
             raise ValueError("sigmoid.out: 'out' tensor must be on CUDA device")
         if out.shape != x.shape:
-            raise ValueError(f"sigmoid.out: 'out' shape {out.shape} does not match input shape {x.shape}")
+            raise ValueError(
+                f"sigmoid.out: 'out' shape {out.shape} does not match input shape {x.shape}"
+            )
         if out.dtype != x.dtype:
-            raise ValueError(f"sigmoid.out: 'out' dtype {out.dtype} must match input dtype {x.dtype}")
+            raise ValueError(
+                f"sigmoid.out: 'out' dtype {out.dtype} must match input dtype {x.dtype}"
+            )
 
     if n_elements == 0:
         return out
 
     x_contig = x.contiguous()
-    out_contig = out if out.is_contiguous() else torch.empty_like(out, memory_format=torch.contiguous_format)
+    out_contig = (
+        out
+        if out.is_contiguous()
+        else torch.empty_like(out, memory_format=torch.contiguous_format)
+    )
 
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
     sigmoid_kernel[grid](x_contig, out_contig, n_elements, BLOCK_SIZE=1024)

--- a/src/flag_gems/experimental_ops/silu.py
+++ b/src/flag_gems/experimental_ops/silu.py
@@ -5,9 +5,9 @@ import triton.language as tl
 
 @triton.jit
 def silu_kernel(
-    x_ptr,           # *Pointer* to input tensor
-    y_ptr,           # *Pointer* to output tensor
-    n_elements,      # Number of elements
+    x_ptr,  # *Pointer* to input tensor
+    y_ptr,  # *Pointer* to output tensor
+    n_elements,  # Number of elements
     BLOCK_SIZE: tl.constexpr,
     COMPUTE_IN_FP32: tl.constexpr,
 ):
@@ -37,9 +37,13 @@ def _silu_impl(x: torch.Tensor, out: torch.Tensor = None):
         if not out.is_cuda:
             raise ValueError("Output tensor must be on CUDA device.")
         if out.shape != x.shape:
-            raise ValueError(f"Output shape {out.shape} does not match input shape {x.shape}.")
+            raise ValueError(
+                f"Output shape {out.shape} does not match input shape {x.shape}."
+            )
         if out.dtype != x.dtype:
-            raise TypeError(f"Output dtype {out.dtype} does not match input dtype {x.dtype}.")
+            raise TypeError(
+                f"Output dtype {out.dtype} does not match input dtype {x.dtype}."
+            )
 
     x_contig = x.contiguous()
     out_contig = out if out.is_contiguous() else torch.empty_like(x_contig)
@@ -53,7 +57,7 @@ def _silu_impl(x: torch.Tensor, out: torch.Tensor = None):
     compute_in_fp32 = x_contig.dtype in (torch.float16, torch.bfloat16)
 
     BLOCK_SIZE = 1024
-    grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']),)
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
     silu_kernel[grid](
         x_contig,
         out_contig,

--- a/src/flag_gems/experimental_ops/sinh_.py
+++ b/src/flag_gems/experimental_ops/sinh_.py
@@ -41,11 +41,15 @@ def sinh_(*args, **kwargs):
         raise RuntimeError("sinh_ Triton kernel requires a CUDA tensor")
 
     if not x.is_contiguous():
-        raise RuntimeError("sinh_ Triton kernel currently supports only contiguous tensors")
+        raise RuntimeError(
+            "sinh_ Triton kernel currently supports only contiguous tensors"
+        )
 
     supported_dtypes = (torch.float16, torch.float32, torch.bfloat16)
     if x.dtype not in supported_dtypes:
-        raise RuntimeError(f"sinh_ Triton kernel supports dtypes {supported_dtypes}, but got {x.dtype}")
+        raise RuntimeError(
+            f"sinh_ Triton kernel supports dtypes {supported_dtypes}, but got {x.dtype}"
+        )
 
     n_elements = x.numel()
     BLOCK_SIZE = 1024

--- a/src/flag_gems/experimental_ops/softshrink.py
+++ b/src/flag_gems/experimental_ops/softshrink.py
@@ -28,7 +28,9 @@ def softshrink_kernel(x_ptr, out_ptr, n_elements, lambd, BLOCK_SIZE: tl.constexp
 
 def _check_supported_dtype(t: torch.Tensor):
     if t.dtype not in (torch.float16, torch.bfloat16, torch.float32):
-        raise TypeError(f"Unsupported dtype {t.dtype}. Supported dtypes are float16, bfloat16, and float32.")
+        raise TypeError(
+            f"Unsupported dtype {t.dtype}. Supported dtypes are float16, bfloat16, and float32."
+        )
 
 
 def _launch_softshrink_kernel(x: torch.Tensor, out: torch.Tensor, lambd: float):
@@ -38,7 +40,10 @@ def _launch_softshrink_kernel(x: torch.Tensor, out: torch.Tensor, lambd: float):
     BLOCK_SIZE = 1024
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
     softshrink_kernel[grid](
-        x, out, n_elements, float(lambd),
+        x,
+        out,
+        n_elements,
+        float(lambd),
         BLOCK_SIZE=BLOCK_SIZE,
         num_warps=4,
     )
@@ -60,9 +65,13 @@ def softshrink_out(input: torch.Tensor, lambd: float = 0.5, out: torch.Tensor = 
     if not input.is_cuda or not out.is_cuda:
         raise ValueError("Input and out tensors must be on CUDA device.")
     if input.shape != out.shape:
-        raise ValueError(f"Shape mismatch: input.shape={input.shape}, out.shape={out.shape}")
+        raise ValueError(
+            f"Shape mismatch: input.shape={input.shape}, out.shape={out.shape}"
+        )
     if input.dtype != out.dtype:
-        raise TypeError(f"Dtype mismatch: input.dtype={input.dtype}, out.dtype={out.dtype}")
+        raise TypeError(
+            f"Dtype mismatch: input.dtype={input.dtype}, out.dtype={out.dtype}"
+        )
     _check_supported_dtype(input)
 
     x = input.contiguous()

--- a/src/flag_gems/experimental_ops/special_i1.py
+++ b/src/flag_gems/experimental_ops/special_i1.py
@@ -54,7 +54,9 @@ def special_i1_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
 
 def _launch_special_i1(x: torch.Tensor, out: torch.Tensor):
     assert x.is_cuda and out.is_cuda, "Tensors must be CUDA tensors"
-    assert x.numel() == out.numel(), "Input and output must have the same number of elements"
+    assert (
+        x.numel() == out.numel()
+    ), "Input and output must have the same number of elements"
     assert x.dtype == out.dtype, "Input and output must have the same dtype"
 
     n_elements = x.numel()
@@ -62,7 +64,7 @@ def _launch_special_i1(x: torch.Tensor, out: torch.Tensor):
         return
 
     BLOCK_SIZE = 1024
-    grid = lambda meta: (triton.cdiv(n_elements, meta['BLOCK_SIZE']),)
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
     special_i1_kernel[grid](x, out, n_elements, BLOCK_SIZE=BLOCK_SIZE)
 
 

--- a/src/flag_gems/experimental_ops/special_xlog1py.py
+++ b/src/flag_gems/experimental_ops/special_xlog1py.py
@@ -75,7 +75,9 @@ def special_xlog1py_self_scalar(self, other):
 
 def special_xlog1py_out(x, y, out):
     out = _ensure_cuda_tensor(out)
-    xb_fp32, yb_fp32, dtype_out = _prepare_inputs(_ensure_cuda_tensor(x), _ensure_cuda_tensor(y))
+    xb_fp32, yb_fp32, dtype_out = _prepare_inputs(
+        _ensure_cuda_tensor(x), _ensure_cuda_tensor(y)
+    )
     # Validate output shape
     expected_shape = torch.broadcast_shapes(xb_fp32.shape, yb_fp32.shape)
     if out.shape != expected_shape:

--- a/src/flag_gems/experimental_ops/square.py
+++ b/src/flag_gems/experimental_ops/square.py
@@ -1,7 +1,8 @@
+from typing import Optional
+
 import torch
 import triton
 import triton.language as tl
-from typing import Optional
 
 
 @triton.jit
@@ -32,7 +33,9 @@ def square(input: torch.Tensor, *, out: Optional[torch.Tensor] = None):
         assert isinstance(out, torch.Tensor), "out must be a torch.Tensor"
         assert out.is_cuda, "out must be on a CUDA device"
         assert out.dtype == input.dtype, "out dtype must match input dtype"
-        assert out.numel() == input.numel(), "out must have the same number of elements as input"
+        assert (
+            out.numel() == input.numel()
+        ), "out must have the same number of elements as input"
         assert out.shape == input.shape, "out must have the same shape as input"
 
     x_c = input.contiguous()
@@ -50,7 +53,9 @@ def square_out(input: torch.Tensor, out: torch.Tensor):
     assert isinstance(out, torch.Tensor), "out must be a torch.Tensor"
     assert input.is_cuda and out.is_cuda, "input and out must be on a CUDA device"
     assert out.dtype == input.dtype, "out dtype must match input dtype"
-    assert out.numel() == input.numel(), "out must have the same number of elements as input"
+    assert (
+        out.numel() == input.numel()
+    ), "out must have the same number of elements as input"
     assert out.shape == input.shape, "out must have the same shape as input"
 
     x_c = input.contiguous()

--- a/tests/experimental/selu__test.py
+++ b/tests/experimental/selu__test.py
@@ -9,18 +9,19 @@ try:
     from tests.accuracy_utils import gems_assert_close
 except ImportError:
     # Fallback values when running outside pytest
-    
+
     def gems_assert_close(res, ref, dtype, **kwargs):
         # Simple fallback comparison
         torch.testing.assert_close(res, ref, **kwargs)
 
+
 import pytest
+import torch
 import triton
 
 import flag_gems
 from flag_gems.experimental_ops.selu_ import selu_ as gems_selu_
 
-import torch
 
 @pytest.mark.selu_
 @pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
@@ -37,6 +38,7 @@ def test_selu__tensor(shape, dtype):
 
     gems_assert_close(act_out, ref_out, dtype=dtype)
 
+
 @pytest.mark.selu_
 @pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
@@ -51,20 +53,14 @@ def test_selu__benchmark_tensor(shape, dtype):
 
     # PyTorch reference implementation
     ms_torch, _, _ = triton.testing.do_bench(
-        lambda: torch.ops.aten.selu_(ref_x),
-        rep=100,
-        quantiles=quantiles
+        lambda: torch.ops.aten.selu_(ref_x), rep=100, quantiles=quantiles
     )
-
 
     # Triton implementation
     with flag_gems.use_gems():
         ms_triton, _, _ = triton.testing.do_bench(
-            lambda: gems_selu_(act_x),
-            rep=100,
-            quantiles=quantiles
+            lambda: gems_selu_(act_x), rep=100, quantiles=quantiles
         )
-
 
     # Calculate speedup and return result
     speedup = ms_torch / ms_triton

--- a/tests/experimental/sinh__test.py
+++ b/tests/experimental/sinh__test.py
@@ -9,18 +9,19 @@ try:
     from tests.accuracy_utils import gems_assert_close
 except ImportError:
     # Fallback values when running outside pytest
-    
+
     def gems_assert_close(res, ref, dtype, **kwargs):
         # Simple fallback comparison
         torch.testing.assert_close(res, ref, **kwargs)
 
+
 import pytest
+import torch
 import triton
 
 import flag_gems
 from flag_gems.experimental_ops.sinh_ import sinh_ as gems_sinh_
 
-import torch
 
 @pytest.mark.sinh_
 @pytest.mark.parametrize("shape", [(), (2, 3), (8, 16, 32), (128, 256), (1024, 1024)])
@@ -37,6 +38,7 @@ def test_sinh__tensor(shape, dtype):
 
     gems_assert_close(act_out, ref_out, dtype=dtype)
 
+
 @pytest.mark.sinh_
 @pytest.mark.parametrize("shape", [(), (2, 3), (8, 16, 32), (128, 256), (1024, 1024)])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
@@ -51,20 +53,14 @@ def test_sinh__benchmark_tensor(shape, dtype):
 
     # PyTorch reference implementation
     ms_torch, _, _ = triton.testing.do_bench(
-        lambda: torch.ops.aten.sinh_(ref_input),
-        rep=100,
-        quantiles=quantiles
+        lambda: torch.ops.aten.sinh_(ref_input), rep=100, quantiles=quantiles
     )
-
 
     # Triton implementation
     with flag_gems.use_gems():
         ms_triton, _, _ = triton.testing.do_bench(
-            lambda: gems_sinh_(act_input),
-            rep=100,
-            quantiles=quantiles
+            lambda: gems_sinh_(act_input), rep=100, quantiles=quantiles
         )
-
 
     # Calculate speedup and return result
     speedup = ms_torch / ms_triton

--- a/tests/experimental/softshrink_test.py
+++ b/tests/experimental/softshrink_test.py
@@ -9,21 +9,23 @@ try:
     from tests.accuracy_utils import gems_assert_close
 except ImportError:
     # Fallback values when running outside pytest
-    
+
     def gems_assert_close(res, ref, dtype, **kwargs):
         # Simple fallback comparison
         torch.testing.assert_close(res, ref, **kwargs)
 
+
 import pytest
+import torch
 import triton
 
 import flag_gems
-from flag_gems.experimental_ops.softshrink import softshrink as gems_softshrink, softshrink_out as gems_softshrink_out
-
-import torch
+from flag_gems.experimental_ops.softshrink import softshrink as gems_softshrink
+from flag_gems.experimental_ops.softshrink import softshrink_out as gems_softshrink_out
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
 from benchmark.performance_utils import GenericBenchmark
+
 
 @pytest.mark.softshrink
 @pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
@@ -57,6 +59,7 @@ def test_softshrink_out(shape, dtype, lambd):
         act_res = gems_softshrink_out(x, lambd, act_out_buf)
 
     gems_assert_close(act_res, ref_res, dtype=dtype)
+
 
 @pytest.mark.softshrink
 def test_perf_aten_softshrink():

--- a/tests/experimental/special_i1_test.py
+++ b/tests/experimental/special_i1_test.py
@@ -9,18 +9,19 @@ try:
     from tests.accuracy_utils import gems_assert_close
 except ImportError:
     # Fallback values when running outside pytest
-    
+
     def gems_assert_close(res, ref, dtype, **kwargs):
         # Simple fallback comparison
         torch.testing.assert_close(res, ref, **kwargs)
 
+
 import pytest
+import torch
 import triton
 
 import flag_gems
-from flag_gems.experimental_ops.special_i1 import special_i1 as gems_special_i1, special_i1_out as gems_special_i1_out
-
-import torch
+from flag_gems.experimental_ops.special_i1 import special_i1 as gems_special_i1
+from flag_gems.experimental_ops.special_i1 import special_i1_out as gems_special_i1_out
 
 
 @pytest.mark.special_i1
@@ -56,6 +57,7 @@ def test_special_i1_out(shape, dtype):
     gems_assert_close(act_ret, ref_ret, dtype=dtype)
     gems_assert_close(act_out_buf, ref_out_buf, dtype=dtype)
 
+
 @pytest.mark.special_i1
 @pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
@@ -69,20 +71,14 @@ def test_special_i1_benchmark_tensor(shape, dtype):
 
     # PyTorch reference implementation
     ms_torch, _, _ = triton.testing.do_bench(
-        lambda: torch.ops.aten.special_i1(ref_x),
-        rep=100,
-        quantiles=quantiles
+        lambda: torch.ops.aten.special_i1(ref_x), rep=100, quantiles=quantiles
     )
-
 
     # Triton implementation
     with flag_gems.use_gems():
         ms_triton, _, _ = triton.testing.do_bench(
-            lambda: gems_special_i1(x),
-            rep=100,
-            quantiles=quantiles
+            lambda: gems_special_i1(x), rep=100, quantiles=quantiles
         )
-
 
     # Calculate speedup and return result
     speedup = ms_torch / ms_triton
@@ -96,7 +92,6 @@ def test_special_i1_benchmark_tensor(shape, dtype):
 @pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
 def test_special_i1_benchmark_out(shape, dtype):
-
     quantiles = [0.5, 0.2, 0.8]
 
     x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
@@ -109,18 +104,14 @@ def test_special_i1_benchmark_out(shape, dtype):
     ms_torch, _, _ = triton.testing.do_bench(
         lambda: torch.ops.aten.special_i1.out(ref_x, out=ref_out_buf),
         rep=100,
-        quantiles=quantiles
+        quantiles=quantiles,
     )
-
 
     # Triton implementation
     with flag_gems.use_gems():
         ms_triton, _, _ = triton.testing.do_bench(
-            lambda: gems_special_i1_out(x, act_out_buf),
-            rep=100,
-            quantiles=quantiles
+            lambda: gems_special_i1_out(x, act_out_buf), rep=100, quantiles=quantiles
         )
-
 
     # Calculate speedup and return result
     speedup = ms_torch / ms_triton

--- a/tests/experimental/special_xlog1py_test.py
+++ b/tests/experimental/special_xlog1py_test.py
@@ -9,21 +9,27 @@ try:
     from tests.accuracy_utils import gems_assert_close
 except ImportError:
     # Fallback values when running outside pytest
-    
+
     def gems_assert_close(res, ref, dtype, **kwargs):
         # Simple fallback comparison
         torch.testing.assert_close(res, ref, **kwargs)
 
+
 import pytest
+import torch
 import triton
 
 import flag_gems
-from flag_gems.experimental_ops.special_xlog1py import special_xlog1py as gems_special_xlog1py, special_xlog1py_out as gems_special_xlog1py_out
-
-import torch
+from flag_gems.experimental_ops.special_xlog1py import (
+    special_xlog1py as gems_special_xlog1py,
+)
+from flag_gems.experimental_ops.special_xlog1py import (
+    special_xlog1py_out as gems_special_xlog1py_out,
+)
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
 from benchmark.performance_utils import GenericBenchmark
+
 
 @pytest.mark.special_xlog1py
 @pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
@@ -95,7 +101,9 @@ def test_special_xlog1py_self_scalar_out(shape, dtype, self_scalar):
     with flag_gems.use_gems():
         act_other = other.clone()
         act_out = torch.empty_like(act_other)
-        torch.ops.aten.special_xlog1py.self_scalar_out(self_scalar, act_other, out=act_out)
+        torch.ops.aten.special_xlog1py.self_scalar_out(
+            self_scalar, act_other, out=act_out
+        )
     gems_assert_close(act_out, ref_out, dtype=dtype, equal_nan=False)
 
 
@@ -111,8 +119,11 @@ def test_special_xlog1py_other_scalar_out(shape, dtype, other_scalar):
     with flag_gems.use_gems():
         act_self = self.clone()
         act_out = torch.empty_like(act_self)
-        torch.ops.aten.special_xlog1py.other_scalar_out(act_self, other_scalar, out=act_out)
+        torch.ops.aten.special_xlog1py.other_scalar_out(
+            act_self, other_scalar, out=act_out
+        )
     gems_assert_close(act_out, ref_out, dtype=dtype, equal_nan=False)
+
 
 @pytest.mark.special_xlog1py
 def test_perf_aten_special_xlog1py():

--- a/tests/experimental/square_test.py
+++ b/tests/experimental/square_test.py
@@ -9,21 +9,23 @@ try:
     from tests.accuracy_utils import gems_assert_close
 except ImportError:
     # Fallback values when running outside pytest
-    
+
     def gems_assert_close(res, ref, dtype, **kwargs):
         # Simple fallback comparison
         torch.testing.assert_close(res, ref, **kwargs)
 
+
 import pytest
+import torch
 import triton
 
 import flag_gems
-from flag_gems.experimental_ops.square import square as gems_square, square_out as gems_square_out
-
-import torch
+from flag_gems.experimental_ops.square import square as gems_square
+from flag_gems.experimental_ops.square import square_out as gems_square_out
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
 from benchmark.performance_utils import GenericBenchmark
+
 
 @pytest.mark.square
 @pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
@@ -51,8 +53,12 @@ def test_square_out(shape, dtype, out_layout):
         ref_out_buf = torch.empty_like(x)
         act_out_buf = torch.empty_like(x)
     else:
-        ref_base = torch.empty((shape[0], shape[1] * 2), dtype=dtype, device=flag_gems.device)
-        act_base = torch.empty((shape[0], shape[1] * 2), dtype=dtype, device=flag_gems.device)
+        ref_base = torch.empty(
+            (shape[0], shape[1] * 2), dtype=dtype, device=flag_gems.device
+        )
+        act_base = torch.empty(
+            (shape[0], shape[1] * 2), dtype=dtype, device=flag_gems.device
+        )
         ref_out_buf = ref_base[:, ::2]
         act_out_buf = act_base[:, ::2]
 
@@ -62,6 +68,7 @@ def test_square_out(shape, dtype, out_layout):
         act_res = gems_square_out(x, act_out_buf)
 
     gems_assert_close(act_res, ref_res, dtype=dtype)
+
 
 @pytest.mark.square
 def test_perf_aten_square():


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
This PR adds 10 experimental operators with their kernel implementations and comprehensive test coverage:

**Changes:**
- Added 10 operator kernel implementations in `src/flag_gems/experimental_ops/`
- Added 10 corresponding test files in `tests/experimental/` (following the new test directory structure)
- All tests include accuracy tests and performance benchmarks
- All tests pass pytest validation

### Issue
N/A

### Progress

- [x] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
All operators include performance benchmarks comparing against PyTorch native implementations. Tests can be run using:

# Run accuracy tests
pytest tests/experimental/ -k "<operator> " -v

# Run performance benchmarks  
pytest tests/experimental/ -k "<operator>" --benchmark-only

All tests have been validated and pass successfully.