### PR TITLE
Fix script of GPU check on iluvatar runners

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -83,7 +83,7 @@ jobs:
     # NOTE: This contains a temporary hack to skip this job for PRs from FODC contest.
     if: |
       contains(needs.preprocess.outputs.labels, 'tests') &&
-      ! contains(github.event.pull_request.labels.*.name, 'competition')
+      ! contains(needs.preprocess.outputs.outputs.labels, 'competition')
     concurrency:
       group: op-test-quick-cpu-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true

--- a/tools/gpu_check_iluvatar.sh
+++ b/tools/gpu_check_iluvatar.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+export PATH=/usr/local/corex/bin:$PATH
+export LD_LIBRARY_PATH=/usr/local/corex/lib64:$LD_LIBRARY_PATH
+
 # Configuration parameters
 memory_usage_max=30000     # Maximum memory usage limit (MB)
 sleep_time=120             # Wait time (seconds), default is 2 minutes

--- a/tools/run_backend_tests.sh
+++ b/tools/run_backend_tests.sh
@@ -9,27 +9,56 @@ export GEMS_VENDOR=$VENDOR
 
 source tools/run_command.sh
 
-echo "Running FlagGems tests with GEMS_VENDOR=$VENDOR"
+echo "Running FlagGems tests for VENDOR $VENDOR"
 
-# Tensor constructor ops
+if [ "$VENDOR" == "iluvatar" ]; then
+  export PATH=/usr/local/corex/bin:$PATH
+  export LD_LIBRARY_PATH=/usr/local/corex/lib64:$LD_LIBRARY_PATH
+  export PYENV_ROOT="$HOME/.pyenv"
+  [[ -d $PYENV_ROOT/bin ]] && export PATH="$PYENV_ROOT/bin:$PATH"
+  eval "$(pyenv init - bash)"
+fi
+
+python -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -U scikit-build-core>=0.11 pybind11 ninja cmake uv
+uv pip install -e '.[test]'
+
+# Reduction ops
+if [ "$VENDOR" != "moore" ]; then
+  # FIXME(moore): Softmax only support float32/float16/bfloat16
+  run_command python3 -m pytest -s tests/test_reduction_ops.py
+  # FIXME(moore): BatchNorm supports Float/Half/BFloat16 input dtype
+  run_command python3 -m pytest -s tests/test_norm_ops.py
+fi
+run_command python3 -m pytest -s tests/test_general_reduction_ops.py
+
+# Pointwise ops
+run_command python3 -m pytest -s tests/test_pointwise_dynamic.py
+if [ "$VENDOR" != "moore" ]; then
+  # FIXME(moore): RuntimeError: _Map_base::at (missing operators)
+  run_command python3 -m pytest -s tests/test_unary_pointwise_ops.py
+fi
+run_command python3 -m pytest -s tests/test_binary_pointwise_ops.py
+run_command python3 -m pytest -s tests/test_pointwise_type_promotion.py
 run_command python3 -m pytest -s tests/test_tensor_constructor_ops.py
+
+# BLAS ops
+run_command python3 -m pytest -s tests/test_attention_ops.py
+if [ "$VENDOR" != "moore" ]; then
+  # FIXME(moore): unsupported data type DOUBLE
+  run_command python3 -m pytest -s tests/test_blas_ops.py
+fi
+
+# Special ops
+run_command python3 -m pytest -s tests/test_special_ops.py
+run_command python3 -m pytest -s tests/test_distribution_ops.py
+
+# Convolution ops
+run_command python3 -m pytest -s tests/test_convolution_ops.py
 
 # Utils
 run_command python3 -m pytest -s tests/test_libentry.py
 run_command python3 -m pytest -s tests/test_shape_utils.py
 run_command python3 -m pytest -s tests/test_tensor_wrapper.py
-
-# Pointwise dynamic ops
-run_command python3 -m pytest -s tests/test_pointwise_dynamic.py
-
-# Distribution ops
-run_command python3 -m pytest -s tests/test_distribution_ops.py
-
-# FIXME(moore): Softmax only support float32/float16/bfloat16
-# run_command python3 -m pytest -s tests/test_reduction_ops.py
-# FIXME(moore): BatchNorm supports Float/Half/BFloat16 input dtype
-# run_command python3 -m pytest -s tests/test_norm_ops.py
-# FIXME(moore): RuntimeError: _Map_base::at (missing operators)
-# run_command python3 -m pytest -s tests/test_unary_pointwise_ops.py
-# FIXME(moore): unsupported data type DOUBLE
-# run_command python3 -m pytest -s tests/test_blas_ops.py


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The tool chain for Iluvatar accelerator lives in a special directory.
This has to be configured before running the GPU check and test cases so that the latter can find GPUs to use.
This PR also attempts to turn all scripts on for Iluvatar platforms, while treating MooreThreads as a special beast.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
