### PR TITLE
[KMCompiler] fix get_device_capability() error

### DIFF
--- a/src/flag_gems/fused/flash_mla.py
+++ b/src/flag_gems/fused/flash_mla.py
@@ -7,6 +7,7 @@ import triton.language as tl
 
 from flag_gems.runtime import device, error, torch_device_fn
 from flag_gems.utils import triton_lang_extension as tle
+from flag_gems.utils.device_info import get_device_capability
 
 vendor_name = device.vendor_name
 device = device.name
@@ -183,7 +184,7 @@ def flash_mla(
 
     o = torch.empty([b * s_q, h_q, dv], dtype=q.dtype, device=device)
 
-    major, _ = torch_device_fn.get_device_capability(device)
+    major, _ = get_device_capability()
     if major == 9:
         BLOCK_H = 64
         num_stages = 3

--- a/src/flag_gems/ops/per_token_group_quant_fp8.py
+++ b/src/flag_gems/ops/per_token_group_quant_fp8.py
@@ -5,8 +5,9 @@ import triton
 import triton.language as tl
 
 from flag_gems.runtime import torch_device_fn
+from flag_gems.utils.device_info import get_device_capability
 
-if torch_device_fn.is_available() and torch_device_fn.get_device_capability() >= (9, 0):
+if torch_device_fn.is_available() and get_device_capability() >= (9, 0):
     SUPPORTED_FP8_DTYPE = torch.float8_e4m3fn
 else:
     SUPPORTED_FP8_DTYPE = torch.float32

--- a/src/flag_gems/runtime/backend/_cambricon/fused/flash_mla.py
+++ b/src/flag_gems/runtime/backend/_cambricon/fused/flash_mla.py
@@ -7,6 +7,7 @@ import triton.language as tl
 
 from flag_gems.runtime import device, error, torch_device_fn
 from flag_gems.utils import triton_lang_extension as tle
+from flag_gems.utils.device_info import get_device_capability
 
 vendor_name = device.vendor_name
 device = device.name
@@ -183,7 +184,7 @@ def flash_mla(
 
     o = torch.empty([b * s_q, h_q, dv], dtype=q.dtype, device=device)
 
-    major, _ = torch_device_fn.get_device_capability(device)
+    major, _ = get_device_capability()
     if major == 9:
         BLOCK_H = 64
         num_stages = 3

--- a/src/flag_gems/runtime/backend/_metax/fused/flash_mla.py
+++ b/src/flag_gems/runtime/backend/_metax/fused/flash_mla.py
@@ -7,6 +7,7 @@ import triton.language as tl
 
 from flag_gems.runtime import device, error, torch_device_fn
 from flag_gems.utils import triton_lang_extension as tle
+from flag_gems.utils.device_info import get_device_capability
 
 vendor_name = device.vendor_name
 device = device.name
@@ -173,7 +174,7 @@ def flash_mla(
 
     o = torch.empty([b * s_q, h_q, dv], dtype=q.dtype, device=device)
 
-    major, _ = torch_device_fn.get_device_capability(device)
+    major, _ = get_device_capability()
     if major == 9:
         BLOCK_H = 64
         num_stages = 3


### PR DESCRIPTION
fix get_device_capability() error when import flag_gems

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

User Experience

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

In Huawei NPU environments, `torch_device_fn.get_device_capability()` may return `None` instead of a version tuple. This causes a `TypeError: '>=' not supported between instances of 'NoneType' and 'tuple'` when the library performs version compatibility checks (e.g., comparing against `(9, 0)`) during the import process of flag_gems.

Following the device information refactor approach in #1506, this PR replaces direct calls to `torch_device_fn.get_device_capability()` with the wrapped function `get_device_capability()` from `flag_gems.utils.device_info`. This utility function provides a robust fallback mechanism for NPU devices, ensuring that a valid tuple is returned even when the underlying torch call fails.


### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
