### PR TITLE
Add 10 operators（group 2）

### DIFF
--- a/src/flag_gems/experimental_ops/amin.py
+++ b/src/flag_gems/experimental_ops/amin.py
@@ -1,0 +1,218 @@
+from functools import reduce
+from operator import mul
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def amin_reduce_last_kernel(
+    x_ptr,
+    out_ptr,
+    M,  # number of rows (outer size)
+    K,  # reduction length (last-axis size)
+    stride_xm,
+    stride_xk,
+    init,  # identity value for min (same dtype as x)
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    mask_m = pid < M
+    acc = init
+    k = 0
+    while k < K:
+        offs = k + tl.arange(0, BLOCK_SIZE)
+        mask = mask_m & (offs < K)
+        vals = tl.load(
+            x_ptr + pid * stride_xm + offs * stride_xk, mask=mask, other=init
+        )
+        block_min = tl.min(vals, axis=0)
+        acc = tl.minimum(acc, block_min)
+        k += BLOCK_SIZE
+    tl.store(out_ptr + pid, acc, mask=mask_m)
+
+
+def _prod(seq):
+    return int(reduce(mul, seq, 1))
+
+
+def _parse_dims(dim, ndim):
+    if dim is None:
+        return list(range(ndim))
+    if isinstance(dim, (list, tuple)):
+        dims = [int(d) for d in dim]
+    else:
+        dims = [int(dim)]
+    # normalize negatives and remove duplicates preserving order
+    seen = set()
+    norm = []
+    for d in dims:
+        dd = d if d >= 0 else d + ndim
+        if dd < 0 or dd >= ndim:
+            raise IndexError("Dimension out of range in amin")
+        if dd not in seen:
+            norm.append(dd)
+            seen.add(dd)
+    return norm
+
+
+def _amin_impl(
+    x: torch.Tensor, dim=None, keepdim: bool = False, out: torch.Tensor = None
+):
+    if not x.is_cuda:
+        raise RuntimeError("Triton amin kernel requires CUDA tensors")
+    ndim = x.ndim
+    reduce_dims = _parse_dims(dim, ndim)
+    if len(reduce_dims) == 0:
+        # No reduction dims specified, return input (or copy into out)
+        if out is None:
+            return x.clone()
+        if out.numel() != x.numel():
+            raise RuntimeError(
+                "out tensor has incorrect number of elements for amin with empty dims"
+            )
+        out.copy_(x)
+        return out
+
+    # Determine output shape
+    input_sizes = list(x.size())
+    keep_sizes = input_sizes.copy()
+    for d in reduce_dims:
+        keep_sizes[d] = 1
+    non_reduce_dims = [i for i in range(ndim) if i not in reduce_dims]
+    non_reduce_sizes = [input_sizes[i] for i in non_reduce_dims]
+
+    final_shape = keep_sizes if keepdim else non_reduce_sizes
+
+    # Prepare permutation: move non-reduced dims first, reduced dims last
+    perm = non_reduce_dims + reduce_dims
+    x_perm = x.permute(perm)
+    x_perm = x_perm.contiguous()
+
+    # Flatten into [M, K]
+    M = _prod(non_reduce_sizes) if len(non_reduce_sizes) > 0 else 1
+    K = _prod([input_sizes[i] for i in reduce_dims]) if len(reduce_dims) > 0 else 1
+
+    if K == 0:
+        raise RuntimeError(
+            "amin reduction has an empty dimension (no identity for min)"
+        )
+
+    x_2d = x_perm.view(M, K)
+
+    # Identity/initial value for min based on dtype
+    dt = x.dtype
+    if dt.is_floating_point:
+        init_val = float("inf")
+    elif dt == torch.bool:
+        init_val = True
+    else:
+        # integer types
+        info = torch.iinfo(dt)
+        init_val = int(info.max)
+
+    # Prepare output row vector of length M
+    if out is None:
+        out_row = torch.empty((M,), dtype=x.dtype, device=x.device)
+        out_target = None
+    else:
+        # Ensure out shape matches final_shape
+        expected_numel = _prod(final_shape) if len(final_shape) > 0 else 1
+        if out.numel() != expected_numel:
+            raise RuntimeError("out tensor has incorrect number of elements")
+        # We will write into a contiguous view; if out isn't contiguous, use a temp and then reshape/copy back
+        if out.is_contiguous():
+            out_row = out.view(M)
+            out_target = out
+        else:
+            out_row = torch.empty((M,), dtype=out.dtype, device=out.device)
+            out_target = out
+
+    # Strides for x_2d (contiguous row-major)
+    stride_xm = x_2d.stride(0)
+    stride_xk = x_2d.stride(1)
+
+    # Launch kernel
+    grid = lambda meta: (M,)
+    BLOCK_SIZE = 1024
+    amin_reduce_last_kernel[grid](
+        x_2d,
+        out_row,
+        M,
+        K,
+        stride_xm,
+        stride_xk,
+        init_val,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+    # Reshape to target final shape
+    if len(final_shape) == 0:
+        result = out_row.view(())
+    else:
+        result = out_row.view(final_shape)
+
+    if out_target is not None:
+        # If original 'out' was non-contiguous, copy result into it respecting shape
+        if not out_target.is_contiguous():
+            # Copy into the provided 'out' tensor
+            out_target.copy_(result)
+            return out_target
+        return out_target
+    return result
+
+
+def amin(*args, **kwargs):
+    # Parse args to match aten.amin
+    if len(args) == 0:
+        raise RuntimeError("amin requires at least one tensor argument")
+    x = args[0]
+    dim = kwargs.get("dim", None)
+    keepdim = kwargs.get("keepdim", False)
+
+    # Positional handling: amin(x, dim), amin(x, dim, keepdim)
+    if len(args) >= 2:
+        if isinstance(args[1], (int, list, tuple)):
+            dim = args[1]
+        elif isinstance(args[1], bool):
+            keepdim = args[1]
+    if len(args) >= 3:
+        if isinstance(args[2], bool):
+            keepdim = args[2]
+
+    return _amin_impl(x, dim=dim, keepdim=keepdim, out=None)
+
+
+def amin_out(*args, **kwargs):
+    # Expected signature: amin_out(x, dim, keepdim, out) or with out as kwarg
+    if len(args) == 0:
+        raise RuntimeError("amin_out requires at least one tensor argument")
+    x = args[0]
+
+    # Extract out
+    out = kwargs.get("out", None)
+    dim = kwargs.get("dim", None)
+    keepdim = kwargs.get("keepdim", False)
+
+    # Positional arguments
+    # Try to detect out as last positional if provided
+    if len(args) >= 2:
+        if isinstance(args[1], (int, list, tuple)):
+            dim = args[1]
+        elif isinstance(args[1], bool):
+            keepdim = args[1]
+        elif isinstance(args[1], torch.Tensor):
+            out = args[1]
+    if len(args) >= 3:
+        if isinstance(args[2], bool):
+            keepdim = args[2]
+        elif isinstance(args[2], torch.Tensor) and out is None:
+            out = args[2]
+    if len(args) >= 4 and out is None and isinstance(args[3], torch.Tensor):
+        out = args[3]
+
+    if out is None:
+        raise RuntimeError("amin_out requires an 'out' tensor argument")
+
+    return _amin_impl(x, dim=dim, keepdim=keepdim, out=out)

--- a/src/flag_gems/experimental_ops/arctanh.py
+++ b/src/flag_gems/experimental_ops/arctanh.py
@@ -1,0 +1,59 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def arctanh_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    x_f32 = x.to(tl.float32)
+
+    one = 1.0
+    # atanh(x) = 0.5 * (log(1 + x) - log(1 - x))
+    y_f32 = 0.5 * (tl.log(one + x_f32) - tl.log(one - x_f32))
+    y = y_f32.to(x.dtype)
+
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _launch_arctanh(x: torch.Tensor, out: torch.Tensor):
+    assert x.is_cuda and out.is_cuda, "Input and output must be CUDA tensors"
+    assert x.shape == out.shape, "Input and output shapes must match"
+    assert out.dtype == x.dtype, "Output dtype must match input dtype"
+    assert x.dtype in (
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+    ), "Supported dtypes: float16, bfloat16, float32"
+
+    x_contig = x.contiguous()
+    out_contig = out if out.is_contiguous() else torch.empty_like(out)
+
+    n_elements = x_contig.numel()
+    if n_elements == 0:
+        if out_contig is not out:
+            out.copy_(out_contig)
+        return out
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    arctanh_kernel[grid](x_contig, out_contig, n_elements, BLOCK_SIZE=1024)
+
+    if out_contig is not out:
+        out.copy_(out_contig)
+    return out
+
+
+def arctanh(x: torch.Tensor):
+    out = torch.empty_like(x)
+    _launch_arctanh(x, out)
+    return out
+
+
+def arctanh_out(x: torch.Tensor, out: torch.Tensor):
+    _launch_arctanh(x, out)
+    return out

--- a/src/flag_gems/experimental_ops/asinh_.py
+++ b/src/flag_gems/experimental_ops/asinh_.py
@@ -1,0 +1,65 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def asinh_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr, COMPUTE_FP32: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    if COMPUTE_FP32:
+        x32 = x.to(tl.float32)
+        y32 = tl.log(x32 + tl.sqrt(x32 * x32 + 1.0))
+        y = y32.to(x.dtype)
+    else:
+        y = tl.log(x + tl.sqrt(x * x + 1.0))
+
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+asinh__kernel = asinh_
+
+
+def asinh_(*args, **kwargs):
+    x = None
+    if len(args) > 0 and isinstance(args[0], torch.Tensor):
+        x = args[0]
+    else:
+        for key in ("input", "self", "x"):
+            val = kwargs.get(key, None)
+            if isinstance(val, torch.Tensor):
+                x = val
+                break
+    if x is None:
+        raise ValueError("asinh_: expected a Tensor as the first argument")
+
+    if not x.is_cuda:
+        return torch.ops.aten.asinh_(x)
+
+    if x.dtype not in (torch.float16, torch.bfloat16, torch.float32, torch.float64):
+        return torch.ops.aten.asinh_(x)
+
+    BLOCK_SIZE = 1024
+    COMPUTE_FP32 = x.dtype in (torch.float16, torch.bfloat16)
+
+    if x.is_contiguous():
+        n_elements = x.numel()
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        asinh__kernel[grid](
+            x, n_elements, BLOCK_SIZE=BLOCK_SIZE, COMPUTE_FP32=COMPUTE_FP32
+        )
+        return x
+    else:
+        y = x.contiguous()
+        n_elements = y.numel()
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        asinh__kernel[grid](
+            y, n_elements, BLOCK_SIZE=BLOCK_SIZE, COMPUTE_FP32=COMPUTE_FP32
+        )
+        x.copy_(y)
+        return x

--- a/src/flag_gems/experimental_ops/celu.py
+++ b/src/flag_gems/experimental_ops/celu.py
@@ -1,0 +1,87 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def celu_kernel(x_ptr, out_ptr, n_elements, alpha, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    x_fp = x.to(tl.float32)
+    y_fp = tl.where(x_fp > 0.0, x_fp, alpha * (tl.exp(x_fp / alpha) - 1.0))
+    y = y_fp.to(x.dtype)
+
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _parse_alpha(alpha):
+    if isinstance(alpha, torch.Tensor):
+        if alpha.numel() != 1:
+            raise ValueError("alpha tensor must be a scalar (numel() == 1)")
+        alpha = float(alpha.item())
+    else:
+        alpha = float(alpha)
+    if alpha == 0.0:
+        raise ValueError("alpha must be non-zero")
+    return alpha
+
+
+def celu(input: torch.Tensor, alpha: float = 1.0):
+    alpha = _parse_alpha(alpha)
+    if not isinstance(input, torch.Tensor):
+        raise TypeError("input must be a torch.Tensor")
+    if not input.is_cuda:
+        raise ValueError("input must be on CUDA device")
+    if not torch.is_floating_point(input):
+        raise TypeError("input must be a floating point tensor")
+
+    x_contig = input.contiguous()
+    out = torch.empty_like(x_contig)
+
+    n_elements = out.numel()
+    if n_elements == 0:
+        return out
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    celu_kernel[grid](x_contig, out, n_elements, alpha, BLOCK_SIZE=1024)
+    return out
+
+
+def celu_out(input: torch.Tensor, alpha: float = 1.0, out: torch.Tensor = None):
+    alpha = _parse_alpha(alpha)
+    if not isinstance(input, torch.Tensor):
+        raise TypeError("input must be a torch.Tensor")
+    if out is None or not isinstance(out, torch.Tensor):
+        raise TypeError("out must be a preallocated torch.Tensor")
+    if not input.is_cuda or not out.is_cuda:
+        raise ValueError("input and out must be on CUDA device")
+    if not torch.is_floating_point(input) or not torch.is_floating_point(out):
+        raise TypeError("input and out must be floating point tensors")
+    if out.shape != input.shape:
+        raise ValueError("out must have the same shape as input")
+    if out.dtype != input.dtype:
+        raise ValueError("out must have the same dtype as input")
+
+    x_contig = input.contiguous()
+    if out.is_contiguous():
+        out_contig = out
+    else:
+        out_contig = torch.empty_like(x_contig)
+
+    n_elements = x_contig.numel()
+    if n_elements == 0:
+        if out_contig is not out:
+            out.copy_(out_contig)
+        return out
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    celu_kernel[grid](x_contig, out_contig, n_elements, alpha, BLOCK_SIZE=1024)
+
+    if out_contig is not out:
+        out.copy_(out_contig)
+    return out

--- a/src/flag_gems/experimental_ops/celu_.py
+++ b/src/flag_gems/experimental_ops/celu_.py
@@ -1,0 +1,39 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def celu_(
+    x_ptr,  # Pointer to input tensor (will be modified in-place)
+    n_elements,  # Number of elements in the tensor
+    alpha,  # CELU alpha parameter (scalar)
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    x32 = tl.cast(x, tl.float32)
+    alpha32 = tl.cast(alpha, tl.float32)
+
+    neg_part = alpha32 * (tl.exp(x32 / alpha32) - 1.0)
+    y32 = tl.where(x32 > 0, x32, neg_part)
+    y = tl.cast(y32, x.dtype)
+
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# Preserve reference to the Triton kernel before defining the Python wrapper with the same name
+celu_kernel = celu_
+
+
+def celu_(x: torch.Tensor, alpha: float = 1.0):
+    assert x.is_cuda, "Input tensor must be on CUDA device."
+    assert x.is_floating_point(), "CELU requires a floating point tensor."
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    celu_kernel[grid](x, n_elements, alpha, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/clamp_max_.py
+++ b/src/flag_gems/experimental_ops/clamp_max_.py
@@ -1,0 +1,225 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def clamp_max_tensor_kernel(
+    x_ptr,
+    other_ptr,
+    n_elements,
+    in_size0,
+    in_size1,
+    in_size2,
+    in_size3,
+    in_size4,
+    in_size5,
+    in_size6,
+    in_size7,
+    other_size0,
+    other_size1,
+    other_size2,
+    other_size3,
+    other_size4,
+    other_size5,
+    other_size6,
+    other_size7,
+    in_stride0,
+    in_stride1,
+    in_stride2,
+    in_stride3,
+    in_stride4,
+    in_stride5,
+    in_stride6,
+    in_stride7,
+    other_stride0,
+    other_stride1,
+    other_stride2,
+    other_stride3,
+    other_stride4,
+    other_stride5,
+    other_stride6,
+    other_stride7,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    rem = offsets
+
+    # Initialize offsets in element units
+    offset_in = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+    offset_other = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+
+    # Dimension 7
+    c7 = rem % in_size7
+    rem = rem // in_size7
+    offset_in += c7 * in_stride7
+    use_other7 = other_size7 != 1
+    o7 = tl.where(use_other7, c7, 0)
+    offset_other += o7 * other_stride7
+
+    # Dimension 6
+    c6 = rem % in_size6
+    rem = rem // in_size6
+    offset_in += c6 * in_stride6
+    use_other6 = other_size6 != 1
+    o6 = tl.where(use_other6, c6, 0)
+    offset_other += o6 * other_stride6
+
+    # Dimension 5
+    c5 = rem % in_size5
+    rem = rem // in_size5
+    offset_in += c5 * in_stride5
+    use_other5 = other_size5 != 1
+    o5 = tl.where(use_other5, c5, 0)
+    offset_other += o5 * other_stride5
+
+    # Dimension 4
+    c4 = rem % in_size4
+    rem = rem // in_size4
+    offset_in += c4 * in_stride4
+    use_other4 = other_size4 != 1
+    o4 = tl.where(use_other4, c4, 0)
+    offset_other += o4 * other_stride4
+
+    # Dimension 3
+    c3 = rem % in_size3
+    rem = rem // in_size3
+    offset_in += c3 * in_stride3
+    use_other3 = other_size3 != 1
+    o3 = tl.where(use_other3, c3, 0)
+    offset_other += o3 * other_stride3
+
+    # Dimension 2
+    c2 = rem % in_size2
+    rem = rem // in_size2
+    offset_in += c2 * in_stride2
+    use_other2 = other_size2 != 1
+    o2 = tl.where(use_other2, c2, 0)
+    offset_other += o2 * other_stride2
+
+    # Dimension 1
+    c1 = rem % in_size1
+    rem = rem // in_size1
+    offset_in += c1 * in_stride1
+    use_other1 = other_size1 != 1
+    o1 = tl.where(use_other1, c1, 0)
+    offset_other += o1 * other_stride1
+
+    # Dimension 0
+    c0 = rem % in_size0
+    rem = rem // in_size0
+    offset_in += c0 * in_stride0
+    use_other0 = other_size0 != 1
+    o0 = tl.where(use_other0, c0, 0)
+    offset_other += o0 * other_stride0
+
+    x = tl.load(x_ptr + offset_in, mask=mask)
+    y = tl.load(other_ptr + offset_other, mask=mask)
+    out = tl.where(x > y, y, x)
+    tl.store(x_ptr + offset_in, out, mask=mask)
+
+
+def _pad_sizes_strides(shape, strides, target_ndim=8):
+    pad = target_ndim - len(shape)
+    sizes = ([1] * pad) + list(shape)
+    s = ([0] * pad) + list(strides)
+    return sizes, s
+
+
+def _check_broadcastable(in_sizes, other_sizes):
+    assert len(in_sizes) == len(other_sizes)
+    for a, b in zip(in_sizes, other_sizes):
+        if not (b == 1 or b == a):
+            raise RuntimeError("Shapes are not broadcastable for clamp_max_.Tensor")
+
+
+def _launch_clamp_max_tensor_kernel(x: torch.Tensor, other: torch.Tensor):
+    assert x.is_cuda and other.is_cuda, "Tensors must be on CUDA device"
+    assert x.dtype == other.dtype, "Dtypes must match for in-place clamp_max_"
+    ndim = max(x.ndim, other.ndim)
+    assert ndim <= 8, "Supported up to 8 dimensions"
+
+    in_sizes, in_strides = _pad_sizes_strides(x.shape, x.stride(), 8)
+    other_sizes, other_strides = _pad_sizes_strides(other.shape, other.stride(), 8)
+    _check_broadcastable(in_sizes, other_sizes)
+
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    clamp_max_tensor_kernel[grid](
+        x,
+        other,
+        n_elements,
+        in_sizes[0],
+        in_sizes[1],
+        in_sizes[2],
+        in_sizes[3],
+        in_sizes[4],
+        in_sizes[5],
+        in_sizes[6],
+        in_sizes[7],
+        other_sizes[0],
+        other_sizes[1],
+        other_sizes[2],
+        other_sizes[3],
+        other_sizes[4],
+        other_sizes[5],
+        other_sizes[6],
+        other_sizes[7],
+        in_strides[0],
+        in_strides[1],
+        in_strides[2],
+        in_strides[3],
+        in_strides[4],
+        in_strides[5],
+        in_strides[6],
+        in_strides[7],
+        other_strides[0],
+        other_strides[1],
+        other_strides[2],
+        other_strides[3],
+        other_strides[4],
+        other_strides[5],
+        other_strides[6],
+        other_strides[7],
+        BLOCK_SIZE=1024,
+    )
+
+
+def clamp_max_(*args, **kwargs):
+    if len(args) >= 2:
+        x, max_val = args[0], args[1]
+    else:
+        x = kwargs.get("self", kwargs.get("input"))
+        max_val = kwargs.get("max")
+    if x is None or max_val is None:
+        raise ValueError("Expected arguments (Tensor self, Scalar max)")
+    assert isinstance(x, torch.Tensor), "self must be a torch.Tensor"
+    assert x.is_cuda, "Tensor must be on CUDA device"
+
+    # Create a single-element tensor for max and broadcast via strides
+    max_tensor = torch.tensor(max_val, dtype=x.dtype, device=x.device)
+    _launch_clamp_max_tensor_kernel(x, max_tensor)
+    return x
+
+
+def clamp_max__Tensor(*args, **kwargs):
+    if len(args) >= 2:
+        x, other = args[0], args[1]
+    else:
+        x = kwargs.get("self", kwargs.get("input"))
+        other = kwargs.get("max")
+    if x is None or other is None:
+        raise ValueError("Expected arguments (Tensor self, Tensor max)")
+    assert isinstance(x, torch.Tensor) and isinstance(
+        other, torch.Tensor
+    ), "Arguments must be torch.Tensors"
+    assert x.is_cuda and other.is_cuda, "Tensors must be on CUDA device"
+    if other.dtype != x.dtype:
+        other = other.to(dtype=x.dtype)
+    _launch_clamp_max_tensor_kernel(x, other)
+    return x

--- a/src/flag_gems/experimental_ops/clamp_min_.py
+++ b/src/flag_gems/experimental_ops/clamp_min_.py
@@ -1,0 +1,109 @@
+from numbers import Number
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def clamp_min_inplace_kernel(
+    x_ptr,  # *Pointer* to input tensor (in-place mutated).
+    other_ptr,  # *Pointer* to other tensor if using Tensor min, unused otherwise.
+    n_elements,  # Number of elements in the tensor.
+    min_val,  # Scalar minimum value if not using Tensor min.
+    min_is_tensor: tl.constexpr,  # Whether to use tensor-based min.
+    BLOCK_SIZE: tl.constexpr,  # Elements per program.
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    if min_is_tensor:
+        y = tl.load(other_ptr + offsets, mask=mask)
+    else:
+        y = min_val
+
+    out = tl.where(x < y, y, x)
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+def _launch_clamp_min_inplace(
+    x: torch.Tensor, other: torch.Tensor | None, min_val: Number | None
+):
+    assert x.is_cuda, "Input tensor must be on CUDA device."
+    assert x.is_contiguous(), "Input tensor must be contiguous."
+    n_elements = x.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    if other is not None:
+        assert (
+            other.is_cuda and other.is_contiguous()
+        ), "Other tensor must be CUDA and contiguous."
+        if other.numel() == 1:
+            # Treat single-element tensor as scalar min
+            min_scalar = other.item()
+            clamp_min_inplace_kernel[grid](
+                x, x, n_elements, min_scalar, min_is_tensor=False, BLOCK_SIZE=BLOCK_SIZE
+            )
+        else:
+            assert (
+                other.numel() == n_elements
+            ), "Other tensor must have the same number of elements as input."
+            assert (
+                other.dtype == x.dtype
+            ), "Dtype of other tensor must match input dtype."
+            clamp_min_inplace_kernel[grid](
+                x, other, n_elements, 0.0, min_is_tensor=True, BLOCK_SIZE=BLOCK_SIZE
+            )
+    else:
+        assert isinstance(
+            min_val, Number
+        ), "min must be a Python number when other tensor is not provided."
+        clamp_min_inplace_kernel[grid](
+            x, x, n_elements, min_val, min_is_tensor=False, BLOCK_SIZE=BLOCK_SIZE
+        )
+    return x
+
+
+def clamp_min_(*args, **kwargs):
+    # Expected: (Tensor self, Scalar min)
+    # If a Tensor is provided for min, delegate to the Tensor variant.
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        x = kwargs.get("self", kwargs.get("input"))
+    if x is None:
+        raise ValueError("clamp_min_: expected a tensor as the first argument")
+
+    # Determine min argument
+    if len(args) >= 2:
+        min_arg = args[1]
+    else:
+        min_arg = kwargs.get("min", kwargs.get("other"))
+
+    if isinstance(min_arg, torch.Tensor):
+        return clamp_min__Tensor(x, min_arg)
+    else:
+        return _launch_clamp_min_inplace(x, None, min_arg)
+
+
+def clamp_min__Tensor(*args, **kwargs):
+    # Expected: (Tensor self, Tensor min)
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        x = kwargs.get("self", kwargs.get("input"))
+    if x is None:
+        raise ValueError("clamp_min__Tensor: expected a tensor as the first argument")
+
+    if len(args) >= 2:
+        other = args[1]
+    else:
+        other = kwargs.get("min", kwargs.get("other"))
+    if other is None or not isinstance(other, torch.Tensor):
+        raise ValueError("clamp_min__Tensor: expected a Tensor for 'min' argument")
+
+    return _launch_clamp_min_inplace(x, other, None)

--- a/src/flag_gems/experimental_ops/copy_.py
+++ b/src/flag_gems/experimental_ops/copy_.py
@@ -1,0 +1,116 @@
+import torch
+import triton
+import triton.language as tl
+
+
+def _tl_dtype_from_torch(dtype: torch.dtype):
+    # Map common torch dtypes to Triton dtypes
+    if dtype == torch.float16:
+        return tl.float16
+    if dtype == torch.bfloat16:
+        return tl.bfloat16
+    if dtype == torch.float32:
+        return tl.float32
+    if dtype == torch.float64:
+        return tl.float64
+    if dtype == torch.int8:
+        return tl.int8
+    if dtype == torch.int16:
+        return tl.int16
+    if dtype == torch.int32:
+        return tl.int32
+    if dtype == torch.int64:
+        return tl.int64
+    if dtype == torch.uint8:
+        return tl.uint8
+    raise NotImplementedError(f"Unsupported dtype for Triton copy_: {dtype}")
+
+
+@triton.jit
+def _copy_kernel(
+    dst_ptr, src_ptr, n_elements, BLOCK_SIZE: tl.constexpr, DST_DTYPE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    vals = tl.load(src_ptr + offsets, mask=mask)
+    vals = tl.cast(vals, DST_DTYPE)
+    tl.store(dst_ptr + offsets, vals, mask=mask)
+
+
+@triton.jit
+def _fill_kernel(
+    dst_ptr, scalar_value, n_elements, BLOCK_SIZE: tl.constexpr, DST_DTYPE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    vals = tl.full((BLOCK_SIZE,), tl.cast(scalar_value, DST_DTYPE), DST_DTYPE)
+    tl.store(dst_ptr + offsets, vals, mask=mask)
+
+
+def _launch_copy_tensor(dst: torch.Tensor, src: torch.Tensor):
+    assert dst.is_cuda and src.is_cuda, "Triton copy_ supports CUDA tensors only."
+    assert (
+        dst.is_contiguous() and src.is_contiguous()
+    ), "Only contiguous tensors are supported."
+    n_elements = dst.numel()
+    assert (
+        src.numel() == n_elements
+    ), "Source and destination must have the same number of elements."
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    DST_DTYPE = _tl_dtype_from_torch(dst.dtype)
+    _copy_kernel[grid](
+        dst,
+        src,
+        n_elements,
+        BLOCK_SIZE=1024,
+        DST_DTYPE=DST_DTYPE,
+    )
+    return dst
+
+
+def _launch_fill_scalar(dst: torch.Tensor, scalar):
+    assert dst.is_cuda, "Triton copy_ (scalar) supports CUDA tensors only."
+    assert dst.is_contiguous(), "Only contiguous tensors are supported."
+    n_elements = dst.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    DST_DTYPE = _tl_dtype_from_torch(dst.dtype)
+    # Convert scalar to a Python number for kernel argument
+    if dst.dtype.is_floating_point:
+        scalar_val = float(scalar)
+    else:
+        scalar_val = int(scalar)
+    _fill_kernel[grid](
+        dst,
+        scalar_val,
+        n_elements,
+        BLOCK_SIZE=1024,
+        DST_DTYPE=DST_DTYPE,
+    )
+    return dst
+
+
+def copy_(self: torch.Tensor, src, non_blocking: bool = False):
+    if isinstance(src, torch.Tensor):
+        return _launch_copy_tensor(self, src)
+    elif isinstance(src, (int, bool)):
+        return _launch_fill_scalar(self, int(src))
+    elif isinstance(src, float):
+        return _launch_fill_scalar(self, float(src))
+    else:
+        raise TypeError(f"Unsupported src type for copy_: {type(src)}")
+
+
+def copy__Tensor(self: torch.Tensor, src: torch.Tensor, non_blocking: bool = False):
+    return _launch_copy_tensor(self, src)
+
+
+def copy__int(self: torch.Tensor, src: int, non_blocking: bool = False):
+    return _launch_fill_scalar(self, int(src))
+
+
+def copy__float(self: torch.Tensor, src: float, non_blocking: bool = False):
+    return _launch_fill_scalar(self, float(src))

--- a/src/flag_gems/experimental_ops/cos_.py
+++ b/src/flag_gems/experimental_ops/cos_.py
@@ -1,0 +1,48 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def cos_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    x_fp32 = x.to(tl.float32)
+    y = tl.cos(x_fp32)
+    y = y.to(x.dtype)
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# Preserve reference to the kernel before defining the wrapper with the same name.
+cos__kernel = cos_
+
+
+def cos_(*args, **kwargs):
+    # Expect a single tensor input, similar to torch.ops.aten.cos_
+    x = None
+    if len(args) == 1 and isinstance(args[0], torch.Tensor):
+        x = args[0]
+    elif "input" in kwargs and isinstance(kwargs["input"], torch.Tensor):
+        x = kwargs["input"]
+    else:
+        raise TypeError(
+            "cos_ expects a single Tensor argument (positional or keyword 'input')."
+        )
+
+    # Fallback to PyTorch for unsupported cases
+    if (
+        (not x.is_cuda)
+        or (not x.is_contiguous())
+        or (
+            x.dtype not in (torch.float16, torch.bfloat16, torch.float32, torch.float64)
+        )
+    ):
+        return torch.cos_(x)
+
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    cos__kernel[grid](x, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/cosh_.py
+++ b/src/flag_gems/experimental_ops/cosh_.py
@@ -1,0 +1,54 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def cosh_(
+    x_ptr,  # *Pointer* to input vector (modified in-place).
+    n_elements,  # Size of the vector.
+    BLOCK_SIZE: tl.constexpr,  # Number of elements each program should process.
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x32 = tl.cast(x, tl.float32)
+    e_pos = tl.exp(x32)
+    e_neg = tl.exp(-x32)
+    y32 = 0.5 * (e_pos + e_neg)
+    tl.store(x_ptr + offsets, y32, mask=mask)
+
+
+_triton_cosh_kernel = cosh_
+
+
+def cosh_(*args, **kwargs):
+    x = (
+        args[0]
+        if len(args) > 0
+        else kwargs.get("input", None)
+        or kwargs.get("x", None)
+        or kwargs.get("self", None)
+    )
+    if x is None:
+        raise ValueError("cosh_ expects a tensor as the first positional argument.")
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("cosh_ expects a torch.Tensor input.")
+    if not x.is_cuda:
+        raise ValueError("cosh_ Triton kernel requires a CUDA tensor.")
+    if not x.is_contiguous():
+        raise ValueError(
+            "cosh_ Triton kernel currently supports contiguous tensors only."
+        )
+    if x.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise TypeError(
+            "cosh_ Triton kernel supports float16, bfloat16, and float32 tensors."
+        )
+
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _triton_cosh_kernel[grid](x, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/tests/experimental_ops/amin_test.py
+++ b/tests/experimental_ops/amin_test.py
@@ -1,0 +1,393 @@
+# AMIN operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.amin import amin as gems_amin
+from flag_gems.experimental_ops.amin import amin_out as gems_amin_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.amin
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 320)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [None, 0, 1, -1, [0, 1]])
+@pytest.mark.parametrize("keepdim", [False, True])
+def test_amin_tensor_reduce_2d(shape, dtype, dim, keepdim):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    if dim is None and not keepdim:
+        ref_out = torch.ops.aten.amin(ref_x)
+        with flag_gems.use_gems():
+            act_out = gems_amin(x)
+    else:
+        use_dim = list(range(len(shape))) if dim is None else dim
+        ref_out = torch.ops.aten.amin(ref_x, use_dim, keepdim)
+        with flag_gems.use_gems():
+            act_out = gems_amin(x, use_dim, keepdim)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.amin
+@pytest.mark.parametrize("shape", [(2, 3, 4), (16, 17, 8), (32, 64, 128)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [None, 0, 1, 2, -1, [0, 2], [1, 2], [0, 1, 2]])
+@pytest.mark.parametrize("keepdim", [False, True])
+def test_amin_tensor_reduce_3d(shape, dtype, dim, keepdim):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    if dim is None and not keepdim:
+        ref_out = torch.ops.aten.amin(ref_x)
+        with flag_gems.use_gems():
+            act_out = gems_amin(x)
+    else:
+        use_dim = list(range(len(shape))) if dim is None else dim
+        ref_out = torch.ops.aten.amin(ref_x, use_dim, keepdim)
+        with flag_gems.use_gems():
+            act_out = gems_amin(x, use_dim, keepdim)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.amin
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 320)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [None, 0, 1, -1, [0, 1]])
+@pytest.mark.parametrize("keepdim", [False, True])
+def test_amin_out_reduce_2d(shape, dtype, dim, keepdim):
+    def test_compute_out_shape(shape, dims, keepdim):
+        if dims is None:
+            # reduce-all default with keepdim=False
+            return ()
+        if isinstance(dims, int):
+            dims = [dims]
+        dims = [(d + len(shape)) % len(shape) for d in dims]
+        if keepdim:
+            out_shape = list(shape)
+            for d in dims:
+                out_shape[d] = 1
+            return tuple(out_shape)
+        else:
+            remaining = [i for i in range(len(shape)) if i not in set(dims)]
+            return tuple(shape[i] for i in remaining)
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    if dim is None and not keepdim:
+        out_shape = test_compute_out_shape(shape, None, keepdim)
+        ref_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+        act_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+        ref_out = torch.ops.aten.amin.out(ref_x, out=ref_out_t)
+        with flag_gems.use_gems():
+            act_out = gems_amin_out(x, act_out_t)
+    else:
+        use_dim = list(range(len(shape))) if dim is None else dim
+        out_shape = test_compute_out_shape(shape, use_dim, keepdim)
+        ref_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+        act_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+        ref_out = torch.ops.aten.amin.out(ref_x, use_dim, keepdim, out=ref_out_t)
+        with flag_gems.use_gems():
+            act_out = gems_amin_out(x, use_dim, keepdim, act_out_t)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.amin
+@pytest.mark.parametrize("shape", [(2, 3, 4), (16, 17, 8), (32, 64, 128)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [None, 0, 1, 2, -1, [0, 2], [1, 2], [0, 1, 2]])
+@pytest.mark.parametrize("keepdim", [False, True])
+def test_amin_out_reduce_3d(shape, dtype, dim, keepdim):
+    def test_compute_out_shape(shape, dims, keepdim):
+        if dims is None:
+            return ()
+        if isinstance(dims, int):
+            dims = [dims]
+        dims = [(d + len(shape)) % len(shape) for d in dims]
+        if keepdim:
+            out_shape = list(shape)
+            for d in dims:
+                out_shape[d] = 1
+            return tuple(out_shape)
+        else:
+            remaining = [i for i in range(len(shape)) if i not in set(dims)]
+            return tuple(shape[i] for i in remaining)
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    if dim is None and not keepdim:
+        out_shape = test_compute_out_shape(shape, None, keepdim)
+        ref_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+        act_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+        ref_out = torch.ops.aten.amin.out(ref_x, out=ref_out_t)
+        with flag_gems.use_gems():
+            act_out = gems_amin_out(x, act_out_t)
+    else:
+        use_dim = list(range(len(shape))) if dim is None else dim
+        out_shape = test_compute_out_shape(shape, use_dim, keepdim)
+        ref_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+        act_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+        ref_out = torch.ops.aten.amin.out(ref_x, use_dim, keepdim, out=ref_out_t)
+        with flag_gems.use_gems():
+            act_out = gems_amin_out(x, use_dim, keepdim, act_out_t)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.amin
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 320)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [None, 0, 1, -1, [0, 1]])
+@pytest.mark.parametrize("keepdim", [False, True])
+def test_amin_tensor_reduce_2d_performance(shape, dtype, dim, keepdim):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    if dim is None and not keepdim:
+        # PyTorch reference implementation
+        ms_torch, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.amin(ref_x), rep=100, quantiles=quantiles
+        )
+
+        # Triton implementation
+        with flag_gems.use_gems():
+            ms_triton, _, _ = triton.testing.do_bench(
+                lambda: gems_amin(x), rep=100, quantiles=quantiles
+            )
+    else:
+        use_dim = list(range(len(shape))) if dim is None else dim
+        # PyTorch reference implementation
+        ms_torch, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.amin(ref_x, use_dim, keepdim),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+        # Triton implementation
+        with flag_gems.use_gems():
+            ms_triton, _, _ = triton.testing.do_bench(
+                lambda: gems_amin(x, use_dim, keepdim), rep=100, quantiles=quantiles
+            )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"amin {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.amin
+@pytest.mark.parametrize("shape", [(2, 3, 4), (16, 17, 8), (32, 64, 128)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [None, 0, 1, 2, -1, [0, 2], [1, 2], [0, 1, 2]])
+@pytest.mark.parametrize("keepdim", [False, True])
+def test_amin_tensor_reduce_3d_performance(shape, dtype, dim, keepdim):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    if dim is None and not keepdim:
+        # PyTorch reference implementation
+        ms_torch, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.amin(ref_x), rep=100, quantiles=quantiles
+        )
+
+        # Triton implementation
+        with flag_gems.use_gems():
+            ms_triton, _, _ = triton.testing.do_bench(
+                lambda: gems_amin(x), rep=100, quantiles=quantiles
+            )
+    else:
+        use_dim = list(range(len(shape))) if dim is None else dim
+        # PyTorch reference implementation
+        ms_torch, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.amin(ref_x, use_dim, keepdim),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+        # Triton implementation
+        with flag_gems.use_gems():
+            ms_triton, _, _ = triton.testing.do_bench(
+                lambda: gems_amin(x, use_dim, keepdim), rep=100, quantiles=quantiles
+            )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"amin {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.amin
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 320)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [None, 0, 1, -1, [0, 1]])
+@pytest.mark.parametrize("keepdim", [False, True])
+def test_amin_out_reduce_2d_performance(shape, dtype, dim, keepdim):
+    quantiles = [0.5, 0.2, 0.8]
+
+    def test_compute_out_shape(shape, dims, keepdim):
+        if dims is None:
+            # reduce-all default with keepdim=False
+            return ()
+        if isinstance(dims, int):
+            dims = [dims]
+        dims = [(d + len(shape)) % len(shape) for d in dims]
+        if keepdim:
+            out_shape = list(shape)
+            for d in dims:
+                out_shape[d] = 1
+            return tuple(out_shape)
+        else:
+            remaining = [i for i in range(len(shape)) if i not in set(dims)]
+            return tuple(shape[i] for i in remaining)
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    if dim is None and not keepdim:
+        out_shape = test_compute_out_shape(shape, None, keepdim)
+        ref_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+        act_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+        # PyTorch reference implementation
+        ms_torch, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.amin.out(ref_x, out=ref_out_t),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+        # Triton implementation
+        with flag_gems.use_gems():
+            ms_triton, _, _ = triton.testing.do_bench(
+                lambda: gems_amin_out(x, act_out_t), rep=100, quantiles=quantiles
+            )
+    else:
+        use_dim = list(range(len(shape))) if dim is None else dim
+        out_shape = test_compute_out_shape(shape, use_dim, keepdim)
+        ref_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+        act_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+        # PyTorch reference implementation
+        ms_torch, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.amin.out(ref_x, use_dim, keepdim, out=ref_out_t),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+        # Triton implementation
+        with flag_gems.use_gems():
+            ms_triton, _, _ = triton.testing.do_bench(
+                lambda: gems_amin_out(x, use_dim, keepdim, act_out_t),
+                rep=100,
+                quantiles=quantiles,
+            )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"amin {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.amin
+@pytest.mark.parametrize("shape", [(2, 3, 4), (16, 17, 8), (32, 64, 128)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [None, 0, 1, 2, -1, [0, 2], [1, 2], [0, 1, 2]])
+@pytest.mark.parametrize("keepdim", [False, True])
+def test_amin_out_reduce_3d_performance(shape, dtype, dim, keepdim):
+    quantiles = [0.5, 0.2, 0.8]
+
+    def test_compute_out_shape(shape, dims, keepdim):
+        if dims is None:
+            return ()
+        if isinstance(dims, int):
+            dims = [dims]
+        dims = [(d + len(shape)) % len(shape) for d in dims]
+        if keepdim:
+            out_shape = list(shape)
+            for d in dims:
+                out_shape[d] = 1
+            return tuple(out_shape)
+        else:
+            remaining = [i for i in range(len(shape)) if i not in set(dims)]
+            return tuple(shape[i] for i in remaining)
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    if dim is None and not keepdim:
+        out_shape = test_compute_out_shape(shape, None, keepdim)
+        ref_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+        act_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+        # PyTorch reference implementation
+        ms_torch, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.amin.out(ref_x, out=ref_out_t),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+        # Triton implementation
+        with flag_gems.use_gems():
+            ms_triton, _, _ = triton.testing.do_bench(
+                lambda: gems_amin_out(x, act_out_t), rep=100, quantiles=quantiles
+            )
+    else:
+        use_dim = list(range(len(shape))) if dim is None else dim
+        out_shape = test_compute_out_shape(shape, use_dim, keepdim)
+        ref_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+        act_out_t = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+        # PyTorch reference implementation
+        ms_torch, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.amin.out(ref_x, use_dim, keepdim, out=ref_out_t),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+        # Triton implementation
+        with flag_gems.use_gems():
+            ms_triton, _, _ = triton.testing.do_bench(
+                lambda: gems_amin_out(x, use_dim, keepdim, act_out_t),
+                rep=100,
+                quantiles=quantiles,
+            )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"amin {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/asinh__test.py
+++ b/tests/experimental_ops/asinh__test.py
@@ -1,0 +1,67 @@
+# ASINH_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.asinh_ import asinh_ as gems_asinh_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.asinh_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_asinh__tensor(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    act_inp = inp.clone()
+
+    ref_out = torch.ops.aten.asinh_(ref_inp)
+
+    with flag_gems.use_gems():
+        act_out = gems_asinh_(act_inp)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.asinh_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_asinh__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    act_inp = inp.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.asinh_(ref_inp), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_asinh_(act_inp), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"asinh_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/celu_test.py
+++ b/tests/experimental_ops/celu_test.py
@@ -1,0 +1,83 @@
+# CELU operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.celu import celu as gems_celu
+from flag_gems.experimental_ops.celu import celu_out as gems_celu_out
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.celu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_celu_tensor_default_alpha(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.celu(ref_x)
+    with flag_gems.use_gems():
+        act_out = gems_celu(x)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.celu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("alpha", [0.5, 1.0, 2.0])
+def test_celu_tensor_alpha(shape, dtype, alpha):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.celu(ref_x, alpha)
+    with flag_gems.use_gems():
+        act_out = gems_celu(x, alpha)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.celu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("alpha", [0.5, 1.0, 2.0])
+def test_celu_out(shape, dtype, alpha):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    out_ref = torch.empty_like(ref_x)
+    ref_out = torch.ops.aten.celu.out(ref_x, alpha, out=out_ref)
+    out_act = torch.empty_like(x)
+    with flag_gems.use_gems():
+        act_out = gems_celu_out(x, alpha, out_act)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.celu
+def test_perf_aten_celu():
+    # Define input generation logic matching the operator arguments
+    def celu_input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=celu_input_fn,
+        op_name="celu",
+        torch_op=torch.ops.aten.celu,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/clamp_max__test.py
+++ b/tests/experimental_ops/clamp_max__test.py
@@ -1,0 +1,79 @@
+# CLAMP_MAX_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.clamp_max_ import clamp_max_ as gems_clamp_max_
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.clamp_max_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("max_value", [-0.25, 0.0, 0.75])
+def test_clamp_max__scalar(shape, dtype, max_value):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.clamp_max_(ref_input, max_value)
+    with flag_gems.use_gems():
+        act_out = gems_clamp_max_(act_input, max_value)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.clamp_max_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_clamp_max__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    max_tensor = torch.rand(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+    ref_max = max_tensor.clone()
+    act_max = max_tensor.clone()
+
+    ref_out = torch.ops.aten.clamp_max_(ref_input, ref_max)
+    with flag_gems.use_gems():
+        act_out = gems_clamp_max_(act_input, act_max)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.clamp_max_
+def test_perf_aten_clamp_max_():
+    # Define input generation logic matching the operator arguments
+    def clamp_max__input_fn(shape, dtype, device):
+        input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        max_value = torch.rand(
+            1, dtype=dtype, device=flag_gems.device
+        )  # Scalar max value
+        yield input_tensor, max_value
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=clamp_max__input_fn,
+        op_name="clamp_max_",
+        torch_op=torch.ops.aten.clamp_max_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/clamp_min__test.py
+++ b/tests/experimental_ops/clamp_min__test.py
@@ -1,0 +1,81 @@
+# CLAMP_MIN_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.clamp_min_ import clamp_min_ as gems_clamp_min_
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.clamp_min_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("min_val", [0.0, -0.5, 1.5])
+def test_clamp_min__scalar(shape, dtype, min_val):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_inp = inp.clone()
+    act_inp = inp.clone()
+
+    ref_out = torch.ops.aten.clamp_min_(ref_inp, min_val)
+    with flag_gems.use_gems():
+        act_out = gems_clamp_min_(act_inp, min_val)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.clamp_min_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_clamp_min__tensor(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    min_t = torch.rand(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_inp = inp.clone()
+    ref_min = min_t.clone()
+    act_inp = inp.clone()
+    act_min = min_t.clone()
+
+    ref_out = torch.ops.aten.clamp_min_.Tensor(ref_inp, ref_min)
+    with flag_gems.use_gems():
+        act_out = torch.ops.aten.clamp_min_.Tensor(act_inp, act_min)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.clamp_min_
+def test_perf_aten_clamp_min_():
+    # Define input generation logic matching the operator arguments
+    def clamp_min__input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        min_val = torch.tensor(
+            0.0, dtype=dtype, device=flag_gems.device
+        )  # Example min_val
+        yield inp, min_val
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=clamp_min__input_fn,
+        op_name="clamp_min_",
+        torch_op=torch.ops.aten.clamp_min_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/copy__test.py
+++ b/tests/experimental_ops/copy__test.py
@@ -1,0 +1,114 @@
+# COPY_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.copy_ import copy_ as gems_copy_
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.copy_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("non_blocking", [False, True])
+def test_copy__default(shape, dtype, non_blocking):
+    dst_base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    src_base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_dst = dst_base.clone()
+    ref_src = src_base.clone()
+    ref_out = torch.ops.aten.copy_(ref_dst, ref_src, non_blocking)
+
+    act_dst = dst_base.clone()
+    act_src = src_base.clone()
+    with flag_gems.use_gems():
+        act_out = gems_copy_(act_dst, act_src, non_blocking)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.copy_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_copy__tensor_overload(shape, dtype):
+    dst_base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    src_base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_dst = dst_base.clone()
+    ref_src = src_base.clone()
+    ref_out = torch.ops.aten.copy_.Tensor(ref_dst, ref_src)
+
+    act_dst = dst_base.clone()
+    act_src = src_base.clone()
+    with flag_gems.use_gems():
+        act_out = torch.ops.aten.copy_.Tensor(act_dst, act_src)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.copy_
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("value", [0, 1, -3, 42])
+def test_copy__scalar_int(dtype, value):
+    dst_base = torch.zeros((), dtype=dtype, device=flag_gems.device)
+
+    ref_dst = dst_base.clone()
+    ref_out = torch.ops.aten.copy_.int(ref_dst, value)
+
+    act_dst = dst_base.clone()
+    with flag_gems.use_gems():
+        act_out = torch.ops.aten.copy_.int(act_dst, value)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.copy_
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("value", [0.0, -1.5, 3.14, 100.5])
+def test_copy__scalar_float(dtype, value):
+    dst_base = torch.zeros((), dtype=dtype, device=flag_gems.device)
+
+    ref_dst = dst_base.clone()
+    ref_out = torch.ops.aten.copy_.float(ref_dst, value)
+
+    act_dst = dst_base.clone()
+    with flag_gems.use_gems():
+        act_out = torch.ops.aten.copy_.float(act_dst, value)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.copy_
+def test_perf_aten_copy_():
+    # Define input generation logic matching the operator arguments
+    def copy__input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=copy__input_fn,
+        op_name="copy_",
+        torch_op=torch.ops.aten.copy_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/cos__test.py
+++ b/tests/experimental_ops/cos__test.py
@@ -1,0 +1,65 @@
+# COS_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.cos_ import cos_ as gems_cos_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.cos_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_cos__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.cos_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_cos_(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.cos_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_cos__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.cos_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_cos_(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"cos_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/cosh__test.py
+++ b/tests/experimental_ops/cosh__test.py
@@ -1,0 +1,69 @@
+# COSH_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.cosh_ import cosh_ as gems_cosh_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.cosh_
+@pytest.mark.parametrize("shape", [(), (3,), (2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_cosh__tensor(shape, dtype):
+    base = torch.empty(shape, device=flag_gems.device, dtype=dtype).uniform_(-5.0, 5.0)
+
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_out = torch.ops.aten.cosh_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_cosh_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.cosh_
+@pytest.mark.parametrize("shape", [(), (3,), (2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_cosh__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.empty(shape, device=flag_gems.device, dtype=dtype).uniform_(-5.0, 5.0)
+
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.cosh_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_cosh_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"cosh_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")


### PR DESCRIPTION
# Add Experimental Operators - Group 2

## Summary
This PR adds 10 experimental operators and their corresponding test files.

## Operators Added
- `amin.py` + `amin_test.py`
- `arctanh.py` + `arctanh_test.py`
- `asinh_.py` + `asinh__test.py`
- `celu_.py` + `celu__test.py`
- `celu.py` + `celu_test.py`
- `clamp_max_.py` + `clamp_max__test.py`
- `clamp_min_.py` + `clamp_min__test.py`
- `copy_.py` + `copy__test.py`
- `cos_.py` + `cos__test.py`
- `cosh_.py` + `cosh__test.py`

## Files Changed
- 10 operator files in `src/flag_gems/experimental_ops/`
- 10 test files in `src/flag_gems/experimental_ops/exp_tests/`

## Pre-commit Status
✅ All pre-commit checks passed

## Testing
- All test files included
- Pre-commit checks passed (flake8, isort, black, etc.)
