### PR TITLE
Fix float64 precision loss in Fill operator and support non-contiguous inputs

### DIFF
--- a/src/flag_gems/ops/fill.py
+++ b/src/flag_gems/ops/fill.py
@@ -11,7 +11,10 @@ logger = logging.getLogger(__name__)
 
 
 @pointwise_dynamic(
-    is_tensor=[True, False], promotion_methods=[(0, "DEFAULT")], num_outputs=1
+    is_tensor=[True, False],
+    dtypes=[None, float],
+    promotion_methods=[(0, "DEFAULT")],
+    num_outputs=1,
 )
 @triton.jit
 def fill_scalar_func(inp, value_scalar):

--- a/src/flag_gems/utils/pointwise_dynamic.py
+++ b/src/flag_gems/utils/pointwise_dynamic.py
@@ -27,11 +27,8 @@ from flag_gems.utils.type_utils import ELEMENTWISE_TYPE_PROMOTION_KIND, type_pro
 # ------------------ Operation Description ---------------------------
 def _type_name(type) -> str:
     "Render typename as string, work for both (bool, int, float, str) and torch.dtype object"
-    if type in (bool, int, float, str):
-        return type.__name__
-    if isinstance(type, torch.dtype):
-        return str(type)
-    return str(type)
+    type_map = {float: "tl.float64", int: "tl.int32", bool: "tl.int1", str: "str"}
+    return type_map.get(type, str(type))
 
 
 def _check_typed_list(container, type):
@@ -825,7 +822,7 @@ class WrapperGenerator:
             max_tile_size = self.config.max_tile_size
             major, _ = get_device_capability()
             if self.name.find("fill_scalar") != -1 and major >= 9:
-                code.writeline("tile_sizes = tuple([64])")
+                code.writeline(f"tile_sizes = tuple([64] * {self.ndim})")
             else:
                 code.writeline(
                     f"tile_sizes = heuristics_for_tile_size({max_tile_size}, *shape)"

--- a/src/flag_gems/utils/pointwise_dynamic.py
+++ b/src/flag_gems/utils/pointwise_dynamic.py
@@ -26,7 +26,8 @@ from flag_gems.utils.type_utils import ELEMENTWISE_TYPE_PROMOTION_KIND, type_pro
 
 # ------------------ Operation Description ---------------------------
 def _type_name(type) -> str:
-    "Render typename as string, work for both (bool, int, float, str) and torch.dtype object"
+    "Render typename as string, mapping Python primitives to Triton types (e.g. float -> tl.float64)"
+    "or handling torch.dtype via str()"
     type_map = {float: "tl.float64", int: "tl.int32", bool: "tl.int1", str: "str"}
     return type_map.get(type, str(type))
 

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -2010,9 +2010,9 @@ def test_accuracy_masked_fill_(shape, dtype, threshold, value):
 
 
 @pytest.mark.fill_
-@pytest.mark.parametrize("value", [0, 1, 9])
+@pytest.mark.parametrize("value", [0, 1, 9, 3.14])
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES + [torch.float64])
 def test_accuracy_fill_(value, shape, dtype):
     # Test fill_.Scalar
     x = torch.ones(shape, device=flag_gems.device, dtype=dtype)

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -2009,6 +2009,30 @@ def test_accuracy_masked_fill_(shape, dtype, threshold, value):
     gems_assert_equal(inp, ref_inp)
 
 
+@pytest.mark.fill
+@pytest.mark.parametrize("value", [0, 1, 9, 3.14])
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES + [torch.float64])
+def test_accuracy_fill(value, shape, dtype):
+    # Test fill.Scalar
+    x = torch.ones(shape, device=flag_gems.device, dtype=dtype)
+    ref_x = to_reference(x, False)
+
+    ref_out = torch.fill(ref_x, value)
+    with flag_gems.use_gems():
+        res_out = torch.fill(x, value)
+    gems_assert_equal(res_out, ref_out)
+
+    # Test fill.Tensor
+    value_tensor = torch.tensor(value, device=flag_gems.device, dtype=dtype)
+    ref_value_tensor = to_reference(value_tensor, False)
+    ref_out_tensor = torch.fill(ref_x, ref_value_tensor)
+    with flag_gems.use_gems():
+        res_out_tensor = torch.fill(x, value_tensor)
+
+    gems_assert_equal(res_out_tensor, ref_out_tensor)
+
+
 @pytest.mark.fill_
 @pytest.mark.parametrize("value", [0, 1, 9, 3.14])
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -1002,9 +1002,9 @@ def test_accuracy_isin(shape, dtype, assume_unique, invert):
 
 
 @pytest.mark.fill
-@pytest.mark.parametrize("value", [0, 1, 9])
+@pytest.mark.parametrize("value", [0, 1, 9, 3.14])
 @pytest.mark.parametrize("shape", SPECIAL_SHAPES)
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES + [torch.float64])
 def test_fill(value, shape, dtype):
     # Test fill.Scalar
     x = torch.ones(shape, device=flag_gems.device, dtype=dtype)
@@ -1013,7 +1013,6 @@ def test_fill(value, shape, dtype):
     ref_out = torch.fill(ref_x, value)
     with flag_gems.use_gems():
         res_out = torch.fill(x, value)
-
     gems_assert_equal(res_out, ref_out)
 
     # Test fill.Tensor

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -1001,30 +1001,6 @@ def test_accuracy_isin(shape, dtype, assume_unique, invert):
     gems_assert_equal(res0_out, ref0_out)
 
 
-@pytest.mark.fill
-@pytest.mark.parametrize("value", [0, 1, 9, 3.14])
-@pytest.mark.parametrize("shape", SPECIAL_SHAPES)
-@pytest.mark.parametrize("dtype", FLOAT_DTYPES + [torch.float64])
-def test_fill(value, shape, dtype):
-    # Test fill.Scalar
-    x = torch.ones(shape, device=flag_gems.device, dtype=dtype)
-    ref_x = to_reference(x, False)
-
-    ref_out = torch.fill(ref_x, value)
-    with flag_gems.use_gems():
-        res_out = torch.fill(x, value)
-    gems_assert_equal(res_out, ref_out)
-
-    # Test fill.Tensor
-    value_tensor = torch.tensor(value, device=flag_gems.device, dtype=dtype)
-    ref_value_tensor = to_reference(value_tensor, False)
-    ref_out_tensor = torch.fill(ref_x, ref_value_tensor)
-    with flag_gems.use_gems():
-        res_out_tensor = torch.fill(x, value_tensor)
-
-    gems_assert_equal(res_out_tensor, ref_out_tensor)
-
-
 CAMBRICON_STACK_SHAPES = [
     [
         (8, 8, 128),


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator 
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix 
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
The Python float (64-bit) primitive was mapped to "float" (32-bit in Triton) by _type_name during code generation. Updated _type_name to correctly map Python float to tl.float64. Added explicit dtypes annotation to the fill operator decorator.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
