### PR TITLE
[FlagGems Operator Development Competition] add logaddexp operator

### DIFF
--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -206,6 +206,8 @@ _FULL_CONFIG = (
     ("linalg_vector_norm", vector_norm),
     ("linspace", linspace),
     ("log", log),
+    ("logaddexp", logaddexp),
+    ("logaddexp.out", logaddexp_out),
     ("log_sigmoid", log_sigmoid),
     ("logical_and", logical_and),
     ("logical_and_", logical_and_),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -117,6 +117,7 @@ from flag_gems.ops.le import le, le_scalar
 from flag_gems.ops.lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tensor_
 from flag_gems.ops.linspace import linspace
 from flag_gems.ops.log import log
+from flag_gems.ops.logaddexp import logaddexp, logaddexp_out
 from flag_gems.ops.log_sigmoid import log_sigmoid
 from flag_gems.ops.log_softmax import log_softmax, log_softmax_backward
 from flag_gems.ops.logical_and import logical_and, logical_and_
@@ -391,6 +392,8 @@ __all__ = [
     "lerp_tensor_",
     "linspace",
     "log",
+    "logaddexp",
+    "logaddexp_out",
     "log_sigmoid",
     "log_softmax",
     "log_softmax_backward",

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -117,9 +117,9 @@ from flag_gems.ops.le import le, le_scalar
 from flag_gems.ops.lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tensor_
 from flag_gems.ops.linspace import linspace
 from flag_gems.ops.log import log
-from flag_gems.ops.logaddexp import logaddexp, logaddexp_out
 from flag_gems.ops.log_sigmoid import log_sigmoid
 from flag_gems.ops.log_softmax import log_softmax, log_softmax_backward
+from flag_gems.ops.logaddexp import logaddexp, logaddexp_out
 from flag_gems.ops.logical_and import logical_and, logical_and_
 from flag_gems.ops.logical_not import logical_not
 from flag_gems.ops.logical_or import logical_or, logical_or_

--- a/src/flag_gems/ops/logaddexp.py
+++ b/src/flag_gems/ops/logaddexp.py
@@ -1,0 +1,31 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(is_tensor=[True, True], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def logaddexp_kernel(x, y):
+    x_fp32 = x.to(tl.float32)
+    y_fp32 = y.to(tl.float32)
+    m = tl.maximum(x_fp32, y_fp32)
+    return m + tl.log(1.0 + tl.exp(-tl.abs(x_fp32 - y_fp32)))
+
+
+def logaddexp(self, other):
+    logger.debug("GEMS LOGADDEXP")
+    if not self.is_floating_point() or not other.is_floating_point():
+        raise RuntimeError("logaddexp is only supported for floating point tensors.")
+    return logaddexp_kernel(self, other)
+
+
+def logaddexp_out(self, other, out):
+    logger.debug("GEMS LOGADDEXP OUT")
+    if not self.is_floating_point() or not other.is_floating_point():
+        raise RuntimeError("logaddexp is only supported for floating point tensors.")
+    return logaddexp_kernel(self, other, out0=out)

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -2166,3 +2166,37 @@ def test_accuracy_addcdiv(shape, dtype):
         res_out = torch.addcdiv(res_inp, t1, t2, value=v)
 
     gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.logaddexp
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_logaddexp(shape, dtype):
+    inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp1 = to_reference(inp1, True)
+    ref_inp2 = to_reference(inp2, True)
+
+    ref_out = torch.logaddexp(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.logaddexp(inp1, inp2)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.logaddexp
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_logaddexp_out(shape, dtype):
+    inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp1 = to_reference(inp1, True)
+    ref_inp2 = to_reference(inp2, True)
+
+    ref_out = torch.empty_like(ref_inp1)
+    torch.logaddexp(ref_inp1, ref_inp2, out=ref_out)
+    with flag_gems.use_gems():
+        res_out = torch.empty_like(inp1)
+        torch.logaddexp(inp1, inp2, out=res_out)
+
+    gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
## Summary
- Add `logaddexp` pointwise operator with numerically stable Triton kernel.
- Register `logaddexp` and `logaddexp.out` in FlagGems.
- Add accuracy tests for forward and out variants.

## Design / Implementation
- Uses stable formulation: `max(x, y) + log(1 + exp(-abs(x - y)))`.
- Promotes inputs to `float32` inside kernel for stability.
- Out variant uses the same kernel via `out0`.

## Compliance (4.1.2)
- **Style**: PEP 8, minimal branching.
- **API parity**: matches `logaddexp(Tensor, Tensor)` and `logaddexp.out`.
- **Originality**: implemented for FlagGems competition.
- **License**: agree to Apache 2.0 inclusion with core-contributor attribution.

## Compatibility (4.1.3)
- **Dtypes**: float16, float32, bfloat16 (where supported).
- **Input dims**: scalar to 5D (POINTWISE_SHAPES).
- **Hardware**: NVIDIA CUDA (user-run).

## Test Coverage Checklist (4.1.4)
- Covers POINTWISE_SHAPES across FLOAT_DTYPES.
- Validates forward and out paths.

## Testing
- `pytest tests/test_binary_pointwise_ops.py -k 'logaddexp' -v`
  - **36 passed**, **0 failed**
