### PR TITLE
feat: add 14 experimental operators with tests

### DIFF
--- a/src/flag_gems/experimental_ops/expm1_.py
+++ b/src/flag_gems/experimental_ops/expm1_.py
@@ -1,0 +1,61 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def expm1_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x_fp32 = x.to(tl.float32)
+    y = tl.exp(x_fp32) - 1.0
+    y = y.to(x.dtype)
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# Preserve a handle to the Triton kernel before defining the Python wrapper with the same name.
+expm1___kernel = expm1_
+
+
+def expm1_(*args, **kwargs):
+    # Extract the input tensor from args/kwargs
+    x = None
+    if len(args) > 0:
+        x = args[0]
+    else:
+        for key in ("input", "self", "x", "tensor"):
+            if key in kwargs:
+                x = kwargs[key]
+                break
+    if x is None:
+        raise TypeError("expm1_ expected a tensor as the first argument")
+
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("expm1_ expected a torch.Tensor")
+
+    if not x.is_cuda:
+        raise AssertionError("expm1_ Triton kernel requires a CUDA tensor")
+
+    if not x.is_floating_point():
+        raise TypeError("expm1_ only supports floating point tensors")
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    if x.is_contiguous():
+        expm1___kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    else:
+        # Fallback: operate on a contiguous copy, then copy back in-place
+        tmp = x.contiguous()
+        expm1___kernel[grid](tmp, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+        x.copy_(tmp)
+
+    return x

--- a/src/flag_gems/experimental_ops/fft_fftshift.py
+++ b/src/flag_gems/experimental_ops/fft_fftshift.py
@@ -1,0 +1,109 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def fft_fftshift(
+    in_ptr,
+    out_ptr,
+    shape_ptr,
+    in_stride_ptr,
+    out_stride_ptr,
+    shift_ptr,
+    n_dims,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    MAX_DIMS: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+
+    # Work with 64-bit indices to avoid overflow on large tensors/strides
+    q64 = offs.to(tl.int64)
+    dst_off = tl.zeros_like(q64)
+    src_off = tl.zeros_like(q64)
+
+    # Unrolled loop up to MAX_DIMS, with masking when t >= n_dims
+    for t in range(MAX_DIMS):
+        active = t < n_dims
+        dd = tl.where(active, n_dims - 1 - t, 0)
+
+        size_d = tl.where(active, tl.load(shape_ptr + dd), 1).to(tl.int64)
+        i_d = q64 % size_d
+        q64 = q64 // size_d
+
+        shift_d = tl.where(active, tl.load(shift_ptr + dd), 0).to(tl.int64)
+        in_stride_d = tl.where(active, tl.load(in_stride_ptr + dd), 0).to(tl.int64)
+        out_stride_d = tl.where(active, tl.load(out_stride_ptr + dd), 0).to(tl.int64)
+
+        src_i_d = i_d - shift_d
+        src_i_d = src_i_d + size_d
+        src_i_d = src_i_d % size_d
+
+        src_off += src_i_d * in_stride_d
+        dst_off += i_d * out_stride_d
+
+    val = tl.load(in_ptr + src_off, mask=mask)
+    tl.store(out_ptr + dst_off, val, mask=mask)
+
+
+_fft_fftshift_kernel = fft_fftshift
+
+
+def fft_fftshift(*args, **kwargs):
+    # Resolve input tensor and dim(s) similar to torch.fft.fftshift
+    if len(args) > 0:
+        x = args[0]
+    else:
+        x = kwargs.get("input", kwargs.get("self", kwargs.get("x", None)))
+    dim = kwargs.get("dim", None)
+    if dim is None and len(args) > 1:
+        dim = args[1]
+
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("fft_fftshift expects a torch.Tensor as the first argument")
+
+    n_dims = x.ndim
+    if dim is None:
+        dims = list(range(n_dims))
+    else:
+        if isinstance(dim, int):
+            dims = [dim]
+        else:
+            dims = list(dim)
+        # Normalize negative dims
+        dims = [(d + n_dims) % n_dims for d in dims]
+
+    # Prepare output tensor
+    out = torch.empty_like(x)
+
+    # Prepare shape and strides
+    device = x.device
+    shape_t = torch.tensor(x.shape, dtype=torch.int64, device=device)
+    in_stride_t = torch.tensor(x.stride(), dtype=torch.int64, device=device)
+    out_stride_t = torch.tensor(out.stride(), dtype=torch.int64, device=device)
+
+    # Prepare per-dim shifts: size//2 for dims, else 0
+    shifts = torch.zeros(n_dims, dtype=torch.int64, device=device)
+    for d in dims:
+        shifts[d] = x.shape[d] // 2
+
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    _fft_fftshift_kernel[grid](
+        x,
+        out,
+        shape_t,
+        in_stride_t,
+        out_stride_t,
+        shifts,
+        n_dims,
+        n_elements,
+        BLOCK_SIZE=1024,
+        MAX_DIMS=16,
+    )
+    return out

--- a/src/flag_gems/experimental_ops/fix_.py
+++ b/src/flag_gems/experimental_ops/fix_.py
@@ -1,0 +1,59 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def fix_(x_ptr, n_elements, DO_UPCAST: tl.constexpr, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    if DO_UPCAST:
+        x_work = x.to(tl.float32)
+    else:
+        x_work = x
+
+    y_floor = tl.floor(x_work)
+    y_ceil = tl.ceil(x_work)
+    y_work = tl.where(x_work >= 0, y_floor, y_ceil)
+
+    if DO_UPCAST:
+        y = y_work.to(x.dtype)
+    else:
+        y = y_work
+
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# Keep reference to the Triton kernel before redefining the name for the Python wrapper
+_fix_kernel = fix_
+
+
+def fix_(*args, **kwargs):
+    x = args[0]
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("fix_ expects a torch.Tensor as the first argument")
+    if not x.is_cuda:
+        raise ValueError("Input tensor must be on CUDA device for Triton kernel")
+    if not x.is_contiguous():
+        raise ValueError("Input tensor must be contiguous")
+
+    # In-place fix_ does nothing for non-floating tensors
+    if not x.is_floating_point():
+        return x
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    # Upcast low-precision types for stable math
+    do_upcast = x.dtype in (torch.float16, torch.bfloat16)
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _fix_kernel[grid](x, n_elements, DO_UPCAST=do_upcast, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/floor_.py
+++ b/src/flag_gems/experimental_ops/floor_.py
@@ -1,0 +1,77 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def floor_(
+    x_ptr,  # pointer to input/output tensor (in-place)
+    n_elements,  # total number of elements
+    BLOCK_SIZE: tl.constexpr,
+    IS_FP32: tl.constexpr,
+    IS_FP16: tl.constexpr,
+    IS_BF16: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    # Apply floor only for floating-point dtypes; otherwise, no-op
+    out = x
+    if IS_FP32:
+        out = tl.floor(x)
+    elif IS_FP16:
+        x_fp32 = tl.cast(x, tl.float32)
+        out = tl.cast(tl.floor(x_fp32), tl.float16)
+    elif IS_BF16:
+        x_fp32 = tl.cast(x, tl.float32)
+        out = tl.cast(tl.floor(x_fp32), tl.bfloat16)
+
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+# Keep a reference to the kernel before defining the wrapper with the same name
+floor__kernel = floor_
+
+
+def floor_(*args, **kwargs):
+    x = args[0] if len(args) > 0 else kwargs.get("input", None)
+    if x is None:
+        raise ValueError(
+            "floor_ expects a Tensor as the first positional argument or 'input' keyword."
+        )
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("floor_ expects a torch.Tensor.")
+    if not x.is_cuda:
+        raise ValueError("floor_ Triton kernel requires a CUDA tensor.")
+    if x.is_complex():
+        raise TypeError("floor_ is not supported for complex tensors.")
+    if not x.is_contiguous():
+        raise ValueError(
+            "floor_ Triton kernel currently supports only contiguous tensors."
+        )
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    dtype = x.dtype
+    IS_FP32 = dtype == torch.float32
+    IS_FP16 = dtype == torch.float16
+    IS_BF16 = dtype == torch.bfloat16
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    floor__kernel[grid](
+        x,  # in-place: pass the same tensor pointer for load/store
+        n_elements,
+        BLOCK_SIZE=BLOCK_SIZE,
+        IS_FP32=IS_FP32,
+        IS_FP16=IS_FP16,
+        IS_BF16=IS_BF16,
+    )
+    return x

--- a/src/flag_gems/experimental_ops/fmin.py
+++ b/src/flag_gems/experimental_ops/fmin.py
@@ -1,0 +1,111 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def fmin_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    out = tl.minimum(x, y)
+    tl.store(out_ptr + offsets, out, mask=mask)
+
+
+def _to_tensor(x, device=None, dtype=None):
+    if isinstance(x, torch.Tensor):
+        t = x
+        if device is not None and t.device != device:
+            t = t.to(device)
+        if dtype is not None and t.dtype != dtype:
+            t = t.to(dtype)
+        return t
+    return torch.tensor(x, device=device, dtype=dtype)
+
+
+def _prepare_inputs(a, b, out=None):
+    # Determine target device
+    dev = None
+    if isinstance(out, torch.Tensor):
+        dev = out.device
+    else:
+        if isinstance(a, torch.Tensor):
+            dev = a.device
+        if isinstance(b, torch.Tensor):
+            dev = b.device if dev is None else dev
+    if dev is None:
+        dev = torch.device("cuda")
+    # Convert to tensors on the target device
+    a = _to_tensor(a, device=dev)
+    b = _to_tensor(b, device=dev)
+    if a.device.type != "cuda" or b.device.type != "cuda":
+        raise ValueError(
+            "Inputs must be CUDA tensors or convertible to CUDA tensors for Triton kernels."
+        )
+    # Broadcast
+    a_b, b_b = torch.broadcast_tensors(a, b)
+    # Determine output dtype
+    out_dtype = torch.result_type(a_b, b_b)
+    if out_dtype.is_complex:
+        raise TypeError("fmin does not support complex dtypes.")
+    # Compute dtype for kernel (avoid bool in kernel by using int8)
+    compute_dtype = torch.int8 if out_dtype == torch.bool else out_dtype
+    a_c = a_b.to(compute_dtype).contiguous()
+    b_c = b_b.to(compute_dtype).contiguous()
+    return a_c, b_c, out_dtype, compute_dtype
+
+
+def fmin(a, b):
+    a_c, b_c, out_dtype, compute_dtype = _prepare_inputs(a, b, out=None)
+    out_shape = a_c.shape  # same as b_c.shape after broadcast
+    # Allocate outputs
+    if compute_dtype == out_dtype:
+        out = torch.empty(out_shape, dtype=out_dtype, device=a_c.device)
+        out_c = out
+    else:
+        out = torch.empty(out_shape, dtype=out_dtype, device=a_c.device)
+        out_c = torch.empty(out_shape, dtype=compute_dtype, device=a_c.device)
+    n_elements = out_c.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    fmin_kernel[grid](a_c, b_c, out_c, n_elements, BLOCK_SIZE=1024)
+    if out_c.dtype != out.dtype:
+        out.copy_(out_c.to(out_dtype))
+    return out
+
+
+def fmin_out(a, b, out):
+    if not isinstance(out, torch.Tensor):
+        raise TypeError("out must be a Tensor")
+    a_c, b_c, out_dtype, compute_dtype = _prepare_inputs(a, b, out=out)
+    # Validate out tensor shape/dtype/device
+    expected_shape = a_c.shape
+    if out.device != a_c.device:
+        raise ValueError("out tensor must be on the same device as inputs.")
+    if out.dtype != out_dtype:
+        raise TypeError(f"out tensor has dtype {out.dtype}, expected {out_dtype}.")
+    if tuple(out.shape) != tuple(expected_shape):
+        raise ValueError(
+            f"out tensor has shape {tuple(out.shape)}, expected {tuple(expected_shape)} after broadcasting."
+        )
+    # Prepare a contiguous buffer to write into
+    if compute_dtype == out_dtype and out.is_contiguous():
+        out_c = out
+    else:
+        # If dtype conversion is needed or out is non-contiguous, use a temporary buffer
+        out_c = torch.empty(expected_shape, dtype=compute_dtype, device=out.device)
+    n_elements = out_c.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    fmin_kernel[grid](a_c, b_c, out_c, n_elements, BLOCK_SIZE=1024)
+    # Move result into out if we used a temporary buffer or dtype differs
+    if out_c is not out:
+        if out_c.dtype != out.dtype:
+            out.copy_(out_c.to(out.dtype))
+        else:
+            if out.is_contiguous():
+                out.copy_(out_c)
+            else:
+                out.view_as(out.contiguous()).copy_(out_c)
+    return out

--- a/src/flag_gems/experimental_ops/frac_.py
+++ b/src/flag_gems/experimental_ops/frac_.py
@@ -1,0 +1,60 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def frac_(
+    x_ptr,  # *Pointer* to input/output tensor (in-place).
+    n_elements,  # Number of elements.
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    x_fp32 = x.to(tl.float32)
+    t = tl.where(x_fp32 >= 0, tl.floor(x_fp32), tl.ceil(x_fp32))
+    f = x_fp32 - t
+    f = f.to(x.dtype)
+    tl.store(x_ptr + offsets, f, mask=mask)
+
+
+# Preserve a handle to the Triton kernel before redefining the Python wrapper with the same name.
+frac__triton_kernel = frac_
+
+
+def frac_(*args, **kwargs):
+    # Expect a single tensor as the first positional arg (in-place operation).
+    x = args[0] if len(args) > 0 else kwargs.get("input", None)
+    if x is None:
+        raise ValueError("frac_ expects a tensor as the first argument")
+
+    if not x.is_cuda:
+        raise ValueError("Input tensor must be on a CUDA device")
+
+    if torch.is_complex(x):
+        raise NotImplementedError(
+            "Complex dtypes are not supported by this Triton frac_ kernel"
+        )
+
+    if not torch.is_floating_point(x):
+        raise TypeError("frac_ expects a floating point tensor")
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    # Ensure we operate on contiguous memory; if not, use a temporary contiguous buffer and copy back.
+    need_copy_back = not x.is_contiguous()
+    target = x.contiguous() if need_copy_back else x
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    frac__triton_kernel[grid](target, n_elements, BLOCK_SIZE=1024)
+
+    if need_copy_back:
+        x.copy_(target)
+
+    return x

--- a/src/flag_gems/experimental_ops/greater_equal_.py
+++ b/src/flag_gems/experimental_ops/greater_equal_.py
@@ -1,0 +1,76 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def ge_inplace_kernel(
+    x_ptr,  # *Pointer* to input/output tensor (in-place).
+    y_ptr,  # *Pointer* to comparison tensor (same shape as x).
+    n_elements,  # Number of elements.
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    out = x >= y
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+def greater_equal__Scalar(*args, **kwargs):
+    # Parse inputs
+    if len(args) >= 2:
+        x = args[0]
+        other = args[1]
+    else:
+        x = kwargs.get("self", kwargs.get("input"))
+        other = kwargs.get("other")
+    assert isinstance(x, torch.Tensor), "self must be a torch.Tensor"
+    assert x.is_cuda, "Input tensor must be on CUDA device"
+    # Create a tensor filled with the scalar 'other' matching x's shape and dtype
+    y = torch.full_like(x, other)
+    # Ensure contiguity
+    if not x.is_contiguous():
+        raise RuntimeError("greater_equal__Scalar: input tensor must be contiguous")
+    if not y.is_contiguous():
+        y = y.contiguous()
+    # Launch kernel
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    ge_inplace_kernel[grid](x, y, n_elements, BLOCK_SIZE=1024)
+    return x
+
+
+def greater_equal__Tensor(*args, **kwargs):
+    # Parse inputs
+    if len(args) >= 2:
+        x = args[0]
+        other = args[1]
+    else:
+        x = kwargs.get("self", kwargs.get("input"))
+        other = kwargs.get("other")
+    assert isinstance(x, torch.Tensor) and isinstance(
+        other, torch.Tensor
+    ), "Inputs must be torch.Tensors"
+    assert x.is_cuda and other.is_cuda, "Both tensors must be on CUDA device"
+    # Cast other to x's dtype to ensure the comparison works in kernel
+    if other.dtype != x.dtype:
+        other = other.to(dtype=x.dtype)
+    # Broadcast other to x's shape and make contiguous for simple indexing
+    if other.shape != x.shape:
+        other = other.expand_as(x).contiguous()
+    else:
+        if not other.is_contiguous():
+            other = other.contiguous()
+    # Ensure x (in-place) is contiguous
+    if not x.is_contiguous():
+        raise RuntimeError("greater_equal__Tensor: input tensor must be contiguous")
+    # Launch kernel
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    ge_inplace_kernel[grid](x, other, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/hardsigmoid.py
+++ b/src/flag_gems/experimental_ops/hardsigmoid.py
@@ -1,0 +1,37 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def hardsigmoid_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    xf = x.to(tl.float32)
+    y = xf * (1.0 / 6.0) + 0.5
+    y = tl.minimum(tl.maximum(y, 0.0), 1.0)
+    y = y.to(x.dtype)
+
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def hardsigmoid(x: torch.Tensor):
+    out = torch.empty_like(x)
+    assert x.is_cuda and out.is_cuda
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    hardsigmoid_kernel[grid](x, out, n_elements, BLOCK_SIZE=1024)
+    return out
+
+
+def hardsigmoid_out(x: torch.Tensor, out: torch.Tensor):
+    assert x.is_cuda and out.is_cuda
+    assert x.numel() == out.numel()
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    hardsigmoid_kernel[grid](x, out, n_elements, BLOCK_SIZE=1024)
+    return out

--- a/src/flag_gems/experimental_ops/heaviside.py
+++ b/src/flag_gems/experimental_ops/heaviside.py
@@ -1,0 +1,81 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _heaviside_kernel(x_ptr, v_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    v = tl.load(v_ptr + offsets, mask=mask)
+
+    zeros = x - x
+    ones = zeros + 1
+    is_pos = x > zeros
+    is_zero = x == zeros
+    out = tl.where(is_zero, v, tl.where(is_pos, ones, zeros))
+
+    tl.store(out_ptr + offsets, out, mask=mask)
+
+
+def heaviside(input, values):
+    # Prepare tensors
+    if not isinstance(values, torch.Tensor):
+        values = torch.as_tensor(values, device=input.device)
+    # Broadcast
+    x_b, v_b = torch.broadcast_tensors(input, values)
+    # Dtype promotion
+    out_dtype = torch.result_type(x_b, v_b)
+    x = x_b.to(dtype=out_dtype).contiguous()
+    v = v_b.to(dtype=out_dtype).contiguous()
+
+    # Allocate output
+    out = torch.empty_like(x)
+
+    # Launch kernel
+    n_elements = out.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _heaviside_kernel[grid](x, v, out, n_elements, BLOCK_SIZE=1024)
+    return out
+
+
+def heaviside_out(input, values, out):
+    # Prepare tensors
+    if not isinstance(values, torch.Tensor):
+        values = torch.as_tensor(values, device=input.device)
+    # Broadcast
+    x_b, v_b = torch.broadcast_tensors(input, values)
+    # Dtype promotion
+    expected_dtype = torch.result_type(x_b, v_b)
+    expected_shape = x_b.shape
+    device = x_b.device
+    # Check output tensor
+    if out.device != device:
+        raise ValueError("out tensor device must match input device")
+    if out.dtype != expected_dtype:
+        raise ValueError("out tensor dtype must be the result type of input and values")
+    if out.shape != expected_shape:
+        raise ValueError(
+            "out tensor shape must be the broadcasted shape of input and values"
+        )
+
+    x = x_b.to(dtype=expected_dtype).contiguous()
+    v = v_b.to(dtype=expected_dtype).contiguous()
+
+    # If out is contiguous, write directly; otherwise use a temp and copy
+    if out.is_contiguous():
+        target = out
+    else:
+        target = torch.empty_like(out, memory_format=torch.contiguous_format)
+
+    n_elements = target.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _heaviside_kernel[grid](x, v, target, n_elements, BLOCK_SIZE=1024)
+
+    if target is not out:
+        out.copy_(target)
+    return out

--- a/src/flag_gems/experimental_ops/im2col.py
+++ b/src/flag_gems/experimental_ops/im2col.py
@@ -1,0 +1,219 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def im2col_kernel(
+    x_ptr,  # *Pointer* to input tensor [N, C, H, W]
+    out_ptr,  # *Pointer* to output tensor [N, C*kH*kW, outH*outW]
+    N,
+    C,
+    H,
+    W,
+    kH,
+    kW,
+    dH,
+    dW,
+    pH,
+    pW,
+    sH,
+    sW,
+    outH,
+    outW,
+    rows_total,  # C * kH * kW
+    L,  # outH * outW
+    num_row_tiles,  # ceil_div(rows_total, BLOCK_M)
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid0 = tl.program_id(0)
+    pid1 = tl.program_id(1)
+
+    n = pid0 // num_row_tiles
+    row_tile = pid0 % num_row_tiles
+
+    row_offsets = row_tile * BLOCK_M + tl.arange(0, BLOCK_M)
+    col_offsets = pid1 * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    mask_rows = row_offsets < rows_total
+    mask_cols = col_offsets < L
+
+    k_area = kH * kW
+
+    c_idx = row_offsets // k_area
+    rem = row_offsets % k_area
+    kh_idx = rem // kW
+    kw_idx = rem % kW
+
+    oh_vec = col_offsets // outW
+    ow_vec = col_offsets % outW
+
+    # Broadcast to [BLOCK_M, BLOCK_N]
+    oh = oh_vec[None, :]
+    ow = ow_vec[None, :]
+    kh = kh_idx[:, None]
+    kw = kw_idx[:, None]
+    c = c_idx[:, None]
+
+    ih = oh * sH - pH + kh * dH
+    iw = ow * sW - pW + kw * dW
+
+    in_h = (ih >= 0) & (ih < H)
+    in_w = (iw >= 0) & (iw < W)
+    in_bounds = in_h & in_w
+
+    # Base offsets
+    base_in = (n.to(tl.int64) * C * H * W).to(tl.int64)
+    base_out = (n.to(tl.int64) * rows_total * L).to(tl.int64)
+
+    # Compute input pointers
+    ptrs_in = (
+        x_ptr + base_in + ((c.to(tl.int64) * H + ih.to(tl.int64)) * W + iw.to(tl.int64))
+    )
+
+    # Compute output pointers
+    ptrs_out = (
+        out_ptr
+        + base_out
+        + (row_offsets[:, None].to(tl.int64) * L + col_offsets[None, :].to(tl.int64))
+    )
+
+    mask = mask_rows[:, None] & mask_cols[None, :] & in_bounds
+
+    vals = tl.load(ptrs_in, mask=mask, other=0)
+    tl.store(ptrs_out, vals, mask=(mask_rows[:, None] & mask_cols[None, :]))
+
+
+def _parse_2tuple(x, name):
+    if isinstance(x, int):
+        return (x, x)
+    if (
+        isinstance(x, (list, tuple))
+        and len(x) == 2
+        and all(isinstance(v, int) for v in x)
+    ):
+        return (int(x[0]), int(x[1]))
+    raise ValueError(f"{name} must be an int or a tuple/list of two ints")
+
+
+def _compute_output_dims(H, W, kH, kW, dH, dW, pH, pW, sH, sW):
+    outH = (H + 2 * pH - (dH * (kH - 1) + 1)) // sH + 1
+    outW = (W + 2 * pW - (dW * (kW - 1) + 1)) // sW + 1
+    return outH, outW
+
+
+def _launch_im2col_kernel(x, out, kH, kW, dH, dW, pH, pW, sH, sW):
+    assert x.is_cuda and out.is_cuda, "Inputs must be CUDA tensors"
+    x = x.contiguous()
+    out = out.contiguous()
+
+    N, C, H, W = x.shape
+    outH, outW = _compute_output_dims(H, W, kH, kW, dH, dW, pH, pW, sH, sW)
+    rows_total = C * kH * kW
+    L = outH * outW
+
+    if rows_total == 0 or L == 0 or N == 0:
+        return  # Nothing to do
+
+    BLOCK_M = 64
+    BLOCK_N = 128
+
+    num_row_tiles = triton.cdiv(rows_total, BLOCK_M)
+    num_col_tiles = triton.cdiv(L, BLOCK_N)
+    grid = (N * num_row_tiles, num_col_tiles)
+
+    im2col_kernel[grid](
+        x,
+        out,
+        N,
+        C,
+        H,
+        W,
+        kH,
+        kW,
+        dH,
+        dW,
+        pH,
+        pW,
+        sH,
+        sW,
+        outH,
+        outW,
+        rows_total,
+        L,
+        num_row_tiles,
+        BLOCK_M=BLOCK_M,
+        BLOCK_N=BLOCK_N,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+def im2col(input, kernel_size, dilation=1, padding=0, stride=1):
+    x = input
+    if x.ndim == 3:
+        x = x.unsqueeze(0)
+    if x.ndim != 4:
+        raise ValueError("im2col expects input of shape (N, C, H, W) or (C, H, W)")
+    kH, kW = _parse_2tuple(kernel_size, "kernel_size")
+    dH, dW = _parse_2tuple(dilation, "dilation")
+    pH, pW = _parse_2tuple(padding, "padding")
+    sH, sW = _parse_2tuple(stride, "stride")
+
+    N, C, H, W = x.shape
+    outH, outW = _compute_output_dims(H, W, kH, kW, dH, dW, pH, pW, sH, sW)
+    rows_total = C * kH * kW
+    L = outH * outW
+
+    out = torch.empty((N, rows_total, L), device=x.device, dtype=x.dtype)
+    if L == 0 or rows_total == 0 or N == 0:
+        return out if input.ndim == 4 else out.squeeze(0)
+
+    _launch_im2col_kernel(x, out, kH, kW, dH, dW, pH, pW, sH, sW)
+    return out if input.ndim == 4 else out.squeeze(0)
+
+
+def im2col_out(input, kernel_size, dilation=1, padding=0, stride=1, out=None):
+    x = input
+    if x.ndim == 3:
+        x = x.unsqueeze(0)
+    if x.ndim != 4:
+        raise ValueError("im2col_out expects input of shape (N, C, H, W) or (C, H, W)")
+    kH, kW = _parse_2tuple(kernel_size, "kernel_size")
+    dH, dW = _parse_2tuple(dilation, "dilation")
+    pH, pW = _parse_2tuple(padding, "padding")
+    sH, sW = _parse_2tuple(stride, "stride")
+
+    N, C, H, W = x.shape
+    outH, outW = _compute_output_dims(H, W, kH, kW, dH, dW, pH, pW, sH, sW)
+    rows_total = C * kH * kW
+    L = outH * outW
+
+    if out is None:
+        out = torch.empty((N, rows_total, L), device=x.device, dtype=x.dtype)
+    else:
+        if out.ndim == 2 and N == 1:
+            # Allow (C*kH*kW, L) for single batch for convenience
+            expected = (rows_total, L)
+        else:
+            expected = (N, rows_total, L)
+        if tuple(out.shape) != expected:
+            raise ValueError(f"out has shape {tuple(out.shape)}, expected {expected}")
+        if out.device != x.device or out.dtype != x.dtype:
+            raise ValueError("out must have same device and dtype as input")
+
+    if L == 0 or rows_total == 0 or N == 0:
+        return out
+
+    # If out was provided as 2D for N=1, make it 3D view for kernel, then restore
+    squeeze_after = False
+    if out.ndim == 2 and N == 1:
+        out_3d = out.view(1, rows_total, L)
+        squeeze_after = True
+    else:
+        out_3d = out
+
+    _launch_im2col_kernel(x, out_3d, kH, kW, dH, dW, pH, pW, sH, sW)
+
+    return out_3d.view(rows_total, L) if squeeze_after else out

--- a/src/flag_gems/experimental_ops/lgamma_.py
+++ b/src/flag_gems/experimental_ops/lgamma_.py
@@ -1,0 +1,104 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def lgamma_(x_ptr, n_elements, IS_FP64: tl.constexpr, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x_raw = tl.load(x_ptr + offsets, mask=mask)
+
+    if IS_FP64:
+        xf = x_raw.to(tl.float64)
+    else:
+        xf = x_raw.to(tl.float32)
+
+    pi = 3.141592653589793
+    half_log_two_pi = 0.9189385332046727
+    g = 7.0
+    c0 = 0.99999999999980993
+    c1 = 676.5203681218851
+    c2 = -1259.1392167224028
+    c3 = 771.32342877765313
+    c4 = -176.61502916214059
+    c5 = 12.507343278686905
+    c6 = -0.13857109526572012
+    c7 = 9.9843695780195716e-6
+    c8 = 1.5056327351493116e-7
+
+    # Lanczos evaluation for xf
+    u = xf
+    u1 = u - 1.0
+    a = c0
+    a = a + c1 / (u1 + 1.0)
+    a = a + c2 / (u1 + 2.0)
+    a = a + c3 / (u1 + 3.0)
+    a = a + c4 / (u1 + 4.0)
+    a = a + c5 / (u1 + 5.0)
+    a = a + c6 / (u1 + 6.0)
+    a = a + c7 / (u1 + 7.0)
+    a = a + c8 / (u1 + 8.0)
+    t = u1 + g + 0.5
+    res_std = half_log_two_pi + (u1 + 0.5) * tl.log(t) - t + tl.log(a)
+
+    # Lanczos evaluation for (1 - xf)
+    u_ref = 1.0 - xf
+    ur1 = u_ref - 1.0
+    ar = c0
+    ar = ar + c1 / (ur1 + 1.0)
+    ar = ar + c2 / (ur1 + 2.0)
+    ar = ar + c3 / (ur1 + 3.0)
+    ar = ar + c4 / (ur1 + 4.0)
+    ar = ar + c5 / (ur1 + 5.0)
+    ar = ar + c6 / (ur1 + 6.0)
+    ar = ar + c7 / (ur1 + 7.0)
+    ar = ar + c8 / (ur1 + 8.0)
+    tr_ = ur1 + g + 0.5
+    lgn_1mz = half_log_two_pi + (ur1 + 0.5) * tl.log(tr_) - tr_ + tl.log(ar)
+
+    s = tl.sin(pi * xf)
+    res_ref = tl.log(pi) - tl.log(tl.abs(s)) - lgn_1mz
+
+    res = tl.where(xf < 0.5, res_ref, res_std)
+
+    y = res.to(x_raw.dtype)
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+_lgamma_kernel = lgamma_
+
+
+def lgamma_(x: torch.Tensor):
+    assert isinstance(x, torch.Tensor), "Input must be a torch.Tensor"
+    assert x.is_cuda, "Input tensor must be on CUDA device"
+    assert x.dtype in (
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+        torch.float64,
+    ), "Unsupported dtype for lgamma_"
+
+    needs_copy_back = False
+    target = x
+    if not x.is_contiguous():
+        target = x.contiguous()
+        needs_copy_back = True
+
+    n_elements = target.numel()
+    if n_elements == 0:
+        return x
+
+    IS_FP64 = target.dtype == torch.float64
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    _lgamma_kernel[grid](target, n_elements, IS_FP64=IS_FP64, BLOCK_SIZE=BLOCK_SIZE)
+
+    if needs_copy_back:
+        x.copy_(target)
+
+    return x

--- a/src/flag_gems/experimental_ops/log10_.py
+++ b/src/flag_gems/experimental_ops/log10_.py
@@ -1,0 +1,53 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def log10_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    x_fp32 = x.to(tl.float32)
+    y_fp32 = tl.log(x_fp32) * 0.4342944819032518  # 1 / ln(10)
+    y = y_fp32.to(x.dtype)
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# Keep a handle to the Triton kernel before defining the Python wrapper with the same name.
+_log10__kernel = log10_
+
+
+def log10_(*args, **kwargs):
+    if len(args) == 0:
+        raise TypeError(
+            "log10_ expects at least one positional argument: a torch.Tensor."
+        )
+    x = args[0]
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("log10_ expects a torch.Tensor as its first argument.")
+    if x.numel() == 0:
+        return x
+    if x.device.type != "cuda":
+        # Fallback to PyTorch implementation for non-CUDA tensors
+        return torch.log10_(x)
+    if x.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        # Fallback to PyTorch for unsupported dtypes (e.g., float64, complex)
+        return torch.log10_(x)
+
+    BLOCK_SIZE = 1024
+    if x.is_contiguous():
+        n_elements = x.numel()
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        _log10__kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    else:
+        buf = x.contiguous()
+        n_elements = buf.numel()
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        _log10__kernel[grid](buf, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+        x.copy_(buf)
+
+    return x

--- a/src/flag_gems/experimental_ops/log1p_.py
+++ b/src/flag_gems/experimental_ops/log1p_.py
@@ -1,0 +1,54 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def log1p_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x_fp32 = x.to(tl.float32)
+    y = tl.log(x_fp32 + 1.0)
+    y_cast = y.to(x.dtype)
+
+    tl.store(x_ptr + offsets, y_cast, mask=mask)
+
+
+_log1p_kernel = log1p_
+
+
+def log1p_(*args, **kwargs):
+    # Accept tensor from positional or keyword args
+    x = None
+    if len(args) > 0:
+        x = args[0]
+    else:
+        x = kwargs.get("input", None)
+
+    if x is None:
+        raise ValueError(
+            "log1p_ expects a tensor as the first argument or keyword 'input'."
+        )
+
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("log1p_ expects a torch.Tensor as input.")
+
+    # Fallback for unsupported device/dtype/layout
+    if not x.is_cuda:
+        return torch.ops.aten.log1p_(x)
+    if not x.is_contiguous():
+        return torch.ops.aten.log1p_(x)
+    if x.dtype not in (torch.float16, torch.bfloat16, torch.float32, torch.float64):
+        return torch.ops.aten.log1p_(x)
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _log1p_kernel[grid](x, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/logaddexp.py
+++ b/src/flag_gems/experimental_ops/logaddexp.py
@@ -1,0 +1,114 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def logaddexp_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0.0)
+
+    xf32 = x.to(tl.float32)
+    yf32 = y.to(tl.float32)
+
+    delta = xf32 - yf32
+    adelta = tl.abs(delta)
+    m = tl.maximum(xf32, yf32)
+    res = m + tl.log(1.0 + tl.exp(-adelta))
+
+    out_ty = out_ptr.dtype.element_ty
+    tl.store(out_ptr + offsets, res.to(out_ty), mask=mask)
+
+
+def _ensure_cuda_tensor(obj, device, dtype):
+    if torch.is_tensor(obj):
+        return obj.to(device=device, dtype=dtype)
+    else:
+        return torch.tensor(obj, device=device, dtype=dtype)
+
+
+def _common_float_dtype(x: torch.Tensor, y: torch.Tensor):
+    dt = torch.result_type(x, y)
+    if dt not in (torch.float16, torch.bfloat16, torch.float32, torch.float64):
+        dt = torch.get_default_dtype()
+    return dt
+
+
+def _launch_logaddexp_kernel(x: torch.Tensor, y: torch.Tensor, out: torch.Tensor):
+    assert x.is_cuda and y.is_cuda and out.is_cuda, "All tensors must be on CUDA device"
+    assert (
+        x.numel() == y.numel() == out.numel()
+    ), "Input and output must have the same number of elements"
+
+    x_flat = x.contiguous().view(-1)
+    y_flat = y.contiguous().view(-1)
+    out_flat = out.contiguous().view(-1)
+
+    n_elements = out_flat.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    logaddexp_kernel[grid](x_flat, y_flat, out_flat, n_elements, BLOCK_SIZE=1024)
+
+    # If out was non-contiguous, copy results back into original layout
+    if not out.is_contiguous():
+        out.copy_(out_flat.view_as(out))
+
+
+def logaddexp(x, y):
+    # Determine device
+    device = None
+    if torch.is_tensor(x) and x.is_cuda:
+        device = x.device
+    if device is None and torch.is_tensor(y) and y.is_cuda:
+        device = y.device
+    if device is None:
+        raise ValueError("At least one input must be a CUDA tensor")
+
+    # Determine dtype
+    x_t = x if torch.is_tensor(x) else torch.tensor(x)
+    y_t = y if torch.is_tensor(y) else torch.tensor(y)
+    dtype = _common_float_dtype(x_t, y_t)
+
+    # Convert to device and dtype
+    x_t = _ensure_cuda_tensor(x, device, dtype)
+    y_t = _ensure_cuda_tensor(y, device, dtype)
+
+    # Broadcast
+    xb, yb = torch.broadcast_tensors(x_t, y_t)
+
+    # Allocate output
+    out = torch.empty_like(xb, dtype=dtype, device=device)
+
+    _launch_logaddexp_kernel(xb, yb, out)
+    return out
+
+
+def logaddexp_out(x, y, out):
+    if not torch.is_tensor(out) or not out.is_cuda:
+        raise ValueError("out must be a CUDA tensor")
+
+    # Determine computation device and dtype from out
+    device = out.device
+    out_dtype = out.dtype
+    if out_dtype not in (torch.float16, torch.bfloat16, torch.float32, torch.float64):
+        raise ValueError("out dtype must be a floating point type")
+
+    # Prepare inputs
+    x_t = _ensure_cuda_tensor(x, device, out_dtype)
+    y_t = _ensure_cuda_tensor(y, device, out_dtype)
+
+    # Broadcast inputs
+    xb, yb = torch.broadcast_tensors(x_t, y_t)
+
+    # Ensure out shape matches
+    if tuple(out.shape) != tuple(xb.shape):
+        raise ValueError(
+            f"out shape {tuple(out.shape)} does not match broadcasted shape {tuple(xb.shape)}"
+        )
+
+    _launch_logaddexp_kernel(xb, yb, out)
+    return out

--- a/tests/experimental_ops/expm1__test.py
+++ b/tests/experimental_ops/expm1__test.py
@@ -1,0 +1,75 @@
+# EXPM1_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.expm1_ import expm1_ as gems_expm1_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.expm1_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("noncontig", [False, True])
+def test_expm1__tensor(shape, dtype, noncontig):
+    base = torch.randn(shape, device=flag_gems.device, dtype=dtype) * 0.5
+    base_ref = base.clone()
+    base_act = base.clone()
+
+    ref_input = base_ref.transpose(0, 1) if noncontig else base_ref
+    act_input = base_act.transpose(0, 1) if noncontig else base_act
+
+    ref_out = torch.ops.aten.expm1_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_expm1_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.expm1_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("noncontig", [False, True])
+def test_expm1__benchmark_tensor(shape, dtype, noncontig):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.randn(shape, device=flag_gems.device, dtype=dtype) * 0.5
+    base_ref = base.clone()
+    base_act = base.clone()
+
+    ref_input = base_ref.transpose(0, 1) if noncontig else base_ref
+    act_input = base_act.transpose(0, 1) if noncontig else base_act
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.expm1_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_expm1_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"expm1_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/fft_fftshift_test.py
+++ b/tests/experimental_ops/fft_fftshift_test.py
@@ -1,0 +1,112 @@
+# FFT_FFTSHIFT operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.fft_fftshift import fft_fftshift as gems_fft_fftshift
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.fft_fftshift
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (64, 32, 16), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_fft_fftshift_dim_none(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.fft_fftshift(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_fft_fftshift(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.fft_fftshift
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (64, 32, 16), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [[0], [-1]])
+def test_fft_fftshift_with_dim(shape, dtype, dim):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.fft_fftshift(ref_input, dim)
+
+    with flag_gems.use_gems():
+        act_out = gems_fft_fftshift(input_tensor, dim)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.fft_fftshift
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (64, 32, 16), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_fft_fftshift_dim_none_performance(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.fft_fftshift(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_fft_fftshift(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"fft_fftshift {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.fft_fftshift
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (64, 32, 16), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [[0], [-1]])
+def test_fft_fftshift_with_dim_performance(shape, dtype, dim):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.fft_fftshift(ref_input, dim),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_fft_fftshift(input_tensor, dim), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"fft_fftshift {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/fix__test.py
+++ b/tests/experimental_ops/fix__test.py
@@ -1,0 +1,65 @@
+# FIX_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.fix_ import fix_ as gems_fix_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.fix_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_fix__tensor(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+
+    ref_out = torch.ops.aten.fix_(ref_inp)
+
+    with flag_gems.use_gems():
+        act_out = gems_fix_(inp)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.fix_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_fix__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.fix_(ref_inp), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_fix_(inp), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"fix_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/floor__test.py
+++ b/tests/experimental_ops/floor__test.py
@@ -1,0 +1,69 @@
+# FLOOR_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.floor_ import floor_ as gems_floor_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.floor_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_floor__tensor(shape, dtype):
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device) * 5.3
+
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_out = torch.ops.aten.floor_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_floor_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.floor_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_floor__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device) * 5.3
+
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.floor_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_floor_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"floor_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/fmin_test.py
+++ b/tests/experimental_ops/fmin_test.py
@@ -1,0 +1,117 @@
+# FMIN operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.fmin import fmin as gems_fmin
+from flag_gems.experimental_ops.fmin import fmin_out as gems_fmin_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.fmin
+@pytest.mark.parametrize(
+    "shape_self,shape_other",
+    [
+        ((2, 3), (2, 3)),
+        ((128, 256), (128, 256)),
+        ((512, 512), (512, 512)),
+        ((4, 1, 32), (1, 32)),
+        ((1, 5, 7), (5, 1, 7)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_fmin_tensor(shape_self, shape_other, dtype):
+    self_tensor = torch.randn(shape_self, dtype=dtype, device=flag_gems.device)
+    other_tensor = torch.randn(shape_other, dtype=dtype, device=flag_gems.device)
+
+    self_mask = torch.rand(shape_self, device=flag_gems.device) < 0.05
+    other_mask = torch.rand(shape_other, device=flag_gems.device) < 0.05
+    self_tensor[self_mask] = float("nan")
+    other_tensor[other_mask] = float("nan")
+
+    ref_self = self_tensor.clone()
+    ref_other = other_tensor.clone()
+    ref_out = torch.ops.aten.fmin(ref_self, ref_other)
+
+    with flag_gems.use_gems():
+        act_out = gems_fmin(self_tensor, other_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype, equal_nan=True)
+
+
+@pytest.mark.fmin
+@pytest.mark.parametrize(
+    "shape_self,shape_other",
+    [
+        ((2, 3), (2, 3)),
+        ((128, 256), (128, 256)),
+        ((512, 512), (512, 512)),
+        ((4, 1, 32), (1, 32)),
+        ((1, 5, 7), (5, 1, 7)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_fmin_out(shape_self, shape_other, dtype):
+    self_tensor = torch.randn(shape_self, dtype=dtype, device=flag_gems.device)
+    other_tensor = torch.randn(shape_other, dtype=dtype, device=flag_gems.device)
+
+    self_mask = torch.rand(shape_self, device=flag_gems.device) < 0.05
+    other_mask = torch.rand(shape_other, device=flag_gems.device) < 0.05
+    self_tensor[self_mask] = float("nan")
+    other_tensor[other_mask] = float("nan")
+
+    ref_self = self_tensor.clone()
+    ref_other = other_tensor.clone()
+    ref_broadcast_self, ref_broadcast_other = torch.broadcast_tensors(
+        ref_self, ref_other
+    )
+    ref_out_buf = torch.empty(
+        ref_broadcast_self.shape, dtype=dtype, device=flag_gems.device
+    )
+    ref_out = torch.ops.aten.fmin.out(ref_self, ref_other, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_broadcast_self, act_broadcast_other = torch.broadcast_tensors(
+            self_tensor, other_tensor
+        )
+        act_out_buf = torch.empty(
+            act_broadcast_self.shape, dtype=dtype, device=flag_gems.device
+        )
+        act_out = gems_fmin_out(self_tensor, other_tensor, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype, equal_nan=True)
+
+
+@pytest.mark.fmin
+def test_perf_aten_fmin():
+    # Define input generation logic matching the operator arguments
+    def fmin_input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=fmin_input_fn,
+        op_name="fmin",
+        torch_op=torch.ops.aten.fmin,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/frac__test.py
+++ b/tests/experimental_ops/frac__test.py
@@ -1,0 +1,112 @@
+# FRAC_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.frac_ import frac_ as gems_frac_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.frac_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_frac__tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out = torch.ops.aten.frac_(ref_x)
+    with flag_gems.use_gems():
+        act_out = gems_frac_(x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.frac_
+@pytest.mark.parametrize("shape", [(64, 33), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_frac__tensor_noncontiguous(shape, dtype):
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    base2 = base.clone()
+
+    ref_inp = base.transpose(0, 1)
+    act_inp = base2.transpose(0, 1)
+
+    ref_out = torch.ops.aten.frac_(ref_inp)
+    with flag_gems.use_gems():
+        act_out = gems_frac_(act_inp)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.frac_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_frac__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.frac_(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_frac_(x), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"frac_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.frac_
+@pytest.mark.parametrize("shape", [(64, 33), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_frac__tensor_noncontiguous_performance(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    base2 = base.clone()
+
+    ref_inp = base.transpose(0, 1)
+    act_inp = base2.transpose(0, 1)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.frac_(ref_inp), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_frac_(act_inp), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"frac_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/greater_equal__test.py
+++ b/tests/experimental_ops/greater_equal__test.py
@@ -1,0 +1,93 @@
+# GREATER_EQUAL_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.greater_equal_ import (
+    greater_equal__Scalar as gems_greater_equal__scalar,
+)
+from flag_gems.experimental_ops.greater_equal_ import (
+    greater_equal__Tensor as gems_greater_equal__tensor,
+)
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.greater_equal_
+@pytest.mark.parametrize(
+    "self_shape,other_shape",
+    [
+        ((2, 3), (2, 3)),
+        ((2, 3), (1, 3)),
+        ((128, 256), (1, 256)),
+        ((128, 256), (128, 1)),
+        ((1024, 1024), (1, 1)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_greater_equal__tensor(self_shape, other_shape, dtype):
+    self_tensor = torch.randn(self_shape, dtype=dtype, device=flag_gems.device)
+    other_tensor = torch.randn(other_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_self = self_tensor.clone()
+    ref_other = other_tensor.clone()
+    ref_out = torch.ops.aten.greater_equal_(ref_self, ref_other)
+
+    act_self = self_tensor.clone()
+    act_other = other_tensor.clone()
+    with flag_gems.use_gems():
+        act_out = gems_greater_equal__tensor(act_self, act_other)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.greater_equal_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("scalar", [-0.5, 0.0, 1.25])
+def test_greater_equal__scalar(shape, dtype, scalar):
+    self_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_self = self_tensor.clone()
+    ref_out = torch.ops.aten.greater_equal_(ref_self, scalar)
+
+    act_self = self_tensor.clone()
+    with flag_gems.use_gems():
+        act_out = gems_greater_equal__scalar(act_self, scalar)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.greater_equal_
+def test_perf_aten_greater_equal_():
+    # Define input generation logic matching the operator arguments
+    def greater_equal__input_fn(shape, dtype, device):
+        # Generate and yield inputs as required by the operator
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=greater_equal__input_fn,
+        op_name="greater_equal_",
+        torch_op=torch.ops.aten.greater_equal_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/hardsigmoid_test.py
+++ b/tests/experimental_ops/hardsigmoid_test.py
@@ -1,0 +1,119 @@
+# HARDSIGMOID operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.hardsigmoid import hardsigmoid as gems_hardsigmoid
+from flag_gems.experimental_ops.hardsigmoid import (
+    hardsigmoid_out as gems_hardsigmoid_out,
+)
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.hardsigmoid
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardsigmoid_tensor(shape, dtype):
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_x = x.clone()
+
+    ref_out = torch.ops.aten.hardsigmoid(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_hardsigmoid(x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardsigmoid
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardsigmoid_out(shape, dtype):
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_x = x.clone()
+
+    ref_out_buf = torch.empty_like(ref_x)
+    act_out_buf = torch.empty_like(x)
+
+    ref_out = torch.ops.aten.hardsigmoid.out(ref_x, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out = gems_hardsigmoid_out(x, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardsigmoid
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardsigmoid_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_x = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.hardsigmoid(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_hardsigmoid(x), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardsigmoid {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.hardsigmoid
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardsigmoid_benchmark_out(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_x = x.clone()
+
+    ref_out_buf = torch.empty_like(ref_x)
+    act_out_buf = torch.empty_like(x)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.hardsigmoid.out(ref_x, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_hardsigmoid_out(x, act_out_buf), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardsigmoid {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/heaviside_test.py
+++ b/tests/experimental_ops/heaviside_test.py
@@ -1,0 +1,85 @@
+# HEAVISIDE operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.heaviside import heaviside as gems_heaviside
+from flag_gems.experimental_ops.heaviside import heaviside_out as gems_heaviside_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.heaviside
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_heaviside_tensor(shape, dtype):
+    self_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    values_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) < 0.1
+    self_tensor[mask] = 0.0
+
+    ref_self = self_tensor.clone()
+    ref_values = values_tensor.clone()
+
+    ref_out = torch.ops.aten.heaviside(ref_self, ref_values)
+
+    with flag_gems.use_gems():
+        act_out = gems_heaviside(self_tensor, values_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.heaviside
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_heaviside_out(shape, dtype):
+    self_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    values_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) < 0.1
+    self_tensor[mask] = 0.0
+
+    ref_self = self_tensor.clone()
+    ref_values = values_tensor.clone()
+    ref_out_buf = torch.empty_like(ref_self)
+
+    ref_out = torch.ops.aten.heaviside.out(ref_self, ref_values, out=ref_out_buf)
+
+    act_out_buf = torch.empty_like(self_tensor)
+    with flag_gems.use_gems():
+        act_out = gems_heaviside_out(self_tensor, values_tensor, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.heaviside
+def test_perf_aten_heaviside():
+    # Define input generation logic matching the operator arguments
+    def heaviside_input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=heaviside_input_fn,
+        op_name="heaviside",
+        torch_op=torch.ops.aten.heaviside,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/im2col_test.py
+++ b/tests/experimental_ops/im2col_test.py
@@ -1,0 +1,187 @@
+# IM2COL operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.im2col import im2col as gems_im2col
+from flag_gems.experimental_ops.im2col import im2col_out as gems_im2col_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.im2col
+@pytest.mark.parametrize("shape", [(3, 8, 8), (16, 64, 64), (32, 128, 128)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "kernel_size, dilation, padding, stride",
+    [
+        ((3, 3), (1, 1), (1, 1), (1, 1)),
+        ((3, 3), (1, 1), (0, 0), (2, 2)),
+        ((5, 4), (2, 2), (2, 1), (1, 2)),
+        ((1, 1), (1, 1), (0, 0), (1, 1)),
+    ],
+)
+def test_im2col_tensor(shape, dtype, kernel_size, dilation, padding, stride):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out = torch.ops.aten.im2col(ref_x, kernel_size, dilation, padding, stride)
+
+    with flag_gems.use_gems():
+        act_out = gems_im2col(x, kernel_size, dilation, padding, stride)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.im2col
+@pytest.mark.parametrize("shape", [(3, 8, 8), (16, 64, 64), (32, 128, 128)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "kernel_size, dilation, padding, stride",
+    [
+        ((3, 3), (1, 1), (1, 1), (1, 1)),
+        ((3, 3), (1, 1), (0, 0), (2, 2)),
+        ((5, 4), (2, 2), (2, 1), (1, 2)),
+        ((1, 1), (1, 1), (0, 0), (1, 1)),
+    ],
+)
+def test_im2col_out(shape, dtype, kernel_size, dilation, padding, stride):
+    def compute_out_shape(c, h, w, k, d, p, s):
+        kH, kW = k
+        dH, dW = d
+        pH, pW = p
+        sH, sW = s
+        out_h = (h + 2 * pH - dH * (kH - 1) - 1) // sH + 1
+        out_w = (w + 2 * pW - dW * (kW - 1) - 1) // sW + 1
+        return (c * kH * kW, out_h * out_w)
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    C, H, W = shape
+    out_shape = compute_out_shape(C, H, W, kernel_size, dilation, padding, stride)
+
+    out_ref = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    out_act = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.ops.aten.im2col.out(
+        ref_x, kernel_size, dilation, padding, stride, out=out_ref
+    )
+
+    with flag_gems.use_gems():
+        act_out = gems_im2col_out(x, kernel_size, dilation, padding, stride, out_act)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.im2col
+@pytest.mark.parametrize("shape", [(3, 8, 8), (16, 64, 64), (32, 128, 128)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "kernel_size, dilation, padding, stride",
+    [
+        ((3, 3), (1, 1), (1, 1), (1, 1)),
+        ((3, 3), (1, 1), (0, 0), (2, 2)),
+        ((5, 4), (2, 2), (2, 1), (1, 2)),
+        ((1, 1), (1, 1), (0, 0), (1, 1)),
+    ],
+)
+def test_im2col_benchmark_tensor(shape, dtype, kernel_size, dilation, padding, stride):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.im2col(ref_x, kernel_size, dilation, padding, stride),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_im2col(x, kernel_size, dilation, padding, stride),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"im2col {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.im2col
+@pytest.mark.parametrize("shape", [(3, 8, 8), (16, 64, 64), (32, 128, 128)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize(
+    "kernel_size, dilation, padding, stride",
+    [
+        ((3, 3), (1, 1), (1, 1), (1, 1)),
+        ((3, 3), (1, 1), (0, 0), (2, 2)),
+        ((5, 4), (2, 2), (2, 1), (1, 2)),
+        ((1, 1), (1, 1), (0, 0), (1, 1)),
+    ],
+)
+def test_im2col_benchmark_out(shape, dtype, kernel_size, dilation, padding, stride):
+    quantiles = [0.5, 0.2, 0.8]
+
+    def compute_out_shape(c, h, w, k, d, p, s):
+        kH, kW = k
+        dH, dW = d
+        pH, pW = p
+        sH, sW = s
+        out_h = (h + 2 * pH - dH * (kH - 1) - 1) // sH + 1
+        out_w = (w + 2 * pW - dW * (kW - 1) - 1) // sW + 1
+        return (c * kH * kW, out_h * out_w)
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    C, H, W = shape
+    out_shape = compute_out_shape(C, H, W, kernel_size, dilation, padding, stride)
+
+    out_ref = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    out_act = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.im2col.out(
+            ref_x, kernel_size, dilation, padding, stride, out=out_ref
+        ),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_im2col_out(x, kernel_size, dilation, padding, stride, out_act),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"im2col {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/lgamma__test.py
+++ b/tests/experimental_ops/lgamma__test.py
@@ -1,0 +1,89 @@
+# LGAMMA_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.lgamma_ import lgamma_ as gems_lgamma_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.lgamma_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("noncontig", [False, True])
+def test_lgamma__tensor(shape, dtype, noncontig):
+    # create stable inputs avoiding singularities (0, negative integers)
+    u1 = torch.rand(shape, device=flag_gems.device, dtype=dtype)
+    u2 = torch.rand(shape, device=flag_gems.device, dtype=dtype)
+    pos = 0.1 + 2.9 * u1
+    neg = -0.1 - 0.8 * u2
+    mask = torch.rand(shape, device=flag_gems.device) > 0.5
+    base = torch.where(mask, pos, neg)
+
+    if noncontig:
+        base = base.t()
+
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_out = torch.ops.aten.lgamma_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_lgamma_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.lgamma_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("noncontig", [False, True])
+def test_lgamma__benchmark_tensor(shape, dtype, noncontig):
+    quantiles = [0.5, 0.2, 0.8]
+
+    # create stable inputs avoiding singularities (0, negative integers)
+    u1 = torch.rand(shape, device=flag_gems.device, dtype=dtype)
+    u2 = torch.rand(shape, device=flag_gems.device, dtype=dtype)
+    pos = 0.1 + 2.9 * u1
+    neg = -0.1 - 0.8 * u2
+    mask = torch.rand(shape, device=flag_gems.device) > 0.5
+    base = torch.where(mask, pos, neg)
+
+    if noncontig:
+        base = base.t()
+
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.lgamma_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_lgamma_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"lgamma_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/log10__test.py
+++ b/tests/experimental_ops/log10__test.py
@@ -1,0 +1,114 @@
+# LOG10_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.log10_ import log10_ as gems_log10_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.log10_
+@pytest.mark.parametrize("shape", [(), (2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_log10__tensor(shape, dtype):
+    base = torch.rand(shape, dtype=dtype, device=flag_gems.device) * 9.0 + 0.1
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_out = torch.ops.aten.log10_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_log10_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.log10_
+@pytest.mark.parametrize("shape", [(64, 128), (32, 256), (256, 64)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_log10__tensor_noncontiguous(shape, dtype):
+    base = torch.rand(shape, dtype=dtype, device=flag_gems.device) * 9.0 + 0.1
+    base_t = base.t()
+    ref_input = base_t.clone()
+    act_input = base_t.clone()
+
+    ref_out = torch.ops.aten.log10_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_log10_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.log10_
+@pytest.mark.parametrize("shape", [(), (2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_log10__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.rand(shape, dtype=dtype, device=flag_gems.device) * 9.0 + 0.1
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.log10_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_log10_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"log10_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.log10_
+@pytest.mark.parametrize("shape", [(64, 128), (32, 256), (256, 64)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_log10__tensor_noncontiguous_performance(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.rand(shape, dtype=dtype, device=flag_gems.device) * 9.0 + 0.1
+    base_t = base.t()
+    ref_input = base_t.clone()
+    act_input = base_t.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.log10_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_log10_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"log10_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/logaddexp_test.py
+++ b/tests/experimental_ops/logaddexp_test.py
@@ -1,0 +1,79 @@
+# LOGADDEXP operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.logaddexp import logaddexp as gems_logaddexp
+from flag_gems.experimental_ops.logaddexp import logaddexp_out as gems_logaddexp_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.logaddexp
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_logaddexp_tensor(shape, dtype):
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    other = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_self = self.clone()
+    ref_other = other.clone()
+    ref_out = torch.ops.aten.logaddexp(ref_self, ref_other)
+
+    with flag_gems.use_gems():
+        act_out = gems_logaddexp(self, other)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.logaddexp
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_logaddexp_out(shape, dtype):
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    other = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_self = self.clone()
+    ref_other = other.clone()
+
+    ref_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+    ref_out = torch.ops.aten.logaddexp.out(ref_self, ref_other, out=ref_out_buf)
+
+    act_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+    with flag_gems.use_gems():
+        act_out = gems_logaddexp_out(self, other, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.logaddexp
+def test_perf_aten_logaddexp():
+    # Define input generation logic matching the operator arguments
+    def logaddexp_input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=logaddexp_input_fn,
+        op_name="logaddexp",
+        torch_op=torch.ops.aten.logaddexp,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()


### PR DESCRIPTION
Another new 14 operators except for the 105 operators！brand new！

Added 14 operators and their tests:
- expm1_, fix_, floor_, fmin
- fft_fftshift, frac_, hardsigmoid, im2col
- heaviside, greater_equal_, lgamma_, log10_
- log1p_, logaddexp

All operators pass pytest accuracy tests and precommit checks.

attach to https://github.com/flagos-ai/FlagGems/issues/1285

Generated with [KernelGen](https://github.com/flagos-ai/KernelGen)