### PR TITLE
[Operator Development] Implement cosh operator with tests and benchmarks

### DIFF
--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -65,6 +65,7 @@ forward_operations = [
     ("silu", torch.nn.functional.silu, FLOAT_DTYPES),
     # Trigonometric operations
     ("cos", torch.cos, FLOAT_DTYPES),
+    ("cosh", torch.cosh, FLOAT_DTYPES),
     ("sin", torch.sin, FLOAT_DTYPES),
     ("tan", torch.tan, FLOAT_DTYPES),
     ("tanh", torch.tanh, FLOAT_DTYPES),
@@ -120,6 +121,7 @@ forward_inplace_operations = [
     ("silu_", lambda a: torch.nn.functional.silu(a, inplace=True), FLOAT_DTYPES),
     # Trigonometric operations
     ("cos_", torch.cos_, FLOAT_DTYPES),
+    ("cosh_", torch.cosh_, FLOAT_DTYPES),
     ("sin_", torch.sin_, FLOAT_DTYPES),
     ("tan_", torch.tan_, FLOAT_DTYPES),
     ("tanh_", torch.tanh_, FLOAT_DTYPES),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -60,6 +60,7 @@ from flag_gems.ops.conv3d import conv3d
 from flag_gems.ops.conv_depthwise2d import _conv_depthwise2d
 from flag_gems.ops.copy import copy, copy_
 from flag_gems.ops.cos import cos, cos_
+from flag_gems.ops.cosh import cosh, cosh_
 from flag_gems.ops.count_nonzero import count_nonzero
 from flag_gems.ops.cummax import cummax
 from flag_gems.ops.cummin import cummin
@@ -306,6 +307,8 @@ __all__ = [
     "copy_",
     "cos",
     "cos_",
+    "cosh",
+    "cosh_",
     "count_nonzero",
     "cummax",
     "cummin",

--- a/src/flag_gems/ops/cosh.py
+++ b/src/flag_gems/ops/cosh.py
@@ -1,0 +1,68 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
+@triton.jit()
+def cosh_kernel(x):
+    """
+    Compute cosh(x) for input x.
+
+    The hyperbolic cosine function: cosh(x) = (exp(x) + exp(-x)) / 2
+
+    Args:
+        x: Input tensor (will be converted to float32 for computation)
+
+    Returns:
+        Tensor with cosh(x) computed element-wise
+    """
+    x_fp32 = x.to(tl.float32)
+    return (tl.exp(x_fp32) + tl.exp(-x_fp32)) / 2.0
+
+
+def cosh(x):
+    """
+    Computes the hyperbolic cosine (cosh) of each element in input.
+
+    Args:
+        x (Tensor): Input tensor with any real values
+
+    Returns:
+        Tensor: Output tensor with values >= 1
+
+    Example:
+        >>> x = torch.tensor([0.0, 1.0, 2.0])
+        >>> torch.cosh(x)
+        tensor([1.0000, 1.5431, 3.7622])
+    """
+    logger.debug("GEMS COSH FORWARD")
+    y = cosh_kernel(x)
+    return y
+
+
+def cosh_(x):
+    """
+    In-place version of cosh.
+
+    Computes the hyperbolic cosine of each element in input, modifying the tensor in-place.
+
+    Args:
+        x (Tensor): Input tensor (modified in-place)
+
+    Returns:
+        Tensor: The modified input tensor
+
+    Example:
+        >>> x = torch.tensor([0.0, 1.0, 2.0])
+        >>> torch.cosh_(x)
+        tensor([1.0000, 1.5431, 3.7622])
+    """
+    logger.debug("GEMS COSH_ INPLACE")
+    cosh_kernel(x, out0=x)
+    return x

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -270,6 +270,35 @@ def test_accuracy_cos_(shape, dtype):
     gems_assert_close(res_out, ref_out, dtype)
 
 
+@pytest.mark.cosh
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_cosh(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+
+    ref_out = torch.cosh(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.cosh(inp)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.inplace
+@pytest.mark.cosh_
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_cosh_(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp.clone(), True)
+
+    ref_out = torch.cosh_(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.cosh_(inp)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
 @pytest.mark.exp
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)


### PR DESCRIPTION
## Summary

Implements the cosh (hyperbolic cosine) operator as a companion to the existing tanh operator.

## Changes

- ✅ Created cosh.py with clean `pointwise_dynamic` implementation
- ✅ Implemented in-place cosh_() function  
- ✅ Exported cosh and cosh_ in __init__.py
- ✅ Added accuracy tests for cosh and cosh_
- ✅ Added performance benchmarks for both versions

## Testing

All functionality implemented with formula `cosh(x) = (exp(x) + exp(-x)) / 2`. 
No domain restrictions - works for all real numbers.

## Notes

This operator complements the existing `tanh` implementation and completes the basic hyperbolic function set.