### PR TITLE
feat: add 12 experimental operators (Group 3) generated by KernelGen

### DIFF
--- a/src/flag_gems/experimental_ops/replication_pad1d.py
+++ b/src/flag_gems/experimental_ops/replication_pad1d.py
@@ -1,0 +1,147 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def replication_pad1d_kernel(
+    in_ptr,
+    out_ptr,
+    B: tl.constexpr,
+    C: tl.constexpr,
+    W_in,
+    W_out,
+    pad_left,
+    in_stride_n,
+    in_stride_c,
+    in_stride_w,
+    out_stride_n,
+    out_stride_c,
+    out_stride_w,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid_w = tl.program_id(axis=0)
+    pid_nc = tl.program_id(axis=1)
+
+    n = pid_nc // C
+    c = pid_nc % C
+
+    off_w = pid_w * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = off_w < W_out
+
+    # Compute clamped source indices for replication pad
+    w_in = off_w - pad_left
+    w_in = tl.maximum(w_in, 0)
+    w_in = tl.minimum(w_in, W_in - 1)
+
+    # Base offsets
+    base_in = n.to(tl.int64) * in_stride_n + c.to(tl.int64) * in_stride_c
+    base_out = n.to(tl.int64) * out_stride_n + c.to(tl.int64) * out_stride_c
+
+    ptrs_in = in_ptr + base_in + w_in.to(tl.int64) * in_stride_w
+    ptrs_out = out_ptr + base_out + off_w.to(tl.int64) * out_stride_w
+
+    x = tl.load(ptrs_in, mask=mask, other=0)
+    tl.store(ptrs_out, x, mask=mask)
+
+
+def _launch_replication_pad1d_kernel(input: torch.Tensor, padding, out: torch.Tensor):
+    if not input.is_cuda or not out.is_cuda:
+        raise RuntimeError("Triton kernels require CUDA tensors")
+
+    if isinstance(padding, torch.Tensor):
+        padding = tuple(padding.tolist())
+    left, right = int(padding[0]), int(padding[1])
+    if left < 0 or right < 0:
+        raise ValueError("Padding values must be non-negative for replication_pad1d")
+
+    dim = input.dim()
+    if dim not in (2, 3):
+        raise ValueError("replication_pad1d expects 2D (C, W) or 3D (N, C, W) input")
+
+    if dim == 3:
+        N, C, W_in = input.shape
+        B = N
+        in_s_n, in_s_c, in_s_w = input.stride()
+        out_s_n, out_s_c, out_s_w = out.stride()
+        expected_out_shape = (N, C, W_in + left + right)
+    else:
+        C, W_in = input.shape
+        B = 1
+        N = 1  # dummy
+        in_s_c, in_s_w = input.stride()
+        in_s_n = 0
+        if out.dim() == 2:
+            out_s_c, out_s_w = out.stride()
+            out_s_n = 0
+        elif out.dim() == 3:
+            out_s_n, out_s_c, out_s_w = out.stride()
+        else:
+            raise ValueError("Output tensor has invalid dimensions")
+        expected_out_shape = (C, W_in + left + right)
+
+    W_out = W_in + left + right
+
+    # Validate output shape
+    if tuple(out.shape) != expected_out_shape:
+        raise ValueError(
+            f"Output tensor has incorrect shape. Expected {expected_out_shape}, got {tuple(out.shape)}"
+        )
+
+    grid = (triton.cdiv(W_out, 256), B * C)
+    replication_pad1d_kernel[grid](
+        input,
+        out,
+        B,
+        C,
+        W_in,
+        W_out,
+        left,
+        in_s_n if dim == 3 else in_s_n,
+        in_s_c,
+        in_s_w,
+        out_s_n if (dim == 3 or out.dim() == 3) else 0,
+        out_s_c,
+        out_s_w,
+        BLOCK_SIZE=256,
+    )
+    return out
+
+
+def replication_pad1d(input: torch.Tensor, padding):
+    if isinstance(padding, torch.Tensor):
+        padding = tuple(padding.tolist())
+    left, right = int(padding[0]), int(padding[1])
+    if input.dim() == 3:
+        N, C, W_in = input.shape
+        out = torch.empty(
+            (N, C, W_in + left + right),
+            device=input.device,
+            dtype=input.dtype,
+            layout=input.layout,
+        )
+    elif input.dim() == 2:
+        C, W_in = input.shape
+        out = torch.empty(
+            (C, W_in + left + right),
+            device=input.device,
+            dtype=input.dtype,
+            layout=input.layout,
+        )
+    else:
+        raise ValueError("replication_pad1d expects 2D (C, W) or 3D (N, C, W) input")
+    return _launch_replication_pad1d_kernel(input, (left, right), out)
+
+
+def replication_pad1d_out(input: torch.Tensor, padding, out: torch.Tensor):
+    if isinstance(padding, torch.Tensor):
+        padding = tuple(padding.tolist())
+    left, right = int(padding[0]), int(padding[1])
+
+    # Validate dtype/device
+    if out.dtype != input.dtype:
+        raise ValueError("Output dtype must match input dtype")
+    if out.device != input.device:
+        raise ValueError("Output device must match input device")
+
+    return _launch_replication_pad1d_kernel(input, (left, right), out)

--- a/src/flag_gems/experimental_ops/rrelu_with_noise_backward.py
+++ b/src/flag_gems/experimental_ops/rrelu_with_noise_backward.py
@@ -1,0 +1,112 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def rrelu_with_noise_backward_kernel(
+    grad_out_ptr,  # *Pointer* to grad_output
+    input_ptr,  # *Pointer* to input (or result if self_is_result, either works)
+    noise_ptr,  # *Pointer* to noise
+    grad_in_ptr,  # *Pointer* to output grad_input
+    n_elements,  # Number of elements
+    lower,  # float32
+    upper,  # float32
+    training,  # int32 (1 for training, 0 for eval)
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    go = tl.load(grad_out_ptr + offsets, mask=mask, other=0)
+    x = tl.load(input_ptr + offsets, mask=mask, other=0)
+    nz = tl.load(noise_ptr + offsets, mask=mask, other=0)
+
+    go_f32 = go.to(tl.float32)
+    x_f32 = x.to(tl.float32)
+    nz_f32 = nz.to(tl.float32)
+
+    slope = (lower + upper) * 0.5
+
+    grad_train = go_f32 * nz_f32
+    grad_eval = go_f32 * tl.where(x_f32 > 0, 1.0, slope)
+
+    cond = tl.full(go_f32.shape, training, tl.int1)
+    grad_f32 = tl.where(cond, grad_train, grad_eval)
+
+    grad_cast = grad_f32.to(go.dtype)
+    tl.store(grad_in_ptr + offsets, grad_cast, mask=mask)
+
+
+def _launch_rrelu_with_noise_backward(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    noise: torch.Tensor,
+    lower: float,
+    upper: float,
+    training: bool,
+    out: torch.Tensor,
+):
+    assert (
+        grad_output.is_cuda and input.is_cuda and noise.is_cuda and out.is_cuda
+    ), "All tensors must be CUDA"
+    assert (
+        grad_output.numel() == input.numel() == noise.numel() == out.numel()
+    ), "All tensors must have the same number of elements"
+    assert (
+        grad_output.dtype == input.dtype == noise.dtype == out.dtype
+    ), "All tensors must have the same dtype"
+
+    go = grad_output.contiguous()
+    x = input.contiguous()
+    nz = noise.contiguous()
+    out_t = out.contiguous()
+
+    n_elements = out_t.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    rrelu_with_noise_backward_kernel[grid](
+        go,
+        x,
+        nz,
+        out_t,
+        n_elements,
+        float(lower),
+        float(upper),
+        1 if training else 0,
+        BLOCK_SIZE=1024,
+    )
+    if out is not out_t:
+        out.copy_(out_t)
+    return out
+
+
+def rrelu_with_noise_backward(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    noise: torch.Tensor,
+    lower: float,
+    upper: float,
+    training: bool,
+    self_is_result: bool = False,
+):
+    out = torch.empty_like(grad_output)
+    return _launch_rrelu_with_noise_backward(
+        grad_output, input, noise, lower, upper, training, out
+    )
+
+
+def rrelu_with_noise_backward_out(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    noise: torch.Tensor,
+    lower: float,
+    upper: float,
+    training: bool,
+    self_is_result: bool,
+    out: torch.Tensor,
+):
+    return _launch_rrelu_with_noise_backward(
+        grad_output, input, noise, lower, upper, training, out
+    )

--- a/src/flag_gems/experimental_ops/selu.py
+++ b/src/flag_gems/experimental_ops/selu.py
@@ -1,0 +1,60 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def selu_kernel(x_ptr, y_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x_f32 = x.to(tl.float32)
+
+    # SELU constants from PyTorch
+    alpha = 1.6732632423543772848170429916717
+    scale = 1.0507009873554804934193349852946
+
+    zero = 0.0
+    x_neg = tl.minimum(x_f32, zero)  # clamp to non-positive to avoid exp overflow
+    neg_part = alpha * (tl.exp(x_neg) - 1.0)
+    out_f32 = tl.where(x_f32 > 0.0, x_f32, neg_part)
+    out_f32 = scale * out_f32
+
+    y = out_f32.to(x.dtype)
+    tl.store(y_ptr + offsets, y, mask=mask)
+
+
+def selu(*args, **kwargs):
+    # Resolve input tensor from args/kwargs
+    x = None
+    if len(args) > 0:
+        x = args[0]
+    elif "input" in kwargs:
+        x = kwargs["input"]
+    elif "self" in kwargs:
+        x = kwargs["self"]
+    else:
+        raise TypeError("selu() missing required argument 'input' (pos 1)")
+
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("selu() expected a torch.Tensor as input")
+
+    # Fallback to PyTorch if not on CUDA
+    if x.device.type != "cuda":
+        return torch.ops.aten.selu(x)
+
+    if not x.is_floating_point():
+        raise TypeError("selu() expected a floating point tensor")
+
+    x_contig = x.contiguous()
+    y = torch.empty_like(x_contig)
+
+    n_elements = y.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    selu_kernel[grid](x_contig, y, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return y

--- a/src/flag_gems/experimental_ops/sgn.py
+++ b/src/flag_gems/experimental_ops/sgn.py
@@ -1,0 +1,103 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def sgn_real_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    # Create typed constants without relying on tl.full
+    zero = x - x
+    one = zero + 1
+    neg_one = -one
+
+    out = tl.where(x > 0, one, tl.where(x < 0, neg_one, zero))
+    tl.store(out_ptr + offsets, out, mask=mask)
+
+
+@triton.jit
+def sgn_complex_kernel(x_ri_ptr, out_ri_ptr, n_complex, BLOCK_SIZE: tl.constexpr):
+    # x_ri_ptr and out_ri_ptr are pointers to the real-imag flattened arrays:
+    # for element k: real at 2*k, imag at 2*k + 1
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_complex
+
+    base = offsets * 2
+    r = tl.load(x_ri_ptr + base, mask=mask)
+    i = tl.load(x_ri_ptr + base + 1, mask=mask)
+
+    # typed constants
+    zero = r - r
+    one = zero + 1
+
+    # Compute norm and its reciprocal
+    norm = tl.sqrt(r * r + i * i)
+    inv = one / norm  # Will be inf when norm == 0; handled by where below
+
+    nz = norm != 0
+    out_r = tl.where(nz, r * inv, zero)
+    out_i = tl.where(nz, i * inv, zero)
+
+    tl.store(out_ri_ptr + base, out_r, mask=mask)
+    tl.store(out_ri_ptr + base + 1, out_i, mask=mask)
+
+
+def _sgn_impl(input: torch.Tensor) -> torch.Tensor:
+    assert isinstance(input, torch.Tensor), "input must be a torch.Tensor"
+    assert input.is_cuda, "input must be on CUDA device"
+    # Compute into a contiguous result buffer
+    result = torch.empty_like(input, memory_format=torch.contiguous_format)
+
+    BLOCK_SIZE = 1024
+    if input.is_complex():
+        # Use real-imag views for complex types
+        in_ri = torch.view_as_real(input).contiguous().view(-1)
+        out_ri = torch.view_as_real(result).contiguous().view(-1)
+        n_complex = input.numel()
+        grid = lambda meta: (triton.cdiv(n_complex, meta["BLOCK_SIZE"]),)
+        sgn_complex_kernel[grid](
+            in_ri,
+            out_ri,
+            n_complex,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+    else:
+        x = input.contiguous().view(-1)
+        out_flat = result.view(-1)
+        n_elements = x.numel()
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        sgn_real_kernel[grid](
+            x,
+            out_flat,
+            n_elements,
+            BLOCK_SIZE=BLOCK_SIZE,
+        )
+    return result
+
+
+def sgn(input: torch.Tensor, *, out: torch.Tensor = None):
+    """
+    Wrapper for ATen operator: ('sgn', <Autograd.disable: False>)
+    """
+    res = _sgn_impl(input)
+    if out is not None:
+        out.copy_(res)
+        return out
+    return res
+
+
+def sgn_out(input: torch.Tensor, out: torch.Tensor):
+    """
+    Wrapper for ATen operator: ('sgn.out', <Autograd.disable: False>)
+    """
+    res = _sgn_impl(input)
+    out.copy_(res)
+    return out

--- a/src/flag_gems/experimental_ops/sign.py
+++ b/src/flag_gems/experimental_ops/sign.py
@@ -1,0 +1,52 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def sign_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    one = tl.full([BLOCK_SIZE], 1, x.dtype)
+    neg_one = tl.full([BLOCK_SIZE], -1, x.dtype)
+
+    res = tl.where(x > 0, one, tl.where(x < 0, neg_one, x))
+    tl.store(out_ptr + offsets, res, mask=mask)
+
+
+def _launch_sign_kernel(x: torch.Tensor, out: torch.Tensor):
+    n_elements = out.numel()
+    if n_elements == 0:
+        return
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    sign_kernel[grid](x, out, n_elements, BLOCK_SIZE=1024)
+
+
+def sign(x: torch.Tensor):
+    if x.is_complex():
+        raise NotImplementedError(
+            "Complex dtypes are not supported by this Triton sign kernel."
+        )
+    out = torch.empty_like(x)
+    _launch_sign_kernel(x.contiguous(), out.contiguous())
+    return out
+
+
+def sign_out(x: torch.Tensor, out: torch.Tensor):
+    if x.is_complex() or out.is_complex():
+        raise NotImplementedError(
+            "Complex dtypes are not supported by this Triton sign kernel."
+        )
+    if out.shape != x.shape:
+        raise ValueError("Output tensor must have the same shape as input tensor.")
+    if out.dtype != x.dtype:
+        raise ValueError("Output tensor must have the same dtype as input tensor.")
+    if out.device != x.device:
+        raise ValueError("Output tensor must be on the same device as input tensor.")
+    _launch_sign_kernel(x.contiguous(), out.contiguous())
+    return out

--- a/src/flag_gems/experimental_ops/sign_.py
+++ b/src/flag_gems/experimental_ops/sign_.py
@@ -1,0 +1,78 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def sign_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    zero = x - x
+    one = zero + 1
+    minus_one = zero - 1
+
+    pos = x > 0
+    neg = x < 0
+
+    res = tl.where(pos, one, zero)
+    res = tl.where(neg, minus_one, res)
+
+    # Preserve NaN for floating-point inputs
+    is_nan = x != x
+    res = tl.where(is_nan, x, res)
+
+    tl.store(x_ptr + offsets, res, mask=mask)
+
+
+_sign_kernel = sign_
+
+
+def sign_(*args, **kwargs):
+    x = None
+    if len(args) > 0:
+        x = args[0]
+    else:
+        x = kwargs.get("input", kwargs.get("self", kwargs.get("x", None)))
+    if x is None:
+        raise ValueError("sign_: expected a Tensor as the first argument")
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("sign_: expected a torch.Tensor as input")
+
+    if x.numel() == 0:
+        return x
+
+    supported_dtypes = (
+        torch.int8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+        torch.uint8,
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+        torch.float64,
+    )
+
+    if (not x.is_cuda) or (x.dtype not in supported_dtypes):
+        torch.sign_(x)
+        return x
+
+    BLOCK_SIZE = 1024
+
+    if not x.is_contiguous():
+        tmp = x.contiguous()
+        n_elements = tmp.numel()
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        _sign_kernel[grid](tmp, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+        x.copy_(tmp)
+        return x
+
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _sign_kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/silu_.py
+++ b/src/flag_gems/experimental_ops/silu_.py
@@ -1,0 +1,47 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def silu_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x_f = x.to(tl.float32)
+    y = x_f * tl.sigmoid(x_f)
+    y = y.to(x.dtype)
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+_silu_kernel = silu_
+
+
+def silu_(*args, **kwargs):
+    x = None
+    if len(args) > 0:
+        x = args[0]
+    else:
+        x = kwargs.get("input", kwargs.get("self", None))
+    if x is None:
+        raise ValueError("silu_ expects a tensor as the first argument (self).")
+    if not x.is_cuda:
+        # Fallback to PyTorch for non-CUDA tensors
+        return torch.ops.aten.silu_(x)
+    if not x.dtype.is_floating_point:
+        raise TypeError(f"silu_ expects a floating point tensor, got {x.dtype}")
+    # Fallback for unsupported dtypes or non-contiguous tensors
+    supported_dtypes = {torch.float16, torch.bfloat16, torch.float32}
+    if (x.dtype not in supported_dtypes) or (not x.is_contiguous()):
+        return torch.ops.aten.silu_(x)
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _silu_kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/sinc.py
+++ b/src/flag_gems/experimental_ops/sinc.py
@@ -1,0 +1,42 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def sinc_kernel_fp32(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)  # fp32
+    y = x * 3.141592653589793
+    siny = tl.sin(y)
+    val = siny / y
+    out = tl.where(x == 0.0, 1.0, val)
+
+    tl.store(out_ptr + offsets, out, mask=mask)
+
+
+def sinc(input: torch.Tensor):
+    x_fp32 = input.contiguous().to(torch.float32)
+    out_fp32 = torch.empty_like(x_fp32)
+    n_elements = x_fp32.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    sinc_kernel_fp32[grid](x_fp32, out_fp32, n_elements, BLOCK_SIZE=1024)
+
+    if input.dtype in (torch.float16, torch.bfloat16, torch.float32, torch.float64):
+        return out_fp32.to(input.dtype)
+    else:
+        return out_fp32
+
+
+def sinc_out(input: torch.Tensor, out: torch.Tensor):
+    x_fp32 = input.contiguous().to(torch.float32)
+    out_fp32 = torch.empty_like(x_fp32)
+    n_elements = x_fp32.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    sinc_kernel_fp32[grid](x_fp32, out_fp32, n_elements, BLOCK_SIZE=1024)
+
+    out.copy_(out_fp32.to(out.dtype))
+    return out

--- a/src/flag_gems/experimental_ops/sinc_.py
+++ b/src/flag_gems/experimental_ops/sinc_.py
@@ -1,0 +1,43 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def sinc_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    x_f32 = x.to(tl.float32)
+
+    pi = 3.141592653589793
+    z = x_f32 * pi
+    is_zero = x_f32 == 0.0
+    denom = tl.where(is_zero, 1.0, z)
+    s = tl.sin(z)
+    y_f32 = s / denom
+    y_f32 = tl.where(is_zero, 1.0, y_f32)
+
+    y = y_f32.to(x.dtype)
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+_sinc_kernel = sinc_
+
+
+def sinc_(x: torch.Tensor):
+    assert x.is_cuda, "Input tensor must be on CUDA device."
+    assert x.is_contiguous(), "Input tensor must be contiguous."
+    assert x.is_floating_point(), "sinc_ expects a floating point tensor."
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _sinc_kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/slice_backward.py
+++ b/src/flag_gems/experimental_ops/slice_backward.py
@@ -1,0 +1,138 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _slice_backward_scatter_kernel(
+    grad_ptr,  # *Pointer* to grad (input) vector
+    out_ptr,  # *Pointer* to output (full grad) vector
+    n_elements,  # numel of grad
+    inner,  # product of sizes after 'dim'
+    gdim,  # size of grad along 'dim'
+    odim,  # size of output along 'dim'
+    start,  # normalized start index along 'dim'
+    step,  # step along 'dim'
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    offs = offs.to(tl.int64)
+    mask = offs < n_elements
+
+    inner_i64 = tl.full([1], inner, tl.int64)
+    gdim_i64 = tl.full([1], gdim, tl.int64)
+    odim_i64 = tl.full([1], odim, tl.int64)
+    start_i64 = tl.full([1], start, tl.int64)
+    step_i64 = tl.full([1], step, tl.int64)
+
+    # Decompose linear index into (outer, g_idx_dim, inner_idx)
+    outer = offs // (gdim_i64 * inner_i64)
+    inner_idx = offs % inner_i64
+    g_idx_dim = (offs // inner_i64) % gdim_i64
+
+    out_dim_index = start_i64 + g_idx_dim * step_i64
+    valid_o = (out_dim_index >= 0) & (out_dim_index < odim_i64)
+    o = outer * (odim_i64 * inner_i64) + out_dim_index * inner_i64 + inner_idx
+
+    m = mask & valid_o
+    val = tl.load(grad_ptr + offs, mask=m, other=0)
+    tl.store(out_ptr + o, val, mask=m)
+
+
+def _normalize_slice_params(input_sizes, dim, start, end, step):
+    D = len(input_sizes)
+    if dim < 0:
+        dim += D
+    size_dim = int(input_sizes[dim])
+
+    if step is None:
+        step = 1
+    if step == 0:
+        raise ValueError("slice step cannot be zero")
+
+    if start is None:
+        start = 0 if step > 0 else size_dim - 1
+
+    # Normalize start into valid index range
+    if start < 0:
+        start += size_dim
+
+    if step > 0:
+        # Clamp into [0, size_dim]
+        if start < 0:
+            start = 0
+        if start > size_dim:
+            start = size_dim
+    else:
+        # Clamp into [0, size_dim-1]
+        if start < 0:
+            start = 0
+        if start >= size_dim:
+            start = size_dim - 1
+
+    return dim, int(start), int(step)
+
+
+def _launch_slice_backward_kernel(grad, input_sizes, dim, start, end, step, out):
+    # Ensure contiguous
+    grad_c = grad.contiguous()
+    out_c = out.contiguous()
+
+    # Normalize parameters
+    dim, start_n, step_n = _normalize_slice_params(
+        list(input_sizes), int(dim), start, end, step
+    )
+
+    # Compute inner, gdim, odim
+    sizes = list(input_sizes)
+    odim = int(sizes[dim])
+    gdim = int(grad_c.shape[dim])
+    inner = 1
+    for s in sizes[dim + 1 :]:
+        inner *= int(s)
+
+    n_elements = grad_c.numel()
+    if n_elements == 0:
+        return out  # nothing to do
+
+    # Zero the output tensor
+    out_c.zero_()
+
+    # Launch Triton kernel
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _slice_backward_scatter_kernel[grid](
+        grad_c,
+        out_c,
+        n_elements,
+        inner,
+        gdim,
+        odim,
+        start_n,
+        step_n,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return out_c
+
+
+def slice_backward(grad, input_sizes, dim, start, end, step):
+    """
+    Python wrapper for aten::slice_backward
+    """
+    out = torch.empty(tuple(input_sizes), device=grad.device, dtype=grad.dtype)
+    out = _launch_slice_backward_kernel(grad, input_sizes, dim, start, end, step, out)
+    return out
+
+
+def slice_backward_out(grad, input_sizes, dim, start, end, step, out):
+    """
+    Python wrapper for aten::slice_backward.out
+    """
+    if tuple(out.shape) != tuple(input_sizes):
+        raise ValueError("Output tensor shape must match input_sizes")
+    if out.device != grad.device or out.dtype != grad.dtype:
+        raise ValueError("Output tensor must have same device and dtype as grad")
+    _launch_slice_backward_kernel(grad, input_sizes, dim, start, end, step, out)
+    return out

--- a/src/flag_gems/experimental_ops/soft_margin_loss.py
+++ b/src/flag_gems/experimental_ops/soft_margin_loss.py
@@ -1,0 +1,189 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _soft_margin_loss_elementwise_kernel(
+    x_ptr, y_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0.0)
+
+    xf = x.to(tl.float32)
+    yf = y.to(tl.float32)
+    z = -xf * yf
+    absz = tl.abs(z)
+    vals = tl.maximum(z, 0.0) + tl.log(1.0 + tl.exp(-absz))
+
+    tl.store(out_ptr + offsets, vals, mask=mask)
+
+
+@triton.jit
+def _soft_margin_loss_sum_kernel(
+    x_ptr, y_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0.0)
+
+    xf = x.to(tl.float32)
+    yf = y.to(tl.float32)
+    z = -xf * yf
+    absz = tl.abs(z)
+    vals = tl.maximum(z, 0.0) + tl.log(1.0 + tl.exp(-absz))
+    vals = tl.where(mask, vals, 0.0)
+
+    acc = tl.sum(vals, axis=0)
+    tl.atomic_add(out_ptr, acc)
+
+
+def _normalize_reduction(reduction):
+    # Accept both string and enum/int forms: 0=none,1=mean,2=sum
+    if isinstance(reduction, str):
+        r = reduction.lower()
+        if r == "none":
+            return 0
+        if r == "mean":
+            return 1
+        if r == "sum":
+            return 2
+        raise ValueError(f"Invalid reduction: {reduction}")
+    if isinstance(reduction, int):
+        if reduction in (0, 1, 2):
+            return reduction
+        raise ValueError(f"Invalid reduction int: {reduction}")
+    raise ValueError(f"Unsupported reduction type: {type(reduction)}")
+
+
+def _check_tensors(input: torch.Tensor, target: torch.Tensor):
+    if not (input.is_cuda and target.is_cuda):
+        raise AssertionError(
+            "soft_margin_loss: input and target must be CUDA tensors for Triton kernel."
+        )
+    if input.device != target.device:
+        raise AssertionError(
+            "soft_margin_loss: input and target must be on the same device."
+        )
+    if input.numel() != target.numel():
+        raise AssertionError(
+            "soft_margin_loss: input and target must have the same number of elements."
+        )
+    if not input.is_contiguous():
+        input = input.contiguous()
+    if not target.is_contiguous():
+        target = target.contiguous()
+    return input, target
+
+
+def soft_margin_loss(input: torch.Tensor, target: torch.Tensor, reduction="mean"):
+    input, target = _check_tensors(input, target)
+    red = _normalize_reduction(reduction)
+    n_elements = input.numel()
+
+    if red == 0:
+        # reduction = 'none'
+        out = torch.empty_like(input)
+        if n_elements == 0:
+            return out
+        BLOCK_SIZE = 1024
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        _soft_margin_loss_elementwise_kernel[grid](
+            input, target, out, n_elements, BLOCK_SIZE=BLOCK_SIZE
+        )
+        return out
+    else:
+        # reduction = 'sum' or 'mean' (1=mean, 2=sum)
+        if n_elements == 0:
+            # Follow PyTorch behavior: sum -> 0, mean -> NaN
+            if red == 2:
+                return torch.zeros((), device=input.device, dtype=input.dtype)
+            else:
+                return torch.full(
+                    (), float("nan"), device=input.device, dtype=input.dtype
+                )
+        tmp_sum = torch.zeros((), device=input.device, dtype=torch.float32)
+        BLOCK_SIZE = 1024
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        _soft_margin_loss_sum_kernel[grid](
+            input, target, tmp_sum, n_elements, BLOCK_SIZE=BLOCK_SIZE
+        )
+        if red == 2:
+            # sum
+            return tmp_sum.to(dtype=input.dtype)
+        else:
+            # mean
+            mean_val = (tmp_sum / float(n_elements)).to(dtype=input.dtype)
+            return mean_val
+
+
+def soft_margin_loss_out(
+    input: torch.Tensor,
+    target: torch.Tensor,
+    reduction="mean",
+    out: torch.Tensor = None,
+):
+    input, target = _check_tensors(input, target)
+    red = _normalize_reduction(reduction)
+    n_elements = input.numel()
+
+    if out is None:
+        # Allocate output based on reduction
+        if red == 0:
+            out = torch.empty_like(input)
+        else:
+            out = torch.empty((), device=input.device, dtype=input.dtype)
+    else:
+        if not out.is_cuda:
+            raise AssertionError("soft_margin_loss_out: out must be a CUDA tensor.")
+        if red == 0:
+            if out.numel() != n_elements:
+                raise AssertionError(
+                    "soft_margin_loss_out: for reduction='none', out must match input shape."
+                )
+        else:
+            if out.numel() != 1:
+                raise AssertionError(
+                    "soft_margin_loss_out: for reduction='sum' or 'mean', out must be a scalar tensor."
+                )
+        if out.device != input.device:
+            raise AssertionError(
+                "soft_margin_loss_out: out must be on the same device as input."
+            )
+
+    if red == 0:
+        if n_elements > 0:
+            BLOCK_SIZE = 1024
+            grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+            _soft_margin_loss_elementwise_kernel[grid](
+                input, target, out, n_elements, BLOCK_SIZE=BLOCK_SIZE
+            )
+        return out
+    else:
+        if n_elements == 0:
+            if red == 2:
+                out.fill_(0)
+            else:
+                out.fill_(float("nan"))
+            return out
+        tmp_sum = torch.zeros((), device=input.device, dtype=torch.float32)
+        BLOCK_SIZE = 1024
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        _soft_margin_loss_sum_kernel[grid](
+            input, target, tmp_sum, n_elements, BLOCK_SIZE=BLOCK_SIZE
+        )
+        if red == 2:
+            out.fill_(tmp_sum.to(dtype=input.dtype))
+        else:
+            mean_val = (tmp_sum / float(n_elements)).to(dtype=input.dtype)
+            out.fill_(mean_val)
+        return out

--- a/src/flag_gems/experimental_ops/special_i0e.py
+++ b/src/flag_gems/experimental_ops/special_i0e.py
@@ -1,0 +1,107 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _special_i0e_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    # Compute in fp32 for accuracy/stability
+    xf = x.to(tl.float32)
+    ax = tl.abs(xf)
+
+    # Small region: x <= 3.75
+    t_small = ax / 3.75
+    t2 = t_small * t_small
+    # Polynomial approximation for I0 in small region (Numerical Recipes)
+    p = 1.0 + t2 * (
+        3.5156229
+        + t2
+        * (
+            3.0899424
+            + t2 * (1.2067492 + t2 * (0.2659732 + t2 * (0.0360768 + t2 * 0.0045813)))
+        )
+    )
+    small = p * tl.exp(-ax)
+
+    # Large region: x > 3.75, use asymptotic expansion to avoid exp overflow
+    # i0e(x) = I0(x)*exp(-|x|) ≈ (1/sqrt(|x|)) * poly(3.75/|x|)
+    t = 3.75 / ax
+    q = 0.39894228 + t * (
+        0.01328592
+        + t
+        * (
+            0.00225319
+            + t
+            * (
+                -0.00157565
+                + t
+                * (
+                    0.00916281
+                    + t
+                    * (
+                        -0.02057706
+                        + t * (0.02635537 + t * (-0.01647633 + t * 0.00392377))
+                    )
+                )
+            )
+        )
+    )
+    large = q / tl.sqrt(ax)
+
+    is_large = ax > 3.75
+    y = tl.where(is_large, large, small)
+
+    # Cast back to input dtype for storage
+    y = y.to(x.dtype)
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _run_special_i0e_kernel(x: torch.Tensor, out: torch.Tensor):
+    assert x.is_cuda and out.is_cuda, "Tensors must be CUDA tensors"
+    assert x.dtype in (
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+        torch.float64,
+    ), "Unsupported dtype"
+    assert out.dtype == x.dtype, "Output dtype must match input dtype"
+
+    x_c = x.contiguous()
+    out_c = out.contiguous()
+
+    n_elements = out_c.numel()
+    if n_elements == 0:
+        return out
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _special_i0e_kernel[grid](x_c, out_c, n_elements, BLOCK_SIZE=1024)
+
+    if out_c.data_ptr() != out.data_ptr():
+        out.copy_(out_c)
+    return out
+
+
+def special_i0e(x: torch.Tensor):
+    """
+    ATen wrapper: special_i0e(Tensor self) -> Tensor
+    """
+    out = torch.empty_like(x)
+    return _run_special_i0e_kernel(x, out)
+
+
+def special_i0e_out(x: torch.Tensor, out: torch.Tensor):
+    """
+    ATen wrapper: special_i0e.out(Tensor self, Tensor out) -> Tensor
+    """
+    # Broadcast input to out's shape if needed
+    if x.shape != out.shape:
+        x = x.expand(out.shape)
+    _run_special_i0e_kernel(x, out)
+    return out

--- a/tests/experimental_ops/replication_pad1d_test.py
+++ b/tests/experimental_ops/replication_pad1d_test.py
@@ -1,0 +1,151 @@
+# REPLICATION_PAD1D operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.replication_pad1d import (
+    replication_pad1d as gems_replication_pad1d,
+)
+from flag_gems.experimental_ops.replication_pad1d import (
+    replication_pad1d_out as gems_replication_pad1d_out,
+)
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.replication_pad1d
+@pytest.mark.parametrize("shape", [(2, 3, 7), (4, 16, 64), (8, 32, 256), (32, 256)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("padding", [(0, 0), (1, 2), (3, 1)])
+def test_replication_pad1d_tensor(shape, dtype, padding):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    act_inp = inp.clone()
+
+    ref_out = torch.ops.aten.replication_pad1d(ref_inp, padding)
+
+    with flag_gems.use_gems():
+        act_out = gems_replication_pad1d(act_inp, padding)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.replication_pad1d
+@pytest.mark.parametrize("shape", [(2, 3, 7), (4, 16, 64), (8, 32, 256), (32, 256)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("padding", [(0, 0), (1, 2), (3, 1)])
+def test_replication_pad1d_out(shape, dtype, padding):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    act_inp = inp.clone()
+
+    pl, pr = padding
+    w_out = shape[-1] + pl + pr
+    if len(shape) == 3:
+        N, C, _ = shape
+        out_shape = (N, C, w_out)
+    else:
+        C, _ = shape
+        out_shape = (C, w_out)
+
+    ref_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    ref_out = torch.ops.aten.replication_pad1d.out(ref_inp, padding, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+        act_out = gems_replication_pad1d_out(act_inp, padding, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.replication_pad1d
+@pytest.mark.parametrize("shape", [(2, 3, 7), (4, 16, 64), (8, 32, 256), (32, 256)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("padding", [(0, 0), (1, 2), (3, 1)])
+def test_replication_pad1d_benchmark_tensor(shape, dtype, padding):
+    quantiles = [0.5, 0.2, 0.8]
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    act_inp = inp.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.replication_pad1d(ref_inp, padding),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_replication_pad1d(act_inp, padding),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"replication_pad1d {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.replication_pad1d
+@pytest.mark.parametrize("shape", [(2, 3, 7), (4, 16, 64), (8, 32, 256), (32, 256)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("padding", [(0, 0), (1, 2), (3, 1)])
+def test_replication_pad1d_benchmark_out(shape, dtype, padding):
+    quantiles = [0.5, 0.2, 0.8]
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = inp.clone()
+    act_inp = inp.clone()
+
+    pl, pr = padding
+    w_out = shape[-1] + pl + pr
+    if len(shape) == 3:
+        N, C, _ = shape
+        out_shape = (N, C, w_out)
+    else:
+        C, _ = shape
+        out_shape = (C, w_out)
+
+    ref_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.replication_pad1d.out(ref_inp, padding, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        act_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_replication_pad1d_out(act_inp, padding, act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"replication_pad1d {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/rrelu_with_noise_backward_test.py
+++ b/tests/experimental_ops/rrelu_with_noise_backward_test.py
@@ -1,0 +1,235 @@
+# RRELU_WITH_NOISE_BACKWARD operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.rrelu_with_noise_backward import (
+    rrelu_with_noise_backward as gems_rrelu_with_noise_backward,
+)
+from flag_gems.experimental_ops.rrelu_with_noise_backward import (
+    rrelu_with_noise_backward_out as gems_rrelu_with_noise_backward_out,
+)
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.rrelu_with_noise_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("training", [True, False])
+def test_rrelu_with_noise_backward_tensor(shape, dtype, training):
+    lower = 0.1
+    upper = 0.3
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    noise = lower + (upper - lower) * torch.rand(
+        shape, dtype=dtype, device=flag_gems.device
+    )
+    self_is_result = False
+
+    ref_self = self.clone()
+    ref_grad_output = grad_output.clone()
+    ref_noise = noise.clone()
+
+    act_self = self.clone()
+    act_grad_output = grad_output.clone()
+    act_noise = noise.clone()
+
+    ref_out = torch.ops.aten.rrelu_with_noise_backward(
+        ref_grad_output, ref_self, ref_noise, lower, upper, training, self_is_result
+    )
+
+    with flag_gems.use_gems():
+        act_out = gems_rrelu_with_noise_backward(
+            act_grad_output, act_self, act_noise, lower, upper, training, self_is_result
+        )
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.rrelu_with_noise_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("training", [True, False])
+def test_rrelu_with_noise_backward_out(shape, dtype, training):
+    lower = 0.1
+    upper = 0.3
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    noise = lower + (upper - lower) * torch.rand(
+        shape, dtype=dtype, device=flag_gems.device
+    )
+    self_is_result = True
+
+    ref_self = self.clone()
+    ref_grad_output = grad_output.clone()
+    ref_noise = noise.clone()
+    ref_out_buf = torch.empty_like(ref_self)
+
+    act_self = self.clone()
+    act_grad_output = grad_output.clone()
+    act_noise = noise.clone()
+    act_out_buf = torch.empty_like(act_self)
+
+    ref_out = torch.ops.aten.rrelu_with_noise_backward.out(
+        ref_grad_output,
+        ref_self,
+        ref_noise,
+        lower,
+        upper,
+        training,
+        self_is_result,
+        out=ref_out_buf,
+    )
+
+    with flag_gems.use_gems():
+        act_out = gems_rrelu_with_noise_backward_out(
+            act_grad_output,
+            act_self,
+            act_noise,
+            lower,
+            upper,
+            training,
+            self_is_result,
+            act_out_buf,
+        )
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.rrelu_with_noise_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("training", [True, False])
+def test_rrelu_with_noise_backward_benchmark_tensor(shape, dtype, training):
+    quantiles = [0.5, 0.2, 0.8]
+
+    lower = 0.1
+    upper = 0.3
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    noise = lower + (upper - lower) * torch.rand(
+        shape, dtype=dtype, device=flag_gems.device
+    )
+    self_is_result = False
+
+    ref_self = self.clone()
+    ref_grad_output = grad_output.clone()
+    ref_noise = noise.clone()
+
+    act_self = self.clone()
+    act_grad_output = grad_output.clone()
+    act_noise = noise.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.rrelu_with_noise_backward(
+            ref_grad_output, ref_self, ref_noise, lower, upper, training, self_is_result
+        ),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_rrelu_with_noise_backward(
+                act_grad_output,
+                act_self,
+                act_noise,
+                lower,
+                upper,
+                training,
+                self_is_result,
+            ),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"rrelu_with_noise_backward {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.rrelu_with_noise_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("training", [True, False])
+def test_rrelu_with_noise_backward_benchmark_out(shape, dtype, training):
+    quantiles = [0.5, 0.2, 0.8]
+
+    lower = 0.1
+    upper = 0.3
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    noise = lower + (upper - lower) * torch.rand(
+        shape, dtype=dtype, device=flag_gems.device
+    )
+    self_is_result = True
+
+    ref_self = self.clone()
+    ref_grad_output = grad_output.clone()
+    ref_noise = noise.clone()
+    ref_out_buf = torch.empty_like(ref_self)
+
+    act_self = self.clone()
+    act_grad_output = grad_output.clone()
+    act_noise = noise.clone()
+    act_out_buf = torch.empty_like(act_self)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.rrelu_with_noise_backward.out(
+            ref_grad_output,
+            ref_self,
+            ref_noise,
+            lower,
+            upper,
+            training,
+            self_is_result,
+            out=ref_out_buf,
+        ),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_rrelu_with_noise_backward_out(
+                act_grad_output,
+                act_self,
+                act_noise,
+                lower,
+                upper,
+                training,
+                self_is_result,
+                act_out_buf,
+            ),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"rrelu_with_noise_backward {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/selu_test.py
+++ b/tests/experimental_ops/selu_test.py
@@ -1,0 +1,71 @@
+# SELU operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.selu import selu as gems_selu
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.selu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_selu_tensor(shape, dtype):
+    input_tensor = torch.randn(shape, device=flag_gems.device, dtype=torch.float32).to(
+        dtype
+    )
+
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.selu(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_selu(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.selu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_selu_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, device=flag_gems.device, dtype=torch.float32).to(
+        dtype
+    )
+
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.selu(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_selu(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"selu {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/sgn_test.py
+++ b/tests/experimental_ops/sgn_test.py
@@ -1,0 +1,115 @@
+# SGN operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.sgn import sgn as gems_sgn
+from flag_gems.experimental_ops.sgn import sgn_out as gems_sgn_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.sgn
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sgn_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out = torch.ops.aten.sgn(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_sgn(x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.sgn
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sgn_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out = torch.empty_like(ref_x)
+    act_out = torch.empty_like(x)
+
+    ref_ret = torch.ops.aten.sgn.out(ref_x, out=ref_out)
+
+    with flag_gems.use_gems():
+        act_ret = gems_sgn_out(x, act_out)
+
+    gems_assert_close(act_ret, ref_ret, dtype=dtype)
+
+
+@pytest.mark.sgn
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sgn_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.sgn(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_sgn(x), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"sgn {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.sgn
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sgn_benchmark_out(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out = torch.empty_like(ref_x)
+    act_out = torch.empty_like(x)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.sgn.out(ref_x, out=ref_out), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_sgn_out(x, act_out), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"sgn {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/sign__test.py
+++ b/tests/experimental_ops/sign__test.py
@@ -1,0 +1,126 @@
+# SIGN_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.sign_ import sign_ as gems_sign_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.sign_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sign__tensor(shape, dtype):
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    if base.numel() >= 4:
+        base.view(-1)[: base.numel() // 4] = 0
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_out = torch.ops.aten.sign_(ref_input)
+    with flag_gems.use_gems():
+        act_out = gems_sign_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.sign_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sign__tensor_noncontiguous(shape, dtype):
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    if base.numel() >= 4:
+        base.view(-1)[: base.numel() // 4] = 0
+
+    base_ref = base.clone()
+    base_act = base.clone()
+
+    ref_input = base_ref.transpose(0, 1)
+    act_input = base_act.transpose(0, 1)
+
+    ref_out = torch.ops.aten.sign_(ref_input)
+    with flag_gems.use_gems():
+        act_out = gems_sign_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.sign_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sign__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    if base.numel() >= 4:
+        base.view(-1)[: base.numel() // 4] = 0
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.sign_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_sign_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"sign_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.sign_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sign__tensor_noncontiguous_performance(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    if base.numel() >= 4:
+        base.view(-1)[: base.numel() // 4] = 0
+
+    base_ref = base.clone()
+    base_act = base.clone()
+
+    ref_input = base_ref.transpose(0, 1)
+    act_input = base_act.transpose(0, 1)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.sign_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_sign_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"sign_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/sign_test.py
+++ b/tests/experimental_ops/sign_test.py
@@ -1,0 +1,107 @@
+# SIGN operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.sign import sign as gems_sign
+from flag_gems.experimental_ops.sign import sign_out as gems_sign_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.sign
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sign_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.sign(ref_x)
+    with flag_gems.use_gems():
+        act_out = gems_sign(x)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.sign
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sign_out_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out_buf = torch.empty_like(ref_x)
+    ref_out = torch.ops.aten.sign.out(ref_x, out=ref_out_buf)
+    out_buf = torch.empty_like(x)
+    with flag_gems.use_gems():
+        act_out = gems_sign_out(x, out_buf)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.sign
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sign_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.sign(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_sign(x), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"sign {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.sign
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sign_out_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out_buf = torch.empty_like(ref_x)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.sign.out(ref_x, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+    out_buf = torch.empty_like(x)
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_sign_out(x, out_buf), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"sign {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/silu__test.py
+++ b/tests/experimental_ops/silu__test.py
@@ -1,0 +1,67 @@
+# SILU_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.silu_ import silu_ as gems_silu_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.silu_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_silu__tensor(shape, dtype):
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_out = torch.ops.aten.silu_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_silu_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.silu_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_silu__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.silu_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_silu_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"silu_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/sinc__test.py
+++ b/tests/experimental_ops/sinc__test.py
@@ -1,0 +1,67 @@
+# SINC_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.sinc_ import sinc_ as gems_sinc_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.sinc_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sinc__tensor(shape, dtype):
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_out = torch.ops.aten.sinc_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_sinc_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.sinc_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sinc__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.sinc_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_sinc_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"sinc_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/sinc_test.py
+++ b/tests/experimental_ops/sinc_test.py
@@ -1,0 +1,70 @@
+# SINC operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton  # noqa: F401
+
+import flag_gems
+from flag_gems.experimental_ops.sinc import sinc as gems_sinc
+from flag_gems.experimental_ops.sinc import sinc_out as gems_sinc_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from benchmark.performance_utils import GenericBenchmark
+    from tests.accuracy_utils import gems_assert_close
+
+
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.sinc
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sinc_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.sinc(ref_x)
+    with flag_gems.use_gems():
+        act_out = gems_sinc(x)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.sinc
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sinc_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out = torch.empty_like(ref_x)
+    torch.ops.aten.sinc.out(ref_x, out=ref_out)
+    with flag_gems.use_gems():
+        act_out = torch.empty_like(x)
+        gems_sinc_out(x, act_out)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.sinc
+def test_perf_aten_sinc():
+    # Define input generation logic matching the operator arguments
+    def sinc_input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=sinc_input_fn,
+        op_name="sinc",
+        torch_op=torch.ops.aten.sinc,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/slice_backward_test.py
+++ b/tests/experimental_ops/slice_backward_test.py
@@ -1,0 +1,283 @@
+# SLICE_BACKWARD operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.slice_backward import (
+    slice_backward as gems_slice_backward,
+)
+from flag_gems.experimental_ops.slice_backward import (
+    slice_backward_out as gems_slice_backward_out,
+)
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.slice_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (17, 33, 65)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_slice_backward_tensor(shape, dtype):
+    input_sizes = list(shape)
+
+    def test_cases_for_size(n):
+        c = []
+        c.append((0, n, 1))
+        c.append((0, n, 2))
+        if n > 1:
+            c.append((1, n, 1))
+        if n > 0:
+            c.append((0, max(n - 1, 0), 1))
+        if n > 3:
+            c.append((1, n - 1, 2))
+        # Filter duplicates and invalid
+        uniq = []
+        seen = set()
+        for s, e, st in c:
+            if st <= 0:
+                continue
+            if e <= s:
+                continue
+            key = (s, e, st)
+            if key not in seen:
+                seen.add(key)
+                uniq.append(key)
+        return uniq
+
+    for dim in range(len(input_sizes)):
+        size_d = input_sizes[dim]
+        for start, end, step in test_cases_for_size(size_d):
+            length = (end - start + step - 1) // step
+            if length <= 0:
+                continue
+            grad_shape = list(input_sizes)
+            grad_shape[dim] = length
+            grad_output_ref = torch.randn(
+                grad_shape, device=flag_gems.device, dtype=dtype
+            )
+            grad_output_act = grad_output_ref.clone()
+
+            ref_out = torch.ops.aten.slice_backward(
+                grad_output_ref, input_sizes, dim, start, end, step
+            )
+            with flag_gems.use_gems():
+                act_out = gems_slice_backward(
+                    grad_output_act, input_sizes, dim, start, end, step
+                )
+
+            gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.slice_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (17, 33, 65)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_slice_backward_out(shape, dtype):
+    input_sizes = list(shape)
+
+    def test_cases_for_size(n):
+        c = []
+        c.append((0, n, 1))
+        c.append((0, n, 2))
+        if n > 1:
+            c.append((1, n, 1))
+        if n > 0:
+            c.append((0, max(n - 1, 0), 1))
+        if n > 3:
+            c.append((1, n - 1, 2))
+        uniq = []
+        seen = set()
+        for s, e, st in c:
+            if st <= 0:
+                continue
+            if e <= s:
+                continue
+            key = (s, e, st)
+            if key not in seen:
+                seen.add(key)
+                uniq.append(key)
+        return uniq
+
+    for dim in range(len(input_sizes)):
+        size_d = input_sizes[dim]
+        for start, end, step in test_cases_for_size(size_d):
+            length = (end - start + step - 1) // step
+            if length <= 0:
+                continue
+            grad_shape = list(input_sizes)
+            grad_shape[dim] = length
+            grad_output_ref = torch.randn(
+                grad_shape, device=flag_gems.device, dtype=dtype
+            )
+            grad_output_act = grad_output_ref.clone()
+
+            ref_out_buf = torch.empty(input_sizes, device=flag_gems.device, dtype=dtype)
+            act_out_buf = torch.empty(input_sizes, device=flag_gems.device, dtype=dtype)
+
+            ref_out = torch.ops.aten.slice_backward.out(
+                grad_output_ref, input_sizes, dim, start, end, step, out=ref_out_buf
+            )
+            with flag_gems.use_gems():
+                act_out = gems_slice_backward_out(
+                    grad_output_act, input_sizes, dim, start, end, step, act_out_buf
+                )
+
+            gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.slice_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (17, 33, 65)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_slice_backward_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_sizes = list(shape)
+
+    def test_cases_for_size(n):
+        c = []
+        c.append((0, n, 1))
+        c.append((0, n, 2))
+        if n > 1:
+            c.append((1, n, 1))
+        if n > 0:
+            c.append((0, max(n - 1, 0), 1))
+        if n > 3:
+            c.append((1, n - 1, 2))
+        # Filter duplicates and invalid
+        uniq = []
+        seen = set()
+        for s, e, st in c:
+            if st <= 0:
+                continue
+            if e <= s:
+                continue
+            key = (s, e, st)
+            if key not in seen:
+                seen.add(key)
+                uniq.append(key)
+        return uniq
+
+    for dim in range(len(input_sizes)):
+        size_d = input_sizes[dim]
+        for start, end, step in test_cases_for_size(size_d):
+            length = (end - start + step - 1) // step
+            if length <= 0:
+                continue
+            grad_shape = list(input_sizes)
+            grad_shape[dim] = length
+            grad_output_ref = torch.randn(
+                grad_shape, device=flag_gems.device, dtype=dtype
+            )
+            grad_output_act = grad_output_ref.clone()
+
+            # PyTorch reference implementation
+            ms_torch, _, _ = triton.testing.do_bench(
+                lambda: torch.ops.aten.slice_backward(
+                    grad_output_ref, input_sizes, dim, start, end, step
+                ),
+                rep=100,
+                quantiles=quantiles,
+            )
+
+            # Triton implementation
+            with flag_gems.use_gems():
+                ms_triton, _, _ = triton.testing.do_bench(
+                    lambda: gems_slice_backward(
+                        grad_output_act, input_sizes, dim, start, end, step
+                    ),
+                    rep=100,
+                    quantiles=quantiles,
+                )
+
+            # Calculate speedup and return result
+            speedup = ms_torch / ms_triton
+
+            print(f"slice_backward {shape} {dtype}:")
+            print(f"  FlagGems: {ms_triton:.3f}ms")
+            print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.slice_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512), (17, 33, 65)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_slice_backward_benchmark_out(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_sizes = list(shape)
+
+    def test_cases_for_size(n):
+        c = []
+        c.append((0, n, 1))
+        c.append((0, n, 2))
+        if n > 1:
+            c.append((1, n, 1))
+        if n > 0:
+            c.append((0, max(n - 1, 0), 1))
+        if n > 3:
+            c.append((1, n - 1, 2))
+        uniq = []
+        seen = set()
+        for s, e, st in c:
+            if st <= 0:
+                continue
+            if e <= s:
+                continue
+            key = (s, e, st)
+            if key not in seen:
+                seen.add(key)
+                uniq.append(key)
+        return uniq
+
+    for dim in range(len(input_sizes)):
+        size_d = input_sizes[dim]
+        for start, end, step in test_cases_for_size(size_d):
+            length = (end - start + step - 1) // step
+            if length <= 0:
+                continue
+            grad_shape = list(input_sizes)
+            grad_shape[dim] = length
+            grad_output_ref = torch.randn(
+                grad_shape, device=flag_gems.device, dtype=dtype
+            )
+            grad_output_act = grad_output_ref.clone()
+
+            ref_out_buf = torch.empty(input_sizes, device=flag_gems.device, dtype=dtype)
+            act_out_buf = torch.empty(input_sizes, device=flag_gems.device, dtype=dtype)
+
+            # PyTorch reference implementation
+            ms_torch, _, _ = triton.testing.do_bench(
+                lambda: torch.ops.aten.slice_backward.out(
+                    grad_output_ref, input_sizes, dim, start, end, step, out=ref_out_buf
+                ),
+                rep=100,
+                quantiles=quantiles,
+            )
+
+            # Triton implementation
+            with flag_gems.use_gems():
+                ms_triton, _, _ = triton.testing.do_bench(
+                    lambda: gems_slice_backward_out(
+                        grad_output_act, input_sizes, dim, start, end, step, act_out_buf
+                    ),
+                    rep=100,
+                    quantiles=quantiles,
+                )
+
+            # Calculate speedup and return result
+            speedup = ms_torch / ms_triton
+
+            print(f"slice_backward {shape} {dtype}:")
+            print(f"  FlagGems: {ms_triton:.3f}ms")
+            print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/soft_margin_loss_test.py
+++ b/tests/experimental_ops/soft_margin_loss_test.py
@@ -1,0 +1,94 @@
+# SOFT_MARGIN_LOSS operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton  # noqa: F401
+
+import flag_gems
+from flag_gems.experimental_ops.soft_margin_loss import (
+    soft_margin_loss as gems_soft_margin_loss,
+)
+from flag_gems.experimental_ops.soft_margin_loss import (
+    soft_margin_loss_out as gems_soft_margin_loss_out,
+)
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from benchmark.performance_utils import GenericBenchmark
+    from tests.accuracy_utils import gems_assert_close
+
+
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.soft_margin_loss
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("reduction", [0, 1, 2])
+def test_soft_margin_loss_tensor(shape, dtype, reduction):
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target = (torch.randint(0, 2, shape, device=flag_gems.device).to(dtype) * 2) - 1
+
+    ref_self = self.clone()
+    ref_target = target.clone()
+    ref_out = torch.ops.aten.soft_margin_loss(ref_self, ref_target, reduction)
+
+    with flag_gems.use_gems():
+        act_out = gems_soft_margin_loss(self, target, reduction)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.soft_margin_loss
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("reduction", [0, 1, 2])
+def test_soft_margin_loss_out(shape, dtype, reduction):
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target = (torch.randint(0, 2, shape, device=flag_gems.device).to(dtype) * 2) - 1
+
+    if reduction == 0:
+        out_ref = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+        out_act = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+    else:
+        out_ref = torch.empty((), dtype=dtype, device=flag_gems.device)
+        out_act = torch.empty((), dtype=dtype, device=flag_gems.device)
+
+    ref_self = self.clone()
+    ref_target = target.clone()
+    ref_out = torch.ops.aten.soft_margin_loss.out(
+        ref_self, ref_target, reduction, out=out_ref
+    )
+
+    with flag_gems.use_gems():
+        act_out = gems_soft_margin_loss_out(self, target, reduction, out_act)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.soft_margin_loss
+def test_perf_aten_soft_margin_loss():
+    # Define input generation logic matching the operator arguments
+    def soft_margin_loss_input_fn(shape, dtype, device):
+        self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        target = (torch.randint(0, 2, shape, device=flag_gems.device).to(dtype) * 2) - 1
+        yield self, target
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=soft_margin_loss_input_fn,
+        op_name="soft_margin_loss",
+        torch_op=torch.ops.aten.soft_margin_loss,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/special_i0e_test.py
+++ b/tests/experimental_ops/special_i0e_test.py
@@ -1,0 +1,73 @@
+# SPECIAL_I0E operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton  # noqa: F401
+
+import flag_gems
+from flag_gems.experimental_ops.special_i0e import special_i0e as gems_special_i0e
+from flag_gems.experimental_ops.special_i0e import (
+    special_i0e_out as gems_special_i0e_out,
+)
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from benchmark.performance_utils import GenericBenchmark
+    from tests.accuracy_utils import gems_assert_close
+
+
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.special_i0e
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_special_i0e_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.special_i0e(ref_x)
+    with flag_gems.use_gems():
+        act_out = gems_special_i0e(x)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.special_i0e
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_special_i0e_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    out_ref = torch.empty_like(ref_x)
+    ref_out = torch.ops.aten.special_i0e.out(ref_x, out=out_ref)
+    out_act = torch.empty_like(x)
+    with flag_gems.use_gems():
+        act_out = gems_special_i0e_out(x, out_act)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+    gems_assert_close(out_act, out_ref, dtype=dtype)
+
+
+@pytest.mark.special_i0e
+def test_perf_aten_special_i0e():
+    # Define input generation logic matching the operator arguments
+    def special_i0e_input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=special_i0e_input_fn,
+        op_name="special_i0e",
+        torch_op=torch.ops.aten.special_i0e,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()


### PR DESCRIPTION
new 12 operators 
  
generated with [KernelGen](https://github.com/flagos-ai/KernelGen)

Add 12 operators with tests:
- replication_pad1d, rrelu_with_noise_backward
- selu, sgn, sign, sign_
- silu_, sinc, sinc_
- slice_backward, soft_margin_loss, special_i0e

  All operators pass accuracy and performance tests.