### PR TITLE
Skip quick CPU CI job for competition PRs

### DIFF
--- a/.github/workflows/op-test-quick-cpu.yaml
+++ b/.github/workflows/op-test-quick-cpu.yaml
@@ -9,6 +9,7 @@ on:
 jobs:
   container-unit-test:
     runs-on: jiuding
+    if: "! contains(github.event.pull_request.labels.*.name, 'competition')"
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

CI/CD

### Description

This PR tries to skip quick-cpu test cases for PRs with label `competition`.

### Issue

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

N/A
