### PR TITLE
[ASCEND]8.5.0 fix part1

### DIFF
--- a/src/flag_gems/runtime/backend/_ascend/__init__.py
+++ b/src/flag_gems/runtime/backend/_ascend/__init__.py
@@ -1,5 +1,7 @@
 from backend_utils import VendorInfoBase  # noqa: E402
 
+from .utils import CORE_NUM  # noqa: F401
+
 
 def get_triton_extra_name():
     try:
@@ -26,7 +28,8 @@ CUSTOMIZED_UNUSED_OPS = (
     "contiguous",
     "sort",
     "sort_stable",
-    "topk",
+    "copy_",
+    "_to_copy",
 )
 
 

--- a/src/flag_gems/runtime/backend/_ascend/heuristics_config_utils.py
+++ b/src/flag_gems/runtime/backend/_ascend/heuristics_config_utils.py
@@ -9,6 +9,19 @@ def argmax_heur_block_n(args):
     return 100
 
 
+def argmax_heur_tile_k(args):
+    tile_k = 64
+    return tile_k
+
+
+def argmax_heur_tile_n_non_inner(args):
+    return 128
+
+
+def argmax_heur_one_tile_per_cta(args):
+    return args["TILE_N"] >= args["N"]
+
+
 def argmin_heur_block_m(args):
     return 16
 
@@ -133,7 +146,7 @@ def softmax_heur_tile_k(args):
 
 
 def softmax_heur_tile_n_non_inner(args):
-    return triton.cdiv(1024, args["TILE_K"])
+    return triton.cdiv(768, args["TILE_K"])
 
 
 def softmax_heur_one_tile_per_cta(args):
@@ -227,6 +240,11 @@ def vdot_heur_block_size(args):
 
 
 HEURISTICS_CONFIGS = {
+    "argmax_non_inner": {
+        "TILE_K": argmax_heur_tile_k,
+        "TILE_N": argmax_heur_tile_n_non_inner,
+        "ONE_TILE_PER_CTA": argmax_heur_one_tile_per_cta,
+    },
     "argmax": {
         "BLOCK_M": argmax_heur_block_m,
         "BLOCK_N": argmax_heur_block_n,

--- a/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
@@ -28,6 +28,7 @@ from .index_add import index_add
 from .index_select import index_select
 from .isin import isin
 from .linspace import linspace
+from .log_softmax import log_softmax, log_softmax_backward
 from .masked_fill import masked_fill, masked_fill_
 from .masked_select import masked_select
 from .max import max, max_dim
@@ -58,6 +59,7 @@ from .stack import stack
 from .threshold import threshold, threshold_backward
 from .triu import triu
 from .unique import _unique2
+from .upsample_nearest2d import upsample_nearest2d
 from .var_mean import var_mean
 from .vector_norm import vector_norm
 from .vstack import vstack
@@ -128,6 +130,8 @@ __all__ = [
     "sort",
     "stack",
     "linspace",
+    "log_softmax",
+    "log_softmax_backward",
     "zeros",
     "vector_norm",
     "outer",
@@ -147,5 +151,6 @@ __all__ = [
     "multinomial",
     "index_add",
     "_unique2",
+    "upsample_nearest2d",
     "randperm",
 ]

--- a/src/flag_gems/runtime/backend/_ascend/ops/full.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/full.py
@@ -5,30 +5,9 @@ import torch
 import triton
 import triton.language as tl
 
-from flag_gems.runtime import torch_device_fn
-from flag_gems.utils import triton_lang_extension as tle
-from flag_gems.utils.shape_utils import volume
+from flag_gems.utils.pointwise_dynamic import pointwise_dynamic
 
-logger = logging.getLogger(f'flag_gems.runtime._ascend.ops.{__name__.split(".")[-1]}')
-
-
-@triton.jit(do_not_specialize=["fill_value_or_ptr"])
-def full_kernel(
-    output_ptr,
-    n_elements,
-    fill_value_or_ptr,
-    FILL_VALUE_IS_PTR: tl.constexpr,
-    BLOCK_SIZE: tl.constexpr,
-):
-    pid = tle.program_id(axis=0)
-    block_start = pid * BLOCK_SIZE
-    offsets = block_start + tl.arange(0, BLOCK_SIZE)
-    mask = offsets < n_elements
-    if FILL_VALUE_IS_PTR:
-        fill_value = tl.load(fill_value_or_ptr)
-    else:
-        fill_value = fill_value_or_ptr
-    tl.store(output_ptr + offsets, fill_value, mask=mask)
+logger = logging.getLogger(__name__)
 
 
 ALL_INT_DTYPES = (torch.int8, torch.int16, torch.int32, torch.int64)
@@ -39,19 +18,35 @@ def check_dtype(fill_value, dtype, device):
     if isinstance(fill_value, bool):
         if dtype != torch.bool:
             fill_value = int(fill_value)
+
     elif (
         dtype in ALL_INT_DTYPES
         and (fill_value < torch.iinfo(dtype).min or fill_value > torch.iinfo(dtype).max)
     ) or (
         dtype in ALL_FLOAT_DTYPES
+        and not (math.isinf(fill_value) or math.isnan(fill_value))
         and (fill_value < torch.finfo(dtype).min or fill_value > torch.finfo(dtype).max)
     ):
         raise RuntimeError(
             f"value cannot be converted to type {dtype} without overflow"
         )
-    if dtype in ALL_FLOAT_DTYPES:
+
+    if dtype == torch.float64:
         fill_value = torch.tensor(fill_value, dtype=dtype, device=device)
+
     return fill_value
+
+
+@pointwise_dynamic(is_tensor=[True, True], promotion_methods=[(0, "DEFAULT")])
+@triton.jit
+def full_func(out, fill_value):
+    return fill_value
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, "DEFAULT")])
+@triton.jit
+def full_func_scalar(out, fill_value):
+    return tl.full(out.shape, fill_value, out.dtype)
 
 
 def full(size, fill_value, *, dtype=None, layout=None, device=None, pin_memory=None):
@@ -69,15 +64,8 @@ def full(size, fill_value, *, dtype=None, layout=None, device=None, pin_memory=N
         fill_value = check_dtype(fill_value, dtype, device)
 
     out = torch.empty(size, device=device, dtype=dtype)
-    N = volume(size)
-    BLOCK_SIZE = triton.next_power_of_2(math.ceil(math.sqrt(N)))
-    grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE"]),)
-    with torch_device_fn.device(device):
-        full_kernel[grid_fn](
-            out,
-            N,
-            fill_value,
-            FILL_VALUE_IS_PTR=isinstance(fill_value, torch.Tensor),
-            BLOCK_SIZE=BLOCK_SIZE,
-        )
-    return out
+
+    if isinstance(fill_value, torch.Tensor):
+        return full_func(out, fill_value, out0=out)
+    else:
+        return full_func_scalar(out, fill_value, out0=out)

--- a/src/flag_gems/runtime/backend/_ascend/ops/full_like.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/full_like.py
@@ -1,14 +1,10 @@
 import logging
-import math
 
 import torch
-import triton
 
-from flag_gems.runtime import torch_device_fn
+from flag_gems.ops.full import check_dtype, full_func, full_func_scalar
 
-from .full import check_dtype, full_kernel
-
-logger = logging.getLogger(f'flag_gems.runtime._ascend.ops.{__name__.split(".")[-1]}')
+logger = logging.getLogger(__name__)
 
 
 def full_like(
@@ -27,16 +23,9 @@ def full_like(
     if dtype is None:
         dtype = x.dtype
     fill_value = check_dtype(fill_value, dtype, device)
-    out = torch.empty_like(x, device=device, dtype=dtype)
-    N = x.numel()
-    BLOCK_SIZE = triton.next_power_of_2(math.ceil(math.sqrt(N)))
-    grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE"]),)
-    with torch_device_fn.device(x.device):
-        full_kernel[grid_fn](
-            out,
-            N,
-            fill_value,
-            FILL_VALUE_IS_PTR=isinstance(fill_value, torch.Tensor),
-            BLOCK_SIZE=BLOCK_SIZE,
-        )
-    return out
+    size = x.size()
+    out = torch.empty(size, device=device, dtype=dtype)
+    if isinstance(fill_value, torch.Tensor):
+        return full_func(out, fill_value)
+    else:
+        return full_func_scalar(out, fill_value)

--- a/src/flag_gems/runtime/backend/_ascend/ops/log_softmax.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/log_softmax.py
@@ -1,0 +1,158 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+
+logger = logging.getLogger(f'flag_gems.runtime._ascend.ops.{__name__.split(".")[-1]}')
+
+
+@libentry()
+@triton.autotune(configs=runtime.get_tuned_config("log_softmax"), key=["M", "N"])
+@triton.jit
+def log_softmax_kernel(
+    output_ptr,
+    input_ptr,
+    M,
+    N,
+    K,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tle.program_id(0)
+    pid_k = tle.program_id(1)
+    m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+
+    # TODO(chenfeiyu): consider float64 add add a utility function to get accumulator type
+    m = tl.full([BLOCK_M, BLOCK_N], value=float("-inf"), dtype=tl.float32)
+    z = tl.full([BLOCK_M, BLOCK_N], value=0.0, dtype=tl.float32)
+    for start_n in range(0, N, BLOCK_N):
+        n_offset = start_n + tl.arange(0, BLOCK_N)
+        offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
+        mask = m_offset[:, None] < M and n_offset[None, :] < N
+        input_ptrs = input_ptr + offset
+        inp = tl.load(input_ptrs, mask=mask, other=-float("inf")).to(tl.float32)
+        m_new = tl.maximum(inp, m)
+        all_neg_inf = m_new == float("-inf")
+        z = tl.where(all_neg_inf, z, z * tl.exp(m - m_new) + tl.exp(inp - m_new))
+        m = m_new
+
+    m_reduced = tl.max(m, 1)
+    z = tl.sum(z * tl.exp(m - m_reduced[:, None]), 1)
+    m = m_reduced
+
+    for start_n in range(0, N, BLOCK_N):
+        n_offset = start_n + tl.arange(0, BLOCK_N)
+        offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
+        mask = m_offset[:, None] < M and n_offset[None, :] < N
+        input_ptrs = input_ptr + offset
+        inp = tl.load(input_ptrs, mask=mask, other=-float("inf")).to(tl.float32)
+        o = inp - m[:, None] - tl.log(z[:, None])
+        tl.store(output_ptr + offset, o, mask=mask)
+
+
+@libentry()
+@triton.autotune(configs=runtime.get_tuned_config("log_softmax"), key=["M", "N"])
+@triton.jit
+def log_softmax_backward_kernel(
+    out_ptr,
+    out_grad_ptr,
+    in_grad_ptr,
+    M,
+    N,
+    K,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_m = tle.program_id(0)
+    pid_k = tle.program_id(1)
+    m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+
+    scale = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for start_n in range(0, N, BLOCK_N):
+        n_offset = start_n + tl.arange(0, BLOCK_N)
+        offsets = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
+        mask = m_offset[:, None] < M and n_offset[None, :] < N
+        out_grad_ptrs = out_grad_ptr + offsets
+        out_grad = tl.load(out_grad_ptrs, mask=mask).to(tl.float32)
+        scale += out_grad
+    scale = tl.sum(scale, 1)
+
+    for start_n in range(0, N, BLOCK_N):
+        n_offset = start_n + tl.arange(0, BLOCK_N)
+        offsets = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
+        mask = m_offset[:, None] < M and n_offset[None, :] < N
+        out_ptrs = out_ptr + offsets
+        out = tl.load(out_ptrs, mask=mask).to(tl.float32)
+        out_grad_ptrs = out_grad_ptr + offsets
+        out_grad = tl.load(out_grad_ptrs, mask=mask).to(tl.float32)
+        in_grad = out_grad - tl.exp(out) * scale[:, None]
+        in_grad_ptrs = in_grad_ptr + offsets
+        tl.store(in_grad_ptrs, in_grad, mask=mask)
+
+
+def log_softmax(self, dim, half_to_float=False):
+    logger.debug("GEMS_ASCEND LOG_SOFTMAX")
+
+    assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
+    dim = dim % self.ndim
+    M = 1
+    N = self.shape[dim]
+    for i in range(dim):
+        M *= self.shape[i]
+    inp = self.contiguous()
+    if half_to_float:
+        dtype = torch.float32
+    else:
+        dtype = self.dtype
+    out = torch.empty_like(inp, dtype=dtype)
+    K = inp.numel() // M // N
+
+    grid = lambda meta: (
+        triton.cdiv(M, meta["BLOCK_M"]),
+        K,
+    )
+    with torch_device_fn.device(inp.device):
+        log_softmax_kernel[grid](
+            out,
+            inp,
+            M,
+            N,
+            K,
+        )
+    return out
+
+
+def log_softmax_backward(grad_output, output, dim, input_dtype):
+    logger.debug("GEMS_ASCEND LOG_SOFTMAX VJP")
+
+    assert dim >= -output.ndim and dim < output.ndim, "Invalid dim"
+    dim = dim % output.ndim
+    M = 1
+    N = output.shape[dim]
+    for i in range(dim):
+        M *= output.shape[i]
+
+    grad_output = grad_output.contiguous()
+    in_grad = torch.empty_like(output, dtype=input_dtype)
+    K = output.numel() // M // N
+
+    grid = lambda meta: (
+        triton.cdiv(M, meta["BLOCK_M"]),
+        K,
+    )
+    with torch_device_fn.device(in_grad.device):
+        log_softmax_backward_kernel[grid](
+            output,
+            grad_output,
+            in_grad,
+            M,
+            N,
+            K,
+        )
+    return in_grad

--- a/src/flag_gems/runtime/backend/_ascend/ops/polar.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/polar.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(f'flag_gems.runtime._ascend.ops.{__name__.split(".")[
 
 
 config_ = CodeGenConfig(
-    512,
+    384,
     tuple([48, 1, 1]),
     32,
     False,

--- a/src/flag_gems/runtime/backend/_ascend/ops/select_scatter.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/select_scatter.py
@@ -1,11 +1,43 @@
 import logging
 
 import torch
+import triton
+import triton.language as tl
 
-from flag_gems.ops.copy import copy
-from flag_gems.utils.shape_utils import has_internal_overlapping
+from flag_gems.utils.shape_utils import MemOverlap, has_internal_overlapping
 
-logger = logging.getLogger(f'flag_gems.runtime._ascend.ops.{__name__.split(".")[-1]}')
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def select_scatter_kernel(
+    out_ptr,
+    inp_ptr,
+    src_ptr,
+    total_elements,
+    dim_size,
+    dim_prod_post,
+    index,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    block_start = pid * BLOCK_SIZE
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = block_start + offsets < total_elements
+    idx = block_start + offsets
+
+    pre_idx = idx // (dim_size * dim_prod_post)
+    dim_idx = (idx // dim_prod_post) % dim_size
+    post_idx = idx % dim_prod_post
+
+    select_mask = dim_idx == index
+
+    inp_data = tl.load(inp_ptr + idx, mask=mask)
+
+    src_idx = pre_idx * dim_prod_post + post_idx
+    src_data = tl.load(src_ptr + src_idx, mask=mask & select_mask)
+    result = tl.where(select_mask, src_data, inp_data)
+    tl.store(out_ptr + idx, result, mask=mask)
 
 
 def select_scatter(inp, src, dim, index):
@@ -21,16 +53,35 @@ def select_scatter(inp, src, dim, index):
         list(src.shape) == valid_shape
     ), "Expected src to have a size equal to the slice of self"
 
-    if has_internal_overlapping(inp):
+    if has_internal_overlapping(inp) == MemOverlap.Yes:
         out = torch.empty(inp.size(), dtype=inp.dtype, device=inp.device)
     else:
         out = torch.empty_strided(
             inp.size(), inp.stride(), dtype=inp.dtype, device=inp.device
         )
 
-    copy(inp, out0=out)
-    indices = [slice(None)] * inp.ndim
-    indices[dim] = index
-    copy(src, out0=out[indices])
+    inp = inp.contiguous()
+    src = src.contiguous()
+
+    total_elements = inp.numel()
+    dim_size = inp.size(dim)
+
+    dim_prod_post = 1
+    for d in range(dim + 1, inp.ndim):
+        dim_prod_post *= inp.size(d)
+
+    BLOCK_SIZE = 1024
+    grid = (triton.cdiv(total_elements, BLOCK_SIZE),)
+
+    select_scatter_kernel[grid](
+        out,
+        inp,
+        src,
+        total_elements,
+        dim_size,
+        dim_prod_post,
+        index,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
 
     return out

--- a/src/flag_gems/runtime/backend/_ascend/ops/upsample_nearest2d.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/upsample_nearest2d.py
@@ -1,0 +1,93 @@
+import logging
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.runtime import device, torch_device_fn
+from flag_gems.utils import triton_lang_extension as tle
+
+logger = logging.getLogger(f'flag_gems.runtime._ascend.ops.{__name__.split(".")[-1]}')
+device = device.name
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 128}),
+        triton.Config({"BLOCK_SIZE": 256}),
+        triton.Config({"BLOCK_SIZE": 512}),
+        triton.Config({"BLOCK_SIZE": 1024}),
+        triton.Config({"BLOCK_SIZE": 2048}),
+        triton.Config({"BLOCK_SIZE": 4096}),
+    ],
+    key=["N", "C", "OH", "OW"],
+)
+@triton.heuristics(runtime.get_heuristic_config("upsample_nearest2d"))
+@triton.jit
+def upsample_nearest2d_kernel(
+    ptr_o,
+    ptr_i,
+    N,
+    C,
+    OH,
+    OW,
+    IH,
+    IW,
+    reciprocal_scale_h,
+    reciprocal_scale_w,
+    BLOCK_SIZE: tl.constexpr,
+    SAME_H: tl.constexpr,
+    SAME_W: tl.constexpr,
+):
+    pid = tle.program_id(axis=0)
+    idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    ow = idx % OW
+    oh = idx // OW % OH
+    c = idx // OW // OH % C
+    n = idx // OW // OH // C % N
+    if SAME_H:
+        ih = oh
+    else:
+        # tl.floor() cannot be found in 2.3.1, using int trunc
+        ih = tl.minimum((oh * reciprocal_scale_h).to(tl.int32), IH - 1)
+    if SAME_W:
+        iw = ow
+    else:
+        iw = tl.minimum((ow * reciprocal_scale_w).to(tl.int32), IW - 1)
+    offset_o = ((n * C + c) * OH + oh) * OW + ow
+    offset_i = ((n * C + c) * IH + ih) * IW + iw
+    data = tl.load(ptr_i + offset_i)
+    tl.store(ptr_o + offset_o, data)
+
+
+def upsample_nearest2d(
+    input: torch.Tensor,
+    output_size: Tuple[int],
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> torch.Tensor:
+    logger.debug("GEMS_ASCEND UPSAMPLE NEAREST2D")
+    assert input.device.type == device
+    assert input.ndim == 4, "The ndim of input must be 4"
+    assert len(output_size) == 2, "The len of output_size must be 2"
+    OH, OW = output_size
+    N, C, IH, IW = input.shape
+    if scales_h is not None:
+        reciprocal_scale_h = 1 / scales_h
+    else:
+        reciprocal_scale_h = IH / OH
+    if scales_w is not None:
+        reciprocal_scale_w = 1 / scales_w
+    else:
+        reciprocal_scale_w = IW / OW
+    # allocate output
+    output = torch.empty((N, C, OH, OW), device=input.device, dtype=input.dtype)
+    total_threads = N * C * OH * OW
+    grid = lambda META: (triton.cdiv(total_threads, META["BLOCK_SIZE"]),)
+    with torch_device_fn.device(input.device):
+        upsample_nearest2d_kernel[grid](
+            output, input, N, C, OH, OW, IH, IW, reciprocal_scale_h, reciprocal_scale_w
+        )
+    return output

--- a/src/flag_gems/runtime/backend/_ascend/ops/zeros.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/zeros.py
@@ -38,6 +38,8 @@ def zeros(size, *, dtype=None, layout=None, device=None, pin_memory=None):
 
     out = torch.empty(size, device=device, dtype=dtype)
     N = volume(size)
+    if N == 0:
+        return out
     grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK_SIZE"]),)
     with torch_device_fn.device(device):
         zeros_kernel[grid_fn](out, N, BLOCK_SIZE=20480, BLOCK_SIZE_SUB=1024)

--- a/src/flag_gems/runtime/backend/_ascend/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_ascend/tune_configs.yaml
@@ -61,8 +61,11 @@ argmin:
 
 log_softmax:
 - META:
-    BLOCK_M: 64
+    BLOCK_M: 32
     BLOCK_N: 8
+- META:
+    BLOCK_M: 64
+    BLOCK_N: 4
 
 mm:
 - META:
@@ -601,9 +604,13 @@ var_mean:
       BLOCK_M: block_m
       BLOCK_N: block_n
   block_m:
-  - 18
+  - 8
+  - 16
+  - 32
   block_n:
+  - 128
   - 256
+  - 512
 
 conv2d_forward:
 - META:

--- a/src/flag_gems/runtime/backend/_ascend/utils/__init__.py
+++ b/src/flag_gems/runtime/backend/_ascend/utils/__init__.py
@@ -1,0 +1,16 @@
+import torch
+
+CORE_NUM = 40
+
+try:
+    import triton.runtime.driver as driver
+
+    CORE_NUM = driver.active.utils.get_device_properties(torch.npu.current_device())[
+        "num_vectorcore"
+    ]
+except (ImportError, AttributeError, RuntimeError, KeyError):
+    CORE_NUM = 40
+
+__all__ = [
+    "CORE_NUM",
+]


### PR DESCRIPTION
### PR Category
<!-- [ Operator ] -->
src\flag_gems\runtime\backend\\_ascend
### Type of Change
<!-- [ Bug Fix] -->
Adapted for Ascend CANN 8.5.0.
Verified on Atlas 800I A2.
Fixed op functions, listed as follows:
argmax
cumsum
full/full_like
log_softmax
nonzero
normal
polar
randn/randn_like
upsample_nearest2d (with TRITON_ALL_BLOCKS_PARALLEL=1)
var_mean
select_scatter (Function fixed, minor precision issues in remaining specific use cases)
softmax (Function fixed, minor precision issues in remaining specific use cases)
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
