### PR TITLE
[FlagGems Operator Development Competition] cosh operator

### DIFF
--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -66,6 +66,7 @@ forward_operations = [
     ("silu", torch.nn.functional.silu, FLOAT_DTYPES),
     # Trigonometric operations
     ("cos", torch.cos, FLOAT_DTYPES),
+    ("cosh", torch.cosh, FLOAT_DTYPES),
     ("sin", torch.sin, FLOAT_DTYPES),
     ("tan", torch.tan, FLOAT_DTYPES),
     ("tanh", torch.tanh, FLOAT_DTYPES),
@@ -122,6 +123,7 @@ forward_inplace_operations = [
     ("silu_", lambda a: torch.nn.functional.silu(a, inplace=True), FLOAT_DTYPES),
     # Trigonometric operations
     ("cos_", torch.cos_, FLOAT_DTYPES),
+    ("cosh_", torch.cosh_, FLOAT_DTYPES),
     ("sin_", torch.sin_, FLOAT_DTYPES),
     ("tan_", torch.tan_, FLOAT_DTYPES),
     ("tanh_", torch.tanh_, FLOAT_DTYPES),

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -116,6 +116,8 @@ _FULL_CONFIG = (
     ),
     ("cos", cos),
     ("cos_", cos_),
+    ("cosh", cosh),
+    ("cosh_", cosh_),
     ("count_nonzero", count_nonzero),
     ("cummax", cummax),
     ("cummin", cummin),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -61,6 +61,7 @@ from flag_gems.ops.conv3d import conv3d
 from flag_gems.ops.conv_depthwise2d import _conv_depthwise2d
 from flag_gems.ops.copy import copy, copy_
 from flag_gems.ops.cos import cos, cos_
+from flag_gems.ops.cosh import cosh, cosh_
 from flag_gems.ops.count_nonzero import count_nonzero
 from flag_gems.ops.cummax import cummax
 from flag_gems.ops.cummin import cummin
@@ -312,6 +313,8 @@ __all__ = [
     "copy_",
     "cos",
     "cos_",
+    "cosh",
+    "cosh_",
     "count_nonzero",
     "cummax",
     "cummin",

--- a/src/flag_gems/ops/cosh.py
+++ b/src/flag_gems/ops/cosh.py
@@ -1,0 +1,27 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
+
+exp = tl_extra_shim.exp
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
+@triton.jit
+def cosh_func(x):
+    x = x.to(tl.float32)
+    return (exp(x) + exp(-x)) * 0.5
+
+
+def cosh(A):
+    logger.debug("GEMS COSH")
+    return cosh_func(A)
+
+
+def cosh_(A):
+    logger.debug("GEMS COSH_")
+    cosh_func(A, out0=A)
+    return A

--- a/src/flag_gems/ops/cosh.py
+++ b/src/flag_gems/ops/cosh.py
@@ -13,7 +13,9 @@ logger = logging.getLogger(__name__)
 @triton.jit
 def cosh_func(x):
     x = x.to(tl.float32)
-    return (exp(x) + exp(-x)) * 0.5
+    ax = tl.abs(x)
+    t = exp(ax)
+    return (t + 1.0 / t) * 0.5
 
 
 def cosh(A):

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -270,6 +270,35 @@ def test_accuracy_cos_(shape, dtype):
     gems_assert_close(res_out, ref_out, dtype)
 
 
+@pytest.mark.cosh
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_cosh(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+
+    ref_out = torch.cosh(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.cosh(inp)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.inplace
+@pytest.mark.cosh_
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_cosh_(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp.clone(), True)
+
+    ref_out = torch.cosh_(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.cosh_(inp)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
 @pytest.mark.exp
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)


### PR DESCRIPTION
## Summary
- Add Triton `cosh` pointwise operator and in-place variant.
- Register operator in FlagGems.
- Add accuracy tests for `cosh` and `cosh_`.

## Design / Implementation
- Implements `cosh(x) = 0.5 * (exp(x) + exp(-x))` in a pointwise kernel.
- Uses FP32 compute path for stability; outputs keep input dtype.
- In-place variant reuses the same kernel via `out0`.

## Compliance (4.1.2)
- **Style**: PEP 8.
- **API parity**: matches `torch.cosh` and `torch.cosh_`.
- **Originality**: implemented for FlagGems competition.
- **License**: agree to Apache 2.0 inclusion with core-contributor attribution.

## Compatibility (4.1.3)
- **Dtypes**: float16, float32, bfloat16.
- **Input dims**: scalar to 5D (POINTWISE_SHAPES).
- **Hardware**: NVIDIA CUDA (user-run).

## Test Coverage Checklist (4.1.4)
- POINTWISE_SHAPES × FLOAT_DTYPES.
- Forward and in-place paths.

## Testing
- `pytest -k 'cosh' tests/test_unary_pointwise_ops.py -v`
  - **36 passed**, **0 failed**
