### PR TITLE
【KernelGen】fix：change import path

### DIFF
--- a/experimental_tests/_adaptive_avg_pool2d_test.py
+++ b/experimental_tests/_adaptive_avg_pool2d_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops._adaptive_avg_pool2d import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/_adaptive_avg_pool3d_test.py
+++ b/experimental_tests/_adaptive_avg_pool3d_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops._adaptive_avg_pool3d import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/_functional_sym_constrain_range_for_size_test.py
+++ b/experimental_tests/_functional_sym_constrain_range_for_size_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops._functional_sym_constrain_range_for_size import 
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 try:

--- a/experimental_tests/_log_softmax_backward_data_test.py
+++ b/experimental_tests/_log_softmax_backward_data_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops._log_softmax_backward_data import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/_reshape_alias_test.py
+++ b/experimental_tests/_reshape_alias_test.py
@@ -13,7 +13,7 @@ from flag_gems.experimental_ops._reshape_alias import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/_safe_softmax_test.py
+++ b/experimental_tests/_safe_softmax_test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops._safe_softmax import _safe_softmax as gems__safe_softmax
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/_unsafe_view_test.py
+++ b/experimental_tests/_unsafe_view_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops._unsafe_view import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:
@@ -24,7 +24,7 @@ except ImportError:
         torch.testing.assert_close(res, ref, **kwargs)
 
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 

--- a/experimental_tests/_upsample_nearest_exact1d_test.py
+++ b/experimental_tests/_upsample_nearest_exact1d_test.py
@@ -15,7 +15,7 @@ from flag_gems.experimental_ops._upsample_nearest_exact1d import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/_upsample_nearest_exact3d_test.py
+++ b/experimental_tests/_upsample_nearest_exact3d_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops._upsample_nearest_exact3d import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/abs__test.py
+++ b/experimental_tests/abs__test.py
@@ -10,7 +10,7 @@ import flag_gems
 from flag_gems.experimental_ops.abs_ import abs_ as gems_abs_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:
@@ -37,7 +37,7 @@ def to_reference(inp, upcast=False):
     return ref_inp
 
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 

--- a/experimental_tests/abs_test.py
+++ b/experimental_tests/abs_test.py
@@ -11,7 +11,7 @@ from flag_gems.experimental_ops.abs import abs as gems_abs
 from flag_gems.experimental_ops.abs import abs_out as gems_abs_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:
@@ -23,7 +23,7 @@ except ImportError:
         torch.testing.assert_close(res, ref, **kwargs)
 
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 

--- a/experimental_tests/absolute__test.py
+++ b/experimental_tests/absolute__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.absolute_ import absolute_ as gems_absolute_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/absolute_test.py
+++ b/experimental_tests/absolute_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.absolute import absolute as gems_absolute
 from flag_gems.experimental_ops.absolute import absolute_out as gems_absolute_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/addcdiv_test.py
+++ b/experimental_tests/addcdiv_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.addcdiv import addcdiv as gems_addcdiv
 from flag_gems.experimental_ops.addcdiv import addcdiv_out as gems_addcdiv_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/addcmul__test.py
+++ b/experimental_tests/addcmul__test.py
@@ -10,7 +10,7 @@ import flag_gems
 from flag_gems.experimental_ops.addcmul_ import addcmul_ as gems_addcmul_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:
@@ -22,7 +22,7 @@ except ImportError:
         torch.testing.assert_close(res, ref, **kwargs)
 
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 

--- a/experimental_tests/alias_copy_test.py
+++ b/experimental_tests/alias_copy_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.alias_copy import alias_copy as gems_alias_copy
 from flag_gems.experimental_ops.alias_copy import alias_copy_out as gems_alias_copy_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/amin_test.py
+++ b/experimental_tests/amin_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.amin import amin as gems_amin
 from flag_gems.experimental_ops.amin import amin_out as gems_amin_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/arccosh__test.py
+++ b/experimental_tests/arccosh__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.arccosh_ import arccosh_ as gems_arccosh_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/arccosh_test.py
+++ b/experimental_tests/arccosh_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.arccosh import arccosh as gems_arccosh
 from flag_gems.experimental_ops.arccosh import arccosh_out as gems_arccosh_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/arcsinh__test.py
+++ b/experimental_tests/arcsinh__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.arcsinh_ import arcsinh_ as gems_arcsinh_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/arcsinh_test.py
+++ b/experimental_tests/arcsinh_test.py
@@ -11,7 +11,7 @@ from flag_gems.experimental_ops.arcsinh import arcsinh as gems_arcsinh
 from flag_gems.experimental_ops.arcsinh import arcsinh_out as gems_arcsinh_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 try:

--- a/experimental_tests/arctanh__test.py
+++ b/experimental_tests/arctanh__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.arctanh_ import arctanh_ as gems_arctanh_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/arctanh_test.py
+++ b/experimental_tests/arctanh_test.py
@@ -11,7 +11,7 @@ from flag_gems.experimental_ops.arctanh import arctanh as gems_arctanh
 from flag_gems.experimental_ops.arctanh import arctanh_out as gems_arctanh_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:
@@ -23,7 +23,7 @@ except ImportError:
         torch.testing.assert_close(res, ref, **kwargs)
 
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 

--- a/experimental_tests/as_strided__test.py
+++ b/experimental_tests/as_strided__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.as_strided_ import as_strided_ as gems_as_strided_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/as_strided_copy_test.py
+++ b/experimental_tests/as_strided_copy_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.as_strided_copy import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/as_strided_scatter_test.py
+++ b/experimental_tests/as_strided_scatter_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.as_strided_scatter import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/as_strided_test.py
+++ b/experimental_tests/as_strided_test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.as_strided import as_strided as gems_as_strided
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/asinh__test.py
+++ b/experimental_tests/asinh__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.asinh_ import asinh_ as gems_asinh_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/atanh__test.py
+++ b/experimental_tests/atanh__test.py
@@ -10,7 +10,7 @@ import flag_gems
 from flag_gems.experimental_ops.atanh_ import atanh_ as gems_atanh_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 try:

--- a/experimental_tests/ceil__test.py
+++ b/experimental_tests/ceil__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.ceil_ import ceil_ as gems_ceil_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/celu__test.py
+++ b/experimental_tests/celu__test.py
@@ -9,11 +9,11 @@ import torch
 import flag_gems
 from flag_gems.experimental_ops.celu_ import celu_ as gems_celu_
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/celu_test.py
+++ b/experimental_tests/celu_test.py
@@ -10,11 +10,11 @@ import flag_gems
 from flag_gems.experimental_ops.celu import celu as gems_celu
 from flag_gems.experimental_ops.celu import celu_out as gems_celu_out
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/clamp_max__test.py
+++ b/experimental_tests/clamp_max__test.py
@@ -9,11 +9,11 @@ import torch
 import flag_gems
 from flag_gems.experimental_ops.clamp_max_ import clamp_max_ as gems_clamp_max_
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/clamp_min__test.py
+++ b/experimental_tests/clamp_min__test.py
@@ -9,11 +9,11 @@ import torch
 import flag_gems
 from flag_gems.experimental_ops.clamp_min_ import clamp_min_ as gems_clamp_min_
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/copy__test.py
+++ b/experimental_tests/copy__test.py
@@ -9,11 +9,11 @@ import torch
 import flag_gems
 from flag_gems.experimental_ops.copy_ import copy_ as gems_copy_
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/cos__test.py
+++ b/experimental_tests/cos__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.cos_ import cos_ as gems_cos_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/cosh__test.py
+++ b/experimental_tests/cosh__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.cosh_ import cosh_ as gems_cosh_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/deg2rad__test.py
+++ b/experimental_tests/deg2rad__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.deg2rad_ import deg2rad_ as gems_deg2rad_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/deg2rad_test.py
+++ b/experimental_tests/deg2rad_test.py
@@ -13,11 +13,11 @@ from flag_gems.experimental_ops.deg2rad import (  # noqa: E402
     deg2rad_out as gems_deg2rad_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/detach_test.py
+++ b/experimental_tests/detach_test.py
@@ -11,7 +11,7 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.detach import detach as gems_detach  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/diag_test.py
+++ b/experimental_tests/diag_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.diag import diag as gems_diag  # noqa: E402
 from flag_gems.experimental_ops.diag import diag_out as gems_diag_out  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/digamma__test.py
+++ b/experimental_tests/digamma__test.py
@@ -11,7 +11,7 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.digamma_ import digamma_ as gems_digamma_  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/elu_test.py
+++ b/experimental_tests/elu_test.py
@@ -11,11 +11,11 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.elu import elu as gems_elu  # noqa: E402
 from flag_gems.experimental_ops.elu import elu_out as gems_elu_out  # noqa: E402
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/eq__test.py
+++ b/experimental_tests/eq__test.py
@@ -11,7 +11,7 @@ from flag_gems.experimental_ops.eq_ import eq__Scalar as gems_eq__Scalar
 from flag_gems.experimental_ops.eq_ import eq__Tensor as gems_eq__Tensor
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 try:

--- a/experimental_tests/erf__test.py
+++ b/experimental_tests/erf__test.py
@@ -10,11 +10,11 @@ import triton  # noqa: E402, F401
 import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.erf_ import erf_ as gems_erf_  # noqa: E402
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/erfinv__test.py
+++ b/experimental_tests/erfinv__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.erfinv_ import erfinv_ as gems_erfinv_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/erfinv_test.py
+++ b/experimental_tests/erfinv_test.py
@@ -13,11 +13,11 @@ from flag_gems.experimental_ops.erfinv import (  # noqa: E402
     erfinv_out as gems_erfinv_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/exp2__test.py
+++ b/experimental_tests/exp2__test.py
@@ -11,7 +11,7 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.exp2_ import exp2_ as gems_exp2_  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/exp2_test.py
+++ b/experimental_tests/exp2_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.exp2 import exp2 as gems_exp2
 from flag_gems.experimental_ops.exp2 import exp2_out as gems_exp2_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/exp__test.py
+++ b/experimental_tests/exp__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.exp_ import exp_ as gems_exp_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/expand_copy_test.py
+++ b/experimental_tests/expand_copy_test.py
@@ -14,7 +14,7 @@ from flag_gems.experimental_ops.expand_copy import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/expand_test.py
+++ b/experimental_tests/expand_test.py
@@ -10,11 +10,11 @@ import triton  # noqa: E402, F401
 import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.expand import expand as gems_expand  # noqa: E402
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/expm1__test.py
+++ b/experimental_tests/expm1__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.expm1_ import expm1_ as gems_expm1_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/eye_test.py
+++ b/experimental_tests/eye_test.py
@@ -13,7 +13,7 @@ from flag_gems.experimental_ops.eye import eye_m_out as gems_eye_m_out
 from flag_gems.experimental_ops.eye import eye_out as gems_eye_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/fft_fftshift_test.py
+++ b/experimental_tests/fft_fftshift_test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.fft_fftshift import fft_fftshift as gems_fft_fftshift
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/fft_ifftshift_test.py
+++ b/experimental_tests/fft_ifftshift_test.py
@@ -12,11 +12,11 @@ from flag_gems.experimental_ops.fft_ifftshift import (  # noqa: E402
     fft_ifftshift as gems_fft_ifftshift,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/fill__test.py
+++ b/experimental_tests/fill__test.py
@@ -10,11 +10,11 @@ import triton  # noqa: E402, F401
 import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.fill_ import fill__Scalar, fill__Tensor  # noqa: E402
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/fix__test.py
+++ b/experimental_tests/fix__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.fix_ import fix_ as gems_fix_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/fix_test.py
+++ b/experimental_tests/fix_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.fix import fix as gems_fix  # noqa: E402
 from flag_gems.experimental_ops.fix import fix_out as gems_fix_out  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/floor__test.py
+++ b/experimental_tests/floor__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.floor_ import floor_ as gems_floor_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/fmin_test.py
+++ b/experimental_tests/fmin_test.py
@@ -11,7 +11,7 @@ from flag_gems.experimental_ops.fmin import fmin as gems_fmin
 from flag_gems.experimental_ops.fmin import fmin_out as gems_fmin_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 try:

--- a/experimental_tests/frac__test.py
+++ b/experimental_tests/frac__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.frac_ import frac_ as gems_frac_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/frac_test.py
+++ b/experimental_tests/frac_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.frac import frac as gems_frac  # noqa: E402
 from flag_gems.experimental_ops.frac import frac_out as gems_frac_out  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/ge__test.py
+++ b/experimental_tests/ge__test.py
@@ -11,7 +11,7 @@ from flag_gems.experimental_ops.ge_ import ge__Scalar as gems_ge__Scalar
 from flag_gems.experimental_ops.ge_ import ge__Tensor as gems_ge__Tensor
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 try:

--- a/experimental_tests/gelu__test.py
+++ b/experimental_tests/gelu__test.py
@@ -10,11 +10,11 @@ import triton  # noqa: E402, F401
 import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.gelu_ import gelu_ as gems_gelu_  # noqa: E402
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/glu_test.py
+++ b/experimental_tests/glu_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.glu import glu as gems_glu
 from flag_gems.experimental_ops.glu import glu_out as gems_glu_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/greater__test.py
+++ b/experimental_tests/greater__test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.greater_ import greater__Scalar as gems_greater_
 from flag_gems.experimental_ops.greater_ import greater__Tensor as gems_greater__Tensor
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/greater_equal__test.py
+++ b/experimental_tests/greater_equal__test.py
@@ -15,7 +15,7 @@ from flag_gems.experimental_ops.greater_equal_ import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 try:

--- a/experimental_tests/hardshrink_test.py
+++ b/experimental_tests/hardshrink_test.py
@@ -15,11 +15,11 @@ from flag_gems.experimental_ops.hardshrink import (  # noqa: E402
     hardshrink_out as gems_hardshrink_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/hardsigmoid__test.py
+++ b/experimental_tests/hardsigmoid__test.py
@@ -13,7 +13,7 @@ from flag_gems.experimental_ops.hardsigmoid_ import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/hardsigmoid_test.py
+++ b/experimental_tests/hardsigmoid_test.py
@@ -14,7 +14,7 @@ from flag_gems.experimental_ops.hardsigmoid import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/hardswish__test.py
+++ b/experimental_tests/hardswish__test.py
@@ -13,7 +13,7 @@ from flag_gems.experimental_ops.hardswish_ import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/hardswish_test.py
+++ b/experimental_tests/hardswish_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.hardswish import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/hardtanh__test.py
+++ b/experimental_tests/hardtanh__test.py
@@ -13,7 +13,7 @@ from flag_gems.experimental_ops.hardtanh_ import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/hardtanh_test.py
+++ b/experimental_tests/hardtanh_test.py
@@ -14,7 +14,7 @@ from flag_gems.experimental_ops.hardtanh import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/heaviside__test.py
+++ b/experimental_tests/heaviside__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.heaviside_ import heaviside_ as gems_heaviside_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/heaviside_test.py
+++ b/experimental_tests/heaviside_test.py
@@ -11,7 +11,7 @@ from flag_gems.experimental_ops.heaviside import heaviside as gems_heaviside
 from flag_gems.experimental_ops.heaviside import heaviside_out as gems_heaviside_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 try:

--- a/experimental_tests/hinge_embedding_loss_test.py
+++ b/experimental_tests/hinge_embedding_loss_test.py
@@ -12,11 +12,11 @@ from flag_gems.experimental_ops.hinge_embedding_loss import (  # noqa: E402
     hinge_embedding_loss as gems_hinge_embedding_loss,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/huber_loss_test.py
+++ b/experimental_tests/huber_loss_test.py
@@ -15,11 +15,11 @@ from flag_gems.experimental_ops.huber_loss import (  # noqa: E402
     huber_loss_out as gems_huber_loss_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/hypot__test.py
+++ b/experimental_tests/hypot__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.hypot_ import hypot_ as gems_hypot_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/hypot_test.py
+++ b/experimental_tests/hypot_test.py
@@ -11,11 +11,11 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.hypot import hypot as gems_hypot  # noqa: E402
 from flag_gems.experimental_ops.hypot import hypot_out as gems_hypot_out  # noqa: E402
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/i0__test.py
+++ b/experimental_tests/i0__test.py
@@ -11,7 +11,7 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.i0_ import i0_ as gems_i0_  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/i0_test.py
+++ b/experimental_tests/i0_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.i0 import i0 as gems_i0
 from flag_gems.experimental_ops.i0 import i0_out as gems_i0_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/im2col_test.py
+++ b/experimental_tests/im2col_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.im2col import im2col as gems_im2col
 from flag_gems.experimental_ops.im2col import im2col_out as gems_im2col_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/le__test.py
+++ b/experimental_tests/le__test.py
@@ -10,11 +10,11 @@ import triton  # noqa: E402, F401
 import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.le_ import le__Scalar, le__Tensor  # noqa: E402
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/leaky_relu__test.py
+++ b/experimental_tests/leaky_relu__test.py
@@ -12,11 +12,11 @@ from flag_gems.experimental_ops.leaky_relu_ import (  # noqa: E402
     leaky_relu_ as gems_leaky_relu_,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/leaky_relu_test.py
+++ b/experimental_tests/leaky_relu_test.py
@@ -15,11 +15,11 @@ from flag_gems.experimental_ops.leaky_relu import (  # noqa: E402
     leaky_relu_out as gems_leaky_relu_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/lerp__test.py
+++ b/experimental_tests/lerp__test.py
@@ -10,11 +10,11 @@ import triton  # noqa: E402, F401
 import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.lerp_ import lerp__Scalar, lerp__Tensor  # noqa: E402
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/less__test.py
+++ b/experimental_tests/less__test.py
@@ -10,11 +10,11 @@ import triton  # noqa: E402, F401
 import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.less_ import less__Scalar, less__Tensor  # noqa: E402
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/less_equal__test.py
+++ b/experimental_tests/less_equal__test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.less_equal_ import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/lgamma__test.py
+++ b/experimental_tests/lgamma__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.lgamma_ import lgamma_ as gems_lgamma_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/lift_fresh_copy_test.py
+++ b/experimental_tests/lift_fresh_copy_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.lift_fresh_copy import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/lift_fresh_test.py
+++ b/experimental_tests/lift_fresh_test.py
@@ -13,7 +13,7 @@ from flag_gems.experimental_ops.lift_fresh import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/lift_test.py
+++ b/experimental_tests/lift_test.py
@@ -11,11 +11,11 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.lift import lift as gems_lift  # noqa: E402
 from flag_gems.experimental_ops.lift import lift_out as gems_lift_out  # noqa: E402
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/log10__test.py
+++ b/experimental_tests/log10__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.log10_ import log10_ as gems_log10_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/log1p__test.py
+++ b/experimental_tests/log1p__test.py
@@ -10,7 +10,7 @@ import flag_gems
 from flag_gems.experimental_ops.log1p_ import log1p_ as gems_log1p_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 try:

--- a/experimental_tests/log2__test.py
+++ b/experimental_tests/log2__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.log2_ import log2_ as gems_log2_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/log2_test.py
+++ b/experimental_tests/log2_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.log2 import log2 as gems_log2  # noqa: E402
 from flag_gems.experimental_ops.log2 import log2_out as gems_log2_out  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/log__test.py
+++ b/experimental_tests/log__test.py
@@ -11,7 +11,7 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.log_ import log_ as gems_log_  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/logaddexp2_test.py
+++ b/experimental_tests/logaddexp2_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.logaddexp2 import logaddexp2 as gems_logaddexp2
 from flag_gems.experimental_ops.logaddexp2 import logaddexp2_out as gems_logaddexp2_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/logaddexp_test.py
+++ b/experimental_tests/logaddexp_test.py
@@ -11,7 +11,7 @@ from flag_gems.experimental_ops.logaddexp import logaddexp as gems_logaddexp
 from flag_gems.experimental_ops.logaddexp import logaddexp_out as gems_logaddexp_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 try:

--- a/experimental_tests/logical_not__test.py
+++ b/experimental_tests/logical_not__test.py
@@ -13,7 +13,7 @@ from flag_gems.experimental_ops.logical_not_ import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/logical_xor__test.py
+++ b/experimental_tests/logical_xor__test.py
@@ -10,7 +10,7 @@ import flag_gems
 from flag_gems.experimental_ops.logical_xor_ import logical_xor_ as gems_logical_xor_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 try:

--- a/experimental_tests/logit__test.py
+++ b/experimental_tests/logit__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.logit_ import logit_ as gems_logit_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/logit_test.py
+++ b/experimental_tests/logit_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.logit import logit as gems_logit
 from flag_gems.experimental_ops.logit import logit_out as gems_logit_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/lt__test.py
+++ b/experimental_tests/lt__test.py
@@ -10,11 +10,11 @@ import triton  # noqa: E402, F401
 import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.lt_ import lt__Scalar, lt__Tensor  # noqa: E402
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/margin_ranking_loss_test.py
+++ b/experimental_tests/margin_ranking_loss_test.py
@@ -13,7 +13,7 @@ from flag_gems.experimental_ops.margin_ranking_loss import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/masked_fill_test.py
+++ b/experimental_tests/masked_fill_test.py
@@ -15,11 +15,11 @@ from flag_gems.experimental_ops.masked_fill import (  # noqa: E402
     masked_fill_Tensor_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/masked_scatter_test.py
+++ b/experimental_tests/masked_scatter_test.py
@@ -15,7 +15,7 @@ from flag_gems.experimental_ops.masked_scatter import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 try:

--- a/experimental_tests/masked_select_test.py
+++ b/experimental_tests/masked_select_test.py
@@ -15,11 +15,11 @@ from flag_gems.experimental_ops.masked_select import (  # noqa: E402
     masked_select_out as gems_masked_select_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/maximum_test.py
+++ b/experimental_tests/maximum_test.py
@@ -13,11 +13,11 @@ from flag_gems.experimental_ops.maximum import (  # noqa: E402
     maximum_out as gems_maximum_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/mse_loss_test.py
+++ b/experimental_tests/mse_loss_test.py
@@ -13,11 +13,11 @@ from flag_gems.experimental_ops.mse_loss import (  # noqa: E402
     mse_loss_out as gems_mse_loss_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/multiply_test.py
+++ b/experimental_tests/multiply_test.py
@@ -13,7 +13,7 @@ from flag_gems.experimental_ops.multiply import multiply_Scalar as gems_multiply
 from flag_gems.experimental_ops.multiply import multiply_Tensor as gems_multiply_Tensor
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/mv_test.py
+++ b/experimental_tests/mv_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.mv import mv as gems_mv  # noqa: E402
 from flag_gems.experimental_ops.mv import mv_out as gems_mv_out  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/native_dropout_backward_test.py
+++ b/experimental_tests/native_dropout_backward_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.native_dropout_backward import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/ne__test.py
+++ b/experimental_tests/ne__test.py
@@ -11,7 +11,7 @@ from flag_gems.experimental_ops.ne_ import ne__Scalar as gems_ne__Scalar
 from flag_gems.experimental_ops.ne_ import ne__Tensor as gems_ne__Tensor
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 try:

--- a/experimental_tests/neg__test.py
+++ b/experimental_tests/neg__test.py
@@ -11,7 +11,7 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.neg_ import neg_ as gems_neg_  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/negative__test.py
+++ b/experimental_tests/negative__test.py
@@ -12,11 +12,11 @@ from flag_gems.experimental_ops.negative_ import (  # noqa: E402
     negative_ as gems_negative_,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/negative_test.py
+++ b/experimental_tests/negative_test.py
@@ -14,7 +14,7 @@ from flag_gems.experimental_ops.negative import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/new_ones_test.py
+++ b/experimental_tests/new_ones_test.py
@@ -13,11 +13,11 @@ from flag_gems.experimental_ops.new_ones import (  # noqa: E402
     new_ones_out as gems_new_ones_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/not_equal__test.py
+++ b/experimental_tests/not_equal__test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.not_equal_ import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/permute_copy_test.py
+++ b/experimental_tests/permute_copy_test.py
@@ -14,7 +14,7 @@ from flag_gems.experimental_ops.permute_copy import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/permute_test.py
+++ b/experimental_tests/permute_test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.permute import permute as gems_permute
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/pixel_shuffle_test.py
+++ b/experimental_tests/pixel_shuffle_test.py
@@ -14,7 +14,7 @@ from flag_gems.experimental_ops.pixel_shuffle import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/pixel_unshuffle_test.py
+++ b/experimental_tests/pixel_unshuffle_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.pixel_unshuffle import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/positive_test.py
+++ b/experimental_tests/positive_test.py
@@ -11,7 +11,7 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.positive import positive as gems_positive  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/prelu_test.py
+++ b/experimental_tests/prelu_test.py
@@ -10,11 +10,11 @@ import triton  # noqa: E402, F401
 import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.prelu import prelu as gems_prelu  # noqa: E402
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/rad2deg__test.py
+++ b/experimental_tests/rad2deg__test.py
@@ -11,7 +11,7 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.rad2deg_ import rad2deg_ as gems_rad2deg_  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/reciprocal__test.py
+++ b/experimental_tests/reciprocal__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.reciprocal_ import reciprocal_ as gems_reciprocal_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/reciprocal_test.py
+++ b/experimental_tests/reciprocal_test.py
@@ -15,11 +15,11 @@ from flag_gems.experimental_ops.reciprocal import (  # noqa: E402
     reciprocal_out as gems_reciprocal_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/reflection_pad1d_test.py
+++ b/experimental_tests/reflection_pad1d_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.reflection_pad1d import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/reflection_pad2d_test.py
+++ b/experimental_tests/reflection_pad2d_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.reflection_pad2d import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/reflection_pad3d_test.py
+++ b/experimental_tests/reflection_pad3d_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.reflection_pad3d import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/relu6_test.py
+++ b/experimental_tests/relu6_test.py
@@ -11,7 +11,7 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.relu6 import relu6 as gems_relu6  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/relu__test.py
+++ b/experimental_tests/relu__test.py
@@ -10,11 +10,11 @@ import triton  # noqa: E402, F401
 import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.relu_ import relu_ as gems_relu_  # noqa: E402
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/replication_pad1d_test.py
+++ b/experimental_tests/replication_pad1d_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.replication_pad1d import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/replication_pad2d_test.py
+++ b/experimental_tests/replication_pad2d_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.replication_pad2d import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/replication_pad3d_test.py
+++ b/experimental_tests/replication_pad3d_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.replication_pad3d import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/reshape_test.py
+++ b/experimental_tests/reshape_test.py
@@ -11,7 +11,7 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.reshape import reshape as gems_reshape  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/rrelu_with_noise_backward_test.py
+++ b/experimental_tests/rrelu_with_noise_backward_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.rrelu_with_noise_backward import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/rsqrt__test.py
+++ b/experimental_tests/rsqrt__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.rsqrt_ import rsqrt_ as gems_rsqrt_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/scalar_tensor_test.py
+++ b/experimental_tests/scalar_tensor_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.scalar_tensor import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/select_backward_test.py
+++ b/experimental_tests/select_backward_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.select_backward import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/selu__test.py
+++ b/experimental_tests/selu__test.py
@@ -11,7 +11,7 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.selu_ import selu_ as gems_selu_  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/selu_test.py
+++ b/experimental_tests/selu_test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.selu import selu as gems_selu
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/sgn__test.py
+++ b/experimental_tests/sgn__test.py
@@ -11,7 +11,7 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.sgn_ import sgn_ as gems_sgn_  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/sgn_test.py
+++ b/experimental_tests/sgn_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.sgn import sgn as gems_sgn
 from flag_gems.experimental_ops.sgn import sgn_out as gems_sgn_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/sigmoid__test.py
+++ b/experimental_tests/sigmoid__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.sigmoid_ import sigmoid_ as gems_sigmoid_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/sigmoid_test.py
+++ b/experimental_tests/sigmoid_test.py
@@ -14,7 +14,7 @@ from flag_gems.experimental_ops.sigmoid import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/sign__test.py
+++ b/experimental_tests/sign__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.sign_ import sign_ as gems_sign_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/sign_test.py
+++ b/experimental_tests/sign_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.sign import sign as gems_sign
 from flag_gems.experimental_ops.sign import sign_out as gems_sign_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/silu__test.py
+++ b/experimental_tests/silu__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.silu_ import silu_ as gems_silu_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/silu_test.py
+++ b/experimental_tests/silu_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.silu import silu as gems_silu  # noqa: E402
 from flag_gems.experimental_ops.silu import silu_out as gems_silu_out  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/sin__test.py
+++ b/experimental_tests/sin__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.sin_ import sin_ as gems_sin_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/sinc__test.py
+++ b/experimental_tests/sinc__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.sinc_ import sinc_ as gems_sinc_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/sinc_test.py
+++ b/experimental_tests/sinc_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.sinc import sinc as gems_sinc
 from flag_gems.experimental_ops.sinc import sinc_out as gems_sinc_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/sinh__test.py
+++ b/experimental_tests/sinh__test.py
@@ -11,7 +11,7 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.sinh_ import sinh_ as gems_sinh_  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/slice_backward_test.py
+++ b/experimental_tests/slice_backward_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.slice_backward import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/slice_scatter_test.py
+++ b/experimental_tests/slice_scatter_test.py
@@ -14,7 +14,7 @@ from flag_gems.experimental_ops.slice_scatter import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/smooth_l1_loss_test.py
+++ b/experimental_tests/smooth_l1_loss_test.py
@@ -15,11 +15,11 @@ from flag_gems.experimental_ops.smooth_l1_loss import (  # noqa: E402
     smooth_l1_loss_out as gems_smooth_l1_loss_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/soft_margin_loss_test.py
+++ b/experimental_tests/soft_margin_loss_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.soft_margin_loss import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/softplus_test.py
+++ b/experimental_tests/softplus_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.softplus import softplus as gems_softplus
 from flag_gems.experimental_ops.softplus import softplus_out as gems_softplus_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/softshrink_test.py
+++ b/experimental_tests/softshrink_test.py
@@ -15,11 +15,11 @@ from flag_gems.experimental_ops.softshrink import (  # noqa: E402
     softshrink_out as gems_softshrink_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/special_i0e_test.py
+++ b/experimental_tests/special_i0e_test.py
@@ -14,7 +14,7 @@ from flag_gems.experimental_ops.special_i0e import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/special_i1_test.py
+++ b/experimental_tests/special_i1_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.special_i1 import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/special_xlog1py_test.py
+++ b/experimental_tests/special_xlog1py_test.py
@@ -15,11 +15,11 @@ from flag_gems.experimental_ops.special_xlog1py import (  # noqa: E402
     special_xlog1py_out as gems_special_xlog1py_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/square__test.py
+++ b/experimental_tests/square__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.square_ import square_ as gems_square_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/square_test.py
+++ b/experimental_tests/square_test.py
@@ -13,11 +13,11 @@ from flag_gems.experimental_ops.square import (  # noqa: E402
     square_out as gems_square_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/squeeze_copy_test.py
+++ b/experimental_tests/squeeze_copy_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.squeeze_copy import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/stack_test.py
+++ b/experimental_tests/stack_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.stack import stack as gems_stack  # noqa: E402
 from flag_gems.experimental_ops.stack import stack_out as gems_stack_out  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/t__test.py
+++ b/experimental_tests/t__test.py
@@ -11,7 +11,7 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.t_ import t_ as gems_t_  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/t_copy_test.py
+++ b/experimental_tests/t_copy_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.t_copy import t_copy as gems_t_copy
 from flag_gems.experimental_ops.t_copy import t_copy_out as gems_t_copy_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/t_test.py
+++ b/experimental_tests/t_test.py
@@ -27,7 +27,7 @@ def to_reference(inp, upcast=False):
 
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/take_test.py
+++ b/experimental_tests/take_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.take import take as gems_take  # noqa: E402
 from flag_gems.experimental_ops.take import take_out as gems_take_out  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/threshold__test.py
+++ b/experimental_tests/threshold__test.py
@@ -12,11 +12,11 @@ from flag_gems.experimental_ops.threshold_ import (  # noqa: E402
     threshold_ as gems_threshold_,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/threshold_test.py
+++ b/experimental_tests/threshold_test.py
@@ -15,11 +15,11 @@ from flag_gems.experimental_ops.threshold import (  # noqa: E402
     threshold_out as gems_threshold_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/trace_test.py
+++ b/experimental_tests/trace_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.trace import trace as gems_trace
 from flag_gems.experimental_ops.trace import trace_out as gems_trace_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/transpose__test.py
+++ b/experimental_tests/transpose__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.transpose_ import transpose_ as gems_transpose_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/transpose_copy_test.py
+++ b/experimental_tests/transpose_copy_test.py
@@ -14,7 +14,7 @@ from flag_gems.experimental_ops.transpose_copy import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/tril__test.py
+++ b/experimental_tests/tril__test.py
@@ -11,7 +11,7 @@ import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.tril_ import tril_ as gems_tril_  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/tril_test.py
+++ b/experimental_tests/tril_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.tril import tril as gems_tril  # noqa: E402
 from flag_gems.experimental_ops.tril import tril_out as gems_tril_out  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/triu__test.py
+++ b/experimental_tests/triu__test.py
@@ -27,7 +27,7 @@ def to_reference(inp, upcast=False):
 
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/triu_test.py
+++ b/experimental_tests/triu_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.triu import triu as gems_triu  # noqa: E402
 from flag_gems.experimental_ops.triu import triu_out as gems_triu_out  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/trunc_test.py
+++ b/experimental_tests/trunc_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.trunc import trunc as gems_trunc
 from flag_gems.experimental_ops.trunc import trunc_out as gems_trunc_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/unsqueeze__test.py
+++ b/experimental_tests/unsqueeze__test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.unsqueeze_ import unsqueeze_ as gems_unsqueeze_
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/unsqueeze_copy_test.py
+++ b/experimental_tests/unsqueeze_copy_test.py
@@ -15,11 +15,11 @@ from flag_gems.experimental_ops.unsqueeze_copy import (  # noqa: E402
     unsqueeze_copy_out as gems_unsqueeze_copy_out,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/unsqueeze_test.py
+++ b/experimental_tests/unsqueeze_test.py
@@ -12,11 +12,11 @@ from flag_gems.experimental_ops.unsqueeze import (  # noqa: E402
     unsqueeze as gems_unsqueeze,
 )
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/upsample_nearest1d_test.py
+++ b/experimental_tests/upsample_nearest1d_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.upsample_nearest1d import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/upsample_nearest3d_test.py
+++ b/experimental_tests/upsample_nearest3d_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.upsample_nearest3d import (
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/view_as_real_test.py
+++ b/experimental_tests/view_as_real_test.py
@@ -11,7 +11,7 @@ import flag_gems
 from flag_gems.experimental_ops.view_as_real import view_as_real as gems_view_as_real
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/xlogy__test.py
+++ b/experimental_tests/xlogy__test.py
@@ -14,7 +14,7 @@ from flag_gems.experimental_ops.xlogy_ import (
 from flag_gems.experimental_ops.xlogy_ import xlogy__Tensor as gems_xlogy__Tensor
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/xlogy_test.py
+++ b/experimental_tests/xlogy_test.py
@@ -22,7 +22,7 @@ from flag_gems.experimental_ops.xlogy import xlogy_Scalar_Self as gems_xlogy_Sca
 from flag_gems.experimental_ops.xlogy import xlogy_Tensor as gems_xlogy_Tensor
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from benchmark.performance_utils import GenericBenchmark
     from tests.accuracy_utils import TO_CPU, gems_assert_close

--- a/experimental_tests/zero__test.py
+++ b/experimental_tests/zero__test.py
@@ -10,11 +10,11 @@ import triton  # noqa: E402, F401
 import flag_gems  # noqa: E402
 from flag_gems.experimental_ops.zero_ import zero_ as gems_zero_  # noqa: E402
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from benchmark.performance_utils import GenericBenchmark  # noqa: E402
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:

--- a/experimental_tests/zero_test.py
+++ b/experimental_tests/zero_test.py
@@ -12,7 +12,7 @@ from flag_gems.experimental_ops.zero import zero as gems_zero
 from flag_gems.experimental_ops.zero import zero_out as gems_zero_out
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close
 except ImportError:

--- a/experimental_tests/zeros_like_test.py
+++ b/experimental_tests/zeros_like_test.py
@@ -16,7 +16,7 @@ from flag_gems.experimental_ops.zeros_like import (  # noqa: E402
 )
 
 # Add parent directory to path to import flag_gems
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../.."))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 try:
     from tests.accuracy_utils import TO_CPU, gems_assert_close  # noqa: E402
 except ImportError:


### PR DESCRIPTION
Since the experimental tests are moved to the root dir, the path to import flag_gems should be change as well.