### PR TITLE
【PerfXLab】optimize Mean op

### DIFF
--- a/src/flag_gems/ops/mean.py
+++ b/src/flag_gems/ops/mean.py
@@ -80,6 +80,59 @@ def mean(inp, *, dtype=None):
 
 
 @libentry()
+@triton.jit
+def mean_dim_kernel_non_inner_vec(
+    output_ptr,
+    input_ptr,
+    M,
+    N,
+    K,
+    BLOCK_SIZE_K: tl.constexpr,  # number of threads per block along K
+    VEC_SIZE: tl.constexpr,  # elements per thread (1 for FP32, 8 for FP16/BF16)
+):
+    # Determine accumulation and load behavior
+    input_dtype = input_ptr.dtype.element_ty
+    if tl.constexpr(input_dtype == tl.float16) or tl.constexpr(
+        input_dtype == tl.bfloat16
+    ):
+        ACC_DTYPE = tl.float32
+        # VEC_SIZE should be 4 or 8 for vectorization
+    else:
+        ACC_DTYPE = input_dtype
+        # VEC_SIZE = 1 for FP32
+
+    pid_m = tle.program_id(0)
+    pid_k = tle.program_id(1)
+
+    # Each thread handles VEC_SIZE consecutive elements
+    k_base = pid_k * BLOCK_SIZE_K * VEC_SIZE
+    k_offsets = (
+        k_base
+        + tl.arange(0, BLOCK_SIZE_K)[:, None] * VEC_SIZE
+        + tl.arange(0, VEC_SIZE)[None, :]
+    )
+    # Shape: [BLOCK_SIZE_K, VEC_SIZE]
+    k_mask = k_offsets < K
+
+    # Accumulator: [BLOCK_SIZE_K, VEC_SIZE]
+    acc = tl.zeros((BLOCK_SIZE_K, VEC_SIZE), dtype=ACC_DTYPE)
+
+    base = pid_m * N * K
+
+    for n in range(N):
+        offsets = base + n * K + k_offsets
+        # This will trigger vectorized load if VEC_SIZE >= 4 and aligned
+        val = tl.load(input_ptr + offsets, mask=k_mask, other=0.0)
+        acc += val.to(ACC_DTYPE)
+
+    mean_val = acc / N
+
+    # Store back
+    out_offsets = pid_m * K + k_offsets
+    tl.store(output_ptr + out_offsets, mean_val, mask=k_mask)
+
+
+@libentry()
 @triton.heuristics(runtime.get_heuristic_config("mean_non_inner"))
 @triton.jit
 def mean_dim_kernel_non_inner(
@@ -267,7 +320,26 @@ def mean_dim_comm(inp, dim=None, keepdim=False, *, dtype=None, out=None):
             out = torch.empty(shape, dtype=dtype, device=inp.device)
 
         with torch_device_fn.device(inp.device):
-            if K > 1:
+            if K >= 1024:
+                input_dtype = inp.dtype
+                if input_dtype in (torch.float16, torch.bfloat16):
+                    VEC_SIZE = 8
+                    BLOCK_SIZE_K = 128
+                else:
+                    VEC_SIZE = 1
+                    BLOCK_SIZE_K = min(triton.next_power_of_2(K), 512)
+                grid = (M, triton.cdiv(K, BLOCK_SIZE_K * VEC_SIZE))
+                mean_dim_kernel_non_inner_vec[grid](
+                    out,
+                    inp,
+                    M,
+                    N,
+                    K,
+                    BLOCK_SIZE_K=BLOCK_SIZE_K,
+                    VEC_SIZE=VEC_SIZE,
+                    num_warps=8 if BLOCK_SIZE_K <= 128 else 16,
+                )
+            elif K > 1:
                 grid = lambda meta: (M, triton.cdiv(K, meta["TILE_K"]), 1)
                 mean_dim_kernel_non_inner[grid](
                     out,


### PR DESCRIPTION
### PR Category
[ Operator ] 

### Type of Change
[ Performance Optimization]

### Description
optimize mean performance of core shape

### Issue


### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

```
test_reduction_perf.py::test_general_reduction_perf[mean-mean-dtypes6]
Operator: mean  Performance Test (dtype=torch.float16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.012672            0.009792               1.294          [torch.Size([1048576])]
SUCCESS               0.006752            0.005792               1.166          [torch.Size([64, 64]), 1]
SUCCESS               0.028608            0.022304               1.283          [torch.Size([4096, 4096]), 1]
SUCCESS               0.031008            0.025184               1.231          [torch.Size([64, 512, 512]), 1]
SUCCESS               0.696928            0.688640               1.012          [torch.Size([1024, 1024, 1024]), 1]


Operator: mean  Performance Test (dtype=torch.float32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.013440            0.010976               1.224          [torch.Size([1048576])]
SUCCESS               0.006656            0.005440               1.224          [torch.Size([64, 64]), 1]
SUCCESS               0.040160            0.034176               1.175          [torch.Size([4096, 4096]), 1]
SUCCESS               0.041728            0.037600               1.110          [torch.Size([64, 512, 512]), 1]
SUCCESS               1.366560            1.361312               1.004          [torch.Size([1024, 1024, 1024]), 1]


Operator: mean  Performance Test (dtype=torch.bfloat16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.012640            0.010048               1.258          [torch.Size([1048576])]
SUCCESS               0.006784            0.005536               1.225          [torch.Size([64, 64]), 1]
SUCCESS               0.028352            0.022080               1.284          [torch.Size([4096, 4096]), 1]
SUCCESS               0.030976            0.024928               1.243          [torch.Size([64, 512, 512]), 1]
SUCCESS               0.687328            0.689408               0.997          [torch.Size([1024, 1024, 1024]), 1]
```

