### PR TITLE
KernelGen: add 17 of 85 (group 1)

### DIFF
--- a/src/flag_gems/experimental_ops/deg2rad.py
+++ b/src/flag_gems/experimental_ops/deg2rad.py
@@ -1,0 +1,117 @@
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def deg2rad_kernel(x_ptr, y_ptr, n_elements, scale, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = x * scale
+    tl.store(y_ptr + offsets, y, mask=mask)
+
+
+def _launch_deg2rad_kernel(x_contig: torch.Tensor, out_contig: torch.Tensor):
+    assert x_contig.is_cuda and out_contig.is_cuda, "Tensors must be on CUDA device"
+    n_elements = out_contig.numel()
+    if n_elements == 0:
+        return
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    scale = math.pi / 180.0
+    deg2rad_kernel[grid](x_contig, out_contig, n_elements, scale, BLOCK_SIZE=1024)
+
+
+def deg2rad(*args, **kwargs):
+    # Expecting a single input tensor
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        x = kwargs.get("input", None)
+        if x is None:
+            x = kwargs.get("self", None)
+    if x is None:
+        raise TypeError("deg2rad expected a single input tensor")
+
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("deg2rad input must be a torch.Tensor")
+
+    if not x.is_cuda:
+        raise AssertionError("deg2rad expects CUDA tensors")
+
+    if x.is_complex():
+        raise NotImplementedError(
+            "Complex tensors are not supported in this Triton implementation"
+        )
+
+    # Determine result dtype: keep floating dtype; promote integer/bool to float32
+    if x.is_floating_point():
+        result_dtype = x.dtype
+    else:
+        result_dtype = torch.float32
+
+    x_cast = x.to(result_dtype)
+    x_contig = x_cast.contiguous()
+    out = torch.empty_like(x_contig, dtype=result_dtype, device=x.device)
+
+    _launch_deg2rad_kernel(x_contig.view(-1), out.view(-1))
+
+    return out.view_as(x)
+
+
+def deg2rad_out(*args, **kwargs):
+    # Expecting input tensor and out tensor, either as positional or keyword args
+    x = None
+    out = None
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        x = kwargs.get("input", None) or kwargs.get("self", None)
+    if len(args) >= 2:
+        out = args[1]
+    else:
+        out = kwargs.get("out", None)
+
+    if x is None or out is None:
+        raise TypeError("deg2rad_out expected (input, out) tensors")
+
+    if not isinstance(x, torch.Tensor) or not isinstance(out, torch.Tensor):
+        raise TypeError("deg2rad_out arguments must be torch.Tensor")
+
+    if not x.is_cuda or not out.is_cuda:
+        raise AssertionError("deg2rad_out expects CUDA tensors")
+
+    if x.is_complex() or out.is_complex():
+        raise NotImplementedError(
+            "Complex tensors are not supported in this Triton implementation"
+        )
+
+    if out.numel() != x.numel():
+        raise RuntimeError(
+            "deg2rad_out: 'out' must have the same number of elements as 'input'"
+        )
+
+    if out.device != x.device:
+        raise RuntimeError("deg2rad_out: 'out' must be on the same device as 'input'")
+
+    # Compute in the dtype of 'out' to match out-variant semantics
+    x_cast = x.to(out.dtype)
+    x_contig = x_cast.contiguous()
+
+    if out.is_contiguous():
+        out_contig = out
+        need_copy_back = False
+    else:
+        out_contig = torch.empty_like(out, memory_format=torch.contiguous_format)
+        need_copy_back = True
+
+    _launch_deg2rad_kernel(x_contig.view(-1), out_contig.view(-1))
+
+    if need_copy_back:
+        out.copy_(out_contig)
+
+    return out

--- a/src/flag_gems/experimental_ops/detach.py
+++ b/src/flag_gems/experimental_ops/detach.py
@@ -1,0 +1,53 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def detach(
+    x_ptr,  # Pointer to input tensor
+    out_ptr,  # Pointer to output tensor
+    n_elements,  # Number of elements
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    tl.store(out_ptr + offsets, x, mask=mask)
+
+
+_detach_kernel = detach
+
+
+def detach(*args, **kwargs):
+    # Extract input tensor from positional or keyword arguments
+    x = None
+    if len(args) >= 1 and isinstance(args[0], torch.Tensor):
+        x = args[0]
+    elif "input" in kwargs and isinstance(kwargs["input"], torch.Tensor):
+        x = kwargs["input"]
+    elif "self" in kwargs and isinstance(kwargs["self"], torch.Tensor):
+        x = kwargs["self"]
+    else:
+        raise ValueError(
+            "detach expects a Tensor as the first positional argument or as 'input'/'self' keyword."
+        )
+
+    # Ensure tensor is on a CUDA device for Triton
+    if not x.is_cuda:
+        raise ValueError("Input tensor must be on a CUDA device.")
+
+    # Create contiguous views for kernel processing
+    x_c = x.contiguous()
+    out_c = torch.empty_like(x_c, memory_format=torch.contiguous_format)
+
+    n_elements = x_c.numel()
+    if n_elements == 0:
+        return out_c.view_as(x)
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _detach_kernel[grid](x_c, out_c, n_elements, BLOCK_SIZE=1024)
+
+    return out_c.view_as(x)

--- a/src/flag_gems/experimental_ops/diag.py
+++ b/src/flag_gems/experimental_ops/diag.py
@@ -1,0 +1,172 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _diag_extract_kernel(
+    a_ptr, out_ptr, i0, j0, L, stride_row, stride_col, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(0)
+    block_start = pid * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < L
+    a_idx = (i0 + offs) * stride_row + (j0 + offs) * stride_col
+    vals = tl.load(a_ptr + a_idx, mask=mask)
+    tl.store(out_ptr + offs, vals, mask=mask)
+
+
+@triton.jit
+def _diag_write_kernel(
+    v_ptr, out_ptr, i0, j0, N, stride_row, stride_col, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(0)
+    block_start = pid * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < N
+    out_idx = (i0 + offs) * stride_row + (j0 + offs) * stride_col
+    vals = tl.load(v_ptr + offs, mask=mask)
+    tl.store(out_ptr + out_idx, vals, mask=mask)
+
+
+def diag(*args, **kwargs):
+    # Parse input tensor and diagonal
+    if len(args) < 1 or not isinstance(args[0], torch.Tensor):
+        raise TypeError("diag expects a torch.Tensor as the first positional argument")
+    input = args[0]
+    diagonal = 0
+    if len(args) >= 2 and isinstance(args[1], int):
+        diagonal = args[1]
+    elif "diagonal" in kwargs and isinstance(kwargs["diagonal"], int):
+        diagonal = kwargs["diagonal"]
+
+    if input.dim() == 1:
+        N = input.numel()
+        k = int(diagonal)
+        i0 = max(0, -k)
+        j0 = max(0, k)
+        size = N + abs(k)
+        out = torch.zeros((size, size), dtype=input.dtype, device=input.device)
+        if N > 0:
+            stride_row, stride_col = out.stride()
+            grid = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE"]),)
+            _diag_write_kernel[grid](
+                input, out, i0, j0, N, stride_row, stride_col, BLOCK_SIZE=1024
+            )
+        return out
+    elif input.dim() == 2:
+        M, Nv = input.shape
+        k = int(diagonal)
+        i0 = max(0, -k)
+        j0 = max(0, k)
+        L = min(M - i0, Nv - j0)
+        L = max(L, 0)
+        out = torch.empty((L,), dtype=input.dtype, device=input.device)
+        if L > 0:
+            stride_row, stride_col = input.stride()
+            grid = lambda meta: (triton.cdiv(L, meta["BLOCK_SIZE"]),)
+            _diag_extract_kernel[grid](
+                input, out, i0, j0, L, stride_row, stride_col, BLOCK_SIZE=1024
+            )
+        return out
+    else:
+        raise RuntimeError("diag expects a 1D or 2D tensor")
+
+
+def diag_out(*args, **kwargs):
+    # Supports signatures:
+    # - diag_out(input, diagonal, out)
+    # - diag_out(out, input, diagonal)
+    # - diag_out(input, diagonal, out=...)
+    # - diag_out(input, out=..., diagonal=...)
+    input = None
+    out = None
+    diagonal = 0
+
+    # Extract out from kwargs if provided
+    if "out" in kwargs and isinstance(kwargs["out"], torch.Tensor):
+        out = kwargs["out"]
+
+    # Try positional interpretations
+    if input is None and len(args) >= 1 and isinstance(args[0], torch.Tensor):
+        # Could be (input, diagonal, out) or (out, input, diagonal)
+        if (
+            out is None
+            and len(args) >= 3
+            and isinstance(args[2], torch.Tensor)
+            and isinstance(args[1], int)
+        ):
+            input = args[0]
+            diagonal = int(args[1])
+            out = args[2]
+        elif (
+            out is None
+            and len(args) >= 3
+            and isinstance(args[0], torch.Tensor)
+            and isinstance(args[1], torch.Tensor)
+            and isinstance(args[2], int)
+        ):
+            out = args[0]
+            input = args[1]
+            diagonal = int(args[2])
+        else:
+            # Fallback: treat first tensor as input
+            input = args[0]
+            if len(args) >= 2 and isinstance(args[1], int):
+                diagonal = int(args[1])
+
+    # Override diagonal from kwargs if provided
+    if "diagonal" in kwargs and isinstance(kwargs["diagonal"], int):
+        diagonal = int(kwargs["diagonal"])
+
+    if input is None or out is None:
+        raise TypeError("diag_out expects input tensor, diagonal, and out tensor")
+
+    if input.dim() == 1:
+        N = input.numel()
+        k = int(diagonal)
+        i0 = max(0, -k)
+        j0 = max(0, k)
+        size = N + abs(k)
+
+        if out.dim() != 2 or out.shape[0] != size or out.shape[1] != size:
+            raise RuntimeError(
+                f"diag_out: expected out shape ({size}, {size}), got {tuple(out.shape)}"
+            )
+        if out.dtype != input.dtype or out.device != input.device:
+            raise RuntimeError("diag_out: out dtype/device must match input")
+
+        # Zero-fill out and write diagonal
+        if out.numel() > 0:
+            out.zero_()
+        if N > 0:
+            stride_row, stride_col = out.stride()
+            grid = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE"]),)
+            _diag_write_kernel[grid](
+                input, out, i0, j0, N, stride_row, stride_col, BLOCK_SIZE=1024
+            )
+        return out
+    elif input.dim() == 2:
+        M, Nv = input.shape
+        k = int(diagonal)
+        i0 = max(0, -k)
+        j0 = max(0, k)
+        L = min(M - i0, Nv - j0)
+        L = max(L, 0)
+
+        if out.dim() != 1 or out.numel() != L:
+            raise RuntimeError(
+                f"diag_out: expected out shape ({L},), got {tuple(out.shape)}"
+            )
+        if out.dtype != input.dtype or out.device != input.device:
+            raise RuntimeError("diag_out: out dtype/device must match input")
+
+        if L > 0:
+            stride_row, stride_col = input.stride()
+            grid = lambda meta: (triton.cdiv(L, meta["BLOCK_SIZE"]),)
+            _diag_extract_kernel[grid](
+                input, out, i0, j0, L, stride_row, stride_col, BLOCK_SIZE=1024
+            )
+        return out
+    else:
+        raise RuntimeError("diag_out expects a 1D or 2D input tensor")

--- a/src/flag_gems/experimental_ops/digamma_.py
+++ b/src/flag_gems/experimental_ops/digamma_.py
@@ -1,0 +1,84 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def digamma_(
+    x_ptr,  # Pointer to input/output tensor (in-place)
+    n_elements,  # Number of elements
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x_f32 = x.to(tl.float32)
+
+    pi = 3.1415926535897932384626433832795028841971
+
+    # Reflection for x < 0.5: psi(x) = psi(1 - x) - pi * cot(pi * x)
+    reflect_mask = x_f32 < 0.5
+    xr = tl.where(reflect_mask, 1.0 - x_f32, x_f32)
+
+    # Use recurrence to shift xr to >= 8 for better asymptotic precision
+    s = tl.zeros_like(x_f32)
+    y = xr
+    for _ in range(8):
+        m = y < 8.0
+        s = s - tl.where(m, 1.0 / y, 0.0)
+        y = tl.where(m, y + 1.0, y)
+
+    # Asymptotic expansion for digamma at large y
+    r = 1.0 / y
+    r2 = r * r
+    t2 = r2
+    t4 = t2 * t2
+    t6 = t4 * t2
+    t8 = t4 * t4
+    series = (
+        (-0.5 * r)
+        + (-1.0 / 12.0) * t2
+        + (1.0 / 120.0) * t4
+        + (-1.0 / 252.0) * t6
+        + (1.0 / 240.0) * t8
+    )
+    psi_y = tl.log(y) + s + series
+
+    # Apply reflection if needed
+    cot_term = tl.cos(pi * x_f32) / tl.sin(pi * x_f32)
+    result = tl.where(reflect_mask, psi_y - pi * cot_term, psi_y)
+
+    result = result.to(x.dtype)
+    tl.store(x_ptr + offsets, result, mask=mask)
+
+
+_KERNEL_DIGAMMA_INPLACE = digamma_
+
+
+def digamma_(*args, **kwargs):
+    x = args[0]
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("digamma_ expects a torch.Tensor as the first argument")
+    if not x.is_cuda:
+        return torch.ops.aten.digamma_(x)
+
+    # Handle non-contiguous tensors by operating on a contiguous copy and copying back
+    if not x.is_contiguous():
+        y = x.contiguous()
+        n_elements = y.numel()
+        if n_elements == 0:
+            return x
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        _KERNEL_DIGAMMA_INPLACE[grid](y, n_elements, BLOCK_SIZE=1024)
+        x.copy_(y)
+        return x
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _KERNEL_DIGAMMA_INPLACE[grid](x, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/elu.py
+++ b/src/flag_gems/experimental_ops/elu.py
@@ -1,0 +1,102 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def elu_kernel(
+    x_ptr, out_ptr, n_elements, alpha, scale, input_scale, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    x32 = x.to(tl.float32)
+
+    pos = x32 > 0.0
+    neg = alpha * (tl.exp(input_scale * x32) - 1.0)
+    y32 = tl.where(pos, x32, neg)
+    y32 = scale * y32
+
+    y = y32.to(x.dtype)
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _parse_elu_args(args, kwargs, expect_out: bool = False):
+    x = None
+    if len(args) > 0 and isinstance(args[0], torch.Tensor):
+        x = args[0]
+        arg_idx = 1
+    else:
+        x = kwargs.get("input", kwargs.get("self", kwargs.get("x", None)))
+        arg_idx = 0
+
+    if x is None:
+        raise ValueError("elu expects a Tensor as the first argument (input/self/x).")
+
+    def _get_scalar(name, default, idx):
+        if name in kwargs:
+            return float(kwargs[name])
+        elif len(args) > idx:
+            return float(args[idx])
+        else:
+            return float(default)
+
+    alpha = _get_scalar("alpha", 1.0, arg_idx + 0)
+    scale = _get_scalar("scale", 1.0, arg_idx + 1)
+    input_scale = _get_scalar("input_scale", 1.0, arg_idx + 2)
+
+    out = None
+    if expect_out:
+        if "out" in kwargs and isinstance(kwargs["out"], torch.Tensor):
+            out = kwargs["out"]
+        elif len(args) > arg_idx + 3 and isinstance(args[arg_idx + 3], torch.Tensor):
+            out = args[arg_idx + 3]
+        elif len(args) > arg_idx + 4 and isinstance(args[arg_idx + 4], torch.Tensor):
+            out = args[arg_idx + 4]
+        else:
+            raise ValueError("elu_out expects an 'out' tensor argument.")
+
+    return x, alpha, scale, input_scale, out
+
+
+def _launch_elu_kernel(
+    x: torch.Tensor, out: torch.Tensor, alpha: float, scale: float, input_scale: float
+):
+    if not x.is_cuda or not out.is_cuda:
+        raise RuntimeError("elu Triton kernel requires CUDA tensors.")
+    if x.numel() != out.numel():
+        raise ValueError("Input and output must have the same number of elements.")
+    if x.dtype != out.dtype:
+        raise ValueError("Input and output must have the same dtype.")
+    if not x.is_contiguous() or not out.is_contiguous():
+        raise ValueError("Input and output must be contiguous tensors.")
+
+    n_elements = x.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    elu_kernel[grid](
+        x,
+        out,
+        n_elements,
+        float(alpha),
+        float(scale),
+        float(input_scale),
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+def elu(*args, **kwargs):
+    x, alpha, scale, input_scale, _ = _parse_elu_args(args, kwargs, expect_out=False)
+    out = torch.empty_like(x)
+    _launch_elu_kernel(x.contiguous(), out, alpha, scale, input_scale)
+    return out
+
+
+def elu_out(*args, **kwargs):
+    x, alpha, scale, input_scale, out = _parse_elu_args(args, kwargs, expect_out=True)
+    if out is None:
+        raise ValueError("elu_out requires an 'out' tensor.")
+    _launch_elu_kernel(x.contiguous(), out, alpha, scale, input_scale)
+    return out

--- a/src/flag_gems/experimental_ops/erf_.py
+++ b/src/flag_gems/experimental_ops/erf_.py
@@ -1,0 +1,83 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def erf_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x32 = x.to(tl.float32)
+
+    ax = tl.abs(x32)
+    t = 1.0 / (1.0 + 0.5 * ax)
+
+    p = 1.00002368 + t * (
+        0.37409196
+        + t
+        * (
+            0.09678418
+            + t
+            * (
+                -0.18628806
+                + t
+                * (
+                    0.27886807
+                    + t
+                    * (
+                        -1.13520398
+                        + t * (1.48851587 + t * (-0.82215223 + t * 0.17087277))
+                    )
+                )
+            )
+        )
+    )
+    s = -x32 * x32 - 1.26551223 + t * p
+    tau = t * tl.exp(s)
+    y32 = tl.where(x32 >= 0, 1.0 - tau, tau - 1.0)
+
+    y = y32.to(x.dtype)
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# keep a reference to the kernel before defining the wrapper with the same name
+erf__kernel = erf_
+
+
+def erf_(*args, **kwargs):
+    # Extract the input tensor
+    x = None
+    if len(args) >= 1 and isinstance(args[0], torch.Tensor):
+        x = args[0]
+    elif "input" in kwargs and isinstance(kwargs["input"], torch.Tensor):
+        x = kwargs["input"]
+    elif "self" in kwargs and isinstance(kwargs["self"], torch.Tensor):
+        x = kwargs["self"]
+    elif (
+        "args" in kwargs
+        and isinstance(kwargs["args"], (list, tuple))
+        and kwargs["args"]
+    ):
+        x = kwargs["args"][0]
+    if x is None:
+        raise TypeError("erf_ expects a tensor as its first argument")
+
+    # Fallback for unsupported devices/dtypes
+    if not x.is_cuda:
+        return x.erf_()
+
+    if x.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        return x.erf_()
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    erf__kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/erfinv.py
+++ b/src/flag_gems/experimental_ops/erfinv.py
@@ -1,0 +1,107 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def erfinv_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    xf = x.to(tl.float32)
+
+    one = 1.0
+    absx = tl.abs(xf)
+    w = -tl.log((one - xf) * (one + xf))
+
+    use_low = w < 5.0
+
+    wl = w - 2.5
+    pl = 2.81022636e-08
+    pl = 3.43273939e-07 + pl * wl
+    pl = -3.5233877e-06 + pl * wl
+    pl = -4.39150654e-06 + pl * wl
+    pl = 2.1858087e-04 + pl * wl
+    pl = -1.25372503e-03 + pl * wl
+    pl = -4.17768164e-03 + pl * wl
+    pl = 2.46640727e-01 + pl * wl
+    pl = 1.50140941e00 + pl * wl
+
+    wh = tl.sqrt(w) - 3.0
+    ph = -2.00214257e-04
+    ph = 1.00950558e-04 + ph * wh
+    ph = 1.34934322e-03 + ph * wh
+    ph = -3.67342844e-03 + ph * wh
+    ph = 5.73950773e-03 + ph * wh
+    ph = -7.62246130e-03 + ph * wh
+    ph = 9.43887047e-03 + ph * wh
+    ph = 1.00167406e00 + ph * wh
+    ph = 2.83297682e00 + ph * wh
+
+    p = tl.where(use_low, pl, ph)
+    res = p * xf
+
+    nan_vec = tl.full([BLOCK_SIZE], float("nan"), dtype=tl.float32)
+    inf_vec = tl.full([BLOCK_SIZE], float("inf"), dtype=tl.float32)
+
+    mask_nan = xf != xf
+    mask_oob = absx > 1.0
+    mask_pos1 = xf == 1.0
+    mask_neg1 = xf == -1.0
+
+    res = tl.where(mask_nan, nan_vec, res)
+    res = tl.where(mask_oob, nan_vec, res)
+    res = tl.where(mask_pos1, inf_vec, res)
+    res = tl.where(mask_neg1, -inf_vec, res)
+
+    y = res.to(x.dtype)
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _launch_erfinv_kernel(x: torch.Tensor, out: torch.Tensor):
+    assert x.is_cuda and out.is_cuda, "Inputs must be CUDA tensors"
+    assert (
+        x.numel() == out.numel()
+    ), "Input and output must have the same number of elements"
+    assert x.dtype == out.dtype, "Input and output must have the same dtype"
+    n_elements = x.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    erfinv_kernel[grid](
+        x,
+        out,
+        n_elements,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+def erfinv(x: torch.Tensor):
+    x_in = x
+    if not x_in.is_contiguous():
+        x_in = x_in.contiguous()
+    out = torch.empty_like(x_in)
+    _launch_erfinv_kernel(x_in, out)
+    # Match original shape/strides of input if needed
+    if out.shape != x.shape or out.stride() != x.stride():
+        out = out.reshape(x.shape).as_strided(x.size(), x.stride())
+    return out
+
+
+def erfinv_out(x: torch.Tensor, out: torch.Tensor):
+    # Resize out to match input shape if necessary
+    if out.shape != x.shape:
+        out.resize_(x.shape)
+    # Ensure dtype matches input dtype for aten out semantics
+    assert out.dtype == x.dtype, "out tensor must have the same dtype as input"
+    x_in = x if x.is_contiguous() else x.contiguous()
+    if out.is_contiguous():
+        _launch_erfinv_kernel(x_in, out)
+        return out
+    else:
+        tmp = torch.empty_like(out, memory_format=torch.contiguous_format)
+        _launch_erfinv_kernel(x_in, tmp)
+        out.copy_(tmp)
+        return out

--- a/src/flag_gems/experimental_ops/exp2_.py
+++ b/src/flag_gems/experimental_ops/exp2_.py
@@ -1,0 +1,40 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def exp2_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x_f32 = x.to(tl.float32)
+    ln2 = 0.693147180559945309417232121458176568
+    y_f32 = tl.exp(x_f32 * ln2)
+    y = y_f32.to(x.dtype)
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# Preserve reference to the Triton kernel before defining the Python wrapper with the same name.
+exp2__kernel = exp2_
+
+
+def exp2_(*args, **kwargs):
+    x = None
+    if len(args) > 0:
+        x = args[0]
+    else:
+        x = kwargs.get("input", None)
+        if x is None:
+            x = kwargs.get("x", None)
+    assert isinstance(
+        x, torch.Tensor
+    ), "exp2_ expects a torch.Tensor as its first argument"
+    assert x.is_cuda, "exp2_ Triton kernel requires a CUDA tensor"
+    n_elements = x.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    exp2__kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/expand.py
+++ b/src/flag_gems/experimental_ops/expand.py
@@ -1,0 +1,143 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def expand(
+    x_ptr,
+    out_ptr,
+    n_elements,
+    ndims,
+    out_shape_ptr,
+    out_cumprod_ptr,
+    in_stride_ptr,
+    BLOCK_SIZE: tl.constexpr,
+    MAX_DIMS: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    # Compute input offsets corresponding to each output linear index
+    in_offsets = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+
+    # Accumulate contributions per dimension
+    for d in range(MAX_DIMS):
+        # Load scalars defining the output decomposition and input strides
+        s = tl.load(out_shape_ptr + d)
+        stride_right = tl.load(out_cumprod_ptr + d)
+        in_stride = tl.load(in_stride_ptr + d)
+        # idx along dimension d for each linear offset
+        idx_d = (offsets // stride_right) % s
+        # contribution to input linear offset
+        in_offsets += idx_d * in_stride
+
+    # Load from input using computed offsets and store to output
+    x = tl.load(x_ptr + in_offsets, mask=mask)
+    tl.store(out_ptr + offsets, x, mask=mask)
+
+
+_expand_kernel = expand
+
+
+def expand(*args, **kwargs):
+    x = args[0]
+    size = args[1]
+    implicit = kwargs.get(  # noqa: F841
+        "implicit", False
+    )  # not used but accepted for signature compatibility
+
+    if not isinstance(size, (list, tuple, torch.Size)):
+        raise TypeError("expand size must be a list/tuple/torch.Size of ints")
+
+    size = list(size)
+    in_shape = list(x.shape)
+    in_strides = list(x.stride())
+
+    out_ndim = len(size)
+    in_ndim = len(in_shape)
+
+    if in_ndim > out_ndim:
+        raise RuntimeError(
+            f"expand: requested size has fewer dimensions ({out_ndim}) than input ({in_ndim})"
+        )
+
+    # Pad input shape/strides on the left to match output ndim
+    if in_ndim < out_ndim:
+        pad = out_ndim - in_ndim
+        in_shape = [1] * pad + in_shape
+        # For padded (new) leading dims, stride effectively is 0 since they will be broadcast
+        in_strides = [0] * pad + in_strides
+
+    # Resolve -1 and validate broadcastability
+    out_shape = []
+    for d in range(out_ndim):
+        req = size[d]
+        src = in_shape[d]
+        if req == -1:
+            target = src
+        else:
+            target = req
+        if src != target and src != 1:
+            raise RuntimeError(
+                f"The expanded size of the tensor ({target}) must match the existing size ({src}) at non-singleton "
+                f"dimension {d}. Target sizes must be the same, or -1, or the size of dimension in the original tensor must be 1."  # noqa: E501
+            )
+        out_shape.append(int(target))
+
+    # Effective input strides: 0 for broadcasted dims, original stride otherwise
+    in_stride_eff = [
+        int(in_strides[d]) if in_shape[d] != 1 else 0 for d in range(out_ndim)
+    ]
+
+    # Prepare decomposition multipliers: product of sizes to the right for each dim
+    out_cumprod_right = [0] * out_ndim
+    prod = 1
+    for d in range(out_ndim - 1, -1, -1):
+        out_cumprod_right[d] = prod
+        prod *= out_shape[d]
+
+    # Allocate output
+    out = torch.empty(out_shape, dtype=x.dtype, device=x.device)
+
+    n_elements = out.numel()
+    if n_elements == 0:
+        return out
+
+    # Triton kernel parameters
+    BLOCK_SIZE = 1024
+    MAX_DIMS = max(out_ndim, 1)  # at least 1
+    # Round up MAX_DIMS to a reasonable static upper bound for compilation (e.g., 16)
+    # but ensure arrays we pass match MAX_DIMS in kernel
+    STATIC_MAX = 16
+    if MAX_DIMS > STATIC_MAX:
+        STATIC_MAX = MAX_DIMS
+
+    # Create device arrays for shapes/strides with padding for MAX_DIMS
+    pad_len = STATIC_MAX - out_ndim
+    out_shape_arr = torch.tensor(
+        out_shape + [1] * pad_len, dtype=torch.int64, device=x.device
+    )
+    out_cumprod_arr = torch.tensor(
+        out_cumprod_right + [1] * pad_len, dtype=torch.int64, device=x.device
+    )
+    in_stride_arr = torch.tensor(
+        in_stride_eff + [0] * pad_len, dtype=torch.int64, device=x.device
+    )
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    _expand_kernel[grid](
+        x,
+        out,
+        n_elements,
+        out_ndim,
+        out_shape_arr,
+        out_cumprod_arr,
+        in_stride_arr,
+        BLOCK_SIZE=BLOCK_SIZE,
+        MAX_DIMS=STATIC_MAX,
+    )
+    return out

--- a/src/flag_gems/experimental_ops/fft_ifftshift.py
+++ b/src/flag_gems/experimental_ops/fft_ifftshift.py
@@ -1,0 +1,146 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def fft_ifftshift(
+    in_ptr_u8,  # pointer to input tensor as bytes
+    out_ptr_u8,  # pointer to output tensor as bytes
+    sizes_ptr,  # int64[NDIMS]
+    in_strides_ptr,  # int64[NDIMS], in elements
+    out_strides_ptr,  # int64[NDIMS], in elements
+    adds_ptr,  # int64[NDIMS], per-dim add = floor(size/2) if shifted else 0
+    n_elements,  # total number of elements
+    ELEMENT_SIZE: tl.constexpr,  # number of bytes per element
+    NDIMS: tl.constexpr,  # number of dimensions
+    BLOCK_SIZE: tl.constexpr,  # tile size
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+    offs64 = offs.to(tl.int64)
+
+    # Compute multi-dimensional indices from linear index (row-major)
+    tmp = offs64
+    in_off_elems = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+    out_off_elems = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+
+    # Iterate from last dim to first to compute indices
+    for d in range(NDIMS - 1, -1, -1):
+        size_d = tl.load(sizes_ptr + d)  # scalar int64
+        idx_d = tmp % size_d
+        tmp = tmp // size_d
+
+        add_d = tl.load(adds_ptr + d)  # scalar int64
+        idx_in_d = idx_d + add_d
+        # modulo to wrap within size_d
+        idx_in_d = idx_in_d - (idx_in_d // size_d) * size_d
+
+        in_stride_d = tl.load(in_strides_ptr + d)
+        out_stride_d = tl.load(out_strides_ptr + d)
+
+        in_off_elems += idx_in_d * in_stride_d
+        out_off_elems += idx_d * out_stride_d
+
+    in_byte_base = in_off_elems * ELEMENT_SIZE
+    out_byte_base = out_off_elems * ELEMENT_SIZE
+
+    # Copy ELEMENT_SIZE bytes per element
+    for b in range(ELEMENT_SIZE):
+        src_addr = in_ptr_u8 + in_byte_base + b
+        dst_addr = out_ptr_u8 + out_byte_base + b
+        val = tl.load(src_addr, mask=mask, other=0)
+        tl.store(dst_addr, val, mask=mask)
+
+
+# Keep a handle to the kernel before defining the wrapper with the same name
+fft_ifftshift_kernel = fft_ifftshift
+
+
+def fft_ifftshift(*args, **kwargs):
+    x = None
+    dims = None
+
+    # Parse input tensor
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        # try kwargs
+        x = (
+            kwargs.get("input", None)
+            or kwargs.get("self", None)
+            or kwargs.get("tensor", None)
+        )
+    if x is None:
+        raise ValueError("fft_ifftshift expects at least one tensor argument as input.")
+
+    # Parse dims (can be in args[1], or kwargs 'dim'/'dims')
+    if len(args) >= 2:
+        dims = args[1]
+    else:
+        dims = kwargs.get("dim", kwargs.get("dims", None))
+
+    # Normalize dims
+    if dims is None:
+        dims_list = list(range(x.ndim))
+    else:
+        if isinstance(dims, int):
+            dims_list = [dims]
+        else:
+            dims_list = list(dims)
+        # normalize negative dims
+        dims_list = [(d + x.ndim) % x.ndim for d in dims_list]
+        # remove duplicates while preserving order
+        seen = set()
+        tmp = []
+        for d in dims_list:
+            if d not in seen:
+                tmp.append(d)
+                seen.add(d)
+        dims_list = tmp
+
+    # Handle scalars or empty tensors quickly
+    if x.ndim == 0 or x.numel() == 0:
+        return x.clone()
+
+    device = x.device
+    dtype = x.dtype  # noqa: F841
+    out = torch.empty_like(x)
+
+    # Prepare metadata
+    sizes = torch.tensor(list(x.shape), device=device, dtype=torch.int64)
+    in_strides = torch.tensor(list(x.stride()), device=device, dtype=torch.int64)
+    out_strides = torch.tensor(list(out.stride()), device=device, dtype=torch.int64)
+
+    # Per-dimension add amount = floor(size/2) if dimension is included, else 0
+    add_list = [
+        (sizes[d].item() // 2) if d in set(dims_list) else 0 for d in range(x.ndim)
+    ]
+    adds = torch.tensor(add_list, device=device, dtype=torch.int64)
+
+    n_elements = x.numel()
+    NDIMS = x.ndim
+    ELEMENT_SIZE = x.element_size()
+
+    # Use byte pointers by viewing as uint8 without changing storage
+    x_u8 = x.view(torch.uint8)
+    out_u8 = out.view(torch.uint8)
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    BLOCK_SIZE = 1024
+
+    fft_ifftshift_kernel[grid](
+        x_u8,
+        out_u8,
+        sizes,
+        in_strides,
+        out_strides,
+        adds,
+        n_elements,
+        ELEMENT_SIZE=ELEMENT_SIZE,
+        NDIMS=NDIMS,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return out

--- a/src/flag_gems/experimental_ops/fill_.py
+++ b/src/flag_gems/experimental_ops/fill_.py
@@ -1,0 +1,69 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def fill_kernel(out_ptr, value_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    val = tl.load(value_ptr)  # load scalar value (1-element tensor)
+    tl.store(out_ptr + offsets, val, mask=mask)
+
+
+def fill__Scalar(*args, **kwargs):
+    # Expecting (self, value)
+    if len(args) >= 2:
+        self = args[0]
+        value = args[1]
+    else:
+        self = kwargs.get("self") or kwargs.get("input") or kwargs.get("tensor")
+        value = kwargs.get("value")
+    if self is None:
+        raise ValueError("fill__Scalar requires a target tensor 'self'.")
+    if value is None:
+        raise ValueError("fill__Scalar requires a scalar 'value'.")
+    assert self.is_cuda, "fill__Scalar requires a CUDA tensor."
+    assert (
+        self.is_contiguous()
+    ), "fill__Scalar currently supports only contiguous tensors."
+    # Create a 1-element tensor on device with matching dtype
+    value_t = torch.tensor([value], dtype=self.dtype, device=self.device)
+    n_elements = self.numel()
+    if n_elements == 0:
+        return self
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    fill_kernel[grid](self, value_t, n_elements, BLOCK_SIZE=1024)
+    return self
+
+
+def fill__Tensor(*args, **kwargs):
+    # Expecting (self, other)
+    if len(args) >= 2:
+        self = args[0]
+        other = args[1]
+    else:
+        self = kwargs.get("self") or kwargs.get("input") or kwargs.get("tensor")
+        other = kwargs.get("other") or kwargs.get("value") or kwargs.get("src")
+    if self is None:
+        raise ValueError("fill__Tensor requires a target tensor 'self'.")
+    if other is None:
+        raise ValueError("fill__Tensor requires a source tensor 'other'.")
+    assert self.is_cuda, "fill__Tensor requires a CUDA tensor."
+    assert (
+        self.is_contiguous()
+    ), "fill__Tensor currently supports only contiguous tensors."
+    if other.numel() != 1:
+        raise RuntimeError(
+            "fill__Tensor expects 'other' to be a 0-dim or 1-element tensor."
+        )
+    # Move/convert 'other' to match device and dtype of 'self'
+    value_t = other.to(device=self.device, dtype=self.dtype).reshape(1)
+    n_elements = self.numel()
+    if n_elements == 0:
+        return self
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    fill_kernel[grid](self, value_t, n_elements, BLOCK_SIZE=1024)
+    return self

--- a/src/flag_gems/experimental_ops/fix.py
+++ b/src/flag_gems/experimental_ops/fix.py
@@ -1,0 +1,82 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _fix_trunc_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    # Upcast to fp32 for stable math, then cast back to input dtype
+    x_fp32 = x.to(tl.float32)
+    res_pos = tl.floor(x_fp32)
+    res_neg = tl.ceil(x_fp32)
+    res_fp32 = tl.where(x_fp32 >= 0, res_pos, res_neg)
+    res = res_fp32.to(x.dtype)
+
+    tl.store(out_ptr + offsets, res, mask=mask)
+
+
+@triton.jit
+def _copy_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    tl.store(out_ptr + offsets, x, mask=mask)
+
+
+def _launch_fix_kernel(x: torch.Tensor, out: torch.Tensor, block_size: int = 1024):
+    assert x.is_cuda and out.is_cuda, "Input and output must be on CUDA device"
+    assert (
+        x.numel() == out.numel()
+    ), "Input and output must have the same number of elements"
+    assert x.device == out.device, "Input and output must be on the same device"
+    assert (
+        x.is_contiguous() and out.is_contiguous()
+    ), "Only contiguous tensors are supported"
+
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    # For floating point types, perform truncation toward zero.
+    # For non-floating types, it's effectively a no-op (copy).
+    if x.is_floating_point():
+        _fix_trunc_kernel[grid](x, out, n_elements, BLOCK_SIZE=block_size)
+    else:
+        _copy_kernel[grid](x, out, n_elements, BLOCK_SIZE=block_size)
+
+
+def fix(self: torch.Tensor):
+    """
+    Wrapper for ATen operator: ('fix', <Autograd.disable: False>)
+    Rounds elements toward zero (like trunc) for floating tensors.
+    Leaves integer tensors unchanged.
+    """
+    if self.is_complex():
+        # Fallback for complex dtypes not supported by Triton: use PyTorch
+        return torch.trunc(self)
+
+    out = torch.empty_like(self)
+    _launch_fix_kernel(self, out)
+    return out
+
+
+def fix_out(self: torch.Tensor, out: torch.Tensor):
+    """
+    Wrapper for ATen operator: ('fix.out', <Autograd.disable: False>)
+    Writes the result into 'out'.
+    """
+    if self.is_complex():
+        # Fallback for complex dtypes not supported by Triton: use PyTorch
+        out.copy_(torch.trunc(self))
+        return out
+
+    _launch_fix_kernel(self, out)
+    return out

--- a/src/flag_gems/experimental_ops/frac.py
+++ b/src/flag_gems/experimental_ops/frac.py
@@ -1,0 +1,100 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def frac_kernel(
+    x_ptr,
+    out_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+    IS_FP16: tl.constexpr,
+    IS_BF16: tl.constexpr,
+    IS_FP64: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+
+    # Choose compute dtype
+    if IS_FP64:
+        x_comp = x.to(tl.float64)
+    elif IS_FP16 or IS_BF16:
+        x_comp = x.to(tl.float32)
+    else:
+        x_comp = x  # float32
+
+    trunc_val = tl.where(x_comp >= 0, tl.floor(x_comp), tl.ceil(x_comp))
+    y_comp = x_comp - trunc_val
+
+    # Cast back to output dtype
+    if IS_FP64:
+        y = y_comp.to(tl.float64)
+    elif IS_FP16:
+        y = y_comp.to(tl.float16)
+    elif IS_BF16:
+        y = y_comp.to(tl.bfloat16)
+    else:
+        y = y_comp.to(tl.float32)
+
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _launch_frac(x: torch.Tensor, out: torch.Tensor):
+    assert x.is_cuda and out.is_cuda, "Inputs must be CUDA tensors"
+    assert (
+        x.numel() == out.numel()
+    ), "Input and output must have the same number of elements"
+    assert x.dtype == out.dtype, "Input and output must have the same dtype"
+    if not x.is_floating_point():
+        raise NotImplementedError("frac is only implemented for floating point dtypes")
+    if x.is_complex():
+        raise NotImplementedError(
+            "frac is not implemented for complex dtypes in this Triton kernel"
+        )
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return out
+
+    # Use contiguous buffers for kernel execution
+    x_contig = x.contiguous()
+    out_contig = out.contiguous()
+
+    is_fp16 = x_contig.dtype == torch.float16
+    is_bf16 = x_contig.dtype == torch.bfloat16
+    is_fp64 = x_contig.dtype == torch.float64
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    frac_kernel[grid](
+        x_contig,
+        out_contig,
+        n_elements,
+        BLOCK_SIZE=1024,
+        IS_FP16=is_fp16,
+        IS_BF16=is_bf16,
+        IS_FP64=is_fp64,
+    )
+
+    # If out was non-contiguous, copy results back
+    if out_contig.data_ptr() != out.data_ptr():
+        out.copy_(out_contig)
+    return out
+
+
+def frac(input: torch.Tensor):
+    out = torch.empty_like(input)
+    _launch_frac(input, out)
+    return out
+
+
+def frac_out(input: torch.Tensor, out: torch.Tensor):
+    # Ensure shape and dtype match per .out contract
+    assert out.shape == input.shape, "out must have the same shape as input"
+    assert out.dtype == input.dtype, "out must have the same dtype as input"
+    _launch_frac(input, out)
+    return out

--- a/src/flag_gems/experimental_ops/gelu_.py
+++ b/src/flag_gems/experimental_ops/gelu_.py
@@ -1,0 +1,115 @@
+import torch  # noqa: F401
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def gelu_(
+    x_ptr,  # *Pointer* to the input/output tensor (in-place).
+    n_elements,  # Number of elements.
+    USE_TANH: tl.constexpr,  # Whether to use tanh approximation.
+    BLOCK_SIZE: tl.constexpr,  # Elements per program.
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    x_f32 = x.to(tl.float32)
+
+    # Compute GELU either exact (via erf approximation) or tanh approximation
+    if USE_TANH:
+        # tanh approximation:
+        # gelu(x) = 0.5 * x * (1 + tanh(sqrt(2/pi) * (x + 0.044715 x^3)))
+        c0 = 0.7978845608028654  # sqrt(2/pi)
+        c1 = 0.044715
+        x3 = x_f32 * x_f32 * x_f32
+        z = c0 * (x_f32 + c1 * x3)
+        # tanh(z) = (1 - e^{-2z}) / (1 + e^{-2z})
+        t = tl.exp(-2.0 * z)
+        tanh_z = (1.0 - t) / (1.0 + t)
+        y = 0.5 * x_f32 * (1.0 + tanh_z)
+    else:
+        # exact (erf-based) GELU:
+        # gelu(x) = 0.5 * x * (1 + erf(x / sqrt(2)))
+        inv_sqrt2 = 0.7071067811865476
+        z = x_f32 * inv_sqrt2
+
+        # Abramowitz and Stegun formula 7.1.26 for erf approximation
+        # erf(x) ≈ sign(x) * (1 - (((((a5*t + a4)*t + a3)*t + a2)*t + a1)*t) * e^{-x^2})
+        # where t = 1 / (1 + p*|x|)
+        p = 0.3275911
+        a1 = 0.254829592
+        a2 = -0.284496736
+        a3 = 1.421413741
+        a4 = -1.453152027
+        a5 = 1.061405429
+
+        az = tl.abs(z)
+        t = 1.0 / (1.0 + p * az)
+        poly = a5
+        poly = poly * t + a4
+        poly = poly * t + a3
+        poly = poly * t + a2
+        poly = poly * t + a1
+        poly = poly * t
+        erf_abs = 1.0 - poly * tl.exp(-az * az)
+        erf_z = tl.where(z >= 0, erf_abs, -erf_abs)
+
+        y = 0.5 * x_f32 * (1.0 + erf_z)
+
+    y_cast = y.to(x.dtype)
+    tl.store(x_ptr + offsets, y_cast, mask=mask)
+
+
+# Preserve a handle to the kernel before defining the Python wrapper of the same name
+gelu__kernel = gelu_
+
+
+def gelu_(*args, **kwargs):
+    # Resolve input tensor
+    x = None
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        # Try common names
+        x = kwargs.get("input", None)
+        if x is None:
+            x = kwargs.get("self", None)
+        if x is None:
+            x = kwargs.get("x", None)
+    if x is None:
+        raise ValueError("gelu_ expects a tensor as the first argument.")
+
+    # Determine approximation mode
+    approx = kwargs.get("approximate", "none")
+    if isinstance(approx, bool):
+        use_tanh = bool(approx)
+    else:
+        approx_str = str(approx).lower()
+        if approx_str in ("tanh", "true"):
+            use_tanh = True
+        elif approx_str in ("none", "false"):
+            use_tanh = False
+        else:
+            raise ValueError(
+                f"Unsupported approximate mode: {approx}. Use 'none' or 'tanh'."
+            )
+
+    if not x.is_cuda:
+        raise AssertionError("Input tensor must be on CUDA device for Triton kernel.")
+    if not x.is_contiguous():
+        raise AssertionError("Input tensor must be contiguous.")
+    if not x.is_floating_point():
+        raise AssertionError("gelu_ expects a floating point tensor.")
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    gelu__kernel[grid](x, n_elements, USE_TANH=use_tanh, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/hardshrink.py
+++ b/src/flag_gems/experimental_ops/hardshrink.py
@@ -1,0 +1,61 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def hardshrink_kernel(x_ptr, out_ptr, n_elements, lambd, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    threshold = lambd
+    keep = (x > threshold) | (x < -threshold)
+    y = tl.where(keep, x, 0.0)
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _hardshrink_launch(x: torch.Tensor, lambd: float, out: torch.Tensor):
+    assert x.is_cuda, "Input tensor must be on CUDA device"
+    assert out.is_cuda, "Output tensor must be on CUDA device"
+    assert (
+        x.numel() == out.numel()
+    ), "Input and output must have the same number of elements"
+    assert x.dtype == out.dtype, "Input and output must have the same dtype"
+    assert x.is_floating_point(), "hardshrink only supports floating point dtypes"
+
+    n_elements = x.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    hardshrink_kernel[grid](x, out, n_elements, float(lambd), BLOCK_SIZE=BLOCK_SIZE)
+
+
+def hardshrink(x: torch.Tensor, lambd: float = 0.5) -> torch.Tensor:
+    x_c = x.contiguous()
+    out = torch.empty_like(x_c)
+    _hardshrink_launch(x_c, lambd, out)
+    return out
+
+
+def hardshrink_out(
+    x: torch.Tensor, lambd: float = 0.5, out: torch.Tensor = None
+) -> torch.Tensor:
+    x_c = x.contiguous()
+    if out is None:
+        out = torch.empty_like(x_c)
+        _hardshrink_launch(x_c, lambd, out)
+        return out
+    # Ensure output is allocated correctly
+    assert out.is_cuda, "Output tensor must be on CUDA device"
+    assert out.dtype == x_c.dtype, "Output dtype must match input dtype"
+    assert out.shape == x_c.shape, "Output shape must match input shape"
+
+    if out.is_contiguous():
+        _hardshrink_launch(x_c, lambd, out)
+    else:
+        tmp = torch.empty_like(x_c)
+        _hardshrink_launch(x_c, lambd, tmp)
+        out.copy_(tmp)
+    return out

--- a/src/flag_gems/experimental_ops/hardsigmoid_.py
+++ b/src/flag_gems/experimental_ops/hardsigmoid_.py
@@ -1,0 +1,56 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def hardsigmoid_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = x + 3.0
+    y = tl.maximum(y, 0.0)
+    y = tl.minimum(y, 6.0)
+    y = y / 6.0
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+_hardsigmoid_triton = hardsigmoid_
+
+
+def hardsigmoid_(*args, **kwargs):
+    # Extract input tensor (supports positional or keyword: 'input' or 'self')
+    x = None
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        x = kwargs.get("input", kwargs.get("self", None))
+    if x is None:
+        raise ValueError("hardsigmoid_ expects a tensor as the first argument.")
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("hardsigmoid_ expects a torch.Tensor as input.")
+    if not x.is_floating_point():
+        raise TypeError("hardsigmoid_ only supports floating point tensors.")
+    if x.device.type != "cuda":
+        raise RuntimeError("hardsigmoid_ Triton kernel requires a CUDA tensor.")
+
+    BLOCK_SIZE = 1024
+
+    def launch(t: torch.Tensor):
+        n_elements = t.numel()
+        if n_elements == 0:
+            return
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        _hardsigmoid_triton[grid](t, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+
+    if not x.is_contiguous():
+        tmp = x.contiguous()
+        launch(tmp)
+        x.copy_(tmp)
+    else:
+        launch(x)
+
+    return x

--- a/src/flag_gems/experimental_ops/hardswish.py
+++ b/src/flag_gems/experimental_ops/hardswish.py
@@ -1,0 +1,112 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def hardswish_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    x32 = x.to(tl.float32)
+
+    lower = x32 <= -3.0
+    upper = x32 >= 3.0
+    mid = (~lower) & (~upper)
+
+    res32 = tl.zeros_like(x32)
+    res32 = tl.where(upper, x32, res32)
+    res32 = tl.where(mid, (x32 * (x32 + 3.0)) / 6.0, res32)
+    # lower region already zero
+
+    res = res32.to(x.dtype)
+    tl.store(out_ptr + offsets, res, mask=mask)
+
+
+def _launch_hardswish(x: torch.Tensor, out: torch.Tensor):
+    n_elements = x.numel()
+    if n_elements == 0:
+        return
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    hardswish_kernel[grid](x, out, n_elements, BLOCK_SIZE=1024)
+
+
+def _parse_input_tensor(*args, **kwargs) -> torch.Tensor:
+    if len(args) >= 1 and isinstance(args[0], torch.Tensor):
+        return args[0]
+    if "self" in kwargs and isinstance(kwargs["self"], torch.Tensor):
+        return kwargs["self"]
+    if "input" in kwargs and isinstance(kwargs["input"], torch.Tensor):
+        return kwargs["input"]
+    raise ValueError(
+        "Expected input tensor as the first positional argument or as 'self'/'input' keyword argument."
+    )
+
+
+def _parse_out_tensor(*args, **kwargs) -> torch.Tensor:
+    if len(args) >= 2 and isinstance(args[1], torch.Tensor):
+        return args[1]
+    if "out" in kwargs and isinstance(kwargs["out"], torch.Tensor):
+        return kwargs["out"]
+    raise ValueError(
+        "Expected 'out' tensor as the second positional argument or as 'out' keyword argument."
+    )
+
+
+def _ensure_cuda_tensor(t: torch.Tensor, name: str):
+    if not isinstance(t, torch.Tensor):
+        raise TypeError(f"{name} must be a torch.Tensor")
+    if not t.is_cuda:
+        raise ValueError(f"{name} must be a CUDA tensor (got device {t.device})")
+
+
+_supported_dtypes = {torch.float16, torch.bfloat16, torch.float32}
+
+
+def _hardswish_impl(x: torch.Tensor, out: torch.Tensor = None):
+    _ensure_cuda_tensor(x, "input")
+    if out is not None:
+        _ensure_cuda_tensor(out, "out")
+        if out.shape != x.shape:
+            raise ValueError(f"out shape {out.shape} must match input shape {x.shape}")
+
+    x_co = x.contiguous()
+    compute_dtype = x_co.dtype if x_co.dtype in _supported_dtypes else torch.float32
+    x_work = x_co if x_co.dtype == compute_dtype else x_co.to(compute_dtype)
+
+    if out is None:
+        final_out = torch.empty_like(x)  # preserve layout/strides of input
+    else:
+        final_out = out
+
+    can_write_direct = (
+        final_out.is_contiguous()
+        and final_out.device == x.device
+        and final_out.dtype in _supported_dtypes
+        and final_out.dtype == compute_dtype
+    )
+
+    if can_write_direct:
+        out_work = final_out
+        _launch_hardswish(x_work, out_work)
+        return final_out
+    else:
+        out_work = torch.empty(x_work.shape, dtype=compute_dtype, device=x_work.device)
+        _launch_hardswish(x_work, out_work)
+        final_out.copy_(out_work.to(final_out.dtype))
+        return final_out
+
+
+def hardswish(*args, **kwargs):
+    x = _parse_input_tensor(*args, **kwargs)
+    return _hardswish_impl(x)
+
+
+def hardswish_out(*args, **kwargs):
+    x = _parse_input_tensor(*args, **kwargs)
+    out = _parse_out_tensor(*args, **kwargs)
+    _hardswish_impl(x, out)
+    return out

--- a/tests/experimental_ops/deg2rad_test.py
+++ b/tests/experimental_ops/deg2rad_test.py
@@ -1,0 +1,79 @@
+# DEG2RAD operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.deg2rad import deg2rad as gems_deg2rad  # noqa: E402
+from flag_gems.experimental_ops.deg2rad import (  # noqa: E402
+    deg2rad_out as gems_deg2rad_out,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.deg2rad
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_deg2rad_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.deg2rad(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_deg2rad(x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.deg2rad
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_deg2rad_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_out = torch.empty_like(ref_x)
+    torch.ops.aten.deg2rad.out(ref_x, out=ref_out)
+
+    act_out = torch.empty_like(x)
+    with flag_gems.use_gems():
+        gems_deg2rad_out(x, act_out)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.deg2rad
+def test_perf_aten_deg2rad():
+    # Define input generation logic matching the operator arguments
+    def deg2rad_input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=deg2rad_input_fn,
+        op_name="deg2rad",
+        torch_op=torch.ops.aten.deg2rad,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/detach_test.py
+++ b/tests/experimental_ops/detach_test.py
@@ -1,0 +1,74 @@
+# DETACH operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.detach import detach as gems_detach  # noqa: E402
+
+
+@pytest.mark.detach
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("requires_grad", [False, True])
+def test_detach_tensor(shape, dtype, requires_grad):
+    input_tensor = torch.randn(
+        shape, dtype=dtype, device=flag_gems.device, requires_grad=requires_grad
+    )
+    ref_input = input_tensor.clone().requires_grad_(requires_grad)
+
+    ref_out = torch.ops.aten.detach(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_detach(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.detach
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("requires_grad", [False, True])
+def test_detach_benchmark_tensor(shape, dtype, requires_grad):
+    import torch.utils.benchmark as benchmark  # noqa: E402, F401
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(
+        shape, dtype=dtype, device=flag_gems.device, requires_grad=requires_grad
+    )
+    ref_input = input_tensor.clone().requires_grad_(requires_grad)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.detach(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_detach(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"detach {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/diag_test.py
+++ b/tests/experimental_ops/diag_test.py
@@ -1,0 +1,160 @@
+# DIAG operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.diag import diag as gems_diag  # noqa: E402
+from flag_gems.experimental_ops.diag import diag_out as gems_diag_out  # noqa: E402
+
+
+@pytest.mark.diag
+@pytest.mark.parametrize(
+    "shape", [(5,), (2, 3), (128,), (128, 256), (512,), (512, 512)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-1, 0, 2])
+def test_diag_tensor(shape, dtype, diagonal):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out = torch.ops.aten.diag(ref_x, diagonal)
+
+    with flag_gems.use_gems():
+        act_out = gems_diag(x, diagonal)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.diag
+@pytest.mark.parametrize(
+    "shape", [(5,), (2, 3), (128,), (128, 256), (512,), (512, 512)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-1, 0, 2])
+def test_diag_out(shape, dtype, diagonal):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # compute out shape
+    if len(shape) == 1:
+        n = shape[0]
+        m = n + abs(diagonal)
+        out_shape = (m, m)
+    else:
+        m, n = shape
+        if diagonal >= 0:
+            l = max(0, min(m, n - diagonal))  # noqa: E741
+        else:
+            l = max(0, min(m + diagonal, n))  # noqa: E741
+        out_shape = (l,)
+
+    ref_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.ops.aten.diag.out(ref_x, diagonal, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out = gems_diag_out(x, diagonal, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.diag
+@pytest.mark.parametrize(
+    "shape", [(5,), (2, 3), (128,), (128, 256), (512,), (512, 512)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-1, 0, 2])
+def test_diag_benchmark_tensor(shape, dtype, diagonal):
+    import torch.utils.benchmark as benchmark  # noqa: E402, F401
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.diag(ref_x, diagonal), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_diag(x, diagonal), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"diag {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.diag
+@pytest.mark.parametrize(
+    "shape", [(5,), (2, 3), (128,), (128, 256), (512,), (512, 512)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("diagonal", [-1, 0, 2])
+def test_diag_benchmark_out(shape, dtype, diagonal):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # compute out shape
+    if len(shape) == 1:
+        n = shape[0]
+        m = n + abs(diagonal)
+        out_shape = (m, m)
+    else:
+        m, n = shape
+        if diagonal >= 0:
+            l = max(0, min(m, n - diagonal))  # noqa: E741
+        else:
+            l = max(0, min(m + diagonal, n))  # noqa: E741
+        out_shape = (l,)
+
+    ref_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.diag.out(ref_x, diagonal, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_diag_out(x, diagonal, act_out_buf),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"diag {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/digamma__test.py
+++ b/tests/experimental_ops/digamma__test.py
@@ -1,0 +1,70 @@
+# DIGAMMA_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.digamma_ import digamma_ as gems_digamma_  # noqa: E402
+
+
+@pytest.mark.digamma_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_digamma__tensor(shape, dtype):
+    base = torch.rand(shape, device=flag_gems.device, dtype=torch.float32) * 9.5 + 0.5
+    input_tensor = base.to(dtype)
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.digamma_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_digamma_(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.digamma_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_digamma__benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark  # noqa: E402, F401
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.rand(shape, device=flag_gems.device, dtype=torch.float32) * 9.5 + 0.5
+    input_tensor = base.to(dtype)
+
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.digamma_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_digamma_(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"digamma_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/elu_test.py
+++ b/tests/experimental_ops/elu_test.py
@@ -1,0 +1,88 @@
+# ELU operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.elu import elu as gems_elu  # noqa: E402
+from flag_gems.experimental_ops.elu import elu_out as gems_elu_out  # noqa: E402
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.elu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("params", [(1.0, 1.0, 1.0), (0.5, 1.0, 1.0), (1.5, 2.0, 0.5)])
+def test_elu_tensor(shape, dtype, params):
+    alpha, scale, input_scale = params
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_out = torch.ops.aten.elu(ref_input, alpha, scale, input_scale)
+
+    with flag_gems.use_gems():
+        act_out = gems_elu(act_input, alpha, scale, input_scale)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.elu
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("params", [(1.0, 1.0, 1.0), (0.5, 1.0, 1.0), (1.5, 2.0, 0.5)])
+def test_elu_out(shape, dtype, params):
+    alpha, scale, input_scale = params
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_outbuf = torch.empty_like(ref_input)
+    ref_res = torch.ops.aten.elu.out(
+        ref_input, alpha, scale, input_scale, out=ref_outbuf
+    )
+
+    act_outbuf = torch.empty_like(act_input)
+    with flag_gems.use_gems():
+        act_res = gems_elu_out(act_input, alpha, scale, input_scale, act_outbuf)
+
+    gems_assert_close(act_res, ref_res, dtype=dtype)
+
+
+@pytest.mark.elu
+def test_perf_aten_elu():
+    # Define input generation logic matching the operator arguments
+    def elu_input_fn(shape, dtype, device):
+        alpha = 1.0  # Example fixed parameter
+        scale = 1.0  # Example fixed parameter
+        input_scale = 1.0  # Example fixed parameter
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp, alpha, scale, input_scale
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=elu_input_fn,
+        op_name="elu",
+        torch_op=torch.ops.aten.elu,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/erf__test.py
+++ b/tests/experimental_ops/erf__test.py
@@ -1,0 +1,74 @@
+# ERF_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.erf_ import erf_ as gems_erf_  # noqa: E402
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.erf_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("noncontig", [False, True])
+def test_erf__tensor(shape, dtype, noncontig):
+    device = "cuda"  # noqa: F841
+    if noncontig:
+        base = torch.randn(
+            (shape[1], shape[0]), device=flag_gems.device, dtype=torch.float32
+        )
+        input_tensor = base.transpose(0, 1).to(dtype)
+    else:
+        input_tensor = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    if dtype in (torch.float16, torch.bfloat16):
+        input_tensor = input_tensor.clamp(-3, 3)
+
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.erf_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_erf_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.erf_
+def test_perf_aten_erf_():
+    # Define input generation logic matching the operator arguments
+    def erf__input_fn(shape, dtype, device):
+        # Generate and yield inputs as required by the operator
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        if dtype in (torch.float16, torch.bfloat16):
+            inp = inp.clamp(-3, 3)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=erf__input_fn,
+        op_name="erf_",
+        torch_op=torch.ops.aten.erf_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/erfinv_test.py
+++ b/tests/experimental_ops/erfinv_test.py
@@ -1,0 +1,85 @@
+# ERFINV operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.erfinv import erfinv as gems_erfinv  # noqa: E402
+from flag_gems.experimental_ops.erfinv import (  # noqa: E402
+    erfinv_out as gems_erfinv_out,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.erfinv
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_erfinv_tensor(shape, dtype):
+    # inputs in valid domain [-1, 1]
+    base = torch.rand(shape, dtype=torch.float32, device=flag_gems.device)
+    input_tensor = (base * 1.98 - 0.99).to(dtype)
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.erfinv(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_erfinv(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.erfinv
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_erfinv_out(shape, dtype):
+    # inputs in valid domain [-1, 1]
+    base = torch.rand(shape, dtype=torch.float32, device=flag_gems.device)
+    input_tensor = (base * 1.98 - 0.99).to(dtype)
+
+    ref_input = input_tensor.clone()
+    ref_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+    ref_out = torch.ops.aten.erfinv.out(ref_input, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+        act_out = gems_erfinv_out(input_tensor, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.erfinv
+def test_perf_aten_erfinv():
+    # Define input generation logic matching the operator arguments
+    def erfinv_input_fn(shape, dtype, device):
+        # Generate inputs in valid domain [-1, 1]
+        base = torch.rand(shape, dtype=torch.float32, device=flag_gems.device)
+        input_tensor = (base * 1.98 - 0.99).to(dtype)
+        yield input_tensor,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=erfinv_input_fn,
+        op_name="erfinv",
+        torch_op=torch.ops.aten.erfinv,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/exp2__test.py
+++ b/tests/experimental_ops/exp2__test.py
@@ -1,0 +1,76 @@
+# EXP2_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.exp2_ import exp2_ as gems_exp2_  # noqa: E402
+
+
+@pytest.mark.exp2_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_exp2__tensor(shape, dtype):
+    device = "cuda"  # noqa: F841
+    base_fp32 = torch.rand(shape, device=flag_gems.device, dtype=torch.float32) * 8 - 4
+    base = base_fp32.to(dtype)
+
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_out = torch.ops.aten.exp2_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_exp2_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.exp2_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_exp2__benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark  # noqa: E402, F401
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    device = "cuda"  # noqa: F841
+    base_fp32 = torch.rand(shape, device=flag_gems.device, dtype=torch.float32) * 8 - 4
+    base = base_fp32.to(dtype)
+
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.exp2_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_exp2_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"exp2_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/expand_test.py
+++ b/tests/experimental_ops/expand_test.py
@@ -1,0 +1,109 @@
+# EXPAND operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.expand import expand as gems_expand  # noqa: E402
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.expand
+@pytest.mark.parametrize(
+    "in_shape_out",
+    [
+        ((2, 3), (2, 3)),
+        ((1, 3), (5, 3)),
+        ((2, 1, 4), (2, 7, 4)),
+        ((128, 1), (128, 256)),
+        ((64, 1, 32), (64, 512, 32)),
+        ((2, 3), (-1, 3)),
+        ((1, 3), (-1, 3)),
+        ((1, 1), (128, 256)),
+        ((16, 1, 1, 8), (16, 32, 64, 8)),
+        ((32, 4), (32, -1)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("implicit", [False, True])
+def test_expand_tensor(in_shape_out, dtype, implicit):
+    in_shape, out_size = in_shape_out
+    input_tensor = torch.randn(in_shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.expand(ref_input, out_size, implicit=implicit)
+
+    with flag_gems.use_gems():
+        act_out = gems_expand(input_tensor, out_size, implicit=implicit)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.expand
+@pytest.mark.parametrize(
+    "base_shape,op,out_size",
+    [
+        ((16, 1, 8), "transpose", (8, 32, 16)),
+        ((4, 1, 5, 1), "permute", (5, 4, 7, 9)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("implicit", [False, True])
+def test_expand_noncontiguous(base_shape, op, out_size, dtype, implicit):
+    base = torch.randn(base_shape, dtype=dtype, device=flag_gems.device)
+    ref_base = base.clone()
+
+    if op == "transpose":
+        input_tensor = base.transpose(0, 2)
+        ref_input = ref_base.transpose(0, 2)
+    else:
+        input_tensor = base.permute(2, 0, 3, 1)
+        ref_input = ref_base.permute(2, 0, 3, 1)
+
+    ref_out = torch.ops.aten.expand(ref_input, out_size, implicit=implicit)
+
+    with flag_gems.use_gems():
+        act_out = gems_expand(input_tensor, out_size, implicit=implicit)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.expand
+def test_perf_aten_expand():
+    # Define input generation logic matching the operator arguments
+    def expand_input_fn(shape, dtype, device):
+        # Generate input tensor and output size
+        input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        # Create output size based on the input shape
+        out_size = tuple(
+            s if s != -1 else input_tensor.size(i) for i, s in enumerate(shape)
+        )
+        yield input_tensor, out_size
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=expand_input_fn,
+        op_name="expand",
+        torch_op=torch.ops.aten.expand,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/fill__test.py
+++ b/tests/experimental_ops/fill__test.py
@@ -1,0 +1,86 @@
+# FILL_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.fill_ import fill__Scalar, fill__Tensor  # noqa: E402
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.fill_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("value", [0.0, 1.25, -3.5])
+def test_fill__scalar(shape, dtype, value):
+    x_ref = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    x_act = x_ref.clone()
+
+    ref_out = torch.ops.aten.fill_(x_ref, value)
+
+    with flag_gems.use_gems():
+        act_out = fill__Scalar(x_act, value)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.fill_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("value", [0.0, 2.0, -1.5])
+def test_fill__tensor(shape, dtype, value):
+    x_ref = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    x_act = x_ref.clone()
+
+    val_ref = torch.tensor(value, dtype=dtype, device=flag_gems.device)
+    val_act = torch.tensor(value, dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.ops.aten.fill_(x_ref, val_ref)
+
+    with flag_gems.use_gems():
+        act_out = fill__Tensor(x_act, val_act)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.fill_
+def test_perf_aten_fill_():
+    # Define input generation logic matching the operator arguments
+    def fill__input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        value = 1.0  # Scalar value to fill
+        yield inp, value
+
+    # Initialize benchmark - using fill__Scalar for performance test
+    def fill__Scalar_wrapper(self, value):
+        return fill__Scalar(self, value)
+
+    bench = GenericBenchmark(
+        input_fn=fill__input_fn,
+        op_name="fill_",
+        torch_op=torch.ops.aten.fill_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    # Replace the op with fill__Scalar
+    bench.op = fill__Scalar_wrapper
+
+    return bench.run()

--- a/tests/experimental_ops/fix_test.py
+++ b/tests/experimental_ops/fix_test.py
@@ -1,0 +1,124 @@
+# FIX operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.fix import fix as gems_fix  # noqa: E402
+from flag_gems.experimental_ops.fix import fix_out as gems_fix_out  # noqa: E402
+
+
+@pytest.mark.fix
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_fix_tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device) * 3.5
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.fix(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_fix(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.fix
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_fix_out_tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device) * 3.5
+
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out_buf = torch.empty_like(ref_input, device=flag_gems.device)
+    act_out_buf = torch.empty_like(act_input, device=flag_gems.device)
+
+    ref_ret = torch.ops.aten.fix.out(ref_input, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_ret = gems_fix_out(act_input, act_out_buf)
+
+    gems_assert_close(act_ret, ref_ret, dtype=dtype)
+
+
+@pytest.mark.fix
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_fix_benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark  # noqa: E402, F401
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device) * 3.5
+
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.fix(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_fix(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"fix {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.fix
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_fix_out_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device) * 3.5
+
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out_buf = torch.empty_like(ref_input, device=flag_gems.device)
+    act_out_buf = torch.empty_like(act_input, device=flag_gems.device)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.fix.out(ref_input, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_fix_out(act_input, act_out_buf), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"fix {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/frac_test.py
+++ b/tests/experimental_ops/frac_test.py
@@ -1,0 +1,118 @@
+# FRAC operator test
+
+import os
+import sys
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.frac import frac as gems_frac  # noqa: E402
+from flag_gems.experimental_ops.frac import frac_out as gems_frac_out  # noqa: E402
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.frac
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_frac_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out = torch.ops.aten.frac(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_frac(x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.frac
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("alias_out", [False, True])
+def test_frac_out(shape, dtype, alias_out):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out_buf = ref_x if alias_out else torch.empty_like(ref_x)
+    ref_out = torch.ops.aten.frac(ref_x, out=ref_out_buf)
+
+    act_out_buf = x if alias_out else torch.empty_like(x)
+    with flag_gems.use_gems():
+        act_out = gems_frac_out(x, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.frac
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_frac_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.frac(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_frac(x), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"frac {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.frac
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("alias_out", [False, True])
+def test_frac_benchmark_out(shape, dtype, alias_out):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out_buf = ref_x if alias_out else torch.empty_like(ref_x)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.frac(ref_x, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    act_out_buf = x if alias_out else torch.empty_like(x)
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_frac_out(x, act_out_buf), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"frac {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/gelu__test.py
+++ b/tests/experimental_ops/gelu__test.py
@@ -1,0 +1,61 @@
+# GELU_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.gelu_ import gelu_ as gems_gelu_  # noqa: E402
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.gelu_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("approximate", ["none", "tanh"])
+def test_gelu__tensor(shape, dtype, approximate):
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = base.clone()
+    ref_out = torch.ops.aten.gelu_(ref_input, approximate=approximate)
+
+    act_input = base.clone()
+    with flag_gems.use_gems():
+        act_out = gems_gelu_(act_input, approximate=approximate)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.gelu_
+def test_perf_aten_gelu_():
+    # Define input generation logic matching the operator arguments
+    def gelu__input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=gelu__input_fn,
+        op_name="gelu_",
+        torch_op=torch.ops.aten.gelu_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/hardshrink_test.py
+++ b/tests/experimental_ops/hardshrink_test.py
@@ -1,0 +1,85 @@
+# HARDSHRINK operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.hardshrink import (  # noqa: E402
+    hardshrink as gems_hardshrink,
+)
+from flag_gems.experimental_ops.hardshrink import (  # noqa: E402
+    hardshrink_out as gems_hardshrink_out,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.hardshrink
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("lambd", [0.0, 0.5, 1.0])
+def test_hardshrink_tensor(shape, dtype, lambd):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    ref_out = torch.ops.aten.hardshrink(ref_x, lambd)
+
+    with flag_gems.use_gems():
+        act_out = gems_hardshrink(x, lambd)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardshrink
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("lambd", [0.0, 0.75, 1.5])
+def test_hardshrink_out(shape, dtype, lambd):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    out_ref = torch.empty_like(ref_x)
+    out_act = torch.empty_like(x)
+
+    ref_out = torch.ops.aten.hardshrink.out(ref_x, lambd, out=out_ref)
+
+    with flag_gems.use_gems():
+        act_out = gems_hardshrink_out(x, lambd, out_act)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardshrink
+def test_perf_aten_hardshrink():
+    # Define input generation logic matching the operator arguments
+    def hardshrink_input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        lambd = 0.5  # Example lambda value, can be varied if needed
+        yield inp, lambd
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=hardshrink_input_fn,
+        op_name="hardshrink",
+        torch_op=torch.ops.aten.hardshrink,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/hardsigmoid__test.py
+++ b/tests/experimental_ops/hardsigmoid__test.py
@@ -1,0 +1,72 @@
+# HARDSIGMOID_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.hardsigmoid_ import (  # noqa: E402
+    hardsigmoid_ as gems_hardsigmoid_,
+)
+
+
+@pytest.mark.hardsigmoid_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardsigmoid__tensor(shape, dtype):
+    x = torch.randn(shape, device=flag_gems.device, dtype=torch.float32).to(dtype)
+
+    ref_input = x.clone()
+
+    ref_out = torch.ops.aten.hardsigmoid_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_hardsigmoid_(x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardsigmoid_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardsigmoid__benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark  # noqa: E402, F401
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, device=flag_gems.device, dtype=torch.float32).to(dtype)
+
+    ref_input = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.hardsigmoid_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_hardsigmoid_(x), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardsigmoid_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/hardswish_test.py
+++ b/tests/experimental_ops/hardswish_test.py
@@ -1,0 +1,131 @@
+# HARDSWISH operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.hardswish import (  # noqa: E402
+    hardswish as gems_hardswish,
+)
+from flag_gems.experimental_ops.hardswish import (  # noqa: E402
+    hardswish_out as gems_hardswish_out,
+)
+
+
+@pytest.mark.hardswish
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardswish_tensor(shape, dtype):
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.hardswish(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_hardswish(x.clone())
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardswish
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardswish_out(shape, dtype):
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_x = x.clone()
+    act_x = x.clone()
+
+    ref_out = torch.empty_like(ref_x)
+    act_out = torch.empty_like(act_x)
+
+    ref_ret = torch.ops.aten.hardswish.out(ref_x, out=ref_out)  # noqa: F841
+    with flag_gems.use_gems():
+        act_ret = gems_hardswish_out(act_x, act_out)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+    gems_assert_close(act_ret, ref_out, dtype=dtype)
+
+
+@pytest.mark.hardswish
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardswish_benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark  # noqa: E402, F401
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_x = x.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.hardswish(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_hardswish(x.clone()), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardswish {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.hardswish
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_hardswish_benchmark_out(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, device=flag_gems.device, dtype=dtype)
+    ref_x = x.clone()
+    act_x = x.clone()
+
+    ref_out = torch.empty_like(ref_x)
+    act_out = torch.empty_like(act_x)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.hardswish.out(ref_x, out=ref_out),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_hardswish_out(act_x, act_out), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardswish {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"hardswish {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")


### PR DESCRIPTION
 generated with [KernelGen](https://github.com/flagos-ai/KernelGen)

Operators: deg2rad, detach, diag, digamma_, elu, erf_, erfinv, exp2_, expand, fft_ifftshift, fill_, fix, frac, gelu_, hardshrink, hardsigmoid_, hardswish

- All operators pass pytest and precommit checks
- Tested: 1181+ tests passed
- Link: https://github.com/flagos-ai/FlagGems/issues/1285
