### PR TITLE
Fix PR label caching problem

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -17,9 +17,14 @@ jobs:
     outputs:
       changed_files: ${{ steps.changed-files.outputs.all_changed_files }}
       pr_id: ${{ steps.get-pr-id.outputs.PR_ID }}
+      labels: ${{ steps.get-labels.outputs.result }}
     steps:
       - id: changed-files
         uses: tj-actions/changed-files@v47
+      - id: wait-for-triage
+        uses: ArcticLampyrid/action-wait-for-workflow@v1.3.0
+        with:
+          workflow: .github/workflows/triage.yaml
       - id: get-pr-id
         shell: bash
         run: |
@@ -30,25 +35,41 @@ jobs:
             PR_ID=${PR_NUMBER}
           fi
           echo "PR_ID=${PR_ID}" >> "$GITHUB_OUTPUT"
-
-      - id: wait-for-triage
-        uses: ArcticLampyrid/action-wait-for-workflow@v1.3.0
+          # NOTE: Preserve these line for debugging's purpose
+          echo "PR_ID: ${PR_ID}"
+      - id: get-labels
+        uses: actions/github-script@v8
         with:
-          workflow: .github/workflows/triage.yaml
+          script: |
+            // Determine if the event is a pull request
+            const isPullRequest = context.eventName === 'pull_request';
+            if (!isPullRequest) {
+              return "";
+            }
+            const prNumber = context.payload.pull_request.number;
+
+            const { data: labels } = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            console.log('Labels:', labels.map(label => label.name));
+            return JSON.stringify(labels.map(label => label.name));
 
   build-doc:
     needs: preprocess
-    if: contains(github.event.pull_request.labels.*.name, 'documentation')
+    if: contains(needs.preprocess.outpus.labels, 'documentation')
     uses: ./.github/workflows/mkdocs.yaml
 
   cpp-op:
     needs: preprocess
-    if: contains(github.event.pull_request.labels.*.name, 'ops/cpp')
+    if: contains(needs.preprocess.outputs.labels, 'ops/cpp')
     uses: ./.github/workflows/cpp-op-test.yaml
 
   blas-op:
     needs: preprocess
-    if: contains(github.event.pull_request.labels.*.name, 'tests')
+    if: contains(needs.preprocess.outputs.labels, 'tests')
     concurrency:
       group: blas-op-test-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
@@ -61,7 +82,7 @@ jobs:
     needs: preprocess
     # NOTE: This contains a temporary hack to skip this job for PRs from FODC contest.
     if: |
-      contains(github.event.pull_request.labels.*.name, 'tests') &&
+      contains(needs.preprocess.outputs.labels, 'tests') &&
       ! contains(github.event.pull_request.labels.*.name, 'competition')
     concurrency:
       group: op-test-quick-cpu-${{ github.event.pull_request.number || github.ref }}
@@ -73,7 +94,7 @@ jobs:
 
   pointwise-op:
     needs: preprocess
-    if: contains(github.event.pull_request.labels.*.name, 'tests')
+    if: contains(needs.preprocess.outputs.labels, 'tests')
     concurrency:
       group: pointwise-op-test-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
@@ -84,7 +105,7 @@ jobs:
 
   reduction-op:
     needs: preprocess
-    if: contains(github.event.pull_request.labels.*.name, 'tests')
+    if: contains(needs.preprocess.outputs.labels, 'tests')
     concurrency:
       group: reduction-op-test-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
@@ -95,7 +116,7 @@ jobs:
 
   special-op:
     needs: preprocess
-    if: contains(github.event.pull_request.labels.*.name, 'tests')
+    if: contains(needs.preprocess.outputs.labels, 'tests')
     concurrency:
       group: special-op-test-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
@@ -106,7 +127,7 @@ jobs:
 
   utils:
     needs: preprocess
-    if: "contains(github.event.pull_request.labels.*.name, 'tests')"
+    if: contains(needs.preprocess.outputs.labels, 'tests')
     concurrency:
       group: op-utils-test-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
@@ -117,7 +138,7 @@ jobs:
 
   examples:
     needs: preprocess
-    if: contains(github.event.pull_request.labels.*.name, 'tests')
+    if: contains(needs.preprocess.outputs.labels, 'examples')
     concurrency:
       group: examples-test-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
@@ -128,7 +149,7 @@ jobs:
 
   backend-nvidia:
     needs: preprocess
-    if: "contains(github.event.pull_request.labels.*.name, 'vendor/NVIDIA')"
+    if: contains(needs.preprocess.outputs.labels, 'vendor/NVIDIA')
     uses: ./.github/workflows/backend-test.yaml
     with:
       vendor: nvidia
@@ -138,7 +159,7 @@ jobs:
 
   backend-ascend:
     needs: preprocess
-    if: "contains(github.event.pull_request.labels.*.name, 'vendor/Ascend')"
+    if: contains(needs.preprocess.outputs.labels, 'vendor/Ascend')
     uses: ./.github/workflows/backend-test.yaml
     with:
       vendor: ascend
@@ -148,7 +169,7 @@ jobs:
 
   backend-iluvatar:
     needs: preprocess
-    if: "contains(github.event.pull_request.labels.*.name, 'vendor/Iluvatar')"
+    if: contains(needs.preprocess.outputs.labels, 'vendor/Iluvatar')
     uses: ./.github/workflows/backend-test.yaml
     with:
       vendor: iluvatar
@@ -158,7 +179,7 @@ jobs:
 
   backend-metax:
     needs: preprocess
-    if: "contains(github.event.pull_request.labels.*.name, 'vendor/MetaX')"
+    if: contains(needs.preprocess.outputs.labels, 'vendor/MetaX')
     uses: ./.github/workflows/backend-test.yaml
     with:
       vendor: metax
@@ -167,7 +188,7 @@ jobs:
 
   backend-moore:
     needs: preprocess
-    if: "contains(github.event.pull_request.labels.*.name, 'vendor/MooreThreads')"
+    if: contains(needs.preprocess.outputs.labels, 'vendor/MooreThreads')
     uses: ./.github/workflows/backend-test.yaml
     with:
       vendor: moore
@@ -177,7 +198,7 @@ jobs:
 
   alpha-ops:
     needs: preprocess
-    if: "contains(github.event.pull_request.labels.*.name, 'ops/alpha')"
+    if: contains(needs.preprocess.outputs.labels, 'ops/alpha')
     uses: ./.github/workflows/backend-test.yaml
     with:
       vendor: nvidia

--- a/tests/test_blas_ops.py
+++ b/tests/test_blas_ops.py
@@ -7,20 +7,30 @@ import torch
 
 import flag_gems
 
-from .accuracy_utils import (
-    FLOAT_DTYPES,
-    SCALARS,
-    UT_SHAPES_1D,
-    gems_assert_close,
-    to_reference,
-)
+from .accuracy_utils import FLOAT_DTYPES as ORIG_FLOAT_DTYPES
+from .accuracy_utils import SCALARS, UT_SHAPES_1D, gems_assert_close, to_reference
 from .conftest import QUICK_MODE
 
-MN_SHAPES = [(1, 32)] if QUICK_MODE else [(1, 32), (160, 1024), (5333, 497)]
-MNK_SHAPES = (
-    [(1, 1, 32)] if QUICK_MODE else [(1, 1, 32), (15, 160, 1024), (495, 5333, 71)]
-)
-FLOAT_DTYPES = [torch.float32] if QUICK_MODE else FLOAT_DTYPES
+if QUICK_MODE:
+    MN_SHAPES = [
+        (1, 32),
+    ]
+    MNK_SHAPES = [
+        (1, 1, 32),
+    ]
+    FLOAT_DTYPES = [torch.float32]
+else:
+    MN_SHAPES = [
+        (1, 32),
+        (160, 1024),
+        (5333, 497),
+    ]
+    MNK_SHAPES = [
+        (1, 1, 32),
+        (15, 160, 1024),
+        (495, 5333, 71),
+    ]
+    FLOAT_DTYPES = ORIG_FLOAT_DTYPES
 
 
 @pytest.mark.addmm


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The original way of checking `github.event.pull_request` context has some problems when determining if a PR has certain labels. The labels are likely to be cached when the unit-test workflow starts. The `triage` workflow might have added new labels to a PR, but we cannot reliably get the latest status using the `github` context. This PR fixes the problem by explicitly invoking github APIs for a fresh state. 

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
