### PR TITLE
【PerfXLab】use tf32x3 to emulate fp32 on matmul op

### DIFF
--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/mm.py
@@ -41,6 +41,36 @@ def get_sm_count():
     return get_device_info()[2]
 
 
+def is_tma_compatible(a, b, N, K):
+    """
+    Check if tensors are compatible with TMA (Tensor Memory Accelerator).
+
+    TMA requires 128-bit (16-byte) alignment for memory access:
+    - For FP16/BF16 (2 bytes/element): N and K must be multiples of 8
+      (8 elements × 2 bytes = 16 bytes)
+    - For FP32 (4 bytes/element): N and K must be multiples of 4
+      (4 elements × 4 bytes = 16 bytes)
+
+    Args:
+        a, b: Input tensors
+        N, K: Matrix dimensions
+
+    Returns:
+        bool: True if compatible with TMA's 128-bit alignment requirement
+    """
+    return (
+        a.dtype in (torch.float16, torch.bfloat16)
+        and b.dtype in (torch.float16, torch.bfloat16)
+        and N % 8 == 0
+        and K % 8 == 0
+    ) or (
+        a.dtype in (torch.float32,)
+        and b.dtype in (torch.float32,)
+        and N % 4 == 0
+        and K % 4 == 0
+    )
+
+
 CACHE_USAGE_THRESHOLD = 0.8
 
 logger = logging.getLogger(__name__)
@@ -317,20 +347,9 @@ def general_mm(a, b, c, M, N, K):
     grid = lambda META: (
         triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
     )
-    if (
-        (
-            a.dtype in (torch.float16, torch.bfloat16)
-            and b.dtype in (torch.float16, torch.bfloat16)
-            and N % 8 == 0
-            and K % 8 == 0
-        )
-        or (
-            a.dtype in (torch.float32,)
-            and b.dtype in (torch.float32,)
-            and N % 4 == 0
-            and K % 4 == 0
-        )
-    ) and triton.__version__ >= "3.5":
+    if hasattr(
+        triton.tools.tensor_descriptor, "TensorDescriptor"
+    ) and is_tma_compatible(a, b, N, K):
         a_row_major = a.stride(1) == 1
         b_row_major = b.stride(1) == 1
         dummy_block = [1, 1]


### PR DESCRIPTION
### PR Category
[ Operator ]

### Type of Change
[Performance Optimization]

### Description
3xTF32 is a technique to emulate FP32 accuracy but with better performance. The trick is just splitting a FP32 MMA into 3 TF32 MMAs.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
```
Operator: mm  Performance Test (dtype=torch.float32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               0.017056            0.012272               1.390               9.228          [torch.Size([384, 384]), torch.Size([384, 384])]
SUCCESS               2.654480            2.519744               1.053              54.545          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.064928            0.046784               1.388              45.902          [torch.Size([1024, 1024]), torch.Size([1024, 1024])]
SUCCESS               0.344448            0.321088               1.073              53.505          [torch.Size([2048, 2048]), torch.Size([2048, 2048])]
SUCCESS               2.658352            2.472288               1.075              55.592          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
```