### PR TITLE
【Benchmark】fix benchmark bug for upsample_nearest1d & nll_loss2d

### DIFF
--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -226,7 +226,7 @@ def test_generic_reduction_benchmark(op_name, torch_op, input_fn, dtypes):
 def test_nll_loss2d_benchmark():
     bench = GenericBenchmark4DOnly(
         input_fn=nll_loss_input_fn,
-        op_name="nll_loss",
+        op_name="nll_loss2d",
         torch_op=torch.nn.functional.nll_loss,
         dtypes=FLOAT_DTYPES,
     )

--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -475,8 +475,9 @@ def test_perf_upsample_bicubic2d_aa():
 @pytest.mark.upsample_nearest1d
 def test_perf_upsample_nearest1d():
     def upsample_nearest1d_input_fn(shape, dtype, device):
-        batch, channel, length = shape
-        input = torch.randn(size=shape, device=device, dtype=dtype)
+        batch, channel, height, width = shape
+        length = height * width  # flatten spatial dims to 1D length
+        input = torch.randn((batch, channel, length), device=device, dtype=dtype)
         scale_factors = 2
         output_size = int(length * scale_factors)
         yield {


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Benchmark

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
- modify operator name for `nll_loss2d`
- Fix `upsample_nearest1d` parameter mismatch
![img_v3_02tv_c53571c5-15c5-4e52-a53e-70047165e2ag](https://github.com/user-attachments/assets/653597e0-b3df-4f1a-afcc-929cb6a3ad00)


### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
