### PR TITLE
【KernelGen】fix: pytest wrong

### DIFF
--- a/experimental_tests/_adaptive_avg_pool3d_test.py
+++ b/experimental_tests/_adaptive_avg_pool3d_test.py
@@ -24,8 +24,13 @@ except ImportError:
     TO_CPU = False  # fallback
 
     def gems_assert_close(res, ref, dtype, **kwargs):
-        # Simple fallback comparison
-        torch.testing.assert_close(res, ref, **kwargs)
+        # Simple fallback comparison aligned with flag_gems.testing.assert_close
+        from flag_gems.testing import assert_close as fg_assert_close  # noqa: E402
+
+        kwargs = dict(kwargs)
+        reduce_dim = kwargs.pop("reduce_dim", 1)
+        equal_nan = kwargs.pop("equal_nan", False)
+        fg_assert_close(res, ref, dtype, equal_nan=equal_nan, reduce_dim=reduce_dim)
 
 
 def to_reference(inp, upcast=False):

--- a/experimental_tests/_functional_sym_constrain_range_for_size_test.py
+++ b/experimental_tests/_functional_sym_constrain_range_for_size_test.py
@@ -7,8 +7,11 @@ import pytest
 import torch
 
 import flag_gems
-from flag_gems.experimental_ops._functional_sym_constrain_range_for_size import (
-    _functional_sym_constrain_range_for_size as gems__functional_sym_constrain_range_for_size,
+from flag_gems.experimental_ops import _functional_sym_constrain_range_for_size
+
+# Use the module attribute to get the function to avoid a very long import line
+gems__functional_sym_constrain_range_for_size = (
+    _functional_sym_constrain_range_for_size._functional_sym_constrain_range_for_size
 )
 
 # Add parent directory to path to import flag_gems

--- a/experimental_tests/_upsample_nearest_exact3d_test.py
+++ b/experimental_tests/_upsample_nearest_exact3d_test.py
@@ -24,8 +24,13 @@ except ImportError:
     TO_CPU = False  # fallback
 
     def gems_assert_close(res, ref, dtype, **kwargs):
-        # Simple fallback comparison
-        torch.testing.assert_close(res, ref, **kwargs)
+        # Simple fallback comparison aligned with flag_gems.testing.assert_close
+        from flag_gems.testing import assert_close as fg_assert_close  # noqa: E402
+
+        kwargs = dict(kwargs)
+        reduce_dim = kwargs.pop("reduce_dim", 1)
+        equal_nan = kwargs.pop("equal_nan", False)
+        fg_assert_close(res, ref, dtype, equal_nan=equal_nan, reduce_dim=reduce_dim)
 
 
 def to_reference(inp, upcast=False):

--- a/experimental_tests/arcsinh__test.py
+++ b/experimental_tests/arcsinh__test.py
@@ -19,8 +19,13 @@ except ImportError:
     TO_CPU = False  # fallback
 
     def gems_assert_close(res, ref, dtype, **kwargs):
-        # Simple fallback comparison
-        torch.testing.assert_close(res, ref, **kwargs)
+        # Simple fallback comparison aligned with flag_gems.testing.assert_close
+        from flag_gems.testing import assert_close as fg_assert_close  # noqa: E402
+
+        kwargs = dict(kwargs)
+        reduce_dim = kwargs.pop("reduce_dim", 1)
+        equal_nan = kwargs.pop("equal_nan", False)
+        fg_assert_close(res, ref, dtype, equal_nan=equal_nan, reduce_dim=reduce_dim)
 
 
 def to_reference(inp, upcast=False):

--- a/experimental_tests/logit__test.py
+++ b/experimental_tests/logit__test.py
@@ -19,8 +19,13 @@ except ImportError:
     TO_CPU = False  # fallback
 
     def gems_assert_close(res, ref, dtype, **kwargs):
-        # Simple fallback comparison
-        torch.testing.assert_close(res, ref, **kwargs)
+        # Simple fallback comparison aligned with flag_gems.testing.assert_close
+        from flag_gems.testing import assert_close as fg_assert_close  # noqa: E402
+
+        kwargs = dict(kwargs)
+        reduce_dim = kwargs.pop("reduce_dim", 1)
+        equal_nan = kwargs.pop("equal_nan", False)
+        fg_assert_close(res, ref, dtype, equal_nan=equal_nan, reduce_dim=reduce_dim)
 
 
 def to_reference(inp, upcast=False):

--- a/experimental_tests/mse_loss_test.py
+++ b/experimental_tests/mse_loss_test.py
@@ -25,8 +25,13 @@ except ImportError:
     TO_CPU = False  # fallback
 
     def gems_assert_close(res, ref, dtype, **kwargs):
-        # Simple fallback comparison
-        torch.testing.assert_close(res, ref, **kwargs)
+        # Simple fallback comparison aligned with flag_gems.testing.assert_close
+        from flag_gems.testing import assert_close as fg_assert_close  # noqa: E402
+
+        kwargs = dict(kwargs)
+        reduce_dim = kwargs.pop("reduce_dim", 1)
+        equal_nan = kwargs.pop("equal_nan", False)
+        fg_assert_close(res, ref, dtype, equal_nan=equal_nan, reduce_dim=reduce_dim)
 
 
 def to_reference(inp, upcast=False):
@@ -54,13 +59,17 @@ def test_mse_loss_tensor(shape, dtype, reduction):
 
     ref_x = to_reference(x)
     ref_y = to_reference(y)
+    if reduction in (1, 2) and dtype == torch.bfloat16:
+        ref_x = ref_x.float()
+        ref_y = ref_y.float()
     ref_out = torch.ops.aten.mse_loss(ref_x, ref_y, reduction)
+    if reduction in (1, 2) and dtype == torch.bfloat16:
+        ref_out = ref_out.to(dtype)
 
     with flag_gems.use_gems():
         act_out = gems_mse_loss(x, y, reduction)
 
-    atol = 1e-3 if dtype in (torch.float16, torch.bfloat16) else 1e-4
-    gems_assert_close(act_out, ref_out, dtype=dtype, atol=atol)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
 
 
 @pytest.mark.mse_loss
@@ -74,20 +83,30 @@ def test_mse_loss_out(shape, dtype, reduction):
     ref_x = to_reference(x)
     ref_y = to_reference(y)
 
+    if reduction in (1, 2) and dtype == torch.bfloat16:
+        ref_compute_dtype = torch.float32
+    else:
+        ref_compute_dtype = dtype
+
     if reduction == 0:
-        ref_out_buf = torch.empty(shape, dtype=dtype, device=ref_x.device)
+        ref_out_buf = torch.empty(shape, dtype=ref_compute_dtype, device=ref_x.device)
         act_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
     else:
-        ref_out_buf = torch.empty((), dtype=dtype, device=ref_x.device)
+        ref_out_buf = torch.empty((), dtype=ref_compute_dtype, device=ref_x.device)
         act_out_buf = torch.empty((), dtype=dtype, device=flag_gems.device)
 
+    if reduction in (1, 2) and dtype == torch.bfloat16:
+        ref_x = ref_x.float()
+        ref_y = ref_y.float()
     ref_out = torch.ops.aten.mse_loss.out(ref_x, ref_y, reduction, out=ref_out_buf)
+    if reduction in (1, 2) and dtype == torch.bfloat16:
+        ref_out_buf = ref_out_buf.to(dtype)
+        ref_out = ref_out_buf
 
     with flag_gems.use_gems():
         act_out = gems_mse_loss_out(x, y, reduction, act_out_buf)
 
-    atol = 1e-3 if dtype in (torch.float16, torch.bfloat16) else 1e-4
-    gems_assert_close(act_out, ref_out, dtype=dtype, atol=atol)
+    gems_assert_close(act_out, ref_out, dtype=dtype)
 
 
 @pytest.mark.mse_loss

--- a/experimental_tests/new_ones_test.py
+++ b/experimental_tests/new_ones_test.py
@@ -85,7 +85,9 @@ def test_perf_aten_new_ones():
         inp1 = torch.randn(
             shape, dtype=torch.float32, device=flag_gems.device
         )  # self_tensor
-        yield inp1, shape  # yield inputs as required by the operator (size as position, dtype as keyword)
+        # yield inputs as required by the operator (size as position,
+        # dtype as keyword)
+        yield inp1, shape
 
     # Create a wrapper function to handle dtype as keyword argument
     def new_ones_wrapper(self_tensor, size):

--- a/experimental_tests/reciprocal__test.py
+++ b/experimental_tests/reciprocal__test.py
@@ -19,8 +19,13 @@ except ImportError:
     TO_CPU = False  # fallback
 
     def gems_assert_close(res, ref, dtype, **kwargs):
-        # Simple fallback comparison
-        torch.testing.assert_close(res, ref, **kwargs)
+        # Simple fallback comparison aligned with flag_gems.testing.assert_close
+        from flag_gems.testing import assert_close as fg_assert_close  # noqa: E402
+
+        kwargs = dict(kwargs)
+        reduce_dim = kwargs.pop("reduce_dim", 1)
+        equal_nan = kwargs.pop("equal_nan", False)
+        fg_assert_close(res, ref, dtype, equal_nan=equal_nan, reduce_dim=reduce_dim)
 
 
 def to_reference(inp, upcast=False):

--- a/experimental_tests/reflection_pad3d_test.py
+++ b/experimental_tests/reflection_pad3d_test.py
@@ -24,8 +24,13 @@ except ImportError:
     TO_CPU = False  # fallback
 
     def gems_assert_close(res, ref, dtype, **kwargs):
-        # Simple fallback comparison
-        torch.testing.assert_close(res, ref, **kwargs)
+        # Simple fallback comparison aligned with flag_gems.testing.assert_close
+        from flag_gems.testing import assert_close as fg_assert_close  # noqa: E402
+
+        kwargs = dict(kwargs)
+        reduce_dim = kwargs.pop("reduce_dim", 1)
+        equal_nan = kwargs.pop("equal_nan", False)
+        fg_assert_close(res, ref, dtype, equal_nan=equal_nan, reduce_dim=reduce_dim)
 
 
 def to_reference(inp, upcast=False):

--- a/experimental_tests/relu_test.py
+++ b/experimental_tests/relu_test.py
@@ -8,6 +8,7 @@ import triton
 
 import flag_gems
 from flag_gems.experimental_ops.relu import relu as gems_relu
+from flag_gems.testing import assert_close as fg_assert_close
 
 
 def relu(input: torch.Tensor) -> torch.Tensor:
@@ -44,10 +45,10 @@ def test_relu_accuracy(shape, dtype):
     # cast to reference dtype if necessary
     ref_input = input.cpu()
 
-    ref_out = relu(ref_input)
-    res_out = gems_relu(input)
+    ref_out = relu(ref_input).to(dtype)
+    res_out = gems_relu(input).cpu()
 
-    torch.testing.assert_close(res_out.cpu(), ref_out, rtol=1e-3, atol=1e-3)
+    fg_assert_close(res_out, ref_out, dtype)
 
 
 @pytest.mark.relu

--- a/experimental_tests/trace_test.py
+++ b/experimental_tests/trace_test.py
@@ -20,8 +20,13 @@ except ImportError:
     TO_CPU = False  # fallback
 
     def gems_assert_close(res, ref, dtype, **kwargs):
-        # Simple fallback comparison
-        torch.testing.assert_close(res, ref, **kwargs)
+        # Simple fallback comparison aligned with flag_gems.testing.assert_close
+        from flag_gems.testing import assert_close as fg_assert_close  # noqa: E402
+
+        kwargs = dict(kwargs)
+        reduce_dim = kwargs.pop("reduce_dim", 1)
+        equal_nan = kwargs.pop("equal_nan", False)
+        fg_assert_close(res, ref, dtype, equal_nan=equal_nan, reduce_dim=reduce_dim)
 
 
 def to_reference(inp, upcast=False):


### PR DESCRIPTION
fix 12 tests used to be failed throught pytest -s
which are :
adaptive_avg_pool3d 
arcsinh_
hinge_embedding_loss
logit_
logit
mse_loss 
reciprocal_
reflection_pad3d 
_safe_softmax
special_i0e
trace
_upsample_nearest_exact3d 

What's more, fix 3 tests used to change the atol.
