### PR TITLE
[KUNLUNXIN] Update exponential_.py

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/exponential_.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/exponential_.py
@@ -102,7 +102,8 @@ def paste_u64(hi: tl.uint32, lo: tl.uint32):
 def transform_exponential(u, lambd, eps):
     eps1 = -0.5 * eps
     is_min = u >= 1.0 + eps1
-    log = tl.where(is_min, eps1, log2(u))
+    trans_scale = 1.0 / 1.4426950408889634
+    log = tl.where(is_min, eps1, log2(u) * trans_scale)
     v = -1.0 / lambd * log
     return v
 


### PR DESCRIPTION
### PR Category
Operator 

### Type of Change
Bug Fix

### Description
- Fix the distribution scaling in the Kunlunxin backend exponential_ : transform_exponential used log2(u) without converting it to the natural log, which inflated the sampled mean/variance (mean ≈ 1/ln2 ).
- Multiply log2(u) by ln(2) to obtain an ln(u) -equivalent transform, bringing the generated samples’ statistics (mean/var) back in line with the Exponential(λ) theoretical values and making test_accuracy_fast_exponential_ pass.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
