### PR TITLE
[Operator Development]int8-gemm

### DIFF
--- a/benchmark/test_int8_gemm_perf.py
+++ b/benchmark/test_int8_gemm_perf.py
@@ -1,0 +1,224 @@
+# benchmark/test_int8_gemm_perf.py
+
+import pytest
+import torch
+
+# import flag_gems
+import flag_gems.ops
+from flag_gems.ops import int8_gemm as gems_int8_gemm
+from benchmark.attri_util import DEFAULT_METRICS, BenchLevel
+from benchmark.conftest import Config
+from benchmark.performance_utils import Benchmark
+
+
+# -----------------------------
+# Quant/Dequant helpers (naive)
+# -----------------------------
+def _quantize_per_tensor_symmetric(x: torch.Tensor, q_scale: float):
+    """
+    Naive symmetric per-tensor quantization to int8, then return (q_int8, q_scale).
+    - x: fp tensor
+    - q_scale: scalar float (must be > 0)
+    """
+    q = torch.clamp(torch.round(x / q_scale), -128, 127).to(torch.int8)
+    return q, q_scale
+
+
+def _dequantize_per_tensor(q: torch.Tensor, q_scale: float):
+    """
+    Naive per-tensor dequantization from int8 to fp32.
+    """
+    return q.float() * q_scale
+
+
+# -----------------------------
+# Baselines
+# -----------------------------
+def int8_gemm_naive_baseline_A(
+    a_int8: torch.Tensor,
+    w_int8: torch.Tensor,
+    a_scale,
+    w_scale,
+    bias=None,
+    out_dtype=torch.float16,
+):
+    """
+    Baseline A:
+      dequant(a,w) -> fp32 matmul -> +bias -> cast(out_dtype)
+    """
+    a = a_int8.float() * float(a_scale)
+    w = w_int8.float() * (w_scale if torch.is_tensor(w_scale) else float(w_scale))
+    out = a @ w
+    if bias is not None:
+        out = out + bias
+    return out.to(out_dtype)
+
+
+def int8_gemm_naive_baseline_B_quant_dequant(
+    a_int8: torch.Tensor,
+    w_int8: torch.Tensor,
+    a_scale,
+    w_scale,
+    bias=None,
+    out_dtype=torch.float16,
+    out_qscale: float = 0.02,
+):
+    """
+    Baseline B:
+      dequant(a,w) -> fp32 matmul -> +bias -> quant(int8) -> dequant(fp32) -> cast(out_dtype)
+    """
+    a = a_int8.float() * float(a_scale)
+    w = w_int8.float() * (w_scale if torch.is_tensor(w_scale) else float(w_scale))
+    out = a @ w
+    if bias is not None:
+        out = out + bias
+
+    q, s = _quantize_per_tensor_symmetric(out, float(out_qscale))
+    out = _dequantize_per_tensor(q, float(s))
+    return out.to(out_dtype)
+
+
+# -----------------------------
+# Benchmark class
+# -----------------------------
+class Int8GemmBenchmark(Benchmark):
+    """
+    Benchmark for custom int8_gemm API:
+      int8_gemm(a_int8, w_int8, a_scale, w_scale, bias=None, out_dtype=fp16/fp32)
+
+    IMPORTANT:
+    - Base Benchmark.init_user_config() loads shapes from YAML (often M,N).
+      That breaks MNK unpacking.
+    - So we override init_user_config() to KEEP MNK shapes and NOT read YAML.
+    """
+
+    DEFAULT_METRICS = DEFAULT_METRICS[:] + ["tflops"]
+    DEFAULT_DTYPES = [torch.float16, torch.float32]
+
+    DEFAULT_SHAPES = [(256, 256, 256)]
+    DEFAULT_SHAPE_DESC = "M, N, K"
+
+    def __init__(self, *args, input_fn, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.input_fn = input_fn
+
+    def init_user_config(self):
+        # keep base behaviors for mode/dtypes/metrics, but DO NOT load shapes from YAML
+        self.mode = Config.mode
+        self.set_dtypes(Config.user_desired_dtypes)
+        self.set_metrics(Config.user_desired_metrics)
+
+        if (
+            hasattr(self, "set_more_shapes")
+            and callable(getattr(self, "set_more_shapes"))
+            and Config.bench_level == BenchLevel.COMPREHENSIVE
+            and not Config.query
+        ):
+            more = self.set_more_shapes()
+            if more:
+                self.shapes = list(dict.fromkeys(list(self.shapes) + list(more)))
+
+    def set_more_shapes(self):
+        return [
+            (128, 128, 128),
+            (256, 512, 1024),
+            (512, 512, 512),
+            (1024, 1024, 1024),
+            (2048, 2048, 1024),
+        ]
+
+    def get_input_iter(self, cur_dtype):
+        for (m, n, k) in self.shapes:
+            yield from self.input_fn(m, n, k, cur_dtype, self.device)
+
+    def get_tflops(self, op, *args, **kwargs):
+        # matmul flops: 2*M*N*K
+        a_int8 = args[0]
+        w_int8 = args[1]
+        M = a_int8.shape[0]
+        K = a_int8.shape[1]
+        N = w_int8.shape[1]
+        return M * N * K * 2
+
+    def get_gbps(self, args, latency=None):
+        raise NotImplementedError
+
+
+# -----------------------------
+# Input generator
+# -----------------------------
+def int8_gemm_input_fn(m, n, k, out_dtype, device):
+    # int8 inputs
+    a = torch.randint(-128, 127, (m, k), dtype=torch.int8, device=device)
+    w = torch.randint(-128, 127, (k, n), dtype=torch.int8, device=device)
+
+    # scales
+    a_scale = 0.02
+
+    if Config.bench_level == BenchLevel.COMPREHENSIVE and not Config.query:
+        # per-channel
+        w_scale = torch.rand((n,), device=device, dtype=torch.float32) * 0.05 + 0.001
+    else:
+        # scalar
+        w_scale = 0.03
+
+    # Optional bias
+    if Config.bench_level == BenchLevel.COMPREHENSIVE and not Config.query:
+        bias = torch.randn((n,), device=device, dtype=torch.float32)
+    else:
+        bias = None
+
+    # IMPORTANT: yield exactly the args that BOTH baseline and flag_gems.int8_gemm accept
+    # (a, w, a_scale, w_scale, bias, out_dtype) -> 6 positional args
+    yield a, w, a_scale, w_scale, bias, out_dtype
+
+
+# -----------------------------
+# Wrappers (stable signature)
+# -----------------------------
+def _baseline_A_wrapper(a, w, a_scale, w_scale, bias, out_dtype):
+    return int8_gemm_naive_baseline_A(
+        a, w, a_scale, w_scale, bias=bias, out_dtype=out_dtype
+    )
+
+
+def _baseline_B_wrapper(a, w, a_scale, w_scale, bias, out_dtype):
+    # baseline-B only: choose a fixed output quant scale for the extra quant/dequant
+    return int8_gemm_naive_baseline_B_quant_dequant(
+        a, w, a_scale, w_scale, bias=bias, out_dtype=out_dtype, out_qscale=0.02
+    )
+
+
+# -----------------------------
+# Benchmarks
+# -----------------------------
+@pytest.mark.int8_gemm
+def test_int8_gemm_benchmark_vs_baseline_A():
+    """
+    Compare flag_gems.int8_gemm vs Baseline A:
+      dequant -> matmul -> (+bias) -> cast
+    """
+    bench = Int8GemmBenchmark(
+        op_name="int8_gemm",
+        torch_op=_baseline_A_wrapper,
+        dtypes=[torch.float16, torch.float32],
+        input_fn=int8_gemm_input_fn,
+    )
+    bench.set_gems(gems_int8_gemm)
+    bench.run()
+
+
+@pytest.mark.int8_gemm
+def test_int8_gemm_benchmark_vs_baseline_B_quant_dequant():
+    """
+    Compare flag_gems.int8_gemm vs Baseline B:
+      dequant -> matmul -> (+bias) -> quant(int8) -> dequant -> cast
+    """
+    bench = Int8GemmBenchmark(
+        op_name="int8_gemm",
+        torch_op=_baseline_B_wrapper,
+        dtypes=[torch.float16, torch.float32],
+        input_fn=int8_gemm_input_fn,
+    )
+    bench.set_gems(gems_int8_gemm)
+    bench.run()

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -1,5 +1,4 @@
 from flag_gems.ops.abs import abs, abs_
-from flag_gems.ops.acos import acos
 from flag_gems.ops.add import add, add_
 from flag_gems.ops.addcdiv import addcdiv
 from flag_gems.ops.addcmul import addcmul
@@ -105,6 +104,7 @@ from flag_gems.ops.index import index
 from flag_gems.ops.index_add import index_add, index_add_
 from flag_gems.ops.index_put import index_put, index_put_
 from flag_gems.ops.index_select import index_select
+from flag_gems.ops.int8_gemm import int8_gemm
 from flag_gems.ops.isclose import allclose, isclose
 from flag_gems.ops.isfinite import isfinite
 from flag_gems.ops.isin import isin
@@ -217,7 +217,6 @@ from flag_gems.ops.triu import triu
 from flag_gems.ops.uniform import uniform_
 from flag_gems.ops.unique import _unique2
 from flag_gems.ops.upsample_bicubic2d_aa import _upsample_bicubic2d_aa
-from flag_gems.ops.upsample_nearest1d import upsample_nearest1d
 from flag_gems.ops.upsample_nearest2d import upsample_nearest2d
 from flag_gems.ops.var_mean import var_mean
 from flag_gems.ops.vdot import vdot
@@ -242,7 +241,6 @@ __all__ = [
     "_upsample_bicubic2d_aa",
     "abs",
     "abs_",
-    "acos",
     "add",
     "add_",
     "addcdiv",
@@ -367,6 +365,7 @@ __all__ = [
     "index_put",
     "index_put_",
     "index_select",
+    "int8_gemm",
     "isclose",
     "isfinite",
     "isin",
@@ -515,7 +514,6 @@ __all__ = [
     "true_divide_out",
     "true_divide_",
     "uniform_",
-    "upsample_nearest1d",
     "upsample_nearest2d",
     "var_mean",
     "vdot",

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -1,4 +1,5 @@
 from flag_gems.ops.abs import abs, abs_
+from flag_gems.ops.acos import acos
 from flag_gems.ops.add import add, add_
 from flag_gems.ops.addcdiv import addcdiv
 from flag_gems.ops.addcmul import addcmul
@@ -217,6 +218,7 @@ from flag_gems.ops.triu import triu
 from flag_gems.ops.uniform import uniform_
 from flag_gems.ops.unique import _unique2
 from flag_gems.ops.upsample_bicubic2d_aa import _upsample_bicubic2d_aa
+from flag_gems.ops.upsample_nearest1d import upsample_nearest1d
 from flag_gems.ops.upsample_nearest2d import upsample_nearest2d
 from flag_gems.ops.var_mean import var_mean
 from flag_gems.ops.vdot import vdot
@@ -241,6 +243,7 @@ __all__ = [
     "_upsample_bicubic2d_aa",
     "abs",
     "abs_",
+    "acos",
     "add",
     "add_",
     "addcdiv",
@@ -514,6 +517,7 @@ __all__ = [
     "true_divide_out",
     "true_divide_",
     "uniform_",
+    "upsample_nearest1d",
     "upsample_nearest2d",
     "var_mean",
     "vdot",

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -1,5 +1,4 @@
 from flag_gems.ops.abs import abs, abs_
-from flag_gems.ops.acos import acos
 from flag_gems.ops.add import add, add_
 from flag_gems.ops.addcdiv import addcdiv
 from flag_gems.ops.addcmul import addcmul
@@ -218,7 +217,6 @@ from flag_gems.ops.triu import triu
 from flag_gems.ops.uniform import uniform_
 from flag_gems.ops.unique import _unique2
 from flag_gems.ops.upsample_bicubic2d_aa import _upsample_bicubic2d_aa
-from flag_gems.ops.upsample_nearest1d import upsample_nearest1d
 from flag_gems.ops.upsample_nearest2d import upsample_nearest2d
 from flag_gems.ops.var_mean import var_mean
 from flag_gems.ops.vdot import vdot
@@ -243,7 +241,6 @@ __all__ = [
     "_upsample_bicubic2d_aa",
     "abs",
     "abs_",
-    "acos",
     "add",
     "add_",
     "addcdiv",
@@ -517,7 +514,6 @@ __all__ = [
     "true_divide_out",
     "true_divide_",
     "uniform_",
-    "upsample_nearest1d",
     "upsample_nearest2d",
     "var_mean",
     "vdot",

--- a/src/flag_gems/ops/int8_gemm.py
+++ b/src/flag_gems/ops/int8_gemm.py
@@ -1,0 +1,191 @@
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.utils import libentry
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"TILE_M": 128, "TILE_N": 128, "TILE_K": 64}, num_stages=3, num_warps=8),
+        triton.Config({"TILE_M": 128, "TILE_N": 128, "TILE_K": 64}, num_stages=4, num_warps=8),
+        
+        triton.Config({"TILE_M": 128, "TILE_N": 256, "TILE_K": 64}, num_stages=2, num_warps=8),
+        triton.Config({"TILE_M": 128, "TILE_N": 256, "TILE_K": 128}, num_stages=2, num_warps=8),
+        
+        triton.Config({"TILE_M": 64, "TILE_N": 64, "TILE_K": 64}, num_stages=4, num_warps=4),
+    ],
+    key=["_M_NPO2", "N", "K"],
+)
+@triton.jit
+def _int8_gemm_unmasked_kernel(
+    c_ptr,
+    a_ptr,
+    b_ptr,
+    a_scale_ptr,
+    b_scale_ptr,
+    bias_ptr,
+    M,
+    N,
+    K,
+    _M_NPO2,
+    stride_am,
+    stride_ak,
+    stride_bk,
+    stride_bn,
+    stride_cm,
+    stride_cn,
+    ACC_DTYPE: tl.constexpr,
+    TILE_M: tl.constexpr,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+    IS_PER_TOKEN_A: tl.constexpr,
+    IS_PER_TOKEN_B: tl.constexpr,
+    GROUP_SIZE_M: tl.constexpr = 8,
+):
+    pid = tl.program_id(axis=0)
+    
+
+    num_pid_m = tl.cdiv(M, TILE_M)
+    num_pid_n = tl.cdiv(N, TILE_N)
+    num_pid_in_group = GROUP_SIZE_M * num_pid_n
+    group_id = pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_SIZE_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_SIZE_M)
+    pid_m = first_pid_m + ((pid % num_pid_in_group) % group_size_m)
+    pid_n = (pid % num_pid_in_group) // group_size_m
+
+    offs_m = pid_m * TILE_M + tl.arange(0, TILE_M)
+    offs_n = pid_n * TILE_N + tl.arange(0, TILE_N)
+    offs_k = tl.arange(0, TILE_K)
+
+    mask_m = offs_m < M
+    mask_n = offs_n < N
+
+    # Block Pointers
+    a_ptrs = a_ptr + (offs_m[:, None] * stride_am + offs_k[None, :] * stride_ak)
+    b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn)
+
+    acc = tl.zeros((TILE_M, TILE_N), dtype=ACC_DTYPE)
+    
+ 
+    a_step_ptr = TILE_K * stride_ak
+    b_step_ptr = TILE_K * stride_bk
+
+
+    for k in range(0, K, TILE_K):
+        mask_k = (k + offs_k) < K
+        
+        load_mask_a = mask_m[:, None] & mask_k[None, :]
+        load_mask_b = mask_k[:, None] & mask_n[None, :]
+        
+        # Load with mask
+        a = tl.load(a_ptrs, mask=load_mask_a, other=0.0)
+        b = tl.load(b_ptrs, mask=load_mask_b, other=0.0)
+        
+        # Matrix multiplication
+        acc = tl.dot(a, b, acc, out_dtype=ACC_DTYPE)
+
+        # Advance pointers
+        a_ptrs += a_step_ptr
+        b_ptrs += b_step_ptr
+
+    acc = acc.to(tl.float32)
+
+    # Scale A
+    if IS_PER_TOKEN_A:
+        # offs_m is 1D (TILE_M,), need 1D mask
+        scale_a = tl.load(a_scale_ptr + offs_m, mask=mask_m, other=1.0)
+        acc = acc * scale_a[:, None]
+    else:
+        scale_a = tl.load(a_scale_ptr)
+        acc = acc * scale_a
+
+    # Scale B
+    if IS_PER_TOKEN_B:
+        # offs_n is 1D (TILE_N,), need 1D mask
+        scale_b = tl.load(b_scale_ptr + offs_n, mask=mask_n, other=1.0)
+        acc = acc * scale_b[None, :]
+    else:
+        scale_b = tl.load(b_scale_ptr)
+        acc = acc * scale_b
+
+    # Bias
+    if bias_ptr is not None:
+        # offs_n is 1D (TILE_N,), need 1D mask
+        bias = tl.load(bias_ptr + offs_n, mask=mask_n, other=0.0)
+        acc = acc + bias[None, :]
+
+    # Store
+    c = acc.to(c_ptr.type.element_ty)
+    c_ptrs = c_ptr + stride_cm * offs_m[:, None] + stride_cn * offs_n[None, :]
+    store_mask = mask_m[:, None] & mask_n[None, :]
+    tl.store(c_ptrs, c, mask=store_mask)
+
+
+
+def int8_gemm(a, w, a_scale, w_scale, bias=None, out_dtype=torch.float16):
+    if a.dtype != torch.int8 or w.dtype != torch.int8:
+        raise TypeError(f"Expected int8 inputs, got a={a.dtype}, w={w.dtype}")
+    if a.dim() != 2 or w.dim() != 2:
+        raise ValueError("Expected 2D tensors: a (M,K), w (K,N)")
+    if a.shape[1] != w.shape[0]:
+        raise ValueError("incompatible dimensions: a.shape[1] must equal w.shape[0]")
+    if out_dtype not in (torch.float16, torch.float32):
+        raise TypeError(f"out_dtype must be torch.float16 or torch.float32, got {out_dtype}")
+
+    if a.device != w.device:
+        raise ValueError("a and w must be on the same device")
+    device = a.device
+
+    # handle non-contiguous inputs if necessary (match mm.py style)
+    if a.stride(0) > 1 and a.stride(1) > 1:
+        a = a.contiguous()
+    if w.stride(0) > 1 and w.stride(1) > 1:
+        w = w.contiguous()
+
+    M, K = a.shape
+    _, N = w.shape
+    
+    if torch.is_tensor(a_scale):
+        a_scale_t = a_scale.to(device=device, dtype=torch.float32).contiguous()
+    else:
+        a_scale_t = torch.tensor([float(a_scale)], device=device, dtype=torch.float32)
+    
+    if torch.is_tensor(w_scale):
+        if w_scale.numel() != 1 and (w_scale.dim() != 1 or w_scale.shape[0] != N):
+             raise ValueError(f"w_scale must be scalar or shape (N,), got {tuple(w_scale.shape)}")
+        w_scale_t = w_scale.to(device=device, dtype=torch.float32).contiguous()
+    else:
+        w_scale_t = torch.tensor([float(w_scale)], device=device, dtype=torch.float32)
+
+    if bias is not None:
+        if not torch.is_tensor(bias):
+             raise TypeError("bias must be a torch.Tensor or None")
+        if bias.dim() != 1 or bias.shape[0] != N:
+             raise ValueError(f"bias must have shape (N,), got {tuple(bias.shape)}")
+        bias = bias.to(device).contiguous()
+
+    c = torch.empty((M, N), device=device, dtype=out_dtype)
+
+    grid = lambda META: (
+        triton.cdiv(M, META["TILE_M"]) * triton.cdiv(N, META["TILE_N"]),
+    )
+    
+    IS_PER_TOKEN_A = a_scale_t.numel() > 1
+    IS_PER_TOKEN_B = w_scale_t.numel() > 1
+
+    _int8_gemm_unmasked_kernel[grid](
+        c, a, w,
+        a_scale_t, w_scale_t, bias,
+        M, N, K,
+        triton.next_power_of_2(M),
+        a.stride(0), a.stride(1),
+        w.stride(0), w.stride(1),
+        c.stride(0), c.stride(1),
+        ACC_DTYPE=tl.int32,
+        IS_PER_TOKEN_A=IS_PER_TOKEN_A,
+        IS_PER_TOKEN_B=IS_PER_TOKEN_B,
+    )
+    return c

--- a/src/flag_gems/ops/int8_gemm.py
+++ b/src/flag_gems/ops/int8_gemm.py
@@ -1,25 +1,33 @@
-
 import torch
 import triton
 import triton.language as tl
 
 from flag_gems.utils import libentry
 
+
 @libentry()
-@triton.autotune(
+@libtuner(
     configs=[
-        triton.Config({"TILE_M": 128, "TILE_N": 128, "TILE_K": 64}, num_stages=3, num_warps=8),
-        triton.Config({"TILE_M": 128, "TILE_N": 128, "TILE_K": 64}, num_stages=4, num_warps=8),
-        
-        triton.Config({"TILE_M": 128, "TILE_N": 256, "TILE_K": 64}, num_stages=2, num_warps=8),
-        triton.Config({"TILE_M": 128, "TILE_N": 256, "TILE_K": 128}, num_stages=2, num_warps=8),
-        
-        triton.Config({"TILE_M": 64, "TILE_N": 64, "TILE_K": 64}, num_stages=4, num_warps=4),
+        triton.Config(
+            {"TILE_M": 128, "TILE_N": 128, "TILE_K": 64}, num_stages=3, num_warps=8
+        ),
+        triton.Config(
+            {"TILE_M": 128, "TILE_N": 128, "TILE_K": 64}, num_stages=4, num_warps=8
+        ),
+        triton.Config(
+            {"TILE_M": 128, "TILE_N": 256, "TILE_K": 64}, num_stages=2, num_warps=8
+        ),
+        triton.Config(
+            {"TILE_M": 128, "TILE_N": 256, "TILE_K": 128}, num_stages=2, num_warps=8
+        ),
+        triton.Config(
+            {"TILE_M": 64, "TILE_N": 64, "TILE_K": 64}, num_stages=4, num_warps=4
+        ),
     ],
     key=["_M_NPO2", "N", "K"],
 )
 @triton.jit
-def _int8_gemm_unmasked_kernel(
+def _int8_gemm_unmasked_kernel( # pragma: no cover
     c_ptr,
     a_ptr,
     b_ptr,
@@ -45,7 +53,6 @@ def _int8_gemm_unmasked_kernel(
     GROUP_SIZE_M: tl.constexpr = 8,
 ):
     pid = tl.program_id(axis=0)
-    
 
     num_pid_m = tl.cdiv(M, TILE_M)
     num_pid_n = tl.cdiv(N, TILE_N)
@@ -68,22 +75,20 @@ def _int8_gemm_unmasked_kernel(
     b_ptrs = b_ptr + (offs_k[:, None] * stride_bk + offs_n[None, :] * stride_bn)
 
     acc = tl.zeros((TILE_M, TILE_N), dtype=ACC_DTYPE)
-    
- 
+
     a_step_ptr = TILE_K * stride_ak
     b_step_ptr = TILE_K * stride_bk
 
-
     for k in range(0, K, TILE_K):
         mask_k = (k + offs_k) < K
-        
+
         load_mask_a = mask_m[:, None] & mask_k[None, :]
         load_mask_b = mask_k[:, None] & mask_n[None, :]
-        
+
         # Load with mask
         a = tl.load(a_ptrs, mask=load_mask_a, other=0.0)
         b = tl.load(b_ptrs, mask=load_mask_b, other=0.0)
-        
+
         # Matrix multiplication
         acc = tl.dot(a, b, acc, out_dtype=ACC_DTYPE)
 
@@ -124,7 +129,6 @@ def _int8_gemm_unmasked_kernel(
     tl.store(c_ptrs, c, mask=store_mask)
 
 
-
 def int8_gemm(a, w, a_scale, w_scale, bias=None, out_dtype=torch.float16):
     if a.dtype != torch.int8 or w.dtype != torch.int8:
         raise TypeError(f"Expected int8 inputs, got a={a.dtype}, w={w.dtype}")
@@ -133,7 +137,9 @@ def int8_gemm(a, w, a_scale, w_scale, bias=None, out_dtype=torch.float16):
     if a.shape[1] != w.shape[0]:
         raise ValueError("incompatible dimensions: a.shape[1] must equal w.shape[0]")
     if out_dtype not in (torch.float16, torch.float32):
-        raise TypeError(f"out_dtype must be torch.float16 or torch.float32, got {out_dtype}")
+        raise TypeError(
+            f"out_dtype must be torch.float16 or torch.float32, got {out_dtype}"
+        )
 
     if a.device != w.device:
         raise ValueError("a and w must be on the same device")
@@ -147,24 +153,26 @@ def int8_gemm(a, w, a_scale, w_scale, bias=None, out_dtype=torch.float16):
 
     M, K = a.shape
     _, N = w.shape
-    
+
     if torch.is_tensor(a_scale):
         a_scale_t = a_scale.to(device=device, dtype=torch.float32).contiguous()
     else:
         a_scale_t = torch.tensor([float(a_scale)], device=device, dtype=torch.float32)
-    
+
     if torch.is_tensor(w_scale):
         if w_scale.numel() != 1 and (w_scale.dim() != 1 or w_scale.shape[0] != N):
-             raise ValueError(f"w_scale must be scalar or shape (N,), got {tuple(w_scale.shape)}")
+            raise ValueError(
+                f"w_scale must be scalar or shape (N,), got {tuple(w_scale.shape)}"
+            )
         w_scale_t = w_scale.to(device=device, dtype=torch.float32).contiguous()
     else:
         w_scale_t = torch.tensor([float(w_scale)], device=device, dtype=torch.float32)
 
     if bias is not None:
         if not torch.is_tensor(bias):
-             raise TypeError("bias must be a torch.Tensor or None")
+            raise TypeError("bias must be a torch.Tensor or None")
         if bias.dim() != 1 or bias.shape[0] != N:
-             raise ValueError(f"bias must have shape (N,), got {tuple(bias.shape)}")
+            raise ValueError(f"bias must have shape (N,), got {tuple(bias.shape)}")
         bias = bias.to(device).contiguous()
 
     c = torch.empty((M, N), device=device, dtype=out_dtype)
@@ -172,18 +180,27 @@ def int8_gemm(a, w, a_scale, w_scale, bias=None, out_dtype=torch.float16):
     grid = lambda META: (
         triton.cdiv(M, META["TILE_M"]) * triton.cdiv(N, META["TILE_N"]),
     )
-    
+
     IS_PER_TOKEN_A = a_scale_t.numel() > 1
     IS_PER_TOKEN_B = w_scale_t.numel() > 1
 
     _int8_gemm_unmasked_kernel[grid](
-        c, a, w,
-        a_scale_t, w_scale_t, bias,
-        M, N, K,
+        c,
+        a,
+        w,
+        a_scale_t,
+        w_scale_t,
+        bias,
+        M,
+        N,
+        K,
         triton.next_power_of_2(M),
-        a.stride(0), a.stride(1),
-        w.stride(0), w.stride(1),
-        c.stride(0), c.stride(1),
+        a.stride(0),
+        a.stride(1),
+        w.stride(0),
+        w.stride(1),
+        c.stride(0),
+        c.stride(1),
         ACC_DTYPE=tl.int32,
         IS_PER_TOKEN_A=IS_PER_TOKEN_A,
         IS_PER_TOKEN_B=IS_PER_TOKEN_B,

--- a/tests/test_int8_gemm.py
+++ b/tests/test_int8_gemm.py
@@ -1,0 +1,191 @@
+# tests/test_int8_gemm.py
+import pytest
+import torch
+
+import flag_gems
+
+
+def to_reference(x, keep_device: bool = True):
+    """
+    Keep tensors on the same device by default.
+    IMPORTANT: do NOT upcast int8 inputs to float64 here, otherwise reference matmul
+    can get dtype-mismatched when mixed with float32 scales.
+    """
+    if x is None:
+        return None
+    if not torch.is_tensor(x):
+        return x
+
+    if keep_device:
+        return x
+
+    # If you ever want CPU reference, keep dtype unchanged as well.
+    return x.detach().cpu()
+
+
+def int8_gemm_reference(
+    a_int8: torch.Tensor,
+    w_int8: torch.Tensor,
+    a_scale,
+    w_scale,
+    bias=None,
+    out_dtype=torch.float32,
+):
+    """
+    Reference: dequant -> fp32 compute -> optional bias -> cast to out_dtype
+
+    a_int8: (M, K) int8
+    w_int8: (K, N) int8
+    a_scale: scalar (python float or 0-d tensor)
+    w_scale: scalar or (N,) tensor
+    bias: None or (N,) tensor
+    """
+    # Always compute in float32 to avoid dtype pollution (e.g., float64 w_scale).
+    compute_dtype = torch.float32
+
+    # a_scale: allow python float or tensor
+    if torch.is_tensor(a_scale):
+        a_scale_t = a_scale.to(device=a_int8.device, dtype=compute_dtype)
+    else:
+        a_scale_t = torch.tensor(a_scale, device=a_int8.device, dtype=compute_dtype)
+
+    # w_scale: allow python float or tensor (scalar or per-channel (N,))
+    if torch.is_tensor(w_scale):
+        w_scale_t = w_scale.to(device=w_int8.device, dtype=compute_dtype)
+    else:
+        w_scale_t = torch.tensor(w_scale, device=w_int8.device, dtype=compute_dtype)
+
+    a = a_int8.to(dtype=compute_dtype) * a_scale_t  # (M, K) fp32
+
+    w = w_int8.to(dtype=compute_dtype)
+    # Broadcast if per-channel scale (N,)
+    w = w * w_scale_t  # (K, N) fp32
+
+    out = a @ w  # (M, N) fp32
+
+    if bias is not None:
+        out = out + bias.to(dtype=compute_dtype)
+
+    return out.to(out_dtype)
+
+
+MNK_SHAPES = [
+    (16, 32, 64),
+    (33, 65, 127),
+    (256, 512, 1024),
+]
+
+
+@pytest.mark.int8_gemm
+@pytest.mark.parametrize("M, N, K", MNK_SHAPES)
+@pytest.mark.parametrize("out_dtype", [torch.float16, torch.float32])
+@pytest.mark.parametrize("w_scale_mode", ["scalar", "per_channel"])
+@pytest.mark.parametrize("bias_mode", ["none", "fp16", "fp32"])
+def test_accuracy_int8_gemm(M, N, K, out_dtype, w_scale_mode, bias_mode):
+    # Inputs
+    a = torch.randint(-128, 127, (M, K), dtype=torch.int8, device=flag_gems.device)
+    w = torch.randint(-128, 127, (K, N), dtype=torch.int8, device=flag_gems.device)
+
+    # Scales
+    a_scale = 0.02
+    if w_scale_mode == "scalar":
+        w_scale = 0.03
+    else:
+        w_scale = (
+            torch.rand((N,), device=flag_gems.device, dtype=torch.float32) * 0.05
+            + 0.001
+        )
+
+    # Bias
+    if bias_mode == "none":
+        bias = None
+    elif bias_mode == "fp16":
+        bias = torch.randn((N,), device=flag_gems.device, dtype=torch.float16)
+    else:
+        bias = torch.randn((N,), device=flag_gems.device, dtype=torch.float32)
+
+    # Reference (keep device; do NOT upcast inputs)
+    ref_a = to_reference(a, True)
+    ref_w = to_reference(w, True)
+    ref_bias = to_reference(bias, True) if bias is not None else None
+    ref_w_scale = to_reference(w_scale, True) if torch.is_tensor(w_scale) else w_scale
+
+    ref_out = int8_gemm_reference(
+        ref_a,
+        ref_w,
+        a_scale,
+        ref_w_scale,
+        bias=ref_bias,
+        out_dtype=out_dtype,
+    )
+
+    # DUT
+    with flag_gems.use_gems():
+        out = flag_gems.ops.int8_gemm(
+            a,
+            w,
+            a_scale=a_scale,
+            w_scale=w_scale,
+            bias=bias,
+            out_dtype=out_dtype,
+        )
+
+    # Tolerances
+    # int8 dequant + matmul + cast fp16: allow slightly looser tolerance
+    if out_dtype == torch.float16:
+        atol, rtol = 5e-2, 5e-2
+    else:
+        atol, rtol = 2e-2, 2e-2
+
+    torch.testing.assert_close(out, ref_out, atol=atol, rtol=rtol)
+
+
+@pytest.mark.int8_gemm
+@pytest.mark.parametrize("out_dtype", [torch.float16, torch.float32])
+def test_accuracy_int8_gemm_noncontiguous_inputs(out_dtype):
+    # Create non-contiguous a and w by slicing/transpose patterns
+    M, N, K = (33, 127, 65)
+    a_base = torch.randint(
+        -128, 127, (M, K * 2), dtype=torch.int8, device=flag_gems.device
+    )
+    a = a_base[:, ::2]  # (M, K), non-contiguous stride
+
+    w_base = torch.randint(
+        -128, 127, (N, K), dtype=torch.int8, device=flag_gems.device
+    )
+    w = w_base.t()  # (K, N), likely non-contiguous
+
+    a_scale = 0.02
+    w_scale = torch.rand((N,), device=flag_gems.device, dtype=torch.float32) * 0.05 + 0.001
+    bias = torch.randn((N,), device=flag_gems.device, dtype=torch.float32)
+
+    ref_a = to_reference(a, True)
+    ref_w = to_reference(w, True)
+    ref_w_scale = to_reference(w_scale, True)
+    ref_bias = to_reference(bias, True)
+
+    ref_out = int8_gemm_reference(
+        ref_a,
+        ref_w,
+        a_scale,
+        ref_w_scale,
+        bias=ref_bias,
+        out_dtype=out_dtype,
+    )
+
+    with flag_gems.use_gems():
+        out = flag_gems.ops.int8_gemm(
+            a,
+            w,
+            a_scale=a_scale,
+            w_scale=w_scale,
+            bias=bias,
+            out_dtype=out_dtype,
+        )
+
+    if out_dtype == torch.float16:
+        atol, rtol = 5e-2, 5e-2
+    else:
+        atol, rtol = 2e-2, 2e-2
+
+    torch.testing.assert_close(out, ref_out, atol=atol, rtol=rtol)


### PR DESCRIPTION
### PR Category
 Operator 

### Type of Change
New Feature 

### Description
Develop forward kernel for standard int8 quantized GEMM (int8-gemm).
开发标准 int8 量化矩阵乘 GEMM 前向功能。

此算子属于 quantization / integer matmul 类，是大多数推理引擎（TensorRT、QNNPACK、FasterTransformer、ONNXRuntime）使用的基础算子。
- 基于 Triton Kernel 实现高效的矩阵乘法。
- 支持 Per-Tensor (A) 和 Per-Channel/Per-Tensor (W) 的量化缩放 (Scaling)。
- 支持可选的 Bias 加法。
- 支持 float16 和 float32 输出类型。
- Registration : 在 src/flag_gems/ops/__init__.py 中注册了该算子，使其可通过 flag_gems.ops.int8_gemm 调用
- Implement efficient matrix multiplication based on Triton Kernel.
- Support Per-Tensor (A) and Per-Channel/Per-Tensor (W) quantization scaling.
- Support optional Bias addition.
- Support float16 and float32 output types.
- Registration: This operator is registered in src/flag_gems/ops/init.py, making it callable via flag_gems.ops.int8_gemm
- 
### Issue

- Resolves #1125

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

**运行正确性测试/Correctness Verification**:
```bash
pytest tests/test_int8_gemm.py
```
<img width="2301" height="834" alt="d78d249e8bfd279c6eba793e6995c8e9" src="https://github.com/user-attachments/assets/9c7ac07b-5341-4f7f-9f61-7d65632d09fe" />


**运行性能基准测试/Performance Test**:
```bash
pytest -s benchmark/test_int8_gemm_perf.py
```
<img width="2631" height="1710" alt="5cc3a30faefb72161d6ece53ffb93b0a" src="https://github.com/user-attachments/assets/fddd472e-d6bc-4601-9e6c-bf5d0fe1f7c6" />

