### PR TITLE
[KUNLUNXIN] fix conv2d

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/conv2d.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/conv2d.py
@@ -544,10 +544,14 @@ class Conv2d(torch.autograd.Function):
         else:
             revert_weight = revert_weight.transpose(0, 1).contiguous()
 
-        new_out_height = out_grad.shape[2] + (stride_height - 1) * (
-            out_grad.shape[2] - 1
+        # Calculate new_out dimensions for transposed convolution
+        # Must account for output_padding when (input + 2*padding - dilation*(kernel-1) - 1) % stride != 0
+        new_out_height = (
+            input_height + 2 * padding_height - dilation_height * (weight_height - 1)
         )
-        new_out_width = out_grad.shape[3] + (stride_width - 1) * (out_grad.shape[3] - 1)
+        new_out_width = (
+            input_width + 2 * padding_width - dilation_width * (weight_width - 1)
+        )
 
         new_out = torch.zeros(
             out_grad.shape[0],

--- a/tests/test_convolution_ops.py
+++ b/tests/test_convolution_ops.py
@@ -91,7 +91,7 @@ SHAPE_CONV2D = [
 
 
 # @pytest.mark.skipif(flag_gems.vendor_name == "hygon", reason="RESULT TODOFIX")
-@pytest.mark.skipif(flag_gems.vendor_name == "kunlunxin", reason="RESULT TODOFIX")
+# @pytest.mark.skipif(flag_gems.vendor_name == "kunlunxin", reason="RESULT TODOFIX")
 @pytest.mark.conv2d
 @pytest.mark.parametrize("shape, kernel,groups", SHAPE_CONV2D)
 @pytest.mark.parametrize("stride", [1, 2])


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description
Problem: Conv2d backward pass produced severe accuracy errors when computing input gradients under specific parameter combinations (43.7% element mismatch, max error up to 49.9).

Root Cause: When using transposed convolution to compute input gradients in the backward pass, the calculation formula for new_out_height/width lacked output_padding compensation. When (input_size + 2*padding - dilation*(kernel-1) - 1) % stride != 0, the original formula produced undersized dilated gradient dimensions, causing subsequent convolution index misalignment.

Fix: Changed the new_out_height/width calculation from an indirect formula based on output size to a direct formula based on input size, which automatically incorporates output_padding compensation