### PR TITLE
【KernelGen】Update other workflow skip testing when experimental op check in

### DIFF
--- a/.github/workflows/blas-op-test.yaml
+++ b/.github/workflows/blas-op-test.yaml
@@ -16,19 +16,21 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: experimental_ops
         with:
+          list-files: shell
           filters: |
-            run_ci:
+            all:
               - '**'
-              - '!src/flag_gems/experimental_ops/**'
-              - '!experimental_tests/**'
+            experimental:
+              - 'src/flag_gems/experimental_ops/**'
+              - 'experimental_tests/**'
 
       - name: Check GPU free
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: tools/gpu_check.sh
 
       - name: BLAS OP
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           echo "current dir: $(pwd)"

--- a/.github/workflows/gems-cpp-extension.yaml
+++ b/.github/workflows/gems-cpp-extension.yaml
@@ -38,19 +38,22 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: experimental_ops
         with:
+          list-files: shell
           filters: |
-            run_ci:
-              - '!src/flag_gems/experimental_ops/**'
-              - '!tests/experimental_ops/**'
+            all:
+              - '**'
+            experimental:
+              - 'src/flag_gems/experimental_ops/**'
+              - 'experimental_tests/**'
 
       - name: Build FlagGems with C-extension
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           SKBUILD_CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON" pip install --no-build-isolation -v -e .
 
       - name: Run FlagGems CTests
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           cd build/cpython-311/ctests

--- a/.github/workflows/gems-test-on-hopper.yaml
+++ b/.github/workflows/gems-test-on-hopper.yaml
@@ -50,14 +50,16 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: experimental_ops
         with:
+          list-files: shell
           filters: |
-            run_ci:
+            all:
               - '**'
-              - '!src/flag_gems/experimental_ops/**'
-              - '!experimental_tests/**'
+            experimental:
+              - 'src/flag_gems/experimental_ops/**'
+              - 'experimental_tests/**'
 
       - name: FlagGems reduction ops on hopper
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           source "/home/zhangzhihui/miniconda3/etc/profile.d/conda.sh"
@@ -68,7 +70,7 @@ jobs:
           run_command pytest -s tests/test_norm_ops.py
 
       - name: FlagGems pointwise ops on hopper
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           source "/home/zhangzhihui/miniconda3/etc/profile.d/conda.sh"
@@ -81,7 +83,7 @@ jobs:
           run_command pytest -s tests/test_tensor_constructor_ops.py
 
       - name: FlagGems blas ops on hopper
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           source "/home/zhangzhihui/miniconda3/etc/profile.d/conda.sh"
@@ -92,7 +94,7 @@ jobs:
           run_command pytest -s tests/test_blas_ops.py
 
       - name: FlagGems special ops on hopper
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           source "/home/zhangzhihui/miniconda3/etc/profile.d/conda.sh"
@@ -102,7 +104,7 @@ jobs:
           run_command pytest -s tests/test_distribution_ops.py
 
       - name: FlagGems convolution ops on hopper
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           source "/home/zhangzhihui/miniconda3/etc/profile.d/conda.sh"
@@ -111,7 +113,7 @@ jobs:
           run_command pytest -s tests/test_convolution_ops.py
 
       - name: FlagGems utils on hopper
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           source "/home/zhangzhihui/miniconda3/etc/profile.d/conda.sh"
@@ -122,7 +124,7 @@ jobs:
           run_command pytest -s tests/test_tensor_wrapper.py
 
       - name: FlagGems examples on hopper
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           source "/home/zhangzhihui/miniconda3/etc/profile.d/conda.sh"

--- a/.github/workflows/gems-test-on-metax.yaml
+++ b/.github/workflows/gems-test-on-metax.yaml
@@ -41,14 +41,16 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: experimental_ops
         with:
+          list-files: shell
           filters: |
-            run_ci:
+            all:
               - '**'
-              - '!src/flag_gems/experimental_ops/**'
-              - '!experimental_tests/**'
+            experimental:
+              - 'src/flag_gems/experimental_ops/**'
+              - 'experimental_tests/**'
 
       - name: FlagGems reduction ops on metax
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           source tools/run_command.sh
@@ -60,7 +62,7 @@ jobs:
           # GEMS_VENDOR=metax run_command pytest -s tests/test_norm_ops.py
 
       - name: FlagGems pointwise ops on metax
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           ### set private mem out of docker in case OOM
@@ -76,7 +78,7 @@ jobs:
           GEMS_VENDOR=metax run_command pytest -s tests/test_tensor_constructor_ops.py
 
       - name: FlagGems blas ops on metax
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           source tools/run_command.sh
@@ -85,7 +87,7 @@ jobs:
           # GEMS_VENDOR=metax run_command pytest -s tests/test_attention_ops.py
 
       - name: FlagGems special ops on metax
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           source tools/run_command.sh
@@ -94,7 +96,7 @@ jobs:
           GEMS_VENDOR=metax run_command pytest -s tests/test_distribution_ops.py
 
       - name: FlagGems utils on metax
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           source tools/run_command.sh
@@ -103,7 +105,7 @@ jobs:
           GEMS_VENDOR=metax run_command pytest -s tests/test_tensor_wrapper.py
 
       - name: FlagGems examples on metax
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           source tools/run_command.sh

--- a/.github/workflows/model-test.yaml
+++ b/.github/workflows/model-test.yaml
@@ -16,19 +16,21 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: experimental_ops
         with:
+          list-files: shell
           filters: |
-            run_ci:
+            all:
               - '**'
-              - '!src/flag_gems/experimental_ops/**'
-              - '!experimental_tests/**'
+            experimental:
+              - 'src/flag_gems/experimental_ops/**'
+              - 'experimental_tests/**'
 
       - name: Check GPU free
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: tools/gpu_check.sh
 
       - name: FlagGems examples
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           echo "current dir: $(pwd)"

--- a/.github/workflows/op-test-quick-cpu.yaml
+++ b/.github/workflows/op-test-quick-cpu.yaml
@@ -16,19 +16,21 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: experimental_ops
         with:
+          list-files: shell
           filters: |
-            run_ci:
+            all:
               - '**'
-              - '!src/flag_gems/experimental_ops/**'
-              - '!experimental_tests/**'
+            experimental:
+              - 'src/flag_gems/experimental_ops/**'
+              - 'experimental_tests/**'
 
       - name: Check GPU free
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: tools/gpu_check.sh
 
       - name: OP Test Quick CPU
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           echo "current dir: $(pwd)"

--- a/.github/workflows/op-utils-test.yaml
+++ b/.github/workflows/op-utils-test.yaml
@@ -16,19 +16,21 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: experimental_ops
         with:
+          list-files: shell
           filters: |
-            run_ci:
+            all:
               - '**'
-              - '!src/flag_gems/experimental_ops/**'
-              - '!experimental_tests/**'
+            experimental:
+              - 'src/flag_gems/experimental_ops/**'
+              - 'experimental_tests/**'
 
       - name: Check GPU free
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: tools/gpu_check.sh
 
       - name: OP Utils Test
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           echo "current dir: $(pwd)"

--- a/.github/workflows/pointwise-op-test.yaml
+++ b/.github/workflows/pointwise-op-test.yaml
@@ -16,19 +16,21 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: experimental_ops
         with:
+          list-files: shell
           filters: |
-            run_ci:
+            all:
               - '**'
-              - '!src/flag_gems/experimental_ops/**'
-              - '!experimental_tests/**'
+            experimental:
+              - 'src/flag_gems/experimental_ops/**'
+              - 'experimental_tests/**'
 
       - name: Check GPU free
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: tools/gpu_check.sh
 
       - name: Pointwise OP Test
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           echo "current dir: $(pwd)"

--- a/.github/workflows/python-coverage.yaml
+++ b/.github/workflows/python-coverage.yaml
@@ -15,6 +15,7 @@ on:
       - '**/*.mk'
       - 'Makefile'
       - '**.yaml'
+      - '**.md'
   pull_request:
     branches: [ "master" ]
     paths:
@@ -29,6 +30,7 @@ on:
       - '**/*.mk'
       - 'Makefile'
       - '**.yaml'
+      - '**.md'
 
 jobs:
   blas-op-test:
@@ -86,14 +88,16 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: experimental_ops
         with:
+          list-files: shell
           filters: |
-            run_ci:
+            all:
               - '**'
-              - '!src/flag_gems/experimental_ops/**'
-              - '!experimental_tests/**'
+            experimental:
+              - 'src/flag_gems/experimental_ops/**'
+              - 'experimental_tests/**'
 
       - name: Get python coverage
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           echo "current dir: $(pwd)"
@@ -109,7 +113,7 @@ jobs:
           bash tools/code_coverage/coverage.sh ${PR_ID}
 
       - name: Report python coverage
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           git config --global --add safe.directory ../FlagGems

--- a/.github/workflows/reduction-op-test.yaml
+++ b/.github/workflows/reduction-op-test.yaml
@@ -16,19 +16,21 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: experimental_ops
         with:
+          list-files: shell
           filters: |
-            run_ci:
+            all:
               - '**'
-              - '!src/flag_gems/experimental_ops/**'
-              - '!experimental_tests/**'
+            experimental:
+              - 'src/flag_gems/experimental_ops/**'
+              - 'experimental_tests/**'
 
       - name: Check GPU free
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: tools/gpu_check.sh
 
       - name: Reduction Op Test
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           echo "current dir: $(pwd)"

--- a/.github/workflows/special-op-test.yaml
+++ b/.github/workflows/special-op-test.yaml
@@ -16,19 +16,21 @@ jobs:
       - uses: dorny/paths-filter@v3
         id: experimental_ops
         with:
+          list-files: shell
           filters: |
-            run_ci:
+            all:
               - '**'
-              - '!src/flag_gems/experimental_ops/**'
-              - '!experimental_tests/**'
+            experimental:
+              - 'src/flag_gems/experimental_ops/**'
+              - 'experimental_tests/**'
 
       - name: Check GPU free
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: tools/gpu_check.sh
 
       - name: Special OP Test
-        if: steps.experimental_ops.outputs.run_ci == 'true'
+        if: steps.experimental_ops.outputs.all_count != steps.experimental_ops.outputs.experimental_count
         shell: bash
         run: |
           echo "current dir: $(pwd)"


### PR DESCRIPTION
### PR Category
CI workflow

### Type of Change
workflow

### Description
In PR https://github.com/flagos-ai/FlagGems/pull/1445, there is only experimental op changed.
Some other workflow tests should not run to save cost.

But in workflow log: https://github.com/flagos-ai/FlagGems/actions/runs/21026844944/job/60453274559
the workflow still runs.
It seems current logic fails to skip testing when experimental op changed.

I used a different logic to skip testing when experimental op changed.


### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ √] Change is fully covered by a UT.
