### PR TITLE
[FlagGems Operator Development Competition] add logaddexp

### DIFF
--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -163,6 +163,8 @@ from flag_gems.ops.lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tens
 from flag_gems.ops.lift_fresh_copy import lift_fresh_copy, lift_fresh_copy_out
 from flag_gems.ops.linspace import linspace
 from flag_gems.ops.log import log
+from flag_gems.ops.log1p_ import log1p_
+from flag_gems.ops.log10 import log10, log10_, log10_out
 from flag_gems.ops.log_sigmoid import log_sigmoid
 from flag_gems.ops.log_softmax import log_softmax, log_softmax_backward
 from flag_gems.ops.logaddexp import logaddexp, logaddexp_out


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
This PR implements the **torch.logaddexp** operator for FlagGems as part of the Operator Development Competition. It provides high-performance Triton kernels for the following aten schemas:

- `logaddexp(Tensor self, Tensor other) -> Tensor`
- `logaddexp.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)`

**Implementation details:**

- **Kernel:** Numerically stable form `log(exp(x) + exp(y)) = m + log(1 + exp(-|x - y|))` with `m = max(x, y)`, using Triton's `tl.maximum`, `tl.abs`, `tl.exp`, and `tl.log`; computation in FP32 for stability.
- **Type promotion:** `DEFAULT` for the two tensor inputs (same as other binary pointwise ops).
- **Integration:** New file `src/flag_gems/ops/logaddexp.py`; registration in `src/flag_gems/__init__.py` for `logaddexp` and `logaddexp.out`; exports in `src/flag_gems/ops/__init__.py`.

**Files changed:**

| File | Change |
|------|--------|
| `src/flag_gems/ops/logaddexp.py` | New |
| `src/flag_gems/__init__.py` | Register logaddexp / logaddexp.out |
| `src/flag_gems/ops/__init__.py` | Import and `__all__` |
| `tests/test_binary_pointwise_ops.py` | Add accuracy tests for logaddexp, logaddexp_out |
| `benchmark/test_binary_pointwise_perf.py` | Add logaddexp to binary pointwise benchmark list |

### Issue
New operator for Operator Development Competition.

###  Performance

**Environment:** `benchmark/test_binary_pointwise_perf.py`, mode=`kernel`, level=`core`.  
**Speedup** = Torch latency / Gems latency; **> 1.0** means Gems is faster.

### float16

| Shape | Torch (ms) | Gems (ms) | Speedup | TFLOPS |
|-------|------------|-----------|---------|--------|
| (1073741824,) | 11.774 | 11.757 | 1.001 | 0.183 |
| (64, 64) | 0.00442 | 0.00403 | **1.095** | 0.002 |
| (4096, 4096) | 0.189 | 0.188 | **1.007** | 0.178 |
| (64, 512, 512) | 0.190 | 0.188 | **1.009** | 0.178 |
| (1024, 1024, 1024) | 11.761 | 11.771 | 0.999 | 0.182 |

### bfloat16

| Shape | Torch (ms) | Gems (ms) | Speedup | TFLOPS |
|-------|------------|-----------|---------|--------|
| (1073741824,) | 11.749 | 11.760 | 0.999 | 0.183 |
| (64, 64) | 0.00454 | 0.00410 | **1.109** | 0.002 |
| (4096, 4096) | 0.190 | 0.188 | **1.009** | 0.179 |
| (64, 512, 512) | 0.190 | 0.188 | **1.010** | 0.179 |
| (1024, 1024, 1024) | 11.749 | 11.766 | 0.999 | 0.183 |