### PR TITLE
[Iluvatar] fix test_accuracy_moe_align_block_size when using cpu as r…

### DIFF
--- a/benchmark/test_attention_perf.py
+++ b/benchmark/test_attention_perf.py
@@ -389,7 +389,7 @@ class FlashAttnVarlenBenchmark(Benchmark):
         )
 
 
-def flash_attn_varlen_legacy(*args):
+def flash_attn_varlen_legacy(*args, **kwargs):
     """
     Compatibility wrapper for running old flash_attn_varlen_func.
     """

--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -516,10 +516,7 @@ class ScaledSoftmaxBenchmark(GenericBenchmark):
 @pytest.mark.scaled_softmax
 def test_perf_scaled_softmax_forward():
     try:
-        from transformer_engine.common import _load_library
-
-        _load_library()
-        import transformer_engine_torch as tex  # type: ignore
+        from transformer_engine.pytorch import cpp_extensions as tex
     except ImportError:
         pytest.skip("TransformerEngine is not available, skipping performance test")
 
@@ -541,10 +538,7 @@ def test_perf_scaled_softmax_forward():
 @pytest.mark.scaled_softmax
 def test_perf_scaled_softmax_backward():
     try:
-        from transformer_engine.common import _load_library
-
-        _load_library()
-        import transformer_engine_torch as tex  # type: ignore
+        from transformer_engine.pytorch import cpp_extensions as tex
     except ImportError:
         pytest.skip("TransformerEngine is not available, skipping performance test")
 

--- a/tests/test_distribution_ops.py
+++ b/tests/test_distribution_ops.py
@@ -18,7 +18,7 @@ def test_accuracy_normal(float, shape, dtype):
     if flag_gems.vendor_name == "cambricon":
         torch.manual_seed(42)
         torch.mlu.manual_seed_all(42)
-    if flag_gems.vendor_name == "metax":
+    if flag_gems.vendor_name in ["metax", "iluvatar"]:
         torch.manual_seed(42)
         torch.cuda.manual_seed_all(42)
     loc = (

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -1716,6 +1716,8 @@ def test_accuracy_moe_align_block_size(
     )
 
     torch.cuda.synchronize()
-    gems_assert_close(sorted_ids, sorted_ids_vllm, dtype=dtype)
-    gems_assert_close(expert_ids, expert_ids_vllm, dtype=dtype)
-    gems_assert_close(num_tokens_post_pad, num_tokens_post_pad_vllm, dtype=dtype)
+    gems_assert_close(sorted_ids, to_reference(sorted_ids_vllm), dtype=dtype)
+    gems_assert_close(expert_ids, to_reference(expert_ids_vllm), dtype=dtype)
+    gems_assert_close(
+        num_tokens_post_pad, to_reference(num_tokens_post_pad_vllm), dtype=dtype
+    )

--- a/tests/test_tensor_constructor_ops.py
+++ b/tests/test_tensor_constructor_ops.py
@@ -36,7 +36,7 @@ def test_accuracy_rand(shape, dtype):
 @pytest.mark.parametrize("shape", DISTRIBUTION_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_accuracy_randn(shape, dtype):
-    if flag_gems.vendor_name == "cambricon":
+    if flag_gems.vendor_name in ["cambricon", "iluvatar"]:
         torch.manual_seed(42)
     with flag_gems.use_gems():
         res_out = torch.randn(shape, dtype=dtype, device=device)


### PR DESCRIPTION
1. Fix `test_accuracy_moe_align_block_size` failing when using `--ref cpu`.

2. Remove `_load_library` call in TE and directly `import transformer_engine_torch as tex`; this avoids issues for backends that do not implement `_load_library` which seems unnecessary.

3. Set random seed for `test_accuracy_normal` and `test_accuracy_randn` like other backends.

4. Add `kwargs` support for `flash_attn_varlen_legacy` to resolve `unexpected keyword` errors.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
