### PR TITLE
【KernelGen】add 17 missed operators

### DIFF
--- a/src/flag_gems/experimental_ops/alias_copy.py
+++ b/src/flag_gems/experimental_ops/alias_copy.py
@@ -1,0 +1,65 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _alias_copy_kernel(src_ptr, dst_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    vals = tl.load(src_ptr + offsets, mask=mask)
+    tl.store(dst_ptr + offsets, vals, mask=mask)
+
+
+def alias_copy(x: torch.Tensor):
+    """
+    Wrapper for aten::alias_copy
+    Creates and returns a copy of `x` with identical content.
+    """
+    if not x.is_cuda:
+        raise RuntimeError("alias_copy: Triton kernel requires CUDA tensors.")
+    out = torch.empty_like(x)
+    n_elements = out.numel()
+    if n_elements == 0:
+        return out
+    # Ensure contiguous memory for efficient linear copy
+    src = x.contiguous() if not x.is_contiguous() else x
+    if not out.is_contiguous():
+        out = out.contiguous()
+    if src.dtype != out.dtype:
+        raise RuntimeError("alias_copy: dtype mismatch between input and output.")
+    if src.device != out.device:
+        raise RuntimeError("alias_copy: input and output must be on the same device.")
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _alias_copy_kernel[grid](src, out, n_elements, BLOCK_SIZE=1024)
+    return out
+
+
+def alias_copy_out(x: torch.Tensor, out: torch.Tensor):
+    """
+    Wrapper for aten::alias_copy.out
+    Copies `x` into `out` and returns `out`.
+    """
+    if not x.is_cuda or not out.is_cuda:
+        raise RuntimeError("alias_copy_out: Triton kernel requires CUDA tensors.")
+    if x.dtype != out.dtype:
+        raise RuntimeError("alias_copy_out: dtype of input and output must match.")
+    if x.numel() != out.numel():
+        raise RuntimeError(
+            "alias_copy_out: input and output must have the same number of elements."
+        )
+    if x.device != out.device:
+        raise RuntimeError(
+            "alias_copy_out: input and output must be on the same device."
+        )
+    if not out.is_contiguous():
+        raise RuntimeError("alias_copy_out: output tensor must be contiguous.")
+    src = x.contiguous() if not x.is_contiguous() else x
+    n_elements = out.numel()
+    if n_elements == 0:
+        return out
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _alias_copy_kernel[grid](src, out, n_elements, BLOCK_SIZE=1024)
+    return out

--- a/src/flag_gems/experimental_ops/eq_.py
+++ b/src/flag_gems/experimental_ops/eq_.py
@@ -1,0 +1,116 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def eq_inplace_scalar_kernel(
+    self_ptr, scalar_ptr, n_elements, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(self_ptr + offsets, mask=mask)
+    s = tl.load(scalar_ptr)  # scalar
+    eq = x == s
+    result = eq.to(x.dtype)
+    tl.store(self_ptr + offsets, result, mask=mask)
+
+
+@triton.jit
+def eq_inplace_tensor_kernel(self_ptr, other_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(self_ptr + offsets, mask=mask)
+    y = tl.load(other_ptr + offsets, mask=mask)
+    eq = x == y
+    result = eq.to(x.dtype)
+    tl.store(self_ptr + offsets, result, mask=mask)
+
+
+def eq__Scalar(*args, **kwargs):
+    # Parse inputs: expect (self, other)
+    if len(args) >= 2:
+        self, other = args[0], args[1]
+    else:
+        # Support keyword styles
+        self = kwargs.get("self", kwargs.get("input"))
+        other = kwargs.get("other", None)
+    if self is None:
+        raise ValueError("eq__Scalar expects a 'self' tensor as the first argument")
+    if other is None:
+        raise ValueError("eq__Scalar expects 'other' scalar as the second argument")
+    if not isinstance(self, torch.Tensor):
+        raise TypeError("eq__Scalar: 'self' must be a torch.Tensor")
+    if not self.is_cuda:
+        raise ValueError("eq__Scalar requires CUDA tensors")
+
+    # Convert other to a scalar tensor of the same dtype/device as self
+    if isinstance(other, torch.Tensor):
+        if other.numel() != 1:
+            # If other is not scalar, redirect to tensor variant
+            return eq__Tensor(self, other)
+        other_val = other.item()
+    else:
+        other_val = other
+
+    scalar_tensor = torch.tensor(other_val, dtype=self.dtype, device=self.device)
+
+    # For simplicity, require contiguous self (common for in-place ops in kernels)
+    if not self.is_contiguous():
+        raise ValueError("eq__Scalar currently supports only contiguous 'self' tensors")
+
+    n_elements = self.numel()
+    if n_elements == 0:
+        return self
+
+    grid = lambda META: (triton.cdiv(n_elements, META["BLOCK_SIZE"]),)
+    eq_inplace_scalar_kernel[grid](self, scalar_tensor, n_elements, BLOCK_SIZE=1024)
+    return self
+
+
+def eq__Tensor(*args, **kwargs):
+    # Parse inputs: expect (self, other)
+    if len(args) >= 2:
+        self, other = args[0], args[1]
+    else:
+        # Support keyword styles
+        self = kwargs.get("self", kwargs.get("input"))
+        other = kwargs.get("other", None)
+    if self is None or other is None:
+        raise ValueError("eq__Tensor expects 'self' and 'other' tensors")
+    if not isinstance(self, torch.Tensor) or not isinstance(other, torch.Tensor):
+        raise TypeError("eq__Tensor: both 'self' and 'other' must be torch.Tensors")
+    if not self.is_cuda:
+        raise ValueError("eq__Tensor requires CUDA tensors")
+
+    # Match device and dtype to self for comparison in kernel
+    other = other.to(device=self.device, dtype=self.dtype)
+
+    # Broadcast other to self's shape, then make contiguous for simple 1D indexing
+    try:
+        other_b = other.expand_as(self)
+    except Exception as e:
+        raise ValueError(f"eq__Tensor: tensors are not broadcastable: {e}")
+    other_c = other_b.contiguous()
+
+    # Require contiguous self (in-place on original storage)
+    if not self.is_contiguous():
+        raise ValueError("eq__Tensor currently supports only contiguous 'self' tensors")
+
+    n_elements = self.numel()
+    if other_c.numel() != n_elements:
+        raise ValueError(
+            "eq__Tensor: broadcasted 'other' does not match number of elements in 'self'"
+        )
+    if n_elements == 0:
+        return self
+
+    grid = lambda META: (triton.cdiv(n_elements, META["BLOCK_SIZE"]),)
+    eq_inplace_tensor_kernel[grid](self, other_c, n_elements, BLOCK_SIZE=1024)
+    return self

--- a/src/flag_gems/experimental_ops/exp2.py
+++ b/src/flag_gems/experimental_ops/exp2.py
@@ -1,0 +1,52 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def exp2_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    ln2 = 0.693147180559945309417232121458176568
+    y = tl.exp(x * ln2)
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def exp2(x: torch.Tensor) -> torch.Tensor:
+    if not x.is_cuda:
+        raise ValueError("exp2: input tensor must be on CUDA device")
+    supported_dtypes = (torch.float16, torch.bfloat16, torch.float32)
+    if x.dtype not in supported_dtypes:
+        raise TypeError(
+            f"exp2: unsupported dtype {x.dtype}. Supported: {supported_dtypes}"
+        )
+    x_contig = x.contiguous()
+    out = torch.empty_like(x_contig)
+    n_elements = out.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    exp2_kernel[grid](x_contig, out, n_elements, BLOCK_SIZE=1024)
+    return out
+
+
+def exp2_out(x: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+    if not x.is_cuda or not out.is_cuda:
+        raise ValueError("exp2_out: both input and out tensors must be on CUDA device")
+    if x.shape != out.shape:
+        raise ValueError("exp2_out: input and out must have the same shape")
+    if x.dtype != out.dtype:
+        raise TypeError("exp2_out: input and out must have the same dtype")
+    supported_dtypes = (torch.float16, torch.bfloat16, torch.float32)
+    if x.dtype not in supported_dtypes:
+        raise TypeError(
+            f"exp2_out: unsupported dtype {x.dtype}. Supported: {supported_dtypes}"
+        )
+    x_contig = x.contiguous()
+    out_contig = out.contiguous()
+    n_elements = out_contig.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    exp2_kernel[grid](x_contig, out_contig, n_elements, BLOCK_SIZE=1024)
+    if out_contig.data_ptr() != out.data_ptr():
+        out.copy_(out_contig)
+    return out

--- a/src/flag_gems/experimental_ops/exp_.py
+++ b/src/flag_gems/experimental_ops/exp_.py
@@ -1,0 +1,61 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def exp_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x_fp32 = x.to(tl.float32)
+    y = tl.exp(x_fp32)
+    y = y.to(x.dtype)
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# Preserve reference to the Triton kernel before defining the Python wrapper
+# with the same name.
+exp__kernel = exp_
+
+
+def exp_(*args, **kwargs):
+    # Extract the input tensor
+    x = None
+    if len(args) >= 1:
+        x = args[0]
+    elif "input" in kwargs:
+        x = kwargs["input"]
+    elif "self" in kwargs:
+        x = kwargs["self"]
+    else:
+        raise ValueError(
+            "exp_ expects a tensor as the first positional argument "
+            "or 'input'/'self' keyword."
+        )
+
+    # Handle empty tensors quickly
+    if x.numel() == 0:
+        return x
+
+    # Fallbacks for unsupported cases
+    # - Non-CUDA tensors
+    # - Non-floating or complex dtypes
+    # - float64 (fp64) dtype
+    # - Non-contiguous tensors
+    if (
+        (not x.is_cuda)
+        or x.is_complex()
+        or (not x.is_floating_point())
+        or (x.dtype == torch.float64)
+        or (not x.is_contiguous())
+    ):
+        # Use PyTorch's in-place operation as a safe fallback
+        return torch.ops.aten.exp_(x)
+
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)  # noqa: E731
+    exp__kernel[grid](x, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/ge_.py
+++ b/src/flag_gems/experimental_ops/ge_.py
@@ -1,0 +1,71 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def ge_inplace_scalar_kernel(x_ptr, n_elements, other, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    cmp = x >= other
+    one = tl.full([BLOCK_SIZE], 1, x.dtype)
+    zero = tl.full([BLOCK_SIZE], 0, x.dtype)
+    out = tl.where(cmp, one, zero)
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+@triton.jit
+def ge_inplace_tensor_kernel(x_ptr, y_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    cmp = x >= y
+    one = tl.full([BLOCK_SIZE], 1, x.dtype)
+    zero = tl.full([BLOCK_SIZE], 0, x.dtype)
+    out = tl.where(cmp, one, zero)
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+def ge__Scalar(*args, **kwargs):
+    x = args[0]
+    other = args[1] if len(args) > 1 else kwargs.get("other", None)
+
+    # If other is a tensor with a single element, treat it as a scalar
+    if isinstance(other, torch.Tensor):
+        if other.numel() == 1:
+            other_val = other.to(dtype=x.dtype, device=x.device).item()
+        else:
+            return ge__Tensor(x, other)
+    else:
+        other_val = other
+
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    ge_inplace_scalar_kernel[grid](x, n_elements, other_val, BLOCK_SIZE=1024)
+    return x
+
+
+def ge__Tensor(*args, **kwargs):
+    x = args[0]
+    y = args[1]
+
+    # Handle scalar-like tensor by delegating to scalar implementation
+    if isinstance(y, torch.Tensor) and y.numel() == 1:
+        return ge__Scalar(x, y)
+
+    # Match device and dtype, then expand and ensure contiguity for y
+    y_prepped = y.to(device=x.device, dtype=x.dtype)
+    if y_prepped.shape != x.shape:
+        y_prepped = y_prepped.expand_as(x)
+    y_prepped = y_prepped.contiguous()
+
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    ge_inplace_tensor_kernel[grid](x, y_prepped, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/glu.py
+++ b/src/flag_gems/experimental_ops/glu.py
@@ -1,0 +1,151 @@
+import math  # noqa: F401
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def glu_kernel(
+    x_ptr,  # *Pointer* to input tensor data (flattened, contiguous).
+    y_ptr,  # *Pointer* to output tensor data (flattened, contiguous).
+    n_out_elements,  # Number of elements in the output tensor.
+    inner_size,  # Product of sizes of dims after 'dim' in output shape.
+    half_size,  # Size along 'dim' in output shape (i.e., original dim size // 2).
+    outer_elems,  # Number of elements per 'outer' slice in the input: (2*half_size)*inner_size.
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_out_elements
+
+    idx = offsets
+    s = half_size
+    inner = inner_size
+    outer_inc = outer_elems
+
+    # Map each output index to the corresponding input indices.
+    # For contiguous tensors:
+    # - output shape: [..., s, ...]; n_out = outer * s * inner
+    # - input shape:  [..., 2*s, ...]
+    # Let:
+    #   o = idx // (s * inner)
+    #   r = idx %  (s * inner)
+    #   d = r // inner
+    #   i = r % inner
+    # Then:
+    #   x_left_index  = o * (2*s*inner) + d * inner + i
+    #   x_right_index = x_left_index + s * inner
+    denom = s * inner
+    o = idx // denom
+    r = idx % denom
+    d = r // inner
+    i = r % inner
+
+    x_index = o * outer_inc + d * inner + i
+    gate_index = x_index + s * inner
+
+    x_val = tl.load(x_ptr + x_index, mask=mask, other=0.0)
+    g_val = tl.load(x_ptr + gate_index, mask=mask, other=0.0)
+
+    x_f = x_val.to(tl.float32)
+    g_f = g_val.to(tl.float32)
+    gate = 1.0 / (1.0 + tl.exp(-g_f))
+    y = x_f * gate
+    y_cast = y.to(x_val.dtype)
+
+    tl.store(y_ptr + idx, y_cast, mask=mask)
+
+
+def _normalize_dim(dim: int, ndim: int) -> int:
+    if dim < 0:
+        dim += ndim
+    if not (0 <= dim < ndim):
+        actual_dim = dim - ndim if dim >= ndim else dim
+        raise IndexError(
+            f"Dimension out of range (expected to be in range of "
+            f"[{-ndim}, {ndim-1}], but got {actual_dim})"
+        )
+    return dim
+
+
+def _check_dtype_supported(dtype: torch.dtype):
+    if dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise TypeError(
+            f"Unsupported dtype {dtype}. Supported dtypes are: float16, bfloat16, float32."
+        )
+
+
+def _glu_launch(x: torch.Tensor, dim: int, out: torch.Tensor = None) -> torch.Tensor:
+    if not x.is_cuda:
+        raise AssertionError("Input tensor must be on CUDA device.")
+    x = x.contiguous()
+    _check_dtype_supported(x.dtype)
+
+    ndim = x.dim()
+    dim = _normalize_dim(dim, ndim)
+    size_dim = x.size(dim)
+    if size_dim % 2 != 0:
+        raise RuntimeError(
+            f"glu: dimension {dim} size must be even, but got {size_dim}."
+        )
+
+    half = size_dim // 2
+
+    # Compute output shape
+    out_shape = list(x.shape)
+    out_shape[dim] = half
+
+    # Prepare output
+    if out is None:
+        out = torch.empty(out_shape, device=x.device, dtype=x.dtype)
+    else:
+        if not out.is_cuda:
+            raise AssertionError("Output tensor must be on CUDA device.")
+        if tuple(out.shape) != tuple(out_shape):
+            raise RuntimeError(
+                f"glu_out: provided out has wrong shape. Expected {tuple(out_shape)}, got {tuple(out.shape)}."
+            )
+        if out.dtype != x.dtype:
+            raise RuntimeError(
+                f"glu_out: dtype mismatch. out.dtype={out.dtype}, expected {x.dtype}."
+            )
+        if not out.is_contiguous():
+            raise RuntimeError("glu_out: output tensor must be contiguous.")
+    out = out.contiguous()
+
+    # Compute mapping parameters for contiguous layout
+    # inner_size = product of dimensions after 'dim' in the output shape
+    inner_size = 1
+    for k in range(dim + 1, ndim):
+        inner_size *= out_shape[k]
+
+    n_out = out.numel()
+    outer_elems = (2 * half) * inner_size  # elements per 'outer' slice in input
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_out, meta["BLOCK_SIZE"]),)  # noqa: E731
+
+    glu_kernel[grid](
+        x,
+        out,
+        n_out,
+        inner_size,
+        half,
+        outer_elems,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return out
+
+
+def glu(input: torch.Tensor, dim: int = -1) -> torch.Tensor:
+    return _glu_launch(input, dim, out=None)
+
+
+def glu_out(
+    input: torch.Tensor, dim: int = -1, out: torch.Tensor = None
+) -> torch.Tensor:
+    if out is None:
+        raise RuntimeError("glu_out: 'out' tensor must be provided.")
+    return _glu_launch(input, dim, out=out)

--- a/src/flag_gems/experimental_ops/i0.py
+++ b/src/flag_gems/experimental_ops/i0.py
@@ -1,0 +1,115 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def i0_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    x_f32 = x.to(tl.float32)
+    ax = tl.abs(x_f32)
+
+    # Small region: |x| <= 3.75
+    t = x_f32 / 3.75
+    y = t * t
+    p_small = 1.0 + y * (
+        3.5156229
+        + y
+        * (
+            3.0899424
+            + y * (1.2067492 + y * (0.2659732 + y * (0.0360768 + y * 0.0045813)))
+        )
+    )
+
+    # Large region: |x| > 3.75
+    yb = 3.75 / ax
+    p_big = 0.39894228 + yb * (
+        0.01328592
+        + yb
+        * (
+            0.00225319
+            + yb
+            * (
+                -0.00157565
+                + yb
+                * (
+                    0.00916281
+                    + yb
+                    * (
+                        -0.02057706
+                        + yb * (0.02635537 + yb * (-0.01647633 + yb * 0.00392377))
+                    )
+                )
+            )
+        )
+    )
+    # Avoid division by zero via masking; big branch only used when ax > 3.75
+    res_big = tl.exp(ax) * p_big / tl.sqrt(ax)
+
+    use_small = ax <= 3.75
+    res = tl.where(use_small, p_small, res_big)
+
+    # Store result; Triton will cast to the dtype of out_ptr as needed
+    tl.store(out_ptr + offsets, res, mask=mask)
+
+
+def _launch_i0(out: torch.Tensor, x: torch.Tensor):
+    assert x.is_cuda and out.is_cuda, "Input and output must be CUDA tensors"
+    assert (
+        out.numel() == x.numel()
+    ), "Input and output must have the same number of elements"
+    assert out.device == x.device, "Input and output must be on the same device"
+
+    x_in = x
+    out_in = out
+
+    # Ensure floating point compute
+    if not x_in.is_floating_point():
+        x_in = x_in.to(torch.get_default_dtype())
+
+    # Cast input to match the desired output dtype if needed
+    # (Compute will be done in fp32 inside kernel; store will cast to out dtype)
+    if x_in.dtype != out_in.dtype:
+        x_in = x_in.to(out_in.dtype)
+
+    x_contig = x_in.contiguous()
+    out_was_noncontig = not out_in.is_contiguous()
+    out_contig = out_in.contiguous() if out_was_noncontig else out_in
+
+    n_elements = out_contig.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    i0_kernel[grid](x_contig, out_contig, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+
+    if out_was_noncontig:
+        out_in.copy_(out_contig)
+    return out_in
+
+
+def i0(x: torch.Tensor):
+    if not x.is_cuda:
+        raise ValueError("i0: input tensor must be on CUDA device")
+    # Result dtype follows PyTorch's floating type behavior; use input dtype if floating, otherwise default
+    out_dtype = x.dtype if x.is_floating_point() else torch.get_default_dtype()
+    out = torch.empty_like(x.to(dtype=out_dtype), dtype=out_dtype, device=x.device)
+    _launch_i0(out, x)
+    return out
+
+
+def i0_out(x: torch.Tensor, out: torch.Tensor):
+    if not (x.is_cuda and out.is_cuda):
+        raise ValueError("i0_out: input and output tensors must be on CUDA device")
+    if not out.is_floating_point():
+        raise TypeError("i0_out: output tensor must be a floating point type")
+    if x.numel() != out.numel():
+        raise ValueError(
+            "i0_out: input and output must have the same number of elements"
+        )
+    _launch_i0(out, x)
+    return out

--- a/src/flag_gems/experimental_ops/logical_xor_.py
+++ b/src/flag_gems/experimental_ops/logical_xor_.py
@@ -1,0 +1,71 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def logical_xor_(a_ptr, b_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    a = tl.load(a_ptr + offsets, mask=mask)
+    b = tl.load(b_ptr + offsets, mask=mask)
+
+    a_bool = a != 0
+    b_bool = b != 0
+    out = a_bool ^ b_bool
+
+    tl.store(a_ptr + offsets, out, mask=mask)
+
+
+# Preserve reference to the Triton kernel before defining the Python wrapper with the same name.
+logical_xor___triton_kernel = logical_xor_
+
+
+def logical_xor_(*args, **kwargs):
+    # Parse inputs: expect (self, other)
+    if len(args) >= 2:
+        self, other = args[0], args[1]
+    else:
+        self = kwargs.get("input", kwargs.get("self", None))
+        other = kwargs.get("other", None)
+
+    if not isinstance(self, torch.Tensor):
+        raise TypeError("logical_xor_: first argument must be a torch.Tensor")
+    if self.dtype is not torch.bool:
+        raise RuntimeError(
+            "logical_xor_: in-place logical operations require self to have dtype torch.bool"
+        )
+
+    if not self.is_cuda:
+        raise RuntimeError("logical_xor_: tensor must be on CUDA device")
+
+    # Prepare 'other' as tensor on same device
+    if isinstance(other, torch.Tensor):
+        other_t = other.to(device=self.device)
+    else:
+        # Create scalar tensor with dtype matching self (bool)
+        other_t = torch.tensor(other, device=self.device, dtype=self.dtype)
+
+    # Broadcast 'other' to self's shape and make it contiguous for simple indexing
+    try:
+        other_bc = torch.broadcast_to(other_t, self.shape).contiguous()
+    except Exception as e:
+        raise RuntimeError(
+            f"logical_xor_: cannot broadcast 'other' to shape {tuple(self.shape)}: {e}"
+        )
+
+    # Work on a contiguous copy if self is not contiguous, then copy back
+    work_self = self if self.is_contiguous() else self.contiguous()
+
+    n_elements = work_self.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    logical_xor___triton_kernel[grid](work_self, other_bc, n_elements, BLOCK_SIZE=1024)
+
+    if work_self.data_ptr() != self.data_ptr():
+        self.copy_(work_self)
+
+    return self

--- a/src/flag_gems/experimental_ops/masked_scatter.py
+++ b/src/flag_gems/experimental_ops/masked_scatter.py
@@ -1,0 +1,143 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _masked_scatter_count_kernel(
+    mask_ptr,  # *Pointer* to mask tensor (bool)
+    counts_ptr,  # *Pointer* to per-block counts (int32)
+    n_elements,  # Number of elements in the flattened input
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    in_bounds = offsets < n_elements
+
+    m = tl.load(mask_ptr + offsets, mask=in_bounds, other=0)
+    m_i32 = m.to(tl.int32)
+    local_count = tl.sum(m_i32, axis=0)
+    tl.store(counts_ptr + pid, local_count)
+
+
+@triton.jit
+def _masked_scatter_apply_kernel(
+    in_ptr,  # *Pointer* to input tensor
+    mask_ptr,  # *Pointer* to mask tensor (bool)
+    src_ptr,  # *Pointer* to source tensor (1D)
+    out_ptr,  # *Pointer* to output tensor
+    n_elements,  # Number of elements in the flattened input
+    prefix_ptr,  # *Pointer* to per-block exclusive prefix sums (int32)
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    in_bounds = offsets < n_elements
+
+    x = tl.load(in_ptr + offsets, mask=in_bounds)
+    m = tl.load(mask_ptr + offsets, mask=in_bounds, other=0)
+    m_i32 = m.to(tl.int32)
+
+    # Compute per-block exclusive ranks for True mask elements
+    inclusive = tl.cumsum(m_i32, axis=0)
+    rank = inclusive - m_i32  # exclusive rank within the block
+
+    block_offset = tl.load(prefix_ptr + pid, mask=True, other=0).to(rank.dtype)
+    global_rank = block_offset + rank
+
+    take = m_i32 != 0
+    gathered = tl.load(src_ptr + global_rank, mask=(in_bounds & take), other=0)
+
+    out_vals = tl.where(take, gathered, x)
+    tl.store(out_ptr + offsets, out_vals, mask=in_bounds)
+
+
+def _launch_masked_scatter(
+    input_tensor: torch.Tensor,
+    mask: torch.Tensor,
+    source: torch.Tensor,
+    out_tensor: torch.Tensor = None,
+):
+    # Validate inputs
+    if input_tensor is None or mask is None or source is None:
+        raise ValueError("masked_scatter requires input, mask, and source tensors")
+
+    if mask.dtype != torch.bool:
+        mask = mask.to(torch.bool)
+
+    if input_tensor.numel() != mask.numel():
+        raise ValueError("input and mask must have the same number of elements")
+
+    if out_tensor is None:
+        out = torch.empty_like(input_tensor)
+    else:
+        out = out_tensor
+        if out.shape != input_tensor.shape:
+            raise ValueError("out tensor must have the same shape as input")
+        if out.dtype != input_tensor.dtype:
+            raise ValueError("out tensor must have the same dtype as input")
+        if out.device != input_tensor.device:
+            raise ValueError("out tensor must be on the same device as input")
+
+    device = input_tensor.device
+    if not device.type == "cuda":
+        raise ValueError("Triton kernels require CUDA tensors")
+
+    # Flatten to 1D contiguous views
+    x_flat = input_tensor.contiguous().view(-1)
+    m_flat = mask.contiguous().view(-1)
+    s_flat = source.contiguous().view(-1)
+    out_flat = out.contiguous().view(-1)
+
+    n_elements = x_flat.numel()
+    if n_elements == 0:
+        # Nothing to do
+        out.copy_(input_tensor)
+        return out
+
+    BLOCK_SIZE = 1024
+    n_blocks = triton.cdiv(n_elements, BLOCK_SIZE)
+
+    # 1) Count number of True mask elements per block
+    counts = torch.empty(n_blocks, dtype=torch.int32, device=device)
+    grid = (n_blocks,)
+    _masked_scatter_count_kernel[grid](
+        m_flat, counts, n_elements, BLOCK_SIZE=BLOCK_SIZE
+    )
+
+    # 2) Compute exclusive prefix sums of per-block counts
+    counts_prefix = torch.cumsum(counts, dim=0)
+    total_true = int(counts_prefix[-1].item()) if n_blocks > 0 else 0
+    if s_flat.numel() < total_true:
+        raise ValueError(
+            f"source has fewer elements ({s_flat.numel()}) than required by mask ({total_true})"
+        )
+    prefix_exclusive = counts_prefix - counts  # int32, same device
+
+    # 3) Apply masked_scatter using per-block prefix offsets
+    _masked_scatter_apply_kernel[grid](
+        x_flat,
+        m_flat,
+        s_flat,
+        out_flat,
+        n_elements,
+        prefix_exclusive,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+    # Reshape already matches; ensure out has the result
+    if out.data_ptr() != out_flat.data_ptr():
+        out.view(-1).copy_(out_flat)
+    return out
+
+
+def masked_scatter(input: torch.Tensor, mask: torch.Tensor, source: torch.Tensor):
+    return _launch_masked_scatter(input, mask, source, out_tensor=None)
+
+
+def masked_scatter_out(
+    input: torch.Tensor, mask: torch.Tensor, source: torch.Tensor, out: torch.Tensor
+):
+    return _launch_masked_scatter(input, mask, source, out_tensor=out)

--- a/src/flag_gems/experimental_ops/ne_.py
+++ b/src/flag_gems/experimental_ops/ne_.py
@@ -1,0 +1,70 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def ne_inplace_kernel(x_ptr, y_ptr, n_elements, y_numel, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    # broadcast y if needed
+    y_offsets = offsets % y_numel
+    y = tl.load(y_ptr + y_offsets, mask=mask)
+
+    cmp = x != y
+    one = tl.full(x.shape, 1, x.dtype)
+    zero = tl.full(x.shape, 0, x.dtype)
+    out = tl.where(cmp, one, zero)
+
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+def _launch_ne_inplace(x: torch.Tensor, y_buf: torch.Tensor, y_numel: int):
+    assert x.is_cuda and y_buf.is_cuda, "Tensors must be on CUDA device"
+    assert x.dtype == y_buf.dtype, "x and y must have the same dtype"
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert y_buf.is_contiguous(), "y buffer must be contiguous"
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+    BLOCK_SIZE = 1024
+    grid = (triton.cdiv(n_elements, BLOCK_SIZE),)
+    ne_inplace_kernel[grid](x, y_buf, n_elements, y_numel, BLOCK_SIZE=BLOCK_SIZE)
+    return x
+
+
+def ne__Scalar(self: torch.Tensor, other):
+    # other is a Python scalar or 0-d tensor
+    if isinstance(other, torch.Tensor):
+        assert other.numel() == 1, "Scalar overload expects a single value"
+        other = other.item()
+    y_buf = (
+        torch.tensor(other, dtype=self.dtype, device=self.device)
+        .reshape(1)
+        .contiguous()
+    )
+    return _launch_ne_inplace(self, y_buf, 1)
+
+
+def ne__Tensor(self: torch.Tensor, other: torch.Tensor):
+    assert other.device == self.device, "Tensors must be on the same device"
+    # Handle scalar-like tensor
+    if other.numel() == 1:
+        y_buf = other.to(dtype=self.dtype).reshape(1).contiguous()
+        return _launch_ne_inplace(self, y_buf, 1)
+    # Broadcast to self's shape
+    try:
+        other_exp = other.to(dtype=self.dtype).expand_as(self)
+    except RuntimeError as e:
+        raise RuntimeError(
+            f"Incompatible shapes for broadcasting: {self.shape} and {other.shape}"
+        ) from e
+    assert (
+        self.numel() == other_exp.numel()
+    ), "Broadcasted tensor must match the number of elements"
+    y_buf = other_exp.contiguous().view(-1)
+    return _launch_ne_inplace(self, y_buf, y_buf.numel())

--- a/src/flag_gems/experimental_ops/pixel_shuffle.py
+++ b/src/flag_gems/experimental_ops/pixel_shuffle.py
@@ -1,0 +1,163 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def pixel_shuffle_kernel(
+    in_ptr,
+    out_ptr,
+    N,
+    C_out,
+    H,
+    W,
+    R,
+    H_out,
+    W_out,
+    s_in_n,
+    s_in_c,
+    s_in_h,
+    s_in_w,
+    s_out_n,
+    s_out_c,
+    s_out_h,
+    s_out_w,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offs32 = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs32 < n_elements
+    offs = tl.cast(offs32, tl.int64)
+
+    N64 = tl.cast(N, tl.int64)  # noqa: F841
+    C64 = tl.cast(C_out, tl.int64)
+    H64 = tl.cast(H, tl.int64)  # noqa: F841
+    W64 = tl.cast(W, tl.int64)  # noqa: F841
+    R64 = tl.cast(R, tl.int64)
+    H_out64 = tl.cast(H_out, tl.int64)
+    W_out64 = tl.cast(W_out, tl.int64)
+
+    s_in_n64 = tl.cast(s_in_n, tl.int64)
+    s_in_c64 = tl.cast(s_in_c, tl.int64)
+    s_in_h64 = tl.cast(s_in_h, tl.int64)
+    s_in_w64 = tl.cast(s_in_w, tl.int64)
+
+    s_out_n64 = tl.cast(s_out_n, tl.int64)
+    s_out_c64 = tl.cast(s_out_c, tl.int64)
+    s_out_h64 = tl.cast(s_out_h, tl.int64)
+    s_out_w64 = tl.cast(s_out_w, tl.int64)
+
+    wo = offs % W_out64
+    tmp = offs // W_out64
+    ho = tmp % H_out64
+    tmp = tmp // H_out64
+    co = tmp % C64
+    no = tmp // C64
+
+    rh = ho % R64
+    h = ho // R64
+    rw = wo % R64
+    w = wo // R64
+
+    cin = co * (R64 * R64) + rh * R64 + rw
+
+    in_idx = no * s_in_n64 + cin * s_in_c64 + h * s_in_h64 + w * s_in_w64
+    out_idx = no * s_out_n64 + co * s_out_c64 + ho * s_out_h64 + wo * s_out_w64
+
+    val = tl.load(in_ptr + in_idx, mask=mask, other=0)
+    tl.store(out_ptr + out_idx, val, mask=mask)
+
+
+def _check_and_get_shapes_strides(x: torch.Tensor, upscale_factor: int):
+    if x.dim() != 4:
+        raise RuntimeError(
+            f"pixel_shuffle expects a 4D tensor (N, C, H, W), but got {x.dim()}D"
+        )
+    if upscale_factor <= 0:
+        raise RuntimeError("upscale_factor must be > 0")
+    N, C_in, H, W = x.shape
+    r2 = upscale_factor * upscale_factor
+    if C_in % r2 != 0:
+        raise RuntimeError(
+            f"Input channel dimension {C_in} is not divisible by upscale_factor^2={r2}"
+        )
+    C_out = C_in // r2
+    H_out = H * upscale_factor
+    W_out = W * upscale_factor
+    in_strides = x.stride()
+    return (N, C_in, H, W, C_out, H_out, W_out, in_strides)
+
+
+def _launch_pixel_shuffle_kernel(
+    x: torch.Tensor, out: torch.Tensor, upscale_factor: int
+):
+    N, C_in, H, W = x.shape
+    C_out = C_in // (upscale_factor * upscale_factor)
+    H_out = H * upscale_factor
+    W_out = W * upscale_factor
+
+    s_in_n, s_in_c, s_in_h, s_in_w = x.stride()
+    s_out_n, s_out_c, s_out_h, s_out_w = out.stride()
+
+    n_elements = out.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)  # noqa: E731
+    pixel_shuffle_kernel[grid](
+        x,
+        out,
+        N,
+        C_out,
+        H,
+        W,
+        upscale_factor,
+        H_out,
+        W_out,
+        s_in_n,
+        s_in_c,
+        s_in_h,
+        s_in_w,
+        s_out_n,
+        s_out_c,
+        s_out_h,
+        s_out_w,
+        n_elements,
+        BLOCK_SIZE=1024,
+    )
+
+
+def pixel_shuffle(self: torch.Tensor, upscale_factor: int):
+    if not self.is_cuda:
+        raise RuntimeError("pixel_shuffle: input must be a CUDA tensor")
+    if not isinstance(upscale_factor, int):
+        raise TypeError("pixel_shuffle: upscale_factor must be an integer")
+    N, C_in, H, W, C_out, H_out, W_out, _ = _check_and_get_shapes_strides(
+        self, upscale_factor
+    )
+    out = torch.empty(
+        (N, C_out, H_out, W_out),
+        dtype=self.dtype,
+        device=self.device,
+        layout=self.layout,
+    )
+    _launch_pixel_shuffle_kernel(self, out, upscale_factor)
+    return out
+
+
+def pixel_shuffle_out(self: torch.Tensor, upscale_factor: int, out: torch.Tensor):
+    if not self.is_cuda or not out.is_cuda:
+        raise RuntimeError("pixel_shuffle_out: input and out must be CUDA tensors")
+    if not isinstance(upscale_factor, int):
+        raise TypeError("pixel_shuffle_out: upscale_factor must be an integer")
+    N, C_in, H, W, C_out, H_out, W_out, _ = _check_and_get_shapes_strides(
+        self, upscale_factor
+    )
+    expected_shape = (N, C_out, H_out, W_out)
+    if tuple(out.shape) != expected_shape:
+        raise RuntimeError(
+            f"pixel_shuffle_out: out tensor has incorrect shape, expected {expected_shape} but got {tuple(out.shape)}"
+        )
+    if out.dtype != self.dtype:
+        raise RuntimeError("pixel_shuffle_out: out dtype must match input dtype")
+    _launch_pixel_shuffle_kernel(self, out, upscale_factor)
+    return out

--- a/src/flag_gems/experimental_ops/reciprocal_.py
+++ b/src/flag_gems/experimental_ops/reciprocal_.py
@@ -1,0 +1,39 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def reciprocal_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    out = 1.0 / x
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+# Preserve a reference to the Triton kernel before defining the Python wrapper with the same name.
+reciprocal___kernel = reciprocal_
+
+
+def reciprocal_(x: torch.Tensor):
+    # Fallback for unsupported cases
+    supported_dtypes = {torch.float16, torch.bfloat16, torch.float32}
+    if (
+        (not isinstance(x, torch.Tensor))
+        or (not x.is_cuda)
+        or (not x.is_contiguous())
+        or (x.dtype not in supported_dtypes)
+    ):
+        return torch.ops.aten.reciprocal_(x)
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)  # noqa: E731
+    reciprocal___kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/rsqrt_.py
+++ b/src/flag_gems/experimental_ops/rsqrt_.py
@@ -1,0 +1,57 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def rsqrt_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x_fp32 = x.to(tl.float32)
+    res_fp32 = 1.0 / tl.sqrt(x_fp32)
+    res = res_fp32.to(x.dtype)
+    tl.store(x_ptr + offsets, res, mask=mask)
+
+
+# Keep a handle to the Triton kernel before defining the Python wrapper with the same name.
+rsqrt__triton_kernel = rsqrt_
+
+
+def rsqrt_(*args, **kwargs):
+    # Resolve input tensor from positional or keyword arguments
+    x = None
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        x = kwargs.get("input", None)
+        if x is None:
+            x = kwargs.get("self", None)
+
+    if x is None:
+        raise ValueError("rsqrt_ expects a tensor as its first argument")
+
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("rsqrt_ expects a torch.Tensor")
+
+    if not x.is_cuda:
+        raise AssertionError("Input tensor must be on CUDA device")
+
+    if not x.is_contiguous():
+        raise AssertionError("Input tensor must be contiguous")
+
+    if x.dtype not in (torch.float16, torch.bfloat16, torch.float32, torch.float64):
+        raise TypeError(
+            "rsqrt_ only supports floating point tensors (float16, bfloat16, float32, float64)"
+        )
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    rsqrt__triton_kernel[grid](x, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/sigmoid_.py
+++ b/src/flag_gems/experimental_ops/sigmoid_.py
@@ -1,0 +1,57 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def sigmoid_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0)
+    x_dtype = x.dtype
+    x_fp32 = x.to(tl.float32)
+
+    exp_neg = tl.exp(-x_fp32)
+    exp_pos = tl.exp(x_fp32)
+    out_pos = 1.0 / (1.0 + exp_neg)
+    out_neg = exp_pos / (1.0 + exp_pos)
+    cond = x_fp32 >= 0
+    y_fp32 = tl.where(cond, out_pos, out_neg)
+    y = y_fp32.to(x_dtype)
+
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# Keep a reference to the Triton kernel before defining the Python wrapper with the same name.
+sigmoid___kernel = sigmoid_
+
+
+def sigmoid_(*args, **kwargs):
+    # Extract the input tensor following aten.sigmoid_ schema (self is the tensor)
+    x = None
+    if args:
+        x = args[0]
+    else:
+        x = kwargs.get("self", kwargs.get("input", None))
+
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("sigmoid_ expects a torch.Tensor as the first argument")
+
+    # Fallback for unsupported cases
+    if x.numel() == 0:
+        return x
+    if (
+        (not x.is_cuda)
+        or (not x.is_contiguous())
+        or x.dtype not in (torch.float16, torch.bfloat16, torch.float32)
+    ):
+        return torch.ops.aten.sigmoid_(x)
+
+    n_elements = x.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    sigmoid___kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/sin_.py
+++ b/src/flag_gems/experimental_ops/sin_.py
@@ -1,0 +1,62 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def sin_(
+    x_ptr,  # Pointer to input/output tensor (in-place).
+    n_elements,  # Number of elements.
+    BLOCK_SIZE: tl.constexpr,  # Elements processed per program.
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    x_fp32 = x.to(tl.float32)
+    y_fp32 = tl.sin(x_fp32)
+    y = y_fp32.to(x.dtype)
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+# Keep a reference to the Triton kernel before defining the Python wrapper with the same name.
+sin__kernel = sin_
+
+
+def sin_(*args, **kwargs):
+    # Extract the tensor argument similar to aten.sin_
+    x = None
+    if len(args) > 0:
+        x = args[0]
+    else:
+        x = kwargs.get("input", kwargs.get("self", None))
+    if x is None:
+        raise ValueError("sin_ expects a tensor as the first argument")
+
+    if not x.is_cuda:
+        raise ValueError("Input tensor must be on CUDA device")
+    if not x.is_contiguous():
+        raise ValueError(
+            "Input tensor must be contiguous for this Triton implementation"
+        )
+
+    # Fallback for unsupported dtypes
+    if not x.is_floating_point() or x.dtype not in (
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+    ):
+        # Use PyTorch fallback for unsupported dtypes (e.g., float64, complex)
+        torch.sin_(x)
+        return x
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    sin__kernel[grid](x, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return x

--- a/src/flag_gems/experimental_ops/slice_scatter.py
+++ b/src/flag_gems/experimental_ops/slice_scatter.py
@@ -1,0 +1,156 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _copy_kernel(x_ptr, y_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+    x = tl.load(x_ptr + offs, mask=mask)
+    tl.store(y_ptr + offs, x, mask=mask)
+
+
+@triton.jit
+def _slice_scatter_kernel(
+    src_ptr,  # pointer to src tensor (flattened)
+    out_ptr,  # pointer to output tensor (flattened)
+    outer,  # number of chunks before the sliced dimension
+    dim_size,  # size of the sliced dimension in the output
+    inner,  # number of elements after the sliced dimension
+    start,  # start index along the sliced dimension
+    step,  # step along the sliced dimension
+    m_size,  # number of indices along the sliced dimension to scatter (len of slice)
+    n_src_elements,  # total number of elements in src (outer * m_size * inner)
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_src_elements
+
+    # Promote to int64 for intermediate index math
+    offs_i64 = offs.to(tl.int64)
+
+    inner64 = tl.full([BLOCK_SIZE], inner, tl.int64)
+    m_size64 = tl.full([BLOCK_SIZE], m_size, tl.int64)
+    dim_size64 = tl.full([BLOCK_SIZE], dim_size, tl.int64)
+    start64 = tl.full([BLOCK_SIZE], start, tl.int64)
+    step64 = tl.full([BLOCK_SIZE], step, tl.int64)
+
+    chunk64 = m_size64 * inner64
+    o = offs_i64 // chunk64
+    rem = offs_i64 - o * chunk64
+    m = rem // inner64
+    i = rem - m * inner64
+
+    dest_d = start64 + m * step64  # index along sliced dimension
+    dest_linear = o * (dim_size64 * inner64) + dest_d * inner64 + i
+
+    val = tl.load(src_ptr + offs, mask=mask)
+    tl.store(out_ptr + dest_linear.to(tl.int32), val, mask=mask)
+
+
+def _normalize_slice_params(size, start, end, step):
+    assert step is not None and step != 0, "step must be non-zero"
+    # This implementation supports only positive step for simplicity
+    assert step > 0, "Only positive step is supported in this Triton implementation"
+    if start is None:
+        start = 0
+    if end is None:
+        end = size
+    if start < 0:
+        start += size
+    if end < 0:
+        end += size
+    # Clamp to [0, size]
+    start = max(0, min(start, size))
+    end = max(0, min(end, size))
+    if end <= start:
+        m = 0
+    else:
+        m = (end - start + step - 1) // step
+    return start, end, step, m
+
+
+def _slice_scatter_impl(input, src, out, dim=0, start=None, end=None, step=1):
+    assert (
+        input.is_cuda and src.is_cuda and out.is_cuda
+    ), "All tensors must be CUDA tensors"
+    assert (
+        input.is_contiguous() and src.is_contiguous() and out.is_contiguous()
+    ), "Tensors must be contiguous"
+    assert input.dtype == src.dtype == out.dtype, "All tensors must have the same dtype"
+    assert input.shape == out.shape, "Output must have same shape as input"
+
+    ndim = input.dim()
+    if ndim == 0:
+        # Scalar case: slice along dim doesn't apply, just copy input to out (and no scatter)
+        if input.numel() > 0:
+            n = input.numel()
+            grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]),)
+            _copy_kernel[grid](input, out, n, BLOCK_SIZE=1024)
+        return out
+
+    dim = dim if dim >= 0 else dim + ndim
+    assert 0 <= dim < ndim, "dim out of range"
+
+    size_d = input.size(dim)
+    s, e, st, m = _normalize_slice_params(size_d, start, end, step)
+
+    # Compute outer and inner sizes
+    outer = 1
+    for k in range(0, dim):
+        outer *= input.size(k)
+    inner = 1
+    for k in range(dim + 1, ndim):
+        inner *= input.size(k)
+
+    # Validate src shape/numel
+    expected_src_numel = outer * m * inner
+    assert src.numel() == expected_src_numel, (
+        f"src numel mismatch: got {src.numel()}, expected {expected_src_numel} "
+        f"(outer={outer}, m={m}, inner={inner})"
+    )
+
+    # 1) Copy input -> out
+    n = input.numel()
+    if n > 0:
+        grid_copy = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]),)
+        _copy_kernel[grid_copy](input, out, n, BLOCK_SIZE=1024)
+
+    # 2) Scatter src into the sliced region
+    if expected_src_numel > 0:
+        grid_scatter = lambda meta: (
+            triton.cdiv(expected_src_numel, meta["BLOCK_SIZE"]),
+        )
+        _slice_scatter_kernel[grid_scatter](
+            src,
+            out,
+            outer,
+            size_d,
+            inner,
+            s,
+            st,
+            m,
+            expected_src_numel,
+            BLOCK_SIZE=1024,
+        )
+
+    return out
+
+
+def slice_scatter(input, src, dim=0, start=None, end=None, step=1):
+    out = torch.empty_like(input)
+    return _slice_scatter_impl(
+        input, src, out, dim=dim, start=start, end=end, step=step
+    )
+
+
+def slice_scatter_out(input, src, dim=0, start=None, end=None, step=1, out=None):
+    if out is None:
+        out = torch.empty_like(input)
+    return _slice_scatter_impl(
+        input, src, out, dim=dim, start=start, end=end, step=step
+    )

--- a/src/flag_gems/experimental_ops/softplus.py
+++ b/src/flag_gems/experimental_ops/softplus.py
@@ -1,0 +1,116 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def softplus_kernel(
+    x_ptr,  # *Pointer* to input tensor
+    out_ptr,  # *Pointer* to output tensor
+    n_elements,  # Number of elements
+    beta,  # beta scalar (float32)
+    threshold,  # threshold scalar (float32)
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x_fp32 = x.to(tl.float32)
+
+    z = x_fp32 * beta
+    # compute softplus in a numerically stable way:
+    # if z > threshold => x
+    # else => log(1 + exp(z)) / beta
+    exp_z = tl.exp(z)
+    sp = tl.log(1.0 + exp_z) / beta
+    y_fp32 = tl.where(z > threshold, x_fp32, sp)
+
+    y = y_fp32.to(x.dtype)
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _softplus_launch(x: torch.Tensor, beta: float, threshold: float, out: torch.Tensor):
+    assert x.is_cuda and out.is_cuda, "Inputs must be CUDA tensors"
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert out.is_contiguous(), "Output tensor must be contiguous"
+    assert (
+        x.numel() == out.numel()
+    ), "Input and output must have the same number of elements"
+    assert x.dtype in (
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+    ), "Supported dtypes: float16, bfloat16, float32"
+    assert out.dtype == x.dtype, "Output dtype must match input dtype"
+
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    softplus_kernel[grid](
+        x, out, n_elements, float(beta), float(threshold), BLOCK_SIZE=1024
+    )
+    return out
+
+
+def _parse_softplus_args(args, kwargs, expect_out: bool = False):
+    # ATen signature: softplus(Tensor self, Scalar beta=1, Scalar threshold=20) -> Tensor
+    # ATen signature: softplus.out(Tensor self, Scalar beta=1, Scalar threshold=20, *, Tensor(a!) out) -> Tensor(a!)
+    x = None
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        x = kwargs.get("self", kwargs.get("input", None))
+    if x is None:
+        raise ValueError("softplus expects 'self' tensor as the first argument")
+
+    beta = kwargs.get("beta", 1.0)
+    if len(args) >= 2:
+        beta = args[1]
+    threshold = kwargs.get("threshold", 20.0)
+    if len(args) >= 3:
+        threshold = args[2]
+
+    out = None
+    if expect_out:
+        if "out" in kwargs:
+            out = kwargs["out"]
+        elif len(args) >= 4:
+            out = args[3]
+
+    return x, float(beta), float(threshold), out
+
+
+def softplus(*args, **kwargs):
+    x, beta, threshold, _ = _parse_softplus_args(args, kwargs, expect_out=False)
+    if not x.is_contiguous():
+        x = x.contiguous()
+    out = torch.empty_like(x)
+    _softplus_launch(x.view(-1), beta, threshold, out.view(-1))
+    return out
+
+
+def softplus_out(*args, **kwargs):
+    x, beta, threshold, out = _parse_softplus_args(args, kwargs, expect_out=True)
+    if out is None:
+        out = torch.empty_like(x)
+    # Ensure contiguous buffers for kernel execution
+    x_c = x.contiguous() if not x.is_contiguous() else x
+    out_c_needs_copyback = False
+    if (
+        (not out.is_contiguous())
+        or (out.shape != x.shape)
+        or (out.dtype != x.dtype)
+        or (out.device != x.device)
+    ):
+        out_c = torch.empty_like(x_c)
+        out_c_needs_copyback = True
+    else:
+        out_c = out
+
+    _softplus_launch(x_c.view(-1), beta, threshold, out_c.view(-1))
+
+    if out_c_needs_copyback:
+        out.copy_(out_c)
+    return out

--- a/tests/experimental_ops/alias_copy_test.py
+++ b/tests/experimental_ops/alias_copy_test.py
@@ -1,0 +1,111 @@
+# ALIAS_COPY operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.alias_copy import alias_copy as gems_alias_copy
+from flag_gems.experimental_ops.alias_copy import alias_copy_out as gems_alias_copy_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.alias_copy
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_alias_copy_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.alias_copy(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_alias_copy(x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.alias_copy
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_alias_copy_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_out = torch.empty_like(ref_x)
+    torch.ops.aten.alias_copy.out(ref_x, out=ref_out)
+
+    act_out = torch.empty_like(x)
+    with flag_gems.use_gems():
+        gems_alias_copy_out(x, act_out)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.alias_copy
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_alias_copy_benchmark(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # PyTorch reference
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.alias_copy(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # FlagGems implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_alias_copy(x), rep=100, quantiles=quantiles
+        )
+
+    speedup = ms_torch / ms_triton
+    print(f"alias_copy {shape} {dtype}:")
+    print(f"  PyTorch: {ms_torch:.3f}ms")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.alias_copy
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_alias_copy_out_benchmark(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out = torch.empty_like(ref_x)
+    act_out = torch.empty_like(x)
+
+    # PyTorch reference
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.alias_copy.out(ref_x, out=ref_out),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # FlagGems implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_alias_copy_out(x, act_out), rep=100, quantiles=quantiles
+        )
+
+    speedup = ms_torch / ms_triton
+    print(f"alias_copy.out {shape} {dtype}:")
+    print(f"  PyTorch: {ms_torch:.3f}ms")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/eq__test.py
+++ b/tests/experimental_ops/eq__test.py
@@ -1,0 +1,96 @@
+# EQ_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.eq_ import eq__Scalar as gems_eq__Scalar
+from flag_gems.experimental_ops.eq_ import eq__Tensor as gems_eq__Tensor
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.eq_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("scalar", [-0.5, 0.0, 1.0])
+def test_eq__scalar(shape, dtype, scalar):
+    x_base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x_base.clone()
+    act_x = x_base.clone()
+
+    ref_out = torch.ops.aten.eq_(ref_x, scalar)
+
+    with flag_gems.use_gems():
+        act_out = gems_eq__Scalar(act_x, scalar)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.eq_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("other_mode", ["same", "row", "col", "scalar0d"])
+def test_eq__tensor(shape, dtype, other_mode):
+    x_base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    if other_mode == "same":
+        other_base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    elif other_mode == "row":
+        other_base = torch.randn((1, shape[1]), dtype=dtype, device=flag_gems.device)
+    elif other_mode == "col":
+        other_base = torch.randn((shape[0], 1), dtype=dtype, device=flag_gems.device)
+    elif other_mode == "scalar0d":
+        other_base = torch.randn((), dtype=dtype, device=flag_gems.device)
+    else:
+        raise ValueError("invalid other_mode")
+
+    ref_x = x_base.clone()
+    act_x = x_base.clone()
+    ref_other = other_base.clone()
+    act_other = other_base.clone()
+
+    ref_out = torch.ops.aten.eq_(ref_x, ref_other)
+
+    with flag_gems.use_gems():
+        # Use Scalar variant for 0-d tensors, Tensor variant for multi-element tensors
+        if other_mode == "scalar0d":
+            act_out = gems_eq__Scalar(act_x, act_other)
+        else:
+            act_out = gems_eq__Tensor(act_x, act_other)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.eq_
+def test_perf_aten_eq_():
+    # Define input generation logic matching the operator arguments
+    def eq__input_fn(shape, dtype, device):
+        # Generate and yield inputs as required by the operator
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=eq__input_fn,
+        op_name="eq_",
+        torch_op=torch.ops.aten.eq_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/exp2_test.py
+++ b/tests/experimental_ops/exp2_test.py
@@ -1,0 +1,117 @@
+# EXP2 operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.exp2 import exp2 as gems_exp2
+from flag_gems.experimental_ops.exp2 import exp2_out as gems_exp2_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+# ============ Accuracy Tests ============
+
+
+@pytest.mark.exp2
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_accuracy_exp2_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.exp2(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_exp2(x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.exp2
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_accuracy_exp2_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_out = torch.empty_like(ref_x)
+    torch.ops.aten.exp2.out(ref_x, out=ref_out)
+
+    with flag_gems.use_gems():
+        act_out = torch.empty_like(x)
+        gems_exp2_out(x, act_out)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+# ============ Performance Tests ============
+
+
+@pytest.mark.exp2
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_perf_exp2_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+
+    # PyTorch reference benchmark
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.exp2(ref_x), rep=100, quantiles=[0.5, 0.2, 0.8]
+    )
+
+    # Triton implementation benchmark
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_exp2(x), rep=100, quantiles=[0.5, 0.2, 0.8]
+        )
+
+    speedup = ms_torch / ms_triton
+    print(
+        f"exp2_tensor: shape={shape}, dtype={dtype}, "
+        f"torch={ms_torch:.4f}ms, triton={ms_triton:.4f}ms, speedup={speedup:.2f}x"
+    )
+
+
+@pytest.mark.exp2
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_perf_exp2_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_out = torch.empty_like(ref_x)
+
+    # PyTorch reference benchmark
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.exp2.out(ref_x, out=ref_out),
+        rep=100,
+        quantiles=[0.5, 0.2, 0.8],
+    )
+
+    # Triton implementation benchmark
+    act_out = torch.empty_like(x)
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_exp2_out(x, act_out), rep=100, quantiles=[0.5, 0.2, 0.8]
+        )
+
+    speedup = ms_torch / ms_triton
+    print(
+        f"exp2_out: shape={shape}, dtype={dtype}, "
+        f"torch={ms_torch:.4f}ms, triton={ms_triton:.4f}ms, speedup={speedup:.2f}x"
+    )

--- a/tests/experimental_ops/exp__test.py
+++ b/tests/experimental_ops/exp__test.py
@@ -1,0 +1,75 @@
+# EXP_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.exp_ import exp_ as gems_exp_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.exp_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_exp__tensor(shape, dtype):
+    base = (
+        torch.empty(shape, device=flag_gems.device, dtype=torch.float32)
+        .uniform_(-6.0, 6.0)
+        .to(dtype)
+    )
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_out = torch.ops.aten.exp_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_exp_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.exp_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_exp__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = (
+        torch.empty(shape, device=flag_gems.device, dtype=torch.float32)
+        .uniform_(-6.0, 6.0)
+        .to(dtype)
+    )
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.exp_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_exp_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"exp_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/ge__test.py
+++ b/tests/experimental_ops/ge__test.py
@@ -1,0 +1,78 @@
+# GE_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.ge_ import ge__Scalar as gems_ge__Scalar
+from flag_gems.experimental_ops.ge_ import ge__Tensor as gems_ge__Tensor
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+try:
+    from tests.accuracy_utils import gems_assert_close
+
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.ge_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_ge__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    other_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    ref_other = other_tensor.clone()
+
+    ref_out = torch.ops.aten.ge_(ref_input, ref_other)
+
+    with flag_gems.use_gems():
+        act_out = gems_ge__Tensor(input_tensor, other_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.ge_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("other", [-0.5, 0.0, 1.25])
+def test_ge__scalar(shape, dtype, other):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.ge_(ref_input, other)
+
+    with flag_gems.use_gems():
+        act_out = gems_ge__Scalar(input_tensor, other)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.ge_
+def test_perf_aten_ge_():
+    # Define input generation logic matching the operator arguments
+    def ge__input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=ge__input_fn,
+        op_name="ge_",
+        torch_op=torch.ops.aten.ge_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/glu_test.py
+++ b/tests/experimental_ops/glu_test.py
@@ -1,0 +1,141 @@
+# GLU operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.glu import glu as gems_glu
+from flag_gems.experimental_ops.glu import glu_out as gems_glu_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.glu
+@pytest.mark.parametrize("shape", [(4, 6), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [-1, 0, 1])
+def test_glu_tensor(shape, dtype, dim):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.glu(ref_input, dim)
+
+    with flag_gems.use_gems():
+        act_out = gems_glu(input_tensor, dim)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.glu
+@pytest.mark.parametrize("shape", [(4, 6), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [-1, 0, 1])
+def test_glu_out(shape, dtype, dim):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ndim = len(shape)
+    dim_idx = dim if dim >= 0 else dim + ndim
+    out_shape = list(shape)
+    out_shape[dim_idx] = out_shape[dim_idx] // 2
+
+    out_ref = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    out_act = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_ret = torch.ops.aten.glu.out(ref_input, dim, out=out_ref)
+
+    with flag_gems.use_gems():
+        act_ret = gems_glu_out(input_tensor, dim, out_act)
+
+    gems_assert_close(act_ret, ref_ret, dtype=dtype)
+    gems_assert_close(out_act, out_ref, dtype=dtype)
+
+
+@pytest.mark.glu
+@pytest.mark.parametrize("shape", [(4, 6), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [-1, 0, 1])
+def test_glu_benchmark_tensor(shape, dtype, dim):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.glu(ref_input, dim), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_glu(input_tensor, dim), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"glu {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.glu
+@pytest.mark.parametrize("shape", [(4, 6), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [-1, 0, 1])
+def test_glu_benchmark_out(shape, dtype, dim):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ndim = len(shape)
+    dim_idx = dim if dim >= 0 else dim + ndim
+    out_shape = list(shape)
+    out_shape[dim_idx] = out_shape[dim_idx] // 2
+
+    out_ref = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    out_act = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.glu.out(ref_input, dim, out=out_ref),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_glu_out(input_tensor, dim, out_act),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"glu {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"glu {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/i0_test.py
+++ b/tests/experimental_ops/i0_test.py
@@ -1,0 +1,109 @@
+# I0 operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.i0 import i0 as gems_i0
+from flag_gems.experimental_ops.i0 import i0_out as gems_i0_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.i0
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_i0_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.i0(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_i0(x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.i0
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_i0_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_out = torch.empty_like(ref_x)
+    torch.ops.aten.i0.out(ref_x, out=ref_out)
+
+    act_out = torch.empty_like(x)
+    with flag_gems.use_gems():
+        gems_i0_out(x, act_out)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.i0
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_i0_benchmark(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # PyTorch reference
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.i0(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # FlagGems implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_i0(x), rep=100, quantiles=quantiles
+        )
+
+    speedup = ms_torch / ms_triton
+    print(f"i0 {shape} {dtype}:")
+    print(f"  PyTorch: {ms_torch:.3f}ms")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.i0
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_i0_out_benchmark(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_out = torch.empty_like(ref_x)
+    act_out = torch.empty_like(x)
+
+    # PyTorch reference
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.i0.out(ref_x, out=ref_out), rep=100, quantiles=quantiles
+    )
+
+    # FlagGems implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_i0_out(x, act_out), rep=100, quantiles=quantiles
+        )
+
+    speedup = ms_torch / ms_triton
+    print(f"i0.out {shape} {dtype}:")
+    print(f"  PyTorch: {ms_torch:.3f}ms")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/logical_xor__test.py
+++ b/tests/experimental_ops/logical_xor__test.py
@@ -1,0 +1,76 @@
+# LOGICAL_XOR_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.logical_xor_ import logical_xor_ as gems_logical_xor_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+try:
+    from tests.accuracy_utils import gems_assert_close
+
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.logical_xor_
+@pytest.mark.parametrize("dtype", [torch.bool])
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        ((2, 3), (2, 3)),
+        ((2, 3), (1, 3)),
+        ((2, 3), (3,)),
+        ((128, 256), (128, 256)),
+        ((128, 256), (1, 1)),
+        ((128, 256), (256,)),
+        ((512, 512), (512, 512)),
+        ((512, 512), (1,)),
+    ],
+)
+def test_logical_xor__tensor(shapes, dtype):
+    self_shape, other_shape = shapes
+    self_input = (torch.rand(self_shape, device=flag_gems.device) > 0.5).to(dtype)
+    other_input = (torch.rand(other_shape, device=flag_gems.device) > 0.5).to(dtype)
+
+    ref_self = self_input.clone()
+    ref_other = other_input.clone()
+    ref_out = torch.ops.aten.logical_xor_(ref_self, ref_other)
+
+    act_self = self_input.clone()
+    act_other = other_input.clone()
+    with flag_gems.use_gems():
+        act_out = gems_logical_xor_(act_self, act_other)
+
+    gems_assert_close(act_out, ref_out, dtype)
+
+
+@pytest.mark.logical_xor_
+def test_perf_aten_logical_xor_():
+    # Define input generation logic matching the operator arguments
+    def logical_xor__input_fn(shape, dtype, device):
+        # Generate and yield inputs as required by the operator
+        inp1 = (torch.rand(shape, device=flag_gems.device) > 0.5).to(dtype)
+        inp2 = (torch.rand(shape, device=flag_gems.device) > 0.5).to(dtype)
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=logical_xor__input_fn,
+        op_name="logical_xor_",
+        torch_op=torch.ops.aten.logical_xor_,
+        dtypes=[torch.bool],  # Use torch.bool as per the correctness test
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/masked_scatter_test.py
+++ b/tests/experimental_ops/masked_scatter_test.py
@@ -1,0 +1,97 @@
+# MASKED_SCATTER operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.masked_scatter import (
+    masked_scatter as gems_masked_scatter,
+)
+from flag_gems.experimental_ops.masked_scatter import (
+    masked_scatter_out as gems_masked_scatter_out,
+)
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+try:
+    from tests.accuracy_utils import gems_assert_close
+
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.masked_scatter
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_masked_scatter_tensor(shape, dtype):
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.75
+    source = torch.randn(self.numel(), dtype=dtype, device=flag_gems.device)
+
+    ref_self = self.clone()
+    ref_mask = mask.clone()
+    ref_source = source.clone()
+    ref_out = torch.ops.aten.masked_scatter(ref_self, ref_mask, ref_source)
+
+    act_self = self.clone()
+    act_mask = mask.clone()
+    act_source = source.clone()
+    with flag_gems.use_gems():
+        act_out = gems_masked_scatter(act_self, act_mask, act_source)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.masked_scatter
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_masked_scatter_out(shape, dtype):
+    self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.75
+    source = torch.randn(self.numel(), dtype=dtype, device=flag_gems.device)
+
+    ref_self = self.clone()
+    ref_mask = mask.clone()
+    ref_source = source.clone()
+    ref_outbuf = torch.empty_like(ref_self)
+    ref_out = torch.ops.aten.masked_scatter.out(
+        ref_self, ref_mask, ref_source, out=ref_outbuf
+    )
+
+    act_self = self.clone()
+    act_mask = mask.clone()
+    act_source = source.clone()
+    act_outbuf = torch.empty_like(act_self)
+    with flag_gems.use_gems():
+        act_out = gems_masked_scatter_out(act_self, act_mask, act_source, act_outbuf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.masked_scatter
+def test_perf_aten_masked_scatter():
+    # Define input generation logic matching the operator arguments
+    def masked_scatter_input_fn(shape, dtype, device):
+        self = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        mask = torch.rand(shape, device=flag_gems.device) > 0.75
+        source = torch.randn(self.numel(), dtype=dtype, device=flag_gems.device)
+        yield self, mask, source
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=masked_scatter_input_fn,
+        op_name="masked_scatter",
+        torch_op=torch.ops.aten.masked_scatter,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/ne__test.py
+++ b/tests/experimental_ops/ne__test.py
@@ -1,0 +1,92 @@
+# NE_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.experimental_ops.ne_ import ne__Scalar as gems_ne__Scalar
+from flag_gems.experimental_ops.ne_ import ne__Tensor as gems_ne__Tensor
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+try:
+    from tests.accuracy_utils import gems_assert_close
+
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.ne_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("other", [0.0, 1.0, -0.5])
+def test_ne__scalar(shape, dtype, other):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.ne_(ref_input, other)
+
+    with flag_gems.use_gems():
+        act_out = gems_ne__Scalar(input_tensor, other)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.ne_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("other_mode", ["same", "row", "col", "scalar0d"])
+def test_ne__tensor(shape, dtype, other_mode):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    if other_mode == "same":
+        other_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    elif other_mode == "row":
+        other_tensor = torch.randn((1, shape[1]), dtype=dtype, device=flag_gems.device)
+    elif other_mode == "col":
+        other_tensor = torch.randn((shape[0], 1), dtype=dtype, device=flag_gems.device)
+    elif other_mode == "scalar0d":
+        other_tensor = torch.randn((), dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    ref_other = other_tensor.clone()
+
+    ref_out = torch.ops.aten.ne_(ref_input, ref_other)
+
+    with flag_gems.use_gems():
+        # Use Scalar variant for 0-d tensors, Tensor variant for multi-element tensors
+        if other_mode == "scalar0d":
+            act_out = gems_ne__Scalar(input_tensor, other_tensor)
+        else:
+            act_out = gems_ne__Tensor(input_tensor, other_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.ne_
+def test_perf_aten_ne_():
+    # Define input generation logic matching the operator arguments
+    def ne__input_fn(shape, dtype, device):
+        # Generate and yield inputs as required by the operator
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=ne__input_fn,
+        op_name="ne_",
+        torch_op=torch.ops.aten.ne_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/pixel_shuffle_test.py
+++ b/tests/experimental_ops/pixel_shuffle_test.py
@@ -1,0 +1,159 @@
+# PIXEL_SHUFFLE operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.pixel_shuffle import pixel_shuffle as gems_pixel_shuffle
+from flag_gems.experimental_ops.pixel_shuffle import (
+    pixel_shuffle_out as gems_pixel_shuffle_out,
+)
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.pixel_shuffle
+@pytest.mark.parametrize(
+    "shape_r",
+    [
+        ((1, 4, 2, 3), 2),
+        ((2, 9, 4, 4), 3),
+        ((4, 64, 32, 32), 2),
+        ((2, 128, 64, 64), 2),
+        ((1, 64, 16, 16), 4),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_pixel_shuffle_tensor(shape_r, dtype):
+    shape, r = shape_r
+    n, c, h, w = shape
+    x = torch.randn((n, c, h, w), dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_out = torch.ops.aten.pixel_shuffle(ref_x, r)
+
+    with flag_gems.use_gems():
+        act_out = gems_pixel_shuffle(x, r)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.pixel_shuffle
+@pytest.mark.parametrize(
+    "shape_r",
+    [
+        ((1, 4, 2, 3), 2),
+        ((2, 9, 4, 4), 3),
+        ((4, 64, 32, 32), 2),
+        ((2, 128, 64, 64), 2),
+        ((1, 64, 16, 16), 4),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_pixel_shuffle_out(shape_r, dtype):
+    shape, r = shape_r
+    n, c, h, w = shape
+    x = torch.randn((n, c, h, w), dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    out_shape = (n, c // (r * r), h * r, w * r)
+    ref_out = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    torch.ops.aten.pixel_shuffle.out(ref_x, r, out=ref_out)
+
+    act_out = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    with flag_gems.use_gems():
+        gems_pixel_shuffle_out(x, r, act_out)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.pixel_shuffle
+@pytest.mark.parametrize(
+    "shape_r",
+    [
+        ((1, 4, 2, 3), 2),
+        ((2, 9, 4, 4), 3),
+        ((4, 64, 32, 32), 2),
+        ((2, 128, 64, 64), 2),
+        ((1, 64, 16, 16), 4),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_pixel_shuffle_benchmark(shape_r, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+    shape, r = shape_r
+    n, c, h, w = shape
+    x = torch.randn((n, c, h, w), dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+
+    # PyTorch reference
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.pixel_shuffle(ref_x, r), rep=100, quantiles=quantiles
+    )
+
+    # FlagGems implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_pixel_shuffle(x, r), rep=100, quantiles=quantiles
+        )
+
+    speedup = ms_torch / ms_triton
+    print(f"pixel_shuffle {shape} r={r} {dtype}:")
+    print(f"  PyTorch: {ms_torch:.3f}ms")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.pixel_shuffle
+@pytest.mark.parametrize(
+    "shape_r",
+    [
+        ((1, 4, 2, 3), 2),
+        ((2, 9, 4, 4), 3),
+        ((4, 64, 32, 32), 2),
+        ((2, 128, 64, 64), 2),
+        ((1, 64, 16, 16), 4),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_pixel_shuffle_out_benchmark(shape_r, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+    shape, r = shape_r
+    n, c, h, w = shape
+    x = torch.randn((n, c, h, w), dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    out_shape = (n, c // (r * r), h * r, w * r)
+    ref_out = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    act_out = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    # PyTorch reference
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.pixel_shuffle.out(ref_x, r, out=ref_out),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # FlagGems implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_pixel_shuffle_out(x, r, act_out), rep=100, quantiles=quantiles
+        )
+
+    speedup = ms_torch / ms_triton
+    print(f"pixel_shuffle.out {shape} r={r} {dtype}:")
+    print(f"  PyTorch: {ms_torch:.3f}ms")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/reciprocal__test.py
+++ b/tests/experimental_ops/reciprocal__test.py
@@ -1,0 +1,67 @@
+# RECIPROCAL_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.reciprocal_ import reciprocal_ as gems_reciprocal_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.reciprocal_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_reciprocal__tensor(shape, dtype):
+    input_tensor = torch.rand(shape, dtype=dtype, device=flag_gems.device) * 1.9 + 0.1
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.reciprocal_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_reciprocal_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype, equal_nan=False, reduce_dim=1)
+
+
+@pytest.mark.reciprocal_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_reciprocal__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.rand(shape, dtype=dtype, device=flag_gems.device) * 1.9 + 0.1
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.reciprocal_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_reciprocal_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"reciprocal_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/rsqrt__test.py
+++ b/tests/experimental_ops/rsqrt__test.py
@@ -1,0 +1,67 @@
+# RSQRT_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.rsqrt_ import rsqrt_ as gems_rsqrt_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.rsqrt_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_rsqrt__tensor(shape, dtype):
+    x = torch.rand(shape, dtype=dtype, device=flag_gems.device) + 0.1
+    ref_x = x.clone()
+    act_x = x.clone()
+
+    ref_out = torch.ops.aten.rsqrt_(ref_x)
+
+    with flag_gems.use_gems():
+        act_out = gems_rsqrt_(act_x)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.rsqrt_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_rsqrt__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.rand(shape, dtype=dtype, device=flag_gems.device) + 0.1
+    ref_x = x.clone()
+    act_x = x.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.rsqrt_(ref_x), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_rsqrt_(act_x), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"rsqrt_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/sigmoid__test.py
+++ b/tests/experimental_ops/sigmoid__test.py
@@ -1,0 +1,67 @@
+# SIGMOID_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.sigmoid_ import sigmoid_ as gems_sigmoid_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.sigmoid_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sigmoid__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.sigmoid_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_sigmoid_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.sigmoid_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sigmoid__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.sigmoid_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_sigmoid_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"sigmoid_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/sin__test.py
+++ b/tests/experimental_ops/sin__test.py
@@ -1,0 +1,67 @@
+# SIN_ operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.sin_ import sin_ as gems_sin_
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.sin_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sin__tensor(shape, dtype):
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    ref_out = torch.ops.aten.sin_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_sin_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.sin_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_sin__benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = base.clone()
+    act_input = base.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.sin_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_sin_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"sin_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/slice_scatter_test.py
+++ b/tests/experimental_ops/slice_scatter_test.py
@@ -1,0 +1,445 @@
+# SLICE_SCATTER operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.slice_scatter import slice_scatter as gems_slice_scatter
+from flag_gems.experimental_ops.slice_scatter import (
+    slice_scatter_out as gems_slice_scatter_out,
+)
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.slice_scatter
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [0, 1])
+@pytest.mark.parametrize("mode", ["none", "front", "mid", "step2", "tail"])
+def test_slice_scatter_tensor_2d(shape, dtype, dim, mode):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    L = shape[dim]
+    if mode == "none":
+        s = None
+        e = None
+        step = 1
+    elif mode == "front":
+        s = 0
+        e = max(1, L // 2)
+        step = 1
+    elif mode == "mid":
+        s = max(0, L // 3)
+        e = max(s + 1, min(L, (2 * L) // 3))
+        step = 1
+    elif mode == "step2":
+        s = 0
+        e = None
+        step = 2
+    elif mode == "tail":
+        s = max(0, L - max(1, L // 2))
+        e = L
+        step = 1
+    else:
+        s = None
+        e = None
+        step = 1
+    s_eff = 0 if s is None else s
+    e_eff = L if e is None else e
+    slice_len = (e_eff - s_eff + step - 1) // step
+    src_shape = list(shape)
+    src_shape[dim] = slice_len
+    src = torch.randn(tuple(src_shape), dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.ops.aten.slice_scatter(x.clone(), src.clone(), dim, s, e, step)
+    with flag_gems.use_gems():
+        act_out = gems_slice_scatter(x.clone(), src.clone(), dim, s, e, step)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.slice_scatter
+@pytest.mark.parametrize("shape", [(3, 4, 5), (64, 128, 32)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [0, 1, 2])
+@pytest.mark.parametrize("mode", ["none", "front", "mid", "step2", "tail"])
+def test_slice_scatter_tensor_3d(shape, dtype, dim, mode):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    L = shape[dim]
+    if mode == "none":
+        s = None
+        e = None
+        step = 1
+    elif mode == "front":
+        s = 0
+        e = max(1, L // 2)
+        step = 1
+    elif mode == "mid":
+        s = max(0, L // 3)
+        e = max(s + 1, min(L, (2 * L) // 3))
+        step = 1
+    elif mode == "step2":
+        s = 0
+        e = None
+        step = 2
+    elif mode == "tail":
+        s = max(0, L - max(1, L // 2))
+        e = L
+        step = 1
+    else:
+        s = None
+        e = None
+        step = 1
+    s_eff = 0 if s is None else s
+    e_eff = L if e is None else e
+    slice_len = (e_eff - s_eff + step - 1) // step
+    src_shape = list(shape)
+    src_shape[dim] = slice_len
+    src = torch.randn(tuple(src_shape), dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.ops.aten.slice_scatter(x.clone(), src.clone(), dim, s, e, step)
+    with flag_gems.use_gems():
+        act_out = gems_slice_scatter(x.clone(), src.clone(), dim, s, e, step)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.slice_scatter
+@pytest.mark.parametrize("shape", [(2, 3), (256, 128)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [0, 1])
+@pytest.mark.parametrize("mode", ["none", "front", "step2"])
+def test_slice_scatter_out_2d(shape, dtype, dim, mode):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    L = shape[dim]
+    if mode == "none":
+        s = None
+        e = None
+        step = 1
+    elif mode == "front":
+        s = 0
+        e = max(1, L // 2)
+        step = 1
+    elif mode == "step2":
+        s = 0
+        e = None
+        step = 2
+    else:
+        s = None
+        e = None
+        step = 1
+    s_eff = 0 if s is None else s
+    e_eff = L if e is None else e
+    slice_len = (e_eff - s_eff + step - 1) // step
+    src_shape = list(shape)
+    src_shape[dim] = slice_len
+    src = torch.randn(tuple(src_shape), dtype=dtype, device=flag_gems.device)
+
+    out_ref = torch.empty_like(x)
+    out_act = torch.empty_like(x)
+    ref_out = torch.ops.aten.slice_scatter.out(
+        x.clone(), src.clone(), dim, s, e, step, out=out_ref
+    )
+    with flag_gems.use_gems():
+        act_out = gems_slice_scatter_out(
+            x.clone(), src.clone(), dim, s, e, step, out_act
+        )
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.slice_scatter
+@pytest.mark.parametrize("shape", [(3, 4, 5)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [2])
+@pytest.mark.parametrize("mode", ["mid", "tail"])
+def test_slice_scatter_out_3d(shape, dtype, dim, mode):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    L = shape[dim]
+    if mode == "mid":
+        s = max(0, L // 3)
+        e = max(s + 1, min(L, (2 * L) // 3))
+        step = 1
+    elif mode == "tail":
+        s = max(0, L - max(1, L // 2))
+        e = L
+        step = 1
+    else:
+        s = None
+        e = None
+        step = 1
+    s_eff = 0 if s is None else s
+    e_eff = L if e is None else e
+    slice_len = (e_eff - s_eff + step - 1) // step
+    src_shape = list(shape)
+    src_shape[dim] = slice_len
+    src = torch.randn(tuple(src_shape), dtype=dtype, device=flag_gems.device)
+
+    out_ref = torch.empty_like(x)
+    out_act = torch.empty_like(x)
+    ref_out = torch.ops.aten.slice_scatter.out(
+        x.clone(), src.clone(), dim, s, e, step, out=out_ref
+    )
+    with flag_gems.use_gems():
+        act_out = gems_slice_scatter_out(
+            x.clone(), src.clone(), dim, s, e, step, out_act
+        )
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.slice_scatter
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [0, 1])
+@pytest.mark.parametrize("mode", ["none", "front", "mid", "step2", "tail"])
+def test_slice_scatter_tensor_2d_performance(shape, dtype, dim, mode):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    L = shape[dim]
+    if mode == "none":
+        s = None
+        e = None
+        step = 1
+    elif mode == "front":
+        s = 0
+        e = max(1, L // 2)
+        step = 1
+    elif mode == "mid":
+        s = max(0, L // 3)
+        e = max(s + 1, min(L, (2 * L) // 3))
+        step = 1
+    elif mode == "step2":
+        s = 0
+        e = None
+        step = 2
+    elif mode == "tail":
+        s = max(0, L - max(1, L // 2))
+        e = L
+        step = 1
+    else:
+        s = None
+        e = None
+        step = 1
+    s_eff = 0 if s is None else s
+    e_eff = L if e is None else e
+    slice_len = (e_eff - s_eff + step - 1) // step
+    src_shape = list(shape)
+    src_shape[dim] = slice_len
+    src = torch.randn(tuple(src_shape), dtype=dtype, device=flag_gems.device)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.slice_scatter(x.clone(), src.clone(), dim, s, e, step),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_slice_scatter(x.clone(), src.clone(), dim, s, e, step),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"slice_scatter {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.slice_scatter
+@pytest.mark.parametrize("shape", [(3, 4, 5), (64, 128, 32)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [0, 1, 2])
+@pytest.mark.parametrize("mode", ["none", "front", "mid", "step2", "tail"])
+def test_slice_scatter_tensor_3d_performance(shape, dtype, dim, mode):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    L = shape[dim]
+    if mode == "none":
+        s = None
+        e = None
+        step = 1
+    elif mode == "front":
+        s = 0
+        e = max(1, L // 2)
+        step = 1
+    elif mode == "mid":
+        s = max(0, L // 3)
+        e = max(s + 1, min(L, (2 * L) // 3))
+        step = 1
+    elif mode == "step2":
+        s = 0
+        e = None
+        step = 2
+    elif mode == "tail":
+        s = max(0, L - max(1, L // 2))
+        e = L
+        step = 1
+    else:
+        s = None
+        e = None
+        step = 1
+    s_eff = 0 if s is None else s
+    e_eff = L if e is None else e
+    slice_len = (e_eff - s_eff + step - 1) // step
+    src_shape = list(shape)
+    src_shape[dim] = slice_len
+    src = torch.randn(tuple(src_shape), dtype=dtype, device=flag_gems.device)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.slice_scatter(x.clone(), src.clone(), dim, s, e, step),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_slice_scatter(x.clone(), src.clone(), dim, s, e, step),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"slice_scatter {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.slice_scatter
+@pytest.mark.parametrize("shape", [(2, 3), (256, 128)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [0, 1])
+@pytest.mark.parametrize("mode", ["none", "front", "step2"])
+def test_slice_scatter_out_2d_performance(shape, dtype, dim, mode):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    L = shape[dim]
+    if mode == "none":
+        s = None
+        e = None
+        step = 1
+    elif mode == "front":
+        s = 0
+        e = max(1, L // 2)
+        step = 1
+    elif mode == "step2":
+        s = 0
+        e = None
+        step = 2
+    else:
+        s = None
+        e = None
+        step = 1
+    s_eff = 0 if s is None else s
+    e_eff = L if e is None else e
+    slice_len = (e_eff - s_eff + step - 1) // step
+    src_shape = list(shape)
+    src_shape[dim] = slice_len
+    src = torch.randn(tuple(src_shape), dtype=dtype, device=flag_gems.device)
+
+    out_ref = torch.empty_like(x)
+    out_act = torch.empty_like(x)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.slice_scatter.out(
+            x.clone(), src.clone(), dim, s, e, step, out=out_ref
+        ),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_slice_scatter_out(
+                x.clone(), src.clone(), dim, s, e, step, out_act
+            ),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"slice_scatter {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.slice_scatter
+@pytest.mark.parametrize("shape", [(3, 4, 5)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("dim", [2])
+@pytest.mark.parametrize("mode", ["mid", "tail"])
+def test_slice_scatter_out_3d_performance(shape, dtype, dim, mode):
+    quantiles = [0.5, 0.2, 0.8]
+
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    L = shape[dim]
+    if mode == "mid":
+        s = max(0, L // 3)
+        e = max(s + 1, min(L, (2 * L) // 3))
+        step = 1
+    elif mode == "tail":
+        s = max(0, L - max(1, L // 2))
+        e = L
+        step = 1
+    else:
+        s = None
+        e = None
+        step = 1
+    s_eff = 0 if s is None else s
+    e_eff = L if e is None else e
+    slice_len = (e_eff - s_eff + step - 1) // step
+    src_shape = list(shape)
+    src_shape[dim] = slice_len
+    src = torch.randn(tuple(src_shape), dtype=dtype, device=flag_gems.device)
+
+    out_ref = torch.empty_like(x)
+    out_act = torch.empty_like(x)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.slice_scatter.out(
+            x.clone(), src.clone(), dim, s, e, step, out=out_ref
+        ),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_slice_scatter_out(
+                x.clone(), src.clone(), dim, s, e, step, out_act
+            ),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"slice_scatter {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/softplus_test.py
+++ b/tests/experimental_ops/softplus_test.py
@@ -1,0 +1,133 @@
+# SOFTPLUS operator test
+
+import os
+import sys
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+from flag_gems.experimental_ops.softplus import softplus as gems_softplus
+from flag_gems.experimental_ops.softplus import softplus_out as gems_softplus_out
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.softplus
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("beta", [1.0, 2.0])
+@pytest.mark.parametrize("threshold", [20.0, 10.0])
+def test_softplus_tensor(shape, dtype, beta, threshold):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.softplus(ref_input, beta, threshold)
+
+    with flag_gems.use_gems():
+        act_out = gems_softplus(input_tensor, beta, threshold)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.softplus
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("beta", [1.0, 2.0])
+@pytest.mark.parametrize("threshold", [20.0, 10.0])
+def test_softplus_out(shape, dtype, beta, threshold):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    out_ref = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+    out_act = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.softplus.out(ref_input, beta, threshold, out=out_ref)
+
+    with flag_gems.use_gems():
+        act_out = gems_softplus_out(input_tensor, beta, threshold, out_act)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.softplus
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("beta", [1.0, 2.0])
+@pytest.mark.parametrize("threshold", [20.0, 10.0])
+def test_softplus_benchmark_tensor(shape, dtype, beta, threshold):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.softplus(ref_input, beta, threshold),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_softplus(input_tensor, beta, threshold),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"softplus {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.softplus
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("beta", [1.0, 2.0])
+@pytest.mark.parametrize("threshold", [20.0, 10.0])
+def test_softplus_benchmark_out(shape, dtype, beta, threshold):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    out_ref = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+    out_act = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.softplus.out(ref_input, beta, threshold, out=out_ref),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_softplus_out(input_tensor, beta, threshold, out_act),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"softplus {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")


### PR DESCRIPTION
   generated with [KernelGen](https://github.com/flagos-ai/KernelGen)
  
  1. alias_copy ✅
  2. eq_ ✅
  3. exp2 ✅ 
  4. exp_ ✅
  5. ge_ ✅
  6. glu ✅
  7. i0 ✅
  8. logical_xor_ ✅
  9 masked_scatter ✅
  10. ne_ ✅
  11. pixel_shuffle ✅
  12. reciprocal_ ✅
  13. rsqrt_ ✅
  14. sigmoid_ ✅
  15. sin_ ✅
  16. slice_scatter ✅
  17. softplus ✅