### PR TITLE
【KernelGen】add 17 of 85 (group 3)

### DIFF
--- a/src/flag_gems/experimental_ops/logical_not_.py
+++ b/src/flag_gems/experimental_ops/logical_not_.py
@@ -1,0 +1,52 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def logical_not__kernel(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    y = x == 0
+    tl.store(x_ptr + offsets, y, mask=mask)
+
+
+def logical_not_(*args, **kwargs):
+    # Extract the input tensor following aten.logical_not_ schema: (Tensor self) -> Tensor
+    x = None
+    if len(args) >= 1:
+        x = args[0]
+    elif "self" in kwargs:
+        x = kwargs["self"]
+    elif "input" in kwargs:
+        x = kwargs["input"]
+    if x is None:
+        raise ValueError("logical_not_ expects a tensor as the first argument.")
+
+    if x.dtype is not torch.bool:
+        raise TypeError(
+            "logical_not_ only supports bool tensors (in-place operation cannot change dtype)."
+        )
+
+    # If not CUDA tensor, fall back to PyTorch implementation for correctness
+    if not x.is_cuda:
+        return torch.ops.aten.logical_not_(x)
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+
+    # Work on a contiguous buffer; copy back if original is not contiguous
+    needs_copy_back = not x.is_contiguous()
+    buf = x if not needs_copy_back else x.contiguous()
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    logical_not__kernel[grid](buf, n_elements, BLOCK_SIZE=1024)
+
+    if needs_copy_back:
+        x.copy_(buf)
+
+    return x

--- a/src/flag_gems/experimental_ops/lt_.py
+++ b/src/flag_gems/experimental_ops/lt_.py
@@ -1,0 +1,82 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def lt_inplace_kernel(
+    x_ptr, y_ptr, n_elements, IS_SCALAR: tl.constexpr, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    if IS_SCALAR:
+        s = tl.load(y_ptr)  # y_ptr points to a single element tensor
+        cmp = x < s
+    else:
+        y = tl.load(y_ptr + offsets, mask=mask)
+        cmp = x < y
+
+    # Cast boolean comparison result to the dtype of x for in-place store
+    one = tl.full(x.shape, 1, x.dtype)
+    zero = tl.full(x.shape, 0, x.dtype)
+    out = tl.where(cmp, one, zero)
+
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+def lt__Tensor(self: torch.Tensor, other: torch.Tensor):
+    assert self.is_cuda, "Input tensor must be on CUDA device"
+    assert other.is_cuda, "Other tensor must be on CUDA device"
+    assert not self.is_complex(), "Complex dtypes are not supported"
+    assert (
+        self.is_contiguous()
+    ), "Only contiguous tensors are supported for in-place lt_"
+    # Support either same numel or scalar-like other (numel == 1)
+    if other.numel() == 1:
+        # Ensure dtype matches self for comparison
+        scalar_buf = other.to(self.dtype).reshape(1).contiguous()
+        n_elements = self.numel()
+        BLOCK_SIZE = 1024
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        lt_inplace_kernel[grid](
+            self, scalar_buf, n_elements, IS_SCALAR=True, BLOCK_SIZE=BLOCK_SIZE
+        )
+        return self
+    else:
+        assert (
+            self.numel() == other.numel()
+        ), "Shapes must match or other must be scalar"
+        assert other.is_contiguous(), "Only contiguous tensors are supported for other"
+        # Cast other to self dtype for comparison
+        other_buf = other.to(self.dtype).contiguous()
+        n_elements = self.numel()
+        BLOCK_SIZE = 1024
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        lt_inplace_kernel[grid](
+            self, other_buf, n_elements, IS_SCALAR=False, BLOCK_SIZE=BLOCK_SIZE
+        )
+        return self
+
+
+def lt__Scalar(self: torch.Tensor, other):
+    assert self.is_cuda, "Input tensor must be on CUDA device"
+    assert not self.is_complex(), "Complex dtypes are not supported"
+    assert (
+        self.is_contiguous()
+    ), "Only contiguous tensors are supported for in-place lt_"
+    # Create a 1-element tensor on device with same dtype as self for scalar compare
+    scalar_buf = torch.tensor(
+        [other], device=self.device, dtype=self.dtype
+    ).contiguous()
+    n_elements = self.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    lt_inplace_kernel[grid](
+        self, scalar_buf, n_elements, IS_SCALAR=True, BLOCK_SIZE=BLOCK_SIZE
+    )
+    return self

--- a/src/flag_gems/experimental_ops/masked_fill.py
+++ b/src/flag_gems/experimental_ops/masked_fill.py
@@ -1,0 +1,144 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def masked_fill_kernel(
+    x_ptr,
+    mask_ptr,
+    fill_ptr,
+    out_ptr,
+    n_elements,
+    shape_ptr,
+    x_stride_ptr,
+    mask_stride_ptr,
+    fill_stride_ptr,
+    out_stride_ptr,
+    NDIMS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    valid = offsets < n_elements
+
+    # Use int64 for address computations
+    rem = offsets.to(tl.int64)
+    out_off = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+    x_off = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+    mask_off = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+    fill_off = tl.zeros([BLOCK_SIZE], dtype=tl.int64)
+
+    # Compute per-dimension indices and offsets
+    for d in range(NDIMS - 1, -1, -1):
+        size_d = tl.load(shape_ptr + d)
+        idx_d = rem % size_d
+        rem = rem // size_d
+
+        sx_d = tl.load(x_stride_ptr + d)
+        sm_d = tl.load(mask_stride_ptr + d)
+        sf_d = tl.load(fill_stride_ptr + d)
+        so_d = tl.load(out_stride_ptr + d)
+
+        x_off += idx_d * sx_d
+        mask_off += idx_d * sm_d
+        fill_off += idx_d * sf_d
+        out_off += idx_d * so_d
+
+    # Load values
+    x_val = tl.load(x_ptr + x_off, mask=valid)
+    m_val = tl.load(mask_ptr + mask_off, mask=valid)
+    f_val = tl.load(fill_ptr + fill_off, mask=valid)
+
+    # Convert mask to boolean
+    m_bool = m_val != 0
+
+    # Compute output
+    out_val = tl.where(m_bool, f_val, x_val)
+
+    # Store
+    tl.store(out_ptr + out_off, out_val, mask=valid)
+
+
+def _launch_masked_fill(
+    x: torch.Tensor, mask: torch.Tensor, fill: torch.Tensor, out: torch.Tensor
+):
+    assert x.is_cuda and mask.is_cuda and fill.is_cuda and out.is_cuda
+    assert x.device == mask.device == fill.device == out.device
+
+    # Output shape is the shape of x
+    shape = tuple(x.shape)
+    NDIMS = len(shape)
+
+    # Ensure dtype matches
+    fill = fill.to(dtype=x.dtype)
+
+    # Make sure mask is boolean then cast to int8 for robust kernel comparison
+    mask = mask.to(torch.bool).to(torch.int8)
+
+    # Expand mask and fill to match x's shape for proper broadcasting strides
+    mask_exp = mask.expand(shape)
+    fill_exp = fill.expand(shape)
+
+    # Prepare stride and shape tensors (int64) on device
+    shape_t = torch.tensor(shape, dtype=torch.int64, device=x.device)
+    x_stride_t = torch.tensor(x.stride(), dtype=torch.int64, device=x.device)
+    mask_stride_t = torch.tensor(mask_exp.stride(), dtype=torch.int64, device=x.device)
+    fill_stride_t = torch.tensor(fill_exp.stride(), dtype=torch.int64, device=x.device)
+    out_stride_t = torch.tensor(out.stride(), dtype=torch.int64, device=x.device)
+
+    n_elements = out.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    masked_fill_kernel[grid](
+        x,
+        mask_exp,
+        fill_exp,
+        out,
+        n_elements,
+        shape_t,
+        x_stride_t,
+        mask_stride_t,
+        fill_stride_t,
+        out_stride_t,
+        NDIMS=NDIMS,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+def masked_fill_Scalar(self: torch.Tensor, mask: torch.Tensor, value):
+    # Create a 1-element tensor of the scalar value on device with matching dtype
+    fill = torch.tensor(value, dtype=self.dtype, device=self.device)
+    out = torch.empty_like(self)
+    _launch_masked_fill(self, mask, fill, out)
+    return out
+
+
+def masked_fill_Tensor(self: torch.Tensor, mask: torch.Tensor, value: torch.Tensor):
+    fill = value.to(device=self.device, dtype=self.dtype)
+    out = torch.empty_like(self)
+    _launch_masked_fill(self, mask, fill, out)
+    return out
+
+
+def masked_fill_Scalar_out(
+    self: torch.Tensor, mask: torch.Tensor, value, out: torch.Tensor
+):
+    assert out.is_cuda and out.device == self.device
+    assert out.shape == self.shape
+    # Create a 1-element tensor of the scalar value on device with matching dtype
+    fill = torch.tensor(value, dtype=self.dtype, device=self.device)
+    _launch_masked_fill(self, mask, fill, out)
+    return out
+
+
+def masked_fill_Tensor_out(
+    self: torch.Tensor, mask: torch.Tensor, value: torch.Tensor, out: torch.Tensor
+):
+    assert out.is_cuda and out.device == self.device
+    assert out.shape == self.shape
+    fill = value.to(device=self.device, dtype=self.dtype)
+    _launch_masked_fill(self, mask, fill, out)
+    return out

--- a/src/flag_gems/experimental_ops/masked_select.py
+++ b/src/flag_gems/experimental_ops/masked_select.py
@@ -1,0 +1,139 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _masked_select_count_kernel(
+    mask_ptr,  # int32* flattened mask (0/1)
+    n_elements,  # int32 number of elements
+    counts_ptr,  # int32* per-block counts
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    in_bounds = offsets < n_elements
+
+    flags = tl.load(mask_ptr + offsets, mask=in_bounds, other=0)  # int32 0/1
+    block_count = tl.sum(flags, axis=0)
+    tl.store(counts_ptr + pid, block_count)
+
+
+@triton.jit
+def _masked_select_scatter_kernel(
+    input_ptr,  # * input data (flattened, contiguous)
+    mask_ptr,  # int32* flattened mask (0/1)
+    block_offsets_ptr,  # int32* per-block exclusive offsets
+    output_ptr,  # * output data
+    n_elements,  # int32 number of elements
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    in_bounds = offsets < n_elements
+
+    flags = tl.load(mask_ptr + offsets, mask=in_bounds, other=0)  # int32
+    # Compute local exclusive positions for true elements
+    inclusive = tl.cumsum(flags, axis=0)
+    local_pos = inclusive - 1  # valid only where flags == 1
+
+    base = tl.load(block_offsets_ptr + pid)  # int32
+    write_idx = base + local_pos
+
+    mstore = in_bounds & (flags != 0)
+    vals = tl.load(input_ptr + offsets, mask=mstore, other=0)
+    tl.store(output_ptr + write_idx, vals, mask=mstore)
+
+
+def _prepare_broadcast_flatten(input: torch.Tensor, mask: torch.Tensor):
+    # Broadcast input and mask to a common shape
+    bshape = torch.broadcast_shapes(tuple(input.shape), tuple(mask.shape))
+    inp_b = input.expand(bshape)
+    msk_b = mask.to(torch.bool).expand(bshape)
+
+    # Make contiguous flattened views
+    inp_flat = inp_b.contiguous().view(-1)
+    msk_flat_bool = msk_b.contiguous().view(-1)
+    # Convert mask to int32 (0/1) for kernels
+    msk_flat_i32 = msk_flat_bool.to(torch.int32)
+    return inp_flat, msk_flat_i32
+
+
+def masked_select(input: torch.Tensor, mask: torch.Tensor):
+    inp_flat, msk_flat_i32 = _prepare_broadcast_flatten(input, mask)
+    device = inp_flat.device
+    assert msk_flat_i32.device == device, "input and mask must be on the same device"
+
+    n_elements = inp_flat.numel()
+    if n_elements == 0:
+        return torch.empty(0, dtype=input.dtype, device=device)
+
+    BLOCK_SIZE = 1024
+    num_blocks = triton.cdiv(n_elements, BLOCK_SIZE)
+
+    counts = torch.empty(num_blocks, dtype=torch.int32, device=device)
+    grid = (num_blocks,)
+    _masked_select_count_kernel[grid](
+        msk_flat_i32, n_elements, counts, BLOCK_SIZE=BLOCK_SIZE
+    )
+
+    # Compute per-block exclusive offsets and total number of selected elements
+    if num_blocks == 1:
+        block_offsets = torch.zeros(1, dtype=torch.int32, device=device)
+        total_selected = int(counts[0].item())
+    else:
+        prefix = torch.cumsum(counts, dim=0)
+        block_offsets = torch.empty_like(counts)
+        block_offsets[0] = 0
+        block_offsets[1:] = prefix[:-1]
+        total_selected = int(prefix[-1].item())
+
+    output = torch.empty(total_selected, dtype=input.dtype, device=device)
+    _masked_select_scatter_kernel[grid](
+        inp_flat, msk_flat_i32, block_offsets, output, n_elements, BLOCK_SIZE=BLOCK_SIZE
+    )
+    return output
+
+
+def masked_select_out(input: torch.Tensor, mask: torch.Tensor, out: torch.Tensor):
+    inp_flat, msk_flat_i32 = _prepare_broadcast_flatten(input, mask)
+    device = inp_flat.device
+    assert msk_flat_i32.device == device, "input and mask must be on the same device"
+    if out.device != device:
+        raise RuntimeError("out tensor must be on the same device as input")
+
+    n_elements = inp_flat.numel()
+    if n_elements == 0:
+        out.resize_(0)
+        return out
+
+    BLOCK_SIZE = 1024
+    num_blocks = triton.cdiv(n_elements, BLOCK_SIZE)
+
+    counts = torch.empty(num_blocks, dtype=torch.int32, device=device)
+    grid = (num_blocks,)
+    _masked_select_count_kernel[grid](
+        msk_flat_i32, n_elements, counts, BLOCK_SIZE=BLOCK_SIZE
+    )
+
+    # Compute per-block exclusive offsets and total number of selected elements
+    if num_blocks == 1:
+        block_offsets = torch.zeros(1, dtype=torch.int32, device=device)
+        total_selected = int(counts[0].item())
+    else:
+        prefix = torch.cumsum(counts, dim=0)
+        block_offsets = torch.empty_like(counts)
+        block_offsets[0] = 0
+        block_offsets[1:] = prefix[:-1]
+        total_selected = int(prefix[-1].item())
+
+    if out.dtype != input.dtype:
+        raise RuntimeError("out tensor dtype must match input dtype")
+    out.resize_(total_selected)
+
+    _masked_select_scatter_kernel[grid](
+        inp_flat, msk_flat_i32, block_offsets, out, n_elements, BLOCK_SIZE=BLOCK_SIZE
+    )
+    return out

--- a/src/flag_gems/experimental_ops/maximum.py
+++ b/src/flag_gems/experimental_ops/maximum.py
@@ -1,0 +1,262 @@
+import torch
+import triton
+import triton.language as tl
+
+MAX_DIMS = 8
+BLOCK_SIZE = 1024
+
+
+@triton.jit
+def maximum_kernel(
+    a_ptr,
+    b_ptr,
+    out_ptr,
+    n_elements,
+    s0,
+    s1,
+    s2,
+    s3,
+    s4,
+    s5,
+    s6,
+    s7,  # shape dims
+    sa0,
+    sa1,
+    sa2,
+    sa3,
+    sa4,
+    sa5,
+    sa6,
+    sa7,  # a strides
+    sb0,
+    sb1,
+    sb2,
+    sb3,
+    sb4,
+    sb5,
+    sb6,
+    sb7,  # b strides
+    so0,
+    so1,
+    so2,
+    so3,
+    so4,
+    so5,
+    so6,
+    so7,  # out strides
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    # Use int64 for address calculations
+    li = offsets.to(tl.int64)
+
+    # Compute multi-dimensional indices from linear index (row-major: last dim fastest)
+    i7 = li % s7
+    li = li // s7
+    i6 = li % s6
+    li = li // s6
+    i5 = li % s5
+    li = li // s5
+    i4 = li % s4
+    li = li // s4
+    i3 = li % s3
+    li = li // s3
+    i2 = li % s2
+    li = li // s2
+    i1 = li % s1
+    li = li // s1
+    i0 = li % s0
+    li = li // s0
+
+    # Compute element offsets for each tensor using strides (in elements)
+    off_a = (
+        i0 * sa0
+        + i1 * sa1
+        + i2 * sa2
+        + i3 * sa3
+        + i4 * sa4
+        + i5 * sa5
+        + i6 * sa6
+        + i7 * sa7
+    )
+    off_b = (
+        i0 * sb0
+        + i1 * sb1
+        + i2 * sb2
+        + i3 * sb3
+        + i4 * sb4
+        + i5 * sb5
+        + i6 * sb6
+        + i7 * sb7
+    )
+    off_o = (
+        i0 * so0
+        + i1 * so1
+        + i2 * so2
+        + i3 * so3
+        + i4 * so4
+        + i5 * so5
+        + i6 * so6
+        + i7 * so7
+    )
+
+    a_vals = tl.load(a_ptr + off_a, mask=mask, other=0)
+    b_vals = tl.load(b_ptr + off_b, mask=mask, other=0)
+    out_vals = tl.maximum(a_vals, b_vals)
+    tl.store(out_ptr + off_o, out_vals, mask=mask)
+
+
+def _as_tensor_on_device(x, device, dtype=None):
+    if torch.is_tensor(x):
+        return (
+            x.to(device=device, dtype=dtype)
+            if (dtype is not None and x.dtype != dtype) or (x.device != device)
+            else x
+        )
+    return torch.tensor(x, device=device, dtype=dtype)
+
+
+def _broadcast_to_common(a, b):
+    a_b, b_b = torch.broadcast_tensors(a, b)
+    return a_b, b_b
+
+
+def _pad_shape_strides(shape, strides):
+    # Ensure shape dims are at least 1 to avoid div by zero
+    shape_list = list(shape)
+    strides_list = list(strides)
+    nd = len(shape_list)
+    assert nd <= MAX_DIMS
+    shape_list = shape_list + [1] * (MAX_DIMS - nd)
+    strides_list = strides_list + [0] * (MAX_DIMS - nd)
+    # Triton expects integers
+    shape_list = [int(s) for s in shape_list]
+    strides_list = [int(s) for s in strides_list]
+    return shape_list, strides_list
+
+
+def _launch_maximum_kernel(a, b, out):
+    # Assumes a and b are broadcastable and already cast to out.dtype and on same device
+    a_b, b_b = _broadcast_to_common(a, b)
+    # Make inputs contiguous to avoid negative/irregular strides complications
+    # Broadcasting uses 0-stride for broadcasted dims; keeping 0-stride is fine
+    # but handle potential negative/non-standard strides by materializing.
+    if any(s < 0 for s in a_b.stride()):
+        a_b = a_b.contiguous()
+    if any(s < 0 for s in b_b.stride()):
+        b_b = b_b.contiguous()
+
+    out_shape = a_b.shape  # == b_b.shape
+    n_elements = int(a_b.numel())
+    if n_elements == 0:
+        return
+
+    # Prepare shape and strides for kernel
+    shp, sa = _pad_shape_strides(out_shape, a_b.stride())
+    _, sb = _pad_shape_strides(out_shape, b_b.stride())
+    _, so = _pad_shape_strides(out_shape, out.stride())
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    maximum_kernel[grid](
+        a_b,
+        b_b,
+        out,
+        n_elements,
+        shp[0],
+        shp[1],
+        shp[2],
+        shp[3],
+        shp[4],
+        shp[5],
+        shp[6],
+        shp[7],
+        sa[0],
+        sa[1],
+        sa[2],
+        sa[3],
+        sa[4],
+        sa[5],
+        sa[6],
+        sa[7],
+        sb[0],
+        sb[1],
+        sb[2],
+        sb[3],
+        sb[4],
+        sb[5],
+        sb[6],
+        sb[7],
+        so[0],
+        so[1],
+        so[2],
+        so[3],
+        so[4],
+        so[5],
+        so[6],
+        so[7],
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+def maximum(a, b):
+    # Determine device
+    dev = None
+    if torch.is_tensor(a):
+        dev = a.device
+    if torch.is_tensor(b):
+        dev = b.device if dev is None else dev
+    if dev is None or dev.type != "cuda":
+        raise ValueError("maximum expects at least one CUDA tensor as input")
+
+    # Determine result dtype per PyTorch promotion rules
+    res_dtype = torch.result_type(a, b)
+    a_t = _as_tensor_on_device(a, dev, dtype=res_dtype)
+    b_t = _as_tensor_on_device(b, dev, dtype=res_dtype)
+
+    # Broadcast to determine output shape
+    a_b, b_b = _broadcast_to_common(a_t, b_t)
+    out = torch.empty(a_b.shape, device=dev, dtype=res_dtype)
+
+    # If out has negative strides or is non-contiguous, compute into a contiguous buffer then copy
+    if not out.is_contiguous() or any(s < 0 for s in out.stride()):
+        out_buf = torch.empty_like(out, memory_format=torch.contiguous_format)
+        _launch_maximum_kernel(a_t, b_t, out_buf)
+        out.copy_(out_buf)
+    else:
+        _launch_maximum_kernel(a_t, b_t, out)
+
+    return out
+
+
+def maximum_out(a, b, out):
+    if not torch.is_tensor(out):
+        raise TypeError("out must be a torch.Tensor")
+    if out.device.type != "cuda":
+        raise ValueError("out tensor must be on CUDA device")
+
+    dev = out.device
+
+    # Cast inputs to out dtype (following typical .out behavior)
+    a_t = _as_tensor_on_device(a, dev, dtype=out.dtype)
+    b_t = _as_tensor_on_device(b, dev, dtype=out.dtype)
+
+    # Validate/broadcast shape against out
+    a_b, b_b = _broadcast_to_common(a_t, b_t)
+    if tuple(a_b.shape) != tuple(out.shape):
+        raise ValueError(
+            f"out shape {tuple(out.shape)} is not broadcast-compatible with inputs shape {tuple(a_b.shape)}"
+        )
+
+    # If out has negative strides or is non-contiguous, compute into a contiguous buffer then copy
+    if not out.is_contiguous() or any(s < 0 for s in out.stride()):
+        out_buf = torch.empty_like(out, memory_format=torch.contiguous_format)
+        _launch_maximum_kernel(a_t, b_t, out_buf)
+        out.copy_(out_buf)
+    else:
+        _launch_maximum_kernel(a_t, b_t, out)
+
+    return out

--- a/src/flag_gems/experimental_ops/mse_loss.py
+++ b/src/flag_gems/experimental_ops/mse_loss.py
@@ -1,0 +1,207 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _mse_elemwise_kernel(x_ptr, y_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    y = tl.load(y_ptr + offsets, mask=mask)
+    diff = x - y
+    sq = diff * diff
+    tl.store(out_ptr + offsets, sq, mask=mask)
+
+
+@triton.jit
+def _mse_reduce_kernel(
+    x_ptr, y_ptr, acc_ptr, n_elements, scale, BLOCK_SIZE: tl.constexpr
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    # load as float32 for stable accumulation
+    x = tl.load(x_ptr + offsets, mask=mask, other=0).to(tl.float32)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0).to(tl.float32)
+    diff = x - y
+    sq = diff * diff
+    sq = sq * scale
+    block_sum = tl.sum(sq, axis=0)
+    tl.atomic_add(acc_ptr, block_sum)
+
+
+def _parse_reduction(reduction):
+    # Accept both strings and integers consistent with ATen Reduction enum:
+    # 0: 'none', 1: 'mean', 2: 'sum'
+    if isinstance(reduction, str):
+        r = reduction.lower()
+        if r == "none":
+            return 0
+        if r == "mean":
+            return 1
+        if r == "sum":
+            return 2
+        raise ValueError(f"Invalid reduction string: {reduction}")
+    # Assume integer
+    if reduction in (0, 1, 2):
+        return int(reduction)
+    raise ValueError(f"Invalid reduction value: {reduction}")
+
+
+def _ensure_supported_dtype(t: torch.Tensor, op_name="mse_loss"):
+    if t.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise TypeError(
+            f"{op_name} Triton kernel supports float16, bfloat16, and float32 dtypes, got {t.dtype}."
+        )
+
+
+def _launch_mse_elemwise(x, y, out):
+    n_elements = out.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _mse_elemwise_kernel[grid](x, y, out, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+
+
+def _launch_mse_reduce(x, y, n_elements, scale):
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    acc = torch.zeros((), device=x.device, dtype=torch.float32)
+    _mse_reduce_kernel[grid](x, y, acc, n_elements, float(scale), BLOCK_SIZE=BLOCK_SIZE)
+    return acc
+
+
+def mse_loss(*args, **kwargs):
+    # Expected calling pattern: mse_loss(self, target, reduction=Mean)
+    if len(args) < 2:
+        raise TypeError(
+            "mse_loss requires at least 2 positional arguments: (input, target)"
+        )
+    inp = args[0]
+    target = args[1]
+    reduction = kwargs.get("reduction", args[2] if len(args) > 2 else 1)
+    reduction = _parse_reduction(reduction)
+
+    if not isinstance(inp, torch.Tensor) or not isinstance(target, torch.Tensor):
+        raise TypeError("mse_loss expects tensor inputs")
+
+    if inp.numel() != target.numel():
+        raise ValueError(
+            "mse_loss: input and target must have the same number of elements"
+        )
+
+    if inp.device != target.device:
+        raise ValueError("mse_loss: input and target must be on the same device")
+
+    _ensure_supported_dtype(inp, "mse_loss")
+    _ensure_supported_dtype(target, "mse_loss")
+
+    x = inp.contiguous()
+    y = target.contiguous()
+
+    n_elements = x.numel()
+
+    if reduction == 0:  # 'none'
+        out = torch.empty_like(x)
+        if not out.is_contiguous():
+            # Ensure output is contiguous for Triton; then copy back
+            tmp = torch.empty_like(x, memory_format=torch.contiguous_format)
+            _launch_mse_elemwise(x, y, tmp)
+            out.copy_(tmp)
+        else:
+            _launch_mse_elemwise(x, y, out)
+        return out.reshape_as(inp)
+
+    # sum or mean -> scalar
+    if n_elements == 0:
+        # Follow a simple convention: return 0 for empty tensors
+        zero = torch.zeros((), device=x.device, dtype=inp.dtype)
+        return zero
+
+    scale = 1.0 if reduction == 2 else (1.0 / float(n_elements))  # sum or mean
+    acc = _launch_mse_reduce(x, y, n_elements, scale)
+    result = acc.to(dtype=inp.dtype)
+    return result
+
+
+def mse_loss_out(*args, **kwargs):
+    # Expected calling pattern: mse_loss_out(self, target, reduction=Mean, *, out)
+    if len(args) < 2:
+        raise TypeError(
+            "mse_loss_out requires at least 2 positional arguments: (input, target)"
+        )
+    inp = args[0]
+    target = args[1]
+    reduction = kwargs.get("reduction", args[2] if len(args) > 2 else 1)
+    out = kwargs.get("out", args[3] if len(args) > 3 else None)
+
+    if out is None:
+        raise TypeError("mse_loss_out requires an 'out' tensor")
+
+    reduction = _parse_reduction(reduction)
+
+    if not isinstance(inp, torch.Tensor) or not isinstance(target, torch.Tensor):
+        raise TypeError("mse_loss_out expects tensor inputs")
+
+    if inp.numel() != target.numel():
+        raise ValueError(
+            "mse_loss_out: input and target must have the same number of elements"
+        )
+
+    if inp.device != target.device:
+        raise ValueError("mse_loss_out: input and target must be on the same device")
+
+    _ensure_supported_dtype(inp, "mse_loss_out")
+    _ensure_supported_dtype(target, "mse_loss_out")
+
+    x = inp.contiguous()
+    y = target.contiguous()
+    n_elements = x.numel()
+
+    if reduction == 0:  # 'none'
+        # out must have same shape as input
+        if out.numel() != n_elements:
+            raise ValueError(
+                "mse_loss_out (reduction='none'): 'out' must have the same number of elements as input"
+            )
+        if out.device != x.device:
+            raise ValueError("mse_loss_out: 'out' must be on the same device as input")
+        if out.dtype != inp.dtype:
+            raise TypeError(
+                "mse_loss_out (reduction='none'): 'out' dtype must match input dtype"
+            )
+
+        if out.is_contiguous():
+            _launch_mse_elemwise(x, y, out)
+        else:
+            tmp = torch.empty_like(x, memory_format=torch.contiguous_format)
+            _launch_mse_elemwise(x, y, tmp)
+            out.copy_(tmp)
+        return out
+
+    # sum or mean
+    if out.device != x.device:
+        raise ValueError("mse_loss_out: 'out' must be on the same device as input")
+    if out.numel() != 1:
+        raise ValueError(
+            "mse_loss_out (reduction in ['sum','mean']): 'out' must be a scalar tensor"
+        )
+    # out dtype must be a supported float dtype
+    if out.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        raise TypeError(
+            "mse_loss_out: 'out' dtype must be one of float16, bfloat16, or float32 for Triton kernel"
+        )
+
+    if n_elements == 0:
+        out.fill_(0)
+        return out
+
+    scale = 1.0 if reduction == 2 else (1.0 / float(n_elements))
+    acc = _launch_mse_reduce(x, y, n_elements, scale)
+    out.fill_(acc.to(dtype=out.dtype))
+    return out

--- a/src/flag_gems/experimental_ops/mv.py
+++ b/src/flag_gems/experimental_ops/mv.py
@@ -1,0 +1,117 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def mv_kernel(
+    A_ptr,  # *Pointer* to matrix A [M, N]
+    x_ptr,  # *Pointer* to vector x [N]
+    y_ptr,  # *Pointer* to output vector y [M]
+    M,  # rows of A
+    N,  # cols of A (and size of x)
+    stride_am,  # stride for A along M (row stride)
+    stride_an,  # stride for A along N (col stride)
+    stride_xn,  # stride for x along N
+    stride_ym,  # stride for y along M
+    BLOCK_N: tl.constexpr,  # tile size along N
+):
+    pid_m = tl.program_id(axis=0)
+    offs_n = tl.arange(0, BLOCK_N)
+    acc = tl.zeros((), dtype=tl.float32)
+
+    row_ptr = A_ptr + pid_m * stride_am
+
+    for n0 in range(0, N, BLOCK_N):
+        idx_n = n0 + offs_n
+        mask = idx_n < N
+        a = tl.load(row_ptr + idx_n * stride_an, mask=mask, other=0.0)
+        x = tl.load(x_ptr + idx_n * stride_xn, mask=mask, other=0.0)
+        # accumulate in fp32 for better precision
+        acc += tl.sum(a.to(tl.float32) * x.to(tl.float32), axis=0)
+
+    tl.store(y_ptr + pid_m * stride_ym, acc)
+
+
+def _launch_mv_kernel(A: torch.Tensor, x: torch.Tensor, y: torch.Tensor):
+    M, N = A.shape
+    assert x.numel() == N
+    grid = (M,)
+    mv_kernel[grid](
+        A,
+        x,
+        y,
+        M,
+        N,
+        A.stride(0),
+        A.stride(1),
+        x.stride(0),
+        y.stride(0),
+        BLOCK_N=256,
+        num_warps=4,
+        num_stages=2,
+    )
+
+
+def mv(A: torch.Tensor, x: torch.Tensor):
+    # Validate inputs
+    assert isinstance(A, torch.Tensor) and isinstance(
+        x, torch.Tensor
+    ), "Inputs must be tensors"
+    assert A.ndim == 2 and x.ndim == 1, "mv expects A: 2D tensor and x: 1D tensor"
+    assert A.shape[1] == x.shape[0], "Incompatible dimensions for mv"
+    assert (
+        A.is_cuda and x.is_cuda and A.device == x.device
+    ), "All tensors must be on the same CUDA device"
+
+    # Determine output dtype following PyTorch's type promotion
+    out_dtype = torch.result_type(A, x)
+    M = A.shape[0]
+    if M == 0:
+        return torch.empty((0,), device=A.device, dtype=out_dtype)
+
+    # Prepare tensors (dtype + contiguous)
+    A_ = A.to(out_dtype).contiguous()
+    x_ = x.to(out_dtype).contiguous()
+    y = torch.empty((M,), device=A.device, dtype=out_dtype)
+    y_ = y.contiguous()
+
+    _launch_mv_kernel(A_, x_, y_)
+
+    if y_.data_ptr() != y.data_ptr():
+        y.copy_(y_)
+    return y
+
+
+def mv_out(A: torch.Tensor, x: torch.Tensor, out: torch.Tensor):
+    # Validate inputs
+    assert (
+        isinstance(A, torch.Tensor)
+        and isinstance(x, torch.Tensor)
+        and isinstance(out, torch.Tensor)
+    ), "Inputs must be tensors"
+    assert (
+        A.ndim == 2 and x.ndim == 1 and out.ndim == 1
+    ), "Shapes must be A: [M, N], x: [N], out: [M]"
+    assert A.shape[1] == x.shape[0], "Incompatible dimensions for mv.out"
+    assert out.shape[0] == A.shape[0], "Output shape must match rows of A"
+    assert A.is_cuda and x.is_cuda and out.is_cuda, "All tensors must be CUDA tensors"
+    assert A.device == x.device == out.device, "All tensors must be on the same device"
+
+    # Execute in the dtype of out (PyTorch .out usually determines dtype by out)
+    compute_dtype = out.dtype
+    M = A.shape[0]
+    if M == 0:
+        return out
+
+    A_ = A.to(compute_dtype).contiguous()
+    x_ = x.to(compute_dtype).contiguous()
+
+    if out.is_contiguous():
+        _launch_mv_kernel(A_, x_, out)
+        return out
+    else:
+        y_tmp = torch.empty_like(out, memory_format=torch.contiguous_format)
+        _launch_mv_kernel(A_, x_, y_tmp)
+        out.copy_(y_tmp)
+        return out

--- a/src/flag_gems/experimental_ops/native_dropout_backward.py
+++ b/src/flag_gems/experimental_ops/native_dropout_backward.py
@@ -1,0 +1,85 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _native_dropout_backward_kernel(
+    grad_ptr,  # *Pointer* to grad_output tensor
+    mask_ptr,  # *Pointer* to mask tensor (cast to same dtype as grad)
+    out_ptr,  # *Pointer* to output grad_input tensor
+    n_elements,  # Number of elements
+    scale,  # Scaling factor (float)
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    in_bounds = offsets < n_elements
+
+    g = tl.load(grad_ptr + offsets, mask=in_bounds, other=0)
+    m = tl.load(mask_ptr + offsets, mask=in_bounds, other=0)
+
+    # grad_input = grad_output * mask * scale
+    out = g * m * scale
+    tl.store(out_ptr + offsets, out, mask=in_bounds)
+
+
+def _launch_native_dropout_backward(
+    grad_output: torch.Tensor, mask: torch.Tensor, scale: float, out: torch.Tensor
+):
+    assert (
+        grad_output.is_cuda and mask.is_cuda and out.is_cuda
+    ), "All tensors must be CUDA tensors"
+    assert (
+        grad_output.numel() == mask.numel() == out.numel()
+    ), "grad_output, mask, and out must have the same number of elements"
+    assert grad_output.dtype in (
+        torch.float16,
+        torch.bfloat16,
+        torch.float32,
+    ), "Supported dtypes: float16, bfloat16, float32"
+    assert out.dtype == grad_output.dtype, "Output dtype must match grad_output dtype"
+    assert (
+        grad_output.device == mask.device == out.device
+    ), "All tensors must be on the same device"
+
+    go = grad_output.contiguous()
+    m = mask.contiguous()
+    if m.dtype != go.dtype:
+        m = m.to(dtype=go.dtype)
+
+    out_contig = out if out.is_contiguous() else torch.empty_like(go)
+
+    n_elements = go.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _native_dropout_backward_kernel[grid](
+        go, m, out_contig, n_elements, float(scale), BLOCK_SIZE=BLOCK_SIZE
+    )
+
+    if out_contig.data_ptr() != out.data_ptr():
+        out.copy_(out_contig)
+    return out
+
+
+def native_dropout_backward(
+    grad_output: torch.Tensor, mask: torch.Tensor, scale: float
+):
+    """
+    Wrapper for aten::native_dropout_backward
+    Computes grad_input = grad_output * mask.to(grad_output.dtype) * scale
+    """
+    out = torch.empty_like(grad_output)
+    return _launch_native_dropout_backward(grad_output, mask, scale, out)
+
+
+def native_dropout_backward_out(
+    grad_output: torch.Tensor, mask: torch.Tensor, scale: float, out: torch.Tensor
+):
+    """
+    Wrapper for aten::native_dropout_backward.out
+    Writes result into 'out'
+    """
+    _launch_native_dropout_backward(grad_output, mask, scale, out)
+    return out

--- a/src/flag_gems/experimental_ops/neg_.py
+++ b/src/flag_gems/experimental_ops/neg_.py
@@ -1,0 +1,43 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def neg__kernel(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x = -x
+    tl.store(x_ptr + offsets, x, mask=mask)
+
+
+def neg_(*args, **kwargs):
+    # Retrieve input tensor (first positional or from kwargs)
+    if len(args) >= 1:
+        x = args[0]
+    elif "input" in kwargs:
+        x = kwargs["input"]
+    elif "self" in kwargs:
+        x = kwargs["self"]
+    else:
+        raise ValueError("neg_ expects a tensor as the first argument")
+
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("neg_ expects a torch.Tensor")
+
+    if x.numel() == 0:
+        return x
+
+    if not x.is_cuda:
+        raise ValueError("neg_ Triton kernel requires a CUDA tensor")
+
+    if not x.is_contiguous():
+        raise ValueError("neg_ Triton kernel requires a contiguous tensor")
+
+    n_elements = x.numel()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    neg__kernel[grid](x, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/negative.py
+++ b/src/flag_gems/experimental_ops/negative.py
@@ -1,0 +1,43 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def negative_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    tl.store(out_ptr + offsets, -x, mask=mask)
+
+
+def _launch_negative(x: torch.Tensor, out: torch.Tensor):
+    assert x.is_cuda and out.is_cuda, "Tensors must be on CUDA device"
+    assert x.dtype == out.dtype, "Input and output must have the same dtype"
+    assert (
+        x.numel() == out.numel()
+    ), "Input and output must have the same number of elements"
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    assert out.is_contiguous(), "Output tensor must be contiguous"
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return out
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    negative_kernel[grid](x, out, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return out
+
+
+def negative(x: torch.Tensor):
+    out = torch.empty_like(x.contiguous())
+    _launch_negative(x.contiguous(), out)
+    return out
+
+
+def negative_out(x: torch.Tensor, out: torch.Tensor):
+    _launch_negative(x, out)
+    return out

--- a/src/flag_gems/experimental_ops/negative_.py
+++ b/src/flag_gems/experimental_ops/negative_.py
@@ -1,0 +1,31 @@
+import torch  # noqa: F401
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def negative_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    x = -x
+    tl.store(x_ptr + offsets, x, mask=mask)
+
+
+_negative__kernel = negative_
+
+
+def negative_(*args, **kwargs):
+    x = args[0] if len(args) > 0 else kwargs.get("input", kwargs.get("self", None))
+    if x is None:
+        raise ValueError("negative_ expects a tensor as the first argument")
+    assert x.is_cuda, "Input tensor must be on CUDA device"
+    assert x.is_contiguous(), "Input tensor must be contiguous"
+    n_elements = x.numel()
+    if n_elements == 0:
+        return x
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _negative__kernel[grid](x, n_elements, BLOCK_SIZE=1024)
+    return x

--- a/src/flag_gems/experimental_ops/new_ones.py
+++ b/src/flag_gems/experimental_ops/new_ones.py
@@ -1,0 +1,169 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _fill_ones_kernel(
+    out_ptr,  # *Pointer* to output tensor
+    n_elements,  # Total number of elements to write
+    BLOCK_SIZE: tl.constexpr,
+    DTYPE: tl.constexpr,  # Triton dtype for output
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    ones = tl.full((BLOCK_SIZE,), 1, dtype=DTYPE)
+    tl.store(out_ptr + offsets, ones, mask=mask)
+
+
+def _torch_dtype_to_triton_dtype(dtype: torch.dtype):
+    if dtype == torch.float32:
+        return tl.float32
+    if dtype == torch.float16:
+        return tl.float16
+    if dtype == torch.bfloat16:
+        return tl.bfloat16
+    if dtype == torch.float64:
+        return tl.float64
+    if dtype == torch.int8:
+        return tl.int8
+    if dtype == torch.uint8:
+        return tl.uint8
+    if dtype == torch.int16:
+        return tl.int16
+    if dtype == torch.int32:
+        return tl.int32
+    if dtype == torch.int64:
+        return tl.int64
+    # Best-effort for bool
+    if dtype == torch.bool:
+        # Triton represents boolean as int1
+        return tl.int1
+    raise TypeError(f"Unsupported dtype for Triton kernel: {dtype}")
+
+
+def _normalize_size_arg(size):
+    if isinstance(size, torch.Size):
+        return tuple(int(s) for s in size)
+    if isinstance(size, (list, tuple)):
+        return tuple(int(s) for s in size)
+    if isinstance(size, int):
+        return (int(size),)
+    raise TypeError(f"Invalid size specification: {size}")
+
+
+def _extract_size_from_args(after_self_pos_args, kwargs):
+    # Try positional
+    if len(after_self_pos_args) == 1 and isinstance(
+        after_self_pos_args[0], (list, tuple, torch.Size, int)
+    ):
+        return _normalize_size_arg(after_self_pos_args[0])
+    if len(after_self_pos_args) >= 1 and all(
+        isinstance(x, int) for x in after_self_pos_args
+    ):
+        return tuple(int(x) for x in after_self_pos_args)
+    # Try kwargs
+    if "size" in kwargs:
+        return _normalize_size_arg(kwargs["size"])
+    if "sizes" in kwargs:
+        return _normalize_size_arg(kwargs["sizes"])
+    raise ValueError(
+        "Size must be provided as a list/tuple/torch.Size or as multiple integer positional arguments."
+    )
+
+
+def _launch_fill_ones(out: torch.Tensor):
+    if out.numel() == 0:
+        return
+    if not out.is_cuda or not out.is_contiguous():
+        out.fill_(1)
+        return
+    triton_dtype = _torch_dtype_to_triton_dtype(out.dtype)
+    n_elements = out.numel()
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _fill_ones_kernel[grid](out, n_elements, BLOCK_SIZE=BLOCK_SIZE, DTYPE=triton_dtype)
+
+
+def new_ones(*args, **kwargs):
+    # Expected schema (aten): new_ones(Tensor self, int[] size, *, dtype?, layout?, device?, pin_memory?)
+    if len(args) == 0:
+        raise TypeError(
+            "new_ones expects at least a 'self' tensor as the first argument."
+        )
+    self = args[0]
+    after_self = list(args[1:])
+    size = _extract_size_from_args(after_self, kwargs)
+
+    # Resolve dtype/device defaults
+    dtype = kwargs.get("dtype", None)
+    if dtype is None:
+        if isinstance(self, torch.Tensor) and self.dtype is not None:
+            dtype = self.dtype
+        else:
+            dtype = torch.get_default_dtype()
+
+    device = kwargs.get("device", None)
+    if device is None:
+        if isinstance(self, torch.Tensor):
+            device = self.device
+        else:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+    out = torch.empty(size, dtype=dtype, device=device)
+    _launch_fill_ones(out)
+    return out
+
+
+def new_ones_out(*args, **kwargs):
+    # Expected schema (aten): new_ones.out(Tensor self, int[] size, *, dtype?, layout?, device?, pin_memory?, Tensor(a!) out) -> Tensor(a!) # noqa: E501
+    if len(args) == 0:
+        raise TypeError(
+            "new_ones_out expects at least a 'self' tensor as the first argument."
+        )
+    self = args[0]  # noqa: F841
+    # Determine 'out' tensor (either in kwargs or as the last positional argument)
+    out = kwargs.get("out", None)
+    pos_after_self = list(args[1:])
+
+    if (
+        out is None
+        and len(pos_after_self) >= 1
+        and isinstance(pos_after_self[-1], torch.Tensor)
+    ):
+        out = pos_after_self[-1]
+        pos_after_self = pos_after_self[:-1]
+
+    if out is None or not isinstance(out, torch.Tensor):
+        raise TypeError(
+            "new_ones_out requires an 'out' tensor (as keyword 'out' or last positional argument)."
+        )
+
+    size = _extract_size_from_args(pos_after_self, kwargs)
+
+    # Validate/align dtype/device if provided
+    if (
+        "dtype" in kwargs
+        and kwargs["dtype"] is not None
+        and out.dtype != kwargs["dtype"]
+    ):
+        raise TypeError(
+            f"Provided dtype {kwargs['dtype']} does not match out.dtype {out.dtype}."
+        )
+    if (
+        "device" in kwargs
+        and kwargs["device"] is not None
+        and torch.device(kwargs["device"]) != out.device
+    ):
+        raise TypeError(
+            f"Provided device {kwargs['device']} does not match out.device {out.device}."
+        )
+
+    # Resize out to requested size if needed
+    if tuple(out.shape) != tuple(size):
+        out.resize_(size)
+
+    _launch_fill_ones(out)
+    return out

--- a/src/flag_gems/experimental_ops/pixel_unshuffle.py
+++ b/src/flag_gems/experimental_ops/pixel_unshuffle.py
@@ -1,0 +1,154 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def pixel_unshuffle_kernel(
+    in_ptr,  # *Pointer* to input tensor (contiguous NCHW)
+    out_ptr,  # *Pointer* to output tensor (contiguous NCHW)
+    n_elements,  # total number of elements (N*C*H*W)
+    N,
+    C,
+    H,
+    W,  # input dimensions
+    R,  # downscale factor
+    C_out,
+    H_out,
+    W_out,  # output dimensions
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    # Strides for contiguous NCHW
+    sN_in = C * H * W
+    sC_in = H * W
+    sH_in = W
+    sW_in = 1
+
+    sN_out = C_out * H_out * W_out
+    sC_out = H_out * W_out
+    sH_out = W_out
+    sW_out = 1  # noqa: F841
+
+    # Decode output linear index into (n, c_out, h_out, w_out)
+    n = offsets // sN_out
+    rem1 = offsets - n * sN_out
+    c_out = rem1 // sC_out
+    rem2 = rem1 - c_out * sC_out
+    h_out = rem2 // sH_out
+    w_out = rem2 - h_out * sH_out
+
+    # Map output channel to input channel and spatial offsets
+    r2 = R * R
+    c_in = c_out // r2
+    remc = c_out - c_in * r2
+    dh = remc // R
+    dw = remc - dh * R
+
+    # Compute input spatial indices
+    h_in = h_out * R + dh
+    w_in = w_out * R + dw
+
+    # Compute input linear index
+    in_index = n * sN_in + c_in * sC_in + h_in * sH_in + w_in * sW_in
+
+    x = tl.load(in_ptr + in_index, mask=mask)
+    tl.store(out_ptr + offsets, x, mask=mask)
+
+
+def _launch_pixel_unshuffle_kernel(
+    inp: torch.Tensor, downscale_factor: int, out: torch.Tensor
+):
+    assert inp.is_cuda and out.is_cuda, "Input and output must be CUDA tensors"
+    assert inp.is_contiguous(), "Input must be contiguous (NCHW)"
+    assert out.is_contiguous(), "Output must be contiguous (NCHW)"
+    assert inp.ndim == 4, "Input must be a 4D tensor (N, C, H, W)"
+    N, C, H, W = inp.shape
+    r = int(downscale_factor)
+    assert r > 0, "downscale_factor must be > 0"
+    assert (H % r == 0) and (
+        W % r == 0
+    ), "H and W must be divisible by downscale_factor"
+    C_out = C * r * r
+    H_out = H // r
+    W_out = W // r
+    assert out.shape == (N, C_out, H_out, W_out), "Output has incorrect shape"
+
+    n_elements = inp.numel()
+    if n_elements == 0:
+        return
+
+    BLOCK_SIZE = 1024
+    grid = lambda META: (triton.cdiv(n_elements, META["BLOCK_SIZE"]),)
+    pixel_unshuffle_kernel[grid](
+        inp,
+        out,
+        n_elements,
+        N,
+        C,
+        H,
+        W,
+        r,
+        C_out,
+        H_out,
+        W_out,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+
+
+def pixel_unshuffle(input, downscale_factor, *, layout=None):
+    """
+    Wrapper for aten::pixel_unshuffle
+    Args:
+      input: Tensor[N, C, H, W] (contiguous)
+      downscale_factor: int
+      layout: unused (for API parity)
+    """
+    x = input
+    if not x.is_contiguous():
+        x = x.contiguous()
+    assert x.ndim == 4, "Input must be a 4D tensor (N, C, H, W)"
+    N, C, H, W = x.shape
+    r = int(downscale_factor)
+    assert r > 0, "downscale_factor must be > 0"
+    assert (H % r == 0) and (
+        W % r == 0
+    ), "H and W must be divisible by downscale_factor"
+
+    out_shape = (N, C * r * r, H // r, W // r)
+    out = torch.empty(out_shape, device=x.device, dtype=x.dtype)
+    _launch_pixel_unshuffle_kernel(x, r, out)
+    return out
+
+
+def pixel_unshuffle_out(input, downscale_factor, out):
+    """
+    Wrapper for aten::pixel_unshuffle.out
+    Args:
+      input: Tensor[N, C, H, W] (contiguous)
+      downscale_factor: int
+      out: preallocated Tensor[N, C*r*r, H//r, W//r] (contiguous)
+    """
+    x = input
+    if not x.is_contiguous():
+        x = x.contiguous()
+    assert x.ndim == 4, "Input must be a 4D tensor (N, C, H, W)"
+    N, C, H, W = x.shape
+    r = int(downscale_factor)
+    assert r > 0, "downscale_factor must be > 0"
+    assert (H % r == 0) and (
+        W % r == 0
+    ), "H and W must be divisible by downscale_factor"
+    expected_shape = (N, C * r * r, H // r, W // r)
+    assert out.shape == expected_shape, f"out must have shape {expected_shape}"
+    assert out.dtype == x.dtype, "out dtype must match input dtype"
+    assert out.device == x.device, "out device must match input device"
+    if not out.is_contiguous():
+        raise ValueError("out must be contiguous")
+
+    _launch_pixel_unshuffle_kernel(x, r, out)
+    return out

--- a/src/flag_gems/experimental_ops/positive.py
+++ b/src/flag_gems/experimental_ops/positive.py
@@ -1,0 +1,51 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def positive(
+    x_ptr,  # *Pointer* to input tensor.
+    output_ptr,  # *Pointer* to output tensor.
+    n_elements,  # Number of elements.
+    BLOCK_SIZE: tl.constexpr,  # Elements processed per program.
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    tl.store(output_ptr + offsets, x, mask=mask)
+
+
+_positive_kernel = positive
+
+
+def positive(*args, **kwargs):
+    # Extract the tensor argument
+    x = None
+    if args:
+        x = args[0]
+    else:
+        x = kwargs.get("input", kwargs.get("self", kwargs.get("x", None)))
+
+    if x is None:
+        raise ValueError("positive expects a torch.Tensor as the first argument")
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("positive expects a torch.Tensor")
+
+    # Fallback for non-CUDA or unsupported types
+    if (not x.is_cuda) or x.is_complex():
+        return torch.ops.aten.positive(x)
+
+    x_contig = x.contiguous()
+    n_elements = x_contig.numel()
+    out = torch.empty_like(x_contig)
+
+    if n_elements == 0:
+        return out
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    _positive_kernel[grid](x_contig, out, n_elements, BLOCK_SIZE=BLOCK_SIZE)
+    return out

--- a/src/flag_gems/experimental_ops/prelu.py
+++ b/src/flag_gems/experimental_ops/prelu.py
@@ -1,0 +1,100 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def prelu(
+    x_ptr,  # *Pointer* to input tensor.
+    w_ptr,  # *Pointer* to weight tensor (scalar or per-channel vector).
+    out_ptr,  # *Pointer* to output tensor.
+    n_elements,  # Total number of elements in input.
+    S,  # Spatial size = product of dims after channel dim (or 1 if none).
+    C,  # Number of channels (or 1).
+    w_is_scalar: tl.constexpr,  # Whether weight is a single scalar.
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+
+    if w_is_scalar:
+        alpha = tl.load(w_ptr)  # scalar
+        y = tl.where(x >= 0, x, alpha * x)
+    else:
+        c = (offsets // S) % C
+        alpha = tl.load(w_ptr + c, mask=mask)
+        y = tl.where(x >= 0, x, alpha * x)
+
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+# Keep a reference to the Triton kernel before defining the Python wrapper with the same name.
+prelu_kernel = prelu
+
+
+def prelu(*args, **kwargs):
+    # Extract inputs
+    if len(args) >= 2:
+        x, weight = args[0], args[1]
+    else:
+        x = kwargs.get("input", kwargs.get("self"))
+        weight = kwargs.get("weight")
+    if x is None or weight is None:
+        raise ValueError("prelu expects (input, weight) as arguments.")
+
+    if not (x.is_cuda and weight.is_cuda):
+        raise AssertionError("Tensors must be CUDA tensors.")
+
+    # Ensure dtype match
+    if weight.dtype != x.dtype:
+        weight = weight.to(dtype=x.dtype)
+
+    # Ensure contiguous
+    x = x.contiguous()
+    weight = weight.contiguous()
+
+    out = torch.empty_like(x)
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return out
+
+    # Determine channel count C and spatial size S
+    ndim = x.dim()
+    if weight.numel() == 1:
+        C = 1
+        S = 1
+        w_is_scalar = True
+    else:
+        if ndim == 0:
+            raise AssertionError("Non-scalar weight provided for a 0-dim input.")
+        if ndim == 1:
+            C = x.shape[0]
+            S = 1
+        else:
+            C = x.shape[1]
+            S = 1
+            if ndim > 2:
+                for d in x.shape[2:]:
+                    S *= d
+        if weight.numel() != C:
+            raise AssertionError(
+                f"Weight numel ({weight.numel()}) must equal channel dimension size ({C})."
+            )
+        w_is_scalar = False
+
+    # Make sure S and C are at least 1 to avoid div/mod by zero in kernel math
+    C = max(int(C), 1)
+    S = max(int(S), 1)
+
+    BLOCK_SIZE = 1024
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    prelu_kernel[grid](
+        x, weight, out, n_elements, S, C, w_is_scalar=w_is_scalar, BLOCK_SIZE=BLOCK_SIZE
+    )
+    return out

--- a/src/flag_gems/experimental_ops/rad2deg_.py
+++ b/src/flag_gems/experimental_ops/rad2deg_.py
@@ -1,0 +1,49 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def rad2deg__kernel(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    x = tl.load(x_ptr + offsets, mask=mask)
+    # Convert radians to degrees: deg = rad * (180/pi)
+    out = x * (180.0 / 3.141592653589793)
+    tl.store(x_ptr + offsets, out, mask=mask)
+
+
+def rad2deg_(*args, **kwargs):
+    # Accept first positional argument or common keyword names
+    x = args[0] if len(args) > 0 else kwargs.get("input", kwargs.get("self", None))
+    if x is None:
+        raise ValueError("rad2deg_ expects a tensor as its first argument")
+    if not isinstance(x, torch.Tensor):
+        raise TypeError("rad2deg_ expects a torch.Tensor")
+    if not x.is_floating_point():
+        raise TypeError(
+            "rad2deg_ only supports floating point tensors for in-place operation"
+        )
+    if not x.is_cuda:
+        raise AssertionError("Input tensor must be on CUDA device")
+
+    # If non-contiguous, operate on a contiguous copy and copy back in place
+    original = x
+    needs_copy_back = False
+    if not x.is_contiguous():
+        x = x.contiguous()
+        needs_copy_back = True
+
+    n_elements = x.numel()
+    if n_elements == 0:
+        return original
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    rad2deg__kernel[grid](x, n_elements, BLOCK_SIZE=1024)
+
+    if needs_copy_back:
+        original.copy_(x)
+        return original
+    return x

--- a/src/flag_gems/experimental_ops/reciprocal.py
+++ b/src/flag_gems/experimental_ops/reciprocal.py
@@ -1,0 +1,86 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def reciprocal_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask)
+    one = tl.full([BLOCK_SIZE], 1, x.dtype)
+    y = one / x
+    tl.store(out_ptr + offsets, y, mask=mask)
+
+
+def _reciprocal_impl(x: torch.Tensor, out: torch.Tensor = None):
+    # Fallback for unsupported dtypes/devices
+    if not x.is_cuda or x.is_complex():
+        if out is None:
+            return torch.ops.aten.reciprocal(x)
+        else:
+            return torch.ops.aten.reciprocal.out(x, out=out)
+
+    if out is None:
+        out = torch.empty_like(x)
+
+    # Ensure same device and dtype
+    assert out.device == x.device, "Input and output must be on the same device"
+    assert out.dtype == x.dtype, "Output dtype must match input dtype"
+    assert (
+        out.numel() == x.numel()
+    ), "Output must have the same number of elements as input"
+
+    x_contig = x.contiguous()
+    out_contig = out.contiguous()
+
+    n_elements = x_contig.numel()
+    if n_elements == 0:
+        return out  # nothing to do
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    reciprocal_kernel[grid](x_contig, out_contig, n_elements, BLOCK_SIZE=1024)
+
+    if out is not out_contig:
+        out.copy_(out_contig)
+    return out
+
+
+# ('reciprocal', <Autograd.disable: False>)
+def reciprocal(*args, **kwargs):
+    # Accept a single tensor argument
+    x = None
+    if len(args) >= 1:
+        x = args[0]
+    else:
+        # Try common keyword names
+        x = kwargs.get(
+            "input", kwargs.get("self", kwargs.get("a", kwargs.get("args", None)))
+        )
+    if x is None:
+        raise ValueError("reciprocal expects a tensor as the first argument")
+    return _reciprocal_impl(x)
+
+
+# ('reciprocal.out', <Autograd.disable: False>)
+def reciprocal_out(*args, **kwargs):
+    # Accept (x, out) or keyword args self/input and out
+    x = None
+    out = None
+    if len(args) >= 2:
+        x, out = args[0], args[1]
+    elif len(args) == 1:
+        x = args[0]
+        out = kwargs.get("out", None)
+    else:
+        x = kwargs.get("input", kwargs.get("self", kwargs.get("a", None)))
+        out = kwargs.get("out", None)
+
+    if x is None or out is None:
+        raise ValueError("reciprocal_out expects arguments (input, out)")
+
+    _reciprocal_impl(x, out=out)
+    return out

--- a/tests/experimental_ops/logical_not__test.py
+++ b/tests/experimental_ops/logical_not__test.py
@@ -1,0 +1,86 @@
+# LOGICAL_NOT_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.logical_not_ import (  # noqa: E402
+    logical_not_ as gems_logical_not_,
+)
+
+
+@pytest.mark.logical_not_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 2048)])
+@pytest.mark.parametrize("dtype", [torch.bool])
+@pytest.mark.parametrize("contig", [True, False])
+def test_logical_not__tensor(shape, dtype, contig):
+    if contig:
+        input_tensor = torch.randint(0, 2, shape, device=flag_gems.device).to(dtype)
+    else:
+        base = torch.randint(0, 2, (shape[1], shape[0]), device=flag_gems.device).to(
+            dtype
+        )
+        input_tensor = base.transpose(0, 1)
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.logical_not_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_logical_not_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.logical_not_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 2048)])
+@pytest.mark.parametrize("dtype", [torch.bool])
+@pytest.mark.parametrize("contig", [True, False])
+def test_logical_not__benchmark_tensor(shape, dtype, contig):
+    import torch.utils.benchmark as benchmark  # noqa: E402, F401
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    if contig:
+        input_tensor = torch.randint(0, 2, shape, device=flag_gems.device).to(dtype)
+    else:
+        base = torch.randint(0, 2, (shape[1], shape[0]), device=flag_gems.device).to(
+            dtype
+        )
+        input_tensor = base.transpose(0, 1)
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.logical_not_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_logical_not_(act_input), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"logical_not_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/lt__test.py
+++ b/tests/experimental_ops/lt__test.py
@@ -1,0 +1,86 @@
+# LT_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.lt_ import lt__Scalar, lt__Tensor  # noqa: E402
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.lt_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_lt__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    other_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+    ref_other = other_tensor.clone()
+
+    ref_out = torch.ops.aten.lt_(ref_input, ref_other)
+
+    with flag_gems.use_gems():
+        act_out = lt__Tensor(input_tensor, other_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.lt_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("other", [-1.0, 0.0, 1.5])
+def test_lt__scalar(shape, dtype, other):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.lt_(ref_input, other)
+
+    with flag_gems.use_gems():
+        act_out = lt__Scalar(input_tensor, other)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.lt_
+def test_perf_aten_lt_():
+    # Define input generation logic matching the operator arguments
+    def lt__input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark - using lt__Tensor for performance test
+    def lt__Tensor_wrapper(self, other):
+        return lt__Tensor(self, other)
+
+    bench = GenericBenchmark(
+        input_fn=lt__input_fn,
+        op_name="lt_",
+        torch_op=torch.ops.aten.lt_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    # Replace the op with lt__Tensor
+    bench.op = lt__Tensor_wrapper
+
+    return bench.run()

--- a/tests/experimental_ops/masked_fill_test.py
+++ b/tests/experimental_ops/masked_fill_test.py
@@ -1,0 +1,125 @@
+# MASKED_FILL operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.masked_fill import (  # noqa: E402
+    masked_fill_Scalar,
+    masked_fill_Scalar_out,
+    masked_fill_Tensor,
+    masked_fill_Tensor_out,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.masked_fill
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("value", [0.0, -1.25, 2.5])
+def test_masked_fill_scalar(shape, dtype, value):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.5
+    ref_x = x.clone()
+    ref_mask = mask.clone()
+    ref_out = torch.ops.aten.masked_fill.Scalar(ref_x, ref_mask, value)
+    with flag_gems.use_gems():
+        act_out = masked_fill_Scalar(x, mask, value)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.masked_fill
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("value", [1.0, -3.0, 0.75])
+def test_masked_fill_tensor(shape, dtype, value):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.5
+    val = torch.tensor(value, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_mask = mask.clone()
+    ref_val = val.clone()
+    ref_out = torch.ops.aten.masked_fill.Tensor(ref_x, ref_mask, ref_val)
+    with flag_gems.use_gems():
+        act_out = masked_fill_Tensor(x, mask, val)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.masked_fill
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("value", [0.0, -2.0, 3.5])
+def test_masked_fill_scalar_out(shape, dtype, value):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.5
+    ref_x = x.clone()
+    ref_mask = mask.clone()
+    ref_out_buf = torch.empty_like(ref_x)
+    ref_out = torch.ops.aten.masked_fill.Scalar_out(
+        ref_x, ref_mask, value, out=ref_out_buf
+    )
+    act_out_buf = torch.empty_like(x)
+    with flag_gems.use_gems():
+        act_out = masked_fill_Scalar_out(x, mask, value, out=act_out_buf)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.masked_fill
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("value", [1.5, -0.5, 4.0])
+def test_masked_fill_tensor_out(shape, dtype, value):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.5
+    val = torch.tensor(value, dtype=dtype, device=flag_gems.device)
+    ref_x = x.clone()
+    ref_mask = mask.clone()
+    ref_val = val.clone()
+    ref_out_buf = torch.empty_like(ref_x)
+    ref_out = torch.ops.aten.masked_fill.Tensor_out(
+        ref_x, ref_mask, ref_val, out=ref_out_buf
+    )
+    act_out_buf = torch.empty_like(x)
+    with flag_gems.use_gems():
+        act_out = masked_fill_Tensor_out(x, mask, val, out=act_out_buf)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.masked_fill
+def test_perf_aten_masked_fill():
+    # Define input generation logic matching the operator arguments
+    def masked_fill_input_fn(shape, dtype, device):
+        x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        mask = torch.rand(shape, device=flag_gems.device) > 0.5
+        value = torch.tensor(
+            1.0, dtype=dtype, device=flag_gems.device
+        )  # Example scalar value
+        yield x, mask, value
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=masked_fill_input_fn,
+        op_name="masked_fill",
+        torch_op=torch.ops.aten.masked_fill,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/masked_select_test.py
+++ b/tests/experimental_ops/masked_select_test.py
@@ -1,0 +1,90 @@
+# MASKED_SELECT operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.masked_select import (  # noqa: E402
+    masked_select as gems_masked_select,
+)
+from flag_gems.experimental_ops.masked_select import (  # noqa: E402
+    masked_select_out as gems_masked_select_out,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.masked_select
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_masked_select_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.5
+
+    ref_x = x.clone()
+    ref_mask = mask.clone()
+
+    ref_out = torch.ops.aten.masked_select(ref_x, ref_mask)
+
+    with flag_gems.use_gems():
+        act_out = gems_masked_select(x, mask)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.masked_select
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_masked_select_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.5
+
+    ref_x = x.clone()
+    ref_mask = mask.clone()
+
+    ref_n = int(ref_mask.sum().item())
+    ref_out_buf = torch.empty((ref_n,), dtype=dtype, device=flag_gems.device)
+    ref_out = torch.ops.aten.masked_select.out(ref_x, ref_mask, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_n = int(mask.sum().item())
+        act_out_buf = torch.empty((act_n,), dtype=dtype, device=flag_gems.device)
+        act_out = gems_masked_select_out(x, mask, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.masked_select
+def test_perf_aten_masked_select():
+    # Define input generation logic matching the operator arguments
+    def masked_select_input_fn(shape, dtype, device):
+        x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        mask = torch.rand(shape, device=flag_gems.device) > 0.5
+        yield x, mask
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=masked_select_input_fn,
+        op_name="masked_select",
+        torch_op=torch.ops.aten.masked_select,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/maximum_test.py
+++ b/tests/experimental_ops/maximum_test.py
@@ -1,0 +1,113 @@
+# MAXIMUM operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.maximum import maximum as gems_maximum  # noqa: E402
+from flag_gems.experimental_ops.maximum import (  # noqa: E402
+    maximum_out as gems_maximum_out,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.maximum
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_maximum_tensor(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    y = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_y = y.clone()
+
+    ref_out = torch.ops.aten.maximum(ref_x, ref_y)
+
+    with flag_gems.use_gems():
+        act_out = gems_maximum(x, y)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.maximum
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_maximum_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    y = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_y = y.clone()
+
+    ref_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+    act_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_out = torch.ops.aten.maximum.out(ref_x, ref_y, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out = gems_maximum_out(x, y, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.maximum
+@pytest.mark.parametrize(
+    "shapes",
+    [
+        ((2, 3, 1), (1, 3, 4)),
+        ((8, 1, 16), (1, 12, 16)),
+        ((64, 1, 256), (1, 128, 1)),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_maximum_tensor_broadcast(shapes, dtype):
+    shape_a, shape_b = shapes
+    x = torch.randn(shape_a, dtype=dtype, device=flag_gems.device)
+    y = torch.randn(shape_b, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_y = y.clone()
+
+    ref_out = torch.ops.aten.maximum(ref_x, ref_y)
+
+    with flag_gems.use_gems():
+        act_out = gems_maximum(x, y)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.maximum
+def test_perf_aten_maximum():
+    # Define input generation logic matching the operator arguments
+    def maximum_input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=maximum_input_fn,
+        op_name="maximum",
+        torch_op=torch.ops.aten.maximum,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/mse_loss_test.py
+++ b/tests/experimental_ops/mse_loss_test.py
@@ -1,0 +1,91 @@
+# MSE_LOSS operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.mse_loss import mse_loss as gems_mse_loss  # noqa: E402
+from flag_gems.experimental_ops.mse_loss import (  # noqa: E402
+    mse_loss_out as gems_mse_loss_out,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.mse_loss
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("reduction", [0, 1, 2])
+def test_mse_loss_tensor(shape, dtype, reduction):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    y = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_y = y.clone()
+    ref_out = torch.ops.aten.mse_loss(ref_x, ref_y, reduction)
+
+    with flag_gems.use_gems():
+        act_out = gems_mse_loss(x, y, reduction)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.mse_loss
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("reduction", [0, 1, 2])
+def test_mse_loss_out(shape, dtype, reduction):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    y = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    if reduction == 0:
+        ref_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+        act_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+    else:
+        ref_out_buf = torch.empty((), dtype=dtype, device=flag_gems.device)
+        act_out_buf = torch.empty((), dtype=dtype, device=flag_gems.device)
+
+    ref_x = x.clone()
+    ref_y = y.clone()
+    ref_out = torch.ops.aten.mse_loss.out(ref_x, ref_y, reduction, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out = gems_mse_loss_out(x, y, reduction, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.mse_loss
+def test_perf_aten_mse_loss():
+    # Define input generation logic matching the operator arguments
+    def mse_loss_input_fn(shape, dtype, device):
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp1, inp2
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=mse_loss_input_fn,
+        op_name="mse_loss",
+        torch_op=torch.ops.aten.mse_loss,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/mv_test.py
+++ b/tests/experimental_ops/mv_test.py
@@ -1,0 +1,131 @@
+# MV operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.mv import mv as gems_mv  # noqa: E402
+from flag_gems.experimental_ops.mv import mv_out as gems_mv_out  # noqa: E402
+
+
+@pytest.mark.mv
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_mv_tensor(shape, dtype):
+    m, n = shape
+    mat = torch.randn((m, n), dtype=dtype, device=flag_gems.device)
+    vec = torch.randn((n,), dtype=dtype, device=flag_gems.device)
+
+    ref_mat = mat.clone()
+    ref_vec = vec.clone()
+    ref_out = torch.ops.aten.mv(ref_mat, ref_vec)
+
+    with flag_gems.use_gems():
+        act_out = gems_mv(mat, vec)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.mv
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_mv_out_tensor(shape, dtype):
+    m, n = shape
+    mat = torch.randn((m, n), dtype=dtype, device=flag_gems.device)
+    vec = torch.randn((n,), dtype=dtype, device=flag_gems.device)
+
+    ref_mat = mat.clone()
+    ref_vec = vec.clone()
+    ref_out_buf = torch.empty((m,), dtype=dtype, device=flag_gems.device)
+    ref_out = torch.ops.aten.mv.out(ref_mat, ref_vec, out=ref_out_buf)
+
+    act_out_buf = torch.empty((m,), dtype=dtype, device=flag_gems.device)
+    with flag_gems.use_gems():
+        act_out = gems_mv_out(mat, vec, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.mv
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_mv_benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark  # noqa: E402, F401
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    m, n = shape
+    mat = torch.randn((m, n), dtype=dtype, device=flag_gems.device)
+    vec = torch.randn((n,), dtype=dtype, device=flag_gems.device)
+
+    ref_mat = mat.clone()
+    ref_vec = vec.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.mv(ref_mat, ref_vec), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_mv(mat, vec), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"mv {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.mv
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_mv_out_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    m, n = shape
+    mat = torch.randn((m, n), dtype=dtype, device=flag_gems.device)
+    vec = torch.randn((n,), dtype=dtype, device=flag_gems.device)
+
+    ref_mat = mat.clone()
+    ref_vec = vec.clone()
+    ref_out_buf = torch.empty((m,), dtype=dtype, device=flag_gems.device)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.mv.out(ref_mat, ref_vec, out=ref_out_buf),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    act_out_buf = torch.empty((m,), dtype=dtype, device=flag_gems.device)
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_mv_out(mat, vec, act_out_buf), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"mv {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/native_dropout_backward_test.py
+++ b/tests/experimental_ops/native_dropout_backward_test.py
@@ -1,0 +1,168 @@
+# NATIVE_DROPOUT_BACKWARD operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.native_dropout_backward import (  # noqa: E402
+    native_dropout_backward as gems_native_dropout_backward,
+)
+from flag_gems.experimental_ops.native_dropout_backward import (  # noqa: E402
+    native_dropout_backward_out as gems_native_dropout_backward_out,
+)
+
+
+@pytest.mark.native_dropout_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("scale", [1.0, 0.5, 2.0])
+def test_native_dropout_backward_tensor(shape, dtype, scale):
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.3
+
+    ref_grad = grad_output.clone()
+    ref_mask = mask.clone()
+    ref_out = torch.ops.aten.native_dropout_backward(ref_grad, ref_mask, float(scale))
+
+    act_grad = grad_output.clone()
+    act_mask = mask.clone()
+    with flag_gems.use_gems():
+        act_out = gems_native_dropout_backward(act_grad, act_mask, float(scale))
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.native_dropout_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("scale", [1.0, 0.5, 2.0])
+def test_native_dropout_backward_out(shape, dtype, scale):
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.6
+
+    ref_grad = grad_output.clone()
+    ref_mask = mask.clone()
+    ref_out_tensor = torch.empty_like(ref_grad)
+    ref_out = torch.ops.aten.native_dropout_backward.out(
+        ref_grad, ref_mask, float(scale), out=ref_out_tensor
+    )
+
+    act_grad = grad_output.clone()
+    act_mask = mask.clone()
+    act_out_tensor = torch.empty_like(act_grad)
+    with flag_gems.use_gems():
+        act_out = gems_native_dropout_backward_out(
+            act_grad, act_mask, float(scale), act_out_tensor
+        )
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+    gems_assert_close(act_out_tensor, ref_out_tensor, dtype=dtype)
+
+
+@pytest.mark.native_dropout_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("scale", [1.0, 0.5, 2.0])
+def test_native_dropout_backward_benchmark_tensor(shape, dtype, scale):
+    import torch.utils.benchmark as benchmark  # noqa: E402, F401
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.3
+
+    ref_grad = grad_output.clone()
+    ref_mask = mask.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.native_dropout_backward(
+            ref_grad, ref_mask, float(scale)
+        ),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    act_grad = grad_output.clone()
+    act_mask = mask.clone()
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_native_dropout_backward(act_grad, act_mask, float(scale)),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"native_dropout_backward {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.native_dropout_backward
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("scale", [1.0, 0.5, 2.0])
+def test_native_dropout_backward_benchmark_out(shape, dtype, scale):
+    quantiles = [0.5, 0.2, 0.8]
+
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.rand(shape, device=flag_gems.device) > 0.6
+
+    ref_grad = grad_output.clone()
+    ref_mask = mask.clone()
+    ref_out_tensor = torch.empty_like(ref_grad)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.native_dropout_backward.out(
+            ref_grad, ref_mask, float(scale), out=ref_out_tensor
+        ),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    act_grad = grad_output.clone()
+    act_mask = mask.clone()
+    act_out_tensor = torch.empty_like(act_grad)
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_native_dropout_backward_out(
+                act_grad, act_mask, float(scale), act_out_tensor
+            ),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"native_dropout_backward {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"native_dropout_backward {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/neg__test.py
+++ b/tests/experimental_ops/neg__test.py
@@ -1,0 +1,68 @@
+# NEG_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.neg_ import neg_ as gems_neg_  # noqa: E402
+
+
+@pytest.mark.neg_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_neg__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.neg_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_neg_(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.neg_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_neg__benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark  # noqa: E402, F401
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.neg_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_neg_(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"neg_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/negative__test.py
+++ b/tests/experimental_ops/negative__test.py
@@ -1,0 +1,62 @@
+# NEGATIVE_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.negative_ import (  # noqa: E402
+    negative_ as gems_negative_,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.negative_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_negative__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    act_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.negative_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_negative_(act_input)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.negative_
+def test_perf_aten_negative_():
+    # Define input generation logic matching the operator arguments
+    def negative__input_fn(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        yield inp,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=negative__input_fn,
+        op_name="negative_",
+        torch_op=torch.ops.aten.negative_,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/negative_test.py
+++ b/tests/experimental_ops/negative_test.py
@@ -1,0 +1,124 @@
+# NEGATIVE operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.negative import negative as gems_negative  # noqa: E402
+from flag_gems.experimental_ops.negative import (  # noqa: E402
+    negative_out as gems_negative_out,
+)
+
+
+@pytest.mark.negative
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_negative_tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.negative(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_negative(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.negative
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_negative_out(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.empty_like(ref_input, device=flag_gems.device)
+    act_out = torch.empty_like(input_tensor, device=flag_gems.device)
+
+    ref_res = torch.ops.aten.negative.out(ref_input, out=ref_out)
+
+    with flag_gems.use_gems():
+        act_res = gems_negative_out(input_tensor, act_out)
+
+    gems_assert_close(act_res, ref_res, dtype=dtype)
+
+
+@pytest.mark.negative
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_negative_benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark  # noqa: E402, F401
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.negative(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_negative(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"negative {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.negative
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_negative_benchmark_out(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.empty_like(ref_input, device=flag_gems.device)
+    act_out = torch.empty_like(input_tensor, device=flag_gems.device)
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.negative.out(ref_input, out=ref_out),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_negative_out(input_tensor, act_out),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"negative {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/new_ones_test.py
+++ b/tests/experimental_ops/new_ones_test.py
@@ -1,0 +1,87 @@
+# NEW_ONES operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.new_ones import new_ones as gems_new_ones  # noqa: E402
+from flag_gems.experimental_ops.new_ones import (  # noqa: E402
+    new_ones_out as gems_new_ones_out,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.new_ones
+@pytest.mark.parametrize("self_shape", [(2, 3), (128, 256)])
+@pytest.mark.parametrize("size", [(2, 3), (128, 256), (32, 16, 8), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_new_ones_default(self_shape, size, dtype):
+    self_tensor = torch.randn(self_shape, dtype=torch.float32, device=flag_gems.device)
+
+    ref_self = self_tensor.clone()
+    ref_out = torch.ops.aten.new_ones(ref_self, size, dtype=dtype)
+
+    with flag_gems.use_gems():
+        act_out = gems_new_ones(self_tensor, size, dtype=dtype)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.new_ones
+@pytest.mark.parametrize("self_shape", [(2, 3), (64, 64)])
+@pytest.mark.parametrize("size", [(2, 3), (128, 256), (16, 8, 4), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_new_ones_out(self_shape, size, dtype):
+    self_tensor = torch.randn(self_shape, dtype=torch.float32, device=flag_gems.device)
+
+    ref_self = self_tensor.clone()
+    ref_out_buf = torch.empty(size, device=flag_gems.device, dtype=dtype)
+    ref_out = torch.ops.aten.new_ones.out(ref_self, size, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        act_out_buf = torch.empty(size, device=flag_gems.device, dtype=dtype)
+        act_out = gems_new_ones_out(self_tensor, size, act_out_buf)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.new_ones
+def test_perf_aten_new_ones():
+    # Define input generation logic matching the operator arguments
+    def new_ones_input_fn(shape, dtype, device):
+        inp1 = torch.randn(
+            shape, dtype=torch.float32, device=flag_gems.device
+        )  # self_tensor
+        yield inp1, shape  # yield inputs as required by the operator (size as position, dtype as keyword)
+
+    # Create a wrapper function to handle dtype as keyword argument
+    def new_ones_wrapper(self_tensor, size):
+        return torch.ops.aten.new_ones(self_tensor, size, dtype=self_tensor.dtype)
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=new_ones_input_fn,
+        op_name="new_ones",
+        torch_op=new_ones_wrapper,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()

--- a/tests/experimental_ops/pixel_unshuffle_test.py
+++ b/tests/experimental_ops/pixel_unshuffle_test.py
@@ -1,0 +1,161 @@
+# PIXEL_UNSHUFFLE operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.pixel_unshuffle import (  # noqa: E402
+    pixel_unshuffle as gems_pixel_unshuffle,
+)
+from flag_gems.experimental_ops.pixel_unshuffle import (  # noqa: E402
+    pixel_unshuffle_out as gems_pixel_unshuffle_out,
+)
+
+
+@pytest.mark.pixel_unshuffle
+@pytest.mark.parametrize(
+    "shape_factor", [((1, 3, 8, 8), 2), ((2, 4, 12, 6), 3), ((4, 16, 64, 48), 4)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_pixel_unshuffle_tensor(shape_factor, dtype):
+    shape, downscale_factor = shape_factor
+    input_tensor = torch.randn(shape, dtype=torch.float32, device=flag_gems.device).to(
+        dtype
+    )
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.pixel_unshuffle(ref_input, downscale_factor)
+
+    with flag_gems.use_gems():
+        act_out = gems_pixel_unshuffle(input_tensor, downscale_factor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.pixel_unshuffle
+@pytest.mark.parametrize(
+    "shape_factor", [((1, 3, 8, 8), 2), ((2, 4, 12, 6), 3), ((4, 16, 64, 48), 4)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_pixel_unshuffle_out(shape_factor, dtype):
+    shape, downscale_factor = shape_factor
+    N, C, H, W = shape
+    r = downscale_factor
+    out_shape = (N, C * (r * r), H // r, W // r)
+
+    input_tensor = torch.randn(shape, dtype=torch.float32, device=flag_gems.device).to(
+        dtype
+    )
+    ref_input = input_tensor.clone()
+
+    out_ref = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    ref_out = torch.ops.aten.pixel_unshuffle.out(
+        ref_input, downscale_factor, out=out_ref
+    )
+
+    out_act = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    with flag_gems.use_gems():
+        act_out = gems_pixel_unshuffle_out(input_tensor, downscale_factor, out_act)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.pixel_unshuffle
+@pytest.mark.parametrize(
+    "shape_factor", [((1, 3, 8, 8), 2), ((2, 4, 12, 6), 3), ((4, 16, 64, 48), 4)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_pixel_unshuffle_benchmark_tensor(shape_factor, dtype):
+    import torch.utils.benchmark as benchmark  # noqa: E402, F401
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    shape, downscale_factor = shape_factor
+    input_tensor = torch.randn(shape, dtype=torch.float32, device=flag_gems.device).to(
+        dtype
+    )
+
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.pixel_unshuffle(ref_input, downscale_factor),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_pixel_unshuffle(input_tensor, downscale_factor),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"pixel_unshuffle {shape_factor} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")
+
+
+@pytest.mark.pixel_unshuffle
+@pytest.mark.parametrize(
+    "shape_factor", [((1, 3, 8, 8), 2), ((2, 4, 12, 6), 3), ((4, 16, 64, 48), 4)]
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_pixel_unshuffle_benchmark_out(shape_factor, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    shape, downscale_factor = shape_factor
+    N, C, H, W = shape
+    r = downscale_factor
+    out_shape = (N, C * (r * r), H // r, W // r)
+
+    input_tensor = torch.randn(shape, dtype=torch.float32, device=flag_gems.device).to(
+        dtype
+    )
+    ref_input = input_tensor.clone()
+
+    out_ref = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.pixel_unshuffle.out(
+            ref_input, downscale_factor, out=out_ref
+        ),
+        rep=100,
+        quantiles=quantiles,
+    )
+
+    out_act = torch.empty(out_shape, dtype=dtype, device=flag_gems.device)
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_pixel_unshuffle_out(input_tensor, downscale_factor, out_act),
+            rep=100,
+            quantiles=quantiles,
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"pixel_unshuffle {shape_factor} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/positive_test.py
+++ b/tests/experimental_ops/positive_test.py
@@ -1,0 +1,61 @@
+# POSITIVE operator test
+
+import os
+import sys
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.positive import positive as gems_positive  # noqa: E402
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close  # noqa: E402
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+@pytest.mark.positive
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_positive_tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.positive(ref_input)
+    with flag_gems.use_gems():
+        act_out = gems_positive(input_tensor)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.positive
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_positive_benchmark_tensor(shape, dtype):
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.positive(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_positive(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"positive {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/rad2deg__test.py
+++ b/tests/experimental_ops/rad2deg__test.py
@@ -1,0 +1,68 @@
+# RAD2DEG_ operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.rad2deg_ import rad2deg_ as gems_rad2deg_  # noqa: E402
+
+
+@pytest.mark.rad2deg_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_rad2deg__tensor(shape, dtype):
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    ref_out = torch.ops.aten.rad2deg_(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_rad2deg_(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.rad2deg_
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_rad2deg__benchmark_tensor(shape, dtype):
+    import torch.utils.benchmark as benchmark  # noqa: E402, F401
+
+    quantiles = [0.5, 0.2, 0.8]
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = input_tensor.clone()
+
+    # PyTorch reference implementation
+    ms_torch, _, _ = triton.testing.do_bench(
+        lambda: torch.ops.aten.rad2deg_(ref_input), rep=100, quantiles=quantiles
+    )
+
+    # Triton implementation
+    with flag_gems.use_gems():
+        ms_triton, _, _ = triton.testing.do_bench(
+            lambda: gems_rad2deg_(input_tensor), rep=100, quantiles=quantiles
+        )
+
+    # Calculate speedup and return result
+    speedup = ms_torch / ms_triton
+
+    print(f"rad2deg_ {shape} {dtype}:")
+    print(f"  FlagGems: {ms_triton:.3f}ms")
+    print(f"  Speedup: {speedup:.2f}x")

--- a/tests/experimental_ops/reciprocal_test.py
+++ b/tests/experimental_ops/reciprocal_test.py
@@ -1,0 +1,87 @@
+# RECIPROCAL operator test
+
+import os
+import sys
+
+# Add parent directory to path to import flag_gems
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../.."))
+try:
+    from tests.accuracy_utils import gems_assert_close
+except ImportError:
+    # Fallback values when running outside pytest
+
+    def gems_assert_close(res, ref, dtype, **kwargs):
+        # Simple fallback comparison
+        torch.testing.assert_close(res, ref, **kwargs)
+
+
+import pytest  # noqa: E402
+import torch  # noqa: E402
+import triton  # noqa: E402, F401
+
+import flag_gems  # noqa: E402
+from flag_gems.experimental_ops.reciprocal import (  # noqa: E402
+    reciprocal as gems_reciprocal,
+)
+from flag_gems.experimental_ops.reciprocal import (  # noqa: E402
+    reciprocal_out as gems_reciprocal_out,
+)
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../../.."))
+from benchmark.performance_utils import GenericBenchmark  # noqa: E402
+
+
+@pytest.mark.reciprocal
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_reciprocal_tensor(shape, dtype):
+    base = torch.rand(shape, dtype=dtype, device=flag_gems.device) * 0.9 + 0.1
+    sign = (torch.randint(0, 2, shape, device=flag_gems.device) * 2 - 1).to(dtype)
+    input_tensor = base * sign
+
+    ref_input = input_tensor.clone()
+    ref_out = torch.ops.aten.reciprocal(ref_input)
+
+    with flag_gems.use_gems():
+        act_out = gems_reciprocal(input_tensor)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.reciprocal
+@pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16, torch.bfloat16])
+def test_reciprocal_out(shape, dtype):
+    base = torch.rand(shape, dtype=dtype, device=flag_gems.device) * 0.9 + 0.1
+    sign = (torch.randint(0, 2, shape, device=flag_gems.device) * 2 - 1).to(dtype)
+    input_tensor = base * sign
+
+    ref_out = torch.empty_like(input_tensor)
+    torch.ops.aten.reciprocal.out(input_tensor.clone(), out=ref_out)
+
+    act_out = torch.empty_like(input_tensor)
+    with flag_gems.use_gems():
+        gems_reciprocal_out(input_tensor, act_out)
+
+    gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.reciprocal
+def test_perf_aten_reciprocal():
+    # Define input generation logic matching the operator arguments
+    def reciprocal_input_fn(shape, dtype, device):
+        # Generate and yield inputs as required by the operator
+        base = torch.rand(shape, dtype=dtype, device=flag_gems.device) * 0.9 + 0.1
+        sign = (torch.randint(0, 2, shape, device=flag_gems.device) * 2 - 1).to(dtype)
+        input_tensor = base * sign
+        yield input_tensor,
+
+    # Initialize benchmark
+    bench = GenericBenchmark(
+        input_fn=reciprocal_input_fn,
+        op_name="reciprocal",
+        torch_op=torch.ops.aten.reciprocal,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
+    )
+
+    return bench.run()


### PR DESCRIPTION
 generated with [KernelGen](https://github.com/flagos-ai/KernelGen)

Operators: logical_not_, lt_, masked_fill, masked_select, maximum, mse_loss, mv, native_dropout_backward, neg_, negative, negative_, new_ones, pixel_unshuffle, positive, prelu, rad2deg_, reciprocal

- All operators pass pytest and precommit checks
- Tested: 1000+ tests passed
- Link: https://github.com/flagos-ai/FlagGems/issues/1285