### PR TITLE
[KUNLUNXIN] fix max_pool2d and avg_pool2d

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/avg_pool2d.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/avg_pool2d.py
@@ -32,15 +32,7 @@ def pool2d_output_size(
 @libentry()
 @triton.autotune(
     configs=[
-        triton.Config({"BLOCK_H": 16, "BLOCK_W": 16}, num_stages=4, num_warps=4),
-        triton.Config({"BLOCK_H": 32, "BLOCK_W": 16}, num_stages=3, num_warps=4),
-        triton.Config({"BLOCK_H": 16, "BLOCK_W": 32}, num_stages=3, num_warps=4),
-        triton.Config({"BLOCK_H": 32, "BLOCK_W": 32}, num_stages=2, num_warps=8),
-        triton.Config({"BLOCK_H": 8, "BLOCK_W": 8}, num_stages=5, num_warps=2),
-        triton.Config({"BLOCK_H": 8, "BLOCK_W": 16}, num_stages=5, num_warps=2),
-        triton.Config({"BLOCK_H": 16, "BLOCK_W": 8}, num_stages=5, num_warps=2),
-        triton.Config({"BLOCK_H": 64, "BLOCK_W": 16}, num_stages=2, num_warps=8),
-        triton.Config({"BLOCK_H": 16, "BLOCK_W": 64}, num_stages=2, num_warps=8),
+        triton.Config({"BLOCK_H": 64, "BLOCK_W": 64}, num_stages=2, num_warps=8),
     ],
     key=["out_h", "out_w", "kernel_h", "kernel_w", "stride_h", "stride_w"],
 )
@@ -91,8 +83,8 @@ def avg_pool2d_forward_kernel(
 
     input_base_ptr = input_ptr + n_idx * in_stride_n + c_idx * in_stride_c
 
-    for kh in range(0, kernel_h):
-        for kw in range(0, kernel_w):
+    for kh in tl.static_range(0, kernel_h):
+        for kw in tl.static_range(0, kernel_w):
             h_in = h_out_offsets[:, None] * stride_h - padding_h + kh * dilation_h
             w_in = w_out_offsets[None, :] * stride_w - padding_w + kw * dilation_w
             in_mask = (h_in >= 0) & (h_in < in_h) & (w_in >= 0) & (w_in < in_w)
@@ -105,12 +97,22 @@ def avg_pool2d_forward_kernel(
             sum_acc += tl.where(in_mask, current_val, 0.0)
             count_acc += in_mask.to(tl.int32)
 
-    if divisor_override != 0:
-        divisor = tl.full((BLOCK_H, BLOCK_W), divisor_override, dtype=tl.float32)
-    elif COUNT_INCLUDE_PAD:
-        divisor = tl.full((BLOCK_H, BLOCK_W), kernel_h * kernel_w, dtype=tl.float32)
+    # Compute divisor: avoid runtime if-else branches that produce different tensor shapes
+    # Use count_acc as base shape reference, then select values via tl.where
+    count_divisor = count_acc.to(tl.float32)
+
+    # Compile-time branch for COUNT_INCLUDE_PAD (constexpr, OK to use if-else)
+    if COUNT_INCLUDE_PAD:
+        default_divisor = tl.where(
+            count_divisor >= 0, float(kernel_h * kernel_w), count_divisor
+        )
     else:
-        divisor = count_acc.to(tl.float32)
+        default_divisor = count_divisor
+
+    # Runtime selection for divisor_override: use tl.where to avoid shape mismatch
+    divisor = tl.where(
+        divisor_override != 0, divisor_override + default_divisor * 0, default_divisor
+    )
 
     output_vals = tl.where(divisor != 0, sum_acc / divisor, 0.0)
 
@@ -130,12 +132,7 @@ def avg_pool2d_forward_kernel(
 @libentry()
 @triton.autotune(
     configs=[
-        triton.Config({"BLOCK_H": 16, "BLOCK_W": 16}, num_stages=4, num_warps=4),
-        triton.Config({"BLOCK_H": 32, "BLOCK_W": 16}, num_stages=3, num_warps=4),
-        triton.Config({"BLOCK_H": 16, "BLOCK_W": 32}, num_stages=3, num_warps=4),
-        triton.Config({"BLOCK_H": 32, "BLOCK_W": 32}, num_stages=2, num_warps=8),
-        triton.Config({"BLOCK_H": 64, "BLOCK_W": 32}, num_stages=2, num_warps=8),
-        triton.Config({"BLOCK_H": 32, "BLOCK_W": 64}, num_stages=2, num_warps=8),
+        triton.Config({"BLOCK_H": 64, "BLOCK_W": 16}, num_warps=8),
     ],
     key=["in_h", "in_w", "kernel_h", "kernel_w", "stride_h", "stride_w"],
 )
@@ -192,8 +189,8 @@ def avg_pool2d_backward_kernel(
 
     grad_acc = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.float32)
 
-    for kh_loop in range(kernel_h):
-        for kw_loop in range(kernel_w):
+    for kh_loop in tl.static_range(0, kernel_h):
+        for kw_loop in tl.static_range(0, kernel_w):
             h_out_num = h_in_offsets[:, None] + padding_h - kh_loop * dilation_h
             w_out_num = w_in_offsets[None, :] + padding_w - kw_loop * dilation_w
 
@@ -207,31 +204,38 @@ def avg_pool2d_backward_kernel(
             w_out_mask = w_valid_map & (w_out < out_w)
             out_mask = h_out_mask & w_out_mask
 
-            if divisor_override != 0:
-                divisor = tl.full(
-                    (BLOCK_H, BLOCK_W), divisor_override, dtype=tl.float32
-                )
-            elif COUNT_INCLUDE_PAD:
-                divisor = tl.full(
-                    (BLOCK_H, BLOCK_W), kernel_h * kernel_w, dtype=tl.float32
+            # Compute count for this output position (for count_include_pad=False)
+            h_start = h_out * stride_h - padding_h
+            w_start = w_out * stride_w - padding_w
+            count = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.int32)
+            for kh_count in tl.static_range(0, kernel_h):
+                for kw_count in tl.static_range(0, kernel_w):
+                    h_in_for_count = h_start + kh_count * dilation_h
+                    w_in_for_count = w_start + kw_count * dilation_w
+                    is_valid = (
+                        (h_in_for_count >= 0)
+                        & (h_in_for_count < in_h)
+                        & (w_in_for_count >= 0)
+                        & (w_in_for_count < in_w)
+                    )
+                    count += is_valid.to(tl.int32)
+
+            count_divisor = count.to(tl.float32)
+
+            # Compile-time branch for COUNT_INCLUDE_PAD
+            if COUNT_INCLUDE_PAD:
+                default_divisor = tl.where(
+                    count_divisor >= 0, float(kernel_h * kernel_w), count_divisor
                 )
             else:
-                h_start = h_out * stride_h - padding_h
-                w_start = w_out * stride_w - padding_w
-                count = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.int32)
-                for kh_count in range(0, kernel_h):
-                    for kw_count in range(0, kernel_w):
-                        h_in_for_count = h_start + kh_count * dilation_h
-                        w_in_for_count = w_start + kw_count * dilation_w
-                        is_valid = (
-                            (h_in_for_count >= 0)
-                            & (h_in_for_count < in_h)
-                            & (w_in_for_count >= 0)
-                            & (w_in_for_count < in_w)
-                        )
-                        count += is_valid.to(tl.int32)
-                divisor = count.to(tl.float32)
+                default_divisor = count_divisor
 
+            # Runtime selection for divisor_override
+            divisor = tl.where(
+                divisor_override != 0,
+                divisor_override + default_divisor * 0,
+                default_divisor,
+            )
             divisor = tl.where(divisor == 0, 1.0, divisor)
 
             grad_out_ptr = (
@@ -239,8 +243,6 @@ def avg_pool2d_backward_kernel(
             )
             grad_out_val = tl.load(grad_out_ptr, mask=out_mask, other=0.0)
             grad_acc += tl.where(out_mask, grad_out_val / divisor, 0.0)
-            # grad_to_add = grad_out_val.to(tl.float32) / divisor.to(tl.float32)
-            # grad_acc += tl.where(out_mask, grad_to_add, 0.0)
 
     grad_input_store_ptr = (
         grad_input_block_ptr

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/max_pool2d_with_indices.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/max_pool2d_with_indices.py
@@ -82,7 +82,7 @@ def max_pool2d_forward_kernel(
     dtype = input_ptr.type.element_ty
     min_val = get_dtype_min(dtype)
     max_val_acc = tl.full((BLOCK_H, BLOCK_W), min_val, dtype=dtype)
-    max_idx_acc = tl.full((BLOCK_H, BLOCK_W), -1, dtype=tl.int64)
+    max_idx_acc = tl.full((BLOCK_H, BLOCK_W), -1, dtype=tl.int32)
 
     input_base_ptr = input_ptr + n_idx * in_stride_n + c_idx * in_stride_c
 
@@ -278,7 +278,7 @@ def max_pool2d_with_indices(
         (in_n, in_c, out_h, out_w), device=input.device, dtype=input.dtype
     )
     indices = torch.empty(
-        (in_n, in_c, out_h, out_w), device=input.device, dtype=torch.int64
+        (in_n, in_c, out_h, out_w), device=input.device, dtype=torch.int32
     )
 
     if output.numel() == 0:
@@ -327,8 +327,12 @@ def max_pool2d_backward(
     ceil_mode,
 ):
     logger.debug("GEMS MAX_POOL2D BACKWARD")
-    grad_output = grad_output.contiguous()
-    indices = indices.contiguous()
+    original_dtype = grad_output.dtype
+    # Convert grad_output to float32 to match grad_input dtype,
+    # since C++ xpudnn API uses grad_output's dtype to interpret grad_input's memory
+    grad_output = grad_output.to(torch.float32).contiguous()
+    # Convert indices to int32 as the C++ xpudnn API expects int32 indices
+    indices = indices.to(torch.int32).contiguous()
 
     params = _parse_pool_params(kernel_size, stride, padding, dilation)
     (
@@ -348,7 +352,7 @@ def max_pool2d_backward(
     grad_input = torch.zeros_like(input, dtype=torch.float32)
 
     if grad_input.numel() == 0:
-        return grad_input.to(grad_output.dtype)
+        return grad_input.to(original_dtype)
 
     grid = lambda meta: (
         in_n * in_c,
@@ -382,4 +386,4 @@ def max_pool2d_backward(
             dilation_w,
         )
 
-    return grad_input.to(grad_output.dtype)
+    return grad_input.to(original_dtype)


### PR DESCRIPTION
### PR Category
Benchmark | Operator

### Type of Change
Bug Fix

### Description
Description
Fix test_perf_max_pool2d_backward benchmark test failure caused by incompatible indices format between PyTorch and FlagGems.

Root Cause:

PyTorch's max_pool2d_with_indices and FlagGems' max_pool2d_with_indices produce indices in different formats

The original test used PyTorch forward to generate indices, then passed them to FlagGems backward

This format mismatch caused illegal memory access errors

Changes:

Benchmark test fix: Modified test_perf_max_pool2d_backward to use flag_gems.max_pool2d_with_indices for forward pass, ensuring indices are compatible with flag_gems.max_pool2d_backward

Indices dtype optimization: Changed indices tensor dtype from int64 to int32 in:

FlagGems/src/flag_gems/ops/max_pool2d_with_indices.py
FlagGems/src/flag_gems/runtime/backend/_kunlunxin/ops/max_pool2d_with_indices.py
C++ layer robustness: Added int64→int32 conversion handling in launch_max_pool2d_backward for cases where indices come as int64 (e.g., from PyTorch native forward), with proper synchronization to prevent use-after-free of temporary buffers
