### PR TITLE
feat: add remaining 85 operators with tests 

### DIFF
--- a/src/flag_gems/experimental_ops/deg2rad.py
+++ b/src/flag_gems/experimental_ops/deg2rad.py
@@ -1,0 +1,117 @@
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def deg2rad_kernel(x_ptr, y_ptr, n_elements, scale, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = x * scale
+    tl.store(y_ptr + offsets, y, mask=mask)
+
+
+def _launch_deg2rad_kernel(x_contig: torch.Tensor, out_contig: torch.Tensor):
+    assert x_contig.is_cuda and out_contig.is_cuda, "Tensors must be on CUDA device"
+    n_elements = out_contig.numel()
+    if n_elements == 0:
+        return
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    scale = math.pi / 180.0
+    deg2rad_kernel[grid](x_contig, out_contig, n_elements, scale, BLOCK_SIZE=1024)
+
+
+def deg2rad(*args, **kwargs):
+    # Expecting a single input tensor
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        x = kwargs.get("input", None)
+        if x is None:
+            x = kwargs.get("self", None)
+    if x is None:
+        raise TypeError("deg2rad expected a single input tensor")
+
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("deg2rad input must be a torch.Tensor")
+
+    if not x.is_cuda:
+        raise AssertionError("deg2rad expects CUDA tensors")
+
+    if x.is_complex():
+        raise NotImplementedError(
+            "Complex tensors are not supported in this Triton implementation"
+        )
+
+    # Determine result dtype: keep floating dtype; promote integer/bool to float32
+    if x.is_floating_point():
+        result_dtype = x.dtype
+    else:
+        result_dtype = torch.float32
+
+    x_cast = x.to(result_dtype)
+    x_contig = x_cast.contiguous()
+    out = torch.empty_like(x_contig, dtype=result_dtype, device=x.device)
+
+    _launch_deg2rad_kernel(x_contig.view(-1), out.view(-1))
+
+    return out.view_as(x)
+
+
+def deg2rad_out(*args, **kwargs):
+    # Expecting input tensor and out tensor, either as positional or keyword args
+    x = None
+    out = None
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        x = kwargs.get("input", None) or kwargs.get("self", None)
+    if len(args) >= 2:
+        out = args[1]
+    else:
+        out = kwargs.get("out", None)
+
+    if x is None or out is None:
+        raise TypeError("deg2rad_out expected (input, out) tensors")
+
+    if not isinstance(x, torch.Tensor) or not isinstance(out, torch.Tensor):
+        raise TypeError("deg2rad_out arguments must be torch.Tensor")
+
+    if not x.is_cuda or not out.is_cuda:
+        raise AssertionError("deg2rad_out expects CUDA tensors")
+
+    if x.is_complex() or out.is_complex():
+        raise NotImplementedError(
+            "Complex tensors are not supported in this Triton implementation"
+        )
+
+    if out.numel() != x.numel():
+        raise RuntimeError(
+            "deg2rad_out: 'out' must have the same number of elements as 'input'"
+        )
+
+    if out.device != x.device:
+        raise RuntimeError("deg2rad_out: 'out' must be on the same device as 'input'")
+
+    # Compute in the dtype of 'out' to match out-variant semantics
+    x_cast = x.to(out.dtype)
+    x_contig = x_cast.contiguous()
+
+    if out.is_contiguous():
+        out_contig = out
+        need_copy_back = False
+    else:
+        out_contig = torch.empty_like(out, memory_format=torch.contiguous_format)
+        need_copy_back = True
+
+    _launch_deg2rad_kernel(x_contig.view(-1), out_contig.view(-1))
+
+    if need_copy_back:
+        out.copy_(out_contig)
+
+    return out

--- a/src/flag_gems/experimental_ops/detach.py
+++ b/src/flag_gems/experimental_ops/detach.py
@@ -1,0 +1,53 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def detach(
+    x_ptr,  # Pointer to input tensor
+    out_ptr,  # Pointer to output tensor
+    n_elements,  # Number of elements
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    tl.store(out_ptr + offsets, x, mask=mask)
+
+
+_detach_kernel = detach
+
+
+def detach(*args, **kwargs):
+    # Extract input tensor from positional or keyword arguments
+    x = None
+    if len(args) >= 1 and isinstance(args[0], torch.Tensor):
+        x = args[0]
+    elif "input" in kwargs and isinstance(kwargs["input"], torch.Tensor):
+        x = kwargs["input"]
+    elif "self" in kwargs and isinstance(kwargs["self"], torch.Tensor):
+        x = kwargs["self"]
+    else:
+        raise ValueError(
+            "detach expects a Tensor as the first positional argument or as 'input'/'self' keyword."
+        )
+
+    # Ensure tensor is on a CUDA device for Triton
+    if not x.is_cuda:
+        raise ValueError("Input tensor must be on a CUDA device.")
+
+    # Create contiguous views for kernel processing
+    x_c = x.contiguous()
+    out_c = torch.empty_like(x_c, memory_format=torch.contiguous_format)
+
+    n_elements = x_c.numel()
+    if n_elements == 0:
+        return out_c.view_as(x)
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _detach_kernel[grid](x_c, out_c, n_elements, BLOCK_SIZE=1024)
+
+    return out_c.view_as(x)

--- a/src/flag_gems/experimental_ops/diag.py
+++ b/src/flag_gems/experimental_ops/diag.py
@@ -1,0 +1,172 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _diag_extract_kernel(
+    a_ptr, out_ptr, i0, j0, L, stride_row, stride_col, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(0)
+    block_start = pid * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < L
+    a_idx = (i0 + offs) * stride_row + (j0 + offs) * stride_col
+    vals = tl.load(a_ptr + a_idx, mask=mask)
+    tl.store(out_ptr + offs, vals, mask=mask)
+
+
+@triton.jit
+def _diag_write_kernel(
+    v_ptr, out_ptr, i0, j0, N, stride_row, stride_col, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(0)
+    block_start = pid * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < N
+    out_idx = (i0 + offs) * stride_row + (j0 + offs) * stride_col
+    vals = tl.load(v_ptr + offs, mask=mask)
+    tl.store(out_ptr + out_idx, vals, mask=mask)
+
+
+def diag(*args, **kwargs):
+    # Parse input tensor and diagonal
+    if len(args) < 1 or not isinstance(args[0], torch.Tensor):
+        raise TypeError("diag expects a torch.Tensor as the first positional argument")
+    input = args[0]
+    diagonal = 0
+    if len(args) >= 2 and isinstance(args[1], int):
+        diagonal = args[1]
+    elif "diagonal" in kwargs and isinstance(kwargs["diagonal"], int):
+        diagonal = kwargs["diagonal"]
+
+    if input.dim() == 1:
+        N = input.numel()
+        k = int(diagonal)
+        i0 = max(0, -k)
+        j0 = max(0, k)
+        size = N + abs(k)
+        out = torch.zeros((size, size), dtype=input.dtype, device=input.device)
+        if N > 0:
+            stride_row, stride_col = out.stride()
+            grid = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE"]),)
+            _diag_write_kernel[grid](
+                input, out, i0, j0, N, stride_row, stride_col, BLOCK_SIZE=1024
+            )
+        return out
+    elif input.dim() == 2:
+        M, Nv = input.shape
+        k = int(diagonal)
+        i0 = max(0, -k)
+        j0 = max(0, k)
+        L = min(M - i0, Nv - j0)
+        L = max(L, 0)
+        out = torch.empty((L,), dtype=input.dtype, device=input.device)
+        if L > 0:
+            stride_row, stride_col = input.stride()
+            grid = lambda meta: (triton.cdiv(L, meta["BLOCK_SIZE"]),)
+            _diag_extract_kernel[grid](
+                input, out, i0, j0, L, stride_row, stride_col, BLOCK_SIZE=1024
+            )
+        return out
+    else:
+        raise RuntimeError("diag expects a 1D or 2D tensor")
+
+
+def diag_out(*args, **kwargs):
+    # Supports signatures:
+    # - diag_out(input, diagonal, out)
+    # - diag_out(out, input, diagonal)
+    # - diag_out(input, diagonal, out=...)
+    # - diag_out(input, out=..., diagonal=...)
+    input = None
+    out = None
+    diagonal = 0
+
+    # Extract out from kwargs if provided
+    if "out" in kwargs and isinstance(kwargs["out"], torch.Tensor):
+        out = kwargs["out"]
+
+    # Try positional interpretations
+    if input is None and len(args) >= 1 and isinstance(args[0], torch.Tensor):
+        # Could be (input, diagonal, out) or (out, input, diagonal)
+        if (
+            out is None
+            and len(args) >= 3
+            and isinstance(args[2], torch.Tensor)
+            and isinstance(args[1], int)
+        ):
+            input = args[0]
+            diagonal = int(args[1])
+            out = args[2]
+        elif (
+            out is None
+            and len(args) >= 3
+            and isinstance(args[0], torch.Tensor)
+            and isinstance(args[1], torch.Tensor)
+            and isinstance(args[2], int)
+        ):
+            out = args[0]
+            input = args[1]
+            diagonal = int(args[2])
+        else:
+            # Fallback: treat first tensor as input
+            input = args[0]
+            if len(args) >= 2 and isinstance(args[1], int):
+                diagonal = int(args[1])
+
+    # Override diagonal from kwargs if provided
+    if "diagonal" in kwargs and isinstance(kwargs["diagonal"], int):
+        diagonal = int(kwargs["diagonal"])
+
+    if input is None or out is None:
+        raise TypeError("diag_out expects input tensor, diagonal, and out tensor")
+
+    if input.dim() == 1:
+        N = input.numel()
+        k = int(diagonal)
+        i0 = max(0, -k)
+        j0 = max(0, k)
+        size = N + abs(k)
+
+        if out.dim() != 2 or out.shape[0] != size or out.shape[1] != size:
+            raise RuntimeError(
+                f"diag_out: expected out shape ({size}, {size}), got {tuple(out.shape)}"
+            )
+        if out.dtype != input.dtype or out.device != input.device:
+            raise RuntimeError("diag_out: out dtype/device must match input")
+
+        # Zero-fill out and write diagonal
+        if out.numel() > 0:
+            out.zero_()
+        if N > 0:
+            stride_row, stride_col = out.stride()
+            grid = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE"]),)
+            _diag_write_kernel[grid](
+                input, out, i0, j0, N, stride_row, stride_col, BLOCK_SIZE=1024
+            )
+        return out
+    elif input.dim() == 2:
+        M, Nv = input.shape
+        k = int(diagonal)
+        i0 = max(0, -k)
+        j0 = max(0, k)
+        L = min(M - i0, Nv - j0)
+        L = max(L, 0)
+
+        if out.dim() != 1 or out.numel() != L:
+            raise RuntimeError(
+                f"diag_out: expected out shape ({L},), got {tuple(out.shape)}"
+            )
+        if out.dtype != input.dtype or out.device != input.device:
+            raise RuntimeError("diag_out: out dtype/device must match input")
+
+        if L > 0:
+            stride_row, stride_col = input.stride()
+            grid = lambda meta: (triton.cdiv(L, meta["BLOCK_SIZE"]),)
+            _diag_extract_kernel[grid](
+                input, out, i0, j0, L, stride_row, stride_col, BLOCK_SIZE=1024
+            )
+        return out
+    else:
+        raise RuntimeError("diag_out expects a 1D or 2D input tensor")

--- a/src/flag_gems/experimental_ops/digamma_.py
+++ b/src/flag_gems/experimental_ops/digamma_.py
@@ -1,0 +1,84 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def digamma_(
+    x_ptr,  # Pointer to input/output tensor (in-place)
+    n_elements,  # Number of elements
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x_f32 = x.to(tl.float32)
+
+    pi = 3.1415926535897932384626433832795028841971
+
+    # Reflection for x < 0.5: psi(x) = psi(1 - x) - pi * cot(pi * x)
+    reflect_mask = x_f32 < 0.5
+    xr = tl.where(reflect_mask, 1.0 - x_f32, x_f32)
+
+    # Use recurrence to shift xr to >= 8 for better asymptotic precision
+    s = tl.zeros_like(x_f32)
+    y = xr
+    for _ in range(8):
+        m = y < 8.0
+        s = s - tl.where(m, 1.0 / y, 0.0)
+        y = tl.where(m, y + 1.0, y)
+
+    # Asymptotic expansion for digamma at large y
+    r = 1.0 / y
+    r2 = r * r
+    t2 = r2
+    t4 = t2 * t2
+    t6 = t4 * t2
+    t8 = t4 * t4
+    series = (
+        (-0.5 * r)
+        + (-1.0 / 12.0) * t2
+        + (1.0 / 120.0) * t4
+        + (-1.0 / 252.0) * t6
+        + (1.0 / 240.0) * t8
+    )
+    psi_y = tl.log(y) + s + series
+
+    # Apply reflection if needed
+    cot_term = tl.cos(pi * x_f32) / tl.sin(pi * x_f32)
+    result = tl.where(reflect_mask, psi_y - pi * cot_term, psi_y)
+
+    result = result.to(x.dtype)
+    tl.store(x_ptr + offsets, result, mask=mask)
+
+
+_KERNEL_DIGAMMA_INPLACE = digamma_
+
+
+def digamma_(*args, **kwargs):
+    x = args[0]
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("digamma_ expects a torch.Tensor as the first argument")
+    if not x.is_cuda:
+        return torch.ops.aten.digamma_(x)
+
+    # Handle non-contiguous tensors by operating on a contiguous copy and copying back
+    if not x.is_contiguous():
+        y = x.contiguous()
+        n_elements = y.numel()
+        if n_elements == 0:
+            return x
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        _KERNEL_DIGAMMA_INPLACE[grid](y, n_elements, BLOCK_SIZE=1024)
+        x.copy_(y)
+        return x
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _KERNEL_DIGAMMA_INPLACE[grid](x, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/elu.py
+++ b/src/flag_gems/experimental_ops/elu.py
@@ -1,0 +1,102 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def elu_kernel(
+    x_ptr, out_ptr, n_elements, alpha, scale, input_scale, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    x32 = x.to(tl.float32)
+
+    pos = x32 > 0.0
+    neg = alpha * (tl.exp(input_scale * x32) - 1.0)
+    y32 = tl.where(pos, x32, neg)
+    y32 = scale * y32
+
+    y = y32.to(x.dtype)
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _parse_elu_args(args, kwargs, expect_out: bool = False):
+    x = None
+    if len(args) > 0 and isinstance(args[0], torch.Tensor):
+        x = args[0]
+        arg_idx = 1
+    else:
+        x = kwargs.get("input", kwargs.get("self", kwargs.get("x", None)))
+        arg_idx = 0
+
+    if x is None:
+        raise ValueError("elu expects a Tensor as the first argument (input/self/x).")
+
+    def _get_scalar(name, default, idx):
+        if name in kwargs:
+            return float(kwargs[name])
+        elif len(args) > idx:
+            return float(args[idx])
+        else:
+            return float(default)
+
+    alpha = _get_scalar("alpha", 1.0, arg_idx + 0)
+    scale = _get_scalar("scale", 1.0, arg_idx + 1)
+    input_scale = _get_scalar("input_scale", 1.0, arg_idx + 2)
+
+    out = None
+    if expect_out:
+        if "out" in kwargs and isinstance(kwargs["out"], torch.Tensor):
+            out = kwargs["out"]
+        elif len(args) > arg_idx + 3 and isinstance(args[arg_idx + 3], torch.Tensor):
+            out = args[arg_idx + 3]
+        elif len(args) > arg_idx + 4 and isinstance(args[arg_idx + 4], torch.Tensor):
+            out = args[arg_idx + 4]
+        else:
+            raise ValueError("elu_out expects an 'out' tensor argument.")
+
+    return x, alpha, scale, input_scale, out
+
+
+def _launch_elu_kernel(
+    x: torch.Tensor, out: torch.Tensor, alpha: float, scale: float, input_scale: float
+):
+    if not x.is_cuda or not out.is_cuda:
+        raise RuntimeError("elu Triton kernel requires CUDA tensors.")
+    if x.numel() != out.numel():
+        raise ValueError("Input and output must have the same number of elements.")
+    if x.dtype != out.dtype:
+        raise ValueError("Input and output must have the same dtype.")
+    if not x.is_contiguous() or not out.is_contiguous():
+        raise ValueError("Input and output must be contiguous tensors.")
+
+    n_elements = x.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    elu_kernel[grid](
+        x,
+        out,
+        n_elements,
+        float(alpha),
+        float(scale),
+        float(input_scale),
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+def elu(*args, **kwargs):
+    x, alpha, scale, input_scale, _ = _parse_elu_args(args, kwargs, expect_out=False)
+    out = torch.empty_like(x)
+    _launch_elu_kernel(x.contiguous(), out, alpha, scale, input_scale)
+    return out
+
+
+def elu_out(*args, **kwargs):
+    x, alpha, scale, input_scale, out = _parse_elu_args(args, kwargs, expect_out=True)
+    if out is None:
+        raise ValueError("elu_out requires an 'out' tensor.")
+    _launch_elu_kernel(x.contiguous(), out, alpha, scale, input_scale)
+    return out

--- a/src/flag_gems/experimental_ops/erf_.py
+++ b/src/flag_gems/experimental_ops/erf_.py
@@ -1,0 +1,83 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def erf_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x32 = x.to(tl.float32)
+
+    ax = tl.abs(x32)
+    t = 1.0 / (1.0 + 0.5 * ax)
+
+    p = 1.00002368 + t * (
+        0.37409196
+        + t
+        * (
+            0.09678418
+            + t
+            * (
+                -0.18628806
+                + t
+                * (
+                    0.27886807
+                    + t
+                    * (
+                        -1.13520398
+                        + t * (1.48851587 + t * (-0.82215223 + t * 0.17087277))
+                    )
+                )
+            )
+        )
+    )
+    s = -x32 * x32 - 1.26551223 + t * p
+    tau = t * tl.exp(s)
+    y32 = tl.where(x32 >= 0, 1.0 - tau, tau - 1.0)
+
+    y = y32.to(x.dtype)
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# keep a reference to the kernel before defining the wrapper with the same name
+erf__kernel = erf_
+
+
+def erf_(*args, **kwargs):
+    # Extract the input tensor
+    x = None
+    if len(args) >= 1 and isinstance(args[0], torch.Tensor):
+        x = args[0]
+    elif "input" in kwargs and isinstance(kwargs["input"], torch.Tensor):
+        x = kwargs["input"]
+    elif "self" in kwargs and isinstance(kwargs["self"], torch.Tensor):
+        x = kwargs["self"]
+    elif (
+        "args" in kwargs
+        and isinstance(kwargs["args"], (list, tuple))
+        and kwargs["args"]
+    ):
+        x = kwargs["args"][0]
+    if x is None:
+        raise TypeError("erf_ expects a tensor as its first argument")
+
+    # Fallback for unsupported devices/dtypes
+    if not x.is_cuda:
+        return x.erf_()
+
+    if x.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        return x.erf_()
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    erf__kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/erfinv.py
+++ b/src/flag_gems/experimental_ops/erfinv.py
@@ -1,0 +1,107 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def erfinv_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    xf = x.to(tl.float32)
+
+    one = 1.0
+    absx = tl.abs(xf)
+    w = -tl.log((one - xf) * (one + xf))
+
+    use_low = w < 5.0
+
+    wl = w - 2.5
+    pl = 2.81022636e-08
+    pl = 3.43273939e-07 + pl * wl
+    pl = -3.5233877e-06 + pl * wl
+    pl = -4.39150654e-06 + pl * wl
+    pl = 2.1858087e-04 + pl * wl
+    pl = -1.25372503e-03 + pl * wl
+    pl = -4.17768164e-03 + pl * wl
+    pl = 2.46640727e-01 + pl * wl
+    pl = 1.50140941e00 + pl * wl
+
+    wh = tl.sqrt(w) - 3.0
+    ph = -2.00214257e-04
+    ph = 1.00950558e-04 + ph * wh
+    ph = 1.34934322e-03 + ph * wh
+    ph = -3.67342844e-03 + ph * wh
+    ph = 5.73950773e-03 + ph * wh
+    ph = -7.62246130e-03 + ph * wh
+    ph = 9.43887047e-03 + ph * wh
+    ph = 1.00167406e00 + ph * wh
+    ph = 2.83297682e00 + ph * wh
+
+    p = tl.where(use_low, pl, ph)
+    res = p * xf
+
+    nan_vec = tl.full([BLOCK_SIZE], float("nan"), dtype=tl.float32)
+    inf_vec = tl.full([BLOCK_SIZE], float("inf"), dtype=tl.float32)
+
+    mask_nan = xf != xf
+    mask_oob = absx > 1.0
+    mask_pos1 = xf == 1.0
+    mask_neg1 = xf == -1.0
+
+    res = tl.where(mask_nan, nan_vec, res)
+    res = tl.where(mask_oob, nan_vec, res)
+    res = tl.where(mask_pos1, inf_vec, res)
+    res = tl.where(mask_neg1, -inf_vec, res)
+
+    y = res.to(x.dtype)
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _launch_erfinv_kernel(x: torch.Tensor, out: torch.Tensor):
+    assert x.is_cuda and out.is_cuda, "Inputs must be CUDA tensors"
+    assert (
+        x.numel() == out.numel()
+    ), "Input and output must have the same number of elements"
+    assert x.dtype == out.dtype, "Input and output must have the same dtype"
+    n_elements = x.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    erfinv_kernel[grid](
+        x,
+        out,
+        n_elements,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+def erfinv(x: torch.Tensor):
+    x_in = x
+    if not x_in.is_contiguous():
+        x_in = x_in.contiguous()
+    out = torch.empty_like(x_in)
+    _launch_erfinv_kernel(x_in, out)
+    # Match original shape/strides of input if needed
+    if out.shape != x.shape or out.stride() != x.stride():
+        out = out.reshape(x.shape).as_strided(x.size(), x.stride())
+    return out
+
+
+def erfinv_out(x: torch.Tensor, out: torch.Tensor):
+    # Resize out to match input shape if necessary
+    if out.shape != x.shape:
+        out.resize_(x.shape)
+    # Ensure dtype matches input dtype for aten out semantics
+    assert out.dtype == x.dtype, "out tensor must have the same dtype as input"
+    x_in = x if x.is_contiguous() else x.contiguous()
+    if out.is_contiguous():
+        _launch_erfinv_kernel(x_in, out)
+        return out
+    else:
+        tmp = torch.empty_like(out, memory_format=torch.contiguous_format)
+        _launch_erfinv_kernel(x_in, tmp)
+        out.copy_(tmp)
+        return out

--- a/src/flag_gems/experimental_ops/exp2_.py
+++ b/src/flag_gems/experimental_ops/exp2_.py
@@ -1,0 +1,40 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def exp2_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x_f32 = x.to(tl.float32)
+    ln2 = 0.693147180559945309417232121458176568
+    y_f32 = tl.exp(x_f32 * ln2)
+    y = y_f32.to(x.dtype)
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# Preserve reference to the Triton kernel before defining the Python wrapper with the same name.
+exp2__kernel = exp2_
+
+
+def exp2_(*args, **kwargs):
+    x = None
+    if len(args) > 0:
+        x = args[0]
+    else:
+        x = kwargs.get("input", None)
+        if x is None:
+            x = kwargs.get("x", None)
+    assert isinstance(
+        x, torch.Tensor
+    ), "exp2_ expects a torch.Tensor as its first argument"
+    assert x.is_cuda, "exp2_ Triton kernel requires a CUDA tensor"
+    n_elements = x.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    exp2__kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/exp_tests/deg2rad_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/deg2rad_test.py
@@ -1,0 +1,75 @@
+# DEG2RAD operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.deg2rad import deg2rad as gems_deg2rad
+from flag_gems.experimental_ops.deg2rad import deg2rad_out as gems_deg2rad_out
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.deg2rad
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_deg2rad_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.deg2rad(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_deg2rad(x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.deg2rad
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_deg2rad_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_out = torch.empty_like(ref_x)
+    torch.ops.aten.deg2rad.out(ref_x, out=ref_out)
+
+    act_out = torch.empty_like(x)
+    with flag_gems.use_gems():
+        gems_deg2rad_out(x, act_out)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.deg2rad
+def test_perf_aten_deg2rad():
+    # Define input generation logic matching the operator arguments
+    def deg2rad_input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=deg2rad_input_fn,
+        op_name="deg2rad",
+        torch_op=torch.ops.aten.deg2rad,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/detach_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/detach_test.py
@@ -1,0 +1,71 @@
+# DETACH operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.detach import detach as gems_detach
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.detach
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("requires_grad", [False, True])
+def test_detach_tensor(shape, dtype, requires_grad):
+    input_tensor = torch.randn(
+        shape, dtype=dtype, device=flag_gems.device, requires_grad=requires_grad
+    )
+    ref_input = input_tensor.clone().requires_grad_(requires_grad)
+
+    ref_out = torch.ops.aten.detach(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_detach(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.detach
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("requires_grad", [False, True])
+def test_detach_benchmark_tensor(shape, dtype, requires_grad):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(
+        shape, dtype=dtype, device=flag_gems.device, requires_grad=requires_grad
+    )
+    ref_input = input_tensor.clone().requires_grad_(requires_grad)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.detach(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_detach(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"detach {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/diag_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/diag_test.py
@@ -1,0 +1,157 @@
+# DIAG operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.diag import diag as gems_diag
+from flag_gems.experimental_ops.diag import diag_out as gems_diag_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.diag
+@pytest.mark.parametrize(
+    "shape", [(5,), (2, 3), (128,), (128, 256), (512,), (512, 512)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-1, 0, 2])
+def test_diag_tensor(shape, dtype, diagonal):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out = torch.ops.aten.diag(ref_x, diagonal)
+
+    with flag_gems.use_gems():
+        act_out = gems_diag(x, diagonal)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.diag
+@pytest.mark.parametrize(
+    "shape", [(5,), (2, 3), (128,), (128, 256), (512,), (512, 512)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-1, 0, 2])
+def test_diag_out(shape, dtype, diagonal):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # compute out shape
+    if len(shape) == 1:
+        n = shape[0]
+        m = n + abs(diagonal)
+        out_shape = (m, m)
+    else:
+        m, n = shape
+        if diagonal >= 0:
+            length = max(0, min(m, n - diagonal))
+        else:
+            length = max(0, min(m + diagonal, n))
+        out_shape = (length,)
+
+    ref_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.ops.aten.diag.out(ref_x, diagonal, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out = gems_diag_out(x, diagonal, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.diag
+@pytest.mark.parametrize(
+    "shape", [(5,), (2, 3), (128,), (128, 256), (512,), (512, 512)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-1, 0, 2])
+def test_diag_benchmark_tensor(shape, dtype, diagonal):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.diag(ref_x, diagonal), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_diag(x, diagonal), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"diag {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.diag
+@pytest.mark.parametrize(
+    "shape", [(5,), (2, 3), (128,), (128, 256), (512,), (512, 512)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-1, 0, 2])
+def test_diag_benchmark_out(shape, dtype, diagonal):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # compute out shape
+    if len(shape) == 1:
+        n = shape[0]
+        m = n + abs(diagonal)
+        out_shape = (m, m)
+    else:
+        m, n = shape
+        if diagonal >= 0:
+            length = max(0, min(m, n - diagonal))
+        else:
+            length = max(0, min(m + diagonal, n))
+        out_shape = (length,)
+
+    ref_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.diag.out(ref_x, diagonal, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_diag_out(x, diagonal, act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"diag {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/digamma__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/digamma__test.py
@@ -1,0 +1,67 @@
+# DIGAMMA_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.digamma_ import digamma_ as gems_digamma_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.digamma_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_digamma__tensor(shape, dtype):
+    base = torch.rand(shape, device=flag_gems.device, dtype=torch.float32) * 9.5 + 0.5
+    input_tensor = base.to(dtype)
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.digamma_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_digamma_(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.digamma_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_digamma__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.rand(shape, device=flag_gems.device, dtype=torch.float32) * 9.5 + 0.5
+    input_tensor = base.to(dtype)
+
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.digamma_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_digamma_(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"digamma_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/elu_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/elu_test.py
@@ -1,0 +1,86 @@
+# ELU operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.elu import elu as gems_elu
+from flag_gems.experimental_ops.elu import elu_out as gems_elu_out
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.elu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("params", [(1.0, 1.0, 1.0), (0.5, 1.0, 1.0), (1.5, 2.0, 0.5)])
+def test_elu_tensor(shape, dtype, params):
+    alpha, scale, input_scale = params
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_out = torch.ops.aten.elu(ref_input, alpha, scale, input_scale)
+
+    with flag_gems.use_gems():
+        act_out = gems_elu(act_input, alpha, scale, input_scale)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.elu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("params", [(1.0, 1.0, 1.0), (0.5, 1.0, 1.0), (1.5, 2.0, 0.5)])
+def test_elu_out(shape, dtype, params):
+    alpha, scale, input_scale = params
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_outbuf = torch.empty_like(ref_input)
+    ref_res = torch.ops.aten.elu.out(
+        ref_input, alpha, scale, input_scale, out=ref_outbuf
+    )
+
+    act_outbuf = torch.empty_like(act_input)
+    with flag_gems.use_gems():
+        act_res = gems_elu_out(act_input, alpha, scale, input_scale, act_outbuf)
+
+    gems_assert_close(act_res, ref_res, dtype=dtype)
+
+
+@pytest.mark.elu
+def test_perf_aten_elu():
+    # Define input generation logic matching the operator arguments
+    def elu_input_fn(shape, dtype, device):
+        alpha = 1.0  # Example fixed parameter
+        scale = 1.0  # Example fixed parameter
+        input_scale = 1.0  # Example fixed parameter
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp, alpha, scale, input_scale
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=elu_input_fn,
+        op_name="elu",
+        torch_op=torch.ops.aten.elu,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/erf__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/erf__test.py
@@ -1,0 +1,71 @@
+# ERF_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.erf_ import erf_ as gems_erf_
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.erf_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("noncontig", [False, True])
+def test_erf__tensor(shape, dtype, noncontig):
+    if noncontig:
+        base = torch.randn(
+            (shape[1], shape[0]), device=flag_gems.device, dtype=torch.float32
+        )
+        input_tensor = base.transpose(0, 1).to(dtype)
+    else:
+        input_tensor = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    if dtype in (torch.float16, torch.bfloat16):
+        input_tensor = input_tensor.clamp(-3, 3)
+
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.erf_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_erf_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.erf_
+def test_perf_aten_erf_():
+    # Define input generation logic matching the operator arguments
+    def erf__input_fn(shape, dtype, device):
+        # Generate and yield inputs as required by the operator
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        if dtype in (torch.float16, torch.bfloat16):
+            inp = inp.clamp(-3, 3)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=erf__input_fn,
+        op_name="erf_",
+        torch_op=torch.ops.aten.erf_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/erfinv_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/erfinv_test.py
@@ -1,0 +1,81 @@
+# ERFINV operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.erfinv import erfinv as gems_erfinv
+from flag_gems.experimental_ops.erfinv import erfinv_out as gems_erfinv_out
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.erfinv
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_erfinv_tensor(shape, dtype):
+    # inputs in valid domain [-1, 1]
+    base = torch.rand(shape, dtype=torch.float32, device=flag_gems.device)
+    input_tensor = (base * 1.98 - 0.99).to(dtype)
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.erfinv(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_erfinv(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.erfinv
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_erfinv_out(shape, dtype):
+    # inputs in valid domain [-1, 1]
+    base = torch.rand(shape, dtype=torch.float32, device=flag_gems.device)
+    input_tensor = (base * 1.98 - 0.99).to(dtype)
+
+    ref_input = input_tensor.clone()
+    ref_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+    ref_out = torch.ops.aten.erfinv.out(ref_input, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+        act_out = gems_erfinv_out(input_tensor, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.erfinv
+def test_perf_aten_erfinv():
+    # Define input generation logic matching the operator arguments
+    def erfinv_input_fn(shape, dtype, device):
+        # Generate inputs in valid domain [-1, 1]
+        base = torch.rand(shape, dtype=torch.float32, device=flag_gems.device)
+        input_tensor = (base * 1.98 - 0.99).to(dtype)
+        yield input_tensor,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=erfinv_input_fn,
+        op_name="erfinv",
+        torch_op=torch.ops.aten.erfinv,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/exp2__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/exp2__test.py
@@ -1,0 +1,71 @@
+# EXP2_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.exp2_ import exp2_ as gems_exp2_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.exp2_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_exp2__tensor(shape, dtype):
+    base_fp32 = torch.rand(shape, device=flag_gems.device, dtype=torch.float32) * 8 - 4
+    base = base_fp32.to(dtype)
+
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_out = torch.ops.aten.exp2_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_exp2_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.exp2_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_exp2__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base_fp32 = torch.rand(shape, device=flag_gems.device, dtype=torch.float32) * 8 - 4
+    base = base_fp32.to(dtype)
+
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.exp2_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_exp2_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"exp2_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/expand_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/expand_test.py
@@ -1,0 +1,107 @@
+# EXPAND operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.expand import expand as gems_expand
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.expand
+@pytest.mark.parametrize(
+    "in_shape_out",
+    [
+        ((2, 3), (2, 3)),
+        ((1, 3), (5, 3)),
+        ((2, 1, 4), (2, 7, 4)),
+        ((128, 1), (128, 256)),
+        ((64, 1, 32), (64, 512, 32)),
+        ((2, 3), (-1, 3)),
+        ((1, 3), (-1, 3)),
+        ((1, 1), (128, 256)),
+        ((16, 1, 1, 8), (16, 32, 64, 8)),
+        ((32, 4), (32, -1)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("implicit", [False, True])
+def test_expand_tensor(in_shape_out, dtype, implicit):
+    in_shape, out_size = in_shape_out
+    input_tensor = torch.randn(in_shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.expand(ref_input, out_size, implicit=implicit)
+
+    with flag_gems.use_gems():
+        act_out = gems_expand(input_tensor, out_size, implicit=implicit)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.expand
+@pytest.mark.parametrize(
+    "base_shape,op,out_size",
+    [
+        ((16, 1, 8), "transpose", (8, 32, 16)),
+        ((4, 1, 5, 1), "permute", (5, 4, 7, 9)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("implicit", [False, True])
+def test_expand_noncontiguous(base_shape, op, out_size, dtype, implicit):
+    base = torch.randn(base_shape, dtype=dtype, device=flag_gems.device)
+    ref_base = base.clone()
+
+    if op == "transpose":
+        input_tensor = base.transpose(0, 2)
+        ref_input = ref_base.transpose(0, 2)
+    else:
+        input_tensor = base.permute(2, 0, 3, 1)
+        ref_input = ref_base.permute(2, 0, 3, 1)
+
+    ref_out = torch.ops.aten.expand(ref_input, out_size, implicit=implicit)
+
+    with flag_gems.use_gems():
+        act_out = gems_expand(input_tensor, out_size, implicit=implicit)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.expand
+def test_perf_aten_expand():
+    # Define input generation logic matching the operator arguments
+    def expand_input_fn(shape, dtype, device):
+        # Generate input tensor and output size
+        input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        # Create output size based on the input shape
+        out_size = tuple(
+            s if s != -1 else input_tensor.size(i) for i, s in enumerate(shape)
+        )
+        yield input_tensor, out_size
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=expand_input_fn,
+        op_name="expand",
+        torch_op=torch.ops.aten.expand,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/fft_ifftshift_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/fft_ifftshift_test.py
@@ -1,0 +1,57 @@
+# FFT_IFFTSHIFT operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.fft_ifftshift import fft_ifftshift as gems_fft_ifftshift
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.fft_ifftshift
+@pytest.mark.parametrize(
+    "shape", [(2, 3), (128, 256), (512, 512), (1024,), (16, 17, 18)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [None, [0], [-1]])
+def test_fft_ifftshift_tensor(shape, dtype, dim):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.fft_ifftshift(ref_input, dim)
+    with flag_gems.use_gems():
+        act_out = gems_fft_ifftshift(input_tensor, dim)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.fft_ifftshift
+def test_perf_aten_fft_ifftshift():
+    # Define input generation logic matching the operator arguments
+    def fft_ifftshift_input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=fft_ifftshift_input_fn,
+        op_name="fft_ifftshift",
+        torch_op=torch.ops.aten.fft_ifftshift,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/fill__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/fill__test.py
@@ -1,0 +1,84 @@
+# FILL_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.fill_ import fill__Scalar, fill__Tensor
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.fill_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("value", [0.0, 1.25, -3.5])
+def test_fill__scalar(shape, dtype, value):
+    x_ref = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    x_act = x_ref.clone()
+
+    ref_out = torch.ops.aten.fill_(x_ref, value)
+
+    with flag_gems.use_gems():
+        act_out = fill__Scalar(x_act, value)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.fill_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("value", [0.0, 2.0, -1.5])
+def test_fill__tensor(shape, dtype, value):
+    x_ref = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    x_act = x_ref.clone()
+
+    val_ref = torch.tensor(value, dtype=dtype, device=flag_gems.device)
+    val_act = torch.tensor(value, dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.ops.aten.fill_(x_ref, val_ref)
+
+    with flag_gems.use_gems():
+        act_out = fill__Tensor(x_act, val_act)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.fill_
+def test_perf_aten_fill_():
+    # Define input generation logic matching the operator arguments
+    def fill__input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        value = 1.0  # Scalar value to fill
+        yield inp, value
+
+    # Initialize benchmark - using fill__Scalar for performance test
+    def fill__Scalar_wrapper(self, value):
+        return fill__Scalar(self, value)
+
+    bench = GenericBenchmark(
+        input_fn=fill__input_fn,
+        op_name="fill_",
+        torch_op=torch.ops.aten.fill_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    # Replace the op with fill__Scalar
+    bench.op = fill__Scalar_wrapper
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/fix_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/fix_test.py
@@ -1,0 +1,121 @@
+# FIX operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.fix import fix as gems_fix
+from flag_gems.experimental_ops.fix import fix_out as gems_fix_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.fix
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_fix_tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device) * 3.5
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.fix(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_fix(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.fix
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_fix_out_tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device) * 3.5
+
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out_buf = torch.empty_like(ref_input, device=flag_gems.device)
+    act_out_buf = torch.empty_like(act_input, device=flag_gems.device)
+
+    ref_ret = torch.ops.aten.fix.out(ref_input, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_ret = gems_fix_out(act_input, act_out_buf)
+
+    gems_assert_close(act_ret, ref_ret, dtype=dtype)
+
+
+@pytest.mark.fix
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_fix_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device) * 3.5
+
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.fix(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_fix(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"fix {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.fix
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_fix_out_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device) * 3.5
+
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out_buf = torch.empty_like(ref_input, device=flag_gems.device)
+    act_out_buf = torch.empty_like(act_input, device=flag_gems.device)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.fix.out(ref_input, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_fix_out(act_input, act_out_buf), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"fix {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/frac_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/frac_test.py
@@ -1,0 +1,118 @@
+# FRAC operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.frac import frac as gems_frac
+from flag_gems.experimental_ops.frac import frac_out as gems_frac_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.frac
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_frac_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out = torch.ops.aten.frac(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_frac(x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.frac
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("alias_out", [False, True])
+def test_frac_out(shape, dtype, alias_out):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out_buf = ref_x if alias_out else torch.empty_like(ref_x)
+    ref_out = torch.ops.aten.frac(ref_x, out=ref_out_buf)
+
+    act_out_buf = x if alias_out else torch.empty_like(x)
+    with flag_gems.use_gems():
+        act_out = gems_frac_out(x, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.frac
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_frac_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.frac(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_frac(x), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"frac {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.frac
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("alias_out", [False, True])
+def test_frac_benchmark_out(shape, dtype, alias_out):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out_buf = ref_x if alias_out else torch.empty_like(ref_x)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.frac(ref_x, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    act_out_buf = x if alias_out else torch.empty_like(x)
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_frac_out(x, act_out_buf), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"frac {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/gelu__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/gelu__test.py
@@ -1,0 +1,59 @@
+# GELU_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.gelu_ import gelu_ as gems_gelu_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.gelu_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("approximate", ["none", "tanh"])
+def test_gelu__tensor(shape, dtype, approximate):
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = base.clone()
+    ref_out = torch.ops.aten.gelu_(ref_input, approximate=approximate)
+
+    act_input = base.clone()
+    with flag_gems.use_gems():
+        act_out = gems_gelu_(act_input, approximate=approximate)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.gelu_
+def test_perf_aten_gelu_():
+    # Define input generation logic matching the operator arguments
+    def gelu__input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=gelu__input_fn,
+        op_name="gelu_",
+        torch_op=torch.ops.aten.gelu_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/hardshrink_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/hardshrink_test.py
@@ -1,0 +1,79 @@
+# HARDSHRINK operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.hardshrink import hardshrink as gems_hardshrink
+from flag_gems.experimental_ops.hardshrink import hardshrink_out as gems_hardshrink_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.hardshrink
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("lambd", [0.0, 0.5, 1.0])
+def test_hardshrink_tensor(shape, dtype, lambd):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out = torch.ops.aten.hardshrink(ref_x, lambd)
+
+    with flag_gems.use_gems():
+        act_out = gems_hardshrink(x, lambd)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardshrink
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("lambd", [0.0, 0.75, 1.5])
+def test_hardshrink_out(shape, dtype, lambd):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    out_ref = torch.empty_like(ref_x)
+    out_act = torch.empty_like(x)
+
+    ref_out = torch.ops.aten.hardshrink.out(ref_x, lambd, out=out_ref)
+
+    with flag_gems.use_gems():
+        act_out = gems_hardshrink_out(x, lambd, out_act)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardshrink
+def test_perf_aten_hardshrink():
+    # Define input generation logic matching the operator arguments
+    def hardshrink_input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        lambd = 0.5  # Example lambda value, can be varied if needed
+        yield inp, lambd
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=hardshrink_input_fn,
+        op_name="hardshrink",
+        torch_op=torch.ops.aten.hardshrink,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/hardsigmoid__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/hardsigmoid__test.py
@@ -1,0 +1,67 @@
+# HARDSIGMOID_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.hardsigmoid_ import hardsigmoid_ as gems_hardsigmoid_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.hardsigmoid_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardsigmoid__tensor(shape, dtype):
+    x = torch.randn(shape, device=flag_gems.device, dtype=torch.float32).to(dtype)
+
+    ref_input = x.clone()
+
+    ref_out = torch.ops.aten.hardsigmoid_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_hardsigmoid_(x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardsigmoid_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardsigmoid__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, device=flag_gems.device, dtype=torch.float32).to(dtype)
+
+    ref_input = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.hardsigmoid_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_hardsigmoid_(x), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardsigmoid_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/hardswish__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/hardswish__test.py
@@ -1,0 +1,67 @@
+# HARDSWISH_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.hardswish_ import hardswish_ as gems_hardswish_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.hardswish_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardswish__tensor(shape, dtype):
+    base = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_out = torch.ops.aten.hardswish_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_hardswish_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardswish_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardswish__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.hardswish_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_hardswish_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardswish_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/hardswish_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/hardswish_test.py
@@ -1,0 +1,124 @@
+# HARDSWISH operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.hardswish import hardswish as gems_hardswish
+from flag_gems.experimental_ops.hardswish import hardswish_out as gems_hardswish_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.hardswish
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardswish_tensor(shape, dtype):
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.hardswish(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_hardswish(x.clone())
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardswish
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardswish_out(shape, dtype):
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_x = x.clone()
+    act_x = x.clone()
+
+    ref_out = torch.empty_like(ref_x)
+    act_out = torch.empty_like(act_x)
+
+    ref_ret = torch.ops.aten.hardswish.out(ref_x, out=ref_out)
+    with flag_gems.use_gems():
+        act_ret = gems_hardswish_out(act_x, act_out)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+    gems_assert_close(act_ret, ref_ret, dtype=dtype)
+
+
+@pytest.mark.hardswish
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardswish_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_x = x.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.hardswish(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_hardswish(x.clone()), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardswish {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.hardswish
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardswish_benchmark_out(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_x = x.clone()
+    act_x = x.clone()
+
+    ref_out = torch.empty_like(ref_x)
+    act_out = torch.empty_like(act_x)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.hardswish.out(ref_x, out=ref_out),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_hardswish_out(act_x, act_out), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardswish {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardswish {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/hardtanh__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/hardtanh__test.py
@@ -1,0 +1,120 @@
+# HARDTANH_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.hardtanh_ import hardtanh_ as gems_hardtanh_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.hardtanh_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardtanh__defaults(shape, dtype):
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype) * 3.0
+    ref_input = x.clone()
+    act_input = x.clone()
+
+    ref_out = torch.ops.aten.hardtanh_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_hardtanh_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardtanh_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("min_max", [(-1.0, 1.0), (0.0, 1.0), (-0.5, 0.5), (0.0, 0.0)])
+def test_hardtanh__minmax(shape, dtype, min_max):
+    min_val, max_val = min_max
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype) * 3.0
+    ref_input = x.clone()
+    act_input = x.clone()
+
+    ref_out = torch.ops.aten.hardtanh_(ref_input, min_val, max_val)
+
+    with flag_gems.use_gems():
+        act_out = gems_hardtanh_(act_input, min_val, max_val)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardtanh_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardtanh__defaults_performance(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype) * 3.0
+    ref_input = x.clone()
+    act_input = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.hardtanh_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_hardtanh_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardtanh_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.hardtanh_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("min_max", [(-1.0, 1.0), (0.0, 1.0), (-0.5, 0.5), (0.0, 0.0)])
+def test_hardtanh__minmax_performance(shape, dtype, min_max):
+    quantiles = [0.5, 0.2, 0.8]
+
+    min_val, max_val = min_max
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype) * 3.0
+    ref_input = x.clone()
+    act_input = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.hardtanh_(ref_input, min_val, max_val),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_hardtanh_(act_input, min_val, max_val),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardtanh_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/hardtanh_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/hardtanh_test.py
@@ -1,0 +1,245 @@
+# HARDTANH operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.hardtanh import hardtanh as gems_hardtanh
+from flag_gems.experimental_ops.hardtanh import hardtanh_out as gems_hardtanh_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.hardtanh
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardtanh_tensor_default(shape, dtype):
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.hardtanh(ref_x)
+
+    with flag_gems.use_gems():
+        act_x = x.clone()
+        act_out = gems_hardtanh(act_x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardtanh
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("min_max", [(-1.0, 1.0), (-0.5, 0.5), (0.0, 6.0), (-2.0, 0.5)])
+def test_hardtanh_tensor_explicit(shape, dtype, min_max):
+    min_val, max_val = min_max
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.hardtanh(ref_x, min_val, max_val)
+
+    with flag_gems.use_gems():
+        act_x = x.clone()
+        act_out = gems_hardtanh(act_x, min_val, max_val)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardtanh
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardtanh_out_default(shape, dtype):
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+
+    ref_x = x.clone()
+    ref_out_buf = torch.empty_like(ref_x)
+    ref_res = torch.ops.aten.hardtanh.out(ref_x, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_x = x.clone()
+        act_out_buf = torch.empty_like(act_x)
+        act_res = gems_hardtanh_out(act_x, out=act_out_buf)
+
+    gems_assert_close(act_out_buf, ref_out_buf, dtype=dtype)
+    gems_assert_close(act_res, ref_res, dtype=dtype)
+
+
+@pytest.mark.hardtanh
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("min_max", [(-1.0, 1.0), (-0.5, 0.5), (0.0, 6.0), (-2.0, 0.5)])
+def test_hardtanh_out_explicit(shape, dtype, min_max):
+    min_val, max_val = min_max
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+
+    ref_x = x.clone()
+    ref_out_buf = torch.empty_like(ref_x)
+    ref_res = torch.ops.aten.hardtanh.out(ref_x, min_val, max_val, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_x = x.clone()
+        act_out_buf = torch.empty_like(act_x)
+        act_res = gems_hardtanh_out(act_x, min_val, max_val, out=act_out_buf)
+
+    gems_assert_close(act_out_buf, ref_out_buf, dtype=dtype)
+    gems_assert_close(act_res, ref_res, dtype=dtype)
+
+
+@pytest.mark.hardtanh
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardtanh_tensor_default_performance(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+
+    ref_x = x.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.hardtanh(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        act_x = x.clone()
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_hardtanh(act_x), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardtanh {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.hardtanh
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("min_max", [(-1.0, 1.0), (-0.5, 0.5), (0.0, 6.0), (-2.0, 0.5)])
+def test_hardtanh_tensor_explicit_performance(shape, dtype, min_max):
+    quantiles = [0.5, 0.2, 0.8]
+
+    min_val, max_val = min_max
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+
+    ref_x = x.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.hardtanh(ref_x, min_val, max_val),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        act_x = x.clone()
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_hardtanh(act_x, min_val, max_val), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardtanh {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.hardtanh
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardtanh_out_default_performance(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+
+    ref_x = x.clone()
+    ref_out_buf = torch.empty_like(ref_x)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.hardtanh.out(ref_x, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        act_x = x.clone()
+        act_out_buf = torch.empty_like(act_x)
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_hardtanh_out(act_x, out=act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardtanh {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardtanh {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.hardtanh
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("min_max", [(-1.0, 1.0), (-0.5, 0.5), (0.0, 6.0), (-2.0, 0.5)])
+def test_hardtanh_out_explicit_performance(shape, dtype, min_max):
+    quantiles = [0.5, 0.2, 0.8]
+
+    min_val, max_val = min_max
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+
+    ref_x = x.clone()
+    ref_out_buf = torch.empty_like(ref_x)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.hardtanh.out(ref_x, min_val, max_val, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        act_x = x.clone()
+        act_out_buf = torch.empty_like(act_x)
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_hardtanh_out(act_x, min_val, max_val, out=act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardtanh {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardtanh {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/hinge_embedding_loss_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/hinge_embedding_loss_test.py
@@ -1,0 +1,93 @@
+# HINGE_EMBEDDING_LOSS operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.hinge_embedding_loss import (
+    hinge_embedding_loss as gems_hinge_embedding_loss,
+)
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.hinge_embedding_loss
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (256, 256)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hinge_embedding_loss_defaults(shape, dtype):
+    self_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target_tensor = (torch.randint(0, 2, shape, device=flag_gems.device) * 2 - 1).to(
+        dtype
+    )
+
+    ref_self = self_tensor.clone()
+    ref_target = target_tensor.clone()
+
+    ref_out = torch.ops.aten.hinge_embedding_loss(ref_self, ref_target)
+
+    with flag_gems.use_gems():
+        act_out = gems_hinge_embedding_loss(self_tensor, target_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hinge_embedding_loss
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (256, 256)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("margin", [0.5, 1.0, 2.0])
+@pytest.mark.parametrize("reduction", [0, 1, 2])
+def test_hinge_embedding_loss_fullargs(shape, dtype, margin, reduction):
+    self_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target_tensor = (torch.randint(0, 2, shape, device=flag_gems.device) * 2 - 1).to(
+        dtype
+    )
+
+    ref_self = self_tensor.clone()
+    ref_target = target_tensor.clone()
+
+    ref_out = torch.ops.aten.hinge_embedding_loss(
+        ref_self, ref_target, float(margin), int(reduction)
+    )
+
+    with flag_gems.use_gems():
+        act_out = gems_hinge_embedding_loss(
+            self_tensor, target_tensor, float(margin), int(reduction)
+        )
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hinge_embedding_loss
+def test_perf_aten_hinge_embedding_loss():
+    # Define input generation logic matching the operator arguments
+    def hinge_embedding_loss_input_fn(shape, dtype, device):
+        self_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        target_tensor = (
+            torch.randint(0, 2, shape, device=flag_gems.device) * 2 - 1
+        ).to(dtype)
+        yield self_tensor, target_tensor
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=hinge_embedding_loss_input_fn,
+        op_name="hinge_embedding_loss",
+        torch_op=torch.ops.aten.hinge_embedding_loss,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/huber_loss_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/huber_loss_test.py
@@ -1,0 +1,97 @@
+# HUBER_LOSS operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.huber_loss import huber_loss as gems_huber_loss
+from flag_gems.experimental_ops.huber_loss import huber_loss_out as gems_huber_loss_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.huber_loss
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("reduction", [0, 1, 2])
+@pytest.mark.parametrize("delta", [0.5, 1.0, 2.0])
+def test_huber_loss_tensor(shape, dtype, reduction, delta):
+    self_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_self = self_tensor.clone()
+    ref_target = target_tensor.clone()
+    ref_out = torch.ops.aten.huber_loss(ref_self, ref_target, reduction, float(delta))
+
+    with flag_gems.use_gems():
+        act_self = self_tensor.clone()
+        act_target = target_tensor.clone()
+        act_out = gems_huber_loss(act_self, act_target, reduction, float(delta))
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.huber_loss
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("reduction", [0, 1, 2])
+@pytest.mark.parametrize("delta", [0.5, 1.0, 2.0])
+def test_huber_loss_out(shape, dtype, reduction, delta):
+    self_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    if reduction == 0:
+        out_shape = shape
+    else:
+        out_shape = ()
+
+    ref_self = self_tensor.clone()
+    ref_target = target_tensor.clone()
+    ref_out = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    torch.ops.aten.huber_loss.out(
+        ref_self, ref_target, reduction, float(delta), out=ref_out
+    )
+
+    with flag_gems.use_gems():
+        act_self = self_tensor.clone()
+        act_target = target_tensor.clone()
+        act_out = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+        gems_huber_loss_out(act_self, act_target, reduction, float(delta), act_out)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.huber_loss
+def test_perf_aten_huber_loss():
+    # Define input generation logic matching the operator arguments
+    def huber_loss_input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        delta = 1.0  # You can choose a fixed delta for benchmarking
+        reduction = 0  # You can choose a fixed reduction for benchmarking
+        yield inp1, inp2, reduction, delta
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=huber_loss_input_fn,
+        op_name="huber_loss",
+        torch_op=torch.ops.aten.huber_loss,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/hypot_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/hypot_test.py
@@ -1,0 +1,86 @@
+# HYPOT operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.hypot import hypot as gems_hypot
+from flag_gems.experimental_ops.hypot import hypot_out as gems_hypot_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.hypot
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (513, 257)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hypot_tensor(shape, dtype):
+    self = torch.randn(shape, device=flag_gems.device, dtype=torch.float32) * 3.0
+    other = torch.randn(shape, device=flag_gems.device, dtype=torch.float32) * 3.0
+    self = self.to(dtype)
+    other = other.to(dtype)
+
+    ref_self = self.clone()
+    ref_other = other.clone()
+
+    ref_out = torch.ops.aten.hypot(ref_self, ref_other)
+
+    with flag_gems.use_gems():
+        act_out = gems_hypot(self, other)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hypot
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (513, 257)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hypot_out(shape, dtype):
+    self = torch.randn(shape, device=flag_gems.device, dtype=torch.float32) * 3.0
+    other = torch.randn(shape, device=flag_gems.device, dtype=torch.float32) * 3.0
+    self = self.to(dtype)
+    other = other.to(dtype)
+
+    ref_self = self.clone()
+    ref_other = other.clone()
+
+    ref_out_buf = torch.empty(shape, device=flag_gems.device, dtype=dtype)
+    ref_out = torch.ops.aten.hypot.out(ref_self, ref_other, out=ref_out_buf)
+
+    act_out_buf = torch.empty(shape, device=flag_gems.device, dtype=dtype)
+    with flag_gems.use_gems():
+        act_out = gems_hypot_out(self, other, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hypot
+def test_perf_aten_hypot():
+    # Define input generation logic matching the operator arguments
+    def hypot_input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=hypot_input_fn,
+        op_name="hypot",
+        torch_op=torch.ops.aten.hypot,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/i0__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/i0__test.py
@@ -1,0 +1,69 @@
+# I0_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.i0_ import i0_ as gems_i0_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.i0_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_i0__tensor(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    act_inp = inp.clone()
+    try:
+        ref_out = torch.ops.aten.i0_(ref_inp)
+    except Exception:
+        return
+    with flag_gems.use_gems():
+        act_out = gems_i0_(act_inp)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.i0_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_i0__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    act_inp = inp.clone()
+    try:
+        # PyTorch reference implementation
+        ms_torch, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.i0_(ref_inp), rep=100, quantiles=quantiles
+        )
+    except Exception:
+        return
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_i0_(act_inp), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"i0_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/le__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/le__test.py
@@ -1,0 +1,84 @@
+# LE_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.le_ import le__Scalar, le__Tensor
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.le_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("scalar", [-0.5, 0.0, 1.25])
+def test_le__scalar(shape, dtype, scalar):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.le_(ref_input, scalar)
+    with flag_gems.use_gems():
+        act_out = le__Scalar(act_input, scalar)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.le_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_le__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    other_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    ref_other = other_tensor.clone()
+    act_input = input_tensor.clone()
+    act_other = other_tensor.clone()
+
+    ref_out = torch.ops.aten.le_(ref_input, ref_other)
+    with flag_gems.use_gems():
+        act_out = le__Tensor(act_input, act_other)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.le_
+def test_perf_aten_le_():
+    # Define input generation logic matching the operator arguments
+    def le__input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark - using le__Tensor for performance test
+    def le__Tensor_wrapper(self, other):
+        return le__Tensor(self, other)
+
+    bench = GenericBenchmark(
+        input_fn=le__input_fn,
+        op_name="le_",
+        torch_op=torch.ops.aten.le_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    # Replace the op with le__Tensor
+    bench.op = le__Tensor_wrapper
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/leaky_relu__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/leaky_relu__test.py
@@ -1,0 +1,75 @@
+# LEAKY_RELU_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.leaky_relu_ import leaky_relu_ as gems_leaky_relu_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.leaky_relu_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_leaky_relu__tensor_default(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    act_x = x.clone()
+
+    ref_out = torch.ops.aten.leaky_relu_(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_leaky_relu_(act_x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.leaky_relu_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("negative_slope", [0.0, 0.01, 0.2, 1.5])
+def test_leaky_relu__tensor_with_slope(shape, dtype, negative_slope):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    act_x = x.clone()
+
+    ref_out = torch.ops.aten.leaky_relu_(ref_x, negative_slope)
+
+    with flag_gems.use_gems():
+        act_out = gems_leaky_relu_(act_x, negative_slope)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.leaky_relu_
+def test_perf_aten_leaky_relu_():
+    # Define input generation logic matching the operator arguments
+    def leaky_relu__input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=leaky_relu__input_fn,
+        op_name="leaky_relu_",
+        torch_op=torch.ops.aten.leaky_relu_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/leaky_relu_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/leaky_relu_test.py
@@ -1,0 +1,76 @@
+# LEAKY_RELU operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.leaky_relu import leaky_relu as gems_leaky_relu
+from flag_gems.experimental_ops.leaky_relu import leaky_relu_out as gems_leaky_relu_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.leaky_relu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("negative_slope", [0.0, 0.01, 0.2])
+def test_leaky_relu_tensor(shape, dtype, negative_slope):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.leaky_relu(ref_input, negative_slope)
+    with flag_gems.use_gems():
+        act_out = gems_leaky_relu(input_tensor, negative_slope)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.leaky_relu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("negative_slope", [0.0, 0.01, 0.2])
+def test_leaky_relu_out(shape, dtype, negative_slope):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    ref_out_buf = torch.empty_like(ref_input)
+    ref_out = torch.ops.aten.leaky_relu.out(ref_input, negative_slope, out=ref_out_buf)
+    with flag_gems.use_gems():
+        act_out_buf = torch.empty_like(input_tensor)
+        act_out = gems_leaky_relu_out(input_tensor, negative_slope, act_out_buf)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+    gems_assert_close(act_out_buf, ref_out_buf, dtype=dtype)
+
+
+@pytest.mark.leaky_relu
+def test_perf_aten_leaky_relu():
+    # Define input generation logic matching the operator arguments
+    def leaky_relu_input_fn(shape, dtype, device):
+        input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield input_tensor,
+
+        # Yield negative_slope as a parameter
+        for negative_slope in [0.0, 0.01, 0.2]:
+            yield input_tensor, negative_slope
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=leaky_relu_input_fn,
+        op_name="leaky_relu",
+        torch_op=torch.ops.aten.leaky_relu,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/lerp__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/lerp__test.py
@@ -1,0 +1,92 @@
+# LERP_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.lerp_ import lerp__Scalar, lerp__Tensor
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.lerp_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("weight", [0.0, 0.5, -0.3, 1.0])
+def test_lerp__scalar(shape, dtype, weight):
+    self_base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    end_base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_self = self_base.clone()
+    ref_end = end_base.clone()
+    ref_out = torch.ops.aten.lerp_(ref_self, ref_end, weight)
+
+    act_self = self_base.clone()
+    act_end = end_base.clone()
+    with flag_gems.use_gems():
+        act_out = lerp__Scalar(act_self, act_end, weight)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.lerp_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_lerp__tensor(shape, dtype):
+    self_base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    end_base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    weight_base = torch.rand(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_self = self_base.clone()
+    ref_end = end_base.clone()
+    ref_weight = weight_base.clone()
+    ref_out = torch.ops.aten.lerp_(ref_self, ref_end, ref_weight)
+
+    act_self = self_base.clone()
+    act_end = end_base.clone()
+    act_weight = weight_base.clone()
+    with flag_gems.use_gems():
+        act_out = lerp__Tensor(act_self, act_end, act_weight)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.lerp_
+def test_perf_aten_lerp_():
+    # Define input generation logic matching the operator arguments
+    def lerp__input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        weight = torch.rand(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2, weight
+
+    # Initialize benchmark - using lerp__Tensor for performance test
+    def lerp__Tensor_wrapper(self, end, weight):
+        return lerp__Tensor(self, end, weight)
+
+    bench = GenericBenchmark(
+        input_fn=lerp__input_fn,
+        op_name="lerp_",
+        torch_op=torch.ops.aten.lerp_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    # Replace the op with lerp__Tensor
+    bench.op = lerp__Tensor_wrapper
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/less__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/less__test.py
@@ -1,0 +1,85 @@
+# LESS_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.less_ import less__Scalar, less__Tensor
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.less_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("other", [-0.5, 0.0, 1.25])
+def test_less__scalar(shape, dtype, other):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_inp = inp.clone()
+    ref_out = torch.ops.aten.less_(ref_inp, other)
+
+    with flag_gems.use_gems():
+        act_inp = inp.clone()
+        act_out = less__Scalar(act_inp, other)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.less_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_less__tensor(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    other = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_inp = inp.clone()
+    ref_other = other.clone()
+    ref_out = torch.ops.aten.less_(ref_inp, ref_other)
+
+    with flag_gems.use_gems():
+        act_inp = inp.clone()
+        act_other = other.clone()
+        act_out = less__Tensor(act_inp, act_other)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.less_
+def test_perf_aten_less_():
+    # Define input generation logic matching the operator arguments
+    def less__input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark - using less__Tensor for performance test
+    def less__Tensor_wrapper(self, other):
+        return less__Tensor(self, other)
+
+    bench = GenericBenchmark(
+        input_fn=less__input_fn,
+        op_name="less_",
+        torch_op=torch.ops.aten.less_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    # Replace the op with less__Tensor
+    bench.op = less__Tensor_wrapper
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/lift_fresh_copy_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/lift_fresh_copy_test.py
@@ -1,0 +1,131 @@
+# LIFT_FRESH_COPY operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.lift_fresh_copy import (
+    lift_fresh_copy as gems_lift_fresh_copy,
+)
+from flag_gems.experimental_ops.lift_fresh_copy import (
+    lift_fresh_copy_out as gems_lift_fresh_copy_out,
+)
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.lift_fresh_copy
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_lift_fresh_copy_tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.lift_fresh_copy(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_lift_fresh_copy(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.lift_fresh_copy
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_lift_fresh_copy_out(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out_buf = torch.empty_like(ref_input)
+    act_out_buf = torch.empty_like(act_input)
+
+    ref_out = torch.ops.aten.lift_fresh_copy.out(ref_input, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out = gems_lift_fresh_copy_out(act_input, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.lift_fresh_copy
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_lift_fresh_copy_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.lift_fresh_copy(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_lift_fresh_copy(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"lift_fresh_copy {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.lift_fresh_copy
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_lift_fresh_copy_benchmark_out(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out_buf = torch.empty_like(ref_input)
+    act_out_buf = torch.empty_like(act_input)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.lift_fresh_copy.out(ref_input, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_lift_fresh_copy_out(act_input, act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"lift_fresh_copy {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/lift_fresh_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/lift_fresh_test.py
@@ -1,0 +1,68 @@
+# LIFT_FRESH operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.lift_fresh import lift_fresh as gems_lift_fresh
+
+
+@pytest.mark.lift_fresh
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_lift_fresh_tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.lift_fresh(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_lift_fresh(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.lift_fresh
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_lift_fresh_benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.lift_fresh(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_lift_fresh(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"lift_fresh {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/lift_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/lift_test.py
@@ -1,0 +1,77 @@
+# LIFT operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.lift import lift as gems_lift
+from flag_gems.experimental_ops.lift import lift_out as gems_lift_out
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.lift
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_lift_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.lift(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_lift(x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.lift
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_lift_out_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_out_buf = torch.empty_like(ref_x)
+    ref_out = torch.ops.aten.lift.out(ref_x, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out_buf = torch.empty_like(x)
+        act_out = gems_lift_out(x, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.lift
+def test_perf_aten_lift():
+    # Define input generation logic matching the operator arguments
+    def lift_input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=lift_input_fn,
+        op_name="lift",
+        torch_op=torch.ops.aten.lift,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/log2_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/log2_test.py
@@ -1,0 +1,120 @@
+# LOG2 operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.log2 import log2 as gems_log2
+from flag_gems.experimental_ops.log2 import log2_out as gems_log2_out
+
+
+@pytest.mark.log2
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_log2_tensor(shape, dtype):
+    input_tensor = torch.rand(shape, dtype=dtype, device=flag_gems.device) + 0.1
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.log2(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_log2(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.log2
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_log2_out(shape, dtype):
+    input_tensor = torch.rand(shape, dtype=dtype, device=flag_gems.device) + 0.1
+    ref_input = input_tensor.clone()
+
+    ref_out_buf = torch.empty_like(ref_input)
+    ref_out = torch.ops.aten.log2.out(ref_input, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out_buf = torch.empty_like(input_tensor)
+        act_out = gems_log2_out(input_tensor, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.log2
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_log2_benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.rand(shape, dtype=dtype, device=flag_gems.device) + 0.1
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.log2(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_log2(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"log2 {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.log2
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_log2_benchmark_out(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.rand(shape, dtype=dtype, device=flag_gems.device) + 0.1
+    ref_input = input_tensor.clone()
+
+    ref_out_buf = torch.empty_like(ref_input)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.log2.out(ref_input, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        act_out_buf = torch.empty_like(input_tensor)
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_log2_out(input_tensor, act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"log2 {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/log__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/log__test.py
@@ -1,0 +1,70 @@
+# LOG_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.log_ import log_ as gems_log_
+
+
+@pytest.mark.log_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_log__tensor(shape, dtype):
+    input_tensor = torch.rand(shape, dtype=dtype, device=flag_gems.device) + 0.1
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.log_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_log_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.log_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_log__benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.rand(shape, dtype=dtype, device=flag_gems.device) + 0.1
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.log_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_log_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"log_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/logical_not__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/logical_not__test.py
@@ -1,0 +1,84 @@
+# LOGICAL_NOT_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.logical_not_ import logical_not_ as gems_logical_not_
+
+
+@pytest.mark.logical_not_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 2048)])
+@pytest.mark.parametrize("dtype", [torch.bool])
+@pytest.mark.parametrize("contig", [True, False])
+def test_logical_not__tensor(shape, dtype, contig):
+    if contig:
+        input_tensor = torch.randint(0, 2, shape, device=flag_gems.device).to(dtype)
+    else:
+        base = torch.randint(0, 2, (shape[1], shape[0]), device=flag_gems.device).to(
+            dtype
+        )
+        input_tensor = base.transpose(0, 1)
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.logical_not_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_logical_not_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.logical_not_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 2048)])
+@pytest.mark.parametrize("dtype", [torch.bool])
+@pytest.mark.parametrize("contig", [True, False])
+def test_logical_not__benchmark_tensor(shape, dtype, contig):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    if contig:
+        input_tensor = torch.randint(0, 2, shape, device=flag_gems.device).to(dtype)
+    else:
+        base = torch.randint(0, 2, (shape[1], shape[0]), device=flag_gems.device).to(
+            dtype
+        )
+        input_tensor = base.transpose(0, 1)
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.logical_not_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_logical_not_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"logical_not_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/lt__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/lt__test.py
@@ -1,0 +1,86 @@
+# LT_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.lt_ import lt__Scalar, lt__Tensor
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.lt_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_lt__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    other_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    ref_other = other_tensor.clone()
+
+    ref_out = torch.ops.aten.lt_(ref_input, ref_other)
+
+    with flag_gems.use_gems():
+        act_out = lt__Tensor(input_tensor, other_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.lt_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("other", [-1.0, 0.0, 1.5])
+def test_lt__scalar(shape, dtype, other):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.lt_(ref_input, other)
+
+    with flag_gems.use_gems():
+        act_out = lt__Scalar(input_tensor, other)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.lt_
+def test_perf_aten_lt_():
+    # Define input generation logic matching the operator arguments
+    def lt__input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark - using lt__Tensor for performance test
+    def lt__Tensor_wrapper(self, other):
+        return lt__Tensor(self, other)
+
+    bench = GenericBenchmark(
+        input_fn=lt__input_fn,
+        op_name="lt_",
+        torch_op=torch.ops.aten.lt_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    # Replace the op with lt__Tensor
+    bench.op = lt__Tensor_wrapper
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/masked_fill_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/masked_fill_test.py
@@ -1,0 +1,125 @@
+# MASKED_FILL operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.masked_fill import (
+    masked_fill_Scalar,
+    masked_fill_Scalar_out,
+    masked_fill_Tensor,
+    masked_fill_Tensor_out,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.masked_fill
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("value", [0.0, -1.25, 2.5])
+def test_masked_fill_scalar(shape, dtype, value):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.5
+    ref_x = x.clone()
+    ref_mask = mask.clone()
+    ref_out = torch.ops.aten.masked_fill.Scalar(ref_x, ref_mask, value)
+    with flag_gems.use_gems():
+        act_out = masked_fill_Scalar(x, mask, value)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.masked_fill
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("value", [1.0, -3.0, 0.75])
+def test_masked_fill_tensor(shape, dtype, value):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.5
+    val = torch.tensor(value, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_mask = mask.clone()
+    ref_val = val.clone()
+    ref_out = torch.ops.aten.masked_fill.Tensor(ref_x, ref_mask, ref_val)
+    with flag_gems.use_gems():
+        act_out = masked_fill_Tensor(x, mask, val)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.masked_fill
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("value", [0.0, -2.0, 3.5])
+def test_masked_fill_scalar_out(shape, dtype, value):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.5
+    ref_x = x.clone()
+    ref_mask = mask.clone()
+    ref_out_buf = torch.empty_like(ref_x)
+    ref_out = torch.ops.aten.masked_fill.Scalar_out(
+        ref_x, ref_mask, value, out=ref_out_buf
+    )
+    act_out_buf = torch.empty_like(x)
+    with flag_gems.use_gems():
+        act_out = masked_fill_Scalar_out(x, mask, value, out=act_out_buf)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.masked_fill
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("value", [1.5, -0.5, 4.0])
+def test_masked_fill_tensor_out(shape, dtype, value):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.5
+    val = torch.tensor(value, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_mask = mask.clone()
+    ref_val = val.clone()
+    ref_out_buf = torch.empty_like(ref_x)
+    ref_out = torch.ops.aten.masked_fill.Tensor_out(
+        ref_x, ref_mask, ref_val, out=ref_out_buf
+    )
+    act_out_buf = torch.empty_like(x)
+    with flag_gems.use_gems():
+        act_out = masked_fill_Tensor_out(x, mask, val, out=act_out_buf)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.masked_fill
+def test_perf_aten_masked_fill():
+    # Define input generation logic matching the operator arguments
+    def masked_fill_input_fn(shape, dtype, device):
+        x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        mask = torch.rand(shape, device=flag_gems.device) > 0.5
+        value = torch.tensor(
+            1.0, dtype=dtype, device=flag_gems.device
+        )  # Example scalar value
+        yield x, mask, value
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=masked_fill_input_fn,
+        op_name="masked_fill",
+        torch_op=torch.ops.aten.masked_fill,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/masked_select_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/masked_select_test.py
@@ -1,0 +1,88 @@
+# MASKED_SELECT operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.masked_select import masked_select as gems_masked_select
+from flag_gems.experimental_ops.masked_select import (
+    masked_select_out as gems_masked_select_out,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.masked_select
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_masked_select_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.5
+
+    ref_x = x.clone()
+    ref_mask = mask.clone()
+
+    ref_out = torch.ops.aten.masked_select(ref_x, ref_mask)
+
+    with flag_gems.use_gems():
+        act_out = gems_masked_select(x, mask)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.masked_select
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_masked_select_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.5
+
+    ref_x = x.clone()
+    ref_mask = mask.clone()
+
+    ref_n = int(ref_mask.sum().item())
+    ref_out_buf = torch.empty((ref_n,), dtype=dtype, device=flag_gems.device)
+    ref_out = torch.ops.aten.masked_select.out(ref_x, ref_mask, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_n = int(mask.sum().item())
+        act_out_buf = torch.empty((act_n,), dtype=dtype, device=flag_gems.device)
+        act_out = gems_masked_select_out(x, mask, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.masked_select
+def test_perf_aten_masked_select():
+    # Define input generation logic matching the operator arguments
+    def masked_select_input_fn(shape, dtype, device):
+        x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        mask = torch.rand(shape, device=flag_gems.device) > 0.5
+        yield x, mask
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=masked_select_input_fn,
+        op_name="masked_select",
+        torch_op=torch.ops.aten.masked_select,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/maximum_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/maximum_test.py
@@ -1,0 +1,111 @@
+# MAXIMUM operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.maximum import maximum as gems_maximum
+from flag_gems.experimental_ops.maximum import maximum_out as gems_maximum_out
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.maximum
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_maximum_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    y = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_y = y.clone()
+
+    ref_out = torch.ops.aten.maximum(ref_x, ref_y)
+
+    with flag_gems.use_gems():
+        act_out = gems_maximum(x, y)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.maximum
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_maximum_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    y = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_y = y.clone()
+
+    ref_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.ops.aten.maximum.out(ref_x, ref_y, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out = gems_maximum_out(x, y, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.maximum
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        ((2, 3, 1), (1, 3, 4)),
+        ((8, 1, 16), (1, 12, 16)),
+        ((64, 1, 256), (1, 128, 1)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_maximum_tensor_broadcast(shapes, dtype):
+    shape_a, shape_b = shapes
+    x = torch.randn(shape_a, dtype=dtype, device=flag_gems.device)
+    y = torch.randn(shape_b, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_y = y.clone()
+
+    ref_out = torch.ops.aten.maximum(ref_x, ref_y)
+
+    with flag_gems.use_gems():
+        act_out = gems_maximum(x, y)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.maximum
+def test_perf_aten_maximum():
+    # Define input generation logic matching the operator arguments
+    def maximum_input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=maximum_input_fn,
+        op_name="maximum",
+        torch_op=torch.ops.aten.maximum,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/mse_loss_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/mse_loss_test.py
@@ -1,0 +1,89 @@
+# MSE_LOSS operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.mse_loss import mse_loss as gems_mse_loss
+from flag_gems.experimental_ops.mse_loss import mse_loss_out as gems_mse_loss_out
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.mse_loss
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("reduction", [0, 1, 2])
+def test_mse_loss_tensor(shape, dtype, reduction):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    y = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_y = y.clone()
+    ref_out = torch.ops.aten.mse_loss(ref_x, ref_y, reduction)
+
+    with flag_gems.use_gems():
+        act_out = gems_mse_loss(x, y, reduction)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.mse_loss
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("reduction", [0, 1, 2])
+def test_mse_loss_out(shape, dtype, reduction):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    y = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    if reduction == 0:
+        ref_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+        act_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+    else:
+        ref_out_buf = torch.empty((), dtype=dtype, device=flag_gems.device)
+        act_out_buf = torch.empty((), dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_y = y.clone()
+    ref_out = torch.ops.aten.mse_loss.out(ref_x, ref_y, reduction, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out = gems_mse_loss_out(x, y, reduction, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.mse_loss
+def test_perf_aten_mse_loss():
+    # Define input generation logic matching the operator arguments
+    def mse_loss_input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=mse_loss_input_fn,
+        op_name="mse_loss",
+        torch_op=torch.ops.aten.mse_loss,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/mv_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/mv_test.py
@@ -1,0 +1,131 @@
+# MV operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.mv import mv as gems_mv
+from flag_gems.experimental_ops.mv import mv_out as gems_mv_out
+
+
+@pytest.mark.mv
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_mv_tensor(shape, dtype):
+    m, n = shape
+    mat = torch.randn((m, n), dtype=dtype, device=flag_gems.device)
+    vec = torch.randn((n,), dtype=dtype, device=flag_gems.device)
+
+    ref_mat = mat.clone()
+    ref_vec = vec.clone()
+    ref_out = torch.ops.aten.mv(ref_mat, ref_vec)
+
+    with flag_gems.use_gems():
+        act_out = gems_mv(mat, vec)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.mv
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_mv_out_tensor(shape, dtype):
+    m, n = shape
+    mat = torch.randn((m, n), dtype=dtype, device=flag_gems.device)
+    vec = torch.randn((n,), dtype=dtype, device=flag_gems.device)
+
+    ref_mat = mat.clone()
+    ref_vec = vec.clone()
+    ref_out_buf = torch.empty((m,), dtype=dtype, device=flag_gems.device)
+    ref_out = torch.ops.aten.mv.out(ref_mat, ref_vec, out=ref_out_buf)
+
+    act_out_buf = torch.empty((m,), dtype=dtype, device=flag_gems.device)
+    with flag_gems.use_gems():
+        act_out = gems_mv_out(mat, vec, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.mv
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_mv_benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    m, n = shape
+    mat = torch.randn((m, n), dtype=dtype, device=flag_gems.device)
+    vec = torch.randn((n,), dtype=dtype, device=flag_gems.device)
+
+    ref_mat = mat.clone()
+    ref_vec = vec.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.mv(ref_mat, ref_vec), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_mv(mat, vec), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"mv {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.mv
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_mv_out_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    m, n = shape
+    mat = torch.randn((m, n), dtype=dtype, device=flag_gems.device)
+    vec = torch.randn((n,), dtype=dtype, device=flag_gems.device)
+
+    ref_mat = mat.clone()
+    ref_vec = vec.clone()
+    ref_out_buf = torch.empty((m,), dtype=dtype, device=flag_gems.device)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.mv.out(ref_mat, ref_vec, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    act_out_buf = torch.empty((m,), dtype=dtype, device=flag_gems.device)
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_mv_out(mat, vec, act_out_buf), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"mv {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/native_dropout_backward_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/native_dropout_backward_test.py
@@ -1,0 +1,168 @@
+# NATIVE_DROPOUT_BACKWARD operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.native_dropout_backward import (
+    native_dropout_backward as gems_native_dropout_backward,
+)
+from flag_gems.experimental_ops.native_dropout_backward import (
+    native_dropout_backward_out as gems_native_dropout_backward_out,
+)
+
+
+@pytest.mark.native_dropout_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("scale", [1.0, 0.5, 2.0])
+def test_native_dropout_backward_tensor(shape, dtype, scale):
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.3
+
+    ref_grad = grad_output.clone()
+    ref_mask = mask.clone()
+    ref_out = torch.ops.aten.native_dropout_backward(ref_grad, ref_mask, float(scale))
+
+    act_grad = grad_output.clone()
+    act_mask = mask.clone()
+    with flag_gems.use_gems():
+        act_out = gems_native_dropout_backward(act_grad, act_mask, float(scale))
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.native_dropout_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("scale", [1.0, 0.5, 2.0])
+def test_native_dropout_backward_out(shape, dtype, scale):
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.6
+
+    ref_grad = grad_output.clone()
+    ref_mask = mask.clone()
+    ref_out_tensor = torch.empty_like(ref_grad)
+    ref_out = torch.ops.aten.native_dropout_backward.out(
+        ref_grad, ref_mask, float(scale), out=ref_out_tensor
+    )
+
+    act_grad = grad_output.clone()
+    act_mask = mask.clone()
+    act_out_tensor = torch.empty_like(act_grad)
+    with flag_gems.use_gems():
+        act_out = gems_native_dropout_backward_out(
+            act_grad, act_mask, float(scale), act_out_tensor
+        )
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+    gems_assert_close(act_out_tensor, ref_out_tensor, dtype=dtype)
+
+
+@pytest.mark.native_dropout_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("scale", [1.0, 0.5, 2.0])
+def test_native_dropout_backward_benchmark_tensor(shape, dtype, scale):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.3
+
+    ref_grad = grad_output.clone()
+    ref_mask = mask.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.native_dropout_backward(
+            ref_grad, ref_mask, float(scale)
+        ),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    act_grad = grad_output.clone()
+    act_mask = mask.clone()
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_native_dropout_backward(act_grad, act_mask, float(scale)),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"native_dropout_backward {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.native_dropout_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("scale", [1.0, 0.5, 2.0])
+def test_native_dropout_backward_benchmark_out(shape, dtype, scale):
+    quantiles = [0.5, 0.2, 0.8]
+
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.6
+
+    ref_grad = grad_output.clone()
+    ref_mask = mask.clone()
+    ref_out_tensor = torch.empty_like(ref_grad)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.native_dropout_backward.out(
+            ref_grad, ref_mask, float(scale), out=ref_out_tensor
+        ),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    act_grad = grad_output.clone()
+    act_mask = mask.clone()
+    act_out_tensor = torch.empty_like(act_grad)
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_native_dropout_backward_out(
+                act_grad, act_mask, float(scale), act_out_tensor
+            ),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"native_dropout_backward {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"native_dropout_backward {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/neg__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/neg__test.py
@@ -1,0 +1,68 @@
+# NEG_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.neg_ import neg_ as gems_neg_
+
+
+@pytest.mark.neg_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_neg__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.neg_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_neg_(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.neg_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_neg__benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.neg_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_neg_(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"neg_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/negative__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/negative__test.py
@@ -1,0 +1,60 @@
+# NEGATIVE_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.negative_ import negative_ as gems_negative_
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.negative_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_negative__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.negative_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_negative_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.negative_
+def test_perf_aten_negative_():
+    # Define input generation logic matching the operator arguments
+    def negative__input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=negative__input_fn,
+        op_name="negative_",
+        torch_op=torch.ops.aten.negative_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/negative_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/negative_test.py
@@ -1,0 +1,122 @@
+# NEGATIVE operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.negative import negative as gems_negative
+from flag_gems.experimental_ops.negative import negative_out as gems_negative_out
+
+
+@pytest.mark.negative
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_negative_tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.negative(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_negative(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.negative
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_negative_out(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.empty_like(ref_input, device=flag_gems.device)
+    act_out = torch.empty_like(input_tensor, device=flag_gems.device)
+
+    ref_res = torch.ops.aten.negative.out(ref_input, out=ref_out)
+
+    with flag_gems.use_gems():
+        act_res = gems_negative_out(input_tensor, act_out)
+
+    gems_assert_close(act_res, ref_res, dtype=dtype)
+
+
+@pytest.mark.negative
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_negative_benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.negative(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_negative(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"negative {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.negative
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_negative_benchmark_out(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.empty_like(ref_input, device=flag_gems.device)
+    act_out = torch.empty_like(input_tensor, device=flag_gems.device)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.negative.out(ref_input, out=ref_out),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_negative_out(input_tensor, act_out),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"negative {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/new_ones_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/new_ones_test.py
@@ -1,0 +1,85 @@
+# NEW_ONES operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.new_ones import new_ones as gems_new_ones
+from flag_gems.experimental_ops.new_ones import new_ones_out as gems_new_ones_out
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.new_ones
+@pytest.mark.parametrize("self_shape", [(2, 3), (128, 256)])
+@pytest.mark.parametrize("size", [(2, 3), (128, 256), (32, 16, 8), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_new_ones_default(self_shape, size, dtype):
+    self_tensor = torch.randn(self_shape, dtype=torch.float32, device=flag_gems.device)
+
+    ref_self = self_tensor.clone()
+    ref_out = torch.ops.aten.new_ones(ref_self, size, dtype=dtype)
+
+    with flag_gems.use_gems():
+        act_out = gems_new_ones(self_tensor, size, dtype=dtype)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.new_ones
+@pytest.mark.parametrize("self_shape", [(2, 3), (64, 64)])
+@pytest.mark.parametrize("size", [(2, 3), (128, 256), (16, 8, 4), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_new_ones_out(self_shape, size, dtype):
+    self_tensor = torch.randn(self_shape, dtype=torch.float32, device=flag_gems.device)
+
+    ref_self = self_tensor.clone()
+    ref_out_buf = torch.empty(size, device=flag_gems.device, dtype=dtype)
+    ref_out = torch.ops.aten.new_ones.out(ref_self, size, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out_buf = torch.empty(size, device=flag_gems.device, dtype=dtype)
+        act_out = gems_new_ones_out(self_tensor, size, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.new_ones
+def test_perf_aten_new_ones():
+    # Define input generation logic matching the operator arguments
+    def new_ones_input_fn(shape, dtype, device):
+        inp1 = torch.randn(
+            shape, dtype=torch.float32, device=flag_gems.device
+        )  # self_tensor
+        yield inp1, shape  # yield inputs as required by the operator (size as position, dtype as keyword)
+
+    # Create a wrapper function to handle dtype as keyword argument
+    def new_ones_wrapper(self_tensor, size):
+        return torch.ops.aten.new_ones(self_tensor, size, dtype=self_tensor.dtype)
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=new_ones_input_fn,
+        op_name="new_ones",
+        torch_op=new_ones_wrapper,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/pixel_unshuffle_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/pixel_unshuffle_test.py
@@ -1,0 +1,161 @@
+# PIXEL_UNSHUFFLE operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.pixel_unshuffle import (
+    pixel_unshuffle as gems_pixel_unshuffle,
+)
+from flag_gems.experimental_ops.pixel_unshuffle import (
+    pixel_unshuffle_out as gems_pixel_unshuffle_out,
+)
+
+
+@pytest.mark.pixel_unshuffle
+@pytest.mark.parametrize(
+    "shape_factor", [((1, 3, 8, 8), 2), ((2, 4, 12, 6), 3), ((4, 16, 64, 48), 4)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_pixel_unshuffle_tensor(shape_factor, dtype):
+    shape, downscale_factor = shape_factor
+    input_tensor = torch.randn(shape, dtype=torch.float32, device=flag_gems.device).to(
+        dtype
+    )
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.pixel_unshuffle(ref_input, downscale_factor)
+
+    with flag_gems.use_gems():
+        act_out = gems_pixel_unshuffle(input_tensor, downscale_factor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.pixel_unshuffle
+@pytest.mark.parametrize(
+    "shape_factor", [((1, 3, 8, 8), 2), ((2, 4, 12, 6), 3), ((4, 16, 64, 48), 4)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_pixel_unshuffle_out(shape_factor, dtype):
+    shape, downscale_factor = shape_factor
+    N, C, H, W = shape
+    r = downscale_factor
+    out_shape = (N, C * (r * r), H // r, W // r)
+
+    input_tensor = torch.randn(shape, dtype=torch.float32, device=flag_gems.device).to(
+        dtype
+    )
+    ref_input = input_tensor.clone()
+
+    out_ref = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    ref_out = torch.ops.aten.pixel_unshuffle.out(
+        ref_input, downscale_factor, out=out_ref
+    )
+
+    out_act = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    with flag_gems.use_gems():
+        act_out = gems_pixel_unshuffle_out(input_tensor, downscale_factor, out_act)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.pixel_unshuffle
+@pytest.mark.parametrize(
+    "shape_factor", [((1, 3, 8, 8), 2), ((2, 4, 12, 6), 3), ((4, 16, 64, 48), 4)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_pixel_unshuffle_benchmark_tensor(shape_factor, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    shape, downscale_factor = shape_factor
+    input_tensor = torch.randn(shape, dtype=torch.float32, device=flag_gems.device).to(
+        dtype
+    )
+
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.pixel_unshuffle(ref_input, downscale_factor),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_pixel_unshuffle(input_tensor, downscale_factor),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"pixel_unshuffle {shape_factor} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.pixel_unshuffle
+@pytest.mark.parametrize(
+    "shape_factor", [((1, 3, 8, 8), 2), ((2, 4, 12, 6), 3), ((4, 16, 64, 48), 4)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_pixel_unshuffle_benchmark_out(shape_factor, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    shape, downscale_factor = shape_factor
+    N, C, H, W = shape
+    r = downscale_factor
+    out_shape = (N, C * (r * r), H // r, W // r)
+
+    input_tensor = torch.randn(shape, dtype=torch.float32, device=flag_gems.device).to(
+        dtype
+    )
+    ref_input = input_tensor.clone()
+
+    out_ref = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.pixel_unshuffle.out(
+            ref_input, downscale_factor, out=out_ref
+        ),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    out_act = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_pixel_unshuffle_out(input_tensor, downscale_factor, out_act),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"pixel_unshuffle {shape_factor} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/positive_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/positive_test.py
@@ -1,0 +1,64 @@
+# POSITIVE operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.positive import positive as gems_positive
+
+
+@pytest.mark.positive
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_positive_tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.positive(ref_input)
+    with flag_gems.use_gems():
+        act_out = gems_positive(input_tensor)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.positive
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_positive_benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.positive(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_positive(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"positive {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/prelu_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/prelu_test.py
@@ -1,0 +1,76 @@
+# PRELU operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.prelu import prelu as gems_prelu
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.prelu
+@pytest.mark.parametrize(
+    "shape",
+    [(2, 3), (128, 256), (512, 512), (4, 8, 16), (2, 32, 16, 16), (2, 128, 64, 64)],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("weight_kind", ["scalar", "per_channel"])
+def test_prelu_tensor(shape, dtype, weight_kind):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    if weight_kind == "scalar":
+        w = torch.randn((), dtype=dtype, device=flag_gems.device)
+    else:
+        c = shape[1]
+        w = torch.randn((c,), dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_w = w.clone()
+
+    ref_out = torch.ops.aten.prelu(ref_x, ref_w)
+
+    with flag_gems.use_gems():
+        act_out = gems_prelu(x, w)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.prelu
+def test_perf_aten_prelu():
+    # Define input generation logic matching the operator arguments
+    def prelu_input_fn(shape, dtype, device):
+        x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        if len(shape) == 1:
+            w = torch.randn((), dtype=dtype, device=flag_gems.device)  # Scalar weight
+        else:
+            w = torch.randn(
+                (shape[1],), dtype=dtype, device=flag_gems.device
+            )  # Per-channel weight
+        yield x, w
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=prelu_input_fn,
+        op_name="prelu",
+        torch_op=torch.ops.aten.prelu,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/rad2deg__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/rad2deg__test.py
@@ -1,0 +1,68 @@
+# RAD2DEG_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.rad2deg_ import rad2deg_ as gems_rad2deg_
+
+
+@pytest.mark.rad2deg_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_rad2deg__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.rad2deg_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_rad2deg_(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.rad2deg_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_rad2deg__benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.rad2deg_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_rad2deg_(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"rad2deg_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/reciprocal_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/reciprocal_test.py
@@ -1,0 +1,83 @@
+# RECIPROCAL operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.reciprocal import reciprocal as gems_reciprocal
+from flag_gems.experimental_ops.reciprocal import reciprocal_out as gems_reciprocal_out
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.reciprocal
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_reciprocal_tensor(shape, dtype):
+    base = torch.rand(shape, dtype=dtype, device=flag_gems.device) * 0.9 + 0.1
+    sign = (torch.randint(0, 2, shape, device=flag_gems.device) * 2 - 1).to(dtype)
+    input_tensor = base * sign
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.reciprocal(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_reciprocal(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.reciprocal
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_reciprocal_out(shape, dtype):
+    base = torch.rand(shape, dtype=dtype, device=flag_gems.device) * 0.9 + 0.1
+    sign = (torch.randint(0, 2, shape, device=flag_gems.device) * 2 - 1).to(dtype)
+    input_tensor = base * sign
+
+    ref_out = torch.empty_like(input_tensor)
+    torch.ops.aten.reciprocal.out(input_tensor.clone(), out=ref_out)
+
+    act_out = torch.empty_like(input_tensor)
+    with flag_gems.use_gems():
+        gems_reciprocal_out(input_tensor, act_out)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.reciprocal
+def test_perf_aten_reciprocal():
+    # Define input generation logic matching the operator arguments
+    def reciprocal_input_fn(shape, dtype, device):
+        # Generate and yield inputs as required by the operator
+        base = torch.rand(shape, dtype=dtype, device=flag_gems.device) * 0.9 + 0.1
+        sign = (torch.randint(0, 2, shape, device=flag_gems.device) * 2 - 1).to(dtype)
+        input_tensor = base * sign
+        yield input_tensor,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=reciprocal_input_fn,
+        op_name="reciprocal",
+        torch_op=torch.ops.aten.reciprocal,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/reflection_pad2d_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/reflection_pad2d_test.py
@@ -1,0 +1,188 @@
+# REFLECTION_PAD2D operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.reflection_pad2d import (
+    reflection_pad2d as gems_reflection_pad2d,
+)
+from flag_gems.experimental_ops.reflection_pad2d import (
+    reflection_pad2d_out as gems_reflection_pad2d_out,
+)
+
+
+@pytest.mark.reflection_pad2d
+@pytest.mark.parametrize(
+    "case",
+    [
+        ((1, 1, 4, 4), (1, 1, 1, 1)),
+        ((2, 3, 8, 8), (1, 1, 2, 2)),
+        ((4, 8, 64, 32), (3, 3, 2, 2)),
+        ((2, 16, 256, 256), (4, 4, 4, 4)),
+        ((3, 16, 16), (2, 2, 2, 2)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_reflection_pad2d_tensor(case, dtype):
+    shape, padding = case
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.reflection_pad2d(ref_input, padding)
+
+    with flag_gems.use_gems():
+        act_out = gems_reflection_pad2d(input_tensor, padding)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.reflection_pad2d
+@pytest.mark.parametrize(
+    "case",
+    [
+        ((1, 1, 4, 4), (1, 1, 1, 1)),
+        ((2, 3, 8, 8), (1, 1, 2, 2)),
+        ((4, 8, 64, 32), (3, 3, 2, 2)),
+        ((2, 16, 256, 256), (4, 4, 4, 4)),
+        ((3, 16, 16), (2, 2, 2, 2)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_reflection_pad2d_out(case, dtype):
+    shape, padding = case
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    pl, pr, pt, pb = padding
+
+    if len(shape) == 3:
+        C, H, W = shape
+        out_shape = (C, H + pt + pb, W + pl + pr)
+    else:
+        N, C, H, W = shape
+        out_shape = (N, C, H + pt + pb, W + pl + pr)
+
+    ref_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.ops.aten.reflection_pad2d.out(ref_input, padding, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out = gems_reflection_pad2d_out(input_tensor, padding, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.reflection_pad2d
+@pytest.mark.parametrize(
+    "case",
+    [
+        ((1, 1, 4, 4), (1, 1, 1, 1)),
+        ((2, 3, 8, 8), (1, 1, 2, 2)),
+        ((4, 8, 64, 32), (3, 3, 2, 2)),
+        ((2, 16, 256, 256), (4, 4, 4, 4)),
+        ((3, 16, 16), (2, 2, 2, 2)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_reflection_pad2d_benchmark_tensor(case, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    shape, padding = case
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.reflection_pad2d(ref_input, padding),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_reflection_pad2d(input_tensor, padding),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"reflection_pad2d {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.reflection_pad2d
+@pytest.mark.parametrize(
+    "case",
+    [
+        ((1, 1, 4, 4), (1, 1, 1, 1)),
+        ((2, 3, 8, 8), (1, 1, 2, 2)),
+        ((4, 8, 64, 32), (3, 3, 2, 2)),
+        ((2, 16, 256, 256), (4, 4, 4, 4)),
+        ((3, 16, 16), (2, 2, 2, 2)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_reflection_pad2d_benchmark_out(case, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    shape, padding = case
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    pl, pr, pt, pb = padding
+
+    if len(shape) == 3:
+        C, H, W = shape
+        out_shape = (C, H + pt + pb, W + pl + pr)
+    else:
+        N, C, H, W = shape
+        out_shape = (N, C, H + pt + pb, W + pl + pr)
+
+    ref_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.reflection_pad2d.out(
+            ref_input, padding, out=ref_out_buf
+        ),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_reflection_pad2d_out(input_tensor, padding, act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"reflection_pad2d {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/relu6_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/relu6_test.py
@@ -1,0 +1,68 @@
+# RELU6 operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.relu6 import relu6 as gems_relu6
+
+
+@pytest.mark.relu6
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_relu6_tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.relu6(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_relu6(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.relu6
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_relu6_benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.relu6(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_relu6(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"relu6 {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/relu__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/relu__test.py
@@ -1,0 +1,61 @@
+# RELU_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.relu_ import relu_ as gems_relu_
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.relu_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_relu__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.relu_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_relu_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.relu_
+def test_perf_aten_relu_():
+    # Define input generation logic matching the operator arguments
+    def relu__input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=relu__input_fn,
+        op_name="relu_",
+        torch_op=torch.ops.aten.relu_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/replication_pad2d_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/replication_pad2d_test.py
@@ -1,0 +1,141 @@
+# REPLICATION_PAD2D operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.replication_pad2d import (
+    replication_pad2d as gems_replication_pad2d,
+)
+from flag_gems.experimental_ops.replication_pad2d import (
+    replication_pad2d_out as gems_replication_pad2d_out,
+)
+
+
+@pytest.mark.replication_pad2d
+@pytest.mark.parametrize("shape", [(2, 3, 8, 8), (4, 8, 128, 256), (2, 4, 512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("padding", [(0, 0, 0, 0), (1, 1, 2, 2), (3, 0, 0, 3)])
+def test_replication_pad2d_tensor(shape, dtype, padding):
+    input_tensor = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.replication_pad2d(ref_input, padding)
+
+    with flag_gems.use_gems():
+        act_out = gems_replication_pad2d(input_tensor, padding)
+
+    gems_assert_close(act_out, ref_out, dtype)
+
+
+@pytest.mark.replication_pad2d
+@pytest.mark.parametrize("shape", [(2, 3, 8, 8), (4, 8, 128, 256), (2, 4, 512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("padding", [(0, 0, 0, 0), (1, 1, 2, 2), (3, 0, 0, 3)])
+def test_replication_pad2d_out(shape, dtype, padding):
+    input_tensor = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    left, right, top, bottom = padding
+    n, c, h, w = shape
+    out_shape = (n, c, h + top + bottom, w + left + right)
+
+    ref_input = input_tensor.clone()
+    ref_out_buf = torch.empty(out_shape, device=flag_gems.device, dtype=dtype)
+    ref_out = torch.ops.aten.replication_pad2d.out(ref_input, padding, out=ref_out_buf)
+
+    act_out_buf = torch.empty(out_shape, device=flag_gems.device, dtype=dtype)
+    with flag_gems.use_gems():
+        act_out = gems_replication_pad2d_out(input_tensor, padding, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype)
+
+
+@pytest.mark.replication_pad2d
+@pytest.mark.parametrize("shape", [(2, 3, 8, 8), (4, 8, 128, 256), (2, 4, 512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("padding", [(0, 0, 0, 0), (1, 1, 2, 2), (3, 0, 0, 3)])
+def test_replication_pad2d_benchmark_tensor(shape, dtype, padding):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.replication_pad2d(ref_input, padding),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_replication_pad2d(input_tensor, padding),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"replication_pad2d {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.replication_pad2d
+@pytest.mark.parametrize("shape", [(2, 3, 8, 8), (4, 8, 128, 256), (2, 4, 512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("padding", [(0, 0, 0, 0), (1, 1, 2, 2), (3, 0, 0, 3)])
+def test_replication_pad2d_benchmark_out(shape, dtype, padding):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    left, right, top, bottom = padding
+    n, c, h, w = shape
+    out_shape = (n, c, h + top + bottom, w + left + right)
+
+    ref_input = input_tensor.clone()
+    ref_out_buf = torch.empty(out_shape, device=flag_gems.device, dtype=dtype)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.replication_pad2d.out(
+            ref_input, padding, out=ref_out_buf
+        ),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    act_out_buf = torch.empty(out_shape, device=flag_gems.device, dtype=dtype)
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_replication_pad2d_out(input_tensor, padding, act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"replication_pad2d {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/replication_pad3d_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/replication_pad3d_test.py
@@ -1,0 +1,154 @@
+# REPLICATION_PAD3D operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.replication_pad3d import (
+    replication_pad3d as gems_replication_pad3d,
+)
+from flag_gems.experimental_ops.replication_pad3d import (
+    replication_pad3d_out as gems_replication_pad3d_out,
+)
+
+
+@pytest.mark.replication_pad3d
+@pytest.mark.parametrize(
+    "shape", [(1, 2, 4, 5, 6), (2, 4, 16, 32, 32), (2, 4, 32, 64, 64)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "padding", [(0, 0, 0, 0, 0, 0), (1, 1, 1, 1, 1, 1), (2, 0, 1, 2, 0, 1)]
+)
+def test_replication_pad3d_tensor(shape, dtype, padding):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out = torch.ops.aten.replication_pad3d(ref_x, padding)
+    with flag_gems.use_gems():
+        act_out = gems_replication_pad3d(x, padding)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.replication_pad3d
+@pytest.mark.parametrize(
+    "shape", [(1, 2, 4, 5, 6), (2, 4, 16, 32, 32), (2, 4, 32, 64, 64)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "padding", [(0, 0, 0, 0, 0, 0), (1, 1, 1, 1, 1, 1), (2, 0, 1, 2, 0, 1)]
+)
+def test_replication_pad3d_out(shape, dtype, padding):
+    def test__out_shape(s, p):
+        return (s[0], s[1], s[2] + p[4] + p[5], s[3] + p[2] + p[3], s[4] + p[0] + p[1])
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    out_shape = test__out_shape(shape, padding)
+    ref_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_ret = torch.ops.aten.replication_pad3d.out(ref_x, padding, out=ref_out_buf)
+    with flag_gems.use_gems():
+        act_ret = gems_replication_pad3d_out(x, padding, act_out_buf)
+
+    gems_assert_close(act_ret, ref_ret, dtype=dtype)
+
+
+@pytest.mark.replication_pad3d
+@pytest.mark.parametrize(
+    "shape", [(1, 2, 4, 5, 6), (2, 4, 16, 32, 32), (2, 4, 32, 64, 64)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "padding", [(0, 0, 0, 0, 0, 0), (1, 1, 1, 1, 1, 1), (2, 0, 1, 2, 0, 1)]
+)
+def test_replication_pad3d_benchmark_tensor(shape, dtype, padding):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.replication_pad3d(ref_x, padding),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_replication_pad3d(x, padding), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"replication_pad3d {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.replication_pad3d
+@pytest.mark.parametrize(
+    "shape", [(1, 2, 4, 5, 6), (2, 4, 16, 32, 32), (2, 4, 32, 64, 64)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "padding", [(0, 0, 0, 0, 0, 0), (1, 1, 1, 1, 1, 1), (2, 0, 1, 2, 0, 1)]
+)
+def test_replication_pad3d_benchmark_out(shape, dtype, padding):
+    quantiles = [0.5, 0.2, 0.8]
+
+    def test__out_shape(s, p):
+        return (s[0], s[1], s[2] + p[4] + p[5], s[3] + p[2] + p[3], s[4] + p[0] + p[1])
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    out_shape = test__out_shape(shape, padding)
+    ref_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.replication_pad3d.out(ref_x, padding, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_replication_pad3d_out(x, padding, act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"replication_pad3d {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/reshape_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/reshape_test.py
@@ -1,0 +1,183 @@
+# RESHAPE operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.reshape import reshape as gems_reshape
+
+
+@pytest.mark.reshape
+@pytest.mark.parametrize(
+    "in_shape,out_shape",
+    [
+        ((2, 3), (3, 2)),
+        ((2, 3), (1, 6)),
+        ((2, 3), (-1,)),
+        ((128, 256), (256, 128)),
+        ((128, 256), (32, -1)),
+        ((128, 256), (-1, 128)),
+        ((64, 64, 64), (-1,)),
+        ((64, 64, 64), (64, 4096)),
+        ((512, 512), (-1,)),
+        ((256, 512), (512, 256)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_reshape_tensor_contiguous(in_shape, out_shape, dtype):
+    input_tensor = torch.randn(in_shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.reshape(ref_input, out_shape)
+
+    with flag_gems.use_gems():
+        act_out = gems_reshape(input_tensor, out_shape)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.reshape
+@pytest.mark.parametrize(
+    "base_shape,out_shape,transform",
+    [
+        ((32, 64), (-1,), "transpose01"),
+        ((64, 128), (128, 64), "transpose01"),
+        ((8, 16, 32), (256, 16), "permute201"),
+        ((64, 64, 64), (4096, 64), "permute120"),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_reshape_tensor_noncontiguous(base_shape, out_shape, transform, dtype):
+    base = torch.randn(base_shape, dtype=dtype, device=flag_gems.device)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    if transform == "transpose01":
+        ref_input = ref_input.transpose(0, 1)
+        act_input = act_input.transpose(0, 1)
+    elif transform == "permute201":
+        ref_input = ref_input.permute(2, 0, 1)
+        act_input = act_input.permute(2, 0, 1)
+    elif transform == "permute120":
+        ref_input = ref_input.permute(1, 2, 0)
+        act_input = act_input.permute(1, 2, 0)
+
+    ref_out = torch.ops.aten.reshape(ref_input, out_shape)
+
+    with flag_gems.use_gems():
+        act_out = gems_reshape(act_input, out_shape)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.reshape
+@pytest.mark.parametrize(
+    "in_shape,out_shape",
+    [
+        ((2, 3), (3, 2)),
+        ((2, 3), (1, 6)),
+        ((2, 3), (-1,)),
+        ((128, 256), (256, 128)),
+        ((128, 256), (32, -1)),
+        ((128, 256), (-1, 128)),
+        ((64, 64, 64), (-1,)),
+        ((64, 64, 64), (64, 4096)),
+        ((512, 512), (-1,)),
+        ((256, 512), (512, 256)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_reshape_tensor_contiguous_performance(in_shape, out_shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(in_shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.reshape(ref_input, out_shape),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_reshape(input_tensor, out_shape), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"reshape {out_shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.reshape
+@pytest.mark.parametrize(
+    "base_shape,out_shape,transform",
+    [
+        ((32, 64), (-1,), "transpose01"),
+        ((64, 128), (128, 64), "transpose01"),
+        ((8, 16, 32), (256, 16), "permute201"),
+        ((64, 64, 64), (4096, 64), "permute120"),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_reshape_tensor_noncontiguous_performance(
+    base_shape, out_shape, transform, dtype
+):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.randn(base_shape, dtype=dtype, device=flag_gems.device)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    if transform == "transpose01":
+        ref_input = ref_input.transpose(0, 1)
+        act_input = act_input.transpose(0, 1)
+    elif transform == "permute201":
+        ref_input = ref_input.permute(2, 0, 1)
+        act_input = act_input.permute(2, 0, 1)
+    elif transform == "permute120":
+        ref_input = ref_input.permute(1, 2, 0)
+        act_input = act_input.permute(1, 2, 0)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.reshape(ref_input, out_shape),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_reshape(act_input, out_shape), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"reshape {out_shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/scalar_tensor_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/scalar_tensor_test.py
@@ -1,0 +1,86 @@
+# SCALAR_TENSOR operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.scalar_tensor import scalar_tensor as gems_scalar_tensor
+from flag_gems.experimental_ops.scalar_tensor import (
+    scalar_tensor_out as gems_scalar_tensor_out,
+)
+
+
+@pytest.mark.scalar_tensor
+@pytest.mark.parametrize("val", [-7, -1, 0, 3, 12345, -1.5, 2.75, 3.14159])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_scalar_tensor_default(val, dtype):
+    ref_out = torch.ops.aten.scalar_tensor(
+        val, dtype=dtype, device=flag_gems.device, layout=None, pin_memory=None
+    )
+    with flag_gems.use_gems():
+        act_out = gems_scalar_tensor(
+            val, dtype=dtype, device=flag_gems.device, layout=None, pin_memory=None
+        )
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.scalar_tensor
+@pytest.mark.parametrize("val", [-7, -1, 0, 3, 12345, -1.5, 2.75, 3.14159])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_scalar_tensor_out(val, dtype):
+    ref_out_buf = torch.empty((), dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty((), dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.ops.aten.scalar_tensor.out(val, out=ref_out_buf)
+    with flag_gems.use_gems():
+        act_out = gems_scalar_tensor_out(val, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.scalar_tensor
+def test_perf_aten_scalar_tensor():
+    # For scalar_tensor, we use a simpler approach with triton.testing.do_bench
+    # since GenericBenchmark doesn't easily support keyword-only args
+    quantiles = [0.5, 0.2, 0.8]
+    dtypes = [torch.float32, torch.float16, torch.bfloat16]
+
+    for dtype in dtypes:
+        val = 1.5
+        # PyTorch reference
+        ms_torch, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.scalar_tensor(
+                val, dtype=dtype, device=flag_gems.device
+            ),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+        # FlagGems implementation
+        with flag_gems.use_gems():
+            ms_gems, _, _ = triton.testing.do_bench(
+                lambda: gems_scalar_tensor(val, dtype=dtype, device=flag_gems.device),
+                rep=100,
+                quantiles=quantiles,
+            )
+
+        speedup = ms_torch / ms_gems
+        print(
+            f"scalar_tensor {dtype}: FlagGems={ms_gems:.3f}ms, Speedup={speedup:.2f}x"
+        )

--- a/src/flag_gems/experimental_ops/exp_tests/select_backward_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/select_backward_test.py
@@ -1,0 +1,192 @@
+# SELECT_BACKWARD operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.select_backward import (
+    select_backward as gems_select_backward,
+)
+from flag_gems.experimental_ops.select_backward import (
+    select_backward_out as gems_select_backward_out,
+)
+
+
+@pytest.mark.select_backward
+@pytest.mark.parametrize("input_sizes", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dim", [0, -1])
+@pytest.mark.parametrize("index_mode", ["first", "mid", "neg1"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_select_backward_default(input_sizes, dim, index_mode, dtype):
+    ndim = len(input_sizes)
+    dim_c = dim % ndim
+    size_d = input_sizes[dim_c]
+    if index_mode == "first":
+        index = 0
+    elif index_mode == "mid":
+        index = size_d // 2
+    else:
+        index = -1
+    out_shape = list(input_sizes)
+    del out_shape[dim_c]
+    out_shape = tuple(out_shape) if len(out_shape) > 0 else ()
+    grad_ref = torch.randn(out_shape, dtype=dtype, device=flag_gems.device)
+    grad_act = grad_ref.clone()
+
+    ref_out = torch.ops.aten.select_backward(grad_ref, list(input_sizes), dim, index)
+
+    with flag_gems.use_gems():
+        act_out = gems_select_backward(grad_act, list(input_sizes), dim, index)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.select_backward
+@pytest.mark.parametrize("input_sizes", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dim", [0, -1])
+@pytest.mark.parametrize("index_mode", ["first", "mid", "neg1"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_select_backward_out(input_sizes, dim, index_mode, dtype):
+    ndim = len(input_sizes)
+    dim_c = dim % ndim
+    size_d = input_sizes[dim_c]
+    if index_mode == "first":
+        index = 0
+    elif index_mode == "mid":
+        index = size_d // 2
+    else:
+        index = -1
+    out_shape = list(input_sizes)
+    del out_shape[dim_c]
+    out_shape = tuple(out_shape) if len(out_shape) > 0 else ()
+    grad_ref = torch.randn(out_shape, dtype=dtype, device=flag_gems.device)
+    grad_act = grad_ref.clone()
+
+    ref_out_buf = torch.empty(input_sizes, dtype=dtype, device=flag_gems.device)
+    ref_out = torch.ops.aten.select_backward.out(
+        grad_ref, list(input_sizes), dim, index, out=ref_out_buf
+    )
+
+    with flag_gems.use_gems():
+        act_out_buf = torch.empty(input_sizes, dtype=dtype, device=flag_gems.device)
+        act_out = gems_select_backward_out(
+            grad_act, list(input_sizes), dim, index, act_out_buf
+        )
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.select_backward
+@pytest.mark.parametrize("input_sizes", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dim", [0, -1])
+@pytest.mark.parametrize("index_mode", ["first", "mid", "neg1"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_select_backward_default_performance(input_sizes, dim, index_mode, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    ndim = len(input_sizes)
+    dim_c = dim % ndim
+    size_d = input_sizes[dim_c]
+    if index_mode == "first":
+        index = 0
+    elif index_mode == "mid":
+        index = size_d // 2
+    else:
+        index = -1
+    out_shape = list(input_sizes)
+    del out_shape[dim_c]
+    out_shape = tuple(out_shape) if len(out_shape) > 0 else ()
+    grad_ref = torch.randn(out_shape, dtype=dtype, device=flag_gems.device)
+    grad_act = grad_ref.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.select_backward(grad_ref, list(input_sizes), dim, index),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_select_backward(grad_act, list(input_sizes), dim, index),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"select_backward {input_sizes} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.select_backward
+@pytest.mark.parametrize("input_sizes", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dim", [0, -1])
+@pytest.mark.parametrize("index_mode", ["first", "mid", "neg1"])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_select_backward_benchmark_out(input_sizes, dim, index_mode, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    ndim = len(input_sizes)
+    dim_c = dim % ndim
+    size_d = input_sizes[dim_c]
+    if index_mode == "first":
+        index = 0
+    elif index_mode == "mid":
+        index = size_d // 2
+    else:
+        index = -1
+    out_shape = list(input_sizes)
+    del out_shape[dim_c]
+    out_shape = tuple(out_shape) if len(out_shape) > 0 else ()
+    grad_ref = torch.randn(out_shape, dtype=dtype, device=flag_gems.device)
+    grad_act = grad_ref.clone()
+
+    ref_out_buf = torch.empty(input_sizes, dtype=dtype, device=flag_gems.device)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.select_backward.out(
+            grad_ref, list(input_sizes), dim, index, out=ref_out_buf
+        ),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        act_out_buf = torch.empty(input_sizes, dtype=dtype, device=flag_gems.device)
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_select_backward_out(
+                grad_act, list(input_sizes), dim, index, act_out_buf
+            ),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"select_backward {input_sizes} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/selu__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/selu__test.py
@@ -1,0 +1,70 @@
+# SELU_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.selu_ import selu_ as gems_selu_
+
+
+@pytest.mark.selu_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_selu__tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    act_x = x.clone()
+
+    ref_out = torch.ops.aten.selu_(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_selu_(act_x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.selu_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_selu__benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    act_x = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.selu_(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_selu_(act_x), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"selu_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/sgn__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/sgn__test.py
@@ -1,0 +1,86 @@
+# SGN_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.sgn_ import sgn_ as gems_sgn_
+
+
+@pytest.mark.sgn_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sgn__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, device=flag_gems.device, dtype=torch.float32).to(
+        dtype
+    )
+    flat = input_tensor.view(-1)
+    if flat.numel() >= 1:
+        flat[0] = flat.new_zeros(1)
+    if flat.numel() >= 5:
+        flat[4] = flat.new_zeros(1)
+
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.sgn_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_sgn_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.sgn_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sgn__benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, device=flag_gems.device, dtype=torch.float32).to(
+        dtype
+    )
+    flat = input_tensor.view(-1)
+    if flat.numel() >= 1:
+        flat[0] = flat.new_zeros(1)
+    if flat.numel() >= 5:
+        flat[4] = flat.new_zeros(1)
+
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.sgn_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_sgn_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"sgn_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/sigmoid_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/sigmoid_test.py
@@ -1,0 +1,120 @@
+# SIGMOID operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.sigmoid import sigmoid as gems_sigmoid
+from flag_gems.experimental_ops.sigmoid import sigmoid_out as gems_sigmoid_out
+
+
+@pytest.mark.sigmoid
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sigmoid_tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.sigmoid(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_sigmoid(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.sigmoid
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sigmoid_out(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    ref_out_buf = torch.empty_like(ref_input)
+    act_out_buf = torch.empty_like(input_tensor)
+
+    ref_out = torch.ops.aten.sigmoid.out(ref_input, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out = gems_sigmoid_out(input_tensor, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.sigmoid
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sigmoid_benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.sigmoid(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_sigmoid(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"sigmoid {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.sigmoid
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sigmoid_benchmark_out(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    ref_out_buf = torch.empty_like(ref_input)
+    act_out_buf = torch.empty_like(input_tensor)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.sigmoid.out(ref_input, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_sigmoid_out(input_tensor, act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"sigmoid {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/silu_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/silu_test.py
@@ -1,0 +1,112 @@
+# SILU operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.silu import silu as gems_silu
+from flag_gems.experimental_ops.silu import silu_out as gems_silu_out
+
+
+@pytest.mark.silu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_silu_tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.silu(ref_input)
+    with flag_gems.use_gems():
+        act_out = gems_silu(input_tensor)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.silu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_silu_out(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    out_tensor = torch.empty_like(input_tensor)
+    ref_input = input_tensor.clone()
+    ref_out_tensor = torch.empty_like(ref_input)
+    ref_out = torch.ops.aten.silu.out(ref_input, out=ref_out_tensor)
+    with flag_gems.use_gems():
+        act_out = gems_silu_out(input_tensor, out_tensor)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.silu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_silu_benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.silu(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_silu(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"silu {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.silu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_silu_benchmark_out(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    out_tensor = torch.empty_like(input_tensor)
+    ref_input = input_tensor.clone()
+    ref_out_tensor = torch.empty_like(ref_input)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.silu.out(ref_input, out=ref_out_tensor),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_silu_out(input_tensor, out_tensor),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"silu {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/sinh__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/sinh__test.py
@@ -1,0 +1,70 @@
+# SINH_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.sinh_ import sinh_ as gems_sinh_
+
+
+@pytest.mark.sinh_
+@pytest.mark.parametrize("shape", [(), (2, 3), (8, 16, 32), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sinh__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.sinh_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_sinh_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.sinh_
+@pytest.mark.parametrize("shape", [(), (2, 3), (8, 16, 32), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sinh__benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.sinh_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_sinh_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"sinh_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/smooth_l1_loss_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/smooth_l1_loss_test.py
@@ -1,0 +1,95 @@
+# SMOOTH_L1_LOSS operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.smooth_l1_loss import (
+    smooth_l1_loss as gems_smooth_l1_loss,
+)
+from flag_gems.experimental_ops.smooth_l1_loss import (
+    smooth_l1_loss_out as gems_smooth_l1_loss_out,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.smooth_l1_loss
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("reduction", [0, 1, 2])
+@pytest.mark.parametrize("beta", [0.5, 1.0, 2.0])
+def test_smooth_l1_loss_tensor(shape, dtype, reduction, beta):
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_self = self.clone()
+    ref_target = target.clone()
+
+    ref_out = torch.ops.aten.smooth_l1_loss(ref_self, ref_target, reduction, beta)
+
+    with flag_gems.use_gems():
+        act_out = gems_smooth_l1_loss(self, target, reduction, beta)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.smooth_l1_loss
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("reduction", [0, 1, 2])
+@pytest.mark.parametrize("beta", [0.5, 1.0, 2.0])
+def test_smooth_l1_loss_out(shape, dtype, reduction, beta):
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    out_shape = shape if reduction == 0 else ()
+
+    ref_out = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    ref_self = self.clone()
+    ref_target = target.clone()
+    ref_out = torch.ops.aten.smooth_l1_loss.out(
+        ref_self, ref_target, reduction, beta, out=ref_out
+    )
+
+    with flag_gems.use_gems():
+        act_out = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+        act_out = gems_smooth_l1_loss_out(self, target, reduction, beta, act_out)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.smooth_l1_loss
+def test_perf_aten_smooth_l1_loss():
+    # Define input generation logic matching the operator arguments
+    def smooth_l1_loss_input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=smooth_l1_loss_input_fn,
+        op_name="smooth_l1_loss",
+        torch_op=torch.ops.aten.smooth_l1_loss,
+        dtypes=[torch.float32, torch.float16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/softshrink_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/softshrink_test.py
@@ -1,0 +1,80 @@
+# SOFTSHRINK operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.softshrink import softshrink as gems_softshrink
+from flag_gems.experimental_ops.softshrink import softshrink_out as gems_softshrink_out
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.softshrink
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("lambd", [0.0, 0.5, 1.25])
+def test_softshrink_tensor(shape, dtype, lambd):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out = torch.ops.aten.softshrink(ref_x, lambd)
+
+    with flag_gems.use_gems():
+        act_out = gems_softshrink(x, lambd)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.softshrink
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("lambd", [0.0, 0.5, 1.25])
+def test_softshrink_out(shape, dtype, lambd):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out_buf = torch.empty_like(ref_x)
+    ref_res = torch.ops.aten.softshrink.out(ref_x, lambd, out=ref_out_buf)
+
+    act_out_buf = torch.empty_like(x)
+    with flag_gems.use_gems():
+        act_res = gems_softshrink_out(x, lambd, act_out_buf)
+
+    gems_assert_close(act_res, ref_res, dtype=dtype)
+
+
+@pytest.mark.softshrink
+def test_perf_aten_softshrink():
+    # Define input generation logic matching the operator arguments
+    def softshrink_input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        lambd = 0.5  # You can choose a fixed lambda for benchmarking
+        yield inp, lambd
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=softshrink_input_fn,
+        op_name="softshrink",
+        torch_op=torch.ops.aten.softshrink,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/special_i1_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/special_i1_test.py
@@ -1,0 +1,128 @@
+# SPECIAL_I1 operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.special_i1 import special_i1 as gems_special_i1
+from flag_gems.experimental_ops.special_i1 import special_i1_out as gems_special_i1_out
+
+
+@pytest.mark.special_i1
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_special_i1_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out = torch.ops.aten.special_i1(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_special_i1(x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.special_i1
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_special_i1_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_ret = torch.ops.aten.special_i1.out(ref_x, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_ret = gems_special_i1_out(x, act_out_buf)
+
+    gems_assert_close(act_ret, ref_ret, dtype=dtype)
+    gems_assert_close(act_out_buf, ref_out_buf, dtype=dtype)
+
+
+@pytest.mark.special_i1
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_special_i1_benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.special_i1(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_special_i1(x), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"special_i1 {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.special_i1
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_special_i1_benchmark_out(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.special_i1.out(ref_x, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_special_i1_out(x, act_out_buf), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"special_i1 {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"special_i1 {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/special_xlog1py_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/special_xlog1py_test.py
@@ -1,0 +1,144 @@
+# SPECIAL_XLOG1PY operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.special_xlog1py import (
+    special_xlog1py as gems_special_xlog1py,
+)
+from flag_gems.experimental_ops.special_xlog1py import (
+    special_xlog1py_out as gems_special_xlog1py_out,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.special_xlog1py
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_special_xlog1py_tensor(shape, dtype):
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    other = torch.rand(shape, dtype=dtype, device=flag_gems.device) - 0.3
+    ref_self = self.clone()
+    ref_other = other.clone()
+    ref_out = torch.ops.aten.special_xlog1py(ref_self, ref_other)
+    with flag_gems.use_gems():
+        act_out = gems_special_xlog1py(self, other)
+    gems_assert_close(act_out, ref_out, dtype=dtype, equal_nan=False)
+
+
+@pytest.mark.special_xlog1py
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("other_scalar", [-0.25, 0.0, 0.5, 1.25])
+def test_special_xlog1py_other_scalar(shape, dtype, other_scalar):
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_self = self.clone()
+    ref_out = torch.ops.aten.special_xlog1py.other_scalar(ref_self, other_scalar)
+    with flag_gems.use_gems():
+        act_out = torch.ops.aten.special_xlog1py.other_scalar(self, other_scalar)
+    gems_assert_close(act_out, ref_out, dtype=dtype, equal_nan=False)
+
+
+@pytest.mark.special_xlog1py
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("self_scalar", [-2.0, -0.5, 0.0, 2.0])
+def test_special_xlog1py_self_scalar(shape, dtype, self_scalar):
+    other = torch.rand(shape, dtype=dtype, device=flag_gems.device) - 0.3
+    ref_other = other.clone()
+    ref_out = torch.ops.aten.special_xlog1py.self_scalar(self_scalar, ref_other)
+    with flag_gems.use_gems():
+        act_out = torch.ops.aten.special_xlog1py.self_scalar(self_scalar, other)
+    gems_assert_close(act_out, ref_out, dtype=dtype, equal_nan=False)
+
+
+@pytest.mark.special_xlog1py
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_special_xlog1py_out_tensor(shape, dtype):
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    other = torch.rand(shape, dtype=dtype, device=flag_gems.device) - 0.3
+    ref_self = self.clone()
+    ref_other = other.clone()
+    ref_out = torch.empty_like(ref_self)
+    torch.ops.aten.special_xlog1py.out(ref_self, ref_other, out=ref_out)
+    with flag_gems.use_gems():
+        act_self = self.clone()
+        act_other = other.clone()
+        act_out = torch.empty_like(act_self)
+        gems_special_xlog1py_out(act_self, act_other, act_out)
+    gems_assert_close(act_out, ref_out, dtype=dtype, equal_nan=False)
+
+
+@pytest.mark.special_xlog1py
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("self_scalar", [-2.0, -0.5, 0.0, 2.0])
+def test_special_xlog1py_self_scalar_out(shape, dtype, self_scalar):
+    other = torch.rand(shape, dtype=dtype, device=flag_gems.device) - 0.3
+    ref_other = other.clone()
+    ref_out = torch.empty_like(ref_other)
+    torch.ops.aten.special_xlog1py.self_scalar_out(self_scalar, ref_other, out=ref_out)
+    with flag_gems.use_gems():
+        act_other = other.clone()
+        act_out = torch.empty_like(act_other)
+        torch.ops.aten.special_xlog1py.self_scalar_out(
+            self_scalar, act_other, out=act_out
+        )
+    gems_assert_close(act_out, ref_out, dtype=dtype, equal_nan=False)
+
+
+@pytest.mark.special_xlog1py
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("other_scalar", [-0.25, 0.0, 0.5, 1.25])
+def test_special_xlog1py_other_scalar_out(shape, dtype, other_scalar):
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_self = self.clone()
+    ref_out = torch.empty_like(ref_self)
+    torch.ops.aten.special_xlog1py.other_scalar_out(ref_self, other_scalar, out=ref_out)
+    with flag_gems.use_gems():
+        act_self = self.clone()
+        act_out = torch.empty_like(act_self)
+        torch.ops.aten.special_xlog1py.other_scalar_out(
+            act_self, other_scalar, out=act_out
+        )
+    gems_assert_close(act_out, ref_out, dtype=dtype, equal_nan=False)
+
+
+@pytest.mark.special_xlog1py
+def test_perf_aten_special_xlog1py():
+    # Define input generation logic matching the operator arguments
+    def special_xlog1py_input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device) - 0.3
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=special_xlog1py_input_fn,
+        op_name="special_xlog1py",
+        torch_op=torch.ops.aten.special_xlog1py,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/square_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/square_test.py
@@ -1,0 +1,88 @@
+# SQUARE operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.square import square as gems_square
+from flag_gems.experimental_ops.square import square_out as gems_square_out
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.square
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_square_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.square(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_square(x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.square
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("out_layout", ["contiguous", "noncontiguous"])
+def test_square_out(shape, dtype, out_layout):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    if out_layout == "contiguous":
+        ref_out_buf = torch.empty_like(x)
+        act_out_buf = torch.empty_like(x)
+    else:
+        ref_base = torch.empty(
+            (shape[0], shape[1] * 2), dtype=dtype, device=flag_gems.device
+        )
+        act_base = torch.empty(
+            (shape[0], shape[1] * 2), dtype=dtype, device=flag_gems.device
+        )
+        ref_out_buf = ref_base[:, ::2]
+        act_out_buf = act_base[:, ::2]
+
+    ref_res = torch.ops.aten.square.out(x.clone(), out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_res = gems_square_out(x, act_out_buf)
+
+    gems_assert_close(act_res, ref_res, dtype=dtype)
+
+
+@pytest.mark.square
+def test_perf_aten_square():
+    # Define input generation logic matching the operator arguments
+    def square_input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=square_input_fn,
+        op_name="square",
+        torch_op=torch.ops.aten.square,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/squeeze_copy_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/squeeze_copy_test.py
@@ -1,0 +1,394 @@
+# SQUEEZE_COPY operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.squeeze_copy import squeeze_copy as gems_squeeze_copy
+from flag_gems.experimental_ops.squeeze_copy import (
+    squeeze_copy_out as gems_squeeze_copy_out,
+)
+
+
+@pytest.mark.squeeze_copy
+@pytest.mark.parametrize(
+    "shape", [(2, 3), (2, 1, 3, 1), (128, 256), (128, 1, 256), (512, 512), (512, 1, 64)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_squeeze_copy_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.squeeze_copy(ref_x)
+    with flag_gems.use_gems():
+        act_out = gems_squeeze_copy(x)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.squeeze_copy
+@pytest.mark.parametrize(
+    "shape_dim",
+    [
+        ((2, 1, 3), 1),
+        ((4, 5), 0),
+        ((8, 1, 1, 2), -2),
+        ((128, 1, 256), 1),
+        ((32, 32), -1),
+        ((512, 1, 64), 1),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_squeeze_copy_dim(shape_dim, dtype):
+    shape, dim = shape_dim
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.squeeze_copy.dim(ref_x, dim)
+    with flag_gems.use_gems():
+        act_out = torch.ops.aten.squeeze_copy.dim(x, dim)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.squeeze_copy
+@pytest.mark.parametrize(
+    "shape_dims",
+    [
+        ((2, 1, 3, 1), [1, 3]),
+        ((1, 4, 1), [0, 2]),
+        ((128, 1, 256, 1), [1]),
+        ((64, 1, 1, 32), [1, -2]),
+        ((16, 8, 4), [0]),
+        ((512, 1, 64), [1]),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_squeeze_copy_dims(shape_dims, dtype):
+    shape, dims = shape_dims
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.squeeze_copy.dims(ref_x, dims)
+    with flag_gems.use_gems():
+        act_out = torch.ops.aten.squeeze_copy.dims(x, dims)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.squeeze_copy
+@pytest.mark.parametrize(
+    "shape", [(2, 3), (2, 1, 3, 1), (128, 256), (128, 1, 256), (512, 512), (512, 1, 64)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_squeeze_copy_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    tmp = torch.ops.aten.squeeze_copy(ref_x)
+    ref_out_buf = torch.empty_like(tmp)
+    ref_out = torch.ops.aten.squeeze_copy.out(ref_x, out=ref_out_buf)
+    act_out_buf = torch.empty_like(tmp)
+    with flag_gems.use_gems():
+        act_out = gems_squeeze_copy_out(x, act_out_buf)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.squeeze_copy
+@pytest.mark.parametrize(
+    "shape_dim",
+    [
+        ((2, 1, 3), 1),
+        ((4, 5), 0),
+        ((8, 1, 1, 2), -2),
+        ((128, 1, 256), 1),
+        ((32, 32), -1),
+        ((512, 1, 64), 1),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_squeeze_copy_dim_out(shape_dim, dtype):
+    shape, dim = shape_dim
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    tmp = torch.ops.aten.squeeze_copy.dim(ref_x, dim)
+    ref_out_buf = torch.empty_like(tmp)
+    ref_out = torch.ops.aten.squeeze_copy.dim_out(ref_x, dim, out=ref_out_buf)
+    act_out_buf = torch.empty_like(tmp)
+    with flag_gems.use_gems():
+        act_out = torch.ops.aten.squeeze_copy.dim_out(x, dim, out=act_out_buf)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.squeeze_copy
+@pytest.mark.parametrize(
+    "shape_dims",
+    [
+        ((2, 1, 3, 1), [1, 3]),
+        ((1, 4, 1), [0, 2]),
+        ((128, 1, 256, 1), [1]),
+        ((64, 1, 1, 32), [1, -2]),
+        ((16, 8, 4), [0]),
+        ((512, 1, 64), [1]),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_squeeze_copy_dims_out(shape_dims, dtype):
+    shape, dims = shape_dims
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    tmp = torch.ops.aten.squeeze_copy.dims(ref_x, dims)
+    ref_out_buf = torch.empty_like(tmp)
+    ref_out = torch.ops.aten.squeeze_copy.dims_out(ref_x, dims, out=ref_out_buf)
+    act_out_buf = torch.empty_like(tmp)
+    with flag_gems.use_gems():
+        act_out = torch.ops.aten.squeeze_copy.dims_out(x, dims, out=act_out_buf)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.squeeze_copy
+@pytest.mark.parametrize(
+    "shape", [(2, 3), (2, 1, 3, 1), (128, 256), (128, 1, 256), (512, 512), (512, 1, 64)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_squeeze_copy_benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.squeeze_copy(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_squeeze_copy(x), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"squeeze_copy {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.squeeze_copy
+@pytest.mark.parametrize(
+    "shape_dim",
+    [
+        ((2, 1, 3), 1),
+        ((4, 5), 0),
+        ((8, 1, 1, 2), -2),
+        ((128, 1, 256), 1),
+        ((32, 32), -1),
+        ((512, 1, 64), 1),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_squeeze_copy_dim_performance(shape_dim, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    shape, dim = shape_dim
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.squeeze_copy.dim(ref_x, dim),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.squeeze_copy.dim(x, dim),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"squeeze_copy {shape_dim} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.squeeze_copy
+@pytest.mark.parametrize(
+    "shape_dims",
+    [
+        ((2, 1, 3, 1), [1, 3]),
+        ((1, 4, 1), [0, 2]),
+        ((128, 1, 256, 1), [1]),
+        ((64, 1, 1, 32), [1, -2]),
+        ((16, 8, 4), [0]),
+        ((512, 1, 64), [1]),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_squeeze_copy_dims_performance(shape_dims, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    shape, dims = shape_dims
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.squeeze_copy.dims(ref_x, dims),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.squeeze_copy.dims(x, dims),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"squeeze_copy {shape_dims} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.squeeze_copy
+@pytest.mark.parametrize(
+    "shape", [(2, 3), (2, 1, 3, 1), (128, 256), (128, 1, 256), (512, 512), (512, 1, 64)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_squeeze_copy_benchmark_out(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    tmp = torch.ops.aten.squeeze_copy(ref_x)
+    ref_out_buf = torch.empty_like(tmp)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.squeeze_copy.out(ref_x, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+    act_out_buf = torch.empty_like(tmp)
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_squeeze_copy_out(x, act_out_buf), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"squeeze_copy {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.squeeze_copy
+@pytest.mark.parametrize(
+    "shape_dim",
+    [
+        ((2, 1, 3), 1),
+        ((4, 5), 0),
+        ((8, 1, 1, 2), -2),
+        ((128, 1, 256), 1),
+        ((32, 32), -1),
+        ((512, 1, 64), 1),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_squeeze_copy_dim_benchmark_out(shape_dim, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    shape, dim = shape_dim
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    tmp = torch.ops.aten.squeeze_copy.dim(ref_x, dim)
+    ref_out_buf = torch.empty_like(tmp)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.squeeze_copy.dim_out(ref_x, dim, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+    act_out_buf = torch.empty_like(tmp)
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.squeeze_copy.dim_out(x, dim, out=act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"squeeze_copy {shape_dim} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.squeeze_copy
+@pytest.mark.parametrize(
+    "shape_dims",
+    [
+        ((2, 1, 3, 1), [1, 3]),
+        ((1, 4, 1), [0, 2]),
+        ((128, 1, 256, 1), [1]),
+        ((64, 1, 1, 32), [1, -2]),
+        ((16, 8, 4), [0]),
+        ((512, 1, 64), [1]),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_squeeze_copy_dims_benchmark_out(shape_dims, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    shape, dims = shape_dims
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    tmp = torch.ops.aten.squeeze_copy.dims(ref_x, dims)
+    ref_out_buf = torch.empty_like(tmp)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.squeeze_copy.dims_out(ref_x, dims, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+    act_out_buf = torch.empty_like(tmp)
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.squeeze_copy.dims_out(x, dims, out=act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"squeeze_copy {shape_dims} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/stack_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/stack_test.py
@@ -1,0 +1,147 @@
+# STACK operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.stack import stack as gems_stack
+from flag_gems.experimental_ops.stack import stack_out as gems_stack_out
+
+
+@pytest.mark.stack
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (64, 32, 16), (512, 256)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("num_tensors", [2, 3, 5])
+@pytest.mark.parametrize("dim", [0, 1, -1])
+def test_stack_tensor(shape, dtype, num_tensors, dim):
+    tensors = [
+        torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        for _ in range(num_tensors)
+    ]
+    ref_tensors = [t.clone() for t in tensors]
+    ref_out = torch.ops.aten.stack(ref_tensors, dim)
+    with flag_gems.use_gems():
+        act_out = gems_stack(tensors, dim)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.stack
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (64, 32, 16), (512, 256)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("num_tensors", [2, 4])
+@pytest.mark.parametrize("dim", [0, 2, -1])
+def test_stack_out(shape, dtype, num_tensors, dim):
+    tensors = [
+        torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        for _ in range(num_tensors)
+    ]
+    ref_tensors = [t.clone() for t in tensors]
+
+    n_dims = len(shape)
+    eff_dim = dim if dim >= 0 else dim + (n_dims + 1)
+    out_shape = list(shape)
+    out_shape.insert(eff_dim, num_tensors)
+
+    ref_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.ops.aten.stack.out(ref_tensors, dim, out=ref_out_buf)
+    with flag_gems.use_gems():
+        act_out = gems_stack_out(tensors, dim, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.stack
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (64, 32, 16), (512, 256)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("num_tensors", [2, 3, 5])
+@pytest.mark.parametrize("dim", [0, 1, -1])
+def test_stack_benchmark_tensor(shape, dtype, num_tensors, dim):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    tensors = [
+        torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        for _ in range(num_tensors)
+    ]
+    ref_tensors = [t.clone() for t in tensors]
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.stack(ref_tensors, dim), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_stack(tensors, dim), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"stack {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.stack
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (64, 32, 16), (512, 256)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("num_tensors", [2, 4])
+@pytest.mark.parametrize("dim", [0, 2, -1])
+def test_stack_benchmark_out(shape, dtype, num_tensors, dim):
+    quantiles = [0.5, 0.2, 0.8]
+
+    tensors = [
+        torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        for _ in range(num_tensors)
+    ]
+    ref_tensors = [t.clone() for t in tensors]
+
+    n_dims = len(shape)
+    eff_dim = dim if dim >= 0 else dim + (n_dims + 1)
+    out_shape = list(shape)
+    out_shape.insert(eff_dim, num_tensors)
+
+    ref_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.stack.out(ref_tensors, dim, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_stack_out(tensors, dim, act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"stack {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/t__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/t__test.py
@@ -1,0 +1,66 @@
+# T_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.t_ import t_ as gems_t_
+
+
+@pytest.mark.t_
+@pytest.mark.parametrize("shape", [(2, 3), (3, 2), (128, 256), (256, 128), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_t__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.t_(ref_input)
+    with flag_gems.use_gems():
+        act_input = input_tensor.clone()
+        act_out = gems_t_(act_input)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.t_
+@pytest.mark.parametrize("shape", [(2, 3), (3, 2), (128, 256), (256, 128), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_t__benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.t_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        act_input = input_tensor.clone()
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_t_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"t_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/t_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/t_test.py
@@ -1,0 +1,74 @@
+# T operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.t import t as gems_t
+
+
+@pytest.mark.t
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("contig", [True, False])
+def test_t_tensor(shape, dtype, contig):
+    if contig:
+        input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    else:
+        base = torch.randn((shape[1], shape[0]), dtype=dtype, device=flag_gems.device)
+        input_tensor = base.t()
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.t(ref_input)
+    with flag_gems.use_gems():
+        act_out = gems_t(input_tensor)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.t
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("contig", [True, False])
+def test_t_benchmark_tensor(shape, dtype, contig):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    if contig:
+        input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    else:
+        base = torch.randn((shape[1], shape[0]), dtype=dtype, device=flag_gems.device)
+        input_tensor = base.t()
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.t(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_t(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"t {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/take_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/take_test.py
@@ -1,0 +1,140 @@
+# TAKE operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.take import take as gems_take
+from flag_gems.experimental_ops.take import take_out as gems_take_out
+
+
+@pytest.mark.take
+@pytest.mark.parametrize("in_shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("idx_shape", [(6,), (32, 32), (1024,)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_take_tensor(in_shape, idx_shape, dtype):
+    x = torch.randn(in_shape, device=flag_gems.device, dtype=dtype)
+    idx = torch.randint(
+        0, x.numel(), idx_shape, device=flag_gems.device, dtype=torch.int64
+    )
+
+    ref_x = x.clone()
+    ref_idx = idx.clone()
+    ref_out = torch.ops.aten.take(ref_x, ref_idx)
+
+    with flag_gems.use_gems():
+        act_out = gems_take(x, idx)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.take
+@pytest.mark.parametrize("in_shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("idx_shape", [(6,), (32, 32), (1024,)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_take_out(in_shape, idx_shape, dtype):
+    x = torch.randn(in_shape, device=flag_gems.device, dtype=dtype)
+    idx = torch.randint(
+        0, x.numel(), idx_shape, device=flag_gems.device, dtype=torch.int64
+    )
+
+    out_ref = torch.empty(idx_shape, device=flag_gems.device, dtype=dtype)
+    out_act = torch.empty(idx_shape, device=flag_gems.device, dtype=dtype)
+
+    ref_x = x.clone()
+    ref_idx = idx.clone()
+    ref_out = torch.ops.aten.take.out(ref_x, ref_idx, out=out_ref)
+
+    with flag_gems.use_gems():
+        act_out = gems_take_out(x, idx, out_act)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.take
+@pytest.mark.parametrize("in_shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("idx_shape", [(6,), (32, 32), (1024,)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_take_benchmark_tensor(in_shape, idx_shape, dtype):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(in_shape, device=flag_gems.device, dtype=dtype)
+    idx = torch.randint(
+        0, x.numel(), idx_shape, device=flag_gems.device, dtype=torch.int64
+    )
+
+    ref_x = x.clone()
+    ref_idx = idx.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.take(ref_x, ref_idx), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_take(x, idx), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"take {idx_shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.take
+@pytest.mark.parametrize("in_shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("idx_shape", [(6,), (32, 32), (1024,)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_take_benchmark_out(in_shape, idx_shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(in_shape, device=flag_gems.device, dtype=dtype)
+    idx = torch.randint(
+        0, x.numel(), idx_shape, device=flag_gems.device, dtype=torch.int64
+    )
+
+    out_ref = torch.empty(idx_shape, device=flag_gems.device, dtype=dtype)
+    out_act = torch.empty(idx_shape, device=flag_gems.device, dtype=dtype)
+
+    ref_x = x.clone()
+    ref_idx = idx.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.take.out(ref_x, ref_idx, out=out_ref),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_take_out(x, idx, out_act), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"take {idx_shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/threshold__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/threshold__test.py
@@ -1,0 +1,65 @@
+# THRESHOLD_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.threshold_ import threshold_ as gems_threshold_
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.threshold_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("threshold", [0.0, 0.25, -0.75, 0])
+@pytest.mark.parametrize("value", [0.0, -0.5, 1.0, 2])
+def test_threshold__tensor_inplace(shape, dtype, threshold, value):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.threshold_(ref_input, threshold, value)
+
+    with flag_gems.use_gems():
+        act_out = gems_threshold_(act_input, threshold, value)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.threshold_
+def test_perf_aten_threshold_():
+    # Define input generation logic matching the operator arguments
+    def threshold__input_fn(shape, dtype, device):
+        input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        threshold = 0.0  # Example threshold
+        value = 1.0  # Example value
+        yield input_tensor, threshold, value
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=threshold__input_fn,
+        op_name="threshold_",
+        torch_op=torch.ops.aten.threshold_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/threshold_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/threshold_test.py
@@ -1,0 +1,77 @@
+# THRESHOLD operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.threshold import threshold as gems_threshold
+from flag_gems.experimental_ops.threshold import threshold_out as gems_threshold_out
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.threshold
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("threshold", [0.0, -0.5, 0.5, 1.0])
+@pytest.mark.parametrize("value", [0.0, 0.1, -1.0, 2.0])
+def test_threshold_tensor(shape, dtype, threshold, value):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.threshold(ref_x, threshold, value)
+    with flag_gems.use_gems():
+        act_out = gems_threshold(x, threshold, value)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.threshold
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("threshold", [0.0, -0.5, 0.5, 1.0])
+@pytest.mark.parametrize("value", [0.0, 0.1, -1.0, 2.0])
+def test_threshold_out(shape, dtype, threshold, value):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out_buf = torch.empty_like(ref_x)
+    ref_out = torch.ops.aten.threshold.out(ref_x, threshold, value, out=ref_out_buf)
+    act_out_buf = torch.empty_like(x)
+    with flag_gems.use_gems():
+        act_out = gems_threshold_out(x, threshold, value, act_out_buf)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.threshold
+def test_perf_aten_threshold():
+    # Define input generation logic matching the operator arguments
+    def threshold_input_fn(shape, dtype, device):
+        x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        threshold = 0.5  # Example threshold
+        value = 1.0  # Example value
+        yield x, threshold, value
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=threshold_input_fn,
+        op_name="threshold",
+        torch_op=torch.ops.aten.threshold,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/transpose_copy_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/transpose_copy_test.py
@@ -1,0 +1,142 @@
+# TRANSPOSE_COPY operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.transpose_copy import (
+    transpose_copy_int,
+    transpose_copy_int_out,
+)
+
+
+@pytest.mark.transpose_copy
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dims", [(0, 1), (1, 0)])
+def test_transpose_copy_int(shape, dtype, dims):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    d0, d1 = dims
+
+    ref_out = torch.ops.aten.transpose_copy(ref_inp, d0, d1)
+
+    with flag_gems.use_gems():
+        act_out = transpose_copy_int(inp, d0, d1)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.transpose_copy
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dims", [(0, 1), (1, 0)])
+def test_transpose_copy_int_out(shape, dtype, dims):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    d0, d1 = dims
+
+    out_shape = list(shape)
+    out_shape[d0], out_shape[d1] = out_shape[d1], out_shape[d0]
+    out_shape = tuple(out_shape)
+
+    ref_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.ops.aten.transpose_copy(ref_inp, d0, d1, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out = transpose_copy_int_out(inp, d0, d1, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.transpose_copy
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dims", [(0, 1), (1, 0)])
+def test_transpose_copy_int_performance(shape, dtype, dims):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    d0, d1 = dims
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.transpose_copy(ref_inp, d0, d1),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: transpose_copy_int(inp, d0, d1), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"transpose_copy {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.transpose_copy
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dims", [(0, 1), (1, 0)])
+def test_transpose_copy_int_benchmark_out(shape, dtype, dims):
+    quantiles = [0.5, 0.2, 0.8]
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    d0, d1 = dims
+
+    out_shape = list(shape)
+    out_shape[d0], out_shape[d1] = out_shape[d1], out_shape[d0]
+    out_shape = tuple(out_shape)
+
+    ref_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.transpose_copy(ref_inp, d0, d1, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: transpose_copy_int_out(inp, d0, d1, act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"transpose_copy {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/tril__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/tril__test.py
@@ -1,0 +1,117 @@
+# TRIL_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.tril_ import tril_ as gems_tril_
+
+
+@pytest.mark.tril_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (32, 64, 64)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-2, -1, 0, 1, 2])
+def test_tril__tensor(shape, dtype, diagonal):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    act_x = x.clone()
+
+    ref_out = torch.ops.aten.tril_(ref_x, diagonal)
+
+    with flag_gems.use_gems():
+        act_out = gems_tril_(act_x, diagonal)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.tril_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (32, 64, 64)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_tril__tensor_default_diagonal(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    act_x = x.clone()
+
+    ref_out = torch.ops.aten.tril_(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_tril_(act_x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.tril_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (32, 64, 64)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-2, -1, 0, 1, 2])
+def test_tril__benchmark_tensor(shape, dtype, diagonal):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    act_x = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.tril_(ref_x, diagonal), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_tril_(act_x, diagonal), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"tril_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.tril_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (32, 64, 64)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_tril__tensor_default_diagonal_performance(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    act_x = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.tril_(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_tril_(act_x), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"tril_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/tril_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/tril_test.py
@@ -1,0 +1,116 @@
+# TRIL operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.tril import tril as gems_tril
+from flag_gems.experimental_ops.tril import tril_out as gems_tril_out
+
+
+@pytest.mark.tril
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-2, -1, 0, 1, 3])
+def test_tril_tensor(shape, dtype, diagonal):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.tril(ref_input, diagonal)
+    with flag_gems.use_gems():
+        act_out = gems_tril(input_tensor, diagonal)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.tril
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-2, -1, 0, 1, 3])
+def test_tril_out(shape, dtype, diagonal):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    out_ref = torch.empty_like(ref_input)
+    ref_out = torch.ops.aten.tril.out(ref_input, diagonal, out=out_ref)
+    out_act = torch.empty_like(input_tensor)
+    with flag_gems.use_gems():
+        act_out = gems_tril_out(input_tensor, diagonal, out_act)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.tril
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-2, -1, 0, 1, 3])
+def test_tril_benchmark_tensor(shape, dtype, diagonal):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.tril(ref_input, diagonal), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_tril(input_tensor, diagonal), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"tril {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.tril
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-2, -1, 0, 1, 3])
+def test_tril_benchmark_out(shape, dtype, diagonal):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    out_ref = torch.empty_like(ref_input)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.tril.out(ref_input, diagonal, out=out_ref),
+        rep=100,
+        quantiles=quantiles,
+    )
+    out_act = torch.empty_like(input_tensor)
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_tril_out(input_tensor, diagonal, out_act),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"tril {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/triu__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/triu__test.py
@@ -1,0 +1,72 @@
+# TRIU_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.triu_ import triu_ as gems_triu_
+
+
+@pytest.mark.triu_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (4, 64, 32)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [0, 1, -1, 3])
+def test_triu__tensor(shape, dtype, diagonal):
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_out = torch.ops.aten.triu_(ref_input, diagonal)
+
+    with flag_gems.use_gems():
+        act_out = gems_triu_(act_input, diagonal)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.triu_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (4, 64, 32)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [0, 1, -1, 3])
+def test_triu__benchmark_tensor(shape, dtype, diagonal):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.triu_(ref_input, diagonal), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_triu_(act_input, diagonal), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"triu_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/triu_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/triu_test.py
@@ -1,0 +1,125 @@
+# TRIU operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.triu import triu as gems_triu
+from flag_gems.experimental_ops.triu import triu_out as gems_triu_out
+
+
+@pytest.mark.triu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (4, 16, 32)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-1, 0, 1, 3])
+def test_triu_tensor(shape, dtype, diagonal):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out = torch.ops.aten.triu(ref_x, diagonal)
+
+    with flag_gems.use_gems():
+        act_out = gems_triu(x, diagonal)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.triu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (4, 16, 32)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-1, 0, 1, 3])
+def test_triu_out(shape, dtype, diagonal):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out_buf = torch.empty_like(ref_x)
+
+    ref_out = torch.ops.aten.triu.out(ref_x, diagonal, out=ref_out_buf)
+
+    act_out_buf = torch.empty_like(x)
+    with flag_gems.use_gems():
+        act_out = gems_triu_out(x, diagonal, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.triu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (4, 16, 32)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-1, 0, 1, 3])
+def test_triu_benchmark_tensor(shape, dtype, diagonal):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.triu(ref_x, diagonal), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_triu(x, diagonal), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"triu {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.triu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (4, 16, 32)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-1, 0, 1, 3])
+def test_triu_benchmark_out(shape, dtype, diagonal):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out_buf = torch.empty_like(ref_x)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.triu.out(ref_x, diagonal, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    act_out_buf = torch.empty_like(x)
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_triu_out(x, diagonal, act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"triu {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/exp_tests/unsqueeze_copy_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/unsqueeze_copy_test.py
@@ -1,0 +1,116 @@
+# UNSQUEEZE_COPY operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.unsqueeze_copy import (
+    unsqueeze_copy as gems_unsqueeze_copy,
+)
+from flag_gems.experimental_ops.unsqueeze_copy import (
+    unsqueeze_copy_out as gems_unsqueeze_copy_out,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.unsqueeze_copy
+@pytest.mark.parametrize("shape", [(2, 3), (128, 64), (64, 32, 16), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("where", ["zero", "neg1", "end", "minneg"])
+def test_unsqueeze_copy_default(shape, dtype, where):
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_x = x.clone()
+
+    n = len(shape)
+    if where == "zero":
+        dim = 0
+    elif where == "neg1":
+        dim = -1
+    elif where == "end":
+        dim = n
+    elif where == "minneg":
+        dim = -(n + 1)
+    else:
+        dim = 0
+
+    ref_out = torch.ops.aten.unsqueeze_copy(ref_x, dim)
+
+    with flag_gems.use_gems():
+        act_out = gems_unsqueeze_copy(x, dim)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.unsqueeze_copy
+@pytest.mark.parametrize("shape", [(2, 3), (128, 64), (64, 32, 16), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("where", ["zero", "neg1", "end", "minneg"])
+def test_unsqueeze_copy_out(shape, dtype, where):
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_x = x.clone()
+
+    n = len(shape)
+    if where == "zero":
+        dim = 0
+    elif where == "neg1":
+        dim = -1
+    elif where == "end":
+        dim = n
+    elif where == "minneg":
+        dim = -(n + 1)
+    else:
+        dim = 0
+
+    pos = dim + n + 1 if dim < 0 else dim
+    new_shape = shape[:pos] + (1,) + shape[pos:]
+
+    ref_out_buf = torch.empty(new_shape, device=flag_gems.device, dtype=dtype)
+    act_out_buf = torch.empty_like(ref_out_buf)
+
+    ref_out = torch.ops.aten.unsqueeze_copy(ref_x, dim, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out = gems_unsqueeze_copy_out(x, dim, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.unsqueeze_copy
+def test_perf_aten_unsqueeze_copy():
+    # Define input generation logic matching the operator arguments
+    def unsqueeze_copy_input_fn(shape, dtype, device):
+        x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        n = len(shape)
+        if n == 0:
+            dim = 0
+        else:
+            dim = 0  # You can modify this to test different dimensions if needed
+        yield x, dim
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=unsqueeze_copy_input_fn,
+        op_name="unsqueeze_copy",
+        torch_op=torch.ops.aten.unsqueeze_copy,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/unsqueeze_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/unsqueeze_test.py
@@ -1,0 +1,91 @@
+# UNSQUEEZE operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.unsqueeze import unsqueeze as gems_unsqueeze
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.unsqueeze
+@pytest.mark.parametrize(
+    "shape_dim",
+    [
+        ((), 0),
+        ((), -1),
+        ((2, 3), -3),
+        ((2, 3), -1),
+        ((2, 3), 0),
+        ((2, 3), 1),
+        ((2, 3), 2),
+        ((128, 256), -3),
+        ((128, 256), -1),
+        ((128, 256), 0),
+        ((128, 256), 2),
+        ((512, 512), -3),
+        ((512, 512), 0),
+        ((512, 512), 2),
+        ((64, 32, 16), -4),
+        ((64, 32, 16), -1),
+        ((64, 32, 16), 0),
+        ((64, 32, 16), 2),
+        ((64, 32, 16), 3),
+        ((4,), -2),
+        ((4,), -1),
+        ((4,), 0),
+        ((4,), 1),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_unsqueeze_tensor(shape_dim, dtype):
+    shape, dim = shape_dim
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.unsqueeze(ref_input, dim)
+
+    with flag_gems.use_gems():
+        act_out = gems_unsqueeze(input_tensor, dim)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.unsqueeze
+def test_perf_aten_unsqueeze():
+    # Define input generation logic matching the operator arguments
+    def unsqueeze_input_fn(shape, dtype, device):
+        # Generate and yield inputs as required by the operator
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        for dim in range(
+            len(shape) + 1
+        ):  # Yielding all possible dimensions for unsqueeze
+            yield inp, dim
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=unsqueeze_input_fn,
+        op_name="unsqueeze",
+        torch_op=torch.ops.aten.unsqueeze,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/zero__test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/zero__test.py
@@ -1,0 +1,60 @@
+# ZERO_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.zero_ import zero_ as gems_zero_
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark
+
+
+@pytest.mark.zero_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_zero__tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = x.clone()
+    act_input = x.clone()
+
+    ref_out = torch.ops.aten.zero_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_zero_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.zero_
+def test_perf_aten_zero_():
+    # Define input generation logic matching the operator arguments
+    def zero__input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=zero__input_fn,
+        op_name="zero_",
+        torch_op=torch.ops.aten.zero_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/src/flag_gems/experimental_ops/exp_tests/zeros_like_test.py
+++ b/src/flag_gems/experimental_ops/exp_tests/zeros_like_test.py
@@ -1,0 +1,220 @@
+# ZEROS_LIKE operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.zeros_like import zeros_like as gems_zeros_like
+from flag_gems.experimental_ops.zeros_like import zeros_like_out as gems_zeros_like_out
+
+
+@pytest.mark.zeros_like
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (16, 8, 32, 32)])
+@pytest.mark.parametrize("in_dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "opts_case",
+    ["none", "dtype_override", "contig_memfmt", "channels_last", "layout_device"],
+)
+def test_zeros_like_default_overload(shape, in_dtype, opts_case):
+    inp = torch.randn(shape, dtype=in_dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    act_inp = inp.clone()
+
+    def pick_alt_dtype(dt):
+        if dt == torch.float32:
+            return torch.float16
+        if dt == torch.float16:
+            return torch.float32
+        return torch.float32
+
+    kwargs = {}
+    if opts_case == "none":
+        kwargs = {}
+    elif opts_case == "dtype_override":
+        kwargs = {"dtype": pick_alt_dtype(in_dtype)}
+    elif opts_case == "contig_memfmt":
+        kwargs = {"device": "cuda", "memory_format": torch.contiguous_format}
+    elif opts_case == "channels_last":
+        if ref_inp.ndim == 4:
+            kwargs = {"device": "cuda", "memory_format": torch.channels_last}
+        else:
+            kwargs = {"device": "cuda", "memory_format": torch.contiguous_format}
+    elif opts_case == "layout_device":
+        kwargs = {"layout": torch.strided, "device": "cuda"}
+
+    ref_out = torch.ops.aten.zeros_like(ref_inp, **kwargs)
+    with flag_gems.use_gems():
+        act_out = gems_zeros_like(act_inp, **kwargs)
+
+    eff_dtype = kwargs.get("dtype", in_dtype)
+    gems_assert_close(act_out, ref_out, dtype=eff_dtype)
+
+
+@pytest.mark.zeros_like
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (16, 8, 32, 32)])
+@pytest.mark.parametrize("in_dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("out_dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("memfmt_case", ["none", "contiguous", "channels_last"])
+def test_zeros_like_out_overload(shape, in_dtype, out_dtype, memfmt_case):
+    inp = torch.randn(shape, dtype=in_dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    act_inp = inp.clone()
+
+    out_ref = torch.empty(shape, dtype=out_dtype, device=flag_gems.device)
+    out_act = torch.empty(shape, dtype=out_dtype, device=flag_gems.device)
+
+    if memfmt_case == "none":
+        ref_out = torch.ops.aten.zeros_like.out(ref_inp, out=out_ref)
+        with flag_gems.use_gems():
+            act_out = gems_zeros_like_out(act_inp, out_act)
+    else:
+        memfmt = (
+            torch.contiguous_format
+            if memfmt_case == "contiguous"
+            else (torch.channels_last if inp.ndim == 4 else torch.contiguous_format)
+        )
+        ref_out = torch.ops.aten.zeros_like.out(
+            ref_inp, memory_format=memfmt, out=out_ref
+        )
+        with flag_gems.use_gems():
+            act_out = gems_zeros_like_out(act_inp, out_act, memory_format=memfmt)
+
+    gems_assert_close(act_out, ref_out, dtype=out_dtype)
+
+
+@pytest.mark.zeros_like
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (16, 8, 32, 32)])
+@pytest.mark.parametrize("in_dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "opts_case",
+    ["none", "dtype_override", "contig_memfmt", "channels_last", "layout_device"],
+)
+def test_zeros_like_default_overload_performance(shape, in_dtype, opts_case):
+    import torch.utils.benchmark as benchmark
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    inp = torch.randn(shape, dtype=in_dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    act_inp = inp.clone()
+
+    def pick_alt_dtype(dt):
+        if dt == torch.float32:
+            return torch.float16
+        if dt == torch.float16:
+            return torch.float32
+        return torch.float32
+
+    kwargs = {}
+    if opts_case == "none":
+        kwargs = {}
+    elif opts_case == "dtype_override":
+        kwargs = {"dtype": pick_alt_dtype(in_dtype)}
+    elif opts_case == "contig_memfmt":
+        kwargs = {"device": "cuda", "memory_format": torch.contiguous_format}
+    elif opts_case == "channels_last":
+        if ref_inp.ndim == 4:
+            kwargs = {"device": "cuda", "memory_format": torch.channels_last}
+        else:
+            kwargs = {"device": "cuda", "memory_format": torch.contiguous_format}
+    elif opts_case == "layout_device":
+        kwargs = {"layout": torch.strided, "device": "cuda"}
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.zeros_like(ref_inp, **kwargs),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_zeros_like(act_inp, **kwargs), rep=100, quantiles=quantiles
+        )
+
+    eff_dtype = kwargs.get("dtype", in_dtype)
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"zeros_like {shape} {eff_dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.zeros_like
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (16, 8, 32, 32)])
+@pytest.mark.parametrize("in_dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("out_dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("memfmt_case", ["none", "contiguous", "channels_last"])
+def test_zeros_like_out_overload_performance(shape, in_dtype, out_dtype, memfmt_case):
+    quantiles = [0.5, 0.2, 0.8]
+
+    inp = torch.randn(shape, dtype=in_dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    act_inp = inp.clone()
+
+    out_ref = torch.empty(shape, dtype=out_dtype, device=flag_gems.device)
+    out_act = torch.empty(shape, dtype=out_dtype, device=flag_gems.device)
+
+    if memfmt_case == "none":
+        # PyTorch reference implementation
+        ms_torch, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.zeros_like.out(ref_inp, out=out_ref),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+        # Triton implementation
+        with flag_gems.use_gems():
+            ms_triton, _, _ = triton.testing.do_bench(
+                lambda: gems_zeros_like_out(act_inp, out_act),
+                rep=100,
+                quantiles=quantiles,
+            )
+    else:
+        memfmt = (
+            torch.contiguous_format
+            if memfmt_case == "contiguous"
+            else (torch.channels_last if inp.ndim == 4 else torch.contiguous_format)
+        )
+        # PyTorch reference implementation
+        ms_torch, _, _ = triton.testing.do_bench(
+            lambda: torch.ops.aten.zeros_like.out(
+                ref_inp, memory_format=memfmt, out=out_ref
+            ),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+        # Triton implementation
+        with flag_gems.use_gems():
+            ms_triton, _, _ = triton.testing.do_bench(
+                lambda: gems_zeros_like_out(act_inp, out_act, memory_format=memfmt),
+                rep=100,
+                quantiles=quantiles,
+            )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"zeros_like {shape} {out_dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/src/flag_gems/experimental_ops/expand.py
+++ b/src/flag_gems/experimental_ops/expand.py
@@ -1,0 +1,142 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def expand(
+    x_ptr,
+    out_ptr,
+    n_elements,
+    ndims,
+    out_shape_ptr,
+    out_cumprod_ptr,
+    in_stride_ptr,
+    BLOCK_SIZE: tl.constexpr,
+    MAX_DIMS: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    # Compute input offsets corresponding to each output linear index
+    in_offsets = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+
+    # Accumulate contributions per dimension
+    for d in range(MAX_DIMS):
+        # Load scalars defining the output decomposition and input strides
+        s = tl.load(out_shape_ptr + d)
+        stride_right = tl.load(out_cumprod_ptr + d)
+        in_stride = tl.load(in_stride_ptr + d)
+        # idx along dimension d for each linear offset
+        idx_d = (offsets // stride_right) % s
+        # contribution to input linear offset
+        in_offsets += idx_d * in_stride
+
+    # Load from input using computed offsets and store to output
+    x = tl.load(x_ptr + in_offsets, mask=mask)
+    tl.store(out_ptr + offsets, x, mask=mask)
+
+
+_expand_kernel = expand
+
+
+def expand(*args, **kwargs):
+    x = args[0]
+    size = args[1]
+    kwargs.get("implicit", False)  # not used but accepted for signature compatibility
+
+    if not isinstance(size, (list, tuple, torch.Size)):
+        raise TypeError("expand size must be a list/tuple/torch.Size of ints")
+
+    size = list(size)
+    in_shape = list(x.shape)
+    in_strides = list(x.stride())
+
+    out_ndim = len(size)
+    in_ndim = len(in_shape)
+
+    if in_ndim > out_ndim:
+        raise RuntimeError(
+            f"expand: requested size has fewer dimensions ({out_ndim}) than input ({in_ndim})"
+        )
+
+    # Pad input shape/strides on the left to match output ndim
+    if in_ndim < out_ndim:
+        pad = out_ndim - in_ndim
+        in_shape = [1] * pad + in_shape
+        # For padded (new) leading dims, stride effectively is 0 since they will be broadcast
+        in_strides = [0] * pad + in_strides
+
+    # Resolve -1 and validate broadcastability
+    out_shape = []
+    for d in range(out_ndim):
+        req = size[d]
+        src = in_shape[d]
+        if req == -1:
+            target = src
+        else:
+            target = req
+        if src != target and src != 1:
+            raise RuntimeError(
+                f"The expanded size of the tensor ({target}) must match the existing size ({src}) "
+                f"at non-singleton dimension {d}. Target sizes must be the same, or -1, "
+                f"or the size of dimension in the original tensor must be 1."
+            )
+        out_shape.append(int(target))
+
+    # Effective input strides: 0 for broadcasted dims, original stride otherwise
+    in_stride_eff = [
+        int(in_strides[d]) if in_shape[d] != 1 else 0 for d in range(out_ndim)
+    ]
+
+    # Prepare decomposition multipliers: product of sizes to the right for each dim
+    out_cumprod_right = [0] * out_ndim
+    prod = 1
+    for d in range(out_ndim - 1, -1, -1):
+        out_cumprod_right[d] = prod
+        prod *= out_shape[d]
+
+    # Allocate output
+    out = torch.empty(out_shape, dtype=x.dtype, device=x.device)
+
+    n_elements = out.numel()
+    if n_elements == 0:
+        return out
+
+    # Triton kernel parameters
+    BLOCK_SIZE = 1024
+    MAX_DIMS = max(out_ndim, 1)  # at least 1
+    # Round up MAX_DIMS to a reasonable static upper bound for compilation (e.g., 16)
+    # but ensure arrays we pass match MAX_DIMS in kernel
+    STATIC_MAX = 16
+    if MAX_DIMS > STATIC_MAX:
+        STATIC_MAX = MAX_DIMS
+
+    # Create device arrays for shapes/strides with padding for MAX_DIMS
+    pad_len = STATIC_MAX - out_ndim
+    out_shape_arr = torch.tensor(
+        out_shape + [1] * pad_len, dtype=torch.int64, device=x.device
+    )
+    out_cumprod_arr = torch.tensor(
+        out_cumprod_right + [1] * pad_len, dtype=torch.int64, device=x.device
+    )
+    in_stride_arr = torch.tensor(
+        in_stride_eff + [0] * pad_len, dtype=torch.int64, device=x.device
+    )
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    _expand_kernel[grid](
+        x,
+        out,
+        n_elements,
+        out_ndim,
+        out_shape_arr,
+        out_cumprod_arr,
+        in_stride_arr,
+        BLOCK_SIZE=BLOCK_SIZE,
+        MAX_DIMS=STATIC_MAX,
+    )
+    return out

--- a/src/flag_gems/experimental_ops/fft_ifftshift.py
+++ b/src/flag_gems/experimental_ops/fft_ifftshift.py
@@ -1,0 +1,145 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def fft_ifftshift(
+    in_ptr_u8,  # pointer to input tensor as bytes
+    out_ptr_u8,  # pointer to output tensor as bytes
+    sizes_ptr,  # int64[NDIMS]
+    in_strides_ptr,  # int64[NDIMS], in elements
+    out_strides_ptr,  # int64[NDIMS], in elements
+    adds_ptr,  # int64[NDIMS], per-dim add = floor(size/2) if shifted else 0
+    n_elements,  # total number of elements
+    ELEMENT_SIZE: tl.constexpr,  # number of bytes per element
+    NDIMS: tl.constexpr,  # number of dimensions
+    BLOCK_SIZE: tl.constexpr,  # tile size
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+    offs64 = offs.to(tl.int64)
+
+    # Compute multi-dimensional indices from linear index (row-major)
+    tmp = offs64
+    in_off_elems = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+    out_off_elems = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+
+    # Iterate from last dim to first to compute indices
+    for d in range(NDIMS - 1, -1, -1):
+        size_d = tl.load(sizes_ptr + d)  # scalar int64
+        idx_d = tmp % size_d
+        tmp = tmp // size_d
+
+        add_d = tl.load(adds_ptr + d)  # scalar int64
+        idx_in_d = idx_d + add_d
+        # modulo to wrap within size_d
+        idx_in_d = idx_in_d - (idx_in_d // size_d) * size_d
+
+        in_stride_d = tl.load(in_strides_ptr + d)
+        out_stride_d = tl.load(out_strides_ptr + d)
+
+        in_off_elems += idx_in_d * in_stride_d
+        out_off_elems += idx_d * out_stride_d
+
+    in_byte_base = in_off_elems * ELEMENT_SIZE
+    out_byte_base = out_off_elems * ELEMENT_SIZE
+
+    # Copy ELEMENT_SIZE bytes per element
+    for b in range(ELEMENT_SIZE):
+        src_addr = in_ptr_u8 + in_byte_base + b
+        dst_addr = out_ptr_u8 + out_byte_base + b
+        val = tl.load(src_addr, mask=mask, other=0)
+        tl.store(dst_addr, val, mask=mask)
+
+
+# Keep a handle to the kernel before defining the wrapper with the same name
+fft_ifftshift_kernel = fft_ifftshift
+
+
+def fft_ifftshift(*args, **kwargs):
+    x = None
+    dims = None
+
+    # Parse input tensor
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        # try kwargs
+        x = (
+            kwargs.get("input", None)
+            or kwargs.get("self", None)
+            or kwargs.get("tensor", None)
+        )
+    if x is None:
+        raise ValueError("fft_ifftshift expects at least one tensor argument as input.")
+
+    # Parse dims (can be in args[1], or kwargs 'dim'/'dims')
+    if len(args) >= 2:
+        dims = args[1]
+    else:
+        dims = kwargs.get("dim", kwargs.get("dims", None))
+
+    # Normalize dims
+    if dims is None:
+        dims_list = list(range(x.ndim))
+    else:
+        if isinstance(dims, int):
+            dims_list = [dims]
+        else:
+            dims_list = list(dims)
+        # normalize negative dims
+        dims_list = [(d + x.ndim) % x.ndim for d in dims_list]
+        # remove duplicates while preserving order
+        seen = set()
+        tmp = []
+        for d in dims_list:
+            if d not in seen:
+                tmp.append(d)
+                seen.add(d)
+        dims_list = tmp
+
+    # Handle scalars or empty tensors quickly
+    if x.ndim == 0 or x.numel() == 0:
+        return x.clone()
+
+    device = x.device
+    out = torch.empty_like(x)
+
+    # Prepare metadata
+    sizes = torch.tensor(list(x.shape), device=device, dtype=torch.int64)
+    in_strides = torch.tensor(list(x.stride()), device=device, dtype=torch.int64)
+    out_strides = torch.tensor(list(out.stride()), device=device, dtype=torch.int64)
+
+    # Per-dimension add amount = floor(size/2) if dimension is included, else 0
+    add_list = [
+        (sizes[d].item() // 2) if d in set(dims_list) else 0 for d in range(x.ndim)
+    ]
+    adds = torch.tensor(add_list, device=device, dtype=torch.int64)
+
+    n_elements = x.numel()
+    NDIMS = x.ndim
+    ELEMENT_SIZE = x.element_size()
+
+    # Use byte pointers by viewing as uint8 without changing storage
+    x_u8 = x.view(torch.uint8)
+    out_u8 = out.view(torch.uint8)
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    BLOCK_SIZE = 1024
+
+    fft_ifftshift_kernel[grid](
+        x_u8,
+        out_u8,
+        sizes,
+        in_strides,
+        out_strides,
+        adds,
+        n_elements,
+        ELEMENT_SIZE=ELEMENT_SIZE,
+        NDIMS=NDIMS,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return out

--- a/src/flag_gems/experimental_ops/fill_.py
+++ b/src/flag_gems/experimental_ops/fill_.py
@@ -1,0 +1,69 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def fill_kernel(out_ptr, value_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    val = tl.load(value_ptr)  # load scalar value (1-element tensor)
+    tl.store(out_ptr + offsets, val, mask=mask)
+
+
+def fill__Scalar(*args, **kwargs):
+    # Expecting (self, value)
+    if len(args) >= 2:
+        self = args[0]
+        value = args[1]
+    else:
+        self = kwargs.get("self") or kwargs.get("input") or kwargs.get("tensor")
+        value = kwargs.get("value")
+    if self is None:
+        raise ValueError("fill__Scalar requires a target tensor 'self'.")
+    if value is None:
+        raise ValueError("fill__Scalar requires a scalar 'value'.")
+    assert self.is_cuda, "fill__Scalar requires a CUDA tensor."
+    assert (
+        self.is_contiguous()
+    ), "fill__Scalar currently supports only contiguous tensors."
+    # Create a 1-element tensor on device with matching dtype
+    value_t = torch.tensor([value], dtype=self.dtype, device=self.device)
+    n_elements = self.numel()
+    if n_elements == 0:
+        return self
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    fill_kernel[grid](self, value_t, n_elements, BLOCK_SIZE=1024)
+    return self
+
+
+def fill__Tensor(*args, **kwargs):
+    # Expecting (self, other)
+    if len(args) >= 2:
+        self = args[0]
+        other = args[1]
+    else:
+        self = kwargs.get("self") or kwargs.get("input") or kwargs.get("tensor")
+        other = kwargs.get("other") or kwargs.get("value") or kwargs.get("src")
+    if self is None:
+        raise ValueError("fill__Tensor requires a target tensor 'self'.")
+    if other is None:
+        raise ValueError("fill__Tensor requires a source tensor 'other'.")
+    assert self.is_cuda, "fill__Tensor requires a CUDA tensor."
+    assert (
+        self.is_contiguous()
+    ), "fill__Tensor currently supports only contiguous tensors."
+    if other.numel() != 1:
+        raise RuntimeError(
+            "fill__Tensor expects 'other' to be a 0-dim or 1-element tensor."
+        )
+    # Move/convert 'other' to match device and dtype of 'self'
+    value_t = other.to(device=self.device, dtype=self.dtype).reshape(1)
+    n_elements = self.numel()
+    if n_elements == 0:
+        return self
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    fill_kernel[grid](self, value_t, n_elements, BLOCK_SIZE=1024)
+    return self

--- a/src/flag_gems/experimental_ops/fix.py
+++ b/src/flag_gems/experimental_ops/fix.py
@@ -1,0 +1,82 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _fix_trunc_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    # Upcast to fp32 for stable math, then cast back to input dtype
+    x_fp32 = x.to(tl.float32)
+    res_pos = tl.floor(x_fp32)
+    res_neg = tl.ceil(x_fp32)
+    res_fp32 = tl.where(x_fp32 >= 0, res_pos, res_neg)
+    res = res_fp32.to(x.dtype)
+
+    tl.store(out_ptr + offsets, res, mask=mask)
+
+
+@triton.jit
+def _copy_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    tl.store(out_ptr + offsets, x, mask=mask)
+
+
+def _launch_fix_kernel(x: torch.Tensor, out: torch.Tensor, block_size: int = 1024):
+    assert x.is_cuda and out.is_cuda, "Input and output must be on CUDA device"
+    assert (
+        x.numel() == out.numel()
+    ), "Input and output must have the same number of elements"
+    assert x.device == out.device, "Input and output must be on the same device"
+    assert (
+        x.is_contiguous() and out.is_contiguous()
+    ), "Only contiguous tensors are supported"
+
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    # For floating point types, perform truncation toward zero.
+    # For non-floating types, it's effectively a no-op (copy).
+    if x.is_floating_point():
+        _fix_trunc_kernel[grid](x, out, n_elements, BLOCK_SIZE=block_size)
+    else:
+        _copy_kernel[grid](x, out, n_elements, BLOCK_SIZE=block_size)
+
+
+def fix(self: torch.Tensor):
+    """
+    Wrapper for ATen operator: ('fix', <Autograd.disable: False>)
+    Rounds elements toward zero (like trunc) for floating tensors.
+    Leaves integer tensors unchanged.
+    """
+    if self.is_complex():
+        # Fallback for complex dtypes not supported by Triton: use PyTorch
+        return torch.trunc(self)
+
+    out = torch.empty_like(self)
+    _launch_fix_kernel(self, out)
+    return out
+
+
+def fix_out(self: torch.Tensor, out: torch.Tensor):
+    """
+    Wrapper for ATen operator: ('fix.out', <Autograd.disable: False>)
+    Writes the result into 'out'.
+    """
+    if self.is_complex():
+        # Fallback for complex dtypes not supported by Triton: use PyTorch
+        out.copy_(torch.trunc(self))
+        return out
+
+    _launch_fix_kernel(self, out)
+    return out

--- a/src/flag_gems/experimental_ops/frac.py
+++ b/src/flag_gems/experimental_ops/frac.py
@@ -1,0 +1,100 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def frac_kernel(
+    x_ptr,
+    out_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    IS_FP16: tl.constexpr,
+    IS_BF16: tl.constexpr,
+    IS_FP64: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+
+    # Choose compute dtype
+    if IS_FP64:
+        x_comp = x.to(tl.float64)
+    elif IS_FP16 or IS_BF16:
+        x_comp = x.to(tl.float32)
+    else:
+        x_comp = x  # float32
+
+    trunc_val = tl.where(x_comp >= 0, tl.floor(x_comp), tl.ceil(x_comp))
+    y_comp = x_comp - trunc_val
+
+    # Cast back to output dtype
+    if IS_FP64:
+        y = y_comp.to(tl.float64)
+    elif IS_FP16:
+        y = y_comp.to(tl.float16)
+    elif IS_BF16:
+        y = y_comp.to(tl.bfloat16)
+    else:
+        y = y_comp.to(tl.float32)
+
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _launch_frac(x: torch.Tensor, out: torch.Tensor):
+    assert x.is_cuda and out.is_cuda, "Inputs must be CUDA tensors"
+    assert (
+        x.numel() == out.numel()
+    ), "Input and output must have the same number of elements"
+    assert x.dtype == out.dtype, "Input and output must have the same dtype"
+    if not x.is_floating_point():
+        raise NotImplementedError("frac is only implemented for floating point dtypes")
+    if x.is_complex():
+        raise NotImplementedError(
+            "frac is not implemented for complex dtypes in this Triton kernel"
+        )
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return out
+
+    # Use contiguous buffers for kernel execution
+    x_contig = x.contiguous()
+    out_contig = out.contiguous()
+
+    is_fp16 = x_contig.dtype == torch.float16
+    is_bf16 = x_contig.dtype == torch.bfloat16
+    is_fp64 = x_contig.dtype == torch.float64
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    frac_kernel[grid](
+        x_contig,
+        out_contig,
+        n_elements,
+        BLOCK_SIZE=1024,
+        IS_FP16=is_fp16,
+        IS_BF16=is_bf16,
+        IS_FP64=is_fp64,
+    )
+
+    # If out was non-contiguous, copy results back
+    if out_contig.data_ptr() != out.data_ptr():
+        out.copy_(out_contig)
+    return out
+
+
+def frac(input: torch.Tensor):
+    out = torch.empty_like(input)
+    _launch_frac(input, out)
+    return out
+
+
+def frac_out(input: torch.Tensor, out: torch.Tensor):
+    # Ensure shape and dtype match per .out contract
+    assert out.shape == input.shape, "out must have the same shape as input"
+    assert out.dtype == input.dtype, "out must have the same dtype as input"
+    _launch_frac(input, out)
+    return out

--- a/src/flag_gems/experimental_ops/gelu_.py
+++ b/src/flag_gems/experimental_ops/gelu_.py
@@ -1,0 +1,114 @@
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def gelu_(
+    x_ptr,  # *Pointer* to the input/output tensor (in-place).
+    n_elements,  # Number of elements.
+    USE_TANH: tl.constexpr,  # Whether to use tanh approximation.
+    BLOCK_SIZE: tl.constexpr,  # Elements per program.
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    x_f32 = x.to(tl.float32)
+
+    # Compute GELU either exact (via erf approximation) or tanh approximation
+    if USE_TANH:
+        # tanh approximation:
+        # gelu(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 x^3)))
+        c0 = 0.7978845608028654  # sqrt(2/pi)
+        c1 = 0.044715
+        x3 = x_f32 * x_f32 * x_f32
+        z = c0 * (x_f32 + c1 * x3)
+        # tanh(z) = (1 - e^{-2z}) / (1 + e^{-2z})
+        t = tl.exp(-2.0 * z)
+        tanh_z = (1.0 - t) / (1.0 + t)
+        y = 0.5 * x_f32 * (1.0 + tanh_z)
+    else:
+        # exact (erf-based) GELU:
+        # gelu(x) = 0.5 * x * (1 + erf(x / sqrt(2)))
+        inv_sqrt2 = 0.7071067811865476
+        z = x_f32 * inv_sqrt2
+
+        # Abramowitz and Stegun formula 7.1.26 for erf approximation
+        # erf(x) ≈ sign(x) * (1 - (((((a5*t + a4)*t + a3)*t + a2)*t + a1)*t) * e^{-x^2})
+        # where t = 1 / (1 + p*|x|)
+        p = 0.3275911
+        a1 = 0.254829592
+        a2 = -0.284496736
+        a3 = 1.421413741
+        a4 = -1.453152027
+        a5 = 1.061405429
+
+        az = tl.abs(z)
+        t = 1.0 / (1.0 + p * az)
+        poly = a5
+        poly = poly * t + a4
+        poly = poly * t + a3
+        poly = poly * t + a2
+        poly = poly * t + a1
+        poly = poly * t
+        erf_abs = 1.0 - poly * tl.exp(-az * az)
+        erf_z = tl.where(z >= 0, erf_abs, -erf_abs)
+
+        y = 0.5 * x_f32 * (1.0 + erf_z)
+
+    y_cast = y.to(x.dtype)
+    tl.store(x_ptr + offsets, y_cast, mask=mask)
+
+
+# Preserve a handle to the kernel before defining the Python wrapper of the same name
+gelu__kernel = gelu_
+
+
+def gelu_(*args, **kwargs):
+    # Resolve input tensor
+    x = None
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        # Try common names
+        x = kwargs.get("input", None)
+        if x is None:
+            x = kwargs.get("self", None)
+        if x is None:
+            x = kwargs.get("x", None)
+    if x is None:
+        raise ValueError("gelu_ expects a tensor as the first argument.")
+
+    # Determine approximation mode
+    approx = kwargs.get("approximate", "none")
+    if isinstance(approx, bool):
+        use_tanh = bool(approx)
+    else:
+        approx_str = str(approx).lower()
+        if approx_str in ("tanh", "true"):
+            use_tanh = True
+        elif approx_str in ("none", "false"):
+            use_tanh = False
+        else:
+            raise ValueError(
+                f"Unsupported approximate mode: {approx}. Use 'none' or 'tanh'."
+            )
+
+    if not x.is_cuda:
+        raise AssertionError("Input tensor must be on CUDA device for Triton kernel.")
+    if not x.is_contiguous():
+        raise AssertionError("Input tensor must be contiguous.")
+    if not x.is_floating_point():
+        raise AssertionError("gelu_ expects a floating point tensor.")
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    gelu__kernel[grid](x, n_elements, USE_TANH=use_tanh, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/hardshrink.py
+++ b/src/flag_gems/experimental_ops/hardshrink.py
@@ -1,0 +1,61 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def hardshrink_kernel(x_ptr, out_ptr, n_elements, lambd, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    lambda_val = lambd
+    keep = (x > lambda_val) | (x < -lambda_val)
+    y = tl.where(keep, x, 0.0)
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _hardshrink_launch(x: torch.Tensor, lambd: float, out: torch.Tensor):
+    assert x.is_cuda, "Input tensor must be on CUDA device"
+    assert out.is_cuda, "Output tensor must be on CUDA device"
+    assert (
+        x.numel() == out.numel()
+    ), "Input and output must have the same number of elements"
+    assert x.dtype == out.dtype, "Input and output must have the same dtype"
+    assert x.is_floating_point(), "hardshrink only supports floating point dtypes"
+
+    n_elements = x.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    hardshrink_kernel[grid](x, out, n_elements, float(lambd), BLOCK_SIZE=BLOCK_SIZE)
+
+
+def hardshrink(x: torch.Tensor, lambd: float = 0.5) -> torch.Tensor:
+    x_c = x.contiguous()
+    out = torch.empty_like(x_c)
+    _hardshrink_launch(x_c, lambd, out)
+    return out
+
+
+def hardshrink_out(
+    x: torch.Tensor, lambd: float = 0.5, out: torch.Tensor = None
+) -> torch.Tensor:
+    x_c = x.contiguous()
+    if out is None:
+        out = torch.empty_like(x_c)
+        _hardshrink_launch(x_c, lambd, out)
+        return out
+    # Ensure output is allocated correctly
+    assert out.is_cuda, "Output tensor must be on CUDA device"
+    assert out.dtype == x_c.dtype, "Output dtype must match input dtype"
+    assert out.shape == x_c.shape, "Output shape must match input shape"
+
+    if out.is_contiguous():
+        _hardshrink_launch(x_c, lambd, out)
+    else:
+        tmp = torch.empty_like(x_c)
+        _hardshrink_launch(x_c, lambd, tmp)
+        out.copy_(tmp)
+    return out

--- a/src/flag_gems/experimental_ops/hardsigmoid_.py
+++ b/src/flag_gems/experimental_ops/hardsigmoid_.py
@@ -1,0 +1,56 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def hardsigmoid_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = x + 3.0
+    y = tl.maximum(y, 0.0)
+    y = tl.minimum(y, 6.0)
+    y = y / 6.0
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+_hardsigmoid_triton = hardsigmoid_
+
+
+def hardsigmoid_(*args, **kwargs):
+    # Extract input tensor (supports positional or keyword: 'input' or 'self')
+    x = None
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        x = kwargs.get("input", kwargs.get("self", None))
+    if x is None:
+        raise ValueError("hardsigmoid_ expects a tensor as the first argument.")
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("hardsigmoid_ expects a torch.Tensor as input.")
+    if not x.is_floating_point():
+        raise TypeError("hardsigmoid_ only supports floating point tensors.")
+    if x.device.type != "cuda":
+        raise RuntimeError("hardsigmoid_ Triton kernel requires a CUDA tensor.")
+
+    BLOCK_SIZE = 1024
+
+    def launch(t: torch.Tensor):
+        n_elements = t.numel()
+        if n_elements == 0:
+            return
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        _hardsigmoid_triton[grid](t, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+
+    if not x.is_contiguous():
+        tmp = x.contiguous()
+        launch(tmp)
+        x.copy_(tmp)
+    else:
+        launch(x)
+
+    return x

--- a/src/flag_gems/experimental_ops/hardswish.py
+++ b/src/flag_gems/experimental_ops/hardswish.py
@@ -1,0 +1,112 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def hardswish_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    x32 = x.to(tl.float32)
+
+    lower = x32 <= -3.0
+    upper = x32 >= 3.0
+    mid = (~lower) & (~upper)
+
+    res32 = tl.zeros_like(x32)
+    res32 = tl.where(upper, x32, res32)
+    res32 = tl.where(mid, (x32 * (x32 + 3.0)) / 6.0, res32)
+    # lower region already zero
+
+    res = res32.to(x.dtype)
+    tl.store(out_ptr + offsets, res, mask=mask)
+
+
+def _launch_hardswish(x: torch.Tensor, out: torch.Tensor):
+    n_elements = x.numel()
+    if n_elements == 0:
+        return
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    hardswish_kernel[grid](x, out, n_elements, BLOCK_SIZE=1024)
+
+
+def _parse_input_tensor(*args, **kwargs) -> torch.Tensor:
+    if len(args) >= 1 and isinstance(args[0], torch.Tensor):
+        return args[0]
+    if "self" in kwargs and isinstance(kwargs["self"], torch.Tensor):
+        return kwargs["self"]
+    if "input" in kwargs and isinstance(kwargs["input"], torch.Tensor):
+        return kwargs["input"]
+    raise ValueError(
+        "Expected input tensor as the first positional argument or as 'self'/'input' keyword argument."
+    )
+
+
+def _parse_out_tensor(*args, **kwargs) -> torch.Tensor:
+    if len(args) >= 2 and isinstance(args[1], torch.Tensor):
+        return args[1]
+    if "out" in kwargs and isinstance(kwargs["out"], torch.Tensor):
+        return kwargs["out"]
+    raise ValueError(
+        "Expected 'out' tensor as the second positional argument or as 'out' keyword argument."
+    )
+
+
+def _ensure_cuda_tensor(t: torch.Tensor, name: str):
+    if not isinstance(t, torch.Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor")
+    if not t.is_cuda:
+        raise ValueError(f"{name} must be a CUDA tensor (got device {t.device})")
+
+
+_supported_dtypes = {torch.float16, torch.bfloat16, torch.float32}
+
+
+def _hardswish_impl(x: torch.Tensor, out: torch.Tensor = None):
+    _ensure_cuda_tensor(x, "input")
+    if out is not None:
+        _ensure_cuda_tensor(out, "out")
+        if out.shape != x.shape:
+            raise ValueError(f"out shape {out.shape} must match input shape {x.shape}")
+
+    x_co = x.contiguous()
+    compute_dtype = x_co.dtype if x_co.dtype in _supported_dtypes else torch.float32
+    x_work = x_co if x_co.dtype == compute_dtype else x_co.to(compute_dtype)
+
+    if out is None:
+        final_out = torch.empty_like(x)  # preserve layout/strides of input
+    else:
+        final_out = out
+
+    can_write_direct = (
+        final_out.is_contiguous()
+        and final_out.device == x.device
+        and final_out.dtype in _supported_dtypes
+        and final_out.dtype == compute_dtype
+    )
+
+    if can_write_direct:
+        out_work = final_out
+        _launch_hardswish(x_work, out_work)
+        return final_out
+    else:
+        out_work = torch.empty(x_work.shape, dtype=compute_dtype, device=x_work.device)
+        _launch_hardswish(x_work, out_work)
+        final_out.copy_(out_work.to(final_out.dtype))
+        return final_out
+
+
+def hardswish(*args, **kwargs):
+    x = _parse_input_tensor(*args, **kwargs)
+    return _hardswish_impl(x)
+
+
+def hardswish_out(*args, **kwargs):
+    x = _parse_input_tensor(*args, **kwargs)
+    out = _parse_out_tensor(*args, **kwargs)
+    _hardswish_impl(x, out)
+    return out

--- a/src/flag_gems/experimental_ops/hardswish_.py
+++ b/src/flag_gems/experimental_ops/hardswish_.py
@@ -1,0 +1,62 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def hardswish_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    three = 3.0
+    six = 6.0
+    zero = 0.0
+
+    tmp = x + three
+    tmp = tl.maximum(tmp, zero)
+    tmp = tl.minimum(tmp, six)
+    y = x * (tmp / six)
+
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# Preserve a reference to the Triton kernel before defining the Python wrapper with the same name.
+hardswish__kernel = hardswish_
+
+
+def hardswish_(*args, **kwargs):
+    # Resolve input tensor from positional or keyword arguments
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        x = kwargs.get("input", kwargs.get("self", None))
+
+    if x is None:
+        raise ValueError("hardswish_: expected a Tensor as the first argument")
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("hardswish_: expected a Tensor")
+    if not x.is_cuda:
+        raise ValueError("hardswish_: expected a CUDA tensor")
+    if not x.is_floating_point():
+        raise TypeError("hardswish_: expected a floating point tensor")
+
+    orig = x
+    x_work = x if x.is_contiguous() else x.contiguous()
+
+    n_elements = x_work.numel()
+    if n_elements == 0:
+        return orig
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    hardswish__kernel[grid](x_work, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+
+    if x_work.data_ptr() != orig.data_ptr():
+        orig.copy_(x_work)
+
+    return orig

--- a/src/flag_gems/experimental_ops/hardtanh.py
+++ b/src/flag_gems/experimental_ops/hardtanh.py
@@ -1,0 +1,78 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def hardtanh_kernel(
+    x_ptr, out_ptr, n_elements, min_val, max_val, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x_fp32 = x.to(tl.float32)
+
+    min_v = min_val  # expected to be float32 scalar
+    max_v = max_val  # expected to be float32 scalar
+    x_clamped = tl.maximum(tl.minimum(x_fp32, max_v), min_v)
+
+    y = x_clamped.to(x.dtype)
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _launch_hardtanh(
+    input: torch.Tensor, output: torch.Tensor, min_val: float, max_val: float
+):
+    assert input.is_cuda and output.is_cuda, "Tensors must be on CUDA device"
+    assert input.device == output.device, "Input and output must be on the same device"
+    assert input.dtype == output.dtype, "Input and output must have the same dtype"
+    n_elements = input.numel()
+    if n_elements == 0:
+        return output
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    hardtanh_kernel[grid](
+        input,
+        output,
+        n_elements,
+        float(min_val),
+        float(max_val),
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return output
+
+
+def hardtanh(self: torch.Tensor, min_val: float = -1.0, max_val: float = 1.0):
+    x = self
+    assert x.is_cuda, "Input tensor must be on CUDA device"
+    x_contig = x.contiguous()
+    out = torch.empty_like(x_contig)
+    _launch_hardtanh(x_contig, out, min_val, max_val)
+    # If original tensor wasn't contiguous, we still return a tensor matching input's shape and dtype
+    return out.view_as(x)
+
+
+def hardtanh_out(
+    self: torch.Tensor,
+    min_val: float = -1.0,
+    max_val: float = 1.0,
+    out: torch.Tensor = None,
+):
+    x = self
+    assert x.is_cuda, "Input tensor must be on CUDA device"
+    if out is None:
+        out = torch.empty_like(x)
+    assert out.is_cuda, "Output tensor must be on CUDA device"
+    assert out.shape == x.shape, "Output tensor must have the same shape as input"
+    assert out.dtype == x.dtype, "Output tensor must have the same dtype as input"
+    if not out.is_contiguous():
+        # For non-contiguous out, compute into a contiguous buffer then copy back
+        out_contig = torch.empty_like(out.contiguous())
+        _launch_hardtanh(x.contiguous(), out_contig, min_val, max_val)
+        out.copy_(out_contig)
+        return out
+    _launch_hardtanh(x.contiguous(), out, min_val, max_val)
+    return out

--- a/src/flag_gems/experimental_ops/hardtanh_.py
+++ b/src/flag_gems/experimental_ops/hardtanh_.py
@@ -1,0 +1,93 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def hardtanh_(
+    x_ptr,  # *Pointer* to input/output tensor (in-place).
+    n_elements,  # Number of elements.
+    min_val,  # Minimum clamp value (scalar).
+    max_val,  # Maximum clamp value (scalar).
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+
+    # Cast min/max to tensor dtype
+    min_v = tl.full([1], min_val, dtype=x.dtype)
+    max_v = tl.full([1], max_val, dtype=x.dtype)
+
+    x = tl.minimum(x, max_v)
+    x = tl.maximum(x, min_v)
+
+    tl.store(x_ptr + offsets, x, mask=mask)
+
+
+# Keep a reference to the Triton kernel before defining the Python wrapper of the same name
+hardtanh___kernel = hardtanh_
+
+
+def hardtanh_(*args, **kwargs):
+    # Parse arguments: expected signature hardtanh_(x, min_val=-1.0, max_val=1.0)
+    if len(args) == 0 and "input" not in kwargs and "self" not in kwargs:
+        raise TypeError("hardtanh_ expected at least 1 argument: a CUDA tensor")
+
+    # Accept common naming: positional 0, or keyword 'input'/'self'
+    x = None
+    if len(args) >= 1:
+        x = args[0]
+    elif "input" in kwargs:
+        x = kwargs["input"]
+    elif "self" in kwargs:
+        x = kwargs["self"]
+
+    # Defaults
+    min_val = -1.0
+    max_val = 1.0
+
+    # Override from positional args if provided
+    if len(args) >= 2:
+        min_val = args[1]
+    if len(args) >= 3:
+        max_val = args[2]
+
+    # Override from kwargs if provided
+    if "min_val" in kwargs and kwargs["min_val"] is not None:
+        min_val = kwargs["min_val"]
+    if "max_val" in kwargs and kwargs["max_val"] is not None:
+        max_val = kwargs["max_val"]
+
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("hardtanh_ expects a torch.Tensor as the first argument")
+
+    # Fallback for unsupported device/dtypes
+    if not x.is_cuda:
+        # CPU fallback using PyTorch
+        return torch.clamp_(x, min=min_val, max=max_val)
+
+    if not x.is_floating_point():
+        # For non-floating types, use PyTorch fallback to preserve semantics
+        return torch.clamp_(x, min=min_val, max=max_val)
+
+    # Require contiguous memory for in-place update
+    if not x.is_contiguous():
+        # To preserve in-place semantics on non-contiguous tensors, use PyTorch
+        return torch.clamp_(x, min=min_val, max=max_val)
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    # Launch Triton kernel
+    hardtanh___kernel[grid](
+        x, n_elements, float(min_val), float(max_val), BLOCK_SIZE=BLOCK_SIZE  # in-place
+    )
+    return x

--- a/src/flag_gems/experimental_ops/hinge_embedding_loss.py
+++ b/src/flag_gems/experimental_ops/hinge_embedding_loss.py
@@ -1,0 +1,103 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def hinge_embedding_loss(
+    input_ptr,  # *Pointer* to input tensor.
+    target_ptr,  # *Pointer* to target tensor.
+    output_ptr,  # *Pointer* to output tensor (per-element losses).
+    n_elements,  # Number of elements.
+    margin,  # Margin (float).
+    BLOCK_SIZE: tl.constexpr,  # Number of elements per program.
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(input_ptr + offsets, mask=mask, other=0)
+    t = tl.load(target_ptr + offsets, mask=mask, other=0)
+
+    # Cast to float32 for stable math
+    x_f = tl.cast(x, tl.float32)
+    t_f = tl.cast(t, tl.float32)
+    margin_f = tl.full([1], margin, tl.float32)
+
+    # HingeEmbeddingLoss:
+    # if target == 1:  loss = input
+    # if target == -1: loss = max(0, margin - input)
+    # else: 0 (undefined target values)
+    is_pos = t_f == 1.0
+    is_neg = t_f == -1.0
+
+    loss_pos = x_f
+    loss_neg = tl.maximum(0.0, margin_f - x_f)
+
+    loss = tl.where(is_pos, loss_pos, tl.where(is_neg, loss_neg, 0.0))
+
+    # Cast back to input dtype for storage
+    loss_out = tl.cast(loss, x.dtype)
+    tl.store(output_ptr + offsets, loss_out, mask=mask)
+
+
+# Preserve kernel reference before defining the Python wrapper with the same name
+_hinge_embedding_loss_kernel = hinge_embedding_loss
+
+
+def hinge_embedding_loss(
+    input: torch.Tensor,
+    target: torch.Tensor,
+    margin: float = 1.0,
+    reduction: str | int = "mean",
+) -> torch.Tensor:
+    # Fallback for non-CUDA tensors
+    if input.device.type != "cuda" or target.device.type != "cuda":
+        return torch.ops.aten.hinge_embedding_loss(input, target, margin, reduction)
+
+    # Ensure shapes and dtypes
+    if input.numel() != target.numel():
+        raise ValueError("input and target must have the same number of elements")
+    if not input.is_contiguous():
+        input = input.contiguous()
+    if not target.is_contiguous():
+        target = target.contiguous()
+
+    supported_dtypes = {torch.float16, torch.bfloat16, torch.float32}
+    if input.dtype not in supported_dtypes:
+        # Fallback if dtype unsupported by Triton
+        return torch.ops.aten.hinge_embedding_loss(input, target, margin, reduction)
+
+    # Allocate output buffer for per-element losses
+    out = torch.empty_like(input)
+
+    n_elements = input.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    _hinge_embedding_loss_kernel[grid](
+        input,
+        target,
+        out,
+        n_elements,
+        float(margin),
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+    # Handle reduction
+    red_map = {0: "none", 1: "mean", 2: "sum"}
+    if isinstance(reduction, int):
+        reduction = red_map.get(reduction, "mean")
+    reduction = reduction.lower()
+
+    if reduction == "none":
+        return out
+    elif reduction == "mean":
+        return out.mean()
+    elif reduction == "sum":
+        return out.sum()
+    else:
+        raise ValueError(
+            f"Invalid reduction: {reduction}. Supported: 'none', 'mean', 'sum'."
+        )

--- a/src/flag_gems/experimental_ops/huber_loss.py
+++ b/src/flag_gems/experimental_ops/huber_loss.py
@@ -1,0 +1,181 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def huber_loss_element_kernel(
+    x_ptr,  # pointer to input tensor (broadcasted, contiguous, flattened)
+    y_ptr,  # pointer to target tensor (broadcasted, contiguous, flattened)
+    out_ptr,  # pointer to output tensor (contiguous, flattened)
+    n_elements,  # number of elements
+    delta,  # huber delta (scalar)
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    diff = x - y
+    absdiff = tl.abs(diff)
+
+    # loss = 0.5 * diff^2 if absdiff <= delta else delta * (absdiff - 0.5 * delta)
+    loss_quad = 0.5 * diff * diff
+    loss_linear = delta * (absdiff - 0.5 * delta)
+    loss = tl.where(absdiff <= delta, loss_quad, loss_linear)
+
+    tl.store(out_ptr + offsets, loss, mask=mask)
+
+
+@triton.jit
+def reduce_sum_kernel(
+    x_ptr,  # pointer to input tensor (contiguous, flattened)
+    out_ptr,  # pointer to single scalar (float32) to accumulate sum into
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    vals = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    vals_f32 = vals.to(tl.float32)
+    partial_sum = tl.sum(vals_f32, axis=0)
+    tl.atomic_add(out_ptr, partial_sum)
+
+
+def _normalize_reduction(reduction):
+    if isinstance(reduction, str):
+        r = reduction.lower()
+        if r == "none":
+            return 0
+        elif r == "mean":
+            return 1
+        elif r == "sum":
+            return 2
+        else:
+            raise ValueError(f"Unsupported reduction: {reduction}")
+    elif isinstance(reduction, int):
+        if reduction in (0, 1, 2):
+            return reduction
+        else:
+            raise ValueError(f"Unsupported reduction: {reduction}")
+    else:
+        raise ValueError(f"Unsupported reduction type: {type(reduction)}")
+
+
+def huber_loss(input, target, reduction=1, delta=1.0):
+    reduction = _normalize_reduction(reduction)
+    if not (input.is_cuda and target.is_cuda):
+        raise AssertionError("Triton kernels require CUDA tensors")
+    device = input.device
+    # Promote dtype similar to PyTorch type promotion rules
+    result_dtype = torch.result_type(input, target)
+
+    # Broadcast tensors to a common shape
+    x_b, y_b = torch.broadcast_tensors(input.to(result_dtype), target.to(result_dtype))
+    x_b = x_b.contiguous()
+    y_b = y_b.contiguous()
+    numel = x_b.numel()
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(numel, meta["BLOCK_SIZE"]),)
+
+    if reduction == 0:  # 'none'
+        out = torch.empty_like(x_b, dtype=result_dtype, device=device)
+        huber_loss_element_kernel[grid](
+            x_b, y_b, out, numel, float(delta), BLOCK_SIZE=BLOCK_SIZE
+        )
+        return out
+    else:
+        # Compute elementwise loss into a temporary buffer
+        tmp = torch.empty_like(x_b, dtype=result_dtype, device=device)
+        huber_loss_element_kernel[grid](
+            x_b, y_b, tmp, numel, float(delta), BLOCK_SIZE=BLOCK_SIZE
+        )
+        # Reduce to scalar using float32 accumulator
+        acc = torch.zeros((), dtype=torch.float32, device=device)
+        reduce_sum_kernel[grid](tmp, acc, numel, BLOCK_SIZE=BLOCK_SIZE)
+        if reduction == 1:  # mean
+            val = (acc / numel).to(result_dtype)
+        else:  # sum
+            val = acc.to(result_dtype)
+        return val
+
+
+def huber_loss_out(input, target, reduction=1, delta=1.0, out=None):
+    if out is None:
+        raise ValueError("huber_loss_out requires an 'out' tensor")
+    reduction = _normalize_reduction(reduction)
+    if not (input.is_cuda and target.is_cuda and out.is_cuda):
+        raise AssertionError("Triton kernels require CUDA tensors")
+
+    device = input.device
+    # Determine result dtype; use out.dtype if provided to match .out behavior
+    # but ensure it's compatible with promoted dtype
+    promoted_dtype = torch.result_type(input, target)
+    result_dtype = out.dtype
+
+    # Broadcast tensors
+    x_b, y_b = torch.broadcast_tensors(
+        input.to(promoted_dtype), target.to(promoted_dtype)
+    )
+    x_b = x_b.contiguous()
+    y_b = y_b.contiguous()
+    numel = x_b.numel()
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(numel, meta["BLOCK_SIZE"]),)
+
+    if reduction == 0:  # 'none'
+        # Ensure out has correct shape
+        if out.numel() != numel or out.shape != x_b.shape:
+            raise ValueError(
+                f"'out' tensor must have shape {tuple(x_b.shape)} for reduction='none'"
+            )
+        # Compute into a temporary if out is not contiguous or dtype mismatches
+        needs_tmp = (not out.is_contiguous()) or (out.dtype != result_dtype)
+        if needs_tmp:
+            tmp = torch.empty_like(x_b, dtype=result_dtype, device=device)
+            huber_loss_element_kernel[grid](
+                x_b.to(result_dtype),
+                y_b.to(result_dtype),
+                tmp,
+                numel,
+                float(delta),
+                BLOCK_SIZE=BLOCK_SIZE,
+            )
+            out.copy_(tmp)
+        else:
+            huber_loss_element_kernel[grid](
+                x_b.to(result_dtype),
+                y_b.to(result_dtype),
+                out,
+                numel,
+                float(delta),
+                BLOCK_SIZE=BLOCK_SIZE,
+            )
+        return out
+    else:
+        # Compute elementwise loss into temporary (in promoted dtype), then reduce to scalar
+        tmp = torch.empty_like(x_b, dtype=promoted_dtype, device=device)
+        huber_loss_element_kernel[grid](
+            x_b, y_b, tmp, numel, float(delta), BLOCK_SIZE=BLOCK_SIZE
+        )
+        acc = torch.zeros((), dtype=torch.float32, device=device)
+        reduce_sum_kernel[grid](tmp, acc, numel, BLOCK_SIZE=BLOCK_SIZE)
+        if reduction == 1:  # mean
+            val = (acc / numel).to(result_dtype)
+        else:  # sum
+            val = acc.to(result_dtype)
+        # Ensure out is scalar/0-d
+        if out.numel() != 1 or out.dim() > 1:
+            raise ValueError(
+                "For reduction='mean' or 'sum', 'out' must be a scalar (0-d or 1-element) tensor"
+            )
+        # Copy the scalar value into out
+        out.copy_(val)
+        return out

--- a/src/flag_gems/experimental_ops/hypot.py
+++ b/src/flag_gems/experimental_ops/hypot.py
@@ -1,0 +1,128 @@
+import torch
+import triton
+import triton.language as tl
+
+
+def _torch_dtype_to_triton(dtype: torch.dtype):
+    if dtype == torch.float16:
+        return tl.float16
+    if dtype == torch.bfloat16:
+        return tl.bfloat16
+    if dtype == torch.float32:
+        return tl.float32
+    if dtype == torch.float64:
+        return tl.float64
+    raise ValueError(f"Unsupported dtype for Triton conversion: {dtype}")
+
+
+@triton.jit
+def _hypot_kernel(
+    x_ptr,
+    y_ptr,
+    out_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    OUT_DTYPE: tl.constexpr,
+    COMPUTE_DTYPE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0)
+
+    xf = x.to(COMPUTE_DTYPE)
+    yf = y.to(COMPUTE_DTYPE)
+
+    ax = tl.abs(xf)
+    ay = tl.abs(yf)
+    t = tl.maximum(ax, ay)
+    m = tl.minimum(ax, ay)
+    t_nz = tl.where(t > 0, t, 1).to(COMPUTE_DTYPE)
+    r = m / t_nz
+    res = tl.where(t > 0, t * tl.sqrt(1 + r * r), m)
+
+    out_val = res.to(OUT_DTYPE)
+    tl.store(out_ptr + offsets, out_val, mask=mask)
+
+
+def _infer_hypot_out_dtype(a: torch.Tensor, b: torch.Tensor) -> torch.dtype:
+    if a.is_complex() or b.is_complex():
+        raise NotImplementedError(
+            "Complex dtypes are not supported for hypot in this implementation."
+        )
+    if a.is_floating_point() or b.is_floating_point():
+        return torch.result_type(a, b)
+    # For integral/bool inputs, follow floating promotion behavior
+    return torch.get_default_dtype()
+
+
+def _launch_hypot_kernel(x: torch.Tensor, y: torch.Tensor, out: torch.Tensor):
+    assert x.device == y.device == out.device, "All tensors must be on the same device"
+    assert out.is_cuda, "Triton kernels require CUDA tensors"
+    n_elements = out.numel()
+    if n_elements == 0:
+        return
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    out_dtype = out.dtype
+    if out_dtype not in (torch.float16, torch.bfloat16, torch.float32, torch.float64):
+        raise ValueError(f"Unsupported output dtype for hypot: {out_dtype}")
+
+    OUT_DTYPE = _torch_dtype_to_triton(out_dtype)
+    COMPUTE_DTYPE = tl.float64 if out_dtype == torch.float64 else tl.float32
+
+    _hypot_kernel[grid](
+        x,
+        y,
+        out,
+        n_elements,
+        BLOCK_SIZE=BLOCK_SIZE,
+        OUT_DTYPE=OUT_DTYPE,
+        COMPUTE_DTYPE=COMPUTE_DTYPE,
+    )
+
+
+def hypot(a: torch.Tensor, b: torch.Tensor):
+    # Determine output dtype and broadcasted shape
+    out_dtype = _infer_hypot_out_dtype(a, b)
+    device = a.device
+    if b.device != device:
+        raise ValueError("Input tensors must be on the same device")
+    if device.type != "cuda":
+        raise ValueError("This implementation requires CUDA tensors")
+
+    out_shape = torch.broadcast_shapes(a.shape, b.shape)
+    out = torch.empty(out_shape, dtype=out_dtype, device=device)
+
+    # Prepare expanded, contiguous inputs
+    x = a.expand(out_shape).contiguous()
+    y = b.expand(out_shape).contiguous()
+
+    _launch_hypot_kernel(x, y, out)
+    return out
+
+
+def hypot_out(a: torch.Tensor, b: torch.Tensor, out: torch.Tensor):
+    # Validate device and shape
+    device = out.device
+    if (not out.is_cuda) or a.device != device or b.device != device:
+        raise ValueError(
+            "All tensors (a, b, out) must be CUDA tensors on the same device"
+        )
+
+    # Validate dtype
+    if out.dtype not in (torch.float16, torch.bfloat16, torch.float32, torch.float64):
+        raise ValueError(f"Unsupported out dtype for hypot_out: {out.dtype}")
+
+    # Validate/broadcast inputs to out shape
+    target_shape = out.shape
+    x = a.expand(target_shape).contiguous()
+    y = b.expand(target_shape).contiguous()
+
+    _launch_hypot_kernel(x, y, out)
+    return out

--- a/src/flag_gems/experimental_ops/i0_.py
+++ b/src/flag_gems/experimental_ops/i0_.py
@@ -1,0 +1,96 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def i0_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    xf = tl.cast(x, tl.float32)
+    ax = tl.abs(xf)
+
+    t_small = ax / 3.75
+    y_small = t_small * t_small
+    poly_small = 1.0 + y_small * (
+        3.5156229
+        + y_small
+        * (
+            3.0899424
+            + y_small
+            * (
+                1.2067492
+                + y_small * (0.2659732 + y_small * (0.0360768 + y_small * 0.0045813))
+            )
+        )
+    )
+
+    y_large = 3.75 / ax
+    poly_large = 0.39894228 + y_large * (
+        0.01328592
+        + y_large
+        * (
+            0.00225319
+            + y_large
+            * (
+                -0.00157565
+                + y_large
+                * (
+                    0.00916281
+                    + y_large
+                    * (
+                        -0.02057706
+                        + y_large
+                        * (0.02635537 + y_large * (-0.01647633 + y_large * 0.00392377))
+                    )
+                )
+            )
+        )
+    )
+    val_large = tl.exp(ax) * poly_large / tl.sqrt(ax)
+
+    result = tl.where(ax <= 3.75, poly_small, val_large)
+
+    result_cast = tl.cast(result, x.dtype)
+    tl.store(x_ptr + offsets, result_cast, mask=mask)
+
+
+# Keep a reference to the Triton kernel before defining the Python wrapper with the same name
+i0__kernel = i0_
+
+
+def i0_(*args, **kwargs):
+    x = None
+    if len(args) > 0:
+        x = args[0]
+    else:
+        # Try common keyword names
+        for k in ("input", "self", "x"):
+            if k in kwargs:
+                x = kwargs[k]
+                break
+    if x is None:
+        raise ValueError(
+            "i0_ expects a tensor as the first positional argument or in keyword 'input'/'self'/'x'."
+        )
+
+    if not x.is_cuda:
+        raise AssertionError("Input tensor must be on a CUDA device.")
+    if not x.is_contiguous():
+        raise AssertionError("Input tensor must be contiguous.")
+    if x.dtype not in (torch.float16, torch.bfloat16, torch.float32, torch.float64):
+        raise AssertionError(
+            "Unsupported dtype for i0_. Supported: float16, bfloat16, float32, float64."
+        )
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    i0__kernel[grid](x, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/le_.py
+++ b/src/flag_gems/experimental_ops/le_.py
@@ -1,0 +1,106 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def le_inplace_kernel(
+    x_ptr,  # *Pointer* to input/output tensor (in-place)
+    y_ptr,  # *Pointer* to second tensor (ignored if is_scalar=True)
+    n_elements,  # Number of elements
+    scalar,  # Scalar value for comparison when is_scalar=True
+    IS_SCALAR: tl.constexpr,  # Whether we are comparing against a scalar
+    X_IS_BOOL: tl.constexpr,  # Whether x dtype is bool
+    BLOCK_SIZE: tl.constexpr,  # Elements per program
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    if IS_SCALAR:
+        y = tl.full((BLOCK_SIZE,), scalar, x.dtype)
+    else:
+        y = tl.load(y_ptr + offsets, mask=mask).to(x.dtype)
+
+    cmp_res = x <= y
+
+    if X_IS_BOOL:
+        out = cmp_res
+    else:
+        one = tl.full((BLOCK_SIZE,), 1, x.dtype)
+        zero = tl.full((BLOCK_SIZE,), 0, x.dtype)
+        out = tl.where(cmp_res, one, zero)
+
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+def _launch_le_inplace(x: torch.Tensor, y: torch.Tensor = None, scalar=None):
+    assert x.is_cuda, "Input tensor must be on CUDA device"
+    assert x.is_contiguous(), "Only contiguous tensors are supported"
+
+    n_elements = x.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    x_is_bool = x.dtype == torch.bool
+
+    if scalar is not None:
+        # Use scalar path; pass x as y_ptr placeholder (unused)
+        le_inplace_kernel[grid](
+            x,
+            x,
+            n_elements,
+            scalar,
+            IS_SCALAR=True,
+            X_IS_BOOL=x_is_bool,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+    else:
+        assert y is not None, "Either a tensor 'y' or a scalar must be provided"
+        assert (
+            y.is_cuda and y.device == x.device
+        ), "Both tensors must be on the same CUDA device"
+        if y.numel() == 1:
+            # Treat 0-dim or single element tensor as scalar
+            scalar_val = y.item()
+            le_inplace_kernel[grid](
+                x,
+                x,
+                n_elements,
+                scalar_val,
+                IS_SCALAR=True,
+                X_IS_BOOL=x_is_bool,
+                BLOCK_SIZE=BLOCK_SIZE,
+            )
+            return x
+        assert y.is_contiguous(), "Only contiguous tensors are supported"
+        assert y.numel() == x.numel(), "Tensors must have the same number of elements"
+        if y.dtype != x.dtype:
+            y = y.to(dtype=x.dtype)
+        le_inplace_kernel[grid](
+            x,
+            y,
+            n_elements,
+            0,  # scalar is unused in tensor path
+            IS_SCALAR=False,
+            X_IS_BOOL=x_is_bool,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+    return x
+
+
+def le__Scalar(self: torch.Tensor, other):
+    """
+    In-place self <= other (scalar). Returns self.
+    """
+    return _launch_le_inplace(self, scalar=other)
+
+
+def le__Tensor(self: torch.Tensor, other: torch.Tensor):
+    """
+    In-place self <= other (tensor). Returns self.
+    """
+    return _launch_le_inplace(self, y=other)

--- a/src/flag_gems/experimental_ops/leaky_relu.py
+++ b/src/flag_gems/experimental_ops/leaky_relu.py
@@ -1,0 +1,61 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _leaky_relu_kernel(
+    x_ptr, y_ptr, n_elements, negative_slope, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    zero = tl.zeros([BLOCK_SIZE], dtype=x.dtype)
+    slope = tl.full([BLOCK_SIZE], negative_slope, dtype=x.dtype)
+    # y = x if x >= 0 else slope * x
+    # Equivalent, branchless:
+    y = tl.maximum(x, zero) + slope * tl.minimum(x, zero)
+
+    tl.store(y_ptr + offsets, y, mask=mask)
+
+
+def _launch_leaky_relu_kernel(
+    x: torch.Tensor, out: torch.Tensor, negative_slope: float
+):
+    if not x.is_cuda or not out.is_cuda:
+        raise ValueError("Input and output tensors must be on CUDA device.")
+    if x.numel() != out.numel():
+        raise ValueError("Input and output must have the same number of elements.")
+    if x.dtype != out.dtype:
+        raise ValueError("Input and output tensors must have the same dtype.")
+    if not x.is_contiguous():
+        x = x.contiguous()
+    if not out.is_contiguous():
+        raise ValueError("Output tensor must be contiguous.")
+
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _leaky_relu_kernel[grid](x, out, n_elements, float(negative_slope), BLOCK_SIZE=1024)
+    return out
+
+
+def leaky_relu(input: torch.Tensor, negative_slope: float = 0.01):
+    """
+    ATen: ('leaky_relu', <Autograd.disable: False>)
+    """
+    out = torch.empty_like(input)
+    return _launch_leaky_relu_kernel(input, out, negative_slope)
+
+
+def leaky_relu_out(
+    input: torch.Tensor, negative_slope: float = 0.01, out: torch.Tensor = None
+):
+    """
+    ATen: ('leaky_relu.out', <Autograd.disable: False>)
+    """
+    if out is None:
+        raise ValueError("Argument 'out' must be provided for leaky_relu_out.")
+    return _launch_leaky_relu_kernel(input, out, negative_slope)

--- a/src/flag_gems/experimental_ops/leaky_relu_.py
+++ b/src/flag_gems/experimental_ops/leaky_relu_.py
@@ -1,0 +1,69 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def leaky_relu_(
+    x_ptr,  # *Pointer* to input tensor data (modified in-place).
+    n_elements,  # Number of elements to process.
+    negative_slope,  # Scalar negative slope.
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.where(x >= 0, x, x * negative_slope)
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+_leaky_relu_kernel = leaky_relu_
+
+
+def leaky_relu_(*args, **kwargs):
+    # Parse arguments: expect (input, negative_slope=0.01)
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        x = kwargs.get("self", kwargs.get("input", None))
+    if x is None:
+        raise TypeError("leaky_relu_ expected a tensor as the first argument")
+
+    negative_slope = 0.01
+    if len(args) >= 2:
+        negative_slope = args[1]
+    else:
+        negative_slope = kwargs.get("negative_slope", negative_slope)
+
+    if isinstance(negative_slope, torch.Tensor):
+        negative_slope = negative_slope.item()
+    negative_slope = float(negative_slope)
+
+    # Fallbacks for unsupported environments/dtypes
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("leaky_relu_ expected a torch.Tensor")
+    if not x.is_cuda or x.numel() == 0:
+        return torch.ops.aten.leaky_relu_(x, negative_slope)
+
+    # For dtypes not well supported by Triton math, fallback to PyTorch
+    supported_dtypes = (torch.float16, torch.bfloat16, torch.float32)
+    if x.dtype not in supported_dtypes:
+        return torch.ops.aten.leaky_relu_(x, negative_slope)
+
+    # Ensure contiguous memory for in-place kernel; otherwise operate on a temp and copy back.
+    if not x.is_contiguous():
+        tmp = x.contiguous()
+        n_elements = tmp.numel()
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        _leaky_relu_kernel[grid](tmp, n_elements, negative_slope, BLOCK_SIZE=1024)
+        x.copy_(tmp)
+        return x
+
+    # Launch Triton kernel in-place
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _leaky_relu_kernel[grid](x, n_elements, negative_slope, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/lerp_.py
+++ b/src/flag_gems/experimental_ops/lerp_.py
@@ -1,0 +1,137 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _lerp_inplace_scalar_kernel(
+    x_ptr, end_ptr, n_elements, weight, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x_raw = tl.load(x_ptr + offsets, mask=mask, other=0)
+    y_raw = tl.load(end_ptr + offsets, mask=mask, other=0)
+
+    x32 = x_raw.to(tl.float32)
+    y32 = y_raw.to(tl.float32)
+    out32 = x32 + weight * (y32 - x32)
+
+    out = out32.to(x_raw.dtype)
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+@triton.jit
+def _lerp_inplace_tensor_kernel(
+    x_ptr, end_ptr, w_ptr, n_elements, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x_raw = tl.load(x_ptr + offsets, mask=mask, other=0)
+    y_raw = tl.load(end_ptr + offsets, mask=mask, other=0)
+    w_raw = tl.load(w_ptr + offsets, mask=mask, other=0)
+
+    x32 = x_raw.to(tl.float32)
+    y32 = y_raw.to(tl.float32)
+    w32 = w_raw.to(tl.float32)
+
+    out32 = x32 + w32 * (y32 - x32)
+    out = out32.to(x_raw.dtype)
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+def _ensure_contig_same_dtype_device(t: torch.Tensor, ref: torch.Tensor):
+    t = t.to(device=ref.device, dtype=ref.dtype)
+    if t.shape != ref.shape or not t.is_contiguous():
+        t = t.expand_as(ref).contiguous()
+    return t
+
+
+def _parse_args_scalar(args, kwargs):
+    # Accept either (self, end, weight) or args wrapped in a single tuple/list
+    if len(args) == 1 and isinstance(args[0], (tuple, list)):
+        args = tuple(args[0])
+    self_t = kwargs.get("self", args[0] if len(args) > 0 else None)
+    end = kwargs.get("end", args[1] if len(args) > 1 else None)
+    weight = kwargs.get("weight", args[2] if len(args) > 2 else None)
+    return self_t, end, weight
+
+
+def _parse_args_tensor(args, kwargs):
+    # Accept either (self, end, weight) or args wrapped in a single tuple/list
+    if len(args) == 1 and isinstance(args[0], (tuple, list)):
+        args = tuple(args[0])
+    self_t = kwargs.get("self", args[0] if len(args) > 0 else None)
+    end = kwargs.get("end", args[1] if len(args) > 1 else None)
+    weight = kwargs.get("weight", args[2] if len(args) > 2 else None)
+    return self_t, end, weight
+
+
+def lerp__Scalar(*args, **kwargs):
+    self_t, end, weight = _parse_args_scalar(args, kwargs)
+    if not isinstance(self_t, torch.Tensor) or not isinstance(end, torch.Tensor):
+        raise TypeError("lerp__Scalar expects tensors for 'self' and 'end'.")
+    if not torch.is_floating_point(self_t):
+        raise TypeError(
+            "lerp__Scalar only supports floating point tensors for in-place operation."
+        )
+    if not self_t.is_cuda or not end.is_cuda:
+        raise ValueError("lerp__Scalar requires CUDA tensors.")
+    if not self_t.is_contiguous():
+        raise ValueError(
+            "lerp__Scalar requires 'self' to be contiguous for in-place operation."
+        )
+
+    # Handle scalar weight (number or 0-dim tensor)
+    if isinstance(weight, torch.Tensor):
+        if weight.numel() != 1:
+            raise ValueError(
+                "Scalar overload received a non-scalar tensor for 'weight'."
+            )
+        weight_val = float(weight.item())
+    else:
+        weight_val = float(weight)
+
+    end_c = _ensure_contig_same_dtype_device(end, self_t)
+
+    n_elements = self_t.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _lerp_inplace_scalar_kernel[grid](
+        self_t, end_c, n_elements, float(weight_val), BLOCK_SIZE=1024
+    )
+    return self_t
+
+
+def lerp__Tensor(*args, **kwargs):
+    self_t, end, weight = _parse_args_tensor(args, kwargs)
+    if (
+        not isinstance(self_t, torch.Tensor)
+        or not isinstance(end, torch.Tensor)
+        or not isinstance(weight, torch.Tensor)
+    ):
+        raise TypeError("lerp__Tensor expects tensors for 'self', 'end', and 'weight'.")
+    if not torch.is_floating_point(self_t):
+        raise TypeError(
+            "lerp__Tensor only supports floating point tensors for in-place operation."
+        )
+    if not self_t.is_cuda or not end.is_cuda or not weight.is_cuda:
+        raise ValueError("lerp__Tensor requires CUDA tensors.")
+    if not self_t.is_contiguous():
+        raise ValueError(
+            "lerp__Tensor requires 'self' to be contiguous for in-place operation."
+        )
+
+    end_c = _ensure_contig_same_dtype_device(end, self_t)
+    weight_c = _ensure_contig_same_dtype_device(weight, self_t)
+
+    n_elements = self_t.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _lerp_inplace_tensor_kernel[grid](
+        self_t, end_c, weight_c, n_elements, BLOCK_SIZE=1024
+    )
+    return self_t

--- a/src/flag_gems/experimental_ops/less_.py
+++ b/src/flag_gems/experimental_ops/less_.py
@@ -1,0 +1,90 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def less_inplace_kernel(
+    x_ptr, y_ptr, n_elements, SCALAR: tl.constexpr, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    if SCALAR:
+        y = tl.load(y_ptr)
+    else:
+        y = tl.load(y_ptr + offsets, mask=mask)
+
+    cmp = x < y
+    one = tl.full([BLOCK_SIZE], 1, x.dtype)
+    zero = tl.full([BLOCK_SIZE], 0, x.dtype)
+    out = tl.where(cmp, one, zero)
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+def _launch_less_inplace(x: torch.Tensor, y_tensor: torch.Tensor, scalar: bool):
+    assert x.is_cuda, "Input tensor must be on CUDA device"
+    assert y_tensor.is_cuda, "Other/scalar tensor must be on CUDA device"
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert y_tensor.is_contiguous(), "Other/scalar tensor must be contiguous"
+    n_elements = x.numel()
+    assert scalar or (
+        y_tensor.numel() == n_elements
+    ), "Shape mismatch for elementwise comparison"
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    less_inplace_kernel[grid](x, y_tensor, n_elements, SCALAR=scalar, BLOCK_SIZE=1024)
+    return x
+
+
+def less__Scalar(self: torch.Tensor, other):
+    x = self
+    # Ensure contiguity; if not, operate on a contiguous copy and copy back.
+    needs_copy_back = not x.is_contiguous()
+    if needs_copy_back:
+        x_work = x.contiguous()
+    else:
+        x_work = x
+
+    # Make scalar tensor on device, cast to x dtype
+    y_tensor = torch.tensor(
+        [other], dtype=x_work.dtype, device=x_work.device
+    ).contiguous()
+
+    _launch_less_inplace(x_work, y_tensor, scalar=True)
+
+    if needs_copy_back:
+        self.copy_(x_work)
+    return self
+
+
+def less__Tensor(self: torch.Tensor, other: torch.Tensor):
+    x = self
+    # Ensure contiguity; if not, operate on a contiguous copy and copy back.
+    needs_copy_back = not x.is_contiguous()
+    if needs_copy_back:
+        x_work = x.contiguous()
+    else:
+        x_work = x
+
+    # Prepare 'other' on same device/dtype and choose scalar or tensor path
+    if other.numel() == 1:
+        y_tensor = (
+            other.to(dtype=x_work.dtype, device=x_work.device).reshape(1).contiguous()
+        )
+        scalar = True
+    else:
+        assert (
+            other.numel() == x_work.numel()
+        ), "Shape mismatch for elementwise comparison"
+        y_tensor = other.to(dtype=x_work.dtype, device=x_work.device).contiguous()
+        scalar = False
+
+    _launch_less_inplace(x_work, y_tensor, scalar=scalar)
+
+    if needs_copy_back:
+        self.copy_(x_work)
+    return self

--- a/src/flag_gems/experimental_ops/lift.py
+++ b/src/flag_gems/experimental_ops/lift.py
@@ -1,0 +1,47 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _copy_kernel(src_ptr, dst_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(src_ptr + offsets, mask=mask)
+    tl.store(dst_ptr + offsets, x, mask=mask)
+
+
+def lift(x: torch.Tensor):
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("lift expects a single Tensor argument")
+    if x.device.type != "cuda":
+        raise RuntimeError("lift: input tensor must be on a CUDA device")
+    out = torch.empty_like(x)
+    n_elements = out.numel()
+    if n_elements > 0:
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        _copy_kernel[grid](x, out, n_elements, BLOCK_SIZE=1024)
+    return out
+
+
+def lift_out(x: torch.Tensor, out: torch.Tensor):
+    if not isinstance(x, torch.Tensor) or not isinstance(out, torch.Tensor):
+        raise TypeError("lift_out expects (Tensor x, Tensor out)")
+    if x.device.type != "cuda" or out.device.type != "cuda":
+        raise RuntimeError(
+            "lift_out: both input and out tensors must be on a CUDA device"
+        )
+    if out.device != x.device:
+        raise RuntimeError("lift_out: out tensor must be on the same device as input")
+    if out.dtype != x.dtype:
+        raise RuntimeError("lift_out: out tensor must have the same dtype as input")
+    # Resize out to match shape; this ensures a contiguous layout and correct size.
+    if tuple(out.shape) != tuple(x.shape):
+        out.resize_(x.shape)
+    n_elements = x.numel()
+    if n_elements > 0:
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        _copy_kernel[grid](x, out, n_elements, BLOCK_SIZE=1024)
+    return out

--- a/src/flag_gems/experimental_ops/lift_fresh.py
+++ b/src/flag_gems/experimental_ops/lift_fresh.py
@@ -1,0 +1,42 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def lift_fresh(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    # No-op: masked load/store ensure no memory access when n_elements == 0
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    tl.store(x_ptr + offsets, x, mask=mask)
+
+
+LIFT_FRESH_KERNEL = lift_fresh
+
+
+def lift_fresh(*args, **kwargs):
+    # Return the first argument unchanged, matching aten.lift_fresh semantics.
+    # Launch a no-op Triton kernel to satisfy kernel launch requirement.
+    x = args[0] if len(args) > 0 else kwargs.get("args", None)
+
+    # Try to find a tensor to determine device/dtype for the dummy launch
+    tensor_arg = None
+    if isinstance(x, torch.Tensor):
+        tensor_arg = x
+    else:
+        for a in args:
+            if isinstance(a, torch.Tensor):
+                tensor_arg = a
+                break
+        if tensor_arg is None and isinstance(kwargs.get("args", None), torch.Tensor):
+            tensor_arg = kwargs["args"]
+
+    if tensor_arg is not None and tensor_arg.is_cuda:
+        dummy = torch.empty((1,), device=tensor_arg.device, dtype=tensor_arg.dtype)
+        grid = lambda meta: (1,)
+        LIFT_FRESH_KERNEL[grid](dummy, 0, BLOCK_SIZE=1)
+
+    return x

--- a/src/flag_gems/experimental_ops/lift_fresh_copy.py
+++ b/src/flag_gems/experimental_ops/lift_fresh_copy.py
@@ -1,0 +1,69 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _copy_kernel(in_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(in_ptr + offsets, mask=mask)
+    tl.store(out_ptr + offsets, x, mask=mask)
+
+
+def lift_fresh_copy(*args, **kwargs):
+    # Attempt to find the input tensor from args/kwargs
+    x = None
+    if len(args) > 0 and isinstance(args[0], torch.Tensor):
+        x = args[0]
+    elif "self" in kwargs and isinstance(kwargs["self"], torch.Tensor):
+        x = kwargs["self"]
+    else:
+        for v in list(args) + list(kwargs.values()):
+            if isinstance(v, torch.Tensor):
+                x = v
+                break
+    if x is None:
+        raise ValueError("lift_fresh_copy expects a Tensor argument")
+
+    if not x.is_cuda:
+        raise ValueError("lift_fresh_copy Triton kernel requires a CUDA tensor")
+
+    x_contig = x.contiguous()
+    out = torch.empty_like(x_contig, memory_format=torch.contiguous_format)
+
+    n_elements = x_contig.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _copy_kernel[grid](x_contig, out, n_elements, BLOCK_SIZE=1024)
+
+    return out.view_as(x_contig)
+
+
+def lift_fresh_copy_out(x: torch.Tensor, out: torch.Tensor = None):
+    if x is None or not isinstance(x, torch.Tensor):
+        raise ValueError("lift_fresh_copy_out expects 'x' to be a Tensor")
+    if not x.is_cuda:
+        raise ValueError("lift_fresh_copy_out Triton kernel requires CUDA tensors")
+
+    x_contig = x.contiguous()
+
+    if out is None:
+        out = torch.empty_like(x_contig, memory_format=torch.contiguous_format)
+    else:
+        if not out.is_cuda:
+            raise ValueError("Output tensor 'out' must be on CUDA")
+        if out.dtype != x_contig.dtype:
+            raise ValueError("Output tensor 'out' must have the same dtype as input")
+        # Resize to match input shape and ensure contiguous layout
+        if out.numel() != x_contig.numel() or not out.is_contiguous():
+            out.resize_(x_contig.shape)
+            if not out.is_contiguous():
+                out = out.contiguous()
+
+    n_elements = x_contig.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _copy_kernel[grid](x_contig, out, n_elements, BLOCK_SIZE=1024)
+
+    return out.view_as(x_contig)

--- a/src/flag_gems/experimental_ops/log2.py
+++ b/src/flag_gems/experimental_ops/log2.py
@@ -1,0 +1,88 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def log2_kernel(x_ptr, y_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    # log2(x) = ln(x) * (1/ln(2))
+    y = tl.log(x) * 1.4426950408889634074  # 1/ln(2)
+    tl.store(y_ptr + offsets, y, mask=mask)
+
+
+def _launch_log2_kernel(x_fp32: torch.Tensor, y_fp32: torch.Tensor):
+    assert x_fp32.is_cuda and y_fp32.is_cuda, "Inputs must be CUDA tensors."
+    assert (
+        x_fp32.dtype == torch.float32 and y_fp32.dtype == torch.float32
+    ), "Kernel expects float32 tensors."
+    assert (
+        x_fp32.numel() == y_fp32.numel()
+    ), "Input and output must have the same number of elements."
+    n_elements = x_fp32.numel()
+    if n_elements == 0:
+        return
+    x_flat = x_fp32.contiguous().view(-1)
+    y_flat = y_fp32.contiguous().view(-1)
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    log2_kernel[grid](x_flat, y_flat, n_elements, BLOCK_SIZE=1024)
+
+
+def log2(input: torch.Tensor):
+    if not isinstance(input, torch.Tensor):
+        raise TypeError("log2: input must be a torch.Tensor")
+    if not input.is_cuda:
+        raise RuntimeError("log2: input must be a CUDA tensor for Triton execution.")
+    if input.is_complex():
+        raise NotImplementedError(
+            "log2: complex dtypes are not supported by this Triton implementation."
+        )
+
+    # Determine output dtype (follow PyTorch behavior: integers -> float32)
+    if input.is_floating_point():
+        out_dtype = input.dtype
+    else:
+        out_dtype = torch.float32
+
+    # Compute in float32 for broad device support, then cast to desired dtype if needed
+    x_fp32 = input.to(torch.float32)
+    y_fp32 = torch.empty_like(x_fp32, dtype=torch.float32)
+    _launch_log2_kernel(x_fp32, y_fp32)
+
+    if out_dtype != torch.float32:
+        return y_fp32.to(dtype=out_dtype)
+    return y_fp32
+
+
+def log2_out(input: torch.Tensor, out: torch.Tensor):
+    if not isinstance(input, torch.Tensor) or not isinstance(out, torch.Tensor):
+        raise TypeError("log2_out: both input and out must be torch.Tensors")
+    if not input.is_cuda or not out.is_cuda:
+        raise RuntimeError(
+            "log2_out: input and out must be CUDA tensors for Triton execution."
+        )
+    if input.is_complex() or out.is_complex():
+        raise NotImplementedError(
+            "log2_out: complex dtypes are not supported by this Triton implementation."
+        )
+    if not out.is_floating_point():
+        raise TypeError("log2_out: out tensor must have a floating-point dtype.")
+    if out.shape != input.shape:
+        raise ValueError("log2_out: out tensor must have the same shape as input.")
+
+    # Compute in float32 and cast/copy to out
+    x_fp32 = input.to(torch.float32)
+    if out.dtype == torch.float32 and out.is_contiguous():
+        y_fp32 = out
+    else:
+        y_fp32 = torch.empty_like(x_fp32, dtype=torch.float32)
+
+    _launch_log2_kernel(x_fp32, y_fp32)
+
+    if y_fp32.data_ptr() != out.data_ptr() or out.dtype != torch.float32:
+        out.copy_(y_fp32.to(dtype=out.dtype))
+    return out

--- a/src/flag_gems/experimental_ops/log_.py
+++ b/src/flag_gems/experimental_ops/log_.py
@@ -1,0 +1,51 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def log_(
+    x_ptr,  # *Pointer* to input/output vector (in-place).
+    n_elements,  # Number of elements.
+    BLOCK_SIZE: tl.constexpr,  # Elements processed per program.
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x_f32 = x.to(tl.float32)
+    y_f32 = tl.log(x_f32)
+    y = y_f32.to(x.dtype)
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# Keep a handle to the Triton kernel before defining the Python wrapper with the same name.
+log__triton_kernel = log_
+
+
+def log_(*args, **kwargs):
+    x = args[0] if len(args) > 0 else kwargs.get("input", None)
+    if x is None:
+        raise ValueError("log_ expects a tensor as the first argument.")
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("log_ expects a torch.Tensor as input.")
+    if not x.is_cuda:
+        raise ValueError("Input tensor must be on a CUDA device.")
+    if not x.is_floating_point():
+        raise TypeError("log_ only supports floating point tensors.")
+    if not x.is_contiguous():
+        raise ValueError(
+            "This log_ Triton implementation requires a contiguous tensor."
+        )
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    log__triton_kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/logical_not_.py
+++ b/src/flag_gems/experimental_ops/logical_not_.py
@@ -1,0 +1,52 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def logical_not__kernel(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    y = x == 0
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+def logical_not_(*args, **kwargs):
+    # Extract the input tensor following aten.logical_not_ schema: (Tensor self) -> Tensor
+    x = None
+    if len(args) >= 1:
+        x = args[0]
+    elif "self" in kwargs:
+        x = kwargs["self"]
+    elif "input" in kwargs:
+        x = kwargs["input"]
+    if x is None:
+        raise ValueError("logical_not_ expects a tensor as the first argument.")
+
+    if x.dtype is not torch.bool:
+        raise TypeError(
+            "logical_not_ only supports bool tensors (in-place operation cannot change dtype)."
+        )
+
+    # If not CUDA tensor, fall back to PyTorch implementation for correctness
+    if not x.is_cuda:
+        return torch.ops.aten.logical_not_(x)
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    # Work on a contiguous buffer; copy back if original is not contiguous
+    needs_copy_back = not x.is_contiguous()
+    buf = x if not needs_copy_back else x.contiguous()
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    logical_not__kernel[grid](buf, n_elements, BLOCK_SIZE=1024)
+
+    if needs_copy_back:
+        x.copy_(buf)
+
+    return x

--- a/src/flag_gems/experimental_ops/lt_.py
+++ b/src/flag_gems/experimental_ops/lt_.py
@@ -1,0 +1,82 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def lt_inplace_kernel(
+    x_ptr, y_ptr, n_elements, IS_SCALAR: tl.constexpr, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    if IS_SCALAR:
+        s = tl.load(y_ptr)  # y_ptr points to a single element tensor
+        cmp = x < s
+    else:
+        y = tl.load(y_ptr + offsets, mask=mask)
+        cmp = x < y
+
+    # Cast boolean comparison result to the dtype of x for in-place store
+    one = tl.full(x.shape, 1, x.dtype)
+    zero = tl.full(x.shape, 0, x.dtype)
+    out = tl.where(cmp, one, zero)
+
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+def lt__Tensor(self: torch.Tensor, other: torch.Tensor):
+    assert self.is_cuda, "Input tensor must be on CUDA device"
+    assert other.is_cuda, "Other tensor must be on CUDA device"
+    assert not self.is_complex(), "Complex dtypes are not supported"
+    assert (
+        self.is_contiguous()
+    ), "Only contiguous tensors are supported for in-place lt_"
+    # Support either same numel or scalar-like other (numel == 1)
+    if other.numel() == 1:
+        # Ensure dtype matches self for comparison
+        scalar_buf = other.to(self.dtype).reshape(1).contiguous()
+        n_elements = self.numel()
+        BLOCK_SIZE = 1024
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        lt_inplace_kernel[grid](
+            self, scalar_buf, n_elements, IS_SCALAR=True, BLOCK_SIZE=BLOCK_SIZE
+        )
+        return self
+    else:
+        assert (
+            self.numel() == other.numel()
+        ), "Shapes must match or other must be scalar"
+        assert other.is_contiguous(), "Only contiguous tensors are supported for other"
+        # Cast other to self dtype for comparison
+        other_buf = other.to(self.dtype).contiguous()
+        n_elements = self.numel()
+        BLOCK_SIZE = 1024
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        lt_inplace_kernel[grid](
+            self, other_buf, n_elements, IS_SCALAR=False, BLOCK_SIZE=BLOCK_SIZE
+        )
+        return self
+
+
+def lt__Scalar(self: torch.Tensor, other):
+    assert self.is_cuda, "Input tensor must be on CUDA device"
+    assert not self.is_complex(), "Complex dtypes are not supported"
+    assert (
+        self.is_contiguous()
+    ), "Only contiguous tensors are supported for in-place lt_"
+    # Create a 1-element tensor on device with same dtype as self for scalar compare
+    scalar_buf = torch.tensor(
+        [other], device=self.device, dtype=self.dtype
+    ).contiguous()
+    n_elements = self.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    lt_inplace_kernel[grid](
+        self, scalar_buf, n_elements, IS_SCALAR=True, BLOCK_SIZE=BLOCK_SIZE
+    )
+    return self

--- a/src/flag_gems/experimental_ops/masked_fill.py
+++ b/src/flag_gems/experimental_ops/masked_fill.py
@@ -1,0 +1,144 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def masked_fill_kernel(
+    x_ptr,
+    mask_ptr,
+    fill_ptr,
+    out_ptr,
+    n_elements,
+    shape_ptr,
+    x_stride_ptr,
+    mask_stride_ptr,
+    fill_stride_ptr,
+    out_stride_ptr,
+    NDIMS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    valid = offsets < n_elements
+
+    # Use int64 for address computations
+    rem = offsets.to(tl.int64)
+    out_off = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+    x_off = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+    mask_off = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+    fill_off = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+
+    # Compute per-dimension indices and offsets
+    for d in range(NDIMS - 1, -1, -1):
+        size_d = tl.load(shape_ptr + d)
+        idx_d = rem % size_d
+        rem = rem // size_d
+
+        sx_d = tl.load(x_stride_ptr + d)
+        sm_d = tl.load(mask_stride_ptr + d)
+        sf_d = tl.load(fill_stride_ptr + d)
+        so_d = tl.load(out_stride_ptr + d)
+
+        x_off += idx_d * sx_d
+        mask_off += idx_d * sm_d
+        fill_off += idx_d * sf_d
+        out_off += idx_d * so_d
+
+    # Load values
+    x_val = tl.load(x_ptr + x_off, mask=valid)
+    m_val = tl.load(mask_ptr + mask_off, mask=valid)
+    f_val = tl.load(fill_ptr + fill_off, mask=valid)
+
+    # Convert mask to boolean
+    m_bool = m_val != 0
+
+    # Compute output
+    out_val = tl.where(m_bool, f_val, x_val)
+
+    # Store
+    tl.store(out_ptr + out_off, out_val, mask=valid)
+
+
+def _launch_masked_fill(
+    x: torch.Tensor, mask: torch.Tensor, fill: torch.Tensor, out: torch.Tensor
+):
+    assert x.is_cuda and mask.is_cuda and fill.is_cuda and out.is_cuda
+    assert x.device == mask.device == fill.device == out.device
+
+    # Output shape is the shape of x
+    shape = tuple(x.shape)
+    NDIMS = len(shape)
+
+    # Ensure dtype matches
+    fill = fill.to(dtype=x.dtype)
+
+    # Make sure mask is boolean then cast to int8 for robust kernel comparison
+    mask = mask.to(torch.bool).to(torch.int8)
+
+    # Expand mask and fill to match x's shape for proper broadcasting strides
+    mask_exp = mask.expand(shape)
+    fill_exp = fill.expand(shape)
+
+    # Prepare stride and shape tensors (int64) on device
+    shape_t = torch.tensor(shape, dtype=torch.int64, device=x.device)
+    x_stride_t = torch.tensor(x.stride(), dtype=torch.int64, device=x.device)
+    mask_stride_t = torch.tensor(mask_exp.stride(), dtype=torch.int64, device=x.device)
+    fill_stride_t = torch.tensor(fill_exp.stride(), dtype=torch.int64, device=x.device)
+    out_stride_t = torch.tensor(out.stride(), dtype=torch.int64, device=x.device)
+
+    n_elements = out.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    masked_fill_kernel[grid](
+        x,
+        mask_exp,
+        fill_exp,
+        out,
+        n_elements,
+        shape_t,
+        x_stride_t,
+        mask_stride_t,
+        fill_stride_t,
+        out_stride_t,
+        NDIMS=NDIMS,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+def masked_fill_Scalar(self: torch.Tensor, mask: torch.Tensor, value):
+    # Create a 1-element tensor of the scalar value on device with matching dtype
+    fill = torch.tensor(value, dtype=self.dtype, device=self.device)
+    out = torch.empty_like(self)
+    _launch_masked_fill(self, mask, fill, out)
+    return out
+
+
+def masked_fill_Tensor(self: torch.Tensor, mask: torch.Tensor, value: torch.Tensor):
+    fill = value.to(device=self.device, dtype=self.dtype)
+    out = torch.empty_like(self)
+    _launch_masked_fill(self, mask, fill, out)
+    return out
+
+
+def masked_fill_Scalar_out(
+    self: torch.Tensor, mask: torch.Tensor, value, out: torch.Tensor
+):
+    assert out.is_cuda and out.device == self.device
+    assert out.shape == self.shape
+    # Create a 1-element tensor of the scalar value on device with matching dtype
+    fill = torch.tensor(value, dtype=self.dtype, device=self.device)
+    _launch_masked_fill(self, mask, fill, out)
+    return out
+
+
+def masked_fill_Tensor_out(
+    self: torch.Tensor, mask: torch.Tensor, value: torch.Tensor, out: torch.Tensor
+):
+    assert out.is_cuda and out.device == self.device
+    assert out.shape == self.shape
+    fill = value.to(device=self.device, dtype=self.dtype)
+    _launch_masked_fill(self, mask, fill, out)
+    return out

--- a/src/flag_gems/experimental_ops/masked_select.py
+++ b/src/flag_gems/experimental_ops/masked_select.py
@@ -1,0 +1,139 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _masked_select_count_kernel(
+    mask_ptr,  # int32* flattened mask (0/1)
+    n_elements,  # int32 number of elements
+    counts_ptr,  # int32* per-block counts
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    in_bounds = offsets < n_elements
+
+    flags = tl.load(mask_ptr + offsets, mask=in_bounds, other=0)  # int32 0/1
+    block_count = tl.sum(flags, axis=0)
+    tl.store(counts_ptr + pid, block_count)
+
+
+@triton.jit
+def _masked_select_scatter_kernel(
+    input_ptr,  # * input data (flattened, contiguous)
+    mask_ptr,  # int32* flattened mask (0/1)
+    block_offsets_ptr,  # int32* per-block exclusive offsets
+    output_ptr,  # * output data
+    n_elements,  # int32 number of elements
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    in_bounds = offsets < n_elements
+
+    flags = tl.load(mask_ptr + offsets, mask=in_bounds, other=0)  # int32
+    # Compute local exclusive positions for true elements
+    inclusive = tl.cumsum(flags, axis=0)
+    local_pos = inclusive - 1  # valid only where flags == 1
+
+    base = tl.load(block_offsets_ptr + pid)  # int32
+    write_idx = base + local_pos
+
+    mstore = in_bounds & (flags != 0)
+    vals = tl.load(input_ptr + offsets, mask=mstore, other=0)
+    tl.store(output_ptr + write_idx, vals, mask=mstore)
+
+
+def _prepare_broadcast_flatten(input: torch.Tensor, mask: torch.Tensor):
+    # Broadcast input and mask to a common shape
+    bshape = torch.broadcast_shapes(tuple(input.shape), tuple(mask.shape))
+    inp_b = input.expand(bshape)
+    msk_b = mask.to(torch.bool).expand(bshape)
+
+    # Make contiguous flattened views
+    inp_flat = inp_b.contiguous().view(-1)
+    msk_flat_bool = msk_b.contiguous().view(-1)
+    # Convert mask to int32 (0/1) for kernels
+    msk_flat_i32 = msk_flat_bool.to(torch.int32)
+    return inp_flat, msk_flat_i32
+
+
+def masked_select(input: torch.Tensor, mask: torch.Tensor):
+    inp_flat, msk_flat_i32 = _prepare_broadcast_flatten(input, mask)
+    device = inp_flat.device
+    assert msk_flat_i32.device == device, "input and mask must be on the same device"
+
+    n_elements = inp_flat.numel()
+    if n_elements == 0:
+        return torch.empty(0, dtype=input.dtype, device=device)
+
+    BLOCK_SIZE = 1024
+    num_blocks = triton.cdiv(n_elements, BLOCK_SIZE)
+
+    counts = torch.empty(num_blocks, dtype=torch.int32, device=device)
+    grid = (num_blocks,)
+    _masked_select_count_kernel[grid](
+        msk_flat_i32, n_elements, counts, BLOCK_SIZE=BLOCK_SIZE
+    )
+
+    # Compute per-block exclusive offsets and total number of selected elements
+    if num_blocks == 1:
+        block_offsets = torch.zeros(1, dtype=torch.int32, device=device)
+        total_selected = int(counts[0].item())
+    else:
+        prefix = torch.cumsum(counts, dim=0)
+        block_offsets = torch.empty_like(counts)
+        block_offsets[0] = 0
+        block_offsets[1:] = prefix[:-1]
+        total_selected = int(prefix[-1].item())
+
+    output = torch.empty(total_selected, dtype=input.dtype, device=device)
+    _masked_select_scatter_kernel[grid](
+        inp_flat, msk_flat_i32, block_offsets, output, n_elements, BLOCK_SIZE=BLOCK_SIZE
+    )
+    return output
+
+
+def masked_select_out(input: torch.Tensor, mask: torch.Tensor, out: torch.Tensor):
+    inp_flat, msk_flat_i32 = _prepare_broadcast_flatten(input, mask)
+    device = inp_flat.device
+    assert msk_flat_i32.device == device, "input and mask must be on the same device"
+    if out.device != device:
+        raise RuntimeError("out tensor must be on the same device as input")
+
+    n_elements = inp_flat.numel()
+    if n_elements == 0:
+        out.resize_(0)
+        return out
+
+    BLOCK_SIZE = 1024
+    num_blocks = triton.cdiv(n_elements, BLOCK_SIZE)
+
+    counts = torch.empty(num_blocks, dtype=torch.int32, device=device)
+    grid = (num_blocks,)
+    _masked_select_count_kernel[grid](
+        msk_flat_i32, n_elements, counts, BLOCK_SIZE=BLOCK_SIZE
+    )
+
+    # Compute per-block exclusive offsets and total number of selected elements
+    if num_blocks == 1:
+        block_offsets = torch.zeros(1, dtype=torch.int32, device=device)
+        total_selected = int(counts[0].item())
+    else:
+        prefix = torch.cumsum(counts, dim=0)
+        block_offsets = torch.empty_like(counts)
+        block_offsets[0] = 0
+        block_offsets[1:] = prefix[:-1]
+        total_selected = int(prefix[-1].item())
+
+    if out.dtype != input.dtype:
+        raise RuntimeError("out tensor dtype must match input dtype")
+    out.resize_(total_selected)
+
+    _masked_select_scatter_kernel[grid](
+        inp_flat, msk_flat_i32, block_offsets, out, n_elements, BLOCK_SIZE=BLOCK_SIZE
+    )
+    return out

--- a/src/flag_gems/experimental_ops/maximum.py
+++ b/src/flag_gems/experimental_ops/maximum.py
@@ -1,0 +1,262 @@
+import torch
+import triton
+import triton.language as tl
+
+MAX_DIMS = 8
+BLOCK_SIZE = 1024
+
+
+@triton.jit
+def maximum_kernel(
+    a_ptr,
+    b_ptr,
+    out_ptr,
+    n_elements,
+    s0,
+    s1,
+    s2,
+    s3,
+    s4,
+    s5,
+    s6,
+    s7,  # shape dims
+    sa0,
+    sa1,
+    sa2,
+    sa3,
+    sa4,
+    sa5,
+    sa6,
+    sa7,  # a strides
+    sb0,
+    sb1,
+    sb2,
+    sb3,
+    sb4,
+    sb5,
+    sb6,
+    sb7,  # b strides
+    so0,
+    so1,
+    so2,
+    so3,
+    so4,
+    so5,
+    so6,
+    so7,  # out strides
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    # Use int64 for address calculations
+    li = offsets.to(tl.int64)
+
+    # Compute multi-dimensional indices from linear index (row-major: last dim fastest)
+    i7 = li % s7
+    li = li // s7
+    i6 = li % s6
+    li = li // s6
+    i5 = li % s5
+    li = li // s5
+    i4 = li % s4
+    li = li // s4
+    i3 = li % s3
+    li = li // s3
+    i2 = li % s2
+    li = li // s2
+    i1 = li % s1
+    li = li // s1
+    i0 = li % s0
+    li = li // s0
+
+    # Compute element offsets for each tensor using strides (in elements)
+    off_a = (
+        i0 * sa0
+        + i1 * sa1
+        + i2 * sa2
+        + i3 * sa3
+        + i4 * sa4
+        + i5 * sa5
+        + i6 * sa6
+        + i7 * sa7
+    )
+    off_b = (
+        i0 * sb0
+        + i1 * sb1
+        + i2 * sb2
+        + i3 * sb3
+        + i4 * sb4
+        + i5 * sb5
+        + i6 * sb6
+        + i7 * sb7
+    )
+    off_o = (
+        i0 * so0
+        + i1 * so1
+        + i2 * so2
+        + i3 * so3
+        + i4 * so4
+        + i5 * so5
+        + i6 * so6
+        + i7 * so7
+    )
+
+    a_vals = tl.load(a_ptr + off_a, mask=mask, other=0)
+    b_vals = tl.load(b_ptr + off_b, mask=mask, other=0)
+    out_vals = tl.maximum(a_vals, b_vals)
+    tl.store(out_ptr + off_o, out_vals, mask=mask)
+
+
+def _as_tensor_on_device(x, device, dtype=None):
+    if torch.is_tensor(x):
+        return (
+            x.to(device=device, dtype=dtype)
+            if (dtype is not None and x.dtype != dtype) or (x.device != device)
+            else x
+        )
+    return torch.tensor(x, device=device, dtype=dtype)
+
+
+def _broadcast_to_common(a, b):
+    a_b, b_b = torch.broadcast_tensors(a, b)
+    return a_b, b_b
+
+
+def _pad_shape_strides(shape, strides):
+    # Ensure shape dims are at least 1 to avoid div by zero
+    shape_list = list(shape)
+    strides_list = list(strides)
+    nd = len(shape_list)
+    assert nd <= MAX_DIMS
+    shape_list = shape_list + [1] * (MAX_DIMS - nd)
+    strides_list = strides_list + [0] * (MAX_DIMS - nd)
+    # Triton expects integers
+    shape_list = [int(s) for s in shape_list]
+    strides_list = [int(s) for s in strides_list]
+    return shape_list, strides_list
+
+
+def _launch_maximum_kernel(a, b, out):
+    # Assumes a and b are broadcastable and already cast to out.dtype and on same device
+    a_b, b_b = _broadcast_to_common(a, b)
+    # Make inputs contiguous to avoid negative/irregular strides complications
+    # Broadcasting uses 0-stride for broadcasted dims; keeping 0-stride is fine
+    # but handle potential negative/non-standard strides by materializing.
+    if any(s < 0 for s in a_b.stride()):
+        a_b = a_b.contiguous()
+    if any(s < 0 for s in b_b.stride()):
+        b_b = b_b.contiguous()
+
+    out_shape = a_b.shape  # == b_b.shape
+    n_elements = int(a_b.numel())
+    if n_elements == 0:
+        return
+
+    # Prepare shape and strides for kernel
+    shp, sa = _pad_shape_strides(out_shape, a_b.stride())
+    _, sb = _pad_shape_strides(out_shape, b_b.stride())
+    _, so = _pad_shape_strides(out_shape, out.stride())
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    maximum_kernel[grid](
+        a_b,
+        b_b,
+        out,
+        n_elements,
+        shp[0],
+        shp[1],
+        shp[2],
+        shp[3],
+        shp[4],
+        shp[5],
+        shp[6],
+        shp[7],
+        sa[0],
+        sa[1],
+        sa[2],
+        sa[3],
+        sa[4],
+        sa[5],
+        sa[6],
+        sa[7],
+        sb[0],
+        sb[1],
+        sb[2],
+        sb[3],
+        sb[4],
+        sb[5],
+        sb[6],
+        sb[7],
+        so[0],
+        so[1],
+        so[2],
+        so[3],
+        so[4],
+        so[5],
+        so[6],
+        so[7],
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+def maximum(a, b):
+    # Determine device
+    dev = None
+    if torch.is_tensor(a):
+        dev = a.device
+    if torch.is_tensor(b):
+        dev = b.device if dev is None else dev
+    if dev is None or dev.type != "cuda":
+        raise ValueError("maximum expects at least one CUDA tensor as input")
+
+    # Determine result dtype per PyTorch promotion rules
+    res_dtype = torch.result_type(a, b)
+    a_t = _as_tensor_on_device(a, dev, dtype=res_dtype)
+    b_t = _as_tensor_on_device(b, dev, dtype=res_dtype)
+
+    # Broadcast to determine output shape
+    a_b, b_b = _broadcast_to_common(a_t, b_t)
+    out = torch.empty(a_b.shape, device=dev, dtype=res_dtype)
+
+    # If out has negative strides or is non-contiguous, compute into a contiguous buffer then copy
+    if not out.is_contiguous() or any(s < 0 for s in out.stride()):
+        out_buf = torch.empty_like(out, memory_format=torch.contiguous_format)
+        _launch_maximum_kernel(a_t, b_t, out_buf)
+        out.copy_(out_buf)
+    else:
+        _launch_maximum_kernel(a_t, b_t, out)
+
+    return out
+
+
+def maximum_out(a, b, out):
+    if not torch.is_tensor(out):
+        raise TypeError("out must be a torch.Tensor")
+    if out.device.type != "cuda":
+        raise ValueError("out tensor must be on CUDA device")
+
+    dev = out.device
+
+    # Cast inputs to out dtype (following typical .out behavior)
+    a_t = _as_tensor_on_device(a, dev, dtype=out.dtype)
+    b_t = _as_tensor_on_device(b, dev, dtype=out.dtype)
+
+    # Validate/broadcast shape against out
+    a_b, b_b = _broadcast_to_common(a_t, b_t)
+    if tuple(a_b.shape) != tuple(out.shape):
+        raise ValueError(
+            f"out shape {tuple(out.shape)} is not broadcast-compatible with inputs shape {tuple(a_b.shape)}"
+        )
+
+    # If out has negative strides or is non-contiguous, compute into a contiguous buffer then copy
+    if not out.is_contiguous() or any(s < 0 for s in out.stride()):
+        out_buf = torch.empty_like(out, memory_format=torch.contiguous_format)
+        _launch_maximum_kernel(a_t, b_t, out_buf)
+        out.copy_(out_buf)
+    else:
+        _launch_maximum_kernel(a_t, b_t, out)
+
+    return out

--- a/src/flag_gems/experimental_ops/mse_loss.py
+++ b/src/flag_gems/experimental_ops/mse_loss.py
@@ -1,0 +1,207 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _mse_elemwise_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    diff = x - y
+    sq = diff * diff
+    tl.store(out_ptr + offsets, sq, mask=mask)
+
+
+@triton.jit
+def _mse_reduce_kernel(
+    x_ptr, y_ptr, acc_ptr, n_elements, scale, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    # load as float32 for stable accumulation
+    x = tl.load(x_ptr + offsets, mask=mask, other=0).to(tl.float32)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0).to(tl.float32)
+    diff = x - y
+    sq = diff * diff
+    sq = sq * scale
+    block_sum = tl.sum(sq, axis=0)
+    tl.atomic_add(acc_ptr, block_sum)
+
+
+def _parse_reduction(reduction):
+    # Accept both strings and integers consistent with ATen Reduction enum:
+    # 0: 'none', 1: 'mean', 2: 'sum'
+    if isinstance(reduction, str):
+        r = reduction.lower()
+        if r == "none":
+            return 0
+        if r == "mean":
+            return 1
+        if r == "sum":
+            return 2
+        raise ValueError(f"Invalid reduction string: {reduction}")
+    # Assume integer
+    if reduction in (0, 1, 2):
+        return int(reduction)
+    raise ValueError(f"Invalid reduction value: {reduction}")
+
+
+def _ensure_supported_dtype(t: torch.Tensor, op_name="mse_loss"):
+    if t.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise TypeError(
+            f"{op_name} Triton kernel supports float16, bfloat16, and float32 dtypes, got {t.dtype}."
+        )
+
+
+def _launch_mse_elemwise(x, y, out):
+    n_elements = out.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _mse_elemwise_kernel[grid](x, y, out, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+
+
+def _launch_mse_reduce(x, y, n_elements, scale):
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    acc = torch.zeros((), device=x.device, dtype=torch.float32)
+    _mse_reduce_kernel[grid](x, y, acc, n_elements, float(scale), BLOCK_SIZE=BLOCK_SIZE)
+    return acc
+
+
+def mse_loss(*args, **kwargs):
+    # Expected calling pattern: mse_loss(self, target, reduction=Mean)
+    if len(args) < 2:
+        raise TypeError(
+            "mse_loss requires at least 2 positional arguments: (input, target)"
+        )
+    inp = args[0]
+    target = args[1]
+    reduction = kwargs.get("reduction", args[2] if len(args) > 2 else 1)
+    reduction = _parse_reduction(reduction)
+
+    if not isinstance(inp, torch.Tensor) or not isinstance(target, torch.Tensor):
+        raise TypeError("mse_loss expects tensor inputs")
+
+    if inp.numel() != target.numel():
+        raise ValueError(
+            "mse_loss: input and target must have the same number of elements"
+        )
+
+    if inp.device != target.device:
+        raise ValueError("mse_loss: input and target must be on the same device")
+
+    _ensure_supported_dtype(inp, "mse_loss")
+    _ensure_supported_dtype(target, "mse_loss")
+
+    x = inp.contiguous()
+    y = target.contiguous()
+
+    n_elements = x.numel()
+
+    if reduction == 0:  # 'none'
+        out = torch.empty_like(x)
+        if not out.is_contiguous():
+            # Ensure output is contiguous for Triton; then copy back
+            tmp = torch.empty_like(x, memory_format=torch.contiguous_format)
+            _launch_mse_elemwise(x, y, tmp)
+            out.copy_(tmp)
+        else:
+            _launch_mse_elemwise(x, y, out)
+        return out.reshape_as(inp)
+
+    # sum or mean -> scalar
+    if n_elements == 0:
+        # Follow a simple convention: return 0 for empty tensors
+        zero = torch.zeros((), device=x.device, dtype=inp.dtype)
+        return zero
+
+    scale = 1.0 if reduction == 2 else (1.0 / float(n_elements))  # sum or mean
+    acc = _launch_mse_reduce(x, y, n_elements, scale)
+    result = acc.to(dtype=inp.dtype)
+    return result
+
+
+def mse_loss_out(*args, **kwargs):
+    # Expected calling pattern: mse_loss_out(self, target, reduction=Mean, *, out)
+    if len(args) < 2:
+        raise TypeError(
+            "mse_loss_out requires at least 2 positional arguments: (input, target)"
+        )
+    inp = args[0]
+    target = args[1]
+    reduction = kwargs.get("reduction", args[2] if len(args) > 2 else 1)
+    out = kwargs.get("out", args[3] if len(args) > 3 else None)
+
+    if out is None:
+        raise TypeError("mse_loss_out requires an 'out' tensor")
+
+    reduction = _parse_reduction(reduction)
+
+    if not isinstance(inp, torch.Tensor) or not isinstance(target, torch.Tensor):
+        raise TypeError("mse_loss_out expects tensor inputs")
+
+    if inp.numel() != target.numel():
+        raise ValueError(
+            "mse_loss_out: input and target must have the same number of elements"
+        )
+
+    if inp.device != target.device:
+        raise ValueError("mse_loss_out: input and target must be on the same device")
+
+    _ensure_supported_dtype(inp, "mse_loss_out")
+    _ensure_supported_dtype(target, "mse_loss_out")
+
+    x = inp.contiguous()
+    y = target.contiguous()
+    n_elements = x.numel()
+
+    if reduction == 0:  # 'none'
+        # out must have same shape as input
+        if out.numel() != n_elements:
+            raise ValueError(
+                "mse_loss_out (reduction='none'): 'out' must have the same number of elements as input"
+            )
+        if out.device != x.device:
+            raise ValueError("mse_loss_out: 'out' must be on the same device as input")
+        if out.dtype != inp.dtype:
+            raise TypeError(
+                "mse_loss_out (reduction='none'): 'out' dtype must match input dtype"
+            )
+
+        if out.is_contiguous():
+            _launch_mse_elemwise(x, y, out)
+        else:
+            tmp = torch.empty_like(x, memory_format=torch.contiguous_format)
+            _launch_mse_elemwise(x, y, tmp)
+            out.copy_(tmp)
+        return out
+
+    # sum or mean
+    if out.device != x.device:
+        raise ValueError("mse_loss_out: 'out' must be on the same device as input")
+    if out.numel() != 1:
+        raise ValueError(
+            "mse_loss_out (reduction in ['sum','mean']): 'out' must be a scalar tensor"
+        )
+    # out dtype must be a supported float dtype
+    if out.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise TypeError(
+            "mse_loss_out: 'out' dtype must be one of float16, bfloat16, or float32 for Triton kernel"
+        )
+
+    if n_elements == 0:
+        out.fill_(0)
+        return out
+
+    scale = 1.0 if reduction == 2 else (1.0 / float(n_elements))
+    acc = _launch_mse_reduce(x, y, n_elements, scale)
+    out.fill_(acc.to(dtype=out.dtype))
+    return out

--- a/src/flag_gems/experimental_ops/mv.py
+++ b/src/flag_gems/experimental_ops/mv.py
@@ -1,0 +1,117 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def mv_kernel(
+    A_ptr,  # *Pointer* to matrix A [M, N]
+    x_ptr,  # *Pointer* to vector x [N]
+    y_ptr,  # *Pointer* to output vector y [M]
+    M,  # rows of A
+    N,  # cols of A (and size of x)
+    stride_am,  # stride for A along M (row stride)
+    stride_an,  # stride for A along N (col stride)
+    stride_xn,  # stride for x along N
+    stride_ym,  # stride for y along M
+    BLOCK_N: tl.constexpr,  # tile size along N
+):
+    pid_m = tl.program_id(axis=0)
+    offs_n = tl.arange(0, BLOCK_N)
+    acc = tl.zeros((), dtype=tl.float32)
+
+    row_ptr = A_ptr + pid_m * stride_am
+
+    for n0 in range(0, N, BLOCK_N):
+        idx_n = n0 + offs_n
+        mask = idx_n < N
+        a = tl.load(row_ptr + idx_n * stride_an, mask=mask, other=0.0)
+        x = tl.load(x_ptr + idx_n * stride_xn, mask=mask, other=0.0)
+        # accumulate in fp32 for better precision
+        acc += tl.sum(a.to(tl.float32) * x.to(tl.float32), axis=0)
+
+    tl.store(y_ptr + pid_m * stride_ym, acc)
+
+
+def _launch_mv_kernel(A: torch.Tensor, x: torch.Tensor, y: torch.Tensor):
+    M, N = A.shape
+    assert x.numel() == N
+    grid = (M,)
+    mv_kernel[grid](
+        A,
+        x,
+        y,
+        M,
+        N,
+        A.stride(0),
+        A.stride(1),
+        x.stride(0),
+        y.stride(0),
+        BLOCK_N=256,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+def mv(A: torch.Tensor, x: torch.Tensor):
+    # Validate inputs
+    assert isinstance(A, torch.Tensor) and isinstance(
+        x, torch.Tensor
+    ), "Inputs must be tensors"
+    assert A.ndim == 2 and x.ndim == 1, "mv expects A: 2D tensor and x: 1D tensor"
+    assert A.shape[1] == x.shape[0], "Incompatible dimensions for mv"
+    assert (
+        A.is_cuda and x.is_cuda and A.device == x.device
+    ), "All tensors must be on the same CUDA device"
+
+    # Determine output dtype following PyTorch's type promotion
+    out_dtype = torch.result_type(A, x)
+    M = A.shape[0]
+    if M == 0:
+        return torch.empty((0,), device=A.device, dtype=out_dtype)
+
+    # Prepare tensors (dtype + contiguous)
+    A_ = A.to(out_dtype).contiguous()
+    x_ = x.to(out_dtype).contiguous()
+    y = torch.empty((M,), device=A.device, dtype=out_dtype)
+    y_ = y.contiguous()
+
+    _launch_mv_kernel(A_, x_, y_)
+
+    if y_.data_ptr() != y.data_ptr():
+        y.copy_(y_)
+    return y
+
+
+def mv_out(A: torch.Tensor, x: torch.Tensor, out: torch.Tensor):
+    # Validate inputs
+    assert (
+        isinstance(A, torch.Tensor)
+        and isinstance(x, torch.Tensor)
+        and isinstance(out, torch.Tensor)
+    ), "Inputs must be tensors"
+    assert (
+        A.ndim == 2 and x.ndim == 1 and out.ndim == 1
+    ), "Shapes must be A: [M, N], x: [N], out: [M]"
+    assert A.shape[1] == x.shape[0], "Incompatible dimensions for mv.out"
+    assert out.shape[0] == A.shape[0], "Output shape must match rows of A"
+    assert A.is_cuda and x.is_cuda and out.is_cuda, "All tensors must be CUDA tensors"
+    assert A.device == x.device == out.device, "All tensors must be on the same device"
+
+    # Execute in the dtype of out (PyTorch .out usually determines dtype by out)
+    compute_dtype = out.dtype
+    M = A.shape[0]
+    if M == 0:
+        return out
+
+    A_ = A.to(compute_dtype).contiguous()
+    x_ = x.to(compute_dtype).contiguous()
+
+    if out.is_contiguous():
+        _launch_mv_kernel(A_, x_, out)
+        return out
+    else:
+        y_tmp = torch.empty_like(out, memory_format=torch.contiguous_format)
+        _launch_mv_kernel(A_, x_, y_tmp)
+        out.copy_(y_tmp)
+        return out

--- a/src/flag_gems/experimental_ops/native_dropout_backward.py
+++ b/src/flag_gems/experimental_ops/native_dropout_backward.py
@@ -1,0 +1,85 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _native_dropout_backward_kernel(
+    grad_ptr,  # *Pointer* to grad_output tensor
+    mask_ptr,  # *Pointer* to mask tensor (cast to same dtype as grad)
+    out_ptr,  # *Pointer* to output grad_input tensor
+    n_elements,  # Number of elements
+    scale,  # Scaling factor (float)
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    in_bounds = offsets < n_elements
+
+    g = tl.load(grad_ptr + offsets, mask=in_bounds, other=0)
+    m = tl.load(mask_ptr + offsets, mask=in_bounds, other=0)
+
+    # grad_input = grad_output * mask * scale
+    out = g * m * scale
+    tl.store(out_ptr + offsets, out, mask=in_bounds)
+
+
+def _launch_native_dropout_backward(
+    grad_output: torch.Tensor, mask: torch.Tensor, scale: float, out: torch.Tensor
+):
+    assert (
+        grad_output.is_cuda and mask.is_cuda and out.is_cuda
+    ), "All tensors must be CUDA tensors"
+    assert (
+        grad_output.numel() == mask.numel() == out.numel()
+    ), "grad_output, mask, and out must have the same number of elements"
+    assert grad_output.dtype in (
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+    ), "Supported dtypes: float16, bfloat16, float32"
+    assert out.dtype == grad_output.dtype, "Output dtype must match grad_output dtype"
+    assert (
+        grad_output.device == mask.device == out.device
+    ), "All tensors must be on the same device"
+
+    go = grad_output.contiguous()
+    m = mask.contiguous()
+    if m.dtype != go.dtype:
+        m = m.to(dtype=go.dtype)
+
+    out_contig = out if out.is_contiguous() else torch.empty_like(go)
+
+    n_elements = go.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _native_dropout_backward_kernel[grid](
+        go, m, out_contig, n_elements, float(scale), BLOCK_SIZE=BLOCK_SIZE
+    )
+
+    if out_contig.data_ptr() != out.data_ptr():
+        out.copy_(out_contig)
+    return out
+
+
+def native_dropout_backward(
+    grad_output: torch.Tensor, mask: torch.Tensor, scale: float
+):
+    """
+    Wrapper for aten::native_dropout_backward
+    Computes grad_input = grad_output * mask.to(grad_output.dtype) * scale
+    """
+    out = torch.empty_like(grad_output)
+    return _launch_native_dropout_backward(grad_output, mask, scale, out)
+
+
+def native_dropout_backward_out(
+    grad_output: torch.Tensor, mask: torch.Tensor, scale: float, out: torch.Tensor
+):
+    """
+    Wrapper for aten::native_dropout_backward.out
+    Writes result into 'out'
+    """
+    _launch_native_dropout_backward(grad_output, mask, scale, out)
+    return out

--- a/src/flag_gems/experimental_ops/neg_.py
+++ b/src/flag_gems/experimental_ops/neg_.py
@@ -1,0 +1,43 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def neg__kernel(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x = -x
+    tl.store(x_ptr + offsets, x, mask=mask)
+
+
+def neg_(*args, **kwargs):
+    # Retrieve input tensor (first positional or from kwargs)
+    if len(args) >= 1:
+        x = args[0]
+    elif "input" in kwargs:
+        x = kwargs["input"]
+    elif "self" in kwargs:
+        x = kwargs["self"]
+    else:
+        raise ValueError("neg_ expects a tensor as the first argument")
+
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("neg_ expects a torch.Tensor")
+
+    if x.numel() == 0:
+        return x
+
+    if not x.is_cuda:
+        raise ValueError("neg_ Triton kernel requires a CUDA tensor")
+
+    if not x.is_contiguous():
+        raise ValueError("neg_ Triton kernel requires a contiguous tensor")
+
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    neg__kernel[grid](x, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/negative.py
+++ b/src/flag_gems/experimental_ops/negative.py
@@ -1,0 +1,43 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def negative_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    tl.store(out_ptr + offsets, -x, mask=mask)
+
+
+def _launch_negative(x: torch.Tensor, out: torch.Tensor):
+    assert x.is_cuda and out.is_cuda, "Tensors must be on CUDA device"
+    assert x.dtype == out.dtype, "Input and output must have the same dtype"
+    assert (
+        x.numel() == out.numel()
+    ), "Input and output must have the same number of elements"
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert out.is_contiguous(), "Output tensor must be contiguous"
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return out
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    negative_kernel[grid](x, out, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return out
+
+
+def negative(x: torch.Tensor):
+    out = torch.empty_like(x.contiguous())
+    _launch_negative(x.contiguous(), out)
+    return out
+
+
+def negative_out(x: torch.Tensor, out: torch.Tensor):
+    _launch_negative(x, out)
+    return out

--- a/src/flag_gems/experimental_ops/negative_.py
+++ b/src/flag_gems/experimental_ops/negative_.py
@@ -1,0 +1,31 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def negative_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x = -x
+    tl.store(x_ptr + offsets, x, mask=mask)
+
+
+_negative__kernel = negative_
+
+
+def negative_(*args, **kwargs):
+    x = args[0] if len(args) > 0 else kwargs.get("input", kwargs.get("self", None))
+    if x is None:
+        raise ValueError("negative_ expects a tensor as the first argument")
+    assert x.is_cuda, "Input tensor must be on CUDA device"
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _negative__kernel[grid](x, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/new_ones.py
+++ b/src/flag_gems/experimental_ops/new_ones.py
@@ -1,0 +1,169 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _fill_ones_kernel(
+    out_ptr,  # *Pointer* to output tensor
+    n_elements,  # Total number of elements to write
+    BLOCK_SIZE: tl.constexpr,
+    DTYPE: tl.constexpr,  # Triton dtype for output
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    ones = tl.full((BLOCK_SIZE,), 1, dtype=DTYPE)
+    tl.store(out_ptr + offsets, ones, mask=mask)
+
+
+def _torch_dtype_to_triton_dtype(dtype: torch.dtype):
+    if dtype == torch.float32:
+        return tl.float32
+    if dtype == torch.float16:
+        return tl.float16
+    if dtype == torch.bfloat16:
+        return tl.bfloat16
+    if dtype == torch.float64:
+        return tl.float64
+    if dtype == torch.int8:
+        return tl.int8
+    if dtype == torch.uint8:
+        return tl.uint8
+    if dtype == torch.int16:
+        return tl.int16
+    if dtype == torch.int32:
+        return tl.int32
+    if dtype == torch.int64:
+        return tl.int64
+    # Best-effort for bool
+    if dtype == torch.bool:
+        # Triton represents boolean as int1
+        return tl.int1
+    raise TypeError(f"Unsupported dtype for Triton kernel: {dtype}")
+
+
+def _normalize_size_arg(size):
+    if isinstance(size, torch.Size):
+        return tuple(int(s) for s in size)
+    if isinstance(size, (list, tuple)):
+        return tuple(int(s) for s in size)
+    if isinstance(size, int):
+        return (int(size),)
+    raise TypeError(f"Invalid size specification: {size}")
+
+
+def _extract_size_from_args(after_self_pos_args, kwargs):
+    # Try positional
+    if len(after_self_pos_args) == 1 and isinstance(
+        after_self_pos_args[0], (list, tuple, torch.Size, int)
+    ):
+        return _normalize_size_arg(after_self_pos_args[0])
+    if len(after_self_pos_args) >= 1 and all(
+        isinstance(x, int) for x in after_self_pos_args
+    ):
+        return tuple(int(x) for x in after_self_pos_args)
+    # Try kwargs
+    if "size" in kwargs:
+        return _normalize_size_arg(kwargs["size"])
+    if "sizes" in kwargs:
+        return _normalize_size_arg(kwargs["sizes"])
+    raise ValueError(
+        "Size must be provided as a list/tuple/torch.Size or as multiple integer positional arguments."
+    )
+
+
+def _launch_fill_ones(out: torch.Tensor):
+    if out.numel() == 0:
+        return
+    if not out.is_cuda or not out.is_contiguous():
+        out.fill_(1)
+        return
+    triton_dtype = _torch_dtype_to_triton_dtype(out.dtype)
+    n_elements = out.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _fill_ones_kernel[grid](out, n_elements, BLOCK_SIZE=BLOCK_SIZE, DTYPE=triton_dtype)
+
+
+def new_ones(*args, **kwargs):
+    # Expected schema (aten): new_ones(Tensor self, int[] size, *, dtype?, layout?, device?, pin_memory?)
+    if len(args) == 0:
+        raise TypeError(
+            "new_ones expects at least a 'self' tensor as the first argument."
+        )
+    self = args[0]
+    after_self = list(args[1:])
+    size = _extract_size_from_args(after_self, kwargs)
+
+    # Resolve dtype/device defaults
+    dtype = kwargs.get("dtype", None)
+    if dtype is None:
+        if isinstance(self, torch.Tensor) and self.dtype is not None:
+            dtype = self.dtype
+        else:
+            dtype = torch.get_default_dtype()
+
+    device = kwargs.get("device", None)
+    if device is None:
+        if isinstance(self, torch.Tensor):
+            device = self.device
+        else:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    out = torch.empty(size, dtype=dtype, device=device)
+    _launch_fill_ones(out)
+    return out
+
+
+def new_ones_out(*args, **kwargs):
+    # Expected schema (aten): new_ones.out(Tensor self, int[] size, *, dtype?, layout?, device?, pin_memory?, Tensor(a!) out) -> Tensor(a!)
+    if len(args) == 0:
+        raise TypeError(
+            "new_ones_out expects at least a 'self' tensor as the first argument."
+        )
+    self = args[0]
+    # Determine 'out' tensor (either in kwargs or as the last positional argument)
+    out = kwargs.get("out", None)
+    pos_after_self = list(args[1:])
+
+    if (
+        out is None
+        and len(pos_after_self) >= 1
+        and isinstance(pos_after_self[-1], torch.Tensor)
+    ):
+        out = pos_after_self[-1]
+        pos_after_self = pos_after_self[:-1]
+
+    if out is None or not isinstance(out, torch.Tensor):
+        raise TypeError(
+            "new_ones_out requires an 'out' tensor (as keyword 'out' or last positional argument)."
+        )
+
+    size = _extract_size_from_args(pos_after_self, kwargs)
+
+    # Validate/align dtype/device if provided
+    if (
+        "dtype" in kwargs
+        and kwargs["dtype"] is not None
+        and out.dtype != kwargs["dtype"]
+    ):
+        raise TypeError(
+            f"Provided dtype {kwargs['dtype']} does not match out.dtype {out.dtype}."
+        )
+    if (
+        "device" in kwargs
+        and kwargs["device"] is not None
+        and torch.device(kwargs["device"]) != out.device
+    ):
+        raise TypeError(
+            f"Provided device {kwargs['device']} does not match out.device {out.device}."
+        )
+
+    # Resize out to requested size if needed
+    if tuple(out.shape) != tuple(size):
+        out.resize_(size)
+
+    _launch_fill_ones(out)
+    return out

--- a/src/flag_gems/experimental_ops/pixel_unshuffle.py
+++ b/src/flag_gems/experimental_ops/pixel_unshuffle.py
@@ -1,0 +1,154 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def pixel_unshuffle_kernel(
+    in_ptr,  # *Pointer* to input tensor (contiguous NCHW)
+    out_ptr,  # *Pointer* to output tensor (contiguous NCHW)
+    n_elements,  # total number of elements (N*C*H*W)
+    N,
+    C,
+    H,
+    W,  # input dimensions
+    R,  # downscale factor
+    C_out,
+    H_out,
+    W_out,  # output dimensions
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    # Strides for contiguous NCHW
+    sN_in = C * H * W
+    sC_in = H * W
+    sH_in = W
+    sW_in = 1
+
+    sN_out = C_out * H_out * W_out
+    sC_out = H_out * W_out
+    sH_out = W_out
+    sW_out = 1
+
+    # Decode output linear index into (n, c_out, h_out, w_out)
+    n = offsets // sN_out
+    rem1 = offsets - n * sN_out
+    c_out = rem1 // sC_out
+    rem2 = rem1 - c_out * sC_out
+    h_out = rem2 // sH_out
+    w_out = rem2 - h_out * sH_out
+
+    # Map output channel to input channel and spatial offsets
+    r2 = R * R
+    c_in = c_out // r2
+    remc = c_out - c_in * r2
+    dh = remc // R
+    dw = remc - dh * R
+
+    # Compute input spatial indices
+    h_in = h_out * R + dh
+    w_in = w_out * R + dw
+
+    # Compute input linear index
+    in_index = n * sN_in + c_in * sC_in + h_in * sH_in + w_in * sW_in
+
+    x = tl.load(in_ptr + in_index, mask=mask)
+    tl.store(out_ptr + offsets, x, mask=mask)
+
+
+def _launch_pixel_unshuffle_kernel(
+    inp: torch.Tensor, downscale_factor: int, out: torch.Tensor
+):
+    assert inp.is_cuda and out.is_cuda, "Input and output must be CUDA tensors"
+    assert inp.is_contiguous(), "Input must be contiguous (NCHW)"
+    assert out.is_contiguous(), "Output must be contiguous (NCHW)"
+    assert inp.ndim == 4, "Input must be a 4D tensor (N, C, H, W)"
+    N, C, H, W = inp.shape
+    r = int(downscale_factor)
+    assert r > 0, "downscale_factor must be > 0"
+    assert (H % r == 0) and (
+        W % r == 0
+    ), "H and W must be divisible by downscale_factor"
+    C_out = C * r * r
+    H_out = H // r
+    W_out = W // r
+    assert out.shape == (N, C_out, H_out, W_out), "Output has incorrect shape"
+
+    n_elements = inp.numel()
+    if n_elements == 0:
+        return
+
+    BLOCK_SIZE = 1024
+    grid = lambda META: (triton.cdiv(n_elements, META["BLOCK_SIZE"]),)
+    pixel_unshuffle_kernel[grid](
+        inp,
+        out,
+        n_elements,
+        N,
+        C,
+        H,
+        W,
+        r,
+        C_out,
+        H_out,
+        W_out,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+def pixel_unshuffle(input, downscale_factor, *, layout=None):
+    """
+    Wrapper for aten::pixel_unshuffle
+    Args:
+      input: Tensor[N, C, H, W] (contiguous)
+      downscale_factor: int
+      layout: unused (for API parity)
+    """
+    x = input
+    if not x.is_contiguous():
+        x = x.contiguous()
+    assert x.ndim == 4, "Input must be a 4D tensor (N, C, H, W)"
+    N, C, H, W = x.shape
+    r = int(downscale_factor)
+    assert r > 0, "downscale_factor must be > 0"
+    assert (H % r == 0) and (
+        W % r == 0
+    ), "H and W must be divisible by downscale_factor"
+
+    out_shape = (N, C * r * r, H // r, W // r)
+    out = torch.empty(out_shape, device=x.device, dtype=x.dtype)
+    _launch_pixel_unshuffle_kernel(x, r, out)
+    return out
+
+
+def pixel_unshuffle_out(input, downscale_factor, out):
+    """
+    Wrapper for aten::pixel_unshuffle.out
+    Args:
+      input: Tensor[N, C, H, W] (contiguous)
+      downscale_factor: int
+      out: preallocated Tensor[N, C*r*r, H//r, W//r] (contiguous)
+    """
+    x = input
+    if not x.is_contiguous():
+        x = x.contiguous()
+    assert x.ndim == 4, "Input must be a 4D tensor (N, C, H, W)"
+    N, C, H, W = x.shape
+    r = int(downscale_factor)
+    assert r > 0, "downscale_factor must be > 0"
+    assert (H % r == 0) and (
+        W % r == 0
+    ), "H and W must be divisible by downscale_factor"
+    expected_shape = (N, C * r * r, H // r, W // r)
+    assert out.shape == expected_shape, f"out must have shape {expected_shape}"
+    assert out.dtype == x.dtype, "out dtype must match input dtype"
+    assert out.device == x.device, "out device must match input device"
+    if not out.is_contiguous():
+        raise ValueError("out must be contiguous")
+
+    _launch_pixel_unshuffle_kernel(x, r, out)
+    return out

--- a/src/flag_gems/experimental_ops/positive.py
+++ b/src/flag_gems/experimental_ops/positive.py
@@ -1,0 +1,51 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def positive(
+    x_ptr,  # *Pointer* to input tensor.
+    output_ptr,  # *Pointer* to output tensor.
+    n_elements,  # Number of elements.
+    BLOCK_SIZE: tl.constexpr,  # Elements processed per program.
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    tl.store(output_ptr + offsets, x, mask=mask)
+
+
+_positive_kernel = positive
+
+
+def positive(*args, **kwargs):
+    # Extract the tensor argument
+    x = None
+    if args:
+        x = args[0]
+    else:
+        x = kwargs.get("input", kwargs.get("self", kwargs.get("x", None)))
+
+    if x is None:
+        raise ValueError("positive expects a torch.Tensor as the first argument")
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("positive expects a torch.Tensor")
+
+    # Fallback for non-CUDA or unsupported types
+    if (not x.is_cuda) or x.is_complex():
+        return torch.ops.aten.positive(x)
+
+    x_contig = x.contiguous()
+    n_elements = x_contig.numel()
+    out = torch.empty_like(x_contig)
+
+    if n_elements == 0:
+        return out
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _positive_kernel[grid](x_contig, out, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return out

--- a/src/flag_gems/experimental_ops/prelu.py
+++ b/src/flag_gems/experimental_ops/prelu.py
@@ -1,0 +1,100 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def prelu(
+    x_ptr,  # *Pointer* to input tensor.
+    w_ptr,  # *Pointer* to weight tensor (scalar or per-channel vector).
+    out_ptr,  # *Pointer* to output tensor.
+    n_elements,  # Total number of elements in input.
+    S,  # Spatial size = product of dims after channel dim (or 1 if none).
+    C,  # Number of channels (or 1).
+    w_is_scalar: tl.constexpr,  # Whether weight is a single scalar.
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    if w_is_scalar:
+        alpha = tl.load(w_ptr)  # scalar
+        y = tl.where(x >= 0, x, alpha * x)
+    else:
+        c = (offsets // S) % C
+        alpha = tl.load(w_ptr + c, mask=mask)
+        y = tl.where(x >= 0, x, alpha * x)
+
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+# Keep a reference to the Triton kernel before defining the Python wrapper with the same name.
+prelu_kernel = prelu
+
+
+def prelu(*args, **kwargs):
+    # Extract inputs
+    if len(args) >= 2:
+        x, weight = args[0], args[1]
+    else:
+        x = kwargs.get("input", kwargs.get("self"))
+        weight = kwargs.get("weight")
+    if x is None or weight is None:
+        raise ValueError("prelu expects (input, weight) as arguments.")
+
+    if not (x.is_cuda and weight.is_cuda):
+        raise AssertionError("Tensors must be CUDA tensors.")
+
+    # Ensure dtype match
+    if weight.dtype != x.dtype:
+        weight = weight.to(dtype=x.dtype)
+
+    # Ensure contiguous
+    x = x.contiguous()
+    weight = weight.contiguous()
+
+    out = torch.empty_like(x)
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return out
+
+    # Determine channel count C and spatial size S
+    ndim = x.dim()
+    if weight.numel() == 1:
+        C = 1
+        S = 1
+        w_is_scalar = True
+    else:
+        if ndim == 0:
+            raise AssertionError("Non-scalar weight provided for a 0-dim input.")
+        if ndim == 1:
+            C = x.shape[0]
+            S = 1
+        else:
+            C = x.shape[1]
+            S = 1
+            if ndim > 2:
+                for d in x.shape[2:]:
+                    S *= d
+        if weight.numel() != C:
+            raise AssertionError(
+                f"Weight numel ({weight.numel()}) must equal channel dimension size ({C})."
+            )
+        w_is_scalar = False
+
+    # Make sure S and C are at least 1 to avoid div/mod by zero in kernel math
+    C = max(int(C), 1)
+    S = max(int(S), 1)
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    prelu_kernel[grid](
+        x, weight, out, n_elements, S, C, w_is_scalar=w_is_scalar, BLOCK_SIZE=BLOCK_SIZE
+    )
+    return out

--- a/src/flag_gems/experimental_ops/rad2deg_.py
+++ b/src/flag_gems/experimental_ops/rad2deg_.py
@@ -1,0 +1,49 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def rad2deg__kernel(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    # Convert radians to degrees: deg = rad * (180/pi)
+    out = x * (180.0 / 3.141592653589793)
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+def rad2deg_(*args, **kwargs):
+    # Accept first positional argument or common keyword names
+    x = args[0] if len(args) > 0 else kwargs.get("input", kwargs.get("self", None))
+    if x is None:
+        raise ValueError("rad2deg_ expects a tensor as its first argument")
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("rad2deg_ expects a torch.Tensor")
+    if not x.is_floating_point():
+        raise TypeError(
+            "rad2deg_ only supports floating point tensors for in-place operation"
+        )
+    if not x.is_cuda:
+        raise AssertionError("Input tensor must be on CUDA device")
+
+    # If non-contiguous, operate on a contiguous copy and copy back in place
+    original = x
+    needs_copy_back = False
+    if not x.is_contiguous():
+        x = x.contiguous()
+        needs_copy_back = True
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return original
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    rad2deg__kernel[grid](x, n_elements, BLOCK_SIZE=1024)
+
+    if needs_copy_back:
+        original.copy_(x)
+        return original
+    return x

--- a/src/flag_gems/experimental_ops/reciprocal.py
+++ b/src/flag_gems/experimental_ops/reciprocal.py
@@ -1,0 +1,86 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def reciprocal_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    one = tl.full([BLOCK_SIZE], 1, x.dtype)
+    y = one / x
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _reciprocal_impl(x: torch.Tensor, out: torch.Tensor = None):
+    # Fallback for unsupported dtypes/devices
+    if not x.is_cuda or x.is_complex():
+        if out is None:
+            return torch.ops.aten.reciprocal(x)
+        else:
+            return torch.ops.aten.reciprocal.out(x, out=out)
+
+    if out is None:
+        out = torch.empty_like(x)
+
+    # Ensure same device and dtype
+    assert out.device == x.device, "Input and output must be on the same device"
+    assert out.dtype == x.dtype, "Output dtype must match input dtype"
+    assert (
+        out.numel() == x.numel()
+    ), "Output must have the same number of elements as input"
+
+    x_contig = x.contiguous()
+    out_contig = out.contiguous()
+
+    n_elements = x_contig.numel()
+    if n_elements == 0:
+        return out  # nothing to do
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    reciprocal_kernel[grid](x_contig, out_contig, n_elements, BLOCK_SIZE=1024)
+
+    if out is not out_contig:
+        out.copy_(out_contig)
+    return out
+
+
+# ('reciprocal', <Autograd.disable: False>)
+def reciprocal(*args, **kwargs):
+    # Accept a single tensor argument
+    x = None
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        # Try common keyword names
+        x = kwargs.get(
+            "input", kwargs.get("self", kwargs.get("a", kwargs.get("args", None)))
+        )
+    if x is None:
+        raise ValueError("reciprocal expects a tensor as the first argument")
+    return _reciprocal_impl(x)
+
+
+# ('reciprocal.out', <Autograd.disable: False>)
+def reciprocal_out(*args, **kwargs):
+    # Accept (x, out) or keyword args self/input and out
+    x = None
+    out = None
+    if len(args) >= 2:
+        x, out = args[0], args[1]
+    elif len(args) == 1:
+        x = args[0]
+        out = kwargs.get("out", None)
+    else:
+        x = kwargs.get("input", kwargs.get("self", kwargs.get("a", None)))
+        out = kwargs.get("out", None)
+
+    if x is None or out is None:
+        raise ValueError("reciprocal_out expects arguments (input, out)")
+
+    _reciprocal_impl(x, out=out)
+    return out

--- a/src/flag_gems/experimental_ops/reflection_pad2d.py
+++ b/src/flag_gems/experimental_ops/reflection_pad2d.py
@@ -1,0 +1,199 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _reflection_pad2d_kernel(
+    in_ptr,
+    out_ptr,
+    N,
+    C,
+    H_in,
+    W_in,
+    H_out,
+    W_out,
+    pad_left,
+    pad_top,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+    offs = offs.to(tl.int64)
+
+    W_out = tl.full([], W_out, tl.int64)
+    H_out = tl.full([], H_out, tl.int64)
+    C = tl.full([], C, tl.int64)
+    W_in = tl.full([], W_in, tl.int64)
+    H_in = tl.full([], H_in, tl.int64)
+    pad_left = tl.full([], pad_left, tl.int64)
+    pad_top = tl.full([], pad_top, tl.int64)
+
+    w_out = offs % W_out
+    tmp = offs // W_out
+    h_out = tmp % H_out
+    tmp = tmp // H_out
+    c = tmp % C
+    n = tmp // C
+
+    w_in = w_out - pad_left
+    h_in = h_out - pad_top
+
+    # reflection index for width
+    m_w = W_in - 1
+    period_w = m_w * 2
+    abs_w = tl.abs(w_in)
+    r_w = tl.where(period_w != 0, abs_w % period_w, 0)
+    w_idx = tl.where(r_w <= m_w, r_w, period_w - r_w)
+
+    # reflection index for height
+    m_h = H_in - 1
+    period_h = m_h * 2
+    abs_h = tl.abs(h_in)
+    r_h = tl.where(period_h != 0, abs_h % period_h, 0)
+    h_idx = tl.where(r_h <= m_h, r_h, period_h - r_h)
+
+    in_index = (((n * C + c) * H_in) + h_idx) * W_in + w_idx
+
+    x = tl.load(in_ptr + in_index, mask=mask)
+    tl.store(out_ptr + offs, x, mask=mask)
+
+
+def _parse_padding(padding):
+    if not isinstance(padding, (list, tuple)) or len(padding) != 4:
+        raise ValueError(
+            "padding must be a sequence of four integers: (pad_left, pad_right, pad_top, pad_bottom)"
+        )
+    pad_left, pad_right, pad_top, pad_bottom = map(int, padding)
+    if pad_left < 0 or pad_right < 0 or pad_top < 0 or pad_bottom < 0:
+        raise ValueError("reflection_pad2d does not support negative padding")
+    return pad_left, pad_right, pad_top, pad_bottom
+
+
+def _launch_reflection_pad2d_kernel(inp, out, padding):
+    assert inp.is_cuda and out.is_cuda, "reflection_pad2d requires CUDA tensors"
+    assert inp.dtype == out.dtype, "input and output dtype must match"
+    assert inp.is_contiguous(), "input must be contiguous"
+    assert out.is_contiguous(), "output must be contiguous"
+
+    pad_left, pad_right, pad_top, pad_bottom = _parse_padding(padding)
+
+    if inp.dim() == 4:
+        N, C, H_in, W_in = inp.shape
+        H_out = H_in + pad_top + pad_bottom
+        W_out = W_in + pad_left + pad_right
+        expected_out_shape = (N, C, H_out, W_out)
+    elif inp.dim() == 3:
+        C, H_in, W_in = inp.shape
+        N = 1
+        H_out = H_in + pad_top + pad_bottom
+        W_out = W_in + pad_left + pad_right
+        expected_out_shape = (C, H_out, W_out)
+    else:
+        raise ValueError("reflection_pad2d expects 3D (C,H,W) or 4D (N,C,H,W) input")
+
+    # Validate output shape
+    if tuple(out.shape) != expected_out_shape:
+        raise ValueError(
+            f"output has incorrect shape, expected {expected_out_shape}, got {tuple(out.shape)}"
+        )
+
+    # PyTorch constraints for reflection padding
+    if H_in <= 0 or W_in <= 0:
+        raise ValueError("input spatial dimensions must be positive")
+    if (pad_left >= W_in) or (pad_right >= W_in):
+        raise ValueError(
+            "Padding size should be less than the corresponding input dimension (width)."
+        )
+    if (pad_top >= H_in) or (pad_bottom >= H_in):
+        raise ValueError(
+            "Padding size should be less than the corresponding input dimension (height)."
+        )
+    if (H_in == 1 and (pad_top > 0 or pad_bottom > 0)) or (
+        W_in == 1 and (pad_left > 0 or pad_right > 0)
+    ):
+        raise ValueError(
+            "For reflection padding, input size must be at least 2 in each dimension being padded."
+        )
+
+    # Prepare parameters for kernel
+    if inp.dim() == 3:
+        N = 1
+        C = inp.shape[0]
+
+    n_elements = out.numel()
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    _reflection_pad2d_kernel[grid](
+        inp,
+        out,
+        N,
+        C,
+        H_in,
+        W_in,
+        H_out,
+        W_out,
+        pad_left,
+        pad_top,
+        n_elements,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+def reflection_pad2d(input: torch.Tensor, padding):
+    pad_left, pad_right, pad_top, pad_bottom = _parse_padding(padding)
+
+    if input.dim() == 4:
+        N, C, H_in, W_in = input.shape
+        H_out = H_in + pad_top + pad_bottom
+        W_out = W_in + pad_left + pad_right
+        out = torch.empty((N, C, H_out, W_out), device=input.device, dtype=input.dtype)
+    elif input.dim() == 3:
+        C, H_in, W_in = input.shape
+        H_out = H_in + pad_top + pad_bottom
+        W_out = W_in + pad_left + pad_right
+        out = torch.empty((C, H_out, W_out), device=input.device, dtype=input.dtype)
+    else:
+        raise ValueError("reflection_pad2d expects 3D (C,H,W) or 4D (N,C,H,W) input")
+
+    _launch_reflection_pad2d_kernel(
+        input.contiguous(), out, (pad_left, pad_right, pad_top, pad_bottom)
+    )
+    return out
+
+
+def reflection_pad2d_out(input: torch.Tensor, padding, out: torch.Tensor):
+    pad_left, pad_right, pad_top, pad_bottom = _parse_padding(padding)
+
+    if input.dim() == 4:
+        N, C, H_in, W_in = input.shape
+        H_out = H_in + pad_top + pad_bottom
+        W_out = W_in + pad_left + pad_right
+        expected_shape = (N, C, H_out, W_out)
+    elif input.dim() == 3:
+        C, H_in, W_in = input.shape
+        H_out = H_in + pad_top + pad_bottom
+        W_out = W_in + pad_left + pad_right
+        expected_shape = (C, H_out, W_out)
+    else:
+        raise ValueError(
+            "reflection_pad2d_out expects 3D (C,H,W) or 4D (N,C,H,W) input"
+        )
+
+    if tuple(out.shape) != expected_shape:
+        raise ValueError(
+            f"out tensor has incorrect shape, expected {expected_shape}, got {tuple(out.shape)}"
+        )
+    if out.device != input.device:
+        raise ValueError("input and out must be on the same device")
+    if out.dtype != input.dtype:
+        raise ValueError("input and out must have the same dtype")
+
+    _launch_reflection_pad2d_kernel(
+        input.contiguous(), out, (pad_left, pad_right, pad_top, pad_bottom)
+    )
+    return out

--- a/src/flag_gems/experimental_ops/relu6.py
+++ b/src/flag_gems/experimental_ops/relu6.py
@@ -1,0 +1,42 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def relu6(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.maximum(x, 0)
+    y = tl.minimum(y, 6)
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+relu6_kernel = relu6
+
+
+def relu6(*args, **kwargs):
+    x = (
+        args[0]
+        if len(args) > 0
+        else kwargs.get("input", kwargs.get("self", kwargs.get("x")))
+    )
+    if x is None:
+        raise TypeError(
+            "relu6 expects a tensor as the first positional argument or keyword 'input'/'self'/'x'."
+        )
+
+    x_contig = x.contiguous()
+
+    if not x_contig.is_cuda:
+        return torch.clamp(x_contig, min=0, max=6)
+
+    out = torch.empty_like(x_contig)
+    n_elements = out.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    relu6_kernel[grid](x_contig, out, n_elements, BLOCK_SIZE=1024)
+    return out

--- a/src/flag_gems/experimental_ops/relu_.py
+++ b/src/flag_gems/experimental_ops/relu_.py
@@ -1,0 +1,43 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def relu_(
+    x_ptr,  # *Pointer* to input/output tensor (in-place).
+    n_elements,  # Number of elements.
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    zero = x * 0
+    y = tl.where(x > 0, x, zero)
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# Keep a reference to the Triton kernel before defining the Python wrapper with the same name.
+relu__kernel = relu_
+
+
+def relu_(*args, **kwargs):
+    # Expect the first positional argument to be the tensor.
+    x = args[0] if len(args) > 0 else kwargs.get("input", kwargs.get("x", None))
+    if x is None:
+        raise ValueError("relu_ expects a tensor as the first positional argument.")
+    if not x.is_cuda:
+        raise ValueError("relu_ Triton implementation requires a CUDA tensor.")
+    if not x.is_contiguous():
+        raise ValueError("relu_ Triton implementation requires a contiguous tensor.")
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    relu__kernel[grid](x, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/replication_pad2d.py
+++ b/src/flag_gems/experimental_ops/replication_pad2d.py
@@ -1,0 +1,151 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def replication_pad2d_kernel(
+    in_ptr,  # *Pointer* to input tensor
+    out_ptr,  # *Pointer* to output tensor
+    N,
+    C,
+    H,
+    W,  # input dimensions
+    OH,
+    OW,  # output H and W
+    PAD_LEFT,
+    PAD_TOP,  # padding sizes
+    TOTAL_ELEMS,  # total number of output elements
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < TOTAL_ELEMS
+
+    # Cast to int64 for safe indexing
+    offs64 = offs.to(tl.int64)
+
+    OW_i64 = tl.full([1], OW, dtype=tl.int64)
+    OH_i64 = tl.full([1], OH, dtype=tl.int64)
+    C_i64 = tl.full([1], C, dtype=tl.int64)
+    W_i64 = tl.full([1], W, dtype=tl.int64)
+    H_i64 = tl.full([1], H, dtype=tl.int64)
+    PAD_LEFT_i64 = tl.full([1], PAD_LEFT, dtype=tl.int64)
+    PAD_TOP_i64 = tl.full([1], PAD_TOP, dtype=tl.int64)
+
+    ow = offs64 % OW_i64
+    tmp = offs64 // OW_i64
+    oh = tmp % OH_i64
+    tmp = tmp // OH_i64
+    c = tmp % C_i64
+    n = tmp // C_i64
+
+    ih = oh - PAD_TOP_i64
+    iw = ow - PAD_LEFT_i64
+
+    zero = tl.full([1], 0, dtype=tl.int64)
+    Hm1 = H_i64 - 1
+    Wm1 = W_i64 - 1
+
+    ih = tl.maximum(zero, tl.minimum(Hm1, ih))
+    iw = tl.maximum(zero, tl.minimum(Wm1, iw))
+
+    in_index = ((n * C_i64 + c) * H_i64 + ih) * W_i64 + iw
+    out_index = offs64
+
+    x = tl.load(in_ptr + in_index, mask=mask)
+    tl.store(out_ptr + out_index, x, mask=mask)
+
+
+def _prepare_dims_and_out(input: torch.Tensor, padding, out: torch.Tensor | None):
+    if not isinstance(padding, (tuple, list)) or len(padding) != 4:
+        raise ValueError(
+            "padding must be a sequence of 4 integers: (pad_left, pad_right, pad_top, pad_bottom)"
+        )
+    pad_left, pad_right, pad_top, pad_bottom = map(int, padding)
+    if pad_left < 0 or pad_right < 0 or pad_top < 0 or pad_bottom < 0:
+        raise ValueError("replication_pad2d does not support negative padding")
+
+    if input.dim() == 4:
+        N, C, H, W = input.shape
+        out_shape = (N, C, H + pad_top + pad_bottom, W + pad_left + pad_right)
+        kernel_N, kernel_C = N, C
+    elif input.dim() == 3:
+        C, H, W = input.shape
+        out_shape = (C, H + pad_top + pad_bottom, W + pad_left + pad_right)
+        kernel_N, kernel_C = 1, C
+    else:
+        raise ValueError(
+            "replication_pad2d expects a 3D (C, H, W) or 4D (N, C, H, W) input"
+        )
+
+    if H <= 0 or W <= 0:
+        raise ValueError(
+            "Input height and width must be greater than 0 for replication padding"
+        )
+
+    if out is None:
+        out = torch.empty(out_shape, device=input.device, dtype=input.dtype)
+    else:
+        if tuple(out.shape) != tuple(out_shape):
+            raise ValueError(
+                f"Provided out tensor has shape {tuple(out.shape)}, expected {out_shape}"
+            )
+        if out.device != input.device:
+            raise ValueError("Input and out must be on the same device")
+        if out.dtype != input.dtype:
+            raise ValueError("Input and out must have the same dtype")
+
+    return (
+        kernel_N,
+        kernel_C,
+        H,
+        W,
+        out.shape[-2],
+        out.shape[-1],
+        pad_left,
+        pad_top,
+    ), out
+
+
+def _launch_replication_pad2d_kernel(
+    input: torch.Tensor, out: torch.Tensor, kernel_params
+):
+    if not input.is_cuda or not out.is_cuda:
+        raise ValueError("Tensors must be CUDA tensors")
+    if not input.is_contiguous() or not out.is_contiguous():
+        raise ValueError("Only contiguous tensors are supported")
+
+    N, C, H, W, OH, OW, pad_left, pad_top = kernel_params
+    total_elems = out.numel()
+    if total_elems == 0:
+        return out
+
+    BLOCK_SIZE = 1024
+    grid = (triton.cdiv(total_elems, BLOCK_SIZE),)
+
+    replication_pad2d_kernel[grid](
+        input,
+        out,
+        N,
+        C,
+        H,
+        W,
+        OH,
+        OW,
+        pad_left,
+        pad_top,
+        total_elems,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return out
+
+
+def replication_pad2d(input: torch.Tensor, padding):
+    kernel_params, out = _prepare_dims_and_out(input, padding, out=None)
+    return _launch_replication_pad2d_kernel(input, out, kernel_params)
+
+
+def replication_pad2d_out(input: torch.Tensor, padding, out: torch.Tensor):
+    kernel_params, out = _prepare_dims_and_out(input, padding, out=out)
+    return _launch_replication_pad2d_kernel(input, out, kernel_params)

--- a/src/flag_gems/experimental_ops/replication_pad3d.py
+++ b/src/flag_gems/experimental_ops/replication_pad3d.py
@@ -1,0 +1,260 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def replication_pad3d_kernel(
+    in_ptr,
+    out_ptr,
+    N,
+    C,
+    D_in,
+    H_in,
+    W_in,
+    D_out,
+    H_out,
+    W_out,
+    pad_d_before,
+    pad_h_before,
+    pad_w_before,
+    in_stride_n,
+    in_stride_c,
+    in_stride_d,
+    in_stride_h,
+    in_stride_w,
+    out_stride_n,
+    out_stride_c,
+    out_stride_d,
+    out_stride_h,
+    out_stride_w,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    # Unravel linear indices into (n, c, d_out, h_out, w_out)
+    w_out = offs % W_out
+    tmp = offs // W_out
+    h_out = tmp % H_out
+    tmp = tmp // H_out
+    d_out = tmp % D_out
+    tmp = tmp // D_out
+    c = tmp % C
+    n = tmp // C
+
+    # Compute clamped input indices
+    w_in = w_out - pad_w_before
+    w_in = tl.maximum(w_in, 0)
+    w_in = tl.minimum(w_in, W_in - 1)
+
+    h_in = h_out - pad_h_before
+    h_in = tl.maximum(h_in, 0)
+    h_in = tl.minimum(h_in, H_in - 1)
+
+    d_in = d_out - pad_d_before
+    d_in = tl.maximum(d_in, 0)
+    d_in = tl.minimum(d_in, D_in - 1)
+
+    # Compute input and output pointers (strided)
+    in_offset = (
+        n * in_stride_n
+        + c * in_stride_c
+        + d_in * in_stride_d
+        + h_in * in_stride_h
+        + w_in * in_stride_w
+    )
+    out_offset = (
+        n * out_stride_n
+        + c * out_stride_c
+        + d_out * out_stride_d
+        + h_out * out_stride_h
+        + w_out * out_stride_w
+    )
+
+    vals = tl.load(in_ptr + in_offset, mask=mask, other=0)
+    tl.store(out_ptr + out_offset, vals, mask=mask)
+
+
+def _normalize_3d_pad(padding):
+    if isinstance(padding, (list, tuple)) and len(padding) == 6:
+        return tuple(int(x) for x in padding)
+    raise ValueError(
+        "padding must be a sequence of 6 integers: (pad_w_left, pad_w_right, pad_h_top, pad_h_bottom, pad_d_front, pad_d_back)"
+    )
+
+
+def _get_5d_shape_and_strides(t: torch.Tensor):
+    # Returns (N, C, D, H, W), (sN, sC, sD, sH, sW), and a flag indicating if original was 4D
+    if t.dim() == 5:
+        N, C, D, H, W = t.shape
+        sN, sC, sD, sH, sW = t.stride()
+        was_4d = False
+        return (N, C, D, H, W), (sN, sC, sD, sH, sW), was_4d
+    elif t.dim() == 4:
+        C, D, H, W = t.shape
+        sC, sD, sH, sW = t.stride()
+        # Emulate leading N=1 dimension with stride 0 for indexing
+        N = 1
+        sN = 0
+        was_4d = True
+        return (N, C, D, H, W), (sN, sC, sD, sH, sW), was_4d
+    else:
+        raise ValueError("Input must be 4D (C, D, H, W) or 5D (N, C, D, H, W).")
+
+
+def _launch_replication_pad3d_kernel(x: torch.Tensor, padding, out: torch.Tensor):
+    assert x.is_cuda and out.is_cuda, "Tensors must be on CUDA device"
+    assert x.dtype == out.dtype, "Input and output dtypes must match"
+    assert x.device == out.device, "Input and output must be on the same device"
+    assert x.is_contiguous(
+        memory_format=torch.contiguous_format
+    ), "Input must be contiguous"
+    # Output can be non-contiguous; we handle via strides
+
+    (
+        pad_w_before,
+        pad_w_after,
+        pad_h_before,
+        pad_h_after,
+        pad_d_before,
+        pad_d_after,
+    ) = _normalize_3d_pad(padding)
+
+    (
+        (N, C, D_in, H_in, W_in),
+        (in_sN, in_sC, in_sD, in_sH, in_sW),
+        x_was_4d,
+    ) = _get_5d_shape_and_strides(x)
+    (
+        (N_o, C_o, D_out, H_out, W_out),
+        (out_sN, out_sC, out_sD, out_sH, out_sW),
+        out_was_4d,
+    ) = _get_5d_shape_and_strides(out)
+
+    # Validate shapes
+    assert N_o == N and C_o == C, "Output N and C must match input"
+    expected_D_out = D_in + pad_d_before + pad_d_after
+    expected_H_out = H_in + pad_h_before + pad_h_after
+    expected_W_out = W_in + pad_w_before + pad_w_after
+    assert (D_out, H_out, W_out) == (
+        expected_D_out,
+        expected_H_out,
+        expected_W_out,
+    ), "Output spatial shape mismatch"
+
+    n_elements = out.numel()
+    if n_elements == 0:
+        return out
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    replication_pad3d_kernel[grid](
+        x,
+        out,
+        N,
+        C,
+        D_in,
+        H_in,
+        W_in,
+        D_out,
+        H_out,
+        W_out,
+        pad_d_before,
+        pad_h_before,
+        pad_w_before,
+        in_sN,
+        in_sC,
+        in_sD,
+        in_sH,
+        in_sW,
+        out_sN,
+        out_sC,
+        out_sD,
+        out_sH,
+        out_sW,
+        n_elements,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return out
+
+
+def replication_pad3d(input: torch.Tensor, padding):
+    (
+        pad_w_before,
+        pad_w_after,
+        pad_h_before,
+        pad_h_after,
+        pad_d_before,
+        pad_d_after,
+    ) = _normalize_3d_pad(padding)
+    (N, C, D_in, H_in, W_in), _, was_4d = _get_5d_shape_and_strides(input)
+
+    D_out = D_in + pad_d_before + pad_d_after
+    H_out = H_in + pad_h_before + pad_h_after
+    W_out = W_in + pad_w_before + pad_w_after
+
+    if was_4d:
+        out_shape = (C, D_out, H_out, W_out)
+    else:
+        out_shape = (N, C, D_out, H_out, W_out)
+
+    out = torch.empty(out_shape, device=input.device, dtype=input.dtype)
+    _launch_replication_pad3d_kernel(
+        input,
+        (
+            pad_w_before,
+            pad_w_after,
+            pad_h_before,
+            pad_h_after,
+            pad_d_before,
+            pad_d_after,
+        ),
+        out,
+    )
+    return out
+
+
+def replication_pad3d_out(input: torch.Tensor, padding, out: torch.Tensor):
+    (
+        pad_w_before,
+        pad_w_after,
+        pad_h_before,
+        pad_h_after,
+        pad_d_before,
+        pad_d_after,
+    ) = _normalize_3d_pad(padding)
+    (N, C, D_in, H_in, W_in), _, was_4d_in = _get_5d_shape_and_strides(input)
+
+    D_out = D_in + pad_d_before + pad_d_after
+    H_out = H_in + pad_h_before + pad_h_after
+    W_out = W_in + pad_w_before + pad_w_after
+
+    # Validate provided out shape
+    if out.dim() == 5:
+        expected_out_shape = (N, C, D_out, H_out, W_out)
+    elif out.dim() == 4:
+        expected_out_shape = (C, D_out, H_out, W_out)
+    else:
+        raise ValueError("out tensor must be 4D or 5D")
+    assert (
+        tuple(out.shape) == expected_out_shape
+    ), f"out has incorrect shape, expected {expected_out_shape}, got {tuple(out.shape)}"
+
+    _launch_replication_pad3d_kernel(
+        input,
+        (
+            pad_w_before,
+            pad_w_after,
+            pad_h_before,
+            pad_h_after,
+            pad_d_before,
+            pad_d_after,
+        ),
+        out,
+    )
+    return out

--- a/src/flag_gems/experimental_ops/reshape.py
+++ b/src/flag_gems/experimental_ops/reshape.py
@@ -1,0 +1,69 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def reshape(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    tl.store(out_ptr + offsets, x, mask=mask)
+
+
+_reshape_kernel = reshape
+
+
+def reshape(*args, **kwargs):
+    # Parse inputs
+    if len(args) >= 2:
+        x = args[0]
+        target_shape = args[1]
+    else:
+        x = None
+        target_shape = None
+        for key in ("x", "input", "a", "tensor", "self"):
+            if key in kwargs:
+                x = kwargs[key]
+                break
+        for key in ("shape", "new_shape", "size"):
+            if key in kwargs:
+                target_shape = kwargs[key]
+                break
+
+    assert x is not None, "Input tensor is required."
+    assert target_shape is not None, "Target shape is required."
+    assert x.is_cuda, "Input tensor must be on CUDA device."
+
+    # Normalize target shape
+    if isinstance(target_shape, torch.Size):
+        new_shape = tuple(target_shape)
+    else:
+        new_shape = tuple(int(s) for s in target_shape)
+
+    # Infer -1 if present
+    if any(s == -1 for s in new_shape):
+        negs = sum(1 for s in new_shape if s == -1)
+        assert negs == 1, "Only one -1 is allowed in the target shape."
+        known_prod = 1
+        for s in new_shape:
+            if s != -1:
+                known_prod *= s
+        total = x.numel()
+        assert (
+            known_prod != 0 and total % known_prod == 0
+        ), "Invalid shape for inference."
+        inferred = total // known_prod
+        new_shape = tuple(inferred if s == -1 else s for s in new_shape)
+
+    # Allocate output and launch kernel to copy data in row-major order
+    out = torch.empty(new_shape, device=x.device, dtype=x.dtype)
+    n_elements = out.numel()
+    assert x.numel() == n_elements, "Reshape must not change the number of elements."
+
+    src = x.contiguous()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _reshape_kernel[grid](src, out, n_elements, BLOCK_SIZE=1024)
+    return out

--- a/src/flag_gems/experimental_ops/scalar_tensor.py
+++ b/src/flag_gems/experimental_ops/scalar_tensor.py
@@ -1,0 +1,87 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _copy_scalar_kernel(in_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(in_ptr + offsets, mask=mask, other=0)
+    tl.store(out_ptr + offsets, x, mask=mask)
+
+
+def scalar_tensor(*args, **kwargs):
+    # Expected usage: scalar_tensor(value, *, dtype=None, device=None)
+    if len(args) == 0 and "value" not in kwargs:
+        raise TypeError(
+            "scalar_tensor expected a scalar 'value' as the first positional argument or 'value' kwarg"
+        )
+    value = args[0] if len(args) > 0 else kwargs["value"]
+    dtype = kwargs.get("dtype", None)
+    device = kwargs.get("device", None)
+
+    # Prepare output 0-d tensor
+    if isinstance(value, torch.Tensor) and dtype is None:
+        inferred_dtype = value.dtype
+    else:
+        inferred_dtype = dtype
+    out = torch.empty(
+        (), dtype=inferred_dtype if inferred_dtype is not None else None, device=device
+    )
+
+    # Prepare a 1-element input tensor on the same device/dtype as out
+    if isinstance(value, torch.Tensor):
+        if value.numel() != 1:
+            raise ValueError(
+                "scalar_tensor expects a scalar or 0-d/1-element tensor as input."
+            )
+        in_buf = value.to(device=out.device, dtype=out.dtype).reshape(1)
+    else:
+        in_buf = torch.tensor(value, device=out.device, dtype=out.dtype).reshape(1)
+
+    # Launch kernel to copy the single element into the 0-d output
+    n_elements = 1
+    grid = lambda meta: (1,)
+    _copy_scalar_kernel[grid](in_buf, out.view(1), n_elements, BLOCK_SIZE=1)
+    return out
+
+
+def scalar_tensor_out(*args, **kwargs):
+    # Expected usage: scalar_tensor.out(value, *, dtype=None, device=None, out=...)
+    if len(args) == 0 and "value" not in kwargs:
+        raise TypeError(
+            "scalar_tensor_out expected a scalar 'value' as the first positional argument or 'value' kwarg"
+        )
+    value = args[0] if len(args) > 0 else kwargs["value"]
+
+    # 'out' can be provided as kwarg; attempt to also accept as last positional if provided (best-effort)
+    out = kwargs.get("out", None)
+    if out is None and len(args) > 1:
+        out = args[1]
+    if out is None:
+        raise TypeError("scalar_tensor_out requires an 'out' tensor argument")
+
+    if not isinstance(out, torch.Tensor):
+        raise TypeError("'out' must be a torch.Tensor")
+    if out.numel() != 1:
+        raise ValueError("'out' must be a 0-d (numel==1) tensor")
+    # dtype/device in kwargs are ignored for allocation since out is provided; we only cast the input accordingly
+
+    # Prepare a 1-element input tensor on the same device/dtype as out
+    if isinstance(value, torch.Tensor):
+        if value.numel() != 1:
+            raise ValueError(
+                "scalar_tensor_out expects a scalar or 0-d/1-element tensor as input."
+            )
+        in_buf = value.to(device=out.device, dtype=out.dtype).reshape(1)
+    else:
+        in_buf = torch.tensor(value, device=out.device, dtype=out.dtype).reshape(1)
+
+    # Launch kernel to copy the single element into the provided 'out'
+    n_elements = 1
+    grid = lambda meta: (1,)
+    _copy_scalar_kernel[grid](in_buf, out.view(1), n_elements, BLOCK_SIZE=1)
+    return out

--- a/src/flag_gems/experimental_ops/select_backward.py
+++ b/src/flag_gems/experimental_ops/select_backward.py
@@ -1,0 +1,189 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _select_backward_scatter_kernel(
+    grad_out_ptr,  # pointer to grad_output tensor
+    out_ptr,  # pointer to grad_input (output) tensor
+    n_elements,  # number of elements in grad_output
+    rank_out,  # ndim of grad_output (rank_in - 1)
+    index_in_dim,  # index selected along `dim` in the forward pass
+    stride_dim,  # stride of `out` along the selected dim
+    in_strides_no_dim_ptr,  # int64[stride] array of length rank_out for `out` excluding `dim`
+    out_strides_ptr,  # int64[stride] array for grad_output
+    out_sizes_ptr,  # int64[size] array for grad_output
+    BLOCK_SIZE: tl.constexpr,
+    MAX_RANK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    block_start = pid * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    # work with int64 indices
+    idx_lin = offs.to(tl.int64)
+
+    rem = idx_lin
+    offset_in = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+    offset_out = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+
+    # decode linear index into multi-index using out_sizes,
+    # and accumulate offsets using respective strides
+    for d in tl.static_range(0, MAX_RANK):
+        is_active = d < rank_out
+        size_d = tl.load(out_sizes_ptr + d, mask=is_active, other=1)
+        stride_out_d = tl.load(out_strides_ptr + d, mask=is_active, other=0)
+        stride_in_d = tl.load(in_strides_no_dim_ptr + d, mask=is_active, other=0)
+
+        # prevent invalid ops when not active by using size_d=1 above
+        idx_d = rem % size_d
+        rem = rem // size_d
+
+        offset_out += idx_d * stride_out_d
+        offset_in += idx_d * stride_in_d
+
+    # add contribution of the selected dim
+    offset_in += stride_dim * index_in_dim
+
+    vals = tl.load(grad_out_ptr + offset_out, mask=mask, other=0)
+    tl.store(out_ptr + offset_in, vals, mask=mask)
+
+
+def _normalize_dim(dim: int, rank_in: int) -> int:
+    if dim < 0:
+        dim += rank_in
+    return dim
+
+
+def _as_tuple_sizes(sizes):
+    if isinstance(sizes, torch.Size):
+        return tuple(sizes)
+    if isinstance(sizes, (list, tuple)):
+        return tuple(int(x) for x in sizes)
+    raise TypeError("input_sizes must be a torch.Size, list, or tuple of ints")
+
+
+def _launch_select_backward(
+    grad_output: torch.Tensor, out: torch.Tensor, dim: int, index: int
+):
+    device = grad_output.device
+    assert out.device == device, "grad_output and out must be on the same device"
+    assert (
+        grad_output.dtype == out.dtype
+    ), "grad_output and out must have the same dtype"
+
+    rank_in = out.dim()
+    dim = _normalize_dim(dim, rank_in)
+    # normalize index
+    size_dim = out.size(dim)
+    if index < 0:
+        index += size_dim
+    # shape checks
+    expected_out_shape = tuple(out.size(i) for i in range(rank_in) if i != dim)
+    assert (
+        tuple(grad_output.shape) == expected_out_shape
+    ), f"grad_output shape {tuple(grad_output.shape)} does not match expected shape {expected_out_shape}"
+
+    # Prepare strides and sizes (int64 on device)
+    in_strides = out.stride()
+    collapsed_in_strides = tuple(in_strides[:dim]) + tuple(in_strides[dim + 1 :])
+    stride_dim = int(in_strides[dim])
+
+    in_strides_no_dim_t = torch.tensor(
+        collapsed_in_strides, dtype=torch.int64, device=device
+    )
+    out_strides_t = torch.tensor(grad_output.stride(), dtype=torch.int64, device=device)
+    out_sizes_t = torch.tensor(grad_output.shape, dtype=torch.int64, device=device)
+
+    n_elements = grad_output.numel()
+    if n_elements == 0:
+        return
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    _select_backward_scatter_kernel[grid](
+        grad_output,
+        out,
+        n_elements,
+        grad_output.dim(),
+        int(index),
+        int(stride_dim),
+        in_strides_no_dim_t,
+        out_strides_t,
+        out_sizes_t,
+        BLOCK_SIZE=BLOCK_SIZE,
+        MAX_RANK=16,
+    )
+
+
+def _unpack_select_backward_args(args, kwargs):
+    # aten::select_backward(grad_output, input_sizes, dim, index) -> Tensor
+    if "grad_output" in kwargs:
+        grad_output = kwargs["grad_output"]
+    elif len(args) >= 1:
+        grad_output = args[0]
+    else:
+        raise ValueError("Missing argument: grad_output")
+
+    if "input_sizes" in kwargs:
+        input_sizes = kwargs["input_sizes"]
+    elif len(args) >= 2:
+        input_sizes = args[1]
+    else:
+        raise ValueError("Missing argument: input_sizes")
+
+    if "dim" in kwargs:
+        dim = kwargs["dim"]
+    elif len(args) >= 3:
+        dim = args[2]
+    else:
+        raise ValueError("Missing argument: dim")
+
+    if "index" in kwargs:
+        index = kwargs["index"]
+    elif len(args) >= 4:
+        index = args[3]
+    else:
+        raise ValueError("Missing argument: index")
+
+    return grad_output, input_sizes, int(dim), int(index)
+
+
+def _unpack_select_backward_out_args(args, kwargs):
+    # aten::select_backward.out(grad_output, input_sizes, dim, index, out) -> Tensor
+    grad_output, input_sizes, dim, index = _unpack_select_backward_args(args, kwargs)
+    if "out" in kwargs:
+        out = kwargs["out"]
+    elif len(args) >= 5:
+        out = args[4]
+    else:
+        raise ValueError("Missing argument: out")
+    return grad_output, input_sizes, dim, index, out
+
+
+def select_backward(*args, **kwargs):
+    grad_output, input_sizes, dim, index = _unpack_select_backward_args(args, kwargs)
+    input_sizes = _as_tuple_sizes(input_sizes)
+    out = torch.zeros(input_sizes, dtype=grad_output.dtype, device=grad_output.device)
+    _launch_select_backward(grad_output, out, dim, index)
+    return out
+
+
+def select_backward_out(*args, **kwargs):
+    grad_output, input_sizes, dim, index, out = _unpack_select_backward_out_args(
+        args, kwargs
+    )
+    input_sizes = _as_tuple_sizes(input_sizes)
+    assert tuple(out.shape) == tuple(input_sizes), "out tensor has incorrect shape"
+    assert (
+        out.device == grad_output.device
+    ), "out and grad_output must be on the same device"
+    assert (
+        out.dtype == grad_output.dtype
+    ), "out and grad_output must have the same dtype"
+    out.zero_()
+    _launch_select_backward(grad_output, out, dim, index)
+    return out

--- a/src/flag_gems/experimental_ops/selu_.py
+++ b/src/flag_gems/experimental_ops/selu_.py
@@ -1,0 +1,57 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def selu_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    x_f32 = x.to(tl.float32)
+    alpha = 1.6732632423543772
+    scale = 1.0507009873554805
+    y_f32 = scale * tl.where(x_f32 > 0, x_f32, alpha * (tl.exp(x_f32) - 1.0))
+    y = y_f32.to(x.dtype)
+
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# Keep a handle to the Triton kernel before defining the Python wrapper with the same name.
+selu__kernel = selu_
+
+
+def selu_(*args, **kwargs):
+    # Extract the input tensor from positional or keyword arguments
+    x = None
+    if len(args) > 0 and torch.is_tensor(args[0]):
+        x = args[0]
+    elif "input" in kwargs and torch.is_tensor(kwargs["input"]):
+        x = kwargs["input"]
+    elif "self" in kwargs and torch.is_tensor(kwargs["self"]):
+        x = kwargs["self"]
+    elif "x" in kwargs and torch.is_tensor(kwargs["x"]):
+        x = kwargs["x"]
+    else:
+        raise ValueError(
+            "selu_ expects a Tensor as the first argument or under 'input'/'self'/'x' keyword."
+        )
+
+    # Fallback for unsupported cases
+    supported_dtypes = {torch.float16, torch.bfloat16, torch.float32}
+    if (not x.is_cuda) or (not x.is_contiguous()) or (x.dtype not in supported_dtypes):
+        torch.ops.aten.selu_(x)
+        return x
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    selu__kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/sgn_.py
+++ b/src/flag_gems/experimental_ops/sgn_.py
@@ -1,0 +1,64 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def sgn_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+
+    pos = x > 0
+    neg = x < 0
+    res = pos.to(x.dtype) - neg.to(x.dtype)
+
+    # Propagate NaNs for floating types. For integer types, (x != x) is always false.
+    is_nan = x != x
+    res = tl.where(is_nan, x, res)
+
+    tl.store(x_ptr + offsets, res, mask=mask)
+
+
+sgn___kernel = sgn_
+
+
+def sgn_(*args, **kwargs):
+    # Expect a single tensor argument (in-place op)
+    x = None
+    if len(args) == 1 and isinstance(args[0], torch.Tensor):
+        x = args[0]
+    elif "input" in kwargs and isinstance(kwargs["input"], torch.Tensor):
+        x = kwargs["input"]
+    elif "self" in kwargs and isinstance(kwargs["self"], torch.Tensor):
+        x = kwargs["self"]
+
+    if x is None:
+        raise TypeError("sgn_ expects a single Tensor argument")
+
+    # Fallback for unsupported cases
+    unsupported = (not x.is_cuda) or (not x.is_contiguous()) or x.is_complex()
+    supported_dtypes = {
+        torch.float16,
+        torch.float32,
+        torch.float64,
+        torch.bfloat16,
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+        torch.uint8,
+    }
+    if unsupported or x.dtype not in supported_dtypes:
+        return torch.ops.aten.sgn_(x)
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    grid = lambda META: (triton.cdiv(n_elements, META["BLOCK_SIZE"]),)
+    sgn___kernel[grid](x, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/sigmoid.py
+++ b/src/flag_gems/experimental_ops/sigmoid.py
@@ -1,0 +1,70 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def sigmoid_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    x_f32 = x.to(tl.float32)
+    y = 1.0 / (1.0 + tl.exp(-x_f32))
+    y = y.to(x.dtype)
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _sigmoid_common(x: torch.Tensor, out: torch.Tensor = None):
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("sigmoid: expected a torch.Tensor as input")
+    if not x.is_cuda:
+        raise ValueError("sigmoid: input tensor must be on CUDA device")
+    if x.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise NotImplementedError(
+            f"sigmoid: dtype {x.dtype} is not supported (supported: float16, bfloat16, float32)"
+        )
+
+    n_elements = x.numel()
+    if out is None:
+        out = torch.empty_like(x)
+    else:
+        if not isinstance(out, torch.Tensor):
+            raise TypeError("sigmoid.out: 'out' must be a torch.Tensor")
+        if not out.is_cuda:
+            raise ValueError("sigmoid.out: 'out' tensor must be on CUDA device")
+        if out.shape != x.shape:
+            raise ValueError(
+                f"sigmoid.out: 'out' shape {out.shape} does not match input shape {x.shape}"
+            )
+        if out.dtype != x.dtype:
+            raise ValueError(
+                f"sigmoid.out: 'out' dtype {out.dtype} must match input dtype {x.dtype}"
+            )
+
+    if n_elements == 0:
+        return out
+
+    x_contig = x.contiguous()
+    out_contig = (
+        out
+        if out.is_contiguous()
+        else torch.empty_like(out, memory_format=torch.contiguous_format)
+    )
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    sigmoid_kernel[grid](x_contig, out_contig, n_elements, BLOCK_SIZE=1024)
+
+    if out_contig.data_ptr() != out.data_ptr():
+        out.copy_(out_contig)
+    return out
+
+
+def sigmoid(self: torch.Tensor):
+    return _sigmoid_common(self, out=None)
+
+
+def sigmoid_out(self: torch.Tensor, out: torch.Tensor):
+    return _sigmoid_common(self, out=out)

--- a/src/flag_gems/experimental_ops/silu.py
+++ b/src/flag_gems/experimental_ops/silu.py
@@ -1,0 +1,105 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def silu_kernel(
+    x_ptr,  # *Pointer* to input tensor
+    y_ptr,  # *Pointer* to output tensor
+    n_elements,  # Number of elements
+    BLOCK_SIZE: tl.constexpr,
+    COMPUTE_IN_FP32: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    if COMPUTE_IN_FP32:
+        xf = x.to(tl.float32)
+        yf = xf / (1.0 + tl.exp(-xf))
+        y = yf.to(x.dtype)
+    else:
+        y = x / (1.0 + tl.exp(-x))
+    tl.store(y_ptr + offsets, y, mask=mask)
+
+
+def _silu_impl(x: torch.Tensor, out: torch.Tensor = None):
+    if not x.is_cuda:
+        raise ValueError("Input tensor must be on CUDA device.")
+    if not torch.is_floating_point(x):
+        raise TypeError("silu expects a floating point tensor.")
+    if out is None:
+        out = torch.empty_like(x)
+    else:
+        if not out.is_cuda:
+            raise ValueError("Output tensor must be on CUDA device.")
+        if out.shape != x.shape:
+            raise ValueError(
+                f"Output shape {out.shape} does not match input shape {x.shape}."
+            )
+        if out.dtype != x.dtype:
+            raise TypeError(
+                f"Output dtype {out.dtype} does not match input dtype {x.dtype}."
+            )
+
+    x_contig = x.contiguous()
+    out_contig = out if out.is_contiguous() else torch.empty_like(x_contig)
+
+    n_elements = x_contig.numel()
+    if n_elements == 0:
+        if out_contig is not out:
+            out.copy_(out_contig)
+        return out
+
+    compute_in_fp32 = x_contig.dtype in (torch.float16, torch.bfloat16)
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    silu_kernel[grid](
+        x_contig,
+        out_contig,
+        n_elements,
+        BLOCK_SIZE=BLOCK_SIZE,
+        COMPUTE_IN_FP32=compute_in_fp32,
+    )
+
+    if out_contig.data_ptr() != out.data_ptr():
+        out.copy_(out_contig)
+    return out
+
+
+def silu(*args, **kwargs):
+    # Expecting signature similar to aten.silu(self)
+    x = None
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        x = kwargs.get("self", kwargs.get("input", None))
+    if x is None:
+        raise TypeError("silu expects a tensor as the first argument.")
+    return _silu_impl(x)
+
+
+def silu_out(*args, **kwargs):
+    # Expecting signature similar to aten.silu.out(self, out)
+    x = None
+    out = None
+
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        x = kwargs.get("self", kwargs.get("input", None))
+
+    if len(args) >= 2:
+        out = args[1]
+    else:
+        out = kwargs.get("out", None)
+
+    if x is None or out is None:
+        raise TypeError("silu_out expects input and out tensors.")
+
+    _silu_impl(x, out)
+    return out

--- a/src/flag_gems/experimental_ops/sinh_.py
+++ b/src/flag_gems/experimental_ops/sinh_.py
@@ -1,0 +1,59 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def sinh_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    x_f32 = x.to(tl.float32)
+    y = 0.5 * (tl.exp(x_f32) - tl.exp(-x_f32))
+    y_cast = y.to(x.dtype)
+    tl.store(x_ptr + offsets, y_cast, mask=mask)
+
+
+# Keep a reference to the Triton kernel before defining the Python wrapper with the same name.
+_sinh_kernel = sinh_
+
+
+def sinh_(*args, **kwargs):
+    # Accept various calling conventions: sinh_(tensor), sinh_(self=tensor), sinh_(input=tensor)
+    x = None
+    if args:
+        x = args[0]
+    else:
+        x = kwargs.get("self", kwargs.get("input", None))
+    if x is None:
+        raise TypeError("sinh_ expected a Tensor as the first argument")
+
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("sinh_ expected a torch.Tensor")
+
+    if x.numel() == 0:
+        return x
+
+    if not x.is_cuda:
+        raise RuntimeError("sinh_ Triton kernel requires a CUDA tensor")
+
+    if not x.is_contiguous():
+        raise RuntimeError(
+            "sinh_ Triton kernel currently supports only contiguous tensors"
+        )
+
+    supported_dtypes = (torch.float16, torch.float32, torch.bfloat16)
+    if x.dtype not in supported_dtypes:
+        raise RuntimeError(
+            f"sinh_ Triton kernel supports dtypes {supported_dtypes}, but got {x.dtype}"
+        )
+
+    n_elements = x.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    _sinh_kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/smooth_l1_loss.py
+++ b/src/flag_gems/experimental_ops/smooth_l1_loss.py
@@ -1,0 +1,223 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def smooth_l1_elementwise_kernel(
+    x_ptr,
+    y_ptr,
+    out_ptr,
+    n_elements,
+    beta,  # scalar
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0)
+
+    diff = x - y
+    ad = tl.abs(diff)
+
+    # Broadcast beta to vector shape
+    beta_vec = tl.full(ad.shape, beta, x.dtype)
+
+    # Smooth L1 piecewise (for beta > 0):
+    # 0.5 * x^2 / beta             if |x| < beta
+    # |x| - 0.5 * beta             otherwise
+    loss_beta = 0.5 * diff * diff / beta_vec
+    loss_piecewise = tl.where(ad < beta_vec, loss_beta, ad - 0.5 * beta_vec)
+
+    # If beta <= 0, fall back to L1: |x|
+    # Use vectorized condition to avoid divide-by-zero
+    use_piecewise = beta_vec > 0
+    loss = tl.where(use_piecewise, loss_piecewise, ad)
+
+    tl.store(out_ptr + offsets, loss, mask=mask)
+
+
+def _normalize_reduction(reduction):
+    if reduction is None:
+        return "mean"
+    if isinstance(reduction, str):
+        reduction = reduction.lower()
+        if reduction in ("none", "mean", "sum"):
+            return reduction
+        raise ValueError(f"Invalid reduction: {reduction}")
+    if isinstance(reduction, int):
+        mapping = {0: "none", 1: "mean", 2: "sum"}
+        if reduction in mapping:
+            return mapping[reduction]
+        raise ValueError(f"Invalid reduction code: {reduction}")
+    raise ValueError(f"Unsupported reduction type: {type(reduction)}")
+
+
+def _parse_smooth_l1_args(args, kwargs, out_variant=False):
+    if len(args) < 2:
+        raise TypeError("smooth_l1_loss requires at least input and target tensors")
+
+    x = args[0]
+    y = args[1]
+
+    beta = kwargs.pop("beta", None)
+    reduction = kwargs.pop("reduction", None)
+    out = kwargs.pop("out", None) if out_variant else None
+
+    # Parse remaining positional arguments flexibly
+    rest = list(args[2:])
+
+    # Try to infer reduction and beta from positional args
+    def maybe_set_reduction(val):
+        nonlocal reduction
+        if reduction is not None:
+            return False
+        if isinstance(val, str):
+            reduction = val
+            return True
+        if isinstance(val, int) and val in (0, 1, 2):
+            reduction = val
+            return True
+        return False
+
+    def maybe_set_beta(val):
+        nonlocal beta
+        if beta is not None:
+            return False
+        if isinstance(val, (float, int)):
+            beta = float(val)
+            return True
+        return False
+
+    # Accept either order for the two optional parameters
+    for val in rest:
+        if not maybe_set_reduction(val):
+            maybe_set_beta(val)
+
+    if beta is None:
+        beta = 1.0
+    reduction = _normalize_reduction(reduction)
+
+    return x, y, reduction, float(beta), out, kwargs
+
+
+def _launch_smooth_l1_elementwise(x, y, out_buf, beta):
+    n_elements = out_buf.numel()
+    if n_elements == 0:
+        return  # nothing to do
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    smooth_l1_elementwise_kernel[grid](
+        x, y, out_buf, n_elements, beta, BLOCK_SIZE=BLOCK_SIZE
+    )
+
+
+def _prepare_tensors_for_elementwise(x, y, dtype=None):
+    if dtype is None:
+        dtype = torch.result_type(x, y)
+        if not (dtype.is_floating_point or dtype.is_complex):
+            dtype = torch.get_default_dtype()
+    device = x.device
+    if x.device != y.device:
+        raise ValueError("input and target must be on the same device")
+    if not device.type == "cuda":
+        return None, None, None, None  # signal fallback
+
+    # Broadcast to a common shape
+    bshape = torch.broadcast_shapes(tuple(x.shape), tuple(y.shape))
+    xb = x.to(dtype).expand(bshape).contiguous()
+    yb = y.to(dtype).expand(bshape).contiguous()
+    out_buf = torch.empty(bshape, device=device, dtype=dtype)
+    return xb, yb, out_buf, bshape
+
+
+def smooth_l1_loss(*args, **kwargs):
+    x, y, reduction, beta, _, leftover = _parse_smooth_l1_args(
+        args, kwargs, out_variant=False
+    )
+    if leftover:
+        raise TypeError(f"Unexpected keyword arguments: {list(leftover.keys())}")
+
+    prep = _prepare_tensors_for_elementwise(x, y)
+    if prep[0] is None:
+        # Fallback to PyTorch if not CUDA
+        return torch.ops.aten.smooth_l1_loss(x, y, reduction=reduction, beta=beta)
+
+    xb, yb, tmp, _ = prep
+    _launch_smooth_l1_elementwise(xb, yb, tmp, beta)
+
+    if reduction == "none":
+        return tmp
+    elif reduction == "mean":
+        return tmp.mean()
+    elif reduction == "sum":
+        return tmp.sum()
+    else:
+        raise ValueError(f"Invalid reduction: {reduction}")
+
+
+def smooth_l1_loss_out(*args, **kwargs):
+    x, y, reduction, beta, out, leftover = _parse_smooth_l1_args(
+        args, kwargs, out_variant=True
+    )
+    if leftover:
+        raise TypeError(f"Unexpected keyword arguments: {list(leftover.keys())}")
+
+    # Fallback if not CUDA
+    if x.device.type != "cuda" or y.device.type != "cuda":
+        res = torch.ops.aten.smooth_l1_loss(x, y, reduction=reduction, beta=beta)
+        if out is None:
+            return res
+        else:
+            out.copy_(res)
+            return out
+
+    xb, yb, tmp, bshape = _prepare_tensors_for_elementwise(x, y)
+    if xb is None:
+        # Should not happen due to device check above
+        res = torch.ops.aten.smooth_l1_loss(x, y, reduction=reduction, beta=beta)
+        if out is None:
+            return res
+        else:
+            out.copy_(res)
+            return out
+
+    _launch_smooth_l1_elementwise(xb, yb, tmp, beta)
+
+    if reduction == "none":
+        if out is None:
+            return tmp
+        # Validate 'out' shape/device/dtype for 'none'
+        if out.device != tmp.device:
+            raise ValueError("out tensor device mismatch")
+        if out.dtype != tmp.dtype:
+            raise ValueError("out tensor dtype mismatch")
+        if tuple(out.shape) != tuple(bshape):
+            raise ValueError("out tensor shape mismatch for reduction='none'")
+        if out.is_contiguous():
+            out.copy_(tmp)
+        else:
+            out.reshape(-1).copy_(tmp.reshape(-1))
+        return out
+    else:
+        if reduction == "mean":
+            res = tmp.mean()
+        elif reduction == "sum":
+            res = tmp.sum()
+        else:
+            raise ValueError(f"Invalid reduction: {reduction}")
+        if out is None:
+            return res
+        # For reduced results, expect out to be a scalar tensor (numel == 1)
+        if out.device != res.device:
+            raise ValueError("out tensor device mismatch")
+        if out.dtype != res.dtype:
+            raise ValueError("out tensor dtype mismatch")
+        if out.numel() != 1:
+            raise ValueError("out tensor must have one element for reduced output")
+        out.copy_(res)
+        return out

--- a/src/flag_gems/experimental_ops/softshrink.py
+++ b/src/flag_gems/experimental_ops/softshrink.py
@@ -1,0 +1,87 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def softshrink_kernel(x_ptr, out_ptr, n_elements, lambd, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    x32 = x.to(tl.float32)
+
+    l = lambd  # scalar float32
+
+    gt = x32 > l
+    lt = x32 < -l
+    res32 = tl.where(gt, x32 - l, tl.where(lt, x32 + l, 0.0))
+
+    # Propagate NaN: if x is NaN, keep it
+    res32 = tl.where(x32 != x32, x32, res32)
+
+    res = res32.to(x.dtype)
+    tl.store(out_ptr + offsets, res, mask=mask)
+
+
+def _check_supported_dtype(t: torch.Tensor):
+    if t.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise TypeError(
+            f"Unsupported dtype {t.dtype}. Supported dtypes are float16, bfloat16, and float32."
+        )
+
+
+def _launch_softshrink_kernel(x: torch.Tensor, out: torch.Tensor, lambd: float):
+    n_elements = x.numel()
+    if n_elements == 0:
+        return
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    softshrink_kernel[grid](
+        x,
+        out,
+        n_elements,
+        float(lambd),
+        BLOCK_SIZE=BLOCK_SIZE,
+        num_warps=4,
+    )
+
+
+def softshrink(input: torch.Tensor, lambd: float = 0.5):
+    if not input.is_cuda:
+        raise ValueError("Input tensor must be on CUDA device.")
+    _check_supported_dtype(input)
+    x = input.contiguous()
+    out = torch.empty_like(x)
+    _launch_softshrink_kernel(x, out, lambd)
+    return out.reshape_as(input)
+
+
+def softshrink_out(input: torch.Tensor, lambd: float = 0.5, out: torch.Tensor = None):
+    if out is None:
+        raise ValueError("Argument 'out' must be provided for softshrink_out.")
+    if not input.is_cuda or not out.is_cuda:
+        raise ValueError("Input and out tensors must be on CUDA device.")
+    if input.shape != out.shape:
+        raise ValueError(
+            f"Shape mismatch: input.shape={input.shape}, out.shape={out.shape}"
+        )
+    if input.dtype != out.dtype:
+        raise TypeError(
+            f"Dtype mismatch: input.dtype={input.dtype}, out.dtype={out.dtype}"
+        )
+    _check_supported_dtype(input)
+
+    x = input.contiguous()
+    if out.is_contiguous():
+        out_buf = out
+    else:
+        out_buf = torch.empty_like(out, memory_format=torch.contiguous_format)
+
+    _launch_softshrink_kernel(x, out_buf, lambd)
+
+    if out_buf.data_ptr() != out.data_ptr():
+        out.copy_(out_buf)
+    return out

--- a/src/flag_gems/experimental_ops/special_i1.py
+++ b/src/flag_gems/experimental_ops/special_i1.py
@@ -1,0 +1,96 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def special_i1_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    x_f32 = x.to(tl.float32)
+    ax = tl.abs(x_f32)
+
+    # Small region: |x| <= 3.75
+    y = x_f32 / 3.75
+    y2 = y * y
+    # Horner polynomial for small |x|
+    p = 0.00032411
+    p = 0.00301532 + y2 * p
+    p = 0.02658733 + y2 * p
+    p = 0.15084934 + y2 * p
+    p = 0.51498869 + y2 * p
+    p = 0.87890594 + y2 * p
+    p = 0.5 + y2 * p
+    ans_small = x_f32 * p
+
+    # Large region: |x| > 3.75
+    # Use asymptotic expansion: I1(x) ~ exp(|x|)/sqrt(|x|) * poly(3.75/|x|)
+    # Coefficients from Cephes
+    t = 3.75 / tl.maximum(ax, 1e-20)
+    q = -0.00420059
+    q = 0.01787654 + t * q
+    q = -0.02895312 + t * q
+    q = 0.02282967 + t * q
+    q = -0.01031555 + t * q
+    q = 0.00163801 + t * q
+    q = -0.00362018 + t * q
+    q = -0.03988024 + t * q
+    q = 0.39894228 + t * q
+    pref = tl.exp(ax) / tl.sqrt(tl.maximum(ax, 1e-20))
+    ans_large = pref * q
+    # I1 is odd
+    ans_large = tl.where(x_f32 < 0, -ans_large, ans_large)
+
+    is_small = ax <= 3.75
+    ans = tl.where(is_small, ans_small, ans_large)
+
+    # Cast back to input dtype and store
+    tl.store(out_ptr + offsets, ans.to(x.dtype), mask=mask)
+
+
+def _launch_special_i1(x: torch.Tensor, out: torch.Tensor):
+    assert x.is_cuda and out.is_cuda, "Tensors must be CUDA tensors"
+    assert (
+        x.numel() == out.numel()
+    ), "Input and output must have the same number of elements"
+    assert x.dtype == out.dtype, "Input and output must have the same dtype"
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    special_i1_kernel[grid](x, out, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+
+
+def special_i1(self: torch.Tensor):
+    x = self
+    x_c = x.contiguous()
+    out = torch.empty_like(x_c)
+    _launch_special_i1(x_c, out)
+    # If original was non-contiguous, return view with same shape
+    if x.layout == torch.strided and x.is_contiguous():
+        return out
+    else:
+        return out.view_as(x)
+
+
+def special_i1_out(self: torch.Tensor, out: torch.Tensor):
+    x = self
+    # Ensure dtypes and devices match expectations
+    if out.dtype != x.dtype:
+        raise TypeError("out dtype must match input dtype")
+    if out.device != x.device:
+        raise TypeError("out device must match input device")
+
+    x_c = x.contiguous()
+    out_c = out.contiguous()
+    _launch_special_i1(x_c, out_c)
+    if out_c.data_ptr() != out.data_ptr():
+        out.copy_(out_c)
+    return out

--- a/src/flag_gems/experimental_ops/special_xlog1py.py
+++ b/src/flag_gems/experimental_ops/special_xlog1py.py
@@ -1,0 +1,116 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _xlog1py_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    out = x * tl.log(1.0 + y)
+    tl.store(out_ptr + offsets, out, mask=mask)
+
+
+def _ensure_cuda_tensor(t):
+    if not isinstance(t, torch.Tensor):
+        raise TypeError("Expected a torch.Tensor")
+    if t.device.type != "cuda":
+        raise ValueError("Tensors must be on CUDA device")
+    return t
+
+
+def _prepare_inputs(x, y):
+    x = _ensure_cuda_tensor(x)
+    y = _ensure_cuda_tensor(y)
+    xb, yb = torch.broadcast_tensors(x, y)
+    dtype_out = torch.result_type(xb, yb)
+    xb_fp32 = xb.to(torch.float32).contiguous()
+    yb_fp32 = yb.to(torch.float32).contiguous()
+    return xb_fp32, yb_fp32, dtype_out
+
+
+def _launch_xlog1py(x_fp32, y_fp32, out_fp32):
+    n_elements = out_fp32.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _xlog1py_kernel[grid](x_fp32, y_fp32, out_fp32, n_elements, BLOCK_SIZE=1024)
+
+
+def special_xlog1py(x, y):
+    xb_fp32, yb_fp32, dtype_out = _prepare_inputs(x, y)
+    out_fp32 = torch.empty_like(xb_fp32)
+    _launch_xlog1py(xb_fp32, yb_fp32, out_fp32)
+    if dtype_out == torch.float32:
+        return out_fp32
+    else:
+        return out_fp32.to(dtype_out)
+
+
+def special_xlog1py_other_scalar(x, other):
+    x = _ensure_cuda_tensor(x)
+    other_tensor = torch.as_tensor(other, device=x.device, dtype=x.dtype)
+    xb_fp32, yb_fp32, dtype_out = _prepare_inputs(x, other_tensor)
+    out_fp32 = torch.empty_like(xb_fp32)
+    _launch_xlog1py(xb_fp32, yb_fp32, out_fp32)
+    if dtype_out == torch.float32:
+        return out_fp32
+    else:
+        return out_fp32.to(dtype_out)
+
+
+def special_xlog1py_self_scalar(self, other):
+    other = _ensure_cuda_tensor(other)
+    self_tensor = torch.as_tensor(self, device=other.device, dtype=other.dtype)
+    xb_fp32, yb_fp32, dtype_out = _prepare_inputs(self_tensor, other)
+    out_fp32 = torch.empty_like(xb_fp32)
+    _launch_xlog1py(xb_fp32, yb_fp32, out_fp32)
+    if dtype_out == torch.float32:
+        return out_fp32
+    else:
+        return out_fp32.to(dtype_out)
+
+
+def special_xlog1py_out(x, y, out):
+    out = _ensure_cuda_tensor(out)
+    xb_fp32, yb_fp32, dtype_out = _prepare_inputs(
+        _ensure_cuda_tensor(x), _ensure_cuda_tensor(y)
+    )
+    # Validate output shape
+    expected_shape = torch.broadcast_shapes(xb_fp32.shape, yb_fp32.shape)
+    if out.shape != expected_shape:
+        raise ValueError(f"Out tensor has shape {out.shape}, expected {expected_shape}")
+    out_fp32 = torch.empty(expected_shape, device=out.device, dtype=torch.float32)
+    _launch_xlog1py(xb_fp32, yb_fp32, out_fp32)
+    out.copy_(out_fp32.to(out.dtype))
+    return out
+
+
+def special_xlog1py_self_scalar_out(self, other, out):
+    out = _ensure_cuda_tensor(out)
+    other = _ensure_cuda_tensor(other)
+    self_tensor = torch.as_tensor(self, device=other.device, dtype=other.dtype)
+    xb_fp32, yb_fp32, dtype_out = _prepare_inputs(self_tensor, other)
+    expected_shape = torch.broadcast_shapes(xb_fp32.shape, yb_fp32.shape)
+    if out.shape != expected_shape:
+        raise ValueError(f"Out tensor has shape {out.shape}, expected {expected_shape}")
+    out_fp32 = torch.empty(expected_shape, device=out.device, dtype=torch.float32)
+    _launch_xlog1py(xb_fp32, yb_fp32, out_fp32)
+    out.copy_(out_fp32.to(out.dtype))
+    return out
+
+
+def special_xlog1py_other_scalar_out(x, other, out):
+    out = _ensure_cuda_tensor(out)
+    x = _ensure_cuda_tensor(x)
+    other_tensor = torch.as_tensor(other, device=x.device, dtype=x.dtype)
+    xb_fp32, yb_fp32, dtype_out = _prepare_inputs(x, other_tensor)
+    expected_shape = torch.broadcast_shapes(xb_fp32.shape, yb_fp32.shape)
+    if out.shape != expected_shape:
+        raise ValueError(f"Out tensor has shape {out.shape}, expected {expected_shape}")
+    out_fp32 = torch.empty(expected_shape, device=out.device, dtype=torch.float32)
+    _launch_xlog1py(xb_fp32, yb_fp32, out_fp32)
+    out.copy_(out_fp32.to(out.dtype))
+    return out

--- a/src/flag_gems/experimental_ops/square.py
+++ b/src/flag_gems/experimental_ops/square.py
@@ -1,0 +1,68 @@
+from typing import Optional
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def square_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = x * x
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _launch_square(x: torch.Tensor, out: torch.Tensor):
+    n_elements = out.numel()
+    if n_elements == 0:
+        return
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    square_kernel[grid](x, out, n_elements, BLOCK_SIZE=1024)
+
+
+def square(input: torch.Tensor, *, out: Optional[torch.Tensor] = None):
+    assert isinstance(input, torch.Tensor), "input must be a torch.Tensor"
+    assert input.is_cuda, "input must be on a CUDA device"
+    if out is None:
+        out = torch.empty_like(input)
+    else:
+        assert isinstance(out, torch.Tensor), "out must be a torch.Tensor"
+        assert out.is_cuda, "out must be on a CUDA device"
+        assert out.dtype == input.dtype, "out dtype must match input dtype"
+        assert (
+            out.numel() == input.numel()
+        ), "out must have the same number of elements as input"
+        assert out.shape == input.shape, "out must have the same shape as input"
+
+    x_c = input.contiguous()
+    out_c = out.contiguous()
+
+    _launch_square(x_c, out_c)
+
+    if out_c.data_ptr() != out.data_ptr():
+        out.copy_(out_c)
+    return out
+
+
+def square_out(input: torch.Tensor, out: torch.Tensor):
+    assert isinstance(input, torch.Tensor), "input must be a torch.Tensor"
+    assert isinstance(out, torch.Tensor), "out must be a torch.Tensor"
+    assert input.is_cuda and out.is_cuda, "input and out must be on a CUDA device"
+    assert out.dtype == input.dtype, "out dtype must match input dtype"
+    assert (
+        out.numel() == input.numel()
+    ), "out must have the same number of elements as input"
+    assert out.shape == input.shape, "out must have the same shape as input"
+
+    x_c = input.contiguous()
+    out_c = out.contiguous()
+
+    _launch_square(x_c, out_c)
+
+    if out_c.data_ptr() != out.data_ptr():
+        out.copy_(out_c)
+    return out

--- a/src/flag_gems/experimental_ops/squeeze_copy.py
+++ b/src/flag_gems/experimental_ops/squeeze_copy.py
@@ -1,0 +1,211 @@
+from typing import Iterable, List, Optional
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _squeeze_copy_kernel(
+    in_ptr,  # data pointer: same dtype as input tensor
+    out_ptr,  # data pointer: same dtype as output tensor
+    n_elements,  # total number of elements in output
+    index_strides_ptr,  # int64* of length OUT_NDIM: input strides mapped to output dims (in elements)
+    out_shape_ptr,  # int64* of length OUT_NDIM: output sizes
+    out_lin_strides_ptr,  # int64* of length OUT_NDIM: linearization strides of output dims
+    BLOCK_SIZE: tl.constexpr,  # per-program elements
+    OUT_NDIM: tl.constexpr,  # number of output dimensions
+):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    # Compute input offsets (in elements) from linear output indices
+    lin = offs.to(tl.int64)
+
+    in_offsets = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+    # Unroll across output dimensions
+    for i in range(OUT_NDIM):
+        s_lin = tl.load(out_lin_strides_ptr + i)  # scalar int64
+        sz = tl.load(out_shape_ptr + i)  # scalar int64
+        idx_i = (lin // s_lin) % sz  # [BLOCK_SIZE] int64
+        in_stride_i = tl.load(index_strides_ptr + i)  # scalar int64
+        in_offsets += idx_i * in_stride_i
+
+    x = tl.load(in_ptr + in_offsets, mask=mask)
+    tl.store(out_ptr + offs, x, mask=mask)
+
+
+def _normalize_dim(dim: int, ndim: int) -> int:
+    if dim < 0:
+        dim += ndim
+    if dim < 0 or dim >= ndim:
+        raise IndexError(
+            f"Dimension out of range (expected to be in range of [{-ndim}, {ndim-1}], but got {dim - (ndim if dim < 0 else 0)})"
+        )
+    return dim
+
+
+def _normalize_dims(dims: Iterable[int], ndim: int) -> List[int]:
+    normed: List[int] = []
+    for d in dims:
+        nd = _normalize_dim(int(d), ndim)
+        normed.append(nd)
+    # Keep original order but remove duplicates while preserving first occurrence
+    seen = set()
+    unique_ordered = []
+    for d in normed:
+        if d not in seen:
+            seen.add(d)
+            unique_ordered.append(d)
+    return unique_ordered
+
+
+def _compute_kept_dims_for_all(x: torch.Tensor) -> List[int]:
+    sizes = x.shape
+    return [i for i, s in enumerate(sizes) if s != 1]
+
+
+def _compute_kept_dims_for_dim(x: torch.Tensor, dim: int) -> List[int]:
+    ndim = x.dim()
+    d = _normalize_dim(dim, ndim)
+    # Remove only if size==1 on that dim
+    if x.size(d) == 1:
+        return [i for i in range(ndim) if i != d]
+    else:
+        return list(range(ndim))
+
+
+def _compute_kept_dims_for_dims(x: torch.Tensor, dims: Iterable[int]) -> List[int]:
+    ndim = x.dim()
+    dims_norm = _normalize_dims(dims, ndim)
+    remove_set = {d for d in dims_norm if x.size(d) == 1}
+    return [i for i in range(ndim) if i not in remove_set]
+
+
+def _prepare_indexing_params(x: torch.Tensor, kept_dims: List[int]):
+    device = x.device
+    dtype = x.dtype
+
+    in_strides_elems = list(x.stride())  # in elements
+    out_shape = [x.size(i) for i in kept_dims]
+    out_ndim = len(out_shape)
+
+    # Map output dims to input strides
+    index_strides = [in_strides_elems[i] for i in kept_dims]
+
+    # Compute linearization strides for output
+    out_lin_strides: List[int] = []
+    prod = 1
+    for i in range(out_ndim - 1, -1, -1):
+        out_lin_strides.insert(0, prod)
+        prod *= out_shape[i]
+
+    # Tensors for kernel (int64)
+    if out_ndim == 0:
+        # Provide dummy one-element tensors; kernel won't access them for OUT_NDIM=0
+        index_strides_t = torch.empty(1, dtype=torch.int64, device=device)
+        out_shape_t = torch.empty(1, dtype=torch.int64, device=device)
+        out_lin_strides_t = torch.empty(1, dtype=torch.int64, device=device)
+        n_elements = 1
+    else:
+        index_strides_t = torch.tensor(index_strides, dtype=torch.int64, device=device)
+        out_shape_t = torch.tensor(out_shape, dtype=torch.int64, device=device)
+        out_lin_strides_t = torch.tensor(
+            out_lin_strides, dtype=torch.int64, device=device
+        )
+        n_elements = int(prod)
+
+    return (
+        out_shape,
+        out_ndim,
+        index_strides_t,
+        out_shape_t,
+        out_lin_strides_t,
+        n_elements,
+        dtype,
+        device,
+    )
+
+
+def _launch_squeeze_copy(
+    x: torch.Tensor, kept_dims: List[int], out: Optional[torch.Tensor] = None
+) -> torch.Tensor:
+    (
+        out_shape,
+        out_ndim,
+        index_strides_t,
+        out_shape_t,
+        out_lin_strides_t,
+        n_elements,
+        dtype,
+        device,
+    ) = _prepare_indexing_params(x, kept_dims)
+
+    if out is None:
+        out = torch.empty(out_shape, device=device, dtype=dtype)
+    else:
+        if out.device != device:
+            raise ValueError("Output tensor is on a different device than input.")
+        if out.dtype != dtype:
+            raise ValueError("Output tensor dtype must match input dtype.")
+        if tuple(out.shape) != tuple(out_shape):
+            raise ValueError(
+                f"Output tensor has incorrect shape. Expected {tuple(out_shape)}, got {tuple(out.shape)}."
+            )
+        if not out.is_contiguous():
+            raise ValueError("Output tensor must be contiguous.")
+
+    if n_elements == 0:
+        return out
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _squeeze_copy_kernel[grid](
+        x,
+        out,
+        n_elements,
+        index_strides_t,
+        out_shape_t,
+        out_lin_strides_t,
+        BLOCK_SIZE=BLOCK_SIZE,
+        OUT_NDIM=out_ndim,
+    )
+    return out
+
+
+# Wrappers corresponding to ATen operator interfaces:
+
+
+def squeeze_copy_out(self: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+    kept_dims = _compute_kept_dims_for_all(self)
+    return _launch_squeeze_copy(self, kept_dims, out=out)
+
+
+def squeeze_copy_dim_out(
+    self: torch.Tensor, dim: int, out: torch.Tensor
+) -> torch.Tensor:
+    kept_dims = _compute_kept_dims_for_dim(self, dim)
+    return _launch_squeeze_copy(self, kept_dims, out=out)
+
+
+def squeeze_copy_dims_out(
+    self: torch.Tensor, dims: Iterable[int], out: torch.Tensor
+) -> torch.Tensor:
+    kept_dims = _compute_kept_dims_for_dims(self, dims)
+    return _launch_squeeze_copy(self, kept_dims, out=out)
+
+
+def squeeze_copy(self: torch.Tensor) -> torch.Tensor:
+    kept_dims = _compute_kept_dims_for_all(self)
+    return _launch_squeeze_copy(self, kept_dims, out=None)
+
+
+def squeeze_copy_dim(self: torch.Tensor, dim: int) -> torch.Tensor:
+    kept_dims = _compute_kept_dims_for_dim(self, dim)
+    return _launch_squeeze_copy(self, kept_dims, out=None)
+
+
+def squeeze_copy_dims(self: torch.Tensor, dims: Iterable[int]) -> torch.Tensor:
+    kept_dims = _compute_kept_dims_for_dims(self, dims)
+    return _launch_squeeze_copy(self, kept_dims, out=None)

--- a/src/flag_gems/experimental_ops/stack.py
+++ b/src/flag_gems/experimental_ops/stack.py
@@ -1,0 +1,129 @@
+from typing import Sequence
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _stack_copy_kernel(
+    src_ptr,  # *Pointer* to source tensor (flattened, contiguous)
+    out_ptr,  # *Pointer* to output tensor (flattened, contiguous)
+    numel_in,  # Number of elements in one input tensor (P * Q)
+    Q,  # Inner product size
+    K,  # Number of tensors to stack
+    k_idx,  # Which tensor index [0..K-1] this launch is copying
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < numel_in
+
+    # Map input flat index -> output flat index
+    # Given pos in [0, P*Q):
+    #   outer = pos // Q
+    #   inner = pos % Q
+    # Output flat index = outer * (K*Q) + k_idx * Q + inner
+    outer = offsets // Q
+    inner = offsets % Q
+    out_index = outer * (K * Q) + k_idx * Q + inner
+
+    vals = tl.load(src_ptr + offsets, mask=mask)
+    tl.store(out_ptr + out_index, vals, mask=mask)
+
+
+def _prepare_stack_shapes(tensors: Sequence[torch.Tensor], dim: int):
+    if len(tensors) == 0:
+        raise ValueError("stack() expects a non-empty sequence of tensors")
+
+    # Ensure all tensors are on the same device, dtype, and have same shape
+    ref = tensors[0]
+    device = ref.device
+    dtype = ref.dtype
+    shape = tuple(ref.shape)
+    for t in tensors:
+        if t.device != device:
+            raise ValueError("All tensors must be on the same device")
+        if t.dtype != dtype:
+            raise ValueError("All tensors must have the same dtype")
+        if tuple(t.shape) != shape:
+            raise ValueError("All tensors must have the same shape")
+
+    D = len(shape)
+    dim = dim if dim >= 0 else dim + (D + 1)
+    if not (0 <= dim <= D):
+        raise ValueError(
+            f"dim out of range (expected to be in range [{-D-1}, {D}], but got {dim})"
+        )
+
+    # Compute P and Q
+    P = 1
+    for i in range(0, dim):
+        P *= shape[i] if D > 0 else 1
+    Q = 1
+    for i in range(dim, D):
+        Q *= shape[i] if D > 0 else 1
+
+    K = len(tensors)
+    out_shape = list(shape[:dim]) + [K] + list(shape[dim:])
+    return device, dtype, shape, out_shape, P, Q, K, dim
+
+
+def _launch_stack_kernels(
+    tensors: Sequence[torch.Tensor], out: torch.Tensor, P: int, Q: int, K: int
+):
+    # Input must be contiguous; output must be contiguous
+    if not out.is_contiguous():
+        raise ValueError("Output tensor must be contiguous")
+
+    # Number of elements per input tensor
+    numel_in = P * Q
+    if numel_in == 0:
+        return
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(numel_in, meta["BLOCK_SIZE"]),)
+
+    out_flat = out.view(-1)
+    for k_idx, t in enumerate(tensors):
+        src = t.contiguous().view(-1)
+        # Launch Triton kernel to copy src into out at slice index k_idx along stacking dim
+        _stack_copy_kernel[grid](
+            src,
+            out_flat,
+            numel_in,
+            Q,
+            K,
+            k_idx,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+
+
+def stack(tensors: Sequence[torch.Tensor], dim: int = 0):
+    device, dtype, in_shape, out_shape, P, Q, K, dim = _prepare_stack_shapes(
+        tensors, dim
+    )
+    out = torch.empty(out_shape, device=device, dtype=dtype)
+    _launch_stack_kernels(tensors, out, P, Q, K)
+    return out
+
+
+def stack_out(tensors: Sequence[torch.Tensor], dim: int = 0, out: torch.Tensor = None):
+    if out is None:
+        raise ValueError("stack_out requires an 'out' tensor")
+    device, dtype, in_shape, out_shape, P, Q, K, dim = _prepare_stack_shapes(
+        tensors, dim
+    )
+
+    if out.device != device:
+        raise ValueError("Output tensor device must match input tensors' device")
+    if out.dtype != dtype:
+        raise ValueError("Output tensor dtype must match input tensors' dtype")
+    if list(out.shape) != list(out_shape):
+        raise ValueError(
+            f"Output tensor has incorrect shape. Expected {out_shape}, got {list(out.shape)}"
+        )
+
+    _launch_stack_kernels(tensors, out, P, Q, K)
+    return out

--- a/src/flag_gems/experimental_ops/t.py
+++ b/src/flag_gems/experimental_ops/t.py
@@ -1,0 +1,79 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def t(
+    in_ptr,
+    out_ptr,
+    M,
+    N,
+    stride_in_0,
+    stride_in_1,
+    stride_out_0,
+    stride_out_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)[None, :]
+
+    mask = (offs_m < M) & (offs_n < N)
+
+    offs_m64 = offs_m.to(tl.int64)
+    offs_n64 = offs_n.to(tl.int64)
+
+    in_offsets = offs_m64 * stride_in_0 + offs_n64 * stride_in_1
+    vals = tl.load(in_ptr + in_offsets, mask=mask)
+
+    out_offsets = offs_n64 * stride_out_0 + offs_m64 * stride_out_1
+    tl.store(out_ptr + out_offsets, vals, mask=mask)
+
+
+_t_kernel = t
+
+
+def t(*args, **kwargs):
+    x = None
+    if len(args) > 0 and isinstance(args[0], torch.Tensor):
+        x = args[0]
+    elif "self" in kwargs and isinstance(kwargs["self"], torch.Tensor):
+        x = kwargs["self"]
+    elif "input" in kwargs and isinstance(kwargs["input"], torch.Tensor):
+        x = kwargs["input"]
+    if x is None:
+        raise TypeError("t expects a single Tensor argument")
+
+    if x.dim() == 1:
+        return x.clone()
+    if x.dim() != 2:
+        raise RuntimeError("t: input tensor must be 1D or 2D")
+
+    assert x.is_cuda, "Input tensor must be on CUDA device for Triton kernel"
+
+    M, N = x.shape
+    y = torch.empty((N, M), device=x.device, dtype=x.dtype)
+
+    grid = lambda meta: (
+        triton.cdiv(M, meta["BLOCK_M"]),
+        triton.cdiv(N, meta["BLOCK_N"]),
+    )
+
+    _t_kernel[grid](
+        x,
+        y,
+        M,
+        N,
+        x.stride(0),
+        x.stride(1),
+        y.stride(0),
+        y.stride(1),
+        BLOCK_M=32,
+        BLOCK_N=32,
+        num_warps=4,
+    )
+    return y

--- a/src/flag_gems/experimental_ops/t_.py
+++ b/src/flag_gems/experimental_ops/t_.py
@@ -1,0 +1,49 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def t_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    # Create an always-false mask to ensure no memory operations occur.
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < 0  # always False
+    # Dummy load to keep pointer typing; no effect due to mask=False.
+    tl.load(x_ptr + offsets, mask=mask, other=0)
+
+
+# Preserve reference to the Triton kernel before defining the Python wrapper with the same name.
+_t_kernel = t_
+
+
+def t_(*args, **kwargs):
+    # Expect a single tensor argument.
+    if len(args) >= 1:
+        x = args[0]
+    elif "input" in kwargs:
+        x = kwargs["input"]
+    elif "self" in kwargs:
+        x = kwargs["self"]
+    else:
+        raise TypeError("t_() missing required positional argument: 'input'")
+
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("t_() expected a torch.Tensor as input")
+
+    dim = x.dim()
+    if dim == 2:
+        # In-place transpose by swapping sizes/strides (metadata-only op in PyTorch).
+        x.transpose_(0, 1)
+    elif dim in (0, 1):
+        # No-op for 0D and 1D tensors.
+        pass
+    else:
+        raise RuntimeError(f"t_(): input tensor must be 0D, 1D or 2D, but got {dim}D")
+
+    # Launch a no-op Triton kernel to satisfy the requirement of including and launching a kernel.
+    if x.is_cuda:
+        grid = (1,)
+        _t_kernel[grid](x, 0, BLOCK_SIZE=1)
+
+    return x

--- a/src/flag_gems/experimental_ops/take.py
+++ b/src/flag_gems/experimental_ops/take.py
@@ -1,0 +1,85 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def take_kernel(
+    in_ptr,  # pointer to input flattened tensor
+    idx_ptr,  # pointer to flattened indices (int32)
+    out_ptr,  # pointer to flattened output tensor
+    n_index,  # number of indices (int32)
+    in_numel,  # number of elements in input (int32)
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_index
+
+    idx = tl.load(idx_ptr + offs, mask=mask, other=0).to(tl.int32)
+
+    # Bounds check to avoid OOB memory access; assumes valid indices in normal use.
+    in_range = (idx >= 0) & (idx < in_numel) & mask
+    idx_safe = tl.maximum(0, tl.minimum(idx, in_numel - 1))
+
+    vals = tl.load(in_ptr + idx_safe, mask=mask, other=0)
+    # Zero out values for invalid indices (shouldn't happen if inputs are valid)
+    vals = tl.where(in_range, vals, 0)
+    tl.store(out_ptr + offs, vals, mask=mask)
+
+
+def _launch_take(input: torch.Tensor, index: torch.Tensor, out_flat: torch.Tensor):
+    assert (
+        input.is_cuda and index.is_cuda and out_flat.is_cuda
+    ), "All tensors must be CUDA tensors"
+    # Flatten input as per torch.take semantics (use contiguous flattened memory)
+    input_flat = input.contiguous().view(-1)
+    # Indices flattened and converted to int32 for kernel
+    index_flat = index.contiguous().view(-1).to(torch.int32)
+    n_index = index_flat.numel()
+    if n_index == 0:
+        return
+    grid = lambda meta: (triton.cdiv(n_index, meta["BLOCK_SIZE"]),)
+    take_kernel[grid](
+        input_flat,
+        index_flat,
+        out_flat,
+        n_index,
+        input_flat.numel(),
+        BLOCK_SIZE=1024,
+    )
+
+
+def take(input: torch.Tensor, index: torch.Tensor):
+    """
+    Wrapper for aten::take
+    Returns a 1-D tensor with elements of input at the given flat indices in index.
+    """
+    assert input.device == index.device, "input and index must be on the same device"
+    out_flat = torch.empty(index.numel(), device=input.device, dtype=input.dtype)
+    _launch_take(input, index, out_flat)
+    return out_flat.view(index.shape)
+
+
+def take_out(input: torch.Tensor, index: torch.Tensor, out: torch.Tensor):
+    """
+    Wrapper for aten::take.out
+    Writes result into 'out' and returns it.
+    """
+    assert (
+        input.device == index.device == out.device
+    ), "All tensors must be on the same device"
+    # Ensure output has correct dtype and shape; resize if needed
+    if out.dtype != input.dtype:
+        raise TypeError(
+            f"out dtype {out.dtype} does not match input dtype {input.dtype}"
+        )
+    if out.numel() != index.numel() or tuple(out.shape) != tuple(index.shape):
+        out.resize_(index.shape)
+
+    # Use a temporary contiguous flat buffer to ensure correctness even if 'out' is non-contiguous
+    tmp_flat = torch.empty(index.numel(), device=input.device, dtype=input.dtype)
+    _launch_take(input, index, tmp_flat)
+    out.copy_(tmp_flat.view(index.shape))
+    return out

--- a/src/flag_gems/experimental_ops/threshold.py
+++ b/src/flag_gems/experimental_ops/threshold.py
@@ -1,0 +1,100 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def threshold_kernel(
+    x_ptr,  # *Pointer* to input tensor
+    y_ptr,  # *Pointer* to output tensor
+    n_elements,  # Number of elements
+    threshold,  # Scalar threshold
+    value,  # Scalar value to use when x <= threshold
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.where(x > threshold, x, value)
+    tl.store(y_ptr + offsets, y, mask=mask)
+
+
+def _coerce_scalars_for_dtype(dtype, threshold, value):
+    if dtype.is_complex:
+        raise TypeError("aten.threshold does not support complex dtypes.")
+    if dtype == torch.bool:
+        raise TypeError("aten.threshold does not support bool dtype.")
+    if dtype.is_floating_point:
+        thr = float(threshold)
+        val = float(value)
+    else:
+        thr = int(threshold)
+        val = int(value)
+    return thr, val
+
+
+def threshold(input: torch.Tensor, threshold, value):
+    if input.device.type != "cuda":
+        raise RuntimeError("This Triton implementation requires CUDA tensors.")
+    x = input.contiguous()
+    n_elements = x.numel()
+    out = torch.empty_like(x)
+
+    if n_elements == 0:
+        return out
+
+    thr_scalar, val_scalar = _coerce_scalars_for_dtype(x.dtype, threshold, value)
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    threshold_kernel[grid](
+        x,
+        out,
+        n_elements,
+        thr_scalar,
+        val_scalar,
+        BLOCK_SIZE=1024,
+    )
+    return out
+
+
+def threshold_out(input: torch.Tensor, threshold, value, out: torch.Tensor):
+    if input.device.type != "cuda" or out.device.type != "cuda":
+        raise RuntimeError("This Triton implementation requires CUDA tensors.")
+    if out.shape != input.shape:
+        raise RuntimeError(
+            f"out shape {out.shape} must match input shape {input.shape}"
+        )
+    if out.dtype != input.dtype:
+        raise RuntimeError(
+            f"out dtype {out.dtype} must match input dtype {input.dtype}"
+        )
+
+    x = input.contiguous()
+    n_elements = x.numel()
+
+    # Prepare output (contiguous temp if needed)
+    y = out if out.is_contiguous() else torch.empty_like(x)
+
+    if n_elements == 0:
+        if y is not out:
+            out.copy_(y)
+        return out
+
+    thr_scalar, val_scalar = _coerce_scalars_for_dtype(x.dtype, threshold, value)
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    threshold_kernel[grid](
+        x,
+        y,
+        n_elements,
+        thr_scalar,
+        val_scalar,
+        BLOCK_SIZE=1024,
+    )
+
+    if y is not out:
+        out.copy_(y)
+    return out

--- a/src/flag_gems/experimental_ops/threshold_.py
+++ b/src/flag_gems/experimental_ops/threshold_.py
@@ -1,0 +1,68 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def threshold_(
+    x_ptr,  # Pointer to input/output tensor (in-place)
+    n_elements,  # Number of elements
+    threshold_ptr,  # Pointer to scalar threshold (0-d tensor)
+    value_ptr,  # Pointer to scalar value (0-d tensor)
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    # Load data
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    # Load scalars (dtype matches x because we pass 0-d tensors of x.dtype)
+    thr = tl.load(threshold_ptr)
+    val = tl.load(value_ptr)
+
+    # Apply threshold in-place: if x <= thr, set to val, else keep x
+    out = tl.where(x <= thr, val, x)
+
+    # Store back
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+# Keep a handle to the Triton kernel before defining the Python wrapper of the same name
+threshold__triton_kernel = threshold_
+
+
+def threshold_(*args, **kwargs):
+    # Extract arguments similar to aten.threshold_ signature: (self, threshold, value=0)
+    x = kwargs.get("input", args[0] if len(args) > 0 else None)
+    threshold = kwargs.get("threshold", args[1] if len(args) > 1 else None)
+    value = kwargs.get("value", args[2] if len(args) > 2 else 0)
+
+    if x is None or threshold is None:
+        raise ValueError("threshold_ requires at least (input, threshold) arguments")
+
+    if not x.is_cuda:
+        raise ValueError(
+            "Input tensor must be on CUDA device for Triton kernel execution"
+        )
+    if x.is_complex():
+        raise ValueError("Complex dtypes are not supported by this kernel")
+    if not x.is_contiguous():
+        raise ValueError("Input tensor must be contiguous for this Triton kernel")
+
+    n_elements = x.numel()
+
+    # Prepare scalar tensors for threshold and value with matching dtype/device
+    thr_t = torch.tensor(threshold, dtype=x.dtype, device=x.device)
+    val_t = torch.tensor(value, dtype=x.dtype, device=x.device)
+
+    # Launch configuration
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    # Launch the Triton kernel (in-place)
+    threshold__triton_kernel[grid](x, n_elements, thr_t, val_t, BLOCK_SIZE=BLOCK_SIZE)
+
+    return x

--- a/src/flag_gems/experimental_ops/transpose_copy.py
+++ b/src/flag_gems/experimental_ops/transpose_copy.py
@@ -1,0 +1,160 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def transpose_copy_kernel(
+    src_ptr,  # *Pointer* to source tensor data
+    dst_ptr,  # *Pointer* to destination tensor data
+    sizes_ptr,  # *Pointer* to int64 sizes of output tensor (after transpose)
+    src_strides_mapped_ptr,  # *Pointer* to int64 source strides mapped to output dims
+    dst_strides_ptr,  # *Pointer* to int64 destination strides
+    n_elements,  # total number of elements
+    RANK: tl.constexpr,  # tensor rank (ndim)
+    BLOCK_SIZE: tl.constexpr,  # block size
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    # Work with int64 for safety
+    linear = offs.to(tl.int64)
+
+    # Compute per-element source and destination offsets using mixed-radix decomposition
+    src_off = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+    dst_off = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+    tmp = linear
+
+    for i in range(RANK):
+        size_i = tl.load(sizes_ptr + i)
+        idx_i = tmp % size_i
+        tmp = tmp // size_i
+
+        dst_stride_i = tl.load(dst_strides_ptr + i)
+        src_stride_i = tl.load(src_strides_mapped_ptr + i)
+
+        dst_off += idx_i * dst_stride_i
+        src_off += idx_i * src_stride_i
+
+    vals = tl.load(src_ptr + src_off, mask=mask)
+    tl.store(dst_ptr + dst_off, vals, mask=mask)
+
+
+def _normalize_dim(dim: int, ndim: int) -> int:
+    if dim < 0:
+        dim += ndim
+    if not (0 <= dim < ndim):
+        raise IndexError(
+            f"Dimension out of range (expected to be in range of [{-ndim}, {ndim-1}], but got {dim - ndim if dim >= ndim else dim})"
+        )
+    return dim
+
+
+def transpose_copy_int_out(x: torch.Tensor, dim0: int, dim1: int, out: torch.Tensor):
+    assert x.is_cuda and out.is_cuda, "Inputs must be CUDA tensors"
+    assert x.dtype == out.dtype, "Input and output dtypes must match"
+
+    ndim = x.dim()
+    dim0 = _normalize_dim(dim0, ndim)
+    dim1 = _normalize_dim(dim1, ndim)
+
+    # Compute output sizes (swap dimensions)
+    sizes_out = list(x.size())
+    sizes_out[dim0], sizes_out[dim1] = sizes_out[dim1], sizes_out[dim0]
+
+    # Validate output shape
+    if list(out.size()) != sizes_out:
+        raise ValueError(
+            f"out tensor has incorrect shape. Expected {sizes_out}, got {list(out.size())}"
+        )
+
+    # Prepare strides
+    strides_src = list(x.stride())
+    # Map source strides to output dimensions (swap dim0 and dim1)
+    src_strides_mapped = strides_src.copy()
+    src_strides_mapped[dim0], src_strides_mapped[dim1] = (
+        strides_src[dim1],
+        strides_src[dim0],
+    )
+
+    # Destination strides from 'out' as-is
+    dst_strides = list(out.stride())
+
+    # Prepare metadata tensors on device
+    device = x.device
+    sizes_t = torch.tensor(sizes_out, dtype=torch.int64, device=device)
+    src_strides_mapped_t = torch.tensor(
+        src_strides_mapped, dtype=torch.int64, device=device
+    )
+    dst_strides_t = torch.tensor(dst_strides, dtype=torch.int64, device=device)
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return out
+
+    BLOCK_SIZE = 1024
+    grid = lambda META: (triton.cdiv(n_elements, META["BLOCK_SIZE"]),)
+    transpose_copy_kernel[grid](
+        x,
+        out,
+        sizes_t,
+        src_strides_mapped_t,
+        dst_strides_t,
+        n_elements,
+        RANK=ndim,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return out
+
+
+def transpose_copy_int(x: torch.Tensor, dim0: int, dim1: int):
+    assert x.is_cuda, "Input must be a CUDA tensor"
+
+    ndim = x.dim()
+    dim0 = _normalize_dim(dim0, ndim)
+    dim1 = _normalize_dim(dim1, ndim)
+
+    # Output sizes and strides (swap dims/strides to match transpose view semantics)
+    sizes_out = list(x.size())
+    strides_out = list(x.stride())
+    sizes_out[dim0], sizes_out[dim1] = sizes_out[dim1], sizes_out[dim0]
+    strides_out[dim0], strides_out[dim1] = strides_out[dim1], strides_out[dim0]
+
+    # Allocate output tensor with transposed strides
+    out = torch.empty_strided(sizes_out, strides_out, dtype=x.dtype, device=x.device)
+
+    # Prepare strides mapping for source (match output dims)
+    strides_src = list(x.stride())
+    src_strides_mapped = strides_src.copy()
+    src_strides_mapped[dim0], src_strides_mapped[dim1] = (
+        strides_src[dim1],
+        strides_src[dim0],
+    )
+
+    # Metadata tensors
+    device = x.device
+    sizes_t = torch.tensor(sizes_out, dtype=torch.int64, device=device)
+    src_strides_mapped_t = torch.tensor(
+        src_strides_mapped, dtype=torch.int64, device=device
+    )
+    dst_strides_t = torch.tensor(out.stride(), dtype=torch.int64, device=device)
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return out
+
+    BLOCK_SIZE = 1024
+    grid = lambda META: (triton.cdiv(n_elements, META["BLOCK_SIZE"]),)
+    transpose_copy_kernel[grid](
+        x,
+        out,
+        sizes_t,
+        src_strides_mapped_t,
+        dst_strides_t,
+        n_elements,
+        RANK=ndim,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return out

--- a/src/flag_gems/experimental_ops/tril.py
+++ b/src/flag_gems/experimental_ops/tril.py
@@ -1,0 +1,74 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _tril_kernel(
+    in_ptr, out_ptr, M, N, B, diag, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    pid_b = tl.program_id(2)
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)[None, :]
+    mask = (offs_m < M) & (offs_n < N)
+
+    base = pid_b * M * N
+    idxs = base + offs_m * N + offs_n
+
+    x = tl.load(in_ptr + idxs, mask=mask, other=0)
+    keep = offs_n <= (offs_m + diag)
+    y = tl.where(keep, x, 0)
+    tl.store(out_ptr + idxs, y, mask=mask)
+
+
+def _launch_tril_kernel(input: torch.Tensor, out: torch.Tensor, diagonal: int):
+    assert input.is_cuda and out.is_cuda, "Input and output must be CUDA tensors"
+    assert (
+        input.is_contiguous() and out.is_contiguous()
+    ), "Only contiguous tensors are supported"
+    assert input.shape == out.shape, "Input and output must have the same shape"
+    assert input.dtype == out.dtype, "Input and output must have the same dtype"
+
+    if input.dim() < 2:
+        out.copy_(input)
+        return out
+
+    M = input.size(-2)
+    N = input.size(-1)
+    B = input.numel() // (M * N)
+
+    if M == 0 or N == 0 or B == 0:
+        # Nothing to compute
+        return out
+
+    BLOCK_M = 32
+    BLOCK_N = 32
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N), B)
+
+    _tril_kernel[grid](
+        input,
+        out,
+        M,
+        N,
+        B,
+        int(diagonal),
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+    )
+    return out
+
+
+def tril(input: torch.Tensor, diagonal: int = 0):
+    out = torch.empty_like(input)
+    return _launch_tril_kernel(input, out, diagonal)
+
+
+def tril_out(input: torch.Tensor, diagonal: int = 0, out: torch.Tensor = None):
+    if out is None:
+        out = torch.empty_like(input)
+    _launch_tril_kernel(input, out, diagonal)
+    return out

--- a/src/flag_gems/experimental_ops/tril_.py
+++ b/src/flag_gems/experimental_ops/tril_.py
@@ -1,0 +1,134 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def tril___kernel(
+    x_ptr,  # *Pointer* to input tensor data (in-place)
+    offsets_ptr,  # *Pointer* to base offsets per batch
+    stride_m,  # stride for the row dimension (elements)
+    stride_n,  # stride for the col dimension (elements)
+    M,  # number of rows
+    N,  # number of cols
+    B,  # number of batch matrices
+    diagonal,  # diagonal offset (int)
+    BLOCK_M: tl.constexpr,  # block size along M
+    BLOCK_N: tl.constexpr,  # block size along N
+):
+    pid_n = tl.program_id(axis=0)  # tile id along N
+    pid_m = tl.program_id(axis=1)  # tile id along M
+    pid_b = tl.program_id(axis=2)  # batch id
+
+    rows = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    cols = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask_m = rows < M
+    mask_n = cols < N
+    mask = mask_m[:, None] & mask_n[None, :]
+
+    # Load base offset for this batch
+    base = tl.load(offsets_ptr + pid_b, mask=True, other=0).to(tl.int64)
+
+    # Compute pointers for the tile
+    row_offsets = rows.to(tl.int64)[:, None] * stride_m
+    col_offsets = cols.to(tl.int64)[None, :] * stride_n
+    ptrs = x_ptr + base + row_offsets + col_offsets
+
+    # Load current values
+    vals = tl.load(ptrs, mask=mask, other=0)
+
+    # Compute keep mask for lower triangle: keep if (col - row) <= diagonal
+    # Cast to int32 for the comparison
+    r = rows[:, None].to(tl.int32)
+    c = cols[None, :].to(tl.int32)
+    k = tl.full((), diagonal, tl.int32)
+    keep = (c - r) <= k
+
+    # Zero out elements above the diagonal
+    out = tl.where(keep, vals, 0)
+
+    # Store back in-place
+    tl.store(ptrs, out, mask=mask)
+
+
+def tril_(*args, **kwargs):
+    # Parse arguments similar to torch.ops.aten.tril_(x, diagonal=0)
+    if len(args) == 0 and "input" not in kwargs and "self" not in kwargs:
+        raise ValueError("tril_ expects at least a tensor argument")
+    x = None
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        x = kwargs.get("input", kwargs.get("self", None))
+    if x is None:
+        raise ValueError("tril_ could not find the input tensor argument")
+
+    # Diagonal argument
+    if "diagonal" in kwargs:
+        diagonal = int(kwargs["diagonal"])
+    elif len(args) >= 2:
+        diagonal = int(args[1])
+    else:
+        diagonal = 0
+
+    # Handle trivial cases or non-CUDA fallback
+    if not x.is_cuda:
+        # Fallback to PyTorch's implementation
+        return torch.tril_(x, diagonal=diagonal)
+    if x.ndim < 2 or x.numel() == 0:
+        return x
+
+    # Shapes and sizes
+    M = x.size(-2)
+    N = x.size(-1)
+    batch_shape = x.shape[:-2]
+    B = 1
+    for s in batch_shape:
+        B *= s
+
+    # If there are zero batch matrices, nothing to do
+    if B == 0 or M == 0 or N == 0:
+        return x
+
+    # Compute per-batch base offsets (in elements) from original strides
+    device = x.device
+    dtype = x.dtype
+    strides = x.stride()
+    stride_m = int(x.stride(-2))
+    stride_n = int(x.stride(-1))
+
+    # Build offsets for each batch index
+    offsets = torch.zeros(B, dtype=torch.int64, device=device)
+    if B > 1:
+        sizes = list(batch_shape)
+        batch_strides = list(strides[:-2])
+        tmp = torch.arange(B, device=device, dtype=torch.int64)
+        for d in range(len(sizes) - 1, -1, -1):
+            sz = sizes[d]
+            if sz == 0:
+                # Shouldn't happen since B==0 would have returned early
+                pass
+            idx_d = tmp % sz
+            offsets += idx_d * batch_strides[d]
+            tmp = tmp // sz
+
+    # Launch kernel
+    BLOCK_M = 32
+    BLOCK_N = 64
+    grid = (triton.cdiv(N, BLOCK_N), triton.cdiv(M, BLOCK_M), B)
+
+    tril___kernel[grid](
+        x,  # x_ptr
+        offsets,  # offsets_ptr
+        stride_m,  # stride_m
+        stride_n,  # stride_n
+        M,  # M
+        N,  # N
+        B,  # B
+        int(diagonal),  # diagonal
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+    )
+
+    return x

--- a/src/flag_gems/experimental_ops/triu.py
+++ b/src/flag_gems/experimental_ops/triu.py
@@ -1,0 +1,165 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def triu_kernel(
+    in_ptr,
+    out_ptr,
+    M,
+    N,
+    B,  # matrix rows, cols, number of batches
+    stride_in_b,
+    stride_in_m,
+    stride_in_n,
+    stride_out_b,
+    stride_out_m,
+    stride_out_n,
+    diagonal: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+    pid_b = tl.program_id(2)
+
+    row = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    col = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask = (row[:, None] < M) & (col[None, :] < N)
+
+    # keep if col - row >= diagonal
+    keep = (col[None, :] - row[:, None]) >= diagonal
+
+    row_i64 = row[:, None].to(tl.int64)
+    col_i64 = col[None, :].to(tl.int64)
+
+    base_in = in_ptr + pid_b.to(tl.int64) * stride_in_b
+    base_out = out_ptr + pid_b.to(tl.int64) * stride_out_b
+
+    in_offsets = row_i64 * stride_in_m + col_i64 * stride_in_n
+    out_offsets = row_i64 * stride_out_m + col_i64 * stride_out_n
+
+    vals = tl.load(base_in + in_offsets, mask=mask & keep, other=0)
+    tl.store(base_out + out_offsets, vals, mask=mask)
+
+
+def _check_supported_dtype(t: torch.Tensor):
+    if t.dtype in (
+        torch.complex64,
+        torch.complex128,
+        torch.complex32 if hasattr(torch, "complex32") else None,
+    ):
+        raise TypeError(
+            "Complex dtypes are not supported by this Triton triu implementation."
+        )
+
+
+def _launch_triu_kernel(inp: torch.Tensor, out: torch.Tensor, diagonal: int):
+    assert inp.is_cuda and out.is_cuda, "Input and output must be CUDA tensors"
+    assert inp.dtype == out.dtype, "Input and output dtypes must match"
+    assert inp.device == out.device, "Input and output must be on the same device"
+    _check_supported_dtype(inp)
+
+    ndim = inp.dim()
+    assert ndim >= 2, "triu expects input with at least 2 dimensions"
+
+    M = inp.shape[-2]
+    N = inp.shape[-1]
+    batch_shape = inp.shape[:-2]
+    B = 1
+    for s in batch_shape:
+        B *= s
+
+    # Ensure contiguous layout for simplicity
+    inp_c = inp.contiguous()
+    out_c = out.contiguous()
+
+    # Strides as int64
+    stride_in_n = inp_c.stride(-1)
+    stride_in_m = inp_c.stride(-2)
+    stride_out_n = out_c.stride(-1)
+    stride_out_m = out_c.stride(-2)
+
+    # Batch stride: distance between consecutive matrices in flattened batch
+    stride_in_b = (
+        M * stride_in_m
+        if len(batch_shape) == 0
+        else inp_c.stride(-3) * inp_c.size(-3)
+        if ndim > 2
+        else M * stride_in_m
+    )
+    stride_out_b = (
+        M * stride_out_m
+        if len(batch_shape) == 0
+        else out_c.stride(-3) * out_c.size(-3)
+        if ndim > 2
+        else M * stride_out_m
+    )
+
+    # For fully contiguous tensors, the above may not equal true batch stride for high dims.
+    # Since we used .contiguous(), we can simply set:
+    if inp_c.is_contiguous():
+        stride_in_n = 1
+        stride_in_m = N
+        stride_in_b = M * N
+    if out_c.is_contiguous():
+        stride_out_n = 1
+        stride_out_m = N
+        stride_out_b = M * N
+
+    BLOCK_M = 32
+    BLOCK_N = 32
+
+    grid = (triton.cdiv(M, BLOCK_M), triton.cdiv(N, BLOCK_N), B)
+
+    triu_kernel[grid](
+        inp_c,
+        out_c,
+        M,
+        N,
+        B,
+        stride_in_b,
+        stride_in_m,
+        stride_in_n,
+        stride_out_b,
+        stride_out_m,
+        stride_out_n,
+        diagonal=diagonal,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+    )
+
+    if out.data_ptr() != out_c.data_ptr():
+        out.copy_(out_c)
+
+
+def triu(input: torch.Tensor, diagonal: int = 0):
+    """
+    Wrapper for ATen op: ('triu', <Autograd.disable: False>)
+    """
+    out = torch.empty_like(input)
+    _launch_triu_kernel(input, out, diagonal)
+    return out
+
+
+def triu_out(input: torch.Tensor, diagonal: int = 0, out: torch.Tensor = None):
+    """
+    Wrapper for ATen op: ('triu.out', <Autograd.disable: False>)
+    """
+    if out is None:
+        out = torch.empty_like(input)
+    else:
+        if out.shape != input.shape:
+            raise ValueError(
+                f"out tensor must have the same shape as input, got {out.shape} vs {input.shape}"
+            )
+        if out.dtype != input.dtype:
+            raise TypeError(
+                f"out dtype must match input dtype, got {out.dtype} vs {input.dtype}"
+            )
+        if not out.is_cuda or out.device != input.device:
+            raise ValueError("out must be a CUDA tensor on the same device as input")
+    _launch_triu_kernel(input, out, diagonal)
+    return out

--- a/src/flag_gems/experimental_ops/triu_.py
+++ b/src/flag_gems/experimental_ops/triu_.py
@@ -1,0 +1,137 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def triu_(
+    x_ptr,
+    base_offsets_ptr,
+    diagonal,
+    M,
+    N,
+    stride_m,
+    stride_n,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tl.program_id(axis=0)
+    pid_n = tl.program_id(axis=1)
+    pid_b = tl.program_id(axis=2)
+
+    # Compute row/col indices this program will handle
+    rows = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    cols = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    # Masks for bounds
+    mask_rows = rows < M
+    mask_cols = cols < N
+    mask = mask_rows[:, None] & mask_cols[None, :]
+
+    # Load base offset for this batch
+    off_b = tl.load(base_offsets_ptr + pid_b)
+
+    # Compute pointers for the tile
+    rows_2d = rows[:, None]
+    cols_2d = cols[None, :]
+    ptrs = x_ptr + off_b + rows_2d * stride_m + cols_2d * stride_n
+
+    # Compute triangular mask: keep if (col - row) >= diagonal
+    keep = (cols_2d - rows_2d) >= diagonal
+
+    # Load, apply mask, and store
+    vals = tl.load(ptrs, mask=mask, other=0)
+    out = tl.where(keep, vals, 0)
+    tl.store(ptrs, out, mask=mask)
+
+
+# Preserve kernel object before defining the wrapper with the same name
+triu___kernel = triu_
+
+
+def triu_(*args, **kwargs):
+    # Parse inputs similar to torch.ops.aten.triu_(input, diagonal=0)
+    if len(args) == 0:
+        x = kwargs.get("input", kwargs.get("self", None))
+        if x is None:
+            raise ValueError("triu_ expects a tensor as the first argument")
+        diagonal = kwargs.get("diagonal", 0)
+    else:
+        x = args[0]
+        if len(args) > 1:
+            diagonal = args[1]
+        else:
+            diagonal = kwargs.get("diagonal", 0)
+
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("triu_ expects a torch.Tensor as input")
+    if not x.is_cuda:
+        raise ValueError("triu_ expects a CUDA tensor")
+
+    # No-op for empty tensors
+    if x.numel() == 0:
+        return x
+    # Require at least 2D to form a matrix; mimic PyTorch behavior by early return for degenerate case
+    if x.ndim < 2:
+        return x
+
+    device = x.device
+    ndim = x.ndim
+    M = x.size(-2)
+    N = x.size(-1)
+    if M == 0 or N == 0:
+        return x
+
+    # Compute base offsets for each batch instance (in elements)
+    batch_ndim = max(0, ndim - 2)
+    if batch_ndim == 0:
+        base_offsets = torch.tensor(
+            [x.storage_offset()], dtype=torch.int64, device=device
+        )
+    else:
+        batch_sizes = list(x.shape[:batch_ndim])
+        batch_strides = list(x.stride()[:batch_ndim])
+        total_batches = 1
+        for s in batch_sizes:
+            total_batches *= s
+        base_offsets = torch.empty(total_batches, dtype=torch.int64, device=device)
+        base = x.storage_offset()
+        # Convert linear batch id to multi-index and compute base offset
+        for b in range(total_batches):
+            rem = b
+            off = base
+            for d in range(batch_ndim - 1, -1, -1):
+                size_d = batch_sizes[d]
+                if size_d > 0:
+                    idx_d = rem % size_d
+                    rem //= size_d
+                else:
+                    idx_d = 0
+                off += idx_d * batch_strides[d]
+            base_offsets[b] = off
+
+    stride_m = x.stride(-2)
+    stride_n = x.stride(-1)
+
+    # Launch kernel
+    BLOCK_M = 32
+    BLOCK_N = 32
+    grid = (
+        triton.cdiv(M, BLOCK_M),
+        triton.cdiv(N, BLOCK_N),
+        base_offsets.numel(),
+    )
+
+    triu___kernel[grid](
+        x,
+        base_offsets,
+        int(diagonal),
+        M,
+        N,
+        stride_m,
+        stride_n,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+    )
+
+    return x

--- a/src/flag_gems/experimental_ops/unsqueeze.py
+++ b/src/flag_gems/experimental_ops/unsqueeze.py
@@ -1,0 +1,80 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def unsqueeze_kernel(
+    src_ptr,  # *Pointer* to input tensor data.
+    dst_ptr,  # *Pointer* to output tensor data.
+    out_numel,  # Total number of elements in output (same as input).
+    in_strides_ptr,  # *Pointer* to input strides (length = RANK-1).
+    out_shape_ptr,  # *Pointer* to output shape (length = RANK).
+    BLOCK_SIZE: tl.constexpr,  # Number of elements processed by each program.
+    RANK: tl.constexpr,  # Rank of the output tensor.
+    UNSQ_DIM: tl.constexpr,  # The dimension at which to unsqueeze (compile-time constant).
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    offsets = offsets.to(tl.int64)
+    mask = offsets < out_numel
+
+    tmp = offsets
+    src_offset = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+    # Decompose linear index into multi-dimensional coordinates and map to input offset
+    for k in range(RANK - 1, -1, -1):
+        s_k = tl.load(out_shape_ptr + k)
+        c_k = tmp % s_k
+        tmp = tmp // s_k
+        if k != UNSQ_DIM:
+            in_k = k if k < UNSQ_DIM else k - 1
+            stride_in_k = tl.load(in_strides_ptr + in_k)
+            src_offset += c_k * stride_in_k
+
+    vals = tl.load(src_ptr + src_offset, mask=mask)
+    tl.store(dst_ptr + offsets, vals, mask=mask)
+
+
+def unsqueeze(*args, **kwargs):
+    # Expect signature: unsqueeze(x, dim)
+    if len(args) >= 2:
+        x, dim = args[0], args[1]
+    else:
+        x = kwargs.get("self", kwargs.get("input", None))
+        dim = kwargs.get("dim", None)
+    assert isinstance(
+        x, torch.Tensor
+    ), "unsqueeze expects a torch.Tensor as the first argument."
+    assert isinstance(dim, int), "unsqueeze expects an integer 'dim' argument."
+    assert x.is_cuda, "Input tensor must be on CUDA device."
+
+    ndims = x.dim()
+    if dim < 0:
+        dim += ndims + 1
+    assert 0 <= dim <= ndims, f"dim must be in range [0, {ndims}] after normalization."
+
+    out_shape = list(x.shape)
+    out_shape.insert(dim, 1)
+    out = torch.empty(out_shape, dtype=x.dtype, device=x.device)
+
+    numel = out.numel()
+    # Prepare strides and shape tensors on device
+    in_strides = torch.tensor(x.stride(), dtype=torch.int64, device=x.device)
+    out_shape_t = torch.tensor(out_shape, dtype=torch.int64, device=x.device)
+
+    RANK = len(out_shape)
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(numel, meta["BLOCK_SIZE"]),)
+
+    unsqueeze_kernel[grid](
+        x,
+        out,
+        numel,
+        in_strides,
+        out_shape_t,
+        BLOCK_SIZE=BLOCK_SIZE,
+        RANK=RANK,
+        UNSQ_DIM=dim,
+    )
+    return out

--- a/src/flag_gems/experimental_ops/unsqueeze_copy.py
+++ b/src/flag_gems/experimental_ops/unsqueeze_copy.py
@@ -1,0 +1,111 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _unsqueeze_copy_kernel(
+    src_ptr,  # pointer to input tensor data
+    dst_ptr,  # pointer to output tensor data
+    sizes_ptr,  # pointer to int64 sizes of src tensor (NDIM)
+    src_strides_ptr,  # pointer to int64 strides of src tensor (NDIM)
+    dst_strides_ptr,  # pointer to int64 strides of dst tensor (NDIM + 1)
+    n_elements,  # total number of elements to copy (src.numel() == dst.numel())
+    NDIM: tl.constexpr,
+    INSERT_DIM: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    # use int64 for index math
+    offs = offs.to(tl.int64)
+
+    # Compute source and destination element offsets using shape/strides
+    src_off = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+    dst_off = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+
+    rem = offs
+    # Decompose linear index into multi-dimensional indices (row-major order)
+    for rev_d in range(NDIM - 1, -1, -1):
+        sz_d = tl.load(sizes_ptr + rev_d)  # scalar int64
+        idx_d = rem % sz_d
+        rem = rem // sz_d
+
+        sstride_d = tl.load(src_strides_ptr + rev_d)
+        src_off += idx_d * sstride_d
+
+        # Map source dim rev_d to destination dim (account for inserted dim)
+        if rev_d < INSERT_DIM:
+            dstride_d = tl.load(dst_strides_ptr + rev_d)
+            dst_off += idx_d * dstride_d
+        else:
+            dstride_shift = tl.load(dst_strides_ptr + (rev_d + 1))
+            dst_off += idx_d * dstride_shift
+
+    vals = tl.load(src_ptr + src_off, mask=mask)
+    tl.store(dst_ptr + dst_off, vals, mask=mask)
+
+
+def _launch_unsqueeze_copy(src: torch.Tensor, dim: int, out: torch.Tensor):
+    assert src.is_cuda and out.is_cuda, "Tensors must be on CUDA device"
+    assert src.dtype == out.dtype, "Dtype mismatch between src and out"
+
+    n_elements = src.numel()
+    if n_elements == 0:
+        return  # nothing to copy
+
+    # Build metadata arrays on device
+    sizes = torch.tensor(list(src.shape), dtype=torch.int64, device=src.device)
+    src_strides = torch.tensor(list(src.stride()), dtype=torch.int64, device=src.device)
+    dst_strides = torch.tensor(list(out.stride()), dtype=torch.int64, device=out.device)
+
+    grid = lambda META: (triton.cdiv(n_elements, META["BLOCK_SIZE"]),)
+    _unsqueeze_copy_kernel[grid](
+        src,
+        out,
+        sizes,
+        src_strides,
+        dst_strides,
+        n_elements,
+        NDIM=src.dim(),
+        INSERT_DIM=dim,
+        BLOCK_SIZE=1024,
+    )
+
+
+def unsqueeze_copy(x: torch.Tensor, dim: int):
+    # Normalize dim
+    dim_normalized = dim if dim >= 0 else dim + x.dim() + 1
+    if not (0 <= dim_normalized <= x.dim()):
+        raise IndexError(f"dim {dim} out of range for tensor with {x.dim()} dims")
+
+    new_shape = list(x.shape)
+    new_shape.insert(dim_normalized, 1)
+    out = torch.empty(new_shape, device=x.device, dtype=x.dtype)
+
+    _launch_unsqueeze_copy(x, dim_normalized, out)
+    return out
+
+
+def unsqueeze_copy_out(x: torch.Tensor, dim: int, out: torch.Tensor):
+    # Normalize dim
+    dim_normalized = dim if dim >= 0 else dim + x.dim() + 1
+    if not (0 <= dim_normalized <= x.dim()):
+        raise IndexError(f"dim {dim} out of range for tensor with {x.dim()} dims")
+
+    if out.device != x.device:
+        raise ValueError("out tensor must be on the same device as input")
+    if out.dtype != x.dtype:
+        raise ValueError("out tensor must have the same dtype as input")
+
+    # Ensure out has the correct shape (resize_ follows PyTorch out semantics)
+    expected_shape = list(x.shape)
+    expected_shape.insert(dim_normalized, 1)
+    if list(out.shape) != expected_shape:
+        out.resize_(expected_shape)
+
+    _launch_unsqueeze_copy(x, dim_normalized, out)
+    return out

--- a/src/flag_gems/experimental_ops/zero_.py
+++ b/src/flag_gems/experimental_ops/zero_.py
@@ -1,0 +1,45 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def zero_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    # Load to obtain dtype, then compute zeros of the same dtype
+    vals = tl.load(x_ptr + offsets, mask=mask, other=0)
+    zeros = vals - vals
+    tl.store(x_ptr + offsets, zeros, mask=mask)
+
+
+_zero_kernel = zero_
+
+
+def zero_(*args, **kwargs):
+    # Extract the tensor argument
+    x = None
+    if len(args) > 0:
+        x = args[0]
+    else:
+        x = kwargs.get("self", kwargs.get("input", None))
+    if x is None:
+        raise ValueError("zero_ expects a Tensor as the first argument.")
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("zero_ expects a torch.Tensor.")
+
+    # Handle empty tensor quickly
+    if x.numel() == 0:
+        return x
+
+    # Fallback for non-CUDA or non-contiguous tensors
+    if (not x.is_cuda) or (not x.is_contiguous()):
+        x.zero_()
+        return x
+
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _zero_kernel[grid](x, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/zeros_like.py
+++ b/src/flag_gems/experimental_ops/zeros_like.py
@@ -1,0 +1,120 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _fill_zero_kernel(
+    out_ptr,  # *Pointer* to output vector.
+    n_elements,  # Number of elements to write.
+    BLOCK_SIZE: tl.constexpr,  # Number of elements per program.
+    OUT_DTYPE: tl.constexpr,  # Triton dtype for the output.
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    zeros = tl.full([BLOCK_SIZE], 0, dtype=OUT_DTYPE)
+    tl.store(out_ptr + offsets, zeros, mask=mask)
+
+
+def _torch_dtype_to_triton_dtype(dtype: torch.dtype):
+    # Map torch dtypes to Triton dtypes
+    if dtype is torch.float32:
+        return tl.float32
+    if dtype is torch.float16:
+        return tl.float16
+    if dtype is torch.bfloat16:
+        return tl.bfloat16
+    if dtype is torch.float64:
+        return tl.float64
+    if dtype is torch.int8:
+        return tl.int8
+    if dtype is torch.uint8:
+        return tl.uint8
+    if dtype is torch.int16:
+        return tl.int16
+    if dtype is torch.int32:
+        return tl.int32
+    if dtype is torch.int64:
+        return tl.int64
+    if dtype is torch.bool:
+        # Triton bool storage is not directly exposed; use int8 for 0/1 storage
+        return tl.int8
+    raise NotImplementedError(f"Unsupported dtype for Triton zeros_like: {dtype}")
+
+
+def _launch_fill_zero(out: torch.Tensor, block_size: int = 4096):
+    # Fallback for non-CUDA or empty tensors
+    n_elements = out.numel()
+    if n_elements == 0:
+        return
+    if not out.is_cuda:
+        out.zero_()
+        return
+    # For simplicity, only handle contiguous tensors with the Triton kernel.
+    # Fallback to PyTorch for non-contiguous outputs.
+    if not out.is_contiguous():
+        out.zero_()
+        return
+    out_dtype = _torch_dtype_to_triton_dtype(out.dtype)
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _fill_zero_kernel[grid](out, n_elements, BLOCK_SIZE=block_size, OUT_DTYPE=out_dtype)
+
+
+def zeros_like(*args, **kwargs):
+    # Extract input tensor (first positional or 'input'/'self' kw)
+    inp = None
+    if len(args) >= 1:
+        inp = args[0]
+    else:
+        inp = kwargs.get("input", kwargs.get("self", None))
+    if inp is None:
+        raise ValueError("zeros_like expects an input tensor as the first argument.")
+
+    dtype = kwargs.get("dtype", None)
+    layout = kwargs.get("layout", None)
+    device = kwargs.get("device", None)
+    pin_memory = kwargs.get("pin_memory", None)
+    memory_format = kwargs.get("memory_format", torch.preserve_format)
+
+    # Allocate output tensor with requested properties
+    out = torch.empty_like(
+        inp,
+        dtype=dtype,
+        layout=layout,
+        device=device,
+        pin_memory=pin_memory if pin_memory is not None else False,
+        memory_format=memory_format,
+    )
+    _launch_fill_zero(out)
+    return out
+
+
+def zeros_like_out(*args, **kwargs):
+    # Expected signature: zeros_like.out(input, *, dtype=None, layout=None, device=None, pin_memory=None, memory_format=None, out)
+    # Extract input and out tensors
+    inp = None
+    if len(args) >= 1:
+        inp = args[0]
+    else:
+        inp = kwargs.get("input", kwargs.get("self", None))
+    out = kwargs.get("out", None)
+    if out is None and len(args) >= 2:
+        out = args[-1]
+    if inp is None or out is None:
+        raise ValueError("zeros_like_out expects 'input' and 'out' tensors.")
+
+    # Optional consistency checks per .out semantics (if provided)
+    dtype = kwargs.get("dtype", None)
+    device = kwargs.get("device", None)
+    if dtype is not None and out.dtype != dtype:
+        raise ValueError(f"Provided dtype {dtype} does not match out.dtype {out.dtype}")
+    if device is not None and str(out.device) != str(device):
+        raise ValueError(
+            f"Provided device {device} does not match out.device {out.device}"
+        )
+    # Shape/layout checks could be added; we keep minimal checks for generality.
+
+    _launch_fill_zero(out)
+    return out


### PR DESCRIPTION
- Add 85 operator implementations
- Add 85 corresponding test files
- All operators pass pre-commit checks
- Operators range from deg2rad to zeros_like

### PR Category
Operator

### Type of Change
New Feature

### Description
This PR adds the remaining 85 operators from the first batch of 105 operators. The first 20 operators were already approved and merged in previous PRs. These operators and their corresponding test files are generated using [KernelGen](https://github.com/flagos-ai/KernelGen), an AI-assisted kernel engineering tool for multi-chip systems.

All operators have passed pre-commit checks and are ready for review.

### Issue
<!-- N/A - Part of the ongoing effort to add 105 operators in batches -->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Performance benchmarks will be conducted as part of the overall operator validation process. -->