### PR TITLE
【pending】revert: restore SQL logic to state at 1c0b5cb3

### DIFF
--- a/src/flag_gems/ops/layernorm.py
+++ b/src/flag_gems/ops/layernorm.py
@@ -7,7 +7,7 @@ import triton.language as tl
 
 from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
-from flag_gems.utils import libentry, libtuner
+from flag_gems.utils import libentry
 from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
@@ -20,7 +20,7 @@ def prev_multiple_of(a, b):
 
 
 @libentry()
-@libtuner(
+@triton.autotune(
     configs=runtime.get_tuned_config("layer_norm_persistent"),
     key=["M", "N"],
 )
@@ -69,7 +69,7 @@ def layer_norm_persistent_kernel(
 
 
 @libentry()
-@libtuner(
+@triton.autotune(
     configs=runtime.get_tuned_config("layer_norm_persistent"),
     key=["M", "N"],
 )
@@ -123,7 +123,7 @@ def layer_norm_persistent_kernel_multiline(
 
 
 @libentry()
-@libtuner(
+@triton.autotune(
     configs=runtime.get_tuned_config("layer_norm_loop"),
     key=["M", "N"],
 )
@@ -220,7 +220,7 @@ def layer_norm_loop_kernel(
 
 
 @libentry()
-@libtuner(
+@triton.autotune(
     configs=runtime.get_tuned_config("layer_norm_backward"),
     key=["M", "N"],
 )
@@ -288,7 +288,7 @@ def layer_norm_backward_kernel(
 
 
 @libentry()
-@libtuner(
+@triton.autotune(
     configs=runtime.get_tuned_config("weight_bias_backward"),
     key=["N"],
 )

--- a/src/flag_gems/ops/randn.py
+++ b/src/flag_gems/ops/randn.py
@@ -5,7 +5,6 @@ import triton
 import triton.language as tl
 
 from flag_gems.runtime import device, torch_device_fn
-from flag_gems.utils import libentry, libtuner
 from flag_gems.utils.random_utils import (
     philox_backend_seed_offset,
     uint_to_uniform_float,
@@ -70,8 +69,7 @@ configs = [
 ]
 
 
-@libentry()
-@libtuner(configs=configs, key=["N"])
+@triton.autotune(configs=configs, key=["N"])
 @triton.jit(do_not_specialize=["philox_seed", "philox_offset"])
 def randn_kernel(
     out_ptr,

--- a/src/flag_gems/ops/vstack.py
+++ b/src/flag_gems/ops/vstack.py
@@ -6,14 +6,14 @@ import triton.language as tl
 
 from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
-from flag_gems.utils import libentry, libtuner
+from flag_gems.utils import libentry
 from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 
 
 @libentry()
-@libtuner(
+@triton.autotune(
     configs=runtime.get_tuned_config("vstack"),
     key=[
         "max_tile_elems",

--- a/src/flag_gems/ops/weightnorm.py
+++ b/src/flag_gems/ops/weightnorm.py
@@ -7,14 +7,16 @@ import triton.language as tl
 
 from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
-from flag_gems.utils import libentry, libtuner, tl_extra_shim
+from flag_gems.utils import libentry, tl_extra_shim
 from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 
 
 @libentry()
-@libtuner(configs=runtime.get_tuned_config("weight_norm_kernel_last"), key=["M", "N"])
+@triton.autotune(
+    configs=runtime.get_tuned_config("weight_norm_kernel_last"), key=["M", "N"]
+)
 @triton.jit(do_not_specialize=["eps"])
 def weight_norm_kernel_last(
     output,
@@ -54,7 +56,9 @@ def weight_norm_kernel_last(
 
 
 @libentry()
-@libtuner(configs=runtime.get_tuned_config("weight_norm_kernel_first"), key=["M", "N"])
+@triton.autotune(
+    configs=runtime.get_tuned_config("weight_norm_kernel_first"), key=["M", "N"]
+)
 @triton.jit(do_not_specialize=["eps"])
 def weight_norm_kernel_first(
     output,
@@ -94,7 +98,9 @@ def weight_norm_kernel_first(
 
 
 @libentry()
-@libtuner(configs=runtime.get_tuned_config("weight_norm_kernel_last"), key=["M", "N"])
+@triton.autotune(
+    configs=runtime.get_tuned_config("weight_norm_kernel_last"), key=["M", "N"]
+)
 @triton.jit(do_not_specialize=["eps"])
 def weight_norm_bwd_kernel_last(
     v_grad,
@@ -143,7 +149,9 @@ def weight_norm_bwd_kernel_last(
 
 
 @libentry()
-@libtuner(configs=runtime.get_tuned_config("weight_norm_kernel_first"), key=["M", "N"])
+@triton.autotune(
+    configs=runtime.get_tuned_config("weight_norm_kernel_first"), key=["M", "N"]
+)
 @triton.jit(do_not_specialize=["eps"])
 def weight_norm_bwd_kernel_first(
     v_grad,

--- a/src/flag_gems/utils/models/model.py
+++ b/src/flag_gems/utils/models/model.py
@@ -1,4 +1,5 @@
 import inspect
+import threading
 from abc import abstractmethod
 from typing import Dict, Final, Optional, Sequence, Tuple, Union, overload
 
@@ -10,6 +11,7 @@ class PersistantModel(object):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        self.lock: Final[threading.Lock] = threading.Lock()
 
     @staticmethod
     def parse_config(config: triton.Config) -> Dict[str, Union[int, float, str]]:

--- a/src/flag_gems/utils/models/sql.py
+++ b/src/flag_gems/utils/models/sql.py
@@ -62,7 +62,7 @@ class SQLPersistantModel(PersistantModel):
         engine: sqlalchemy.engine.Engine,
     ) -> Optional[Type[Base]]:
         AutoBase: sqlalchemy.ext.automap.AutomapBase = (
-            sqlalchemy.ext.automap.automap_base()
+            sqlalchemy.ext.automap.automap_base(Base)
         )
         AutoBase.prepare(engine)
         ModelCls: Optional[Type[Base]] = AutoBase.classes.get(name)
@@ -90,26 +90,25 @@ class SQLPersistantModel(PersistantModel):
         keys: Mapping[str, Union[Any, Type]] = {},
         values: Mapping[str, Union[Any, Type]] = {},
     ) -> Callable[[str, Optional[Mapping[str, Type]]], Optional[Type[Base]]]:
-        ModelCls: Optional[Type[Base]] = self.sql_model_pool.get(name)
-        if ModelCls is not None:
-            return ModelCls
-        ModelCls: Optional[Type[Base]] = SQLPersistantModel.build_sql_model_by_db(
-            name, self.engine
-        )
-        if ModelCls is not None:
+        with self.lock:
+            ModelCls: Optional[Type[Base]] = self.sql_model_pool.get(name)
+            if ModelCls is not None:
+                return ModelCls
+            ModelCls = SQLPersistantModel.build_sql_model_by_db(name, self.engine)
+            if ModelCls is not None:
+                self.sql_model_pool[name] = ModelCls
+                return ModelCls
+            if not keys or not values:
+                return None
+            ModelCls = SQLPersistantModel.build_sql_model_by_py(name, keys, values)
+            with self.engine.begin() as conn:
+                conn.execute(
+                    sqlalchemy.schema.CreateTable(
+                        ModelCls.__table__, if_not_exists=True
+                    )
+                )
             self.sql_model_pool[name] = ModelCls
             return ModelCls
-        if not keys or not values:
-            return None
-        ModelCls: Type[Base] = SQLPersistantModel.build_sql_model_by_py(
-            name, keys, values
-        )
-        with self.engine.begin() as conn:
-            conn.execute(
-                sqlalchemy.schema.CreateTable(ModelCls.__table__, if_not_exists=True)
-            )
-        self.sql_model_pool[name] = ModelCls
-        return ModelCls
 
     @override
     def get_config(


### PR DESCRIPTION
Rollback changes after 1c0b5cb3a257... to fix regression introduced by the warning fix.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Other


### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix


### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Restore SQL logic to the state at commit `1c0b5cb3`.

PRs #1396 and #1392 introduced a regression that results in a new runtime error.
The root cause is not yet clearly identified and may require deeper investigation.

To prioritize stability and unblock users, this PR reverts the changes and
restores the previously stable behavior.


## Scope

- Reverts changes from #1396 and #1392
- Restores behavior identical to commit `1c0b5cb3`
- No new functionality introduced

## Follow-up

A proper fix for the original SQL warning will be proposed separately once the
root cause is identified.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
