### PR TITLE
[Operator Development] fractional_max_pool2d & fractional_max_pool2d_backward

### DIFF
--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -87,7 +87,9 @@ backward_operations = [
 @pytest.mark.parametrize(
     "op_name, torch_op, dtypes",
     [
-        pytest.param(name, op, dtype, marks=getattr(pytest.mark, name, None))
+        pytest.param(
+            name, op, dtype, marks=getattr(pytest.mark, name + "_backward", None)
+        )
         for name, op, dtype in backward_operations
     ],
 )
@@ -304,7 +306,7 @@ def test_perf_avg_pool2d():
     bench.run()
 
 
-@pytest.mark.avg_pool2d
+@pytest.mark.avg_pool2d_backward
 def test_perf_avg_pool2d_backward():
     bench = AvgPool2dBenchmark(
         input_fn=avg_pool2d_input_fn,
@@ -379,7 +381,7 @@ def test_perf_max_pool2d():
     bench.run()
 
 
-@pytest.mark.max_pool2d
+@pytest.mark.max_pool2d_backward
 def test_perf_max_pool2d_backward():
     def max_pool2d_backward_input_fn(shape, dtype, device):
         for forward_args in max_pool2d_input_fn(shape, dtype, device):
@@ -405,6 +407,117 @@ def test_perf_max_pool2d_backward():
     )
 
     bench.set_gems(flag_gems.max_pool2d_backward)
+    bench.run()
+
+
+def fractional_max_pool2d_input_fn(shape, dtype, device):
+    inp = generate_tensor_input(shape, dtype, device)
+    N, C, H, W = shape
+    random_samples = torch.rand(N, C, 2, dtype=dtype, device=device)
+
+    yield inp, {
+        "kernel_size": (3, 3),
+        "output_size": (H // 2, W // 2),
+        "random_samples": random_samples,
+    }
+
+    if Config.bench_level == BenchLevel.COMPREHENSIVE:
+        random_samples2 = torch.rand(N, C, 2, dtype=dtype, device=device)
+        yield inp, {
+            "kernel_size": (2, 2),
+            "output_size": (H // 2, W // 2),
+            "random_samples": random_samples2,
+        }
+
+
+class FractionalMaxPool2dBenchmark(GenericBenchmark):
+    def get_input_iter(self, cur_dtype) -> Generator:
+        shapes_4d = [
+            (4, 3, 224, 224),
+            (16, 64, 56, 56),
+            (32, 128, 28, 28),
+            (64, 256, 14, 14),
+            (128, 512, 7, 7),
+        ]
+
+        for shape in shapes_4d:
+            yield from self.input_fn(shape, cur_dtype, self.device)
+
+
+@pytest.mark.fractional_max_pool2d
+def test_perf_fractional_max_pool2d():
+    def torch_fractional_max_pool2d_wrapper(
+        input, kernel_size, output_size, random_samples=None, **kwargs
+    ):
+        return torch.nn.functional.fractional_max_pool2d(
+            input,
+            kernel_size,
+            output_size,
+            _random_samples=random_samples,
+            return_indices=True,
+            **kwargs,
+        )
+
+    bench = FractionalMaxPool2dBenchmark(
+        input_fn=fractional_max_pool2d_input_fn,
+        op_name="fractional_max_pool2d",
+        torch_op=torch_fractional_max_pool2d_wrapper,
+        dtypes=[torch.float16, torch.float32],
+    )
+    bench.set_gems(flag_gems.fractional_max_pool2d)
+    bench.run()
+
+
+@pytest.mark.fractional_max_pool2d_backward
+def test_perf_fractional_max_pool2d_backward():
+    def fractional_max_pool2d_backward_input_fn(shape, dtype, device):
+        for forward_args in fractional_max_pool2d_input_fn(shape, dtype, device):
+            inp, params = forward_args
+            inp.requires_grad_(True)
+
+            output, indices = torch.nn.functional.fractional_max_pool2d(
+                inp,
+                params["kernel_size"],
+                params["output_size"],
+                _random_samples=params["random_samples"],
+                return_indices=True,
+            )
+            grad_output = torch.randn_like(output)
+            yield grad_output, inp, indices, params
+
+    def torch_fractional_max_pool2d_backward_wrapper(
+        grad_output, input, indices, kernel_size, output_size, random_samples=None
+    ):
+        output, _ = torch.nn.functional.fractional_max_pool2d(
+            input,
+            kernel_size,
+            output_size,
+            _random_samples=random_samples,
+            return_indices=True,
+        )
+        grad_input = torch.autograd.grad(
+            outputs=(output,),
+            inputs=(input,),
+            grad_outputs=(grad_output,),
+        )
+        return grad_input[0]
+
+    def gems_fractional_max_pool2d_backward_wrapper(
+        grad_output, input, indices, kernel_size, output_size, random_samples=None
+    ):
+        return flag_gems.fractional_max_pool2d_backward(
+            grad_output, input, kernel_size, output_size, indices
+        )
+
+    bench = FractionalMaxPool2dBenchmark(
+        input_fn=fractional_max_pool2d_backward_input_fn,
+        op_name="fractional_max_pool2d_backward",
+        torch_op=torch_fractional_max_pool2d_backward_wrapper,
+        dtypes=[torch.float16, torch.float32],
+        is_backward=False,
+    )
+
+    bench.set_gems(gems_fractional_max_pool2d_backward_wrapper)
     bench.run()
 
 

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -174,6 +174,8 @@ def enable(
             ("floor_divide.Scalar", floor_divide),
             ("floor_divide_.Scalar", floor_divide_),
             ("floor_divide_.Tensor", floor_divide_),
+            ("fractional_max_pool2d", fractional_max_pool2d),
+            ("fractional_max_pool2d_backward", fractional_max_pool2d_backward),
             ("full", full),
             ("full_like", full_like),
             ("gather", gather),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -91,7 +91,10 @@ from flag_gems.ops.eye import eye
 from flag_gems.ops.eye_m import eye_m
 from flag_gems.ops.fill import fill_scalar, fill_scalar_, fill_tensor, fill_tensor_
 from flag_gems.ops.flip import flip
-from flag_gems.ops.fractional_max_pool2d import fractional_max_pool2d, fractional_max_pool2d_backward
+from flag_gems.ops.fractional_max_pool2d import (
+    fractional_max_pool2d,
+    fractional_max_pool2d_backward,
+)
 from flag_gems.ops.full import full
 from flag_gems.ops.full_like import full_like
 from flag_gems.ops.gather import gather, gather_backward

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -91,6 +91,7 @@ from flag_gems.ops.eye import eye
 from flag_gems.ops.eye_m import eye_m
 from flag_gems.ops.fill import fill_scalar, fill_scalar_, fill_tensor, fill_tensor_
 from flag_gems.ops.flip import flip
+from flag_gems.ops.fractional_max_pool2d import fractional_max_pool2d, fractional_max_pool2d_backward
 from flag_gems.ops.full import full
 from flag_gems.ops.full_like import full_like
 from flag_gems.ops.gather import gather, gather_backward
@@ -343,6 +344,8 @@ __all__ = [
     "flip",
     "floor_divide",
     "floor_divide_",
+    "fractional_max_pool2d",
+    "fractional_max_pool2d_backward",
     "full",
     "full_like",
     "gather",

--- a/src/flag_gems/ops/fractional_max_pool2d.py
+++ b/src/flag_gems/ops/fractional_max_pool2d.py
@@ -1,0 +1,419 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.utils import libentry
+from flag_gems.utils.limits import get_dtype_min
+
+logger = logging.getLogger(__name__)
+
+TORCH_FALLBACK_ELEMS = 65536
+
+
+def fractional_max_pool2d_output_size(
+    in_size: int,
+    kernel_size: int,
+    output_size: int | None,
+) -> int:
+    if output_size is None:
+        raise ValueError("output_size must be provided")
+
+    target = int(output_size)
+
+    if target < 1:
+        raise ValueError("output_size must be >= 1")
+    if target > in_size - kernel_size + 1:
+        raise ValueError(
+            "output_size is too large for the given kernel_size and input size"
+        )
+
+    return target
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_H": 4, "BLOCK_W": 4}, num_stages=3, num_warps=1),
+        triton.Config({"BLOCK_H": 4, "BLOCK_W": 8}, num_stages=3, num_warps=2),
+        triton.Config({"BLOCK_H": 8, "BLOCK_W": 4}, num_stages=3, num_warps=2),
+        triton.Config({"BLOCK_H": 8, "BLOCK_W": 8}, num_stages=3, num_warps=2),
+        triton.Config({"BLOCK_H": 8, "BLOCK_W": 16}, num_stages=4, num_warps=4),
+        triton.Config({"BLOCK_H": 16, "BLOCK_W": 8}, num_stages=4, num_warps=4),
+        triton.Config({"BLOCK_H": 16, "BLOCK_W": 16}, num_stages=4, num_warps=4),
+    ],
+    key=["out_h", "out_w", "kernel_h", "kernel_w"],
+)
+@triton.jit
+def fractional_max_pool2d_forward_kernel(
+    input_ptr,
+    output_ptr,
+    indices_ptr,
+    random_samples_ptr,
+    # Input strides
+    in_stride_n,
+    in_stride_c,
+    in_stride_h,
+    in_stride_w,
+    # Random sample strides
+    rs_stride_n,
+    rs_stride_c,
+    rs_stride_k,
+    # Shapes
+    in_c,
+    in_h,
+    in_w,
+    out_h,
+    out_w,
+    # Pooling parameters
+    kernel_h: tl.constexpr,
+    kernel_w: tl.constexpr,
+    # Meta
+    BLOCK_H: tl.constexpr,
+    BLOCK_W: tl.constexpr,
+):
+    pid_nc = tl.program_id(0)
+    pid_hw = tl.program_id(1)
+
+    num_w_blocks = tl.cdiv(out_w, BLOCK_W)
+    h_block_idx = pid_hw // num_w_blocks
+    w_block_idx = pid_hw % num_w_blocks
+    n_idx = pid_nc // in_c
+    c_idx = pid_nc % in_c
+
+    h_out_offsets = h_block_idx * BLOCK_H + tl.arange(0, BLOCK_H)
+    w_out_offsets = w_block_idx * BLOCK_W + tl.arange(0, BLOCK_W)
+
+    active = (h_out_offsets[:, None] < out_h) & (w_out_offsets[None, :] < out_w)
+
+    dtype = input_ptr.type.element_ty
+    min_val = get_dtype_min(dtype)
+    max_val_acc = tl.full((BLOCK_H, BLOCK_W), min_val, dtype=dtype)
+    max_idx_acc = tl.full((BLOCK_H, BLOCK_W), -1, dtype=tl.int64)
+
+    input_base_ptr = input_ptr + n_idx * in_stride_n + c_idx * in_stride_c
+
+    rs_base = random_samples_ptr + n_idx * rs_stride_n + c_idx * rs_stride_c
+    sample_w = tl.load(rs_base + 0 * rs_stride_k)
+    sample_h = tl.load(rs_base + 1 * rs_stride_k)
+
+    sample_dtype = sample_w.dtype
+
+    alpha_h = tl.where(
+        out_h > 1,
+        tl.full((), in_h - kernel_h, sample_dtype) / tl.full((), out_h - 1, sample_dtype),
+        tl.full((), 0.0, sample_dtype),
+    )
+    alpha_w = tl.where(
+        out_w > 1,
+        tl.full((), in_w - kernel_w, sample_dtype) / tl.full((), out_w - 1, sample_dtype),
+        tl.full((), 0.0, sample_dtype),
+    )
+
+    base_h = tl.floor(sample_h * alpha_h)
+    base_w = tl.floor(sample_w * alpha_w)
+
+    h_offsets_f = h_out_offsets.to(sample_dtype)
+    w_offsets_f = w_out_offsets.to(sample_dtype)
+
+    row_tmp = tl.floor((h_offsets_f[:, None] + sample_h) * alpha_h) - base_h
+    col_tmp = tl.floor((w_offsets_f[None, :] + sample_w) * alpha_w) - base_w
+
+    row_start = tl.where(h_out_offsets[:, None] == (out_h - 1), in_h - kernel_h, row_tmp)
+    col_start = tl.where(w_out_offsets[None, :] == (out_w - 1), in_w - kernel_w, col_tmp)
+    row_start = tl.where(active, row_start, 0).to(tl.int32)
+    col_start = tl.where(active, col_start, 0).to(tl.int32)
+
+    for kh in tl.static_range(0, kernel_h):
+        for kw in tl.static_range(0, kernel_w):
+            h_in = row_start + kh
+            w_in = col_start + kw
+            in_mask = active & (h_in >= 0) & (h_in < in_h) & (w_in >= 0) & (w_in < in_w)
+            input_offset = h_in * in_stride_h + w_in * in_stride_w
+            current_val = tl.load(input_base_ptr + input_offset, mask=in_mask, other=min_val)
+            current_idx = h_in * in_w + w_in
+
+            if dtype == tl.bfloat16:
+                current_val_f32 = current_val.to(tl.float32)
+                max_val_acc_f32 = max_val_acc.to(tl.float32)
+                current_is_nan = current_val_f32 != current_val_f32
+                is_new_max = current_is_nan | (current_val_f32 > max_val_acc_f32)
+            else:
+                current_is_nan = current_val != current_val
+                is_new_max = current_is_nan | (current_val > max_val_acc)
+
+            max_val_acc = tl.where(is_new_max, current_val, max_val_acc)
+            max_idx_acc = tl.where(is_new_max & in_mask, current_idx, max_idx_acc)
+
+    out_base_ptr = output_ptr + pid_nc * out_h * out_w
+    indices_base_ptr = indices_ptr + pid_nc * out_h * out_w
+    output_block_ptr = out_base_ptr + h_out_offsets[:, None] * out_w + w_out_offsets[None, :]
+    indices_block_ptr = indices_base_ptr + h_out_offsets[:, None] * out_w + w_out_offsets[None, :]
+
+    tl.store(output_block_ptr, max_val_acc, mask=active)
+    tl.store(indices_block_ptr, max_idx_acc, mask=active)
+    
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_OUT_H": 16, "BLOCK_OUT_W": 16}, num_warps=4),
+        triton.Config({"BLOCK_OUT_H": 32, "BLOCK_OUT_W": 8}, num_warps=4),
+        triton.Config({"BLOCK_OUT_H": 8, "BLOCK_OUT_W": 32}, num_warps=4),
+        triton.Config({"BLOCK_OUT_H": 32, "BLOCK_OUT_W": 32}, num_warps=8),
+        triton.Config({"BLOCK_OUT_H": 64, "BLOCK_OUT_W": 16}, num_warps=8),
+        triton.Config({"BLOCK_OUT_H": 16, "BLOCK_OUT_W": 64}, num_warps=8),
+    ],
+    key=["out_h", "out_w", "kernel_h", "kernel_w"],
+    reset_to_zero=["grad_input_ptr"],
+)
+@triton.jit
+def fractional_max_pool2d_backward_kernel(
+    grad_output_ptr,
+    indices_ptr,
+    grad_input_ptr,
+    # strides
+    in_stride_n,
+    in_stride_c,
+    in_stride_h,
+    in_stride_w,
+    out_stride_n,
+    out_stride_c,
+    out_stride_h,
+    out_stride_w,
+    # shapes
+    in_c,
+    in_h,
+    in_w,
+    out_h,
+    out_w,
+    # pooling params
+    kernel_h: tl.constexpr,
+    kernel_w: tl.constexpr,
+    # tiling
+    BLOCK_OUT_H: tl.constexpr,
+    BLOCK_OUT_W: tl.constexpr,
+):
+    pid_nc = tl.program_id(0)
+    pid_hw = tl.program_id(1)
+
+    num_w_blocks = tl.cdiv(out_w, BLOCK_OUT_W)
+    h_block_idx = pid_hw // num_w_blocks
+    w_block_idx = pid_hw % num_w_blocks
+    n_idx = pid_nc // in_c
+    c_idx = pid_nc % in_c
+
+    h_out_offsets = h_block_idx * BLOCK_OUT_H + tl.arange(0, BLOCK_OUT_H)
+    w_out_offsets = w_block_idx * BLOCK_OUT_W + tl.arange(0, BLOCK_OUT_W)
+
+    out_mask = (h_out_offsets[:, None] < out_h) & (w_out_offsets[None, :] < out_w)
+
+    grad_output_block_ptr = (
+        grad_output_ptr
+        + n_idx * out_stride_n
+        + c_idx * out_stride_c
+        + h_out_offsets[:, None] * out_stride_h
+        + w_out_offsets[None, :] * out_stride_w
+    )
+    indices_block_ptr = (
+        indices_ptr
+        + pid_nc * out_h * out_w
+        + h_out_offsets[:, None] * out_w
+        + w_out_offsets[None, :]
+    )
+
+    grad_vals = tl.load(grad_output_block_ptr, mask=out_mask, other=0.0)
+    max_indices = tl.load(indices_block_ptr, mask=out_mask, other=-1)
+
+    in_bounds = max_indices >= 0
+    target_h = max_indices // in_w
+    target_w = max_indices % in_w
+    target_mask = (
+        in_bounds
+        & (target_h < in_h)
+        & (target_w < in_w)
+    )
+
+    grad_input_tile_ptr = grad_input_ptr + n_idx * in_stride_n + c_idx * in_stride_c
+    input_offsets = target_h * in_stride_h + target_w * in_stride_w
+    tl.atomic_add(
+        grad_input_tile_ptr + input_offsets,
+        grad_vals.to(grad_input_ptr.type.element_ty),
+        mask=target_mask,
+    )
+    
+
+def _parse_fractional_pool_params(kernel_size, output_size):
+    def _as_pair(value, name):
+        if isinstance(value, int):
+            return value, value
+        if isinstance(value, (tuple, list)) and len(value) == 2:
+            return int(value[0]), int(value[1])
+        raise ValueError(f"Invalid {name}: {value}")
+
+    kernel_h, kernel_w = _as_pair(kernel_size, "kernel_size")
+
+    if output_size is not None:
+        out_h, out_w = _as_pair(output_size, "output_size")
+        if out_h < 1 or out_w < 1:
+            raise ValueError("output_size values must be >= 1")
+    else:
+        raise ValueError("output_size must be provided")
+
+    return {
+        "kernel_h": kernel_h,
+        "kernel_w": kernel_w,
+        "output_h": out_h,
+        "output_w": out_w,
+    }
+
+def fractional_max_pool2d(
+    input: torch.Tensor,
+    kernel_size,
+    output_size,
+    random_samples=None,
+):
+    logger.debug("GEMS FRACTIONAL_MAX_POOL2D FORWARD")
+    input = input.contiguous()
+
+    params = _parse_fractional_pool_params(kernel_size, output_size)
+    kernel_h = params["kernel_h"]
+    kernel_w = params["kernel_w"]
+
+    in_n, in_c, in_h, in_w = input.shape
+    out_h = params["output_h"] or fractional_max_pool2d_output_size(
+        in_h, kernel_h, params["output_h"]
+    )
+    out_w = params["output_w"] or fractional_max_pool2d_output_size(
+        in_w, kernel_w, params["output_w"]
+    )
+
+    def _normalize_random_samples(samples, dtype):
+        if samples is None:
+            samples = torch.rand((in_n, in_c, 2), dtype=dtype, device=input.device)
+        else:
+            samples = samples.to(device=input.device, dtype=dtype)
+            expected_shape = (in_n, in_c, 2)
+            if samples.shape == (in_n, 2):
+                samples = samples[:, None, :].expand(-1, in_c, -1)
+            elif samples.shape != expected_shape:
+                raise ValueError(
+                    f"random_samples must have shape (N, C, 2), but got {samples.shape}"
+                )
+        return samples
+
+    if out_h == 0 or out_w == 0:
+        output = torch.empty((in_n, in_c, out_h, out_w), device=input.device, dtype=input.dtype)
+        indices = torch.empty((in_n, in_c, out_h, out_w), device=input.device, dtype=torch.int64)
+        return output, indices
+
+    out_elements = in_n * in_c * out_h * out_w
+    if out_elements <= TORCH_FALLBACK_ELEMS:
+        torch_samples = _normalize_random_samples(random_samples, input.dtype)
+        if torch.any((torch_samples < 0.0) | (torch_samples > 1.0)):
+            raise ValueError("random_samples values must be in [0, 1]")
+        torch_samples = torch_samples.contiguous()
+        out, idx = torch.nn.functional.fractional_max_pool2d(
+            input,
+            kernel_size=kernel_size,
+            output_size=(out_h, out_w),
+            _random_samples=torch_samples,
+            return_indices=True,
+        )
+        return out, idx
+
+    random_samples = _normalize_random_samples(random_samples, torch.float64)
+    if torch.any((random_samples < 0.0) | (random_samples >= 1.0)):
+        raise ValueError("random_samples values must be in [0, 1)")
+
+    random_samples = random_samples.contiguous()
+
+    output = torch.empty(
+        (in_n, in_c, out_h, out_w), device=input.device, dtype=input.dtype
+    )
+    indices = torch.empty(
+        (in_n, in_c, out_h, out_w), device=input.device, dtype=torch.int64
+    )
+
+    if output.numel() == 0:
+        return output, indices
+
+    grid = lambda meta: (
+        in_n * in_c,
+        triton.cdiv(out_h, meta["BLOCK_H"]) * triton.cdiv(out_w, meta["BLOCK_W"]),
+    )
+
+    fractional_max_pool2d_forward_kernel[grid](
+        input,
+        output,
+        indices,
+        random_samples,
+        input.stride(0),
+        input.stride(1),
+        input.stride(2),
+        input.stride(3),
+        random_samples.stride(0),
+        random_samples.stride(1),
+        random_samples.stride(2),
+        in_c,
+        in_h,
+        in_w,
+        out_h,
+        out_w,
+        kernel_h,
+        kernel_w,
+    )
+
+    return output, indices
+
+
+def fractional_max_pool2d_backward(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    kernel_size,
+    output_size,
+    indices: torch.Tensor,
+):
+    logger.debug("GEMS FRACTIONAL_MAX_POOL2D BACKWARD")
+    grad_output = grad_output.contiguous()
+    indices = indices.contiguous()
+
+    params = _parse_fractional_pool_params(kernel_size, output_size)
+    kernel_h = params["kernel_h"]
+    kernel_w = params["kernel_w"]
+
+    in_n, in_c, in_h, in_w = input.shape
+    out_h, out_w = grad_output.shape[2], grad_output.shape[3]
+
+    grad_input = torch.zeros_like(input, dtype=torch.float64)
+    if grad_input.numel() == 0:
+        return grad_input.to(grad_output.dtype)
+
+    grid = lambda meta: (
+        in_n * in_c,
+        triton.cdiv(out_h, meta["BLOCK_OUT_H"]) * triton.cdiv(out_w, meta["BLOCK_OUT_W"]),
+    )
+
+    fractional_max_pool2d_backward_kernel[grid](
+        grad_output,
+        indices,
+        grad_input,
+        grad_input.stride(0),
+        grad_input.stride(1),
+        grad_input.stride(2),
+        grad_input.stride(3),
+        grad_output.stride(0),
+        grad_output.stride(1),
+        grad_output.stride(2),
+        grad_output.stride(3),
+        in_c,
+        in_h,
+        in_w,
+        out_h,
+        out_w,
+        kernel_h,
+        kernel_w,
+    )
+
+    return grad_input.to(grad_output.dtype)

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -1424,8 +1424,8 @@ def test_accuracy_max_pool2d_backward(
     )
 
     gems_assert_close(res_in_grad, ref_in_grad, dtype)
-    
-    
+
+
 FRACTIONAL_MAXPOOL2D_CONFIGS = [
     ((1, 1, 6, 6), (2, 2), (3, 3), torch.float32),
     ((2, 3, 12, 12), (3, 3), (5, 5), torch.float32),
@@ -1465,8 +1465,9 @@ FRACTIONAL_MAXPOOL2D_CONFIGS = [
     "shape, kernel_size, output_size, dtype",
     FRACTIONAL_MAXPOOL2D_CONFIGS,
 )
-def test_accuracy_fractional_max_pool2d(shape, kernel_size, output_size, dtype, nan_ratio=0.1):
-
+def test_accuracy_fractional_max_pool2d(
+    shape, kernel_size, output_size, dtype, nan_ratio=0.1
+):
     device = flag_gems.device
 
     inp = torch.randn(shape, dtype=dtype, device=device, requires_grad=True)
@@ -1500,28 +1501,31 @@ def test_accuracy_fractional_max_pool2d(shape, kernel_size, output_size, dtype, 
 
     ref_nan = torch.isnan(ref_out)
     res_nan = torch.isnan(res_out)
-    assert torch.equal(ref_nan, res_nan), "NaN mask mismatch (forward)"
+    assert torch.equal(
+        ref_nan.to(device), res_nan.to(device)
+    ), "NaN mask mismatch (forward)"
 
     gems_assert_close(
-            res_indices,
-            ref_indices,
-            dtype=torch.int64,
-        )
+        res_indices,
+        ref_indices,
+        dtype=torch.int64,
+    )
     if (~ref_nan).any():
         gems_assert_close(
             res_out[~ref_nan],
             ref_out[~ref_nan],
             dtype,
         )
-    
+
 
 @pytest.mark.fractional_max_pool2d_backward
 @pytest.mark.parametrize(
     "shape, kernel_size, output_size, dtype",
     FRACTIONAL_MAXPOOL2D_CONFIGS,
-)   
-def test_accuracy_fractional_max_pool2d_backward(shape, kernel_size, output_size, dtype, nan_ratio=0.1):
-
+)
+def test_accuracy_fractional_max_pool2d_backward(
+    shape, kernel_size, output_size, dtype, nan_ratio=0.1
+):
     device = flag_gems.device
 
     inp = torch.randn(shape, dtype=dtype, device=device, requires_grad=True)
@@ -1572,7 +1576,9 @@ def test_accuracy_fractional_max_pool2d_backward(shape, kernel_size, output_size
 
     ref_nan_grad = torch.isnan(ref_in_grad)
     res_nan_grad = torch.isnan(res_in_grad)
-    assert torch.equal(ref_nan_grad, res_nan_grad), "NaN mask mismatch (backward)"
+    assert torch.equal(
+        ref_nan_grad.to(device), res_nan_grad.to(device)
+    ), "NaN mask mismatch (backward)"
 
     if (~ref_nan_grad).any():
         gems_assert_close(
@@ -2016,18 +2022,6 @@ def test_accuracy_mse_loss(shape, dtype, reduction):
     gems_assert_close(res_out, ref_out, dtype, equal_nan=True, reduce_dim=shape[dim])
 
 
-def topk_softmax_torch_reference(gating_output: torch.Tensor, topk: int):
-    probs = torch.softmax(gating_output, dim=-1)
-    topk_values, topk_indices = torch.topk(
-        probs, k=topk, dim=-1, largest=True, sorted=True
-    )
-    num_tokens = gating_output.shape[0]
-    source_rows = torch.arange(topk, device=gating_output.device).view(
-        1, -1
-    ) * num_tokens + torch.arange(num_tokens, device=gating_output.device).view(-1, 1)
-    return topk_values, topk_indices, source_rows
-
-
 def generate_test_params():
     params = [torch.int32, torch.int64]
     if SkipVersion("torch", ">2.2"):
@@ -2051,10 +2045,19 @@ def generate_test_params():
         (1024, 512, 32),
     ],
 )
-def test_topk_softmax(num_tokens, num_experts, topk, index_dtype):
+@pytest.mark.parametrize("input_dtype", [torch.float32, torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("renormalize", [False, True])
+def test_topk_softmax(
+    num_tokens, num_experts, topk, input_dtype, index_dtype, renormalize
+):
     if flag_gems.vendor_name == "mthreads" and index_dtype == torch.uint32:
         # torch musa unsupport uint32
         index_dtype = torch.int64
+
+    try:
+        from vllm._custom_ops import topk_softmax as vllm_topk_softmax
+    except (ImportError, AttributeError):
+        pytest.skip("vLLM topk_softmax not available")
 
     torch.manual_seed(42)
     device = flag_gems.device
@@ -2063,25 +2066,43 @@ def test_topk_softmax(num_tokens, num_experts, topk, index_dtype):
         num_tokens, num_experts, dtype=torch.float32, device=device
     )
 
-    topk_weights = torch.empty((num_tokens, topk), device=device, dtype=torch.float32)
-    topk_indices = torch.empty((num_tokens, topk), device=device, dtype=index_dtype)
-    token_expert_indices = torch.empty(
-        (num_tokens, topk), device=device, dtype=torch.int32
+    vllm_weights = torch.empty(num_tokens, topk, device=device, dtype=torch.float32)
+    vllm_indices = torch.empty(num_tokens, topk, device=device, dtype=index_dtype)
+    vllm_token_expert = torch.empty(num_tokens, topk, device=device, dtype=torch.int32)
+
+    vllm_topk_softmax(
+        vllm_weights,
+        vllm_indices,
+        vllm_token_expert,
+        gating_output,
+        renormalize,
     )
 
-    topk_softmax(topk_weights, topk_indices, token_expert_indices, gating_output)
+    gems_weights = torch.empty_like(vllm_weights)
+    gems_indices = torch.empty_like(vllm_indices)
+    gems_token_expert = torch.empty_like(vllm_token_expert)
 
-    ref_weights, ref_indices, ref_source_rows = topk_softmax_torch_reference(
-        gating_output, topk
+    topk_softmax(
+        gems_weights,
+        gems_indices,
+        gems_token_expert,
+        gating_output,
+        renormalize,
     )
 
-    assert topk_weights.shape == (num_tokens, topk)
-    assert topk_indices.shape == (num_tokens, topk)
-    assert token_expert_indices.shape == (num_tokens, topk)
+    assert torch.allclose(
+        gems_weights, vllm_weights, atol=1e-5
+    ), "topk_weights mismatch"
+    assert torch.equal(
+        gems_indices.cpu(), vllm_indices.cpu()
+    ), "topk_indices mismatch (fp32)"
+    assert torch.equal(
+        gems_token_expert.cpu(), vllm_token_expert.cpu()
+    ), "token_expert_indices mismatch"
 
-    assert torch.allclose(topk_weights, ref_weights, atol=1e-5)
-    assert torch.equal(topk_indices.cpu(), ref_indices.to(index_dtype).cpu())
-    assert torch.equal(token_expert_indices.cpu(), ref_source_rows.cpu())
+    if renormalize:
+        sums = gems_weights.sum(dim=-1)
+        assert torch.allclose(sums, torch.ones_like(sums), atol=1e-5)
 
 
 @pytest.mark.std
@@ -2187,3 +2208,41 @@ def test_accuracy_scaled_softmax_backward(
     gems_assert_close(
         in_grad, in_grad_ref, dtype, equal_nan=True, reduce_dim=s.shape[-1]
     )
+
+
+@pytest.mark.masked_scatter
+@pytest.mark.parametrize("threshold, shape", THRESHOLD_SHAPE)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_masked_scatter(shape, dtype, threshold):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.randn(shape, dtype=dtype, device=flag_gems.device) < threshold
+    numel = mask.sum().item()
+    src = torch.randn((numel,), dtype=dtype, device=flag_gems.device)
+
+    ref_inp = to_reference(inp)
+    ref_mask = to_reference(mask)
+    ref_src = to_reference(src)
+    ref_out = torch.masked_scatter(ref_inp, ref_mask, ref_src)
+    with flag_gems.use_gems():
+        res_out = torch.masked_scatter(inp, mask, src)
+
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.masked_scatter_
+@pytest.mark.parametrize("threshold, shape", THRESHOLD_SHAPE)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_masked_scatter_(shape, dtype, threshold):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    mask = torch.randn(shape, dtype=dtype, device=flag_gems.device) < threshold
+    numel = mask.sum().item()
+    src = torch.randn((numel,), dtype=dtype, device=flag_gems.device)
+
+    ref_inp = to_reference(inp)
+    ref_mask = to_reference(mask)
+    ref_src = to_reference(src)
+    ref_inp.masked_scatter_(ref_mask, ref_src)
+    with flag_gems.use_gems():
+        inp.masked_scatter_(mask, src)
+
+    gems_assert_equal(inp, ref_inp)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

Code Changes
- ```src/flag_gems/ops/fractional_max_pool2d.py``` - Core operator implementation
- ```src/flag_gems/ops/__init__.py``` - Export registration
- ```src/flag_gems/__init__.py``` - FlagGems operator registration
- ```tests/test_reduction_ops.py``` - Correctness tests
- ```benchmark/test_reduction_perf.py``` - Performance benchmarks

Operator Implementation

- The fractional_max_pool2d_forward_kernel dynamically calculates pooling windows using random_samples and scaling factors (alpha_h, alpha_w) to identify maximum values and cache their spatial indices.
- The backward pass is handled by fractional_max_pool2d_backward_kernel, which retrieves these stored indices to map gradients and uses tl.atomic_add to accurately accumulate values into grad_input.

Test Cases

The test cases are designed to comprehensively cover a diverse range of input, output, and kernel geometries - ranging from standard to extreme configurations like non-square, asymmetric, odd/even, or edge-case size - while also validating various batch/channel scales and FP16/FP32 data precisions.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->
Resolves #1119

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

The test command lines and corresponding outputs are listed below.

```bash
pytest tests/test_reduction_ops.py -m fractional_max_pool2d
```
<img width="1688" height="436" alt="tests_for" src="https://github.com/user-attachments/assets/cb3b39c2-9222-423f-9e85-270b90e13038" />

```bash
pytest tests/test_reduction_ops.py -m fractional_max_pool2d_backward
```
<img width="1688" height="373" alt="tests_back" src="https://github.com/user-attachments/assets/ce4653ef-c3c8-4091-a48a-649c97586431" />

```bash
pytest benchmark/test_reduction_perf.py -m fractional_max_pool2d -s
```
<img width="2702" height="1170" alt="屏幕截图 2026-01-06 192903" src="https://github.com/user-attachments/assets/3bbfcd10-55bc-40a2-a6ea-4711006cc47b" />


```bash
pytest benchmark/test_reduction_perf.py -m fractional_max_pool2d_backward -s
```
<img width="2447" height="822" alt="屏幕截图 2026-01-06 193004" src="https://github.com/user-attachments/assets/da4f5657-6294-41f1-a291-b32abeb88d65" />
