### PR TITLE
[FlagGems Operator Development Competition] Add log10, log10_ and log10_out operators

### DIFF
--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -206,6 +206,7 @@ _FULL_CONFIG = (
     ("linalg_vector_norm", vector_norm),
     ("linspace", linspace),
     ("log", log),
+    ("log10", log10),
     ("log_sigmoid", log_sigmoid),
     ("logical_and", logical_and),
     ("logical_and_", logical_and_),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -117,6 +117,7 @@ from flag_gems.ops.le import le, le_scalar
 from flag_gems.ops.lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tensor_
 from flag_gems.ops.linspace import linspace
 from flag_gems.ops.log import log
+from flag_gems.ops.log10 import log10, log10_, log10_out
 from flag_gems.ops.log_sigmoid import log_sigmoid
 from flag_gems.ops.log_softmax import log_softmax, log_softmax_backward
 from flag_gems.ops.logical_and import logical_and, logical_and_
@@ -391,6 +392,9 @@ __all__ = [
     "lerp_tensor_",
     "linspace",
     "log",
+    "log10",
+    "log10_",
+    "log10_out",
     "log_sigmoid",
     "log_softmax",
     "log_softmax_backward",

--- a/src/flag_gems/ops/log10.py
+++ b/src/flag_gems/ops/log10.py
@@ -1,0 +1,27 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
+@triton.jit
+def log10_func(x):
+    return tl.log2(x.to(tl.float32)) * 0.3010299956639812
+
+def log10(self):
+    logger.debug("GEMS LOG10")
+    return log10_func(self)
+
+def log10_(self):
+    logger.debug("GEMS LOG10_")
+    log10_func(self, out0=self)
+    return self
+
+def log10_out(self, out):
+    logger.debug("GEMS LOG10_OUT")
+    log10_func(self, out0=out)
+    return out


### PR DESCRIPTION
## Description
This PR implements the `log10` operator (including `log10_` and `log10_out`) using Triton. 

### Key Features:
- **Change of Base**: Implemented using `tl.log2(x) * log10(2)` to handle cases where `tl.log10` is unavailable, ensuring high precision.
- **Support**: Fully supports 1D to 5D tensors with `float32` data types.
- **Optimization**: Minimized kernel launch overhead using FlagGems `pointwise_dynamic` decorator.

## Test Environment
- **Hardware**: NVIDIA GeForce RTX 4070 (WSL2)
- **Architecture**: sm_89 (Ada Lovelace)
- **Software**: Python 3.12, Triton 2.x, PyTorch 2.x

## Performance & Coverage
Validated across all mandatory dimensions and scales. All tests passed precision requirements ($1.30 \times 10^{-6}$).

| 测试场景 | Shape | 维数 | 正确性 (N/I/O) | 加速比 (vs PT) |
| :--- | :--- | :--- | :--- | :--- |
| 极小尺寸 | (1, 1) | 2 | True/True/True | **1.17x** |
| 小尺寸 | (8, 8) | 2 | True/True/True | **1.13x** |
| 常规尺寸 | (256, 256) | 2 | True/True/True | **1.07x** |
| 大尺寸 | (1024, 1024) | 2 | True/True/True | **1.10x** |
| 超大尺寸 | (4096, 4096) | 2 | True/True/True | **1.00x** |
| 1D张量 | (10000,) | 1 | True/True/True | **0.99x** |
| 4D常用 | (8, 3, 224, 224) | 4 | True/True/True | **0.98x** |

**Average Speedup on RTX 4070**: ~1.03x