### PR TITLE
Tweak operator registration

### DIFF
--- a/docs/how_to_use_flaggems.md
+++ b/docs/how_to_use_flaggems.md
@@ -27,7 +27,7 @@ To enable only specific operators and skip the rest:
 import flag_gems
 
 # Enable only selected ops
-flag_gems.only_enable(include=["rms_norm", "softmax"])
+flag_gems.enable(include=["rms_norm", "softmax"])
 ```
 
 This is useful when you want to accelerate only a subset of operators.
@@ -71,16 +71,17 @@ If both are provided, `exclude` is ignored.
 
 ## Advanced Usage
 
-The `flag_gems.enable(...)` and `flag_gems.only_enable(...)` functions support several optional parameters
+The `flag_gems.enable(...)` functions support several optional parameters
 which give you finer-grained control over how acceleration is applied.
-This allows for more flexible integration and easier debugging or profiling when working with complex workflows.
+This allows for more flexible integration and easier debugging or profiling
+when working with complex workflows.
 
 ### Parameters
 
 | Parameter      | Type      | Description                                         |
 | -------------- | --------- | --------------------------------------------------- |
-| `unused`       | List[str] | Disable specific operators (for `enable`)           |
-| `include`      | List[str] | Enable only specific operators (for `only_enable`)  |
+| `exclude`      | List[str] | Disable specific operators                          |
+| `include`      | List[str] | Enable only specific operators                      |
 | `record`       | bool      | Log operator calls for debugging or profiling       |
 | `path`         | str       | Log file path (only used when `record=True`)        |
 
@@ -99,10 +100,10 @@ while all other supported operators will use the *FlagGems* version.
 
 ### Example : Selectively Enable Specific Operators
 
-You can use `only_enable()` with the `include` parameter to accelerate only a subset of operators:
+You can use `enable()` with the `include` parameter to accelerate only a subset of operators:
 
 ```python
-flag_gems.only_enable(include=["rms_norm", "softmax"])
+flag_gems.enable(include=["rms_norm", "softmax"])
 ```
 
 This registers only the specified operators, skipping all the others.

--- a/src/flag_gems/logging_utils.py
+++ b/src/flag_gems/logging_utils.py
@@ -2,12 +2,12 @@
 
 Notes
 -----
-1) When you enter through the public APIs `enable`, `only_enable`, or the
-    context manager `use_gems`, the `record` flag controls whether op-level
-    logging is enabled and where it is written.
+1) When you enter through the public APIs `enable` or the context manager
+   `use_gems`, the `record` flag controls whether op-level logging is enabled
+   and where it is written.
 2) If you import `flag_gems` and call operators directly (e.g., `flag_gems.mm`)
-    without those helpers, call `setup_flaggems_logging()` yourself to initialize
-    the logging mode and file handler.
+   without those helpers, call `setup_flaggems_logging()` yourself to initialize
+   the logging mode and file handler.
 """
 
 import logging

--- a/src/flag_gems/runtime/register.py
+++ b/src/flag_gems/runtime/register.py
@@ -79,7 +79,8 @@ class Register:
 
         if not self.include_config:
             warnings.warn(
-                "only_enable failed: No op to register. Check if include is correct."
+                "Registration failed for empty operator list. "
+                "Check if the 'include' is specified correctly."
             )
             return
 

--- a/tests/test_enable_api.py
+++ b/tests/test_enable_api.py
@@ -75,7 +75,7 @@ def test_enable_with_exclude(exclude_op, tmp_path):
         assert not present, f"Found excluded op '{op}' in log file: {present}"
 
 
-@pytest.mark.only_enable
+@pytest.mark.enable
 @pytest.mark.parametrize(
     "include_op", [["sum"], ["mul", "sum"], ["bitwise_not", "masked_fill"]]
 )
@@ -94,7 +94,7 @@ def test_only_enable(include_op, tmp_path):
         ), f"Found unexpected op '{op}' in log file. Allowed op: {include_op}"
 
 
-@pytest.mark.only_enable
+@pytest.mark.enable
 def test_only_enable_with_yaml(tmp_path):
     include_ops = ["sum", "mul"]
     yaml_path = tmp_path / "only_enable.yaml"
@@ -116,7 +116,7 @@ def test_only_enable_with_yaml(tmp_path):
     assert not unexpected, f"Found unexpected ops via YAML include: {unexpected}"
 
 
-@pytest.mark.only_enable
+@pytest.mark.enable
 def test_only_enable_default(tmp_path, monkeypatch):
     # Create a mock YAML file with known include ops
     include_ops = ["sum", "mul", "add"]


### PR DESCRIPTION
### PR Category

Other

### Type of Change

Refactor

### Description

This PR combines the `only_enable` and `enable` function. We only need one user-facing interface for toggling the list of operators to include/exclude.
There are other refactoring in this PR as well.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
