### PR TITLE
[FlagGems Operator Development Competition]  median Operator

### DIFF
--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -132,6 +132,16 @@ def cumsum_input_fn(shape, cur_dtype, device):
     yield inp, 1
 
 
+def median_input_fn(shape, cur_dtype, device):
+    inp = generate_tensor_input(shape, cur_dtype, device)
+    dim = -1 if inp.ndim > 1 else 0
+    yield inp, dim
+    if Config.bench_level == BenchLevel.COMPREHENSIVE:
+        if inp.ndim > 1:
+            yield inp, 0
+            yield inp, dim, {"keepdim": True}
+
+
 def mse_loss_input_fn(shape, cur_dtype, device):
     inp = generate_tensor_input(shape, cur_dtype, device)
     target = generate_tensor_input(shape, cur_dtype, device)
@@ -200,6 +210,13 @@ def mse_loss_input_fn(shape, cur_dtype, device):
             mse_loss_input_fn,
             FLOAT_DTYPES,
             marks=pytest.mark.mse_loss,
+        ),
+        pytest.param(
+            "median",
+            torch.median,
+            median_input_fn,
+            FLOAT_DTYPES,
+            marks=pytest.mark.median,
         ),
     ],
 )

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -11,6 +11,7 @@ from flag_gems.fused import *  # noqa: F403
 from flag_gems.logging_utils import setup_flaggems_logging
 from flag_gems.modules import *  # noqa: F403
 from flag_gems.ops import *  # noqa: F403
+from flag_gems.ops.median import median_dim
 from flag_gems.patches import *  # noqa: F403
 from flag_gems.runtime.register import Register
 
@@ -233,6 +234,7 @@ def enable(
             ("max_pool2d_backward", max_pool2d_backward),
             ("mean", mean),
             ("mean.dim", mean_dim),
+            ("median.dim", median_dim),
             ("min", min),
             ("min.dim", min_dim),
             ("minimum", minimum),

--- a/src/flag_gems/ops/median.py
+++ b/src/flag_gems/ops/median.py
@@ -128,7 +128,9 @@ def _find_pattern_kernel(
         has = tl.sum(match, axis=0) > 0
         idx_in = tl.argmax(match, axis=0).to(tl.int32)
         cand_idx = (c + idx_in).to(tl.int32)
-        cand_val = tl.load(inp_ptr + row * stride_sm + cand_idx * stride_sn, mask=row_mask)
+        cand_val = tl.load(
+            inp_ptr + row * stride_sm + cand_idx * stride_sn, mask=row_mask
+        )
 
         do_set = (~found) & has
         first_idx = tl.where(do_set, cand_idx, first_idx)
@@ -192,7 +194,9 @@ def _radix_kthvalue_lastdim(inp_2d: torch.Tensor, k: int, *, largest: bool):
         prev = torch.zeros_like(k_to_find)
         has_prev = bin_idx_work > 0
         if has_prev.any():
-            prev_vals = prefix.gather(-1, (bin_idx_work - 1).clamp(min=0).unsqueeze(-1)).squeeze(-1)
+            prev_vals = prefix.gather(
+                -1, (bin_idx_work - 1).clamp(min=0).unsqueeze(-1)
+            ).squeeze(-1)
             prev = torch.where(has_prev, prev_vals, prev)
 
         k_to_find = k_to_find - prev
@@ -250,17 +254,23 @@ def median_dim(inp, dim=-1, keepdim=False):
         first_nan = nan_mask.int().argmax(dim=-1)
 
     if has_nan is not None and has_nan.any():
-        nan_val = torch.tensor(float("nan"), device=out_value.device, dtype=out_value.dtype)
+        nan_val = torch.tensor(
+            float("nan"), device=out_value.device, dtype=out_value.dtype
+        )
         out_value = torch.where(has_nan, nan_val, out_value)
         out_index[has_nan] = first_nan[has_nan]
 
         no_nan = ~has_nan
         if no_nan.any():
-            v, idx = _radix_kthvalue_lastdim(inp_2d[no_nan], median_pos + 1, largest=False)
+            v, idx = _radix_kthvalue_lastdim(
+                inp_2d[no_nan], median_pos + 1, largest=False
+            )
             out_value[no_nan] = v
             out_index[no_nan] = idx
     else:
-        out_value, out_index = _radix_kthvalue_lastdim(inp_2d, median_pos + 1, largest=False)
+        out_value, out_index = _radix_kthvalue_lastdim(
+            inp_2d, median_pos + 1, largest=False
+        )
 
     shape[dim] = 1
     out_value = out_value.reshape(shape)

--- a/src/flag_gems/ops/median.py
+++ b/src/flag_gems/ops/median.py
@@ -1,52 +1,234 @@
 import logging
-import os
 from collections import namedtuple
 
 import torch
 import triton
 import triton.language as tl
 
-from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
-from flag_gems.utils import dim_compress, libentry, libtuner
+from flag_gems.utils import dim_compress, libentry
 from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 
 
-@libentry()
-@libtuner(
-    configs=runtime.get_tuned_config("naive_reduction"),
-    key=["M", "N"],
-)
 @triton.jit
-def median_value_kernel(
-    sorted_inp,
-    out_value,
+def _radix_convert(v, elem_ty: tl.constexpr):
+    if elem_ty is tl.float32:
+        x = v.to(tl.uint32, bitcast=True)
+        sign = x & 0x8000_0000
+        mask = tl.where(sign != 0, 0xFFFF_FFFF, 0x8000_0000).to(tl.uint32)
+        y = x ^ mask
+        y = tl.where(v == v, y, 0xFFFF_FFFF).to(tl.uint32)
+        return y
+    if elem_ty is tl.float16:
+        x16 = v.to(tl.uint16, bitcast=True)
+        x = x16.to(tl.uint32)
+        sign = x & 0x0000_8000
+        mask = tl.where(sign != 0, 0x0000_FFFF, 0x0000_8000).to(tl.uint32)
+        y = x ^ mask
+        y = tl.where(v == v, y, 0x0000_FFFF).to(tl.uint32)
+        return y
+    if elem_ty is tl.bfloat16:
+        x16 = v.to(tl.uint16, bitcast=True)
+        x = x16.to(tl.uint32)
+        sign = x & 0x0000_8000
+        mask = tl.where(sign != 0, 0x0000_FFFF, 0x0000_8000).to(tl.uint32)
+        y = x ^ mask
+        y = tl.where(v == v, y, 0x0000_FFFF).to(tl.uint32)
+        return y
+    if elem_ty is tl.int32:
+        x = v.to(tl.uint32, bitcast=True)
+        return x ^ 0x8000_0000
+    if elem_ty is tl.int16:
+        x16 = v.to(tl.uint16, bitcast=True)
+        x = x16.to(tl.uint32)
+        return x ^ 0x0000_8000
+    return v.to(tl.uint32)
+
+
+@libentry()
+@triton.jit
+def _radix_count_kernel(
+    inp_ptr,
+    counts_ptr,
+    desired_ptr,
+    desired_mask_ptr,
+    stride_sm,
+    stride_sn,
+    stride_counts_m,
+    M,
+    N,
+    BIT_OFFSET: tl.constexpr,
+    K_BITS: tl.constexpr,
+    NUM_BINS: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    row = tle.program_id(0)
+    row_mask = row < M
+
+    desired = tl.load(desired_ptr + row, mask=row_mask, other=0).to(tl.uint32)
+    desired_mask = tl.load(desired_mask_ptr + row, mask=row_mask, other=0).to(tl.uint32)
+
+    counts = tl.zeros([NUM_BINS], dtype=tl.int32)
+
+    for c in range(0, N, BLOCK_N):
+        cols = c + tl.arange(0, BLOCK_N)
+        m = row_mask & (cols < N)
+        ptr = inp_ptr + row * stride_sm + cols * stride_sn
+        vals = tl.load(ptr, mask=m, other=0)
+        key = _radix_convert(vals, inp_ptr.dtype.element_ty)
+
+        ok = m & ((key & desired_mask) == desired)
+        digit = (key >> BIT_OFFSET) & (NUM_BINS - 1)
+
+        for b in tl.static_range(NUM_BINS):
+            counts_b = tl.sum(ok & (digit == b), axis=0)
+            counts = tl.where(
+                tl.arange(0, NUM_BINS) == b,
+                counts + tl.cast(counts_b, tl.int32),
+                counts,
+            )
+
+    base = counts_ptr + row * stride_counts_m
+    tl.store(base + tl.arange(0, NUM_BINS), counts, mask=row_mask)
+
+
+@libentry()
+@triton.jit
+def _find_pattern_kernel(
+    inp_ptr,
+    out_val_ptr,
+    out_idx_ptr,
+    desired_ptr,
+    desired_mask_ptr,
     stride_sm,
     stride_sn,
     M,
     N,
-    median_pos,
-    BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
-    pid = tle.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
-    mask = pid < M
+    row = tle.program_id(0)
+    row_mask = row < M
 
-    base = sorted_inp + pid * stride_sm + median_pos * stride_sn
-    val = tl.load(base, mask=mask)
+    desired = tl.load(desired_ptr + row, mask=row_mask, other=0).to(tl.uint32)
+    desired_mask = tl.load(desired_mask_ptr + row, mask=row_mask, other=0).to(tl.uint32)
 
-    tl.store(out_value + pid, val, mask=mask)
+    found = tl.zeros((), dtype=tl.int1)
+    first_idx = tl.zeros((), dtype=tl.int32)
+    first_val = tl.zeros((), dtype=inp_ptr.dtype.element_ty)
+
+    for c in range(0, N, BLOCK_N):
+        cols = c + tl.arange(0, BLOCK_N)
+        m = row_mask & (cols < N)
+        ptr = inp_ptr + row * stride_sm + cols * stride_sn
+        vals = tl.load(ptr, mask=m, other=0)
+        key = _radix_convert(vals, inp_ptr.dtype.element_ty)
+        match = m & ((key & desired_mask) == desired)
+        has = tl.sum(match, axis=0) > 0
+        idx_in = tl.argmax(match, axis=0).to(tl.int32)
+        cand_idx = (c + idx_in).to(tl.int32)
+        cand_val = tl.load(inp_ptr + row * stride_sm + cand_idx * stride_sn, mask=row_mask)
+
+        do_set = (~found) & has
+        first_idx = tl.where(do_set, cand_idx, first_idx)
+        first_val = tl.where(do_set, cand_val, first_val)
+        found = found | has
+
+    tl.store(out_val_ptr + row, first_val, mask=row_mask)
+    tl.store(out_idx_ptr + row, first_idx.to(tl.int64), mask=row_mask)
+
+
+def _radix_kthvalue_lastdim(inp_2d: torch.Tensor, k: int, *, largest: bool):
+    assert inp_2d.dim() == 2
+    M, N = inp_2d.shape
+    device = inp_2d.device
+
+    if inp_2d.dtype in (torch.float16, torch.bfloat16, torch.int16):
+        num_bits = 16
+    elif inp_2d.dtype in (torch.float32, torch.int32):
+        num_bits = 32
+    else:
+        raise RuntimeError(f"radix_select: unsupported dtype {inp_2d.dtype}")
+
+    K_BITS = 4
+    NUM_BINS = 1 << K_BITS
+    BLOCK_N = 256
+
+    desired = torch.zeros((M,), device=device, dtype=torch.int32)
+    desired_mask = torch.zeros((M,), device=device, dtype=torch.int32)
+    k_to_find = torch.full((M,), int(k), device=device, dtype=torch.int32)
+
+    counts = torch.empty((M, NUM_BINS), device=device, dtype=torch.int32)
+
+    grid = (M,)
+    for bit_offset in range(num_bits - K_BITS, -1, -K_BITS):
+        with torch_device_fn.device(device):
+            _radix_count_kernel[grid](
+                inp_2d,
+                counts,
+                desired,
+                desired_mask,
+                inp_2d.stride(0),
+                inp_2d.stride(1),
+                counts.stride(0),
+                M,
+                N,
+                BIT_OFFSET=bit_offset,
+                K_BITS=K_BITS,
+                NUM_BINS=NUM_BINS,
+                BLOCK_N=BLOCK_N,
+            )
+
+        if largest:
+            counts_work = counts.flip(-1)
+        else:
+            counts_work = counts
+
+        prefix = torch.cumsum(counts_work, dim=-1)
+        ge = prefix >= k_to_find.unsqueeze(-1)
+        bin_idx_work = ge.int().argmax(dim=-1)
+
+        prev = torch.zeros_like(k_to_find)
+        has_prev = bin_idx_work > 0
+        if has_prev.any():
+            prev_vals = prefix.gather(-1, (bin_idx_work - 1).clamp(min=0).unsqueeze(-1)).squeeze(-1)
+            prev = torch.where(has_prev, prev_vals, prev)
+
+        k_to_find = k_to_find - prev
+
+        if largest:
+            bin_idx = (NUM_BINS - 1) - bin_idx_work
+        else:
+            bin_idx = bin_idx_work
+
+        desired = desired | (bin_idx << bit_offset)
+        desired_mask = desired_mask | ((NUM_BINS - 1) << bit_offset)
+
+    out_val = torch.empty((M,), device=device, dtype=inp_2d.dtype)
+    out_idx = torch.empty((M,), device=device, dtype=torch.int64)
+    with torch_device_fn.device(device):
+        _find_pattern_kernel[grid](
+            inp_2d,
+            out_val,
+            out_idx,
+            desired,
+            desired_mask,
+            inp_2d.stride(0),
+            inp_2d.stride(1),
+            M,
+            N,
+            BLOCK_N=BLOCK_N,
+        )
+    return out_val, out_idx
 
 
 def median_dim(inp, dim=-1, keepdim=False):
     logger.debug("GEMS MEDIAN DIM")
 
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
-
-    dim_arg = dim
     dim = dim % inp.ndim
+
     shape = list(inp.shape)
     N = shape[dim]
     if N == 0:
@@ -58,64 +240,28 @@ def median_dim(inp, dim=-1, keepdim=False):
     M = inp_c.numel() // N
     inp_2d = inp_c.reshape(M, N)
 
-    sorted_vals, sorted_idx = torch.sort(inp_2d, dim=-1, stable=True)
-
-    out_value = torch.empty(
-        (M,),
-        dtype=inp.dtype,
-        device=inp.device,
-    )
-
-    grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
-    with torch_device_fn.device(inp.device):
-        median_value_kernel[grid](
-            sorted_vals,
-            out_value,
-            sorted_vals.stride(0),
-            sorted_vals.stride(1),
-            M,
-            N,
-            median_pos,
-        )
-
-    out_index = torch.empty(
-        (M,),
-        dtype=torch.int64,
-        device=inp.device,
-    )
+    out_value = torch.empty((M,), device=inp.device, dtype=inp.dtype)
+    out_index = torch.empty((M,), device=inp.device, dtype=torch.int64)
 
     has_nan = None
     if inp_2d.is_floating_point() or inp_2d.is_complex():
         nan_mask = torch.isnan(inp_2d)
         has_nan = nan_mask.any(dim=-1)
-        first_nan_index = nan_mask.int().argmax(dim=-1)
+        first_nan = nan_mask.int().argmax(dim=-1)
 
-        if has_nan.any():
-            nan_value = torch.tensor(
-                float("nan"),
-                dtype=out_value.dtype,
-                device=out_value.device,
-            )
-            out_value = torch.where(has_nan, nan_value, out_value)
-            out_index[has_nan] = first_nan_index[has_nan]
+    if has_nan is not None and has_nan.any():
+        nan_val = torch.tensor(float("nan"), device=out_value.device, dtype=out_value.dtype)
+        out_value = torch.where(has_nan, nan_val, out_value)
+        out_index[has_nan] = first_nan[has_nan]
 
-    if has_nan is None:
-        no_nan_mask = torch.ones((M,), dtype=torch.bool, device=inp.device)
+        no_nan = ~has_nan
+        if no_nan.any():
+            v, idx = _radix_kthvalue_lastdim(inp_2d[no_nan], median_pos + 1, largest=False)
+            out_value[no_nan] = v
+            out_index[no_nan] = idx
     else:
-        no_nan_mask = ~has_nan
+        out_value, out_index = _radix_kthvalue_lastdim(inp_2d, median_pos + 1, largest=False)
 
-    if no_nan_mask.any():
-        rows = torch.nonzero(no_nan_mask, as_tuple=False).squeeze(1)
-
-        vals = out_value[rows]
-        src = inp_2d[rows]
-        eq_mask = src == vals.unsqueeze(1)
-
-        assert eq_mask.any(dim=-1).all()
-
-        first_eq_index = eq_mask.int().argmax(dim=-1)
-        out_index[rows] = first_eq_index
-        
     shape[dim] = 1
     out_value = out_value.reshape(shape)
     out_index = out_index.reshape(shape)

--- a/src/flag_gems/ops/median.py
+++ b/src/flag_gems/ops/median.py
@@ -11,6 +11,9 @@ from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 
+# Reuse the namedtuple type across calls (avoid recreating it inside median_dim).
+Median_out = namedtuple("median", ["values", "indices"])
+
 
 @triton.jit
 def _radix_convert(v, elem_ty: tl.constexpr):
@@ -280,5 +283,4 @@ def median_dim(inp, dim=-1, keepdim=False):
         out_value = out_value.squeeze(dim)
         out_index = out_index.squeeze(dim)
 
-    Median_out = namedtuple("median", ["values", "indices"])
     return Median_out(values=out_value, indices=out_index)

--- a/src/flag_gems/ops/median.py
+++ b/src/flag_gems/ops/median.py
@@ -1,0 +1,128 @@
+import logging
+import os
+from collections import namedtuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry, libtuner
+from flag_gems.utils import triton_lang_extension as tle
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@libtuner(
+    configs=runtime.get_tuned_config("naive_reduction"),
+    key=["M", "N"],
+)
+@triton.jit
+def median_value_kernel(
+    sorted_inp,
+    out_value,
+    stride_sm,
+    stride_sn,
+    M,
+    N,
+    median_pos,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid = tle.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    mask = pid < M
+
+    base = sorted_inp + pid * stride_sm + median_pos * stride_sn
+    val = tl.load(base, mask=mask)
+
+    tl.store(out_value + pid, val, mask=mask)
+
+
+def median_dim(inp, dim=-1, keepdim=False):
+    logger.debug("GEMS MEDIAN DIM")
+
+    assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
+
+    dim_arg = dim
+    dim = dim % inp.ndim
+    shape = list(inp.shape)
+    N = shape[dim]
+    if N == 0:
+        raise RuntimeError("median: dimension is empty")
+
+    median_pos = (N - 1) // 2
+
+    inp_c = dim_compress(inp, dim)
+    M = inp_c.numel() // N
+    inp_2d = inp_c.reshape(M, N)
+
+    sorted_vals, sorted_idx = torch.sort(inp_2d, dim=-1, stable=True)
+
+    out_value = torch.empty(
+        (M,),
+        dtype=inp.dtype,
+        device=inp.device,
+    )
+
+    grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
+    with torch_device_fn.device(inp.device):
+        median_value_kernel[grid](
+            sorted_vals,
+            out_value,
+            sorted_vals.stride(0),
+            sorted_vals.stride(1),
+            M,
+            N,
+            median_pos,
+        )
+
+    out_index = torch.empty(
+        (M,),
+        dtype=torch.int64,
+        device=inp.device,
+    )
+
+    has_nan = None
+    if inp_2d.is_floating_point() or inp_2d.is_complex():
+        nan_mask = torch.isnan(inp_2d)
+        has_nan = nan_mask.any(dim=-1)
+        first_nan_index = nan_mask.int().argmax(dim=-1)
+
+        if has_nan.any():
+            nan_value = torch.tensor(
+                float("nan"),
+                dtype=out_value.dtype,
+                device=out_value.device,
+            )
+            out_value = torch.where(has_nan, nan_value, out_value)
+            out_index[has_nan] = first_nan_index[has_nan]
+
+    if has_nan is None:
+        no_nan_mask = torch.ones((M,), dtype=torch.bool, device=inp.device)
+    else:
+        no_nan_mask = ~has_nan
+
+    if no_nan_mask.any():
+        rows = torch.nonzero(no_nan_mask, as_tuple=False).squeeze(1)
+
+        vals = out_value[rows]
+        src = inp_2d[rows]
+        eq_mask = src == vals.unsqueeze(1)
+
+        assert eq_mask.any(dim=-1).all()
+
+        first_eq_index = eq_mask.int().argmax(dim=-1)
+        out_index[rows] = first_eq_index
+        
+    shape[dim] = 1
+    out_value = out_value.reshape(shape)
+    out_index = out_index.reshape(shape)
+
+    if not keepdim:
+        out_value = out_value.squeeze(dim)
+        out_index = out_index.squeeze(dim)
+
+    Median_out = namedtuple("median", ["values", "indices"])
+    return Median_out(values=out_value, indices=out_index)

--- a/tests/test_median.py
+++ b/tests/test_median.py
@@ -15,7 +15,9 @@ from .accuracy_utils import (
 )
 
 
-def assert_median_indices_equal_if_no_duplicates(inp, res_out, ref_out, *, dim, keepdim):
+def assert_median_indices_equal_if_no_duplicates(
+    inp, res_out, ref_out, *, dim, keepdim
+):
     def _dup_mask_along_dim(inp: torch.Tensor, *, dim: int) -> torch.Tensor:
         dim = dim % inp.ndim
         x = inp.movedim(dim, -1).contiguous()
@@ -26,7 +28,7 @@ def assert_median_indices_equal_if_no_duplicates(inp, res_out, ref_out, *, dim, 
         xs, _ = torch.sort(x2d, dim=-1)
         dup = (xs[:, 1:] == xs[:, :-1]).any(dim=-1)
         return dup.reshape(x.shape[:-1])
-    
+
     dup = _dup_mask_along_dim(inp, dim=dim)
     if keepdim:
         dup = dup.unsqueeze(dim % inp.ndim)
@@ -544,7 +546,6 @@ def test_median_nan_handling():
         gems_assert_equal(res_out.indices, ref_out.indices)
 
 
-
 @pytest.mark.median
 def test_median_inf_handling():
     inp = torch.tensor(
@@ -562,4 +563,3 @@ def test_median_inf_handling():
     else:
         gems_assert_close(res_out.values, ref_out.values, torch.float32)
         gems_assert_equal(res_out.indices, ref_out.indices)
-

--- a/tests/test_median.py
+++ b/tests/test_median.py
@@ -1,0 +1,526 @@
+import os
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.ops.median import median_dim
+
+from .accuracy_utils import (
+    FLOAT_DTYPES,
+    INT_DTYPES,
+    gems_assert_close,
+    gems_assert_equal,
+    to_reference,
+)
+
+
+def assert_median_indices_valid(inp, out, *, dim, keepdim):
+    dim = dim % inp.ndim
+    idx = out.indices
+    if not keepdim:
+        idx = idx.unsqueeze(dim)
+    gathered = torch.gather(inp, dim, idx)
+    if not keepdim:
+        gathered = gathered.squeeze(dim)
+    torch.testing.assert_close(gathered, out.values, atol=0, rtol=0, equal_nan=True)
+
+
+SHAPE_SMALL = [
+    (1,),
+    (2,),
+    (3,),
+    (1, 1),
+    (2, 2),
+    (3, 3),
+    (1, 1, 1),
+    (2, 2, 2),
+]
+
+SHAPE_MEDIUM = [
+    (8,),
+    (16,),
+    (32,),
+    (64,),
+    (8, 8),
+    (16, 16),
+    (32, 32),
+    (4, 8, 8),
+    (8, 16, 16),
+    (2, 4, 8, 8),
+    (4, 4, 16, 16),
+]
+
+SHAPE_LARGE = [
+    (256,),
+    (512,),
+    (1024,),
+    (128, 128),
+    (256, 256),
+    (16, 128, 128),
+    (8, 16, 64, 64),
+    (4, 8, 32, 32, 32),
+]
+
+
+SHAPE_DIMENSIONS = [
+    (1,),
+    (8,),
+    (32,),
+    (128,),
+    (1, 1),
+    (4, 8),
+    (16, 32),
+    (64, 128),
+    (1, 1, 1),
+    (2, 4, 8),
+    (8, 16, 32),
+    (16, 32, 64),
+    (1, 1, 1, 1),
+    (2, 4, 8, 16),
+    (4, 8, 16, 32),
+    (8, 16, 32, 64),
+    (1, 1, 1, 1, 1),
+    (2, 2, 4, 8, 16),
+    (4, 4, 8, 16, 32),
+]
+
+DIM_VALUES = [
+    -1,
+    0,
+    1,
+    2,
+]
+
+KEEPDIM_VALUES = [True, False]
+
+
+SHAPE_EXTREME_VALUES = [
+    (1,),
+    (2,),
+    (3,),
+    (1000,),
+]
+
+SHAPE_WITH_ZEROS = [
+    (8,),
+    (16,),
+    (32,),
+    (4, 8),
+    (8, 16),
+]
+
+SHAPE_WITH_NEGATIVES = [
+    (8,),
+    (16,),
+    (32,),
+    (4, 8),
+    (8, 16),
+]
+
+SHAPE_EMPTY = [
+    (0,),
+    (0, 1),
+    (1, 0),
+    (0, 0),
+]
+
+
+
+@pytest.mark.median
+@pytest.mark.parametrize("shape", SHAPE_SMALL)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_median_small(shape, dtype):
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        os.environ["MUSA_ENABLE_SQMMA"] = "1"
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
+    ref_inp = to_reference(inp, True)
+    
+    ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
+    res_out = median_dim(inp, dim=-1, keepdim=False)
+    
+    gems_assert_close(res_out.values, ref_out.values, dtype)
+    # gems_assert_equal(res_out.indices, ref_out.indices)
+    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        del os.environ["MUSA_ENABLE_SQMMA"]
+
+
+@pytest.mark.median
+@pytest.mark.parametrize("shape", SHAPE_MEDIUM)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_median_medium(shape, dtype):
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        os.environ["MUSA_ENABLE_SQMMA"] = "1"
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
+    ref_inp = to_reference(inp, True)
+    
+    ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
+    res_out = median_dim(inp, dim=-1, keepdim=False)
+    
+    gems_assert_close(res_out.values, ref_out.values, dtype)
+    # gems_assert_equal(res_out.indices, ref_out.indices)
+    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        del os.environ["MUSA_ENABLE_SQMMA"]
+
+
+@pytest.mark.median
+@pytest.mark.parametrize("shape", SHAPE_LARGE)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_median_large(shape, dtype):
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        os.environ["MUSA_ENABLE_SQMMA"] = "1"
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
+    ref_inp = to_reference(inp, True)
+    
+    ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
+    res_out = median_dim(inp, dim=-1, keepdim=False)
+    
+    gems_assert_close(res_out.values, ref_out.values, dtype)
+    # gems_assert_equal(res_out.indices, ref_out.indices)
+    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        del os.environ["MUSA_ENABLE_SQMMA"]
+
+
+@pytest.mark.median
+@pytest.mark.parametrize("shape", SHAPE_DIMENSIONS)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_median_dimensions(shape, dtype):
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        os.environ["MUSA_ENABLE_SQMMA"] = "1"
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
+    ref_inp = to_reference(inp, True)
+    
+    for dim in range(-inp.ndim, inp.ndim):
+        ref_out = torch.median(ref_inp, dim=dim, keepdim=False)
+        res_out = median_dim(inp, dim=dim, keepdim=False)
+        
+        gems_assert_close(res_out.values, ref_out.values, dtype)
+        # gems_assert_equal(res_out.indices, ref_out.indices)
+        assert_median_indices_valid(inp, res_out, dim=dim, keepdim=False)
+
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        del os.environ["MUSA_ENABLE_SQMMA"]
+
+
+@pytest.mark.median
+@pytest.mark.parametrize("shape", [(8,), (16,), (4, 8), (8, 16), (2, 4, 8)])
+@pytest.mark.parametrize("keepdim", KEEPDIM_VALUES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_median_keepdim(shape, keepdim, dtype):
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        os.environ["MUSA_ENABLE_SQMMA"] = "1"
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
+    ref_inp = to_reference(inp, True)
+    
+    ref_out = torch.median(ref_inp, dim=-1, keepdim=keepdim)
+    res_out = median_dim(inp, dim=-1, keepdim=keepdim)
+    
+    gems_assert_close(res_out.values, ref_out.values, dtype)
+    # gems_assert_equal(res_out.indices, ref_out.indices)
+    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=keepdim)
+
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        del os.environ["MUSA_ENABLE_SQMMA"]
+
+
+@pytest.mark.median
+@pytest.mark.parametrize("shape", SHAPE_EXTREME_VALUES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_median_extreme_values(shape, dtype):
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        os.environ["MUSA_ENABLE_SQMMA"] = "1"
+
+    max_val = torch.finfo(dtype).max if dtype.is_floating_point else torch.iinfo(dtype).max
+    inp_max = torch.full(shape, max_val, dtype=dtype, device=flag_gems.device)
+    ref_inp_max = to_reference(inp_max, True)
+    
+    ref_out_max = torch.median(ref_inp_max, dim=-1, keepdim=False)
+    res_out_max = median_dim(inp_max, dim=-1, keepdim=False)
+    
+    gems_assert_close(res_out_max.values, ref_out_max.values, dtype)
+    # gems_assert_equal(res_out_max.indices, ref_out_max.indices)
+    assert_median_indices_valid(inp_max, res_out_max, dim=-1, keepdim=False)
+    
+    min_val = torch.finfo(dtype).min if dtype.is_floating_point else torch.iinfo(dtype).min
+    inp_min = torch.full(shape, min_val, dtype=dtype, device=flag_gems.device)
+    ref_inp_min = to_reference(inp_min, True)
+    
+    ref_out_min = torch.median(ref_inp_min, dim=-1, keepdim=False)
+    res_out_min = median_dim(inp_min, dim=-1, keepdim=False)
+    
+    gems_assert_close(res_out_min.values, ref_out_min.values, dtype)
+    # gems_assert_equal(res_out_min.indices, ref_out_min.indices)
+    assert_median_indices_valid(inp_min, res_out_min, dim=-1, keepdim=False)
+
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        del os.environ["MUSA_ENABLE_SQMMA"]
+
+
+@pytest.mark.median
+@pytest.mark.parametrize("shape", SHAPE_WITH_ZEROS)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_median_with_zeros(shape, dtype):
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        os.environ["MUSA_ENABLE_SQMMA"] = "1"
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
+    zero_indices = torch.randint(0, inp.numel(), (inp.numel() // 4,))
+    inp_flatten = inp.flatten()
+    inp_flatten[zero_indices] = 0
+    inp = inp_flatten.reshape(shape)
+    
+    ref_inp = to_reference(inp, True)
+    ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
+    res_out = median_dim(inp, dim=-1, keepdim=False)
+    
+    gems_assert_close(res_out.values, ref_out.values, dtype)
+    # gems_assert_equal(res_out.indices, ref_out.indices)
+    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        del os.environ["MUSA_ENABLE_SQMMA"]
+
+
+@pytest.mark.median
+@pytest.mark.parametrize("shape", SHAPE_WITH_NEGATIVES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_median_with_negatives(shape, dtype):
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        os.environ["MUSA_ENABLE_SQMMA"] = "1"
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
+    neg_indices = torch.randint(0, inp.numel(), (inp.numel() // 2,))
+    inp_flatten = inp.flatten()
+    inp_flatten[neg_indices] = -inp_flatten[neg_indices]
+    inp = inp_flatten.reshape(shape)
+    
+    ref_inp = to_reference(inp, True)
+    ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
+    res_out = median_dim(inp, dim=-1, keepdim=False)
+    
+    gems_assert_close(res_out.values, ref_out.values, dtype)
+    # gems_assert_equal(res_out.indices, ref_out.indices)
+    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        del os.environ["MUSA_ENABLE_SQMMA"]
+
+
+@pytest.mark.median
+@pytest.mark.parametrize("shape", [(1,), (2,), (3,), (4,), (5,), (100,), (1000,)])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_median_dynamic_shapes(shape, dtype):
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        os.environ["MUSA_ENABLE_SQMMA"] = "1"
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
+    ref_inp = to_reference(inp, True)
+    
+    ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
+    res_out = median_dim(inp, dim=-1, keepdim=False)
+    
+    gems_assert_close(res_out.values, ref_out.values, dtype)
+    # gems_assert_equal(res_out.indices, ref_out.indices)
+    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        del os.environ["MUSA_ENABLE_SQMMA"]
+
+
+@pytest.mark.median
+@pytest.mark.parametrize("shape", [(8,), (16,), (4, 8), (8, 16)])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_median_sorted_input(shape, dtype):
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        os.environ["MUSA_ENABLE_SQMMA"] = "1"
+
+    inp = torch.sort(torch.randn(shape, dtype=dtype, device=flag_gems.device), dim=-1)[0]
+    ref_inp = to_reference(inp, True)
+    
+    ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
+    res_out = median_dim(inp, dim=-1, keepdim=False)
+    
+    gems_assert_close(res_out.values, ref_out.values, dtype)
+    # gems_assert_equal(res_out.indices, ref_out.indices)
+    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+    
+    inp_desc = torch.sort(torch.randn(shape, dtype=dtype, device=flag_gems.device), dim=-1, descending=True)[0]
+    ref_inp_desc = to_reference(inp_desc, True)
+    
+    ref_out_desc = torch.median(ref_inp_desc, dim=-1, keepdim=False)
+    res_out_desc = median_dim(inp_desc, dim=-1, keepdim=False)
+    
+    gems_assert_close(res_out_desc.values, ref_out_desc.values, dtype)
+    # gems_assert_equal(res_out_desc.indices, ref_out_desc.indices)
+    assert_median_indices_valid(inp_desc, res_out_desc, dim=-1, keepdim=False)
+
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        del os.environ["MUSA_ENABLE_SQMMA"]
+
+
+@pytest.mark.median
+@pytest.mark.parametrize("shape", [(8,), (16,), (4, 8), (8, 16)])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_median_duplicate_values(shape, dtype):
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        os.environ["MUSA_ENABLE_SQMMA"] = "1"
+
+    base_val = torch.randn(1, dtype=dtype, device=flag_gems.device).item()
+    inp = torch.full(shape, base_val, dtype=dtype, device=flag_gems.device)
+    
+    ref_inp = to_reference(inp, True)
+    ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
+    res_out = median_dim(inp, dim=-1, keepdim=False)
+    
+    gems_assert_close(res_out.values, ref_out.values.to(dtype), dtype)
+    # gems_assert_equal(res_out.indices, ref_out.indices)
+    assert torch.allclose(res_out.values.to(ref_out.values.dtype), ref_out.values, atol=1e-5)
+
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        del os.environ["MUSA_ENABLE_SQMMA"]
+
+
+@pytest.mark.median
+def test_median_invalid_dim():
+    inp = torch.randn((8, 16), dtype=torch.float32, device=flag_gems.device)
+    
+    with pytest.raises(AssertionError, match="Invalid dim"):
+        median_dim(inp, dim=2)
+    
+    with pytest.raises(AssertionError, match="Invalid dim"):
+        median_dim(inp, dim=-3)
+    
+    inp_1d = torch.randn((8,), dtype=torch.float32, device=flag_gems.device)
+    with pytest.raises(AssertionError, match="Invalid dim"):
+        median_dim(inp_1d, dim=1)
+
+
+@pytest.mark.median
+def test_median_empty_dimension():
+    inp = torch.empty((0, 8), dtype=torch.float32, device=flag_gems.device)
+    with pytest.raises(RuntimeError, match="median: dimension is empty"):
+        median_dim(inp, dim=0)
+    
+    inp = torch.empty((8, 0), dtype=torch.float32, device=flag_gems.device)
+    with pytest.raises(RuntimeError, match="median: dimension is empty"):
+        median_dim(inp, dim=1)
+    
+    inp = torch.empty((0,), dtype=torch.float32, device=flag_gems.device)
+    with pytest.raises(RuntimeError, match="median: dimension is empty"):
+        median_dim(inp, dim=0)
+
+
+@pytest.mark.median
+def test_median_dtype_compatibility():
+    shape = (8,)
+    
+    for dtype in FLOAT_DTYPES:
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        ref_inp = to_reference(inp, True)
+        
+        ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
+        res_out = median_dim(inp, dim=-1, keepdim=False)
+        
+        gems_assert_close(res_out.values, ref_out.values, dtype)
+        # gems_assert_equal(res_out.indices, ref_out.indices)
+        assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+    
+    for dtype in INT_DTYPES:
+        try:
+            inp = torch.randint(-100, 100, shape, dtype=dtype, device=flag_gems.device)
+            ref_inp = to_reference(inp, True)
+            
+            ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
+            res_out = median_dim(inp, dim=-1, keepdim=False)
+            
+            gems_assert_close(res_out.values, ref_out.values, dtype)
+            # gems_assert_equal(res_out.indices, ref_out.indices)
+            assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+        except (RuntimeError, TypeError, AssertionError) as e:
+            pytest.skip(f"dtype {dtype} not supported: {e}")
+
+
+@pytest.mark.median
+def test_median_different_dim_combinations():
+    inp = torch.randn((4, 8, 16), dtype=torch.float32, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+    
+    for dim in range(-inp.ndim, inp.ndim):
+        for keepdim in [True, False]:
+            ref_out = torch.median(ref_inp, dim=dim, keepdim=keepdim)
+            res_out = median_dim(inp, dim=dim, keepdim=keepdim)
+            
+            gems_assert_close(res_out.values, ref_out.values, torch.float32)
+            # gems_assert_equal(res_out.indices, ref_out.indices)
+            assert_median_indices_valid(inp, res_out, dim=dim, keepdim=keepdim)
+            
+            assert res_out.values.shape == ref_out.values.shape
+            assert res_out.indices.shape == ref_out.indices.shape
+
+
+@pytest.mark.median
+@pytest.mark.parametrize("shape", [(1,), (2,), (3,), (4,), (5,), (100,)])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_median_odd_even_elements(shape, dtype):
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        os.environ["MUSA_ENABLE_SQMMA"] = "1"
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
+    ref_inp = to_reference(inp, True)
+    
+    ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
+    res_out = median_dim(inp, dim=-1, keepdim=False)
+    
+    gems_assert_close(res_out.values, ref_out.values, dtype)
+    # gems_assert_equal(res_out.indices, ref_out.indices)
+    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        del os.environ["MUSA_ENABLE_SQMMA"]
+
+
+@pytest.mark.median
+def test_median_nan_handling():
+    inp = torch.tensor([1.0, 2.0, float('nan'), 4.0, 5.0], dtype=torch.float32, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+    
+    ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
+    res_out = median_dim(inp, dim=-1, keepdim=False)
+    
+    if torch.isnan(ref_out.values):
+        assert torch.isnan(res_out.values), f"Expected NaN but got {res_out.values}"
+    else:
+        assert not torch.isnan(res_out.values), f"Expected non-NaN but got NaN"
+        gems_assert_close(res_out.values, ref_out.values, torch.float32)
+    
+    # gems_assert_equal(res_out.indices, ref_out.indices)
+    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+
+
+@pytest.mark.median
+def test_median_inf_handling():
+    inp = torch.tensor([1.0, 2.0, float('inf'), 4.0, 5.0], dtype=torch.float32, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+    
+    ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
+    res_out = median_dim(inp, dim=-1, keepdim=False)
+    
+    if torch.isinf(ref_out.values):
+        assert torch.isinf(res_out.values)
+        assert torch.sign(ref_out.values) == torch.sign(res_out.values)
+    else:
+        gems_assert_close(res_out.values, ref_out.values, torch.float32)
+    
+    # gems_assert_equal(res_out.indices, ref_out.indices)
+    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)

--- a/tests/test_median.py
+++ b/tests/test_median.py
@@ -15,15 +15,27 @@ from .accuracy_utils import (
 )
 
 
-def assert_median_indices_valid(inp, out, *, dim, keepdim):
-    dim = dim % inp.ndim
-    idx = out.indices
-    if not keepdim:
-        idx = idx.unsqueeze(dim)
-    gathered = torch.gather(inp, dim, idx)
-    if not keepdim:
-        gathered = gathered.squeeze(dim)
-    torch.testing.assert_close(gathered, out.values, atol=0, rtol=0, equal_nan=True)
+def assert_median_indices_equal_if_no_duplicates(inp, res_out, ref_out, *, dim, keepdim):
+    def _dup_mask_along_dim(inp: torch.Tensor, *, dim: int) -> torch.Tensor:
+        dim = dim % inp.ndim
+        x = inp.movedim(dim, -1).contiguous()
+        n = x.shape[-1]
+        if n <= 1:
+            return torch.zeros(x.shape[:-1], device=inp.device, dtype=torch.bool)
+        x2d = x.reshape(-1, n)
+        xs, _ = torch.sort(x2d, dim=-1)
+        dup = (xs[:, 1:] == xs[:, :-1]).any(dim=-1)
+        return dup.reshape(x.shape[:-1])
+    
+    dup = _dup_mask_along_dim(inp, dim=dim)
+    if keepdim:
+        dup = dup.unsqueeze(dim % inp.ndim)
+    mask = (~dup).reshape(-1)
+    if mask.any():
+        gems_assert_equal(
+            res_out.indices.reshape(-1)[mask],
+            ref_out.indices.reshape(-1)[mask],
+        )
 
 
 SHAPE_SMALL = [
@@ -126,7 +138,6 @@ SHAPE_EMPTY = [
 ]
 
 
-
 @pytest.mark.median
 @pytest.mark.parametrize("shape", SHAPE_SMALL)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
@@ -136,13 +147,14 @@ def test_accuracy_median_small(shape, dtype):
 
     inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
     ref_inp = to_reference(inp, True)
-    
+
     ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
     res_out = median_dim(inp, dim=-1, keepdim=False)
-    
+
     gems_assert_close(res_out.values, ref_out.values, dtype)
-    # gems_assert_equal(res_out.indices, ref_out.indices)
-    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+    assert_median_indices_equal_if_no_duplicates(
+        inp, res_out, ref_out, dim=-1, keepdim=False
+    )
 
     if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
         del os.environ["MUSA_ENABLE_SQMMA"]
@@ -157,13 +169,14 @@ def test_accuracy_median_medium(shape, dtype):
 
     inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
     ref_inp = to_reference(inp, True)
-    
+
     ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
     res_out = median_dim(inp, dim=-1, keepdim=False)
-    
+
     gems_assert_close(res_out.values, ref_out.values, dtype)
-    # gems_assert_equal(res_out.indices, ref_out.indices)
-    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+    assert_median_indices_equal_if_no_duplicates(
+        inp, res_out, ref_out, dim=-1, keepdim=False
+    )
 
     if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
         del os.environ["MUSA_ENABLE_SQMMA"]
@@ -178,13 +191,14 @@ def test_accuracy_median_large(shape, dtype):
 
     inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
     ref_inp = to_reference(inp, True)
-    
+
     ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
     res_out = median_dim(inp, dim=-1, keepdim=False)
-    
+
     gems_assert_close(res_out.values, ref_out.values, dtype)
-    # gems_assert_equal(res_out.indices, ref_out.indices)
-    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+    assert_median_indices_equal_if_no_duplicates(
+        inp, res_out, ref_out, dim=-1, keepdim=False
+    )
 
     if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
         del os.environ["MUSA_ENABLE_SQMMA"]
@@ -199,14 +213,15 @@ def test_accuracy_median_dimensions(shape, dtype):
 
     inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
     ref_inp = to_reference(inp, True)
-    
+
     for dim in range(-inp.ndim, inp.ndim):
         ref_out = torch.median(ref_inp, dim=dim, keepdim=False)
         res_out = median_dim(inp, dim=dim, keepdim=False)
-        
+
         gems_assert_close(res_out.values, ref_out.values, dtype)
-        # gems_assert_equal(res_out.indices, ref_out.indices)
-        assert_median_indices_valid(inp, res_out, dim=dim, keepdim=False)
+        assert_median_indices_equal_if_no_duplicates(
+            inp, res_out, ref_out, dim=dim, keepdim=False
+        )
 
     if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
         del os.environ["MUSA_ENABLE_SQMMA"]
@@ -222,13 +237,14 @@ def test_accuracy_median_keepdim(shape, keepdim, dtype):
 
     inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
     ref_inp = to_reference(inp, True)
-    
+
     ref_out = torch.median(ref_inp, dim=-1, keepdim=keepdim)
     res_out = median_dim(inp, dim=-1, keepdim=keepdim)
-    
+
     gems_assert_close(res_out.values, ref_out.values, dtype)
-    # gems_assert_equal(res_out.indices, ref_out.indices)
-    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=keepdim)
+    assert_median_indices_equal_if_no_duplicates(
+        inp, res_out, ref_out, dim=-1, keepdim=keepdim
+    )
 
     if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
         del os.environ["MUSA_ENABLE_SQMMA"]
@@ -241,27 +257,33 @@ def test_accuracy_median_extreme_values(shape, dtype):
     if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
         os.environ["MUSA_ENABLE_SQMMA"] = "1"
 
-    max_val = torch.finfo(dtype).max if dtype.is_floating_point else torch.iinfo(dtype).max
+    max_val = (
+        torch.finfo(dtype).max if dtype.is_floating_point else torch.iinfo(dtype).max
+    )
     inp_max = torch.full(shape, max_val, dtype=dtype, device=flag_gems.device)
     ref_inp_max = to_reference(inp_max, True)
-    
+
     ref_out_max = torch.median(ref_inp_max, dim=-1, keepdim=False)
     res_out_max = median_dim(inp_max, dim=-1, keepdim=False)
-    
+
     gems_assert_close(res_out_max.values, ref_out_max.values, dtype)
-    # gems_assert_equal(res_out_max.indices, ref_out_max.indices)
-    assert_median_indices_valid(inp_max, res_out_max, dim=-1, keepdim=False)
-    
-    min_val = torch.finfo(dtype).min if dtype.is_floating_point else torch.iinfo(dtype).min
+    assert_median_indices_equal_if_no_duplicates(
+        inp_max, res_out_max, ref_out_max, dim=-1, keepdim=False
+    )
+
+    min_val = (
+        torch.finfo(dtype).min if dtype.is_floating_point else torch.iinfo(dtype).min
+    )
     inp_min = torch.full(shape, min_val, dtype=dtype, device=flag_gems.device)
     ref_inp_min = to_reference(inp_min, True)
-    
+
     ref_out_min = torch.median(ref_inp_min, dim=-1, keepdim=False)
     res_out_min = median_dim(inp_min, dim=-1, keepdim=False)
-    
+
     gems_assert_close(res_out_min.values, ref_out_min.values, dtype)
-    # gems_assert_equal(res_out_min.indices, ref_out_min.indices)
-    assert_median_indices_valid(inp_min, res_out_min, dim=-1, keepdim=False)
+    assert_median_indices_equal_if_no_duplicates(
+        inp_min, res_out_min, ref_out_min, dim=-1, keepdim=False
+    )
 
     if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
         del os.environ["MUSA_ENABLE_SQMMA"]
@@ -279,14 +301,15 @@ def test_accuracy_median_with_zeros(shape, dtype):
     inp_flatten = inp.flatten()
     inp_flatten[zero_indices] = 0
     inp = inp_flatten.reshape(shape)
-    
+
     ref_inp = to_reference(inp, True)
     ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
     res_out = median_dim(inp, dim=-1, keepdim=False)
-    
+
     gems_assert_close(res_out.values, ref_out.values, dtype)
-    # gems_assert_equal(res_out.indices, ref_out.indices)
-    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+    assert_median_indices_equal_if_no_duplicates(
+        inp, res_out, ref_out, dim=-1, keepdim=False
+    )
 
     if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
         del os.environ["MUSA_ENABLE_SQMMA"]
@@ -304,14 +327,15 @@ def test_accuracy_median_with_negatives(shape, dtype):
     inp_flatten = inp.flatten()
     inp_flatten[neg_indices] = -inp_flatten[neg_indices]
     inp = inp_flatten.reshape(shape)
-    
+
     ref_inp = to_reference(inp, True)
     ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
     res_out = median_dim(inp, dim=-1, keepdim=False)
-    
+
     gems_assert_close(res_out.values, ref_out.values, dtype)
-    # gems_assert_equal(res_out.indices, ref_out.indices)
-    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+    assert_median_indices_equal_if_no_duplicates(
+        inp, res_out, ref_out, dim=-1, keepdim=False
+    )
 
     if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
         del os.environ["MUSA_ENABLE_SQMMA"]
@@ -326,13 +350,14 @@ def test_accuracy_median_dynamic_shapes(shape, dtype):
 
     inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
     ref_inp = to_reference(inp, True)
-    
+
     ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
     res_out = median_dim(inp, dim=-1, keepdim=False)
-    
+
     gems_assert_close(res_out.values, ref_out.values, dtype)
-    # gems_assert_equal(res_out.indices, ref_out.indices)
-    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+    assert_median_indices_equal_if_no_duplicates(
+        inp, res_out, ref_out, dim=-1, keepdim=False
+    )
 
     if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
         del os.environ["MUSA_ENABLE_SQMMA"]
@@ -345,25 +370,33 @@ def test_accuracy_median_sorted_input(shape, dtype):
     if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
         os.environ["MUSA_ENABLE_SQMMA"] = "1"
 
-    inp = torch.sort(torch.randn(shape, dtype=dtype, device=flag_gems.device), dim=-1)[0]
+    inp = torch.sort(torch.randn(shape, dtype=dtype, device=flag_gems.device), dim=-1)[
+        0
+    ]
     ref_inp = to_reference(inp, True)
-    
+
     ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
     res_out = median_dim(inp, dim=-1, keepdim=False)
-    
+
     gems_assert_close(res_out.values, ref_out.values, dtype)
-    # gems_assert_equal(res_out.indices, ref_out.indices)
-    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
-    
-    inp_desc = torch.sort(torch.randn(shape, dtype=dtype, device=flag_gems.device), dim=-1, descending=True)[0]
+    assert_median_indices_equal_if_no_duplicates(
+        inp, res_out, ref_out, dim=-1, keepdim=False
+    )
+
+    inp_desc = torch.sort(
+        torch.randn(shape, dtype=dtype, device=flag_gems.device),
+        dim=-1,
+        descending=True,
+    )[0]
     ref_inp_desc = to_reference(inp_desc, True)
-    
+
     ref_out_desc = torch.median(ref_inp_desc, dim=-1, keepdim=False)
     res_out_desc = median_dim(inp_desc, dim=-1, keepdim=False)
-    
+
     gems_assert_close(res_out_desc.values, ref_out_desc.values, dtype)
-    # gems_assert_equal(res_out_desc.indices, ref_out_desc.indices)
-    assert_median_indices_valid(inp_desc, res_out_desc, dim=-1, keepdim=False)
+    assert_median_indices_equal_if_no_duplicates(
+        inp_desc, res_out_desc, ref_out_desc, dim=-1, keepdim=False
+    )
 
     if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
         del os.environ["MUSA_ENABLE_SQMMA"]
@@ -378,14 +411,12 @@ def test_accuracy_median_duplicate_values(shape, dtype):
 
     base_val = torch.randn(1, dtype=dtype, device=flag_gems.device).item()
     inp = torch.full(shape, base_val, dtype=dtype, device=flag_gems.device)
-    
+
     ref_inp = to_reference(inp, True)
     ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
     res_out = median_dim(inp, dim=-1, keepdim=False)
-    
+
     gems_assert_close(res_out.values, ref_out.values.to(dtype), dtype)
-    # gems_assert_equal(res_out.indices, ref_out.indices)
-    assert torch.allclose(res_out.values.to(ref_out.values.dtype), ref_out.values, atol=1e-5)
 
     if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
         del os.environ["MUSA_ENABLE_SQMMA"]
@@ -394,13 +425,13 @@ def test_accuracy_median_duplicate_values(shape, dtype):
 @pytest.mark.median
 def test_median_invalid_dim():
     inp = torch.randn((8, 16), dtype=torch.float32, device=flag_gems.device)
-    
+
     with pytest.raises(AssertionError, match="Invalid dim"):
         median_dim(inp, dim=2)
-    
+
     with pytest.raises(AssertionError, match="Invalid dim"):
         median_dim(inp, dim=-3)
-    
+
     inp_1d = torch.randn((8,), dtype=torch.float32, device=flag_gems.device)
     with pytest.raises(AssertionError, match="Invalid dim"):
         median_dim(inp_1d, dim=1)
@@ -411,11 +442,11 @@ def test_median_empty_dimension():
     inp = torch.empty((0, 8), dtype=torch.float32, device=flag_gems.device)
     with pytest.raises(RuntimeError, match="median: dimension is empty"):
         median_dim(inp, dim=0)
-    
+
     inp = torch.empty((8, 0), dtype=torch.float32, device=flag_gems.device)
     with pytest.raises(RuntimeError, match="median: dimension is empty"):
         median_dim(inp, dim=1)
-    
+
     inp = torch.empty((0,), dtype=torch.float32, device=flag_gems.device)
     with pytest.raises(RuntimeError, match="median: dimension is empty"):
         median_dim(inp, dim=0)
@@ -424,29 +455,31 @@ def test_median_empty_dimension():
 @pytest.mark.median
 def test_median_dtype_compatibility():
     shape = (8,)
-    
+
     for dtype in FLOAT_DTYPES:
         inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
         ref_inp = to_reference(inp, True)
-        
+
         ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
         res_out = median_dim(inp, dim=-1, keepdim=False)
-        
+
         gems_assert_close(res_out.values, ref_out.values, dtype)
-        # gems_assert_equal(res_out.indices, ref_out.indices)
-        assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
-    
+        assert_median_indices_equal_if_no_duplicates(
+            inp, res_out, ref_out, dim=-1, keepdim=False
+        )
+
     for dtype in INT_DTYPES:
         try:
             inp = torch.randint(-100, 100, shape, dtype=dtype, device=flag_gems.device)
             ref_inp = to_reference(inp, True)
-            
+
             ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
             res_out = median_dim(inp, dim=-1, keepdim=False)
-            
+
             gems_assert_close(res_out.values, ref_out.values, dtype)
-            # gems_assert_equal(res_out.indices, ref_out.indices)
-            assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+            assert_median_indices_equal_if_no_duplicates(
+                inp, res_out, ref_out, dim=-1, keepdim=False
+            )
         except (RuntimeError, TypeError, AssertionError) as e:
             pytest.skip(f"dtype {dtype} not supported: {e}")
 
@@ -455,16 +488,17 @@ def test_median_dtype_compatibility():
 def test_median_different_dim_combinations():
     inp = torch.randn((4, 8, 16), dtype=torch.float32, device=flag_gems.device)
     ref_inp = to_reference(inp, True)
-    
+
     for dim in range(-inp.ndim, inp.ndim):
         for keepdim in [True, False]:
             ref_out = torch.median(ref_inp, dim=dim, keepdim=keepdim)
             res_out = median_dim(inp, dim=dim, keepdim=keepdim)
-            
+
             gems_assert_close(res_out.values, ref_out.values, torch.float32)
-            # gems_assert_equal(res_out.indices, ref_out.indices)
-            assert_median_indices_valid(inp, res_out, dim=dim, keepdim=keepdim)
-            
+            assert_median_indices_equal_if_no_duplicates(
+                inp, res_out, ref_out, dim=dim, keepdim=keepdim
+            )
+
             assert res_out.values.shape == ref_out.values.shape
             assert res_out.indices.shape == ref_out.indices.shape
 
@@ -478,13 +512,14 @@ def test_accuracy_median_odd_even_elements(shape, dtype):
 
     inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
     ref_inp = to_reference(inp, True)
-    
+
     ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
     res_out = median_dim(inp, dim=-1, keepdim=False)
-    
+
     gems_assert_close(res_out.values, ref_out.values, dtype)
-    # gems_assert_equal(res_out.indices, ref_out.indices)
-    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+    assert_median_indices_equal_if_no_duplicates(
+        inp, res_out, ref_out, dim=-1, keepdim=False
+    )
 
     if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
         del os.environ["MUSA_ENABLE_SQMMA"]
@@ -492,35 +527,39 @@ def test_accuracy_median_odd_even_elements(shape, dtype):
 
 @pytest.mark.median
 def test_median_nan_handling():
-    inp = torch.tensor([1.0, 2.0, float('nan'), 4.0, 5.0], dtype=torch.float32, device=flag_gems.device)
+    inp = torch.tensor(
+        [1.0, 2.0, float("nan"), 4.0, 5.0], dtype=torch.float32, device=flag_gems.device
+    )
     ref_inp = to_reference(inp, True)
-    
+
     ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
     res_out = median_dim(inp, dim=-1, keepdim=False)
-    
+
     if torch.isnan(ref_out.values):
         assert torch.isnan(res_out.values), f"Expected NaN but got {res_out.values}"
+        gems_assert_equal(res_out.indices, ref_out.indices)
     else:
-        assert not torch.isnan(res_out.values), f"Expected non-NaN but got NaN"
+        assert not torch.isnan(res_out.values), "Expected non-NaN but got NaN"
         gems_assert_close(res_out.values, ref_out.values, torch.float32)
-    
-    # gems_assert_equal(res_out.indices, ref_out.indices)
-    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+        gems_assert_equal(res_out.indices, ref_out.indices)
+
 
 
 @pytest.mark.median
 def test_median_inf_handling():
-    inp = torch.tensor([1.0, 2.0, float('inf'), 4.0, 5.0], dtype=torch.float32, device=flag_gems.device)
+    inp = torch.tensor(
+        [1.0, 2.0, float("inf"), 4.0, 5.0], dtype=torch.float32, device=flag_gems.device
+    )
     ref_inp = to_reference(inp, True)
-    
+
     ref_out = torch.median(ref_inp, dim=-1, keepdim=False)
     res_out = median_dim(inp, dim=-1, keepdim=False)
-    
+
     if torch.isinf(ref_out.values):
         assert torch.isinf(res_out.values)
         assert torch.sign(ref_out.values) == torch.sign(res_out.values)
+        gems_assert_equal(res_out.indices, ref_out.indices)
     else:
         gems_assert_close(res_out.values, ref_out.values, torch.float32)
-    
-    # gems_assert_equal(res_out.indices, ref_out.indices)
-    assert_median_indices_valid(inp, res_out, dim=-1, keepdim=False)
+        gems_assert_equal(res_out.indices, ref_out.indices)
+


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
This PR implements the `median` operation with radix selection algorithm, following PyTorch's `SortingRadixSelect.cuh` approach. The implementation includes:

- **Core implementation** (`src/flag_gems/ops/median.py`): Radix-based kth value selection using Triton kernels
- **Comprehensive tests** (`tests/test_median.py`): 279 test cases covering various shapes, dtypes, edge cases (NaN, Inf, duplicates)
- **Benchmark integration** (`benchmark/test_reduction_perf.py`): Performance benchmarks for median operation

#### Key Implementation Details

The median operation uses a radix selection algorithm that:
1. Converts values to unsigned integer keys preserving sort order
2. Performs digit-by-digit counting to narrow down the kth element
3. Finds the exact value and index using pattern matching

#### Test Strategy for Indices

According to [PyTorch's median documentation](https://docs.pytorch.org/docs/stable/generated/torch.median.html), `indices does not necessarily contain the first occurrence of each median value found, unless it is unique.` 
<img width="845" height="161" alt="image" src="https://github.com/user-attachments/assets/fe51d29f-ae3c-48b0-b793-e61ae2d24c08" />

Therefore, the test suite uses a custom comparison function `assert_median_indices_equal_if_no_duplicates()` that:
- Only checks indices equality for slices **without duplicate values** using `gems_assert_equal`
- Skips indices validation for slices **with duplicate values** (where indices may vary)
- Always validates median **values** using `gems_assert_close` for all cases

This approach ensures correctness while accounting for the non-deterministic nature of indices when duplicate values exist.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
bench 
```
======================================================= test session starts ========================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /data1/yuxuewen/FlagGems
configfile: pytest.ini
collected 34 items / 33 deselected / 1 selected                                                                                    

benchmark/test_reduction_perf.py 
Operator: median  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.006144            0.006272               0.980          [torch.Size([64, 64]), -1]
SUCCESS               0.006144            0.006144               1.000          [torch.Size([64, 64]), 0]
SUCCESS               0.006144            0.006144               1.000          ([torch.Size([64, 64]), -1], {'keepdim': True})
SUCCESS               0.007168            0.007168               1.000          [torch.Size([256, 256]), -1]
SUCCESS               0.009216            0.008992               1.025          [torch.Size([256, 256]), 0]
SUCCESS               0.007168            0.007168               1.000          ([torch.Size([256, 256]), -1], {'keepdim': True})
SUCCESS               0.041984            0.041984               1.000          [torch.Size([1024, 1024]), -1]
SUCCESS               0.106144            0.105472               1.006          [torch.Size([1024, 1024]), 0]
SUCCESS               0.041984            0.041984               1.000          ([torch.Size([1024, 1024]), -1], {'keepdim': True})
SUCCESS               0.307200            0.306992               1.001          [torch.Size([4096, 4096]), -1]
SUCCESS               1.906576            4.266576               0.447          [torch.Size([4096, 4096]), 0]
SUCCESS               0.306464            0.306944               0.998          ([torch.Size([4096, 4096]), -1], {'keepdim': True})
SUCCESS               1.170432            3.514368               0.333          [torch.Size([1024, 65536]), -1]
SUCCESS               7.029760           14.119936               0.498          [torch.Size([1024, 65536]), 0]
SUCCESS               1.168384            1.168384               1.000          ([torch.Size([1024, 65536]), -1], {'keepdim': True})
SUCCESS               0.009216            0.009216               1.000          [torch.Size([10000, 1]), -1]
SUCCESS               0.027648            0.026752               1.033          [torch.Size([10000, 1]), 0]
SUCCESS               0.009216            0.009216               1.000          ([torch.Size([10000, 1]), -1], {'keepdim': True})
SUCCESS               0.061440            0.060432               1.017          [torch.Size([10000, 256]), -1]
SUCCESS               0.292864            0.291840               1.004          [torch.Size([10000, 256]), 0]
SUCCESS               0.060688            0.060416               1.005          ([torch.Size([10000, 256]), -1], {'keepdim': True})
SUCCESS              10.448896           10.447872               1.000          [torch.Size([10000, 65536]), -1]
SUCCESS              74.711037           74.717186               1.000          [torch.Size([10000, 65536]), 0]
SUCCESS              10.466304           10.466304               1.000          ([torch.Size([10000, 65536]), -1], {'keepdim': True})


Operator: median  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.006144            0.006144               1.000          [torch.Size([64, 64]), -1]
SUCCESS               0.006176            0.006144               1.005          [torch.Size([64, 64]), 0]
SUCCESS               0.006144            0.006144               1.000          ([torch.Size([64, 64]), -1], {'keepdim': True})
SUCCESS               0.007424            0.007168               1.036          [torch.Size([256, 256]), -1]
SUCCESS               0.010240            0.009984               1.026          [torch.Size([256, 256]), 0]
SUCCESS               0.007168            0.007168               1.000          ([torch.Size([256, 256]), -1], {'keepdim': True})
SUCCESS               0.049152            0.049152               1.000          [torch.Size([1024, 1024]), -1]
SUCCESS               0.118784            0.118784               1.000          [torch.Size([1024, 1024]), 0]
SUCCESS               0.049152            0.049152               1.000          ([torch.Size([1024, 1024]), -1], {'keepdim': True})
SUCCESS               0.362496            0.361472               1.003          [torch.Size([4096, 4096]), -1]
SUCCESS               2.294784            2.292736               1.001          [torch.Size([4096, 4096]), 0]
SUCCESS               0.362496            0.361472               1.003          ([torch.Size([4096, 4096]), -1], {'keepdim': True})
SUCCESS               1.454080            1.453056               1.001          [torch.Size([1024, 65536]), -1]
SUCCESS              11.479040           11.478368               1.000          [torch.Size([1024, 65536]), 0]
SUCCESS               1.453056            1.452032               1.001          ([torch.Size([1024, 65536]), -1], {'keepdim': True})
SUCCESS               0.009216            0.009216               1.000          [torch.Size([10000, 1]), -1]
SUCCESS               0.026368            0.025600               1.030          [torch.Size([10000, 1]), 0]
SUCCESS               0.009216            0.009216               1.000          ([torch.Size([10000, 1]), -1], {'keepdim': True})
SUCCESS               0.072704            0.072704               1.000          [torch.Size([10000, 256]), -1]
SUCCESS               0.353280            0.353152               1.000          [torch.Size([10000, 256]), 0]
SUCCESS               0.072704            0.072704               1.000          ([torch.Size([10000, 256]), -1], {'keepdim': True})
SUCCESS              12.886016           12.878848               1.001          [torch.Size([10000, 65536]), -1]
SUCCESS             117.791740          245.787643               0.479          [torch.Size([10000, 65536]), 0]
SUCCESS              12.895232           12.888064               1.001          ([torch.Size([10000, 65536]), -1], {'keepdim': True})


Operator: median  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.006144            0.006144               1.000          [torch.Size([64, 64]), -1]
SUCCESS               0.006144            0.006144               1.000          [torch.Size([64, 64]), 0]
SUCCESS               0.006144            0.006144               1.000          ([torch.Size([64, 64]), -1], {'keepdim': True})
SUCCESS               0.007168            0.007168               1.000          [torch.Size([256, 256]), -1]
SUCCESS               0.009216            0.009216               1.000          [torch.Size([256, 256]), 0]
SUCCESS               0.007168            0.007168               1.000          ([torch.Size([256, 256]), -1], {'keepdim': True})
SUCCESS               0.050176            0.050176               1.000          [torch.Size([1024, 1024]), -1]
SUCCESS               0.118784            0.117760               1.009          [torch.Size([1024, 1024]), 0]
SUCCESS               0.050176            0.050176               1.000          ([torch.Size([1024, 1024]), -1], {'keepdim': True})
SUCCESS               0.369664            0.367616               1.006          [torch.Size([4096, 4096]), -1]
SUCCESS               2.240896            4.620288               0.485          [torch.Size([4096, 4096]), 0]
SUCCESS               0.369664            0.367616               1.006          ([torch.Size([4096, 4096]), -1], {'keepdim': True})
SUCCESS               1.334272            1.333248               1.001          [torch.Size([1024, 65536]), -1]
SUCCESS               8.522752            8.521920               1.000          [torch.Size([1024, 65536]), 0]
SUCCESS               1.338080            1.337344               1.001          ([torch.Size([1024, 65536]), -1], {'keepdim': True})
SUCCESS               0.009216            0.009216               1.000          [torch.Size([10000, 1]), -1]
SUCCESS               0.025600            0.025536               1.003          [torch.Size([10000, 1]), 0]
SUCCESS               0.009216            0.009216               1.000          ([torch.Size([10000, 1]), -1], {'keepdim': True})
SUCCESS               0.073728            0.073728               1.000          [torch.Size([10000, 256]), -1]
SUCCESS               0.333824            0.333824               1.000          [torch.Size([10000, 256]), 0]
SUCCESS               0.073728            0.073728               1.000          ([torch.Size([10000, 256]), -1], {'keepdim': True})
SUCCESS              26.366976           12.046848               2.189          [torch.Size([10000, 65536]), -1]
SUCCESS              85.159935          154.712067               0.550          [torch.Size([10000, 65536]), 0]
SUCCESS              23.974913           26.378241               0.909          ([torch.Size([10000, 65536]), -1], {'keepdim': True})

.
```
tests:
```bash
(flag_gems) yuxuewen@algo-4090-2:~/workspace2/FlagGems$ pytest tests/test_median.py -v
======================================================= test session starts ========================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0 -- /data1/yuxuewen/FlagGems/.pixi/envs/default/bin/python3.12
cachedir: .pytest_cache
rootdir: /data1/yuxuewen/FlagGems
configfile: pytest.ini
collected 279 items                                                                                                                

tests/test_median.py::test_accuracy_median_small[dtype0-shape0] PASSED                                                       [  0%]
tests/test_median.py::test_accuracy_median_small[dtype0-shape1] PASSED                                                       [  0%]
tests/test_median.py::test_accuracy_median_small[dtype0-shape2] PASSED                                                       [  1%]
tests/test_median.py::test_accuracy_median_small[dtype0-shape3] PASSED                                                       [  1%]
tests/test_median.py::test_accuracy_median_small[dtype0-shape4] PASSED                                                       [  1%]
tests/test_median.py::test_accuracy_median_small[dtype0-shape5] PASSED                                                       [  2%]
tests/test_median.py::test_accuracy_median_small[dtype0-shape6] PASSED                                                       [  2%]
tests/test_median.py::test_accuracy_median_small[dtype0-shape7] PASSED                                                       [  2%]
tests/test_median.py::test_accuracy_median_small[dtype1-shape0] PASSED                                                       [  3%]
tests/test_median.py::test_accuracy_median_small[dtype1-shape1] PASSED                                                       [  3%]
tests/test_median.py::test_accuracy_median_small[dtype1-shape2] PASSED                                                       [  3%]
tests/test_median.py::test_accuracy_median_small[dtype1-shape3] PASSED                                                       [  4%]
tests/test_median.py::test_accuracy_median_small[dtype1-shape4] PASSED                                                       [  4%]
tests/test_median.py::test_accuracy_median_small[dtype1-shape5] PASSED                                                       [  5%]
tests/test_median.py::test_accuracy_median_small[dtype1-shape6] PASSED                                                       [  5%]
tests/test_median.py::test_accuracy_median_small[dtype1-shape7] PASSED                                                       [  5%]
tests/test_median.py::test_accuracy_median_small[dtype2-shape0] PASSED                                                       [  6%]
tests/test_median.py::test_accuracy_median_small[dtype2-shape1] PASSED                                                       [  6%]
tests/test_median.py::test_accuracy_median_small[dtype2-shape2] PASSED                                                       [  6%]
tests/test_median.py::test_accuracy_median_small[dtype2-shape3] PASSED                                                       [  7%]
tests/test_median.py::test_accuracy_median_small[dtype2-shape4] PASSED                                                       [  7%]
tests/test_median.py::test_accuracy_median_small[dtype2-shape5] PASSED                                                       [  7%]
tests/test_median.py::test_accuracy_median_small[dtype2-shape6] PASSED                                                       [  8%]
tests/test_median.py::test_accuracy_median_small[dtype2-shape7] PASSED                                                       [  8%]
tests/test_median.py::test_accuracy_median_medium[dtype0-shape0] PASSED                                                      [  8%]
tests/test_median.py::test_accuracy_median_medium[dtype0-shape1] PASSED                                                      [  9%]
tests/test_median.py::test_accuracy_median_medium[dtype0-shape2] PASSED                                                      [  9%]
tests/test_median.py::test_accuracy_median_medium[dtype0-shape3] PASSED                                                      [ 10%]
tests/test_median.py::test_accuracy_median_medium[dtype0-shape4] PASSED                                                      [ 10%]
tests/test_median.py::test_accuracy_median_medium[dtype0-shape5] PASSED                                                      [ 10%]
tests/test_median.py::test_accuracy_median_medium[dtype0-shape6] PASSED                                                      [ 11%]
tests/test_median.py::test_accuracy_median_medium[dtype0-shape7] PASSED                                                      [ 11%]
tests/test_median.py::test_accuracy_median_medium[dtype0-shape8] PASSED                                                      [ 11%]
tests/test_median.py::test_accuracy_median_medium[dtype0-shape9] PASSED                                                      [ 12%]
tests/test_median.py::test_accuracy_median_medium[dtype0-shape10] PASSED                                                     [ 12%]
tests/test_median.py::test_accuracy_median_medium[dtype1-shape0] PASSED                                                      [ 12%]
tests/test_median.py::test_accuracy_median_medium[dtype1-shape1] PASSED                                                      [ 13%]
tests/test_median.py::test_accuracy_median_medium[dtype1-shape2] PASSED                                                      [ 13%]
tests/test_median.py::test_accuracy_median_medium[dtype1-shape3] PASSED                                                      [ 13%]
tests/test_median.py::test_accuracy_median_medium[dtype1-shape4] PASSED                                                      [ 14%]
tests/test_median.py::test_accuracy_median_medium[dtype1-shape5] PASSED                                                      [ 14%]
tests/test_median.py::test_accuracy_median_medium[dtype1-shape6] PASSED                                                      [ 15%]
tests/test_median.py::test_accuracy_median_medium[dtype1-shape7] PASSED                                                      [ 15%]
tests/test_median.py::test_accuracy_median_medium[dtype1-shape8] PASSED                                                      [ 15%]
tests/test_median.py::test_accuracy_median_medium[dtype1-shape9] PASSED                                                      [ 16%]
tests/test_median.py::test_accuracy_median_medium[dtype1-shape10] PASSED                                                     [ 16%]
tests/test_median.py::test_accuracy_median_medium[dtype2-shape0] PASSED                                                      [ 16%]
tests/test_median.py::test_accuracy_median_medium[dtype2-shape1] PASSED                                                      [ 17%]
tests/test_median.py::test_accuracy_median_medium[dtype2-shape2] PASSED                                                      [ 17%]
tests/test_median.py::test_accuracy_median_medium[dtype2-shape3] PASSED                                                      [ 17%]
tests/test_median.py::test_accuracy_median_medium[dtype2-shape4] PASSED                                                      [ 18%]
tests/test_median.py::test_accuracy_median_medium[dtype2-shape5] PASSED                                                      [ 18%]
tests/test_median.py::test_accuracy_median_medium[dtype2-shape6] PASSED                                                      [ 18%]
tests/test_median.py::test_accuracy_median_medium[dtype2-shape7] PASSED                                                      [ 19%]
tests/test_median.py::test_accuracy_median_medium[dtype2-shape8] PASSED                                                      [ 19%]
tests/test_median.py::test_accuracy_median_medium[dtype2-shape9] PASSED                                                      [ 20%]
tests/test_median.py::test_accuracy_median_medium[dtype2-shape10] PASSED                                                     [ 20%]
tests/test_median.py::test_accuracy_median_large[dtype0-shape0] PASSED                                                       [ 20%]
tests/test_median.py::test_accuracy_median_large[dtype0-shape1] PASSED                                                       [ 21%]
tests/test_median.py::test_accuracy_median_large[dtype0-shape2] PASSED                                                       [ 21%]
tests/test_median.py::test_accuracy_median_large[dtype0-shape3] PASSED                                                       [ 21%]
tests/test_median.py::test_accuracy_median_large[dtype0-shape4] PASSED                                                       [ 22%]
tests/test_median.py::test_accuracy_median_large[dtype0-shape5] PASSED                                                       [ 22%]
tests/test_median.py::test_accuracy_median_large[dtype0-shape6] PASSED                                                       [ 22%]
tests/test_median.py::test_accuracy_median_large[dtype0-shape7] PASSED                                                       [ 23%]
tests/test_median.py::test_accuracy_median_large[dtype1-shape0] PASSED                                                       [ 23%]
tests/test_median.py::test_accuracy_median_large[dtype1-shape1] PASSED                                                       [ 24%]
tests/test_median.py::test_accuracy_median_large[dtype1-shape2] PASSED                                                       [ 24%]
tests/test_median.py::test_accuracy_median_large[dtype1-shape3] PASSED                                                       [ 24%]
tests/test_median.py::test_accuracy_median_large[dtype1-shape4] PASSED                                                       [ 25%]
tests/test_median.py::test_accuracy_median_large[dtype1-shape5] PASSED                                                       [ 25%]
tests/test_median.py::test_accuracy_median_large[dtype1-shape6] PASSED                                                       [ 25%]
tests/test_median.py::test_accuracy_median_large[dtype1-shape7] PASSED                                                       [ 26%]
tests/test_median.py::test_accuracy_median_large[dtype2-shape0] PASSED                                                       [ 26%]
tests/test_median.py::test_accuracy_median_large[dtype2-shape1] PASSED                                                       [ 26%]
tests/test_median.py::test_accuracy_median_large[dtype2-shape2] PASSED                                                       [ 27%]
tests/test_median.py::test_accuracy_median_large[dtype2-shape3] PASSED                                                       [ 27%]
tests/test_median.py::test_accuracy_median_large[dtype2-shape4] PASSED                                                       [ 27%]
tests/test_median.py::test_accuracy_median_large[dtype2-shape5] PASSED                                                       [ 28%]
tests/test_median.py::test_accuracy_median_large[dtype2-shape6] PASSED                                                       [ 28%]
tests/test_median.py::test_accuracy_median_large[dtype2-shape7] PASSED                                                       [ 29%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape0] PASSED                                                  [ 29%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape1] PASSED                                                  [ 29%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape2] PASSED                                                  [ 30%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape3] PASSED                                                  [ 30%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape4] PASSED                                                  [ 30%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape5] PASSED                                                  [ 31%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape6] PASSED                                                  [ 31%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape7] PASSED                                                  [ 31%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape8] PASSED                                                  [ 32%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape9] PASSED                                                  [ 32%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape10] PASSED                                                 [ 32%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape11] PASSED                                                 [ 33%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape12] PASSED                                                 [ 33%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape13] PASSED                                                 [ 34%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape14] PASSED                                                 [ 34%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape15] PASSED                                                 [ 34%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape16] PASSED                                                 [ 35%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape17] PASSED                                                 [ 35%]
tests/test_median.py::test_accuracy_median_dimensions[dtype0-shape18] PASSED                                                 [ 35%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape0] PASSED                                                  [ 36%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape1] PASSED                                                  [ 36%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape2] PASSED                                                  [ 36%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape3] PASSED                                                  [ 37%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape4] PASSED                                                  [ 37%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape5] PASSED                                                  [ 37%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape6] PASSED                                                  [ 38%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape7] PASSED                                                  [ 38%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape8] PASSED                                                  [ 39%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape9] PASSED                                                  [ 39%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape10] PASSED                                                 [ 39%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape11] PASSED                                                 [ 40%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape12] PASSED                                                 [ 40%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape13] PASSED                                                 [ 40%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape14] PASSED                                                 [ 41%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape15] PASSED                                                 [ 41%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape16] PASSED                                                 [ 41%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape17] PASSED                                                 [ 42%]
tests/test_median.py::test_accuracy_median_dimensions[dtype1-shape18] PASSED                                                 [ 42%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape0] PASSED                                                  [ 43%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape1] PASSED                                                  [ 43%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape2] PASSED                                                  [ 43%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape3] PASSED                                                  [ 44%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape4] PASSED                                                  [ 44%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape5] PASSED                                                  [ 44%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape6] PASSED                                                  [ 45%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape7] PASSED                                                  [ 45%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape8] PASSED                                                  [ 45%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape9] PASSED                                                  [ 46%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape10] PASSED                                                 [ 46%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape11] PASSED                                                 [ 46%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape12] PASSED                                                 [ 47%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape13] PASSED                                                 [ 47%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape14] PASSED                                                 [ 48%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape15] PASSED                                                 [ 48%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape16] PASSED                                                 [ 48%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape17] PASSED                                                 [ 49%]
tests/test_median.py::test_accuracy_median_dimensions[dtype2-shape18] PASSED                                                 [ 49%]
tests/test_median.py::test_accuracy_median_keepdim[dtype0-True-shape0] PASSED                                                [ 49%]
tests/test_median.py::test_accuracy_median_keepdim[dtype0-True-shape1] PASSED                                                [ 50%]
tests/test_median.py::test_accuracy_median_keepdim[dtype0-True-shape2] PASSED                                                [ 50%]
tests/test_median.py::test_accuracy_median_keepdim[dtype0-True-shape3] PASSED                                                [ 50%]
tests/test_median.py::test_accuracy_median_keepdim[dtype0-True-shape4] PASSED                                                [ 51%]
tests/test_median.py::test_accuracy_median_keepdim[dtype0-False-shape0] PASSED                                               [ 51%]
tests/test_median.py::test_accuracy_median_keepdim[dtype0-False-shape1] PASSED                                               [ 51%]
tests/test_median.py::test_accuracy_median_keepdim[dtype0-False-shape2] PASSED                                               [ 52%]
tests/test_median.py::test_accuracy_median_keepdim[dtype0-False-shape3] PASSED                                               [ 52%]
tests/test_median.py::test_accuracy_median_keepdim[dtype0-False-shape4] PASSED                                               [ 53%]
tests/test_median.py::test_accuracy_median_keepdim[dtype1-True-shape0] PASSED                                                [ 53%]
tests/test_median.py::test_accuracy_median_keepdim[dtype1-True-shape1] PASSED                                                [ 53%]
tests/test_median.py::test_accuracy_median_keepdim[dtype1-True-shape2] PASSED                                                [ 54%]
tests/test_median.py::test_accuracy_median_keepdim[dtype1-True-shape3] PASSED                                                [ 54%]
tests/test_median.py::test_accuracy_median_keepdim[dtype1-True-shape4] PASSED                                                [ 54%]
tests/test_median.py::test_accuracy_median_keepdim[dtype1-False-shape0] PASSED                                               [ 55%]
tests/test_median.py::test_accuracy_median_keepdim[dtype1-False-shape1] PASSED                                               [ 55%]
tests/test_median.py::test_accuracy_median_keepdim[dtype1-False-shape2] PASSED                                               [ 55%]
tests/test_median.py::test_accuracy_median_keepdim[dtype1-False-shape3] PASSED                                               [ 56%]
tests/test_median.py::test_accuracy_median_keepdim[dtype1-False-shape4] PASSED                                               [ 56%]
tests/test_median.py::test_accuracy_median_keepdim[dtype2-True-shape0] PASSED                                                [ 56%]
tests/test_median.py::test_accuracy_median_keepdim[dtype2-True-shape1] PASSED                                                [ 57%]
tests/test_median.py::test_accuracy_median_keepdim[dtype2-True-shape2] PASSED                                                [ 57%]
tests/test_median.py::test_accuracy_median_keepdim[dtype2-True-shape3] PASSED                                                [ 58%]
tests/test_median.py::test_accuracy_median_keepdim[dtype2-True-shape4] PASSED                                                [ 58%]
tests/test_median.py::test_accuracy_median_keepdim[dtype2-False-shape0] PASSED                                               [ 58%]
tests/test_median.py::test_accuracy_median_keepdim[dtype2-False-shape1] PASSED                                               [ 59%]
tests/test_median.py::test_accuracy_median_keepdim[dtype2-False-shape2] PASSED                                               [ 59%]
tests/test_median.py::test_accuracy_median_keepdim[dtype2-False-shape3] PASSED                                               [ 59%]
tests/test_median.py::test_accuracy_median_keepdim[dtype2-False-shape4] PASSED                                               [ 60%]
tests/test_median.py::test_accuracy_median_extreme_values[dtype0-shape0] PASSED                                              [ 60%]
tests/test_median.py::test_accuracy_median_extreme_values[dtype0-shape1] PASSED                                              [ 60%]
tests/test_median.py::test_accuracy_median_extreme_values[dtype0-shape2] PASSED                                              [ 61%]
tests/test_median.py::test_accuracy_median_extreme_values[dtype0-shape3] PASSED                                              [ 61%]
tests/test_median.py::test_accuracy_median_extreme_values[dtype1-shape0] PASSED                                              [ 62%]
tests/test_median.py::test_accuracy_median_extreme_values[dtype1-shape1] PASSED                                              [ 62%]
tests/test_median.py::test_accuracy_median_extreme_values[dtype1-shape2] PASSED                                              [ 62%]
tests/test_median.py::test_accuracy_median_extreme_values[dtype1-shape3] PASSED                                              [ 63%]
tests/test_median.py::test_accuracy_median_extreme_values[dtype2-shape0] PASSED                                              [ 63%]
tests/test_median.py::test_accuracy_median_extreme_values[dtype2-shape1] PASSED                                              [ 63%]
tests/test_median.py::test_accuracy_median_extreme_values[dtype2-shape2] PASSED                                              [ 64%]
tests/test_median.py::test_accuracy_median_extreme_values[dtype2-shape3] PASSED                                              [ 64%]
tests/test_median.py::test_accuracy_median_with_zeros[dtype0-shape0] PASSED                                                  [ 64%]
tests/test_median.py::test_accuracy_median_with_zeros[dtype0-shape1] PASSED                                                  [ 65%]
tests/test_median.py::test_accuracy_median_with_zeros[dtype0-shape2] PASSED                                                  [ 65%]
tests/test_median.py::test_accuracy_median_with_zeros[dtype0-shape3] PASSED                                                  [ 65%]
tests/test_median.py::test_accuracy_median_with_zeros[dtype0-shape4] PASSED                                                  [ 66%]
tests/test_median.py::test_accuracy_median_with_zeros[dtype1-shape0] PASSED                                                  [ 66%]
tests/test_median.py::test_accuracy_median_with_zeros[dtype1-shape1] PASSED                                                  [ 67%]
tests/test_median.py::test_accuracy_median_with_zeros[dtype1-shape2] PASSED                                                  [ 67%]
tests/test_median.py::test_accuracy_median_with_zeros[dtype1-shape3] PASSED                                                  [ 67%]
tests/test_median.py::test_accuracy_median_with_zeros[dtype1-shape4] PASSED                                                  [ 68%]
tests/test_median.py::test_accuracy_median_with_zeros[dtype2-shape0] PASSED                                                  [ 68%]
tests/test_median.py::test_accuracy_median_with_zeros[dtype2-shape1] PASSED                                                  [ 68%]
tests/test_median.py::test_accuracy_median_with_zeros[dtype2-shape2] PASSED                                                  [ 69%]
tests/test_median.py::test_accuracy_median_with_zeros[dtype2-shape3] PASSED                                                  [ 69%]
tests/test_median.py::test_accuracy_median_with_zeros[dtype2-shape4] PASSED                                                  [ 69%]
tests/test_median.py::test_accuracy_median_with_negatives[dtype0-shape0] PASSED                                              [ 70%]
tests/test_median.py::test_accuracy_median_with_negatives[dtype0-shape1] PASSED                                              [ 70%]
tests/test_median.py::test_accuracy_median_with_negatives[dtype0-shape2] PASSED                                              [ 70%]
tests/test_median.py::test_accuracy_median_with_negatives[dtype0-shape3] PASSED                                              [ 71%]
tests/test_median.py::test_accuracy_median_with_negatives[dtype0-shape4] PASSED                                              [ 71%]
tests/test_median.py::test_accuracy_median_with_negatives[dtype1-shape0] PASSED                                              [ 72%]
tests/test_median.py::test_accuracy_median_with_negatives[dtype1-shape1] PASSED                                              [ 72%]
tests/test_median.py::test_accuracy_median_with_negatives[dtype1-shape2] PASSED                                              [ 72%]
tests/test_median.py::test_accuracy_median_with_negatives[dtype1-shape3] PASSED                                              [ 73%]
tests/test_median.py::test_accuracy_median_with_negatives[dtype1-shape4] PASSED                                              [ 73%]
tests/test_median.py::test_accuracy_median_with_negatives[dtype2-shape0] PASSED                                              [ 73%]
tests/test_median.py::test_accuracy_median_with_negatives[dtype2-shape1] PASSED                                              [ 74%]
tests/test_median.py::test_accuracy_median_with_negatives[dtype2-shape2] PASSED                                              [ 74%]
tests/test_median.py::test_accuracy_median_with_negatives[dtype2-shape3] PASSED                                              [ 74%]
tests/test_median.py::test_accuracy_median_with_negatives[dtype2-shape4] PASSED                                              [ 75%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype0-shape0] PASSED                                              [ 75%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype0-shape1] PASSED                                              [ 75%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype0-shape2] PASSED                                              [ 76%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype0-shape3] PASSED                                              [ 76%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype0-shape4] PASSED                                              [ 77%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype0-shape5] PASSED                                              [ 77%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype0-shape6] PASSED                                              [ 77%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype1-shape0] PASSED                                              [ 78%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype1-shape1] PASSED                                              [ 78%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype1-shape2] PASSED                                              [ 78%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype1-shape3] PASSED                                              [ 79%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype1-shape4] PASSED                                              [ 79%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype1-shape5] PASSED                                              [ 79%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype1-shape6] PASSED                                              [ 80%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype2-shape0] PASSED                                              [ 80%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype2-shape1] PASSED                                              [ 81%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype2-shape2] PASSED                                              [ 81%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype2-shape3] PASSED                                              [ 81%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype2-shape4] PASSED                                              [ 82%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype2-shape5] PASSED                                              [ 82%]
tests/test_median.py::test_accuracy_median_dynamic_shapes[dtype2-shape6] PASSED                                              [ 82%]
tests/test_median.py::test_accuracy_median_sorted_input[dtype0-shape0] PASSED                                                [ 83%]
tests/test_median.py::test_accuracy_median_sorted_input[dtype0-shape1] PASSED                                                [ 83%]
tests/test_median.py::test_accuracy_median_sorted_input[dtype0-shape2] PASSED                                                [ 83%]
tests/test_median.py::test_accuracy_median_sorted_input[dtype0-shape3] PASSED                                                [ 84%]
tests/test_median.py::test_accuracy_median_sorted_input[dtype1-shape0] PASSED                                                [ 84%]
tests/test_median.py::test_accuracy_median_sorted_input[dtype1-shape1] PASSED                                                [ 84%]
tests/test_median.py::test_accuracy_median_sorted_input[dtype1-shape2] PASSED                                                [ 85%]
tests/test_median.py::test_accuracy_median_sorted_input[dtype1-shape3] PASSED                                                [ 85%]
tests/test_median.py::test_accuracy_median_sorted_input[dtype2-shape0] PASSED                                                [ 86%]
tests/test_median.py::test_accuracy_median_sorted_input[dtype2-shape1] PASSED                                                [ 86%]
tests/test_median.py::test_accuracy_median_sorted_input[dtype2-shape2] PASSED                                                [ 86%]
tests/test_median.py::test_accuracy_median_sorted_input[dtype2-shape3] PASSED                                                [ 87%]
tests/test_median.py::test_accuracy_median_duplicate_values[dtype0-shape0] PASSED                                            [ 87%]
tests/test_median.py::test_accuracy_median_duplicate_values[dtype0-shape1] PASSED                                            [ 87%]
tests/test_median.py::test_accuracy_median_duplicate_values[dtype0-shape2] PASSED                                            [ 88%]
tests/test_median.py::test_accuracy_median_duplicate_values[dtype0-shape3] PASSED                                            [ 88%]
tests/test_median.py::test_accuracy_median_duplicate_values[dtype1-shape0] PASSED                                            [ 88%]
tests/test_median.py::test_accuracy_median_duplicate_values[dtype1-shape1] PASSED                                            [ 89%]
tests/test_median.py::test_accuracy_median_duplicate_values[dtype1-shape2] PASSED                                            [ 89%]
tests/test_median.py::test_accuracy_median_duplicate_values[dtype1-shape3] PASSED                                            [ 89%]
tests/test_median.py::test_accuracy_median_duplicate_values[dtype2-shape0] PASSED                                            [ 90%]
tests/test_median.py::test_accuracy_median_duplicate_values[dtype2-shape1] PASSED                                            [ 90%]
tests/test_median.py::test_accuracy_median_duplicate_values[dtype2-shape2] PASSED                                            [ 91%]
tests/test_median.py::test_accuracy_median_duplicate_values[dtype2-shape3] PASSED                                            [ 91%]
tests/test_median.py::test_median_invalid_dim PASSED                                                                         [ 91%]
tests/test_median.py::test_median_empty_dimension PASSED                                                                     [ 92%]
tests/test_median.py::test_median_dtype_compatibility PASSED                                                                 [ 92%]
tests/test_median.py::test_median_different_dim_combinations PASSED                                                          [ 92%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype0-shape0] PASSED                                           [ 93%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype0-shape1] PASSED                                           [ 93%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype0-shape2] PASSED                                           [ 93%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype0-shape3] PASSED                                           [ 94%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype0-shape4] PASSED                                           [ 94%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype0-shape5] PASSED                                           [ 94%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype1-shape0] PASSED                                           [ 95%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype1-shape1] PASSED                                           [ 95%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype1-shape2] PASSED                                           [ 96%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype1-shape3] PASSED                                           [ 96%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype1-shape4] PASSED                                           [ 96%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype1-shape5] PASSED                                           [ 97%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype2-shape0] PASSED                                           [ 97%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype2-shape1] PASSED                                           [ 97%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype2-shape2] PASSED                                           [ 98%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype2-shape3] PASSED                                           [ 98%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype2-shape4] PASSED                                           [ 98%]
tests/test_median.py::test_accuracy_median_odd_even_elements[dtype2-shape5] PASSED                                           [ 99%]
tests/test_median.py::test_median_nan_handling PASSED                                                                        [ 99%]
tests/test_median.py::test_median_inf_handling PASSED                                                                        [100%]

========================================================= warnings summary =========================================================
.pixi/envs/default/lib/python3.12/site-packages/triton/runtime/autotuner.py:99: 16 warnings
  /data1/yuxuewen/FlagGems/.pixi/envs/default/lib/python3.12/site-packages/triton/runtime/autotuner.py:99: DeprecationWarning: warmup, rep, and use_cuda_graph parameters are deprecated. See https://github.com/triton-lang/triton/pull/4496 for details.
    warnings.warn(("warmup, rep, and use_cuda_graph parameters are deprecated. See "

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
================================================= 279 passed, 16 warnings in 3.08s =================================================
```