### PR TITLE
[FlagGems Operator Development Competition] add upsample_nearest2d backward

### DIFF
--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -347,6 +347,7 @@ _FULL_CONFIG = (
     ("uniform_", uniform_),
     ("upsample_nearest1d", upsample_nearest1d),
     ("upsample_nearest2d", upsample_nearest2d),
+    ("upsample_nearest2d_backward", upsample_nearest2d_backward),
     ("var_mean.correction", var_mean),
     ("vdot", vdot),
     ("vstack", vstack),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -221,7 +221,10 @@ from flag_gems.ops.uniform import uniform_
 from flag_gems.ops.unique import _unique2
 from flag_gems.ops.upsample_bicubic2d_aa import _upsample_bicubic2d_aa
 from flag_gems.ops.upsample_nearest1d import upsample_nearest1d
-from flag_gems.ops.upsample_nearest2d import upsample_nearest2d
+from flag_gems.ops.upsample_nearest2d import (
+    upsample_nearest2d,
+    upsample_nearest2d_backward,
+)
 from flag_gems.ops.var_mean import var_mean
 from flag_gems.ops.vdot import vdot
 from flag_gems.ops.vector_norm import vector_norm
@@ -530,6 +533,7 @@ __all__ = [
     "uniform_",
     "upsample_nearest1d",
     "upsample_nearest2d",
+    "upsample_nearest2d_backward",
     "var_mean",
     "vdot",
     "vector_norm",

--- a/src/flag_gems/ops/upsample_nearest2d.py
+++ b/src/flag_gems/ops/upsample_nearest2d.py
@@ -11,6 +11,38 @@ from flag_gems.runtime import device, torch_device_fn
 device = device.name
 logger = logging.getLogger(__name__)
 
+_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeExplicitAutograd
+)
+
+
+def _to_copy_fallback(x: torch.Tensor, dtype: torch.dtype) -> torch.Tensor:
+    if x.dtype == dtype:
+        return x
+    return torch.ops.aten._to_copy.default.redispatch(
+        _FALLBACK_KEYSET,
+        x,
+        dtype=dtype,
+        layout=None,
+        device=x.device,
+        pin_memory=None,
+        non_blocking=False,
+        memory_format=torch.preserve_format,
+    )
+
+
+def _get_reciprocal_scale(
+    input_size: int, output_size: int, scale: Optional[float]
+) -> float:
+    if scale is not None:
+        return float(torch.tensor(1.0 / scale, dtype=torch.float32).item())
+    return float(
+        (
+            torch.tensor(input_size, dtype=torch.float32)
+            / torch.tensor(output_size, dtype=torch.float32)
+        ).item()
+    )
+
 
 @triton.autotune(
     configs=runtime.get_tuned_config("upsample_nearest2d"), key=["N", "C", "OH", "OW"]
@@ -78,14 +110,8 @@ def upsample_nearest2d(
     assert len(output_size) == 2, "The len of output_size must be 2"
     OH, OW = output_size
     N, C, IH, IW = input.shape
-    if scales_h is not None:
-        reciprocal_scale_h = 1 / scales_h
-    else:
-        reciprocal_scale_h = IH / OH
-    if scales_w is not None:
-        reciprocal_scale_w = 1 / scales_w
-    else:
-        reciprocal_scale_w = IW / OW
+    reciprocal_scale_h = _get_reciprocal_scale(IH, OH, scales_h)
+    reciprocal_scale_w = _get_reciprocal_scale(IW, OW, scales_w)
     # allocate output
     output = torch.empty((N, C, OH, OW), device=input.device, dtype=input.dtype)
     total_threads = OH * OW
@@ -108,3 +134,53 @@ def upsample_nearest2d(
             reciprocal_scale_w,
         )
     return output
+
+
+def upsample_nearest2d_backward(
+    grad_output: torch.Tensor,
+    output_size: Tuple[int],
+    input_size: Tuple[int],
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> torch.Tensor:
+    logger.debug("GEMS UPSAMPLE NEAREST2D BACKWARD")
+    assert grad_output.device.type == device
+    assert grad_output.ndim == 4, "The ndim of grad_output must be 4"
+    assert len(output_size) == 2, "The len of output_size must be 2"
+    assert len(input_size) == 4, "The len of input_size must be 4"
+
+    OH, OW = int(output_size[0]), int(output_size[1])
+    N, C, IH, IW = [int(dim) for dim in input_size]
+    reciprocal_scale_h = _get_reciprocal_scale(IH, OH, scales_h)
+    reciprocal_scale_w = _get_reciprocal_scale(IW, OW, scales_w)
+
+    if scales_h is None and OH == IH:
+        ih = torch.arange(OH, device=grad_output.device, dtype=torch.int64)
+    else:
+        oh = torch.arange(OH, device=grad_output.device, dtype=torch.float32)
+        ih = torch.clamp((oh * reciprocal_scale_h).to(torch.int64), max=IH - 1)
+
+    if scales_w is None and OW == IW:
+        iw = torch.arange(OW, device=grad_output.device, dtype=torch.int64)
+    else:
+        ow = torch.arange(OW, device=grad_output.device, dtype=torch.float32)
+        iw = torch.clamp((ow * reciprocal_scale_w).to(torch.int64), max=IW - 1)
+
+    index = (ih[:, None] * IW + iw[None, :]).reshape(1, 1, -1)
+    index = index.expand(N, C, -1)
+
+    accum_dtype = (
+        torch.float32
+        if grad_output.dtype in (torch.float16, torch.bfloat16)
+        else grad_output.dtype
+    )
+    grad_output_accum = _to_copy_fallback(grad_output, accum_dtype)
+    grad_output_flat = grad_output_accum.reshape(N, C, -1)
+    grad_input_flat = torch.zeros(
+        (N, C, IH * IW), device=grad_output.device, dtype=accum_dtype
+    )
+    torch.ops.aten.scatter_add_.default.redispatch(
+        _FALLBACK_KEYSET, grad_input_flat, 2, index, grad_output_flat
+    )
+    grad_input = grad_input_flat.reshape(N, C, IH, IW)
+    return _to_copy_fallback(grad_input, grad_output.dtype)


### PR DESCRIPTION
## Summary
- Add `upsample_nearest2d_backward` with explicit index mapping and scatter accumulation.
- Share reciprocal scale helper between forward/backward.
- Bypass FlagGems `to_copy` and `scatter_add_` via redispatch.
- Add backward accuracy tests and document results.

## Design / Implementation
- Computes input indices from `output_size` and reciprocal scales (matching forward).
- Builds flattened index map and accumulates via `scatter_add_` redispatch.
- Uses `_to_copy` redispatch for dtype conversion (fp16/bf16 → fp32 → original).

## Compliance (4.1.2)
- **Style**: PEP 8.
- **API parity**: matches `upsample_nearest2d_backward` signature.
- **Originality**: implemented for FlagGems competition.
- **License**: agree to Apache 2.0 inclusion with core-contributor attribution.

## Compatibility (4.1.3)
- **Dtypes**: float16, float32, bfloat16.
- **Input dims**: NCHW 4D.
- **Hardware**: NVIDIA CUDA (user-run).

## Test Coverage Checklist (4.1.4)
- Shapes: (1,1,4,4), (2,3,32,32), (1,4,128,128).
- Scales: (2.0, 2.0), (1.5, 0.75), (0.5, 0.5).
- Scale modes: explicit scales and derived output_size.

## Testing
- `python -m pytest tests/test_special_ops.py::test_upsample_nearest2d_backward -v`
  - **54 passed**, **0 failed**
