### PR TITLE
[Operator Development] Implement sinh operator with tests and benchmarks

### DIFF
--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -66,6 +66,7 @@ forward_operations = [
     # Trigonometric operations
     ("cos", torch.cos, FLOAT_DTYPES),
     ("sin", torch.sin, FLOAT_DTYPES),
+    ("sinh", torch.sinh, FLOAT_DTYPES),
     ("tan", torch.tan, FLOAT_DTYPES),
     ("tanh", torch.tanh, FLOAT_DTYPES),
     ("atan", torch.atan, FLOAT_DTYPES),
@@ -121,6 +122,7 @@ forward_inplace_operations = [
     # Trigonometric operations
     ("cos_", torch.cos_, FLOAT_DTYPES),
     ("sin_", torch.sin_, FLOAT_DTYPES),
+    ("sinh_", torch.sinh_, FLOAT_DTYPES),
     ("tan_", torch.tan_, FLOAT_DTYPES),
     ("tanh_", torch.tanh_, FLOAT_DTYPES),
     ("atan_", torch.atan_, FLOAT_DTYPES),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -197,6 +197,7 @@ from flag_gems.ops.select_scatter import select_scatter
 from flag_gems.ops.sigmoid import sigmoid, sigmoid_, sigmoid_backward
 from flag_gems.ops.silu import silu, silu_, silu_backward
 from flag_gems.ops.sin import sin, sin_
+from flag_gems.ops.sinh import sinh, sinh_
 from flag_gems.ops.slice_scatter import slice_scatter
 from flag_gems.ops.softmax import softmax, softmax_backward
 from flag_gems.ops.softplus import softplus
@@ -484,6 +485,8 @@ __all__ = [
     "silu_backward",
     "sin",
     "sin_",
+    "sinh",
+    "sinh_",
     "slice_scatter",
     "softmax",
     "softmax_backward",

--- a/src/flag_gems/ops/sinh.py
+++ b/src/flag_gems/ops/sinh.py
@@ -1,0 +1,68 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
+@triton.jit()
+def sinh_kernel(x):
+    """
+    Compute sinh(x) for input x.
+
+    The hyperbolic sine function: sinh(x) = (exp(x) - exp(-x)) / 2
+
+    Args:
+        x: Input tensor (will be converted to float32 for computation)
+
+    Returns:
+        Tensor with sinh(x) computed element-wise
+    """
+    x_fp32 = x.to(tl.float32)
+    return (tl.exp(x_fp32) - tl.exp(-x_fp32)) / 2.0
+
+
+def sinh(x):
+    """
+    Computes the hyperbolic sine (sinh) of each element in input.
+
+    Args:
+        x (Tensor): Input tensor with any real values
+
+    Returns:
+        Tensor: Output tensor with sinh values
+
+    Example:
+        >>> x = torch.tensor([0.0, 1.0, 2.0])
+        >>> torch.sinh(x)
+        tensor([0.0000, 1.1752, 3.6269])
+    """
+    logger.debug("GEMS SINH FORWARD")
+    y = sinh_kernel(x)
+    return y
+
+
+def sinh_(x):
+    """
+    In-place version of sinh.
+
+    Computes the hyperbolic sine of each element in input, modifying the tensor in-place.
+
+    Args:
+        x (Tensor): Input tensor (modified in-place)
+
+    Returns:
+        Tensor: The modified input tensor
+
+    Example:
+        >>> x = torch.tensor([0.0, 1.0, 2.0])
+        >>> torch.sinh_(x)
+        tensor([0.0000, 1.1752, 3.6269])
+    """
+    logger.debug("GEMS SINH_ INPLACE")
+    sinh_kernel(x, out0=x)
+    return x

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -856,6 +856,35 @@ def test_accuracy_sigmoid_(shape, dtype):
     gems_assert_close(res_out, ref_out, dtype)
 
 
+@pytest.mark.sinh
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_sinh(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+
+    ref_out = torch.sinh(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.sinh(inp)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.inplace
+@pytest.mark.sinh_
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_sinh_(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp.clone(), True)
+
+    ref_out = torch.sinh_(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.sinh_(inp)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
 SPECIAL_VALUES = [float("-inf"), float("inf"), -300]
 
 


### PR DESCRIPTION
## Summary

Implements the sinh (hyperbolic sine) operator, completing the hyperbolic function set.

## Changes

- ✅ Created sinh.py with `pointwise_dynamic` implementation
- ✅ Implemented in-place sinh_() function  
- ✅ Exported sinh and sinh_ in __init__.py
- ✅ Added accuracy tests for sinh and sinh_
- ✅ Added performance benchmarks for both versions

## Testing

Uses formula `sinh(x) = (exp(x) - exp(-x)) / 2`. 
No domain restrictions - works for all real numbers.

## Notes

This operator pairs with PR #1528 (cosh) to complete the basic hyperbolic function set alongside the existing tanh implementation.