### PR TITLE
[FlagGems Operator Development Competition] add roll operator

### DIFF
--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -293,6 +293,7 @@ _FULL_CONFIG = (
     ("repeat_interleave.self_int", repeat_interleave_self_int),
     ("repeat_interleave.self_Tensor", repeat_interleave_self_tensor),
     ("repeat_interleave.Tensor", repeat_interleave_tensor),
+    ("roll", roll),
     ("resolve_conj", resolve_conj),
     ("resolve_neg", resolve_neg),
     ("rms_norm", rms_norm),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -193,6 +193,7 @@ from flag_gems.ops.resolve_conj import resolve_conj
 from flag_gems.ops.resolve_neg import resolve_neg
 from flag_gems.ops.rms_norm import rms_norm, rms_norm_backward, rms_norm_forward
 from flag_gems.ops.rsqrt import rsqrt, rsqrt_
+from flag_gems.ops.roll import roll
 from flag_gems.ops.scaled_softmax import scaled_softmax_backward, scaled_softmax_forward
 from flag_gems.ops.scatter import scatter, scatter_
 from flag_gems.ops.scatter_add_ import scatter_add_
@@ -476,6 +477,7 @@ __all__ = [
     "rms_norm_forward",
     "rsqrt",
     "rsqrt_",
+    "roll",
     "scaled_dot_product_attention",
     "scaled_dot_product_attention_backward",
     "scaled_dot_product_attention_forward",

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -192,8 +192,8 @@ from flag_gems.ops.repeat_interleave import (
 from flag_gems.ops.resolve_conj import resolve_conj
 from flag_gems.ops.resolve_neg import resolve_neg
 from flag_gems.ops.rms_norm import rms_norm, rms_norm_backward, rms_norm_forward
-from flag_gems.ops.rsqrt import rsqrt, rsqrt_
 from flag_gems.ops.roll import roll
+from flag_gems.ops.rsqrt import rsqrt, rsqrt_
 from flag_gems.ops.scaled_softmax import scaled_softmax_backward, scaled_softmax_forward
 from flag_gems.ops.scatter import scatter, scatter_
 from flag_gems.ops.scatter_add_ import scatter_add_

--- a/src/flag_gems/ops/roll.py
+++ b/src/flag_gems/ops/roll.py
@@ -8,7 +8,9 @@ logger = logging.getLogger(__name__)
 def _normalize_shifts_dims(shifts, dims, ndim):
     if dims is None:
         if isinstance(shifts, (list, tuple)):
-            raise RuntimeError("shifts and dimensions must align for roll.")
+            if len(shifts) != 1:
+                raise RuntimeError("shifts and dimensions must align for roll.")
+            shifts = shifts[0]
         return (int(shifts),), (0,)
 
     if isinstance(dims, int):

--- a/src/flag_gems/ops/roll.py
+++ b/src/flag_gems/ops/roll.py
@@ -4,13 +4,57 @@ import torch
 
 logger = logging.getLogger(__name__)
 
-_FALLBACK_KEYSET = torch._C.DispatchKeySet(
-    torch._C.DispatchKey.CompositeExplicitAutograd
-)
+
+def _normalize_shifts_dims(shifts, dims, ndim):
+    if dims is None:
+        if isinstance(shifts, (list, tuple)):
+            if len(shifts) != 1:
+                raise RuntimeError("shifts and dimensions must align for roll.")
+            shifts = shifts[0]
+        return (int(shifts),), (0,)
+
+    if isinstance(dims, int):
+        dims_tuple = (dims,)
+    else:
+        dims_tuple = tuple(int(d) for d in dims)
+
+    if isinstance(shifts, int):
+        shifts_tuple = (int(shifts),) * len(dims_tuple)
+    else:
+        shifts_tuple = tuple(int(s) for s in shifts)
+
+    if len(shifts_tuple) != len(dims_tuple):
+        raise RuntimeError("shifts and dimensions must align for roll.")
+
+    dims_tuple = tuple(d % ndim for d in dims_tuple)
+    if len(set(dims_tuple)) != len(dims_tuple):
+        raise RuntimeError("dims cannot contain duplicate values.")
+
+    return shifts_tuple, dims_tuple
+
+
+def _roll_dim(x: torch.Tensor, shift: int, dim: int) -> torch.Tensor:
+    size = x.size(dim)
+    if size == 0:
+        return x
+    shift = shift % size
+    if shift == 0:
+        return x
+    left = x.narrow(dim, size - shift, shift)
+    right = x.narrow(dim, 0, size - shift)
+    return torch.cat((left, right), dim=dim)
 
 
 def roll(self, shifts, dims=None):
     logger.debug("GEMS ROLL")
-    return torch.ops.aten.roll.default.redispatch(
-        _FALLBACK_KEYSET, self, shifts, dims
-    )
+    shifts_tuple, dims_tuple = _normalize_shifts_dims(shifts, dims, self.dim())
+
+    if dims is None:
+        flat = self.reshape(-1)
+        rolled = _roll_dim(flat, shifts_tuple[0], 0)
+        return rolled.reshape(self.shape)
+
+    out = self
+    for shift, dim in zip(shifts_tuple, dims_tuple):
+        out = _roll_dim(out, shift, dim)
+    return out

--- a/src/flag_gems/ops/roll.py
+++ b/src/flag_gems/ops/roll.py
@@ -8,27 +8,24 @@ logger = logging.getLogger(__name__)
 def _normalize_shifts_dims(shifts, dims, ndim):
     if dims is None:
         if isinstance(shifts, (list, tuple)):
-            if len(shifts) != 1:
-                raise RuntimeError("shifts and dimensions must align for roll.")
-            shifts = shifts[0]
+            raise RuntimeError("shifts and dimensions must align for roll.")
         return (int(shifts),), (0,)
 
     if isinstance(dims, int):
-        dims_tuple = (dims,)
+        dims_tuple = (int(dims),)
     else:
         dims_tuple = tuple(int(d) for d in dims)
 
-    if isinstance(shifts, int):
-        shifts_tuple = (int(shifts),) * len(dims_tuple)
-    else:
+    if isinstance(shifts, (list, tuple)):
         shifts_tuple = tuple(int(s) for s in shifts)
-
-    if len(shifts_tuple) != len(dims_tuple):
-        raise RuntimeError("shifts and dimensions must align for roll.")
+        if len(shifts_tuple) != len(dims_tuple):
+            raise RuntimeError("shifts and dimensions must align for roll.")
+    else:
+        if len(dims_tuple) != 1:
+            raise RuntimeError("shifts and dimensions must align for roll.")
+        shifts_tuple = (int(shifts),)
 
     dims_tuple = tuple(d % ndim for d in dims_tuple)
-    # PyTorch applies shifts sequentially even if dims normalize to the same value
-    # So we keep all shifts and dims as-is, without deduplication
     return shifts_tuple, dims_tuple
 
 

--- a/src/flag_gems/ops/roll.py
+++ b/src/flag_gems/ops/roll.py
@@ -1,0 +1,16 @@
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeExplicitAutograd
+)
+
+
+def roll(self, shifts, dims=None):
+    logger.debug("GEMS ROLL")
+    return torch.ops.aten.roll.default.redispatch(
+        _FALLBACK_KEYSET, self, shifts, dims
+    )

--- a/src/flag_gems/ops/roll.py
+++ b/src/flag_gems/ops/roll.py
@@ -27,9 +27,8 @@ def _normalize_shifts_dims(shifts, dims, ndim):
         raise RuntimeError("shifts and dimensions must align for roll.")
 
     dims_tuple = tuple(d % ndim for d in dims_tuple)
-    if len(set(dims_tuple)) != len(dims_tuple):
-        raise RuntimeError("dims cannot contain duplicate values.")
-
+    # PyTorch applies shifts sequentially even if dims normalize to the same value
+    # So we keep all shifts and dims as-is, without deduplication
     return shifts_tuple, dims_tuple
 
 

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -54,6 +54,35 @@ SCORING_FUNC_LIST = [0, 1] if not QUICK_MODE else [0]
 DTYPE_LIST = [torch.bfloat16, torch.float32] if not QUICK_MODE else [torch.float32]
 LARGE_SCALE_DTYPE_LIST = [torch.float32, torch.bfloat16]
 
+ROLL_SHAPES = [
+    (8,),
+    (2, 5),
+    (2, 3, 4),
+    (2, 3, 4, 5),
+    (2, 3, 4, 5, 6),
+]
+
+ROLL_CASES = [
+    (1, None),
+    (-2, 0),
+    (1, (0, -1)),
+    ((1, -1), (0, -1)),
+]
+
+
+def _roll_is_valid(shape, shifts, dims):
+    ndim = len(shape)
+    if dims is None:
+        return not isinstance(shifts, (tuple, list))
+    if isinstance(dims, int):
+        return -ndim <= dims < ndim
+    dims_tuple = tuple(dims)
+    if any(d < -ndim or d >= ndim for d in dims_tuple):
+        return False
+    if isinstance(shifts, (tuple, list)) and len(shifts) != len(dims_tuple):
+        return False
+    return True
+
 
 def check_valid_config(n_expert, n_group, topk):
     if n_expert % n_group != 0:
@@ -135,6 +164,23 @@ def test_accuracy_grouped_topk(
 
     atol, rtol = get_tolerance(dtype, scoring_func, renormalize)
     torch.testing.assert_close(res_topk_weights, ref_topk_weights, atol=atol, rtol=rtol)
+
+
+@pytest.mark.roll
+@pytest.mark.parametrize("shape", ROLL_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("shifts,dims", ROLL_CASES)
+def test_accuracy_roll(shape, dtype, shifts, dims):
+    if not _roll_is_valid(shape, shifts, dims):
+        pytest.skip("Invalid shifts/dims for input shape.")
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp)
+
+    ref_out = torch.roll(ref_inp, shifts=shifts, dims=dims)
+    with flag_gems.use_gems():
+        res_out = torch.roll(inp, shifts=shifts, dims=dims)
+
+    gems_assert_equal(res_out, ref_out)
 
 
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -75,11 +75,18 @@ def _roll_is_valid(shape, shifts, dims):
     if dims is None:
         return not isinstance(shifts, (tuple, list))
     if isinstance(dims, int):
-        return -ndim <= dims < ndim
+        if not (-ndim <= dims < ndim):
+            return False
+        if isinstance(shifts, (tuple, list)) and len(shifts) != 1:
+            return False
+        return True
     dims_tuple = tuple(dims)
     if any(d < -ndim or d >= ndim for d in dims_tuple):
         return False
-    if isinstance(shifts, (tuple, list)) and len(shifts) != len(dims_tuple):
+    if isinstance(shifts, (tuple, list)):
+        if len(shifts) != len(dims_tuple):
+            return False
+    else:
         return False
     return True
 


### PR DESCRIPTION
## Summary
- Implement `roll` directly via `narrow` + `cat` to avoid recursion.
- Align shifts/dims validation with PyTorch semantics, including single-item shifts list/tuple when `dims=None`.
- Register `roll` and add accuracy tests for 1D–5D shapes.

## Design / Implementation
- Normalizes `shifts`/`dims` (negative dims supported).
- If `dims=None`, flattens to 1D, rolls, then reshapes back.
- For multiple dims, applies roll sequentially per dimension using `narrow` + `cat`.
- Mirrors PyTorch error semantics for invalid `(shifts, dims)` combinations.

## Compliance (4.1.2)
- **Style**: PEP 8, minimal branching.
- **API parity**: matches `torch.roll(input, shifts, dims=None)`.
- **Originality**: implemented for FlagGems competition.
- **License**: agree to Apache 2.0 inclusion with core-contributor attribution.

## Compatibility (4.1.3)
- **Dtypes**: float16, float32, bfloat16.
- **Input dims**: 1D–5D.
- **Hardware**: NVIDIA CUDA (user-run).

## Test Coverage Checklist (4.1.4)
- Shapes: (8,), (2,5), (2,3,4), (2,3,4,5), (2,3,4,5,6).
- Cases: `(1, None)`, `(-2, 0)`, `((1, -1), (0, -1))`.
- Skip: single shift with multiple dims (unsupported by PyTorch).

## Testing
- `python -m pytest tests/test_special_ops.py -k 'roll' -v`
  - **45 passed**, **15 skipped** (PyTorch unsupported: single shift with multiple dims)
