### PR TITLE
Restore wait-triage step

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -39,12 +39,10 @@ jobs:
   wait-triage:
     runs-on: ubuntu-latest
     steps:
-      - run: |
-          echo "done"
-      # - name: Wait for PR triage
-      #   uses: ArcticLampyrid/action-wait-for-workflow@v1
-      #   with:
-      #     workflow: .github/workflows/triage.yaml
+      - name: Wait for PR triage
+        uses: ArcticLampyrid/action-wait-for-workflow@v1
+        with:
+          workflow: .github/workflows/triage.yaml
 
   build-doc:
     needs: wait-triage


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Refactor

### Description

Restore the `wait-triage` step in hope the `unit-test` workflow will show up after a few days.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
