### PR TITLE
[KUNLUNXIN] manually set seed in normal operator tests

### DIFF
--- a/tests/test_distribution_ops.py
+++ b/tests/test_distribution_ops.py
@@ -18,7 +18,7 @@ def test_accuracy_normal(float, shape, dtype):
     if flag_gems.vendor_name == "cambricon":
         torch.manual_seed(42)
         torch.mlu.manual_seed_all(42)
-    if flag_gems.vendor_name in ["metax", "iluvatar"]:
+    if flag_gems.vendor_name in ["metax", "iluvatar", "kunlunxin"]:
         torch.manual_seed(42)
         torch.cuda.manual_seed_all(42)
     loc = (


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
- Extend the existing seed-based stabilization in test_accuracy_normal to include Kunlunxin, matching the behavior already applied for other backends.
- This avoids occasional test flakiness caused by random sampling variance in normal distribution checks.
- The normal distribution test uses a finite sample size, so mean/variance (or distribution) checks can fail stochastically.
- Seeding ensures deterministic sampling and aligns Kunlunxin’s test behavior with other backends that already use

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
