### PR TITLE
[FlagGems Operator Development Competition] add leaky_relu operator

### DIFF
--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -284,6 +284,8 @@ _FULL_CONFIG = (
     ("reciprocal_", reciprocal_),
     ("relu", relu),
     ("relu_", relu_),
+    ("leaky_relu", leaky_relu),
+    ("leaky_relu_", leaky_relu_),
     ("remainder.Scalar", remainder),
     ("remainder.Scalar_Tensor", remainder),
     ("remainder.Tensor", remainder),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -113,6 +113,7 @@ from flag_gems.ops.isinf import isinf
 from flag_gems.ops.isnan import isnan
 from flag_gems.ops.kron import kron
 from flag_gems.ops.layernorm import layer_norm, layer_norm_backward
+from flag_gems.ops.leaky_relu import leaky_relu, leaky_relu_
 from flag_gems.ops.le import le, le_scalar
 from flag_gems.ops.lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tensor_
 from flag_gems.ops.linspace import linspace
@@ -383,6 +384,8 @@ __all__ = [
     "kron",
     "layer_norm",
     "layer_norm_backward",
+    "leaky_relu",
+    "leaky_relu_",
     "le",
     "le_scalar",
     "lerp_scalar",

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -113,8 +113,8 @@ from flag_gems.ops.isinf import isinf
 from flag_gems.ops.isnan import isnan
 from flag_gems.ops.kron import kron
 from flag_gems.ops.layernorm import layer_norm, layer_norm_backward
-from flag_gems.ops.leaky_relu import leaky_relu, leaky_relu_
 from flag_gems.ops.le import le, le_scalar
+from flag_gems.ops.leaky_relu import leaky_relu, leaky_relu_
 from flag_gems.ops.lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tensor_
 from flag_gems.ops.linspace import linspace
 from flag_gems.ops.log import log

--- a/src/flag_gems/ops/leaky_relu.py
+++ b/src/flag_gems/ops/leaky_relu.py
@@ -1,0 +1,25 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, "DEFAULT")])
+@triton.jit
+def leaky_relu_kernel(x, negative_slope):
+    x_fp32 = x.to(tl.float32)
+    return tl.where(x_fp32 > 0, x_fp32, x_fp32 * negative_slope)
+
+
+def leaky_relu(A, negative_slope=0.01):
+    logger.debug("GEMS LEAKY_RELU")
+    return leaky_relu_kernel(A, negative_slope)
+
+
+def leaky_relu_(A, negative_slope=0.01):
+    logger.debug("GEMS LEAKY_RELU_")
+    return leaky_relu_kernel(A, negative_slope, out0=A)

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -767,6 +767,43 @@ def test_accuracy_relu_(shape, dtype):
     gems_assert_close(res_out, ref_out, dtype)
 
 
+@pytest.mark.leaky_relu
+@pytest.mark.parametrize("negative_slope", [0.01, 0.1, 2.0])
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_leaky_relu(shape, dtype, negative_slope):
+    res_inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(res_inp, True)
+
+    ref_out = torch.nn.functional.leaky_relu(ref_inp, negative_slope=negative_slope)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.leaky_relu(
+            res_inp, negative_slope=negative_slope
+        )
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.inplace
+@pytest.mark.leaky_relu_
+@pytest.mark.parametrize("negative_slope", [0.01, 0.1, 2.0])
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_leaky_relu_(shape, dtype, negative_slope):
+    res_inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(res_inp.clone(), True)
+
+    ref_out = torch.nn.functional.leaky_relu(
+        ref_inp, negative_slope=negative_slope, inplace=True
+    )
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.leaky_relu(
+            res_inp, negative_slope=negative_slope, inplace=True
+        )
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
 @pytest.mark.softplus
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -777,9 +777,7 @@ def test_accuracy_leaky_relu(shape, dtype, negative_slope):
 
     ref_out = torch.nn.functional.leaky_relu(ref_inp, negative_slope=negative_slope)
     with flag_gems.use_gems():
-        res_out = torch.nn.functional.leaky_relu(
-            res_inp, negative_slope=negative_slope
-        )
+        res_out = torch.nn.functional.leaky_relu(res_inp, negative_slope=negative_slope)
 
     gems_assert_close(res_out, ref_out, dtype)
 


### PR DESCRIPTION
## Summary
- Add `leaky_relu` pointwise operator with Triton kernel.
- Register `leaky_relu` and `leaky_relu_` in FlagGems.
- Add accuracy tests for forward and in-place variants.

## Design / Implementation
- Kernel computes `where(x > 0, x, x * negative_slope)` with FP32 compute.
- Supports configurable `negative_slope` and in-place path.

## Compliance (4.1.2)
- **Style**: PEP 8.
- **API parity**: matches `torch.nn.functional.leaky_relu` and in-place variant.
- **Originality**: implemented for FlagGems competition.
- **License**: agree to Apache 2.0 inclusion with core-contributor attribution.

## Compatibility (4.1.3)
- **Dtypes**: float16, float32, bfloat16.
- **Input dims**: scalar to 5D (POINTWISE_SHAPES).
- **Hardware**: NVIDIA CUDA (user-run).

## Test Coverage Checklist (4.1.4)
- POINTWISE_SHAPES × FLOAT_DTYPES × negative_slope {0.01, 0.1, 2.0}.
- Covers forward and in-place branches.

## Testing
- `python -m pytest tests/test_unary_pointwise_ops.py -k 'leaky_relu' -v`
  - **108 passed**, **0 failed**
