### PR TITLE
Add tril (lower triangular) operator to main ops

### DIFF
--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -338,6 +338,8 @@ _FULL_CONFIG = (
     ("tile", tile),
     ("topk", topk),
     ("trace", trace),
+    ("tril", tril),
+    ("tril_", tril_),
     ("triu", triu),
     ("triu_", triu_),
     ("true_divide.Scalar", true_divide),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -216,6 +216,7 @@ from flag_gems.ops.tile import tile
 from flag_gems.ops.to import to_copy
 from flag_gems.ops.topk import topk
 from flag_gems.ops.trace import trace
+from flag_gems.ops.tril import tril, tril_
 from flag_gems.ops.triu import triu, triu_
 from flag_gems.ops.uniform import uniform_
 from flag_gems.ops.unique import _unique2
@@ -522,6 +523,8 @@ __all__ = [
     "to_copy",
     "topk",
     "trace",
+    "tril",
+    "tril_",
     "triu",
     "triu_",
     "true_divide",

--- a/src/flag_gems/ops/tril.py
+++ b/src/flag_gems/ops/tril.py
@@ -1,0 +1,185 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.autotune(configs=runtime.get_tuned_config("tril"), key=["M", "N"])
+@triton.jit(do_not_specialize=["diagonal"])
+def tril_kernel(
+    X,
+    Y,
+    M,
+    N,
+    diagonal,
+    M_BLOCK_SIZE: tl.constexpr,
+    N_BLOCK_SIZE: tl.constexpr,
+):
+    pid = tle.program_id(0)
+    row = pid * M_BLOCK_SIZE + tl.arange(0, M_BLOCK_SIZE)[:, None]
+    m_mask = row < M
+    X += row * N
+    Y += row * N
+
+    for n_offset in range(0, N, N_BLOCK_SIZE):
+        cols = n_offset + tl.arange(0, N_BLOCK_SIZE)[None, :]
+        n_mask = cols < N
+        mask = m_mask and n_mask
+
+        x = tl.load(X + cols, mask, other=0.0)
+        y = tl.where(cols <= row + diagonal, x, 0.0)
+        tl.store(Y + cols, y, mask=mask)
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("tril_batch"),
+    key=["batch", "MN", "N", "diagonal"],
+)
+@triton.jit(do_not_specialize=["diagonal"])
+def tril_batch_kernel(
+    X,
+    Y,
+    batch,
+    MN,
+    N,
+    diagonal,
+    BATCH_BLOCK_SIZE: tl.constexpr,
+    MN_BLOCK_SIZE: tl.constexpr,
+):
+    batch_id = tle.program_id(0)
+    mn_id = tle.program_id(1)
+    row = batch_id * BATCH_BLOCK_SIZE + tl.arange(0, BATCH_BLOCK_SIZE)[:, None]
+    batch_mask = row < batch
+    X += row * MN
+    Y += row * MN
+
+    cols = mn_id * MN_BLOCK_SIZE + tl.arange(0, MN_BLOCK_SIZE)[None, :]
+    mn_mask = cols < MN
+    mask = batch_mask and mn_mask
+    x = tl.load(X + cols, mask, other=0.0)
+    m = cols // N
+    n = cols % N
+    y = tl.where(n <= m + diagonal, x, 0.0)
+    tl.store(Y + cols, y, mask=mask)
+
+
+def _check_batch_contiguous(tensor, allow_zero_stride=True):
+    if tensor.is_contiguous():
+        return True, tensor
+
+    dims = tensor.dim()
+
+    if dims >= 2:
+        n = tensor.size(-1)
+        stride_row, stride_col = tensor.stride(-2), tensor.stride(-1)
+
+        if not (stride_col == 1 and stride_row == n):
+            return False, tensor.contiguous()
+
+    if allow_zero_stride and dims <= 3:
+        return True, tensor
+
+    expected_stride = tensor.size(-1) * tensor.size(-2)
+    for i in range(dims - 3, -1, -1):
+        if (
+            allow_zero_stride
+            and i == 0
+            and (tensor.stride(i) == 0 or tensor.size(i) == 1)
+        ):
+            continue
+
+        if tensor.stride(i) != expected_stride:
+            return False, tensor.contiguous()
+
+        expected_stride *= tensor.size(i)
+
+    return True, tensor
+
+
+def tril(A, diagonal=0):
+    logger.debug("GEMS TRIL")
+
+    assert len(A.shape) > 1, "Input tensor must have at least 2 dimensions"
+
+    can_use_directly, A_input = _check_batch_contiguous(A, allow_zero_stride=False)
+
+    out = torch.empty(
+        A.shape, dtype=A.dtype, device=A.device, memory_format=torch.contiguous_format
+    )
+
+    M, N = A_input.shape[-2:]
+
+    with torch_device_fn.device(A_input.device):
+        if len(A_input.shape) == 2:
+            grid = lambda meta: (triton.cdiv(M, meta["M_BLOCK_SIZE"]),)
+            tril_kernel[grid](A_input, out, M, N, diagonal)
+        else:
+            batch = int(torch.numel(A_input) / M / N)
+            B = A_input.view(batch, -1)
+            grid = lambda meta: (
+                triton.cdiv(batch, meta["BATCH_BLOCK_SIZE"]),
+                triton.cdiv(M * N, meta["MN_BLOCK_SIZE"]),
+            )
+            tril_batch_kernel[grid](B, out, batch, M * N, N, diagonal)
+            out = out.view(A.shape)
+
+    return out
+
+
+def tril_(A, diagonal=0):
+    logger.debug("GEMS TRIL_ (inplace)")
+
+    assert len(A.shape) > 1, "Input tensor must have at least 2 dimensions"
+    diagonal = int(diagonal)
+    M, N = A.shape[-2:]
+
+    can_use_directly, A_to_use = _check_batch_contiguous(A, allow_zero_stride=True)
+
+    if not can_use_directly:
+        logger.debug(
+            "Input tensor does not satisfy contiguity requirements, "
+            "using temporary tensor for computation"
+        )
+
+        result_temp = torch.empty_like(A_to_use, memory_format=torch.contiguous_format)
+
+        with torch_device_fn.device(A.device):
+            if len(A.shape) == 2:
+                grid = lambda meta: (triton.cdiv(M, meta["M_BLOCK_SIZE"]),)
+                tril_kernel[grid](A_to_use, result_temp, M, N, diagonal)
+            else:
+                batch = int(torch.numel(A) / M / N)
+                B = A_to_use.view(batch, -1)
+                result_temp_flat = result_temp.view(batch, -1)
+                grid = lambda meta: (
+                    triton.cdiv(batch, meta["BATCH_BLOCK_SIZE"]),
+                    triton.cdiv(M * N, meta["MN_BLOCK_SIZE"]),
+                )
+                tril_batch_kernel[grid](B, result_temp_flat, batch, M * N, N, diagonal)
+
+        A.copy_(result_temp)
+    else:
+        with torch_device_fn.device(A.device):
+            if len(A.shape) == 2:
+                grid = lambda meta: (triton.cdiv(M, meta["M_BLOCK_SIZE"]),)
+                tril_kernel[grid](A, A, M, N, diagonal)
+            else:
+                batch = int(torch.numel(A) / M / N)
+                B = A.view(batch, -1)
+                grid = lambda meta: (
+                    triton.cdiv(batch, meta["BATCH_BLOCK_SIZE"]),
+                    triton.cdiv(M * N, meta["MN_BLOCK_SIZE"]),
+                )
+                tril_batch_kernel[grid](B, B, batch, M * N, N, diagonal)
+
+    return A

--- a/src/flag_gems/runtime/backend/_aipu/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_aipu/tune_configs.yaml
@@ -766,6 +766,34 @@ sum:
   - 2
   - 4
   - 8
+tril:
+- gen: true
+  param_map:
+    META:
+      M_BLOCK_SIZE: 1
+      N_BLOCK_SIZE: 2048
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+tril_batch:
+- gen: true
+  param_map:
+    META:
+      BATCH_BLOCK_SIZE: 1
+      MN_BLOCK_SIZE: 512
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
 triu:
 - gen: true
   param_map:

--- a/src/flag_gems/runtime/backend/_amd/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_amd/tune_configs.yaml
@@ -584,6 +584,34 @@ vstack:
       - 1024
       - 2048
       - 4096
+tril:
+  - gen: true
+    param_map:
+      META:
+        M_BLOCK_SIZE: 1
+        N_BLOCK_SIZE: 2048
+      num_warps: warps
+    warps:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
+tril_batch:
+  - gen: true
+    param_map:
+      META:
+        BATCH_BLOCK_SIZE: 1
+        MN_BLOCK_SIZE: 512
+      num_warps: warps
+    warps:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
 triu:
   - gen: true
     param_map:

--- a/src/flag_gems/runtime/backend/_arm/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_arm/tune_configs.yaml
@@ -558,6 +558,34 @@ sum:
   - 2
   - 4
   - 8
+tril:
+- gen: true
+  param_map:
+    META:
+      M_BLOCK_SIZE: 1
+      N_BLOCK_SIZE: 2048
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+tril_batch:
+- gen: true
+  param_map:
+    META:
+      BATCH_BLOCK_SIZE: 1
+      MN_BLOCK_SIZE: 512
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
 triu:
 - gen: true
   param_map:

--- a/src/flag_gems/runtime/backend/_ascend/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_ascend/tune_configs.yaml
@@ -522,6 +522,20 @@ sum:
   - 128
   - 256
 
+tril:
+- gen: true
+  param_map:
+    META:
+      M_BLOCK_SIZE: 2
+      N_BLOCK_SIZE: 2048
+
+tril_batch:
+- gen: true
+  param_map:
+    META:
+      BATCH_BLOCK_SIZE: 16
+      MN_BLOCK_SIZE: 512
+
 triu:
 - gen: true
   param_map:

--- a/src/flag_gems/runtime/backend/_cambricon/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_cambricon/tune_configs.yaml
@@ -1110,6 +1110,34 @@ sum:
   - 512
   - 1024
 #######################################
+tril:
+- META:
+    M_BLOCK_SIZE: 1
+  num_warps: 1
+  num_stages: 3
+- META:
+    M_BLOCK_SIZE: 4
+  num_warps: 1
+  num_stages: 3
+- META:
+    M_BLOCK_SIZE: 8
+  num_warps: 1
+  num_stages: 3
+- META:
+    M_BLOCK_SIZE: 16
+  num_warps: 1
+  num_stages: 3
+#######################################
+tril_batch:
+- gen: true
+  param_map:
+    META:
+      BATCH_BLOCK_SIZE: 1
+      MN_BLOCK_SIZE: 512
+    num_warps: warps
+  warps:
+  - 1
+#######################################
 triu:
 - META:
     M_BLOCK_SIZE: 1

--- a/src/flag_gems/runtime/backend/_hygon/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_hygon/tune_configs.yaml
@@ -1001,6 +1001,32 @@ sum:
   - 2
   - 4
   - 8
+tril:
+- gen: true
+  param_map:
+    META:
+      M_BLOCK_SIZE: 1
+      N_BLOCK_SIZE: 2048
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+tril_batch:
+- gen: true
+  param_map:
+    META:
+      BATCH_BLOCK_SIZE: 1
+      MN_BLOCK_SIZE: 512
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
 triu:
 - gen: true
   param_map:

--- a/src/flag_gems/runtime/backend/_iluvatar/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_iluvatar/tune_configs.yaml
@@ -1697,6 +1697,34 @@ sum:
   - 2
   - 4
   - 8
+tril:
+- gen: true
+  param_map:
+    META:
+      M_BLOCK_SIZE: 1
+      N_BLOCK_SIZE: 2048
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+tril_batch:
+- gen: true
+  param_map:
+    META:
+      BATCH_BLOCK_SIZE: 1
+      MN_BLOCK_SIZE: 512
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
 triu:
 - gen: true
   param_map:

--- a/src/flag_gems/runtime/backend/_kunlunxin/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_kunlunxin/tune_configs.yaml
@@ -837,6 +837,34 @@ sum:
   - 2
   - 4
   - 8
+tril:
+- gen: true
+  param_map:
+    META:
+      M_BLOCK_SIZE: 1
+      N_BLOCK_SIZE: 2048
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+tril_batch:
+- gen: true
+  param_map:
+    META:
+      BATCH_BLOCK_SIZE: 1
+      MN_BLOCK_SIZE: 512
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
 triu:
 - gen: true
   param_map:

--- a/src/flag_gems/runtime/backend/_metax/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_metax/tune_configs.yaml
@@ -1019,6 +1019,32 @@ sum:
   - 2
   - 4
   - 8
+tril:
+- gen: true
+  param_map:
+    META:
+      M_BLOCK_SIZE: 1
+      N_BLOCK_SIZE: 2048
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+tril_batch:
+- gen: true
+  param_map:
+    META:
+      BATCH_BLOCK_SIZE: 1
+      MN_BLOCK_SIZE: 512
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
 triu:
 - gen: true
   param_map:

--- a/src/flag_gems/runtime/backend/_mthreads/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_mthreads/tune_configs.yaml
@@ -388,6 +388,34 @@ vstack:
       - 1024
       - 2048
       - 4096
+tril:
+  - gen: true
+    param_map:
+      META:
+        M_BLOCK_SIZE: 1
+        N_BLOCK_SIZE: 2048
+      num_warps: warps
+    warps:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
+tril_batch:
+  - gen: true
+    param_map:
+      META:
+        BATCH_BLOCK_SIZE: 1
+        MN_BLOCK_SIZE: 512
+      num_warps: warps
+    warps:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
 triu:
   - gen: true
     param_map:

--- a/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
@@ -743,6 +743,34 @@ vstack:
       - 1024
       - 2048
       - 4096
+tril:
+  - gen: true
+    param_map:
+      META:
+        M_BLOCK_SIZE: 1
+        N_BLOCK_SIZE: 2048
+      num_warps: warps
+    warps:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
+tril_batch:
+  - gen: true
+    param_map:
+      META:
+        BATCH_BLOCK_SIZE: 1
+        MN_BLOCK_SIZE: 512
+      num_warps: warps
+    warps:
+      - 1
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
 triu:
   - gen: true
     param_map:

--- a/src/flag_gems/runtime/backend/_sunrise/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_sunrise/tune_configs.yaml
@@ -608,6 +608,34 @@ vstack:
   - 1024
   - 2048
   - 4096
+tril:
+- gen: true
+  param_map:
+    META:
+      M_BLOCK_SIZE: 1
+      N_BLOCK_SIZE: 2048
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
+tril_batch:
+- gen: true
+  param_map:
+    META:
+      BATCH_BLOCK_SIZE: 1
+      MN_BLOCK_SIZE: 512
+    num_warps: warps
+  warps:
+  - 1
+  - 2
+  - 4
+  - 8
+  - 16
+  - 32
 triu:
 - gen: true
   param_map:

--- a/src/flag_gems/runtime/backend/_tsingmicro/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_tsingmicro/tune_configs.yaml
@@ -553,6 +553,24 @@ vstack:
       - 1024
       - 2048
       - 4096
+tril:
+  - gen: true
+    param_map:
+      META:
+        M_BLOCK_SIZE: 1
+        N_BLOCK_SIZE: 2048
+      num_warps: warps
+    warps:
+      - 1
+tril_batch:
+  - gen: true
+    param_map:
+      META:
+        BATCH_BLOCK_SIZE: 1
+        MN_BLOCK_SIZE: 512
+      num_warps: warps
+    warps:
+      - 1
 triu:
   - gen: true
     param_map:

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -1890,3 +1890,37 @@ def test_accuracy_moe_align_block_size(
     gems_assert_close(
         num_tokens_post_pad, to_reference(num_tokens_post_pad_vllm), dtype=dtype
     )
+
+
+TRIL_SHAPES = [(2, 3), (128, 256), (512, 512), (4, 16, 32)]
+TRIL_DIAGONALS = [-2, -1, 0, 1, 3]
+
+
+@pytest.mark.tril
+@pytest.mark.parametrize("shape", TRIL_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("diagonal", TRIL_DIAGONALS)
+def test_accuracy_tril(shape, dtype, diagonal):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp)
+
+    ref_out = torch.tril(ref_inp, diagonal)
+    with flag_gems.use_gems():
+        res_out = torch.tril(inp, diagonal)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.tril
+@pytest.mark.parametrize("shape", TRIL_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("diagonal", TRIL_DIAGONALS)
+def test_accuracy_tril_(shape, dtype, diagonal):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp)
+
+    ref_out = torch.tril_(ref_inp.clone(), diagonal)
+    with flag_gems.use_gems():
+        res_out = torch.tril_(inp.clone(), diagonal)
+
+    gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
## Summary
- Add production-ready `tril` and `tril_` operators mirroring the existing `triu` implementation, with inverted masking condition (`cols <= row + diagonal`) to keep elements at or below the diagonal
- Include 2D kernel with autotune, batch kernel for N-D tensors, and inplace variant with proper contiguity handling
- Add autotune configs for all 13 backends and parametrized tests (shapes, dtypes, diagonals including batched tensors)

## Test plan
- [ ] `pytest tests/test_special_ops.py -k tril -v` — 120 test cases (4 shapes x 3 dtypes x 5 diagonals x 2 functions)
- [ ] Verify correctness: `torch.allclose(gems_tril(x, diag), torch.tril(x, diag))` for 2D and batched inputs
- [ ] Verify inplace variant modifies tensor in-place correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)