### PR TITLE
Add logical_or_

### DIFF
--- a/benchmark/test_binary_pointwise_perf.py
+++ b/benchmark/test_binary_pointwise_perf.py
@@ -95,6 +95,7 @@ def test_general_binary_pointwise_perf(op_name, torch_op, dtypes):
             ("pow_", lambda a, b: a.pow_(b), FLOAT_DTYPES),
             ("floor_divide_", lambda a, b: a.floor_divide_(b), INT_DTYPES),
             ("remainder_", lambda a, b: a.remainder_(b), INT_DTYPES),
+            ("logical_or_", lambda a, b: a.logical_or_(b), INT_DTYPES + BOOL_DTYPES),
             # Bitwise operations
             ("bitwise_and_", lambda a, b: a.bitwise_and_(b), INT_DTYPES + BOOL_DTYPES),
             ("bitwise_or_", lambda a, b: a.bitwise_or_(b), INT_DTYPES + BOOL_DTYPES),

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -206,6 +206,7 @@ _FULL_CONFIG = (
     ("logical_and", logical_and),
     ("logical_not", logical_not),
     ("logical_or", logical_or),
+    ("logical_or_", logical_or_),
     ("logical_xor", logical_xor),
     ("logspace", logspace),
     ("lt.Scalar", lt_scalar),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -120,7 +120,7 @@ from flag_gems.ops.log_sigmoid import log_sigmoid
 from flag_gems.ops.log_softmax import log_softmax, log_softmax_backward
 from flag_gems.ops.logical_and import logical_and
 from flag_gems.ops.logical_not import logical_not
-from flag_gems.ops.logical_or import logical_or
+from flag_gems.ops.logical_or import logical_or, logical_or_
 from flag_gems.ops.logical_xor import logical_xor
 from flag_gems.ops.logspace import logspace
 from flag_gems.ops.lt import lt, lt_scalar
@@ -390,6 +390,7 @@ __all__ = [
     "logical_and",
     "logical_not",
     "logical_or",
+    "logical_or_",
     "logical_xor",
     "logspace",
     "lt",

--- a/src/flag_gems/ops/logical_or.py
+++ b/src/flag_gems/ops/logical_or.py
@@ -17,3 +17,9 @@ def logical_or_func(x, y):
 def logical_or(A, B):
     logger.debug("GEMS LOGICAL_OR")
     return logical_or_func(A, B)
+
+
+def logical_or_(A, B):
+    logger.debug("GEMS LOGICAL_OR_")
+    logical_or_func(A, B, out0=A)
+    return A

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -1766,6 +1766,37 @@ def test_accuracy_logical_or(shape, dtype):
     gems_assert_equal(res_out, ref_out)
 
 
+@pytest.mark.logical_or_
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", ALL_FLOAT_DTYPES + ALL_INT_DTYPES + BOOL_TYPES)
+def test_accuracy_logical_or_(shape, dtype):
+    if dtype in ALL_FLOAT_DTYPES:
+        inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    elif dtype in ALL_INT_DTYPES:
+        inp1 = torch.randint(-1000, 1000, shape, dtype=dtype, device="cpu").to(
+            flag_gems.device
+        )
+        inp2 = torch.randint(-1000, 1000, shape, dtype=dtype, device="cpu").to(
+            flag_gems.device
+        )
+    elif dtype in BOOL_TYPES:
+        inp1 = torch.randint(0, 2, shape, dtype=dtype, device="cpu").to(
+            flag_gems.device
+        )
+        inp2 = torch.randint(0, 2, shape, dtype=dtype, device="cpu").to(
+            flag_gems.device
+        )
+    ref_inp1 = to_reference(inp1.clone())
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = ref_inp1.logical_or_(ref_inp2)
+    with flag_gems.use_gems():
+        res_out = inp1.logical_or_(inp2)
+
+    gems_assert_equal(res_out, ref_out)
+
+
 @pytest.mark.logical_and
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", ALL_FLOAT_DTYPES + ALL_INT_DTYPES + BOOL_TYPES)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
This PR implements the inplace version of  logical_or.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
```
benchmark/test_binary_pointwise_perf.py::test_general_inplace_binary_pointwise_perf[logical_or_-<lambda>-dtypes7] 
Operator: logical_or_  Performance Test (dtype=torch.int16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               2.529472            4.769664               0.530               0.450          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.006688            0.006272               1.066               0.001          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.047200            0.044224               1.067               0.759          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.047232            0.044000               1.073               0.763          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               2.533312            4.757776               0.532               0.451          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.006816            0.005696               1.197               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.006720            0.006176               1.088               0.005          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.007104            0.006576               1.080               0.080          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.017248            0.016480               1.047               0.509          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.166112            0.185760               0.894               0.723          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.006912            0.005712               1.210               0.001          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.007136            0.006432               1.109               0.020          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.009312            0.008896               1.047               0.236          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.047104            0.043968               1.071               0.763          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               0.638624            1.032736               0.618               0.520          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]
```
```
Operator: logical_or_  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               5.646464            9.488576               0.595               0.226          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.006656            0.005968               1.115               0.001          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.072960            0.072000               1.013               0.466          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.072608            0.072368               1.003               0.464          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               9.204752            9.502368               0.969               0.226          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.006848            0.005680               1.206               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.006752            0.005952               1.134               0.006          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.007616            0.007488               1.017               0.070          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.023712            0.023456               1.011               0.358          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.266784            0.268096               0.995               0.501          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.006944            0.005680               1.223               0.001          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.007296            0.006560               1.112               0.020          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.010912            0.010816               1.009               0.194          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.072928            0.072416               1.007               0.463          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               3.047152            1.076544               2.830               0.499          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]
```
```
Operator: logical_or_  Performance Test (dtype=torch.bool, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               1.041808            3.204864               0.325               0.670          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.006016            0.006016               1.000               0.001          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.023744            0.028576               0.831               1.174          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.023616            0.028608               0.826               1.173          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               1.040880            3.180064               0.327               0.675          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.005984            0.005952               1.005               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.006112            0.005824               1.049               0.006          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.006336            0.006336               1.000               0.083          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.010752            0.011936               0.901               0.703          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.072128            0.107360               0.672               1.250          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.006048            0.005728               1.056               0.001          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.006304            0.006368               0.990               0.021          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.007488            0.007712               0.971               0.272          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.023520            0.028576               0.823               1.174          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               0.265408            0.631728               0.420               0.850          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]
```