### PR TITLE
fix concat_and_cache_mla UT failed when using cpu as reference.

### DIFF
--- a/tests/test_quant.py
+++ b/tests/test_quant.py
@@ -147,8 +147,7 @@ def test_concat_and_cache_mla(
                 expected_temp, ref_kv_cache, scale.item(), kv_dtype=kv_cache_dtype
             )
             dtype = torch.float8_e4m3fn
-            if flag_gems.vendor_name == "mthreads":
-                result_temp = to_reference(result_temp)
+            result_temp = to_reference(result_temp)
             # TODO: RuntimeError: Comparing
             # maybe a bug in torch.testing.assert_close
             # gems_assert_close(kv_cache.view(dtype), ref_kv_cache.view(dtype), dtype)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
concat_and_cache_mla  UT failed when using `--ref cpu`, same issue on NV H100.
```
            if kv_cache_dtype == "fp8":
                result_temp = torch.empty_like(kv_cache, dtype=torch.uint8)
                convert_fp8(
                    result_temp,
                    kv_cache.contiguous(),
                    scale.item(),
                    kv_dtype=kv_cache_dtype,
                )
                expected_temp = to_reference(
                    torch.empty_like(ref_kv_cache, dtype=torch.uint8)
                )
                convert_fp8(
                    expected_temp, ref_kv_cache, scale.item(), kv_dtype=kv_cache_dtype
                )
                dtype = torch.float8_e4m3fn
                if flag_gems.vendor_name == "mthreads":
                    result_temp = to_reference(result_temp)
                # TODO: RuntimeError: Comparing
                # maybe a bug in torch.testing.assert_close
                # gems_assert_close(kv_cache.view(dtype), ref_kv_cache.view(dtype), dtype)
>               torch.testing.assert_close(result_temp, expected_temp, atol=0.001, rtol=0.1)
E               AssertionError: The values for attribute 'device' do not match: cuda:0 != cpu.

test_quant.py:155: AssertionError
=========================== short test summary info ============================
FAILED test_quant.py::test_concat_and_cache_mla[fp8-cuda:0-0-dtype0-8-16-42-64-512]
FAILED test_quant.py::test_concat_and_cache_mla[fp8-cuda:0-0-dtype1-8-16-42-64-512]
FAILED test_quant.py::test_concat_and_cache_mla[fp8-cuda:0-0-dtype2-8-16-42-64-512]
========== 3 failed, 6 passed, 22041 deselected, 29 warnings in 5.98s ==========
```


### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
