### PR TITLE
Remove redundant settings for coverage tool

### DIFF
--- a/.coverage.rc
+++ b/.coverage.rc
@@ -1,5 +1,0 @@
-[run]
-omit = [
-    "*/.flaggems/*",
-    "*/usr/lib/*",
-]

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source = src/flag_gems
+omit =
+    "*/.flaggems/*"
+    "*/usr/lib/*"
+parallel = true

--- a/tools/blas-op-test.sh
+++ b/tools/blas-op-test.sh
@@ -6,11 +6,12 @@ ID_SHA="${PR_ID}-${GITHUB_SHA}"
 echo ID_SHA $ID_SHA
 
 source tools/run_command.sh
-COVERAGE_ARGS="--parallel-mode --omit "*/.flaggems/*","*/usr/lib/*" --source=./src,./tests --data-file=${ID_SHA}-op"
+
+COVERAGE_ARGS="--data-file=${ID_SHA}-op"
+
 bash tools/pytest_mark_check.sh && \
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_blas_ops.py && \
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_attention_ops.py
-
 
 mkdir -p /home/zhangbo/PR_Coverage/PR${PR_ID}/${ID_SHA}
 mv ${ID_SHA}* /home/zhangbo/PR_Coverage/PR${PR_ID}/${ID_SHA}

--- a/tools/examples-test.sh
+++ b/tools/examples-test.sh
@@ -6,7 +6,7 @@ ID_SHA="${PR_ID}-${GITHUB_SHA}"
 echo ID_SHA $ID_SHA
 
 source tools/run_command.sh
-COVERAGE_ARGS="--parallel-mode --omit "*/.flaggems/*","*/usr/lib/*" --source=./src,./tests --data-file=${ID_SHA}-model"
+COVERAGE_ARGS="--data-file=${ID_SHA}-model"
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s examples/model_bert_test.py
 
 mkdir -p /home/zhangbo/PR_Coverage/PR${PR_ID}/${ID_SHA}

--- a/tools/op-test-quick-cpu.sh
+++ b/tools/op-test-quick-cpu.sh
@@ -6,7 +6,7 @@ ID_SHA="${PR_ID}-${GITHUB_SHA}"
 echo ID_SHA $ID_SHA
 
 source tools/run_command.sh
-COVERAGE_ARGS="--parallel-mode --omit "*/.flaggems/*","*/usr/lib/*" --source=./src,./tests --data-file=${ID_SHA}-op"
+COVERAGE_ARGS="--data-file=${ID_SHA}-op"
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_blas_ops.py --ref=cpu --mode=quick && \
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_reduction_ops.py --ref=cpu --mode=quick && \
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_general_reduction_ops.py --ref=cpu --mode=quick && \

--- a/tools/op-utils-test.sh
+++ b/tools/op-utils-test.sh
@@ -7,7 +7,7 @@ echo ID_SHA $ID_SHA
 
 echo $PWD
 source tools/run_command.sh
-COVERAGE_ARGS="--parallel-mode --omit "*/.flaggems/*","*/usr/lib/*" --source=./src,./tests --data-file=${ID_SHA}-op"
+COVERAGE_ARGS="--data-file=${ID_SHA}-utils"
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_libentry.py && \
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_shape_utils.py && \
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_tensor_wrapper.py

--- a/tools/pointwise-op-test.sh
+++ b/tools/pointwise-op-test.sh
@@ -6,7 +6,7 @@ ID_SHA="${PR_ID}-${GITHUB_SHA}"
 echo ID_SHA $ID_SHA
 
 source tools/run_command.sh
-COVERAGE_ARGS="--parallel-mode --omit "*/.flaggems/*","*/usr/lib/*" --source=./src,./tests --data-file=${ID_SHA}-op"
+COVERAGE_ARGS="--data-file=${ID_SHA}-op"
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_pointwise_dynamic.py && \
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_unary_pointwise_ops.py && \
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_unary_pointwise_ops.py -m abs --record=log && \

--- a/tools/reduction-op-test.sh
+++ b/tools/reduction-op-test.sh
@@ -6,7 +6,7 @@ ID_SHA="${PR_ID}-${GITHUB_SHA}"
 echo ID_SHA $ID_SHA
 
 source tools/run_command.sh
-COVERAGE_ARGS="--parallel-mode --omit "*/.flaggems/*","*/usr/lib/*" --source=./src,./tests --data-file=${ID_SHA}-op"
+COVERAGE_ARGS="--data-file=${ID_SHA}-op"
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_reduction_ops.py && \
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_general_reduction_ops.py && \
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_norm_ops.py

--- a/tools/special-op-test.sh
+++ b/tools/special-op-test.sh
@@ -6,7 +6,7 @@ ID_SHA="${PR_ID}-${GITHUB_SHA}"
 echo ID_SHA $ID_SHA
 
 source tools/run_command.sh
-COVERAGE_ARGS="--parallel-mode --omit "*/.flaggems/*","*/usr/lib/*" --source=./src,./tests --data-file=${ID_SHA}-op"
+COVERAGE_ARGS="--data-file=${ID_SHA}-op"
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_special_ops.py && \
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_tensor_constructor_ops.py && \
 run_command coverage run ${COVERAGE_ARGS} -m pytest -s tests/test_distribution_ops.py


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Refactor

### Description

This PR removes the duplicated coverage settings in the unit test scripts.
The coverage settings are identical and can be perfectly covered by a single `.coveragerc` file.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
