### PR TITLE
【KernelGen】Add top_k_per_row_decode operator for vLLM speculative decoding

### DIFF
--- a/benchmark/test_vllm_perf.py
+++ b/benchmark/test_vllm_perf.py
@@ -367,11 +367,11 @@ class TopKPerRowDecodeBenchmark(Benchmark):
     DEFAULT_METRICS = ["latency_base", "latency", "speedup"]
 
     def __init__(self):
-        from flag_gems.fused.top_k_per_row_decode import top_k_per_row_decode
-
         # vLLM reference function
         # Must import vllm._C first to register torch.ops._C.top_k_per_row_decode
         import vllm._C  # noqa: F401
+
+        from flag_gems.fused.top_k_per_row_decode import top_k_per_row_decode
 
         def vllm_top_k_per_row_decode(
             logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k

--- a/benchmark/test_vllm_perf.py
+++ b/benchmark/test_vllm_perf.py
@@ -239,3 +239,206 @@ class CutlassScaledMMBenchmark(Benchmark):
 def test_cutlass_scaled_mm_benchmark():
     bench = CutlassScaledMMBenchmark()
     bench.run()
+
+
+# ============ cp_gather_indexer_k_quant_cache benchmark ============
+class CpGatherIndexerKQuantCacheBenchmark(Benchmark):
+    """Benchmark for cp_gather_indexer_k_quant_cache operator.
+
+    Note: vLLM's C++ kernel requires head_dim % 128 == 0.
+    FlagGems implementation is more flexible.
+    This benchmark tests FlagGems implementation only (latency measurement).
+    """
+
+    DEFAULT_METRICS = ["latency"]
+
+    def __init__(self):
+        from flag_gems.fused.cp_gather_indexer_k_quant_cache import (
+            cp_gather_indexer_k_quant_cache,
+        )
+
+        super().__init__(
+            "cp_gather_indexer_k_quant_cache",
+            cp_gather_indexer_k_quant_cache,  # Use gems op as torch_op for latency
+            dtypes=["fp8"],
+        )
+
+    def set_shapes(self, shape_file_path=None):
+        # (batch_size, max_seq_len, head_dim, block_size)
+        self.shapes = [
+            (1, 128, 64, 16),
+            (2, 256, 64, 16),
+            (4, 512, 128, 32),
+            (8, 256, 64, 16),
+            (16, 128, 64, 32),
+            (32, 64, 128, 16),
+            (4, 1024, 64, 64),
+            (8, 512, 128, 32),
+            (16, 1024, 128, 32),
+            (32, 512, 128, 64),
+        ]
+
+    def get_input_iter(self, dtype):
+        for batch_size, max_seq_len, head_dim, block_size in self.shapes:
+            device = flag_gems.device
+
+            # Generate deterministic sequence lengths (must be divisible by 4 for fp8->fp32 view)
+            # Use max_seq_len for all batches to ensure num_tokens % 4 == 0
+            seq_lens = torch.full(
+                (batch_size,),
+                max_seq_len,
+                device=device,
+                dtype=torch.int32,
+            )
+
+            # Create cumulative sequence lengths
+            cu_seq_lens = torch.zeros(batch_size + 1, device=device, dtype=torch.int32)
+            cu_seq_lens[1:] = torch.cumsum(seq_lens, dim=0)
+            num_tokens = int(cu_seq_lens[-1].item())
+            # Ensure num_tokens is divisible by 4
+            num_tokens = (num_tokens // 4) * 4
+            if num_tokens < 4:
+                num_tokens = 4
+            cu_seq_lens[-1] = num_tokens
+
+            # Calculate number of blocks needed
+            num_blocks_per_seq = (max_seq_len + block_size - 1) // block_size
+            total_blocks = batch_size * num_blocks_per_seq
+
+            # cache_stride = head_dim + 4 (4 bytes for float32 scale per token)
+            cache_stride = head_dim + 4
+
+            # Create kv_cache: [num_blocks, block_size, cache_stride]
+            kv_cache = torch.zeros(
+                total_blocks,
+                block_size,
+                cache_stride,
+                dtype=torch.float8_e4m3fn,
+                device=device,
+            )
+
+            # Fill with random data
+            for b in range(batch_size):
+                seq_len = int(seq_lens[b].item())
+                for pos in range(seq_len):
+                    block_idx = b * num_blocks_per_seq + pos // block_size
+                    block_offset = pos % block_size
+                    kv_cache[block_idx, block_offset, :head_dim] = to_fp8(
+                        torch.randn(head_dim, device=device) * 0.1
+                    )
+                    scale_val = torch.tensor(
+                        [0.5 + pos * 0.01], dtype=torch.float32, device=device
+                    )
+                    kv_cache[block_idx, block_offset, head_dim:] = scale_val.view(
+                        torch.float8_e4m3fn
+                    )
+
+            # Create block_table: [batch_size, num_blocks_per_seq]
+            block_table = torch.arange(
+                total_blocks, device=device, dtype=torch.int32
+            ).view(batch_size, num_blocks_per_seq)
+
+            # Create output tensors
+            dst_k = torch.empty(
+                num_tokens, head_dim, dtype=torch.float8_e4m3fn, device=device
+            )
+            dst_scale = torch.empty(
+                num_tokens, 1, dtype=torch.float8_e4m3fn, device=device
+            )
+
+            yield (kv_cache, dst_k, dst_scale, block_table, cu_seq_lens)
+
+
+@pytest.mark.cp_gather_indexer_k_quant_cache
+@pytest.mark.performance
+def test_cp_gather_indexer_k_quant_cache_benchmark():
+    bench = CpGatherIndexerKQuantCacheBenchmark()
+    bench.run()
+
+
+# ============ top_k_per_row_decode benchmark ============
+class TopKPerRowDecodeBenchmark(Benchmark):
+    """Benchmark for top_k_per_row_decode operator.
+
+    Compares FlagGems Triton implementation with vLLM CUDA implementation.
+    Uses histogram-based radix select O(n) algorithm.
+    """
+
+    DEFAULT_METRICS = ["latency_base", "latency", "speedup"]
+
+    def __init__(self):
+        from flag_gems.fused.top_k_per_row_decode import top_k_per_row_decode
+
+        # vLLM reference function
+        # Must import vllm._C first to register torch.ops._C.top_k_per_row_decode
+        import vllm._C  # noqa: F401
+
+        def vllm_top_k_per_row_decode(
+            logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k
+        ):
+            torch.ops._C.top_k_per_row_decode(
+                logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k
+            )
+
+        super().__init__(
+            "top_k_per_row_decode",
+            vllm_top_k_per_row_decode,
+            dtypes=["small_rows", "medium_rows", "large_rows"],
+        )
+        self.set_gems(top_k_per_row_decode)
+
+    def set_shapes(self, shape_file_path=None):
+        # (num_rows, vocab_size, stride, top_k)
+        self.shapes = {
+            "small_rows": [
+                (32, 20000, 1, 10),
+                (32, 128256, 1, 10),
+            ],
+            "medium_rows": [
+                (128, 20000, 1, 10),
+                (128, 128256, 1, 10),
+            ],
+            "large_rows": [
+                (1024, 20000, 1, 10),
+                (1024, 128256, 1, 10),
+                (2048, 20000, 1, 10),
+                (2048, 128256, 1, 10),
+                (4096, 20000, 1, 10),
+                (4096, 128256, 1, 10),
+                (8192, 20000, 1, 10),
+                (8192, 128256, 1, 10),
+            ],
+        }
+
+    def get_input_iter(self, dtype):
+        shapes = self.shapes.get(dtype, [])
+        for num_rows, vocab_size, stride, top_k in shapes:
+            device = flag_gems.device
+            batch_size = num_rows
+            next_n = 1
+
+            # Create logits tensor
+            logits = torch.randn(
+                num_rows, vocab_size, dtype=torch.float32, device=device
+            )
+
+            # Create seq_lens - each sequence has vocab_size valid elements
+            seq_lens = torch.full(
+                (batch_size,), vocab_size, dtype=torch.int32, device=device
+            )
+
+            # Create output indices tensor
+            indices = torch.empty(num_rows, top_k, dtype=torch.int32, device=device)
+
+            stride0 = logits.stride(0)
+            stride1 = logits.stride(1)
+
+            yield (logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k)
+
+
+@pytest.mark.skipif(not VLLM_AVAILABLE, reason="requires vLLM")
+@pytest.mark.top_k_per_row_decode
+@pytest.mark.performance
+def test_top_k_per_row_decode_benchmark():
+    bench = TopKPerRowDecodeBenchmark()
+    bench.run()

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -27,6 +27,7 @@ from flag_gems.fused.rwkv_mm_sparsity import rwkv_mm_sparsity
 from flag_gems.fused.silu_and_mul import silu_and_mul, silu_and_mul_out
 from flag_gems.fused.skip_layernorm import skip_layer_norm
 from flag_gems.fused.swiglu import dswiglu, swiglu
+from flag_gems.fused.top_k_per_row_decode import top_k_per_row_decode
 from flag_gems.fused.topk_softmax import topk_softmax
 from flag_gems.fused.weight_norm import weight_norm
 
@@ -60,6 +61,7 @@ __all__ = [
     "silu_and_mul_out",
     "skip_layer_norm",
     "swiglu",
+    "top_k_per_row_decode",
     "topk_softmax",
     "weight_norm",
 ]

--- a/src/flag_gems/fused/top_k_per_row_decode.py
+++ b/src/flag_gems/fused/top_k_per_row_decode.py
@@ -1,0 +1,283 @@
+"""
+top_k_per_row_decode: Triton implementation for vLLM's top_k_per_row_decode kernel.
+
+Uses histogram-based radix select (O(n) algorithm) for efficient top-k selection.
+Based on bin_topk.py, with fixed block sizes and proper boundary handling.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+
+
+@triton.jit
+def convert_to_uint32(x):
+    """Convert float32 to uint32 for histogram binning, preserving order."""
+    bits_uint = x.cast(dtype=tl.uint32, bitcast=True)
+    bits_uint = tl.where(
+        x < 0,
+        ~bits_uint & tl.cast((0xFFFFFFFF), tl.uint32, bitcast=True),
+        bits_uint | tl.cast((0x80000000), tl.uint32, bitcast=True),
+    )
+    return bits_uint
+
+
+@triton.jit
+def kernel_topk_decode_histogram(
+    inputs,  # (num_rows, vocab_size) logits
+    indices,  # (num_rows, K) output topk indices
+    s_input_ids,  # Temp buffer for candidates
+    seq_lens,  # (batch_size,) sequence lengths
+    next_n,  # number of speculative tokens
+    stride0,  # logits.stride(0)
+    stride1,  # logits.stride(1)
+    S: tl.constexpr,  # vocab_size
+    K: tl.constexpr,  # top_k
+    HISTOGRAM_SIZE: tl.constexpr,
+    SMEM_INPUT_SIZE: tl.constexpr,
+    BS: tl.constexpr,  # block size for vocab iteration
+    BSS: tl.constexpr,  # block size for candidate iteration
+):
+    """
+    Histogram-based radix select for top-k selection.
+    Uses O(n) algorithm with 256-bin histogram and multi-round refinement.
+    Properly handles boundary case where valid_count < K.
+    """
+    row_idx = tl.program_id(0)
+
+    # Compute row boundaries based on decode semantics
+    batch_idx = row_idx // next_n
+    next_n_offset = row_idx % next_n
+    seq_len = tl.load(seq_lens + batch_idx)
+    l_end_idx = seq_len - next_n + next_n_offset + 1
+    l_end_idx = tl.minimum(l_end_idx, S)
+    l_end_idx = tl.maximum(l_end_idx, 0)
+    l_start_idx = 0
+
+    # Calculate valid element count and actual k to select
+    valid_count = l_end_idx - l_start_idx
+    actual_k = tl.minimum(K, valid_count)
+
+    # Block base pointer definitions
+    s_base = inputs + row_idx * stride0
+    indices_base = indices + row_idx * K
+    s_input_ids_base = s_input_ids + row_idx * SMEM_INPUT_SIZE
+
+    # Early exit if no valid elements
+    if valid_count <= 0:
+        return
+
+    # Histogram initialization
+    s_histogram = tl.zeros([HISTOGRAM_SIZE], dtype=tl.int32)
+
+    # Record how many positions remain to fill the topk array
+    l_new_topk = actual_k
+
+    # Round 0: Build histogram using uint32 high 8 bits
+    TS = tl.cdiv(S, BS)
+    for s in range(TS):
+        input_idx = s * BS + tl.arange(0, BS)
+        input_mask = (input_idx < l_end_idx) & (input_idx >= l_start_idx) & (input_idx < S)
+        if stride1 == 1:
+            input_val = tl.load(s_base + input_idx, input_mask, other=float("-inf")).to(tl.float32)
+        else:
+            input_val = tl.load(s_base + input_idx * stride1, input_mask, other=float("-inf")).to(tl.float32)
+        inval_uint8 = (convert_to_uint32(input_val) >> 24) & 0xFF
+        s_histogram += inval_uint8.to(tl.int32).histogram(HISTOGRAM_SIZE)
+
+    # Find threshold bin using suffix sum
+    s_histogram = s_histogram.cumsum(0, reverse=True)
+    mv_idx = (tl.arange(1, HISTOGRAM_SIZE + 1) % HISTOGRAM_SIZE)
+    cond = (s_histogram > l_new_topk) & ((s_histogram.gather(mv_idx, 0) <= l_new_topk) | (mv_idx == 0))
+    l_threshold_bin_id = cond.argmax(0)
+    l_new_topk -= tl.where(tl.arange(0, HISTOGRAM_SIZE) == l_threshold_bin_id + 1, s_histogram, 0).max(0)
+
+    # Partition elements: above threshold -> output, equal threshold -> candidates
+    sum_val = 0
+    thre_bin_sum = 0
+    for s in range(TS):
+        input_idx = s * BS + tl.arange(0, BS)
+        input_mask = (input_idx < l_end_idx) & (input_idx >= l_start_idx) & (input_idx < S)
+        if stride1 == 1:
+            input_val = tl.load(s_base + input_idx, input_mask, other=float("-inf")).to(tl.float32)
+        else:
+            input_val = tl.load(s_base + input_idx * stride1, input_mask, other=float("-inf")).to(tl.float32)
+        inval_uint8 = (convert_to_uint32(input_val) >> 24) & 0xFF
+
+        # Must AND with input_mask to exclude invalid positions
+        over_thre = (inval_uint8.to(tl.int32) > l_threshold_bin_id) & input_mask
+        cur_sum = over_thre.to(tl.int32).sum(-1)
+        eq_thre = (inval_uint8.to(tl.int32) == l_threshold_bin_id) & input_mask
+        thre_bin_cur_sum = eq_thre.to(tl.int32).sum(-1)
+
+        topk_idx = over_thre.to(tl.int32).cumsum(-1)
+        thre_bin_idx = eq_thre.to(tl.int32).cumsum(-1)
+
+        # Bound check for candidate storage to avoid buffer overflow
+        candidate_write_pos = thre_bin_sum + thre_bin_idx - 1
+        eq_thre_bounded = eq_thre & (candidate_write_pos < SMEM_INPUT_SIZE)
+
+        concat_mask = tl.cat(over_thre, eq_thre_bounded, True)
+        concat_input = tl.cat(input_idx, input_idx, True)
+        concat_pointer_matrix = tl.cat(
+            indices_base + sum_val + topk_idx - 1,
+            s_input_ids_base + candidate_write_pos,
+            True,
+        )
+        tl.store(concat_pointer_matrix, concat_input, mask=concat_mask)
+
+        # Track actual candidates stored (bounded by SMEM_INPUT_SIZE)
+        thre_bin_sum = tl.minimum(thre_bin_sum + thre_bin_cur_sum, SMEM_INPUT_SIZE)
+        sum_val += cur_sum
+
+    # Subsequent rounds: refine using more bits (23-16, 15-8, 7-0)
+    # Use fixed max iterations to avoid dynamic loop bound issues in Triton JIT
+    MAX_CAND_ITERS: tl.constexpr = (SMEM_INPUT_SIZE + BSS - 1) // BSS
+
+    round_num = 1
+    while round_num < 4 and l_new_topk > 0:
+        ss = tl.cdiv(thre_bin_sum, BSS)
+        s_histogram = tl.zeros([HISTOGRAM_SIZE], dtype=tl.int32)
+        padding_num = 0.0
+
+        for s in range(MAX_CAND_ITERS):
+            if s < ss:
+                s_input_idx = s * BSS + tl.arange(0, BSS)
+                s_input_idx_mask = s_input_idx < thre_bin_sum
+                input_idx = tl.load(s_input_ids_base + s_input_idx, s_input_idx_mask, other=-1)
+                if stride1 == 1:
+                    s_input = tl.load(s_base + input_idx, s_input_idx_mask, other=padding_num).to(tl.float32)
+                else:
+                    s_input = tl.load(s_base + input_idx * stride1, s_input_idx_mask, other=padding_num).to(tl.float32)
+                inval_int32 = (convert_to_uint32(s_input) >> (24 - round_num * 8)) & 0xFF
+                s_histogram += inval_int32.to(tl.int32).histogram(HISTOGRAM_SIZE)
+
+        s_histogram = s_histogram.cumsum(0, reverse=True)
+        mv_idx = (tl.arange(1, HISTOGRAM_SIZE + 1) % HISTOGRAM_SIZE)
+        cond = (s_histogram > l_new_topk) & ((s_histogram.gather(mv_idx, 0) <= l_new_topk) | (mv_idx == 0))
+        l_threshold_bin_id = cond.argmax(0)
+        l_new_topk -= tl.where(tl.arange(0, HISTOGRAM_SIZE) == l_threshold_bin_id + 1, s_histogram, 0).max(0)
+        thre_bin_sum, old_thre_bin_sum = 0, thre_bin_sum
+        old_ss = ss
+
+        for s in range(MAX_CAND_ITERS):
+            if s < old_ss:
+                s_input_idx = s * BSS + tl.arange(0, BSS)
+                s_input_idx_mask = s_input_idx < old_thre_bin_sum
+                input_idx = tl.load(s_input_ids_base + s_input_idx, s_input_idx_mask, other=-1)
+                if stride1 == 1:
+                    s_input = tl.load(s_base + input_idx, s_input_idx_mask, other=padding_num).to(tl.float32)
+                else:
+                    s_input = tl.load(s_base + input_idx * stride1, s_input_idx_mask, other=padding_num).to(tl.float32)
+                inval_int32 = (convert_to_uint32(s_input) >> (24 - round_num * 8)) & 0xFF
+
+                # Must AND with s_input_idx_mask to exclude invalid positions (padding values)
+                over_thre = (inval_int32.to(tl.int32) > l_threshold_bin_id) & s_input_idx_mask
+                cur_sum = over_thre.to(tl.int32).sum(-1)
+                eq_thre = (inval_int32.to(tl.int32) == l_threshold_bin_id) & s_input_idx_mask
+                thre_bin_cur_sum = eq_thre.to(tl.int32).sum(-1)
+
+                topk_idx = over_thre.to(tl.int32).cumsum(-1)
+                thre_bin_idx = eq_thre.to(tl.int32).cumsum(-1)
+
+                # Bound check for candidate storage to avoid buffer overflow
+                candidate_write_pos = thre_bin_sum + thre_bin_idx - 1
+                eq_thre_bounded = eq_thre & (candidate_write_pos < SMEM_INPUT_SIZE)
+
+                concat_mask = tl.cat(over_thre, eq_thre_bounded, True)
+                concat_input = tl.cat(input_idx, input_idx, True)
+                concat_pointer_matrix = tl.cat(
+                    indices_base + sum_val + topk_idx - 1,
+                    s_input_ids_base + candidate_write_pos,
+                    True,
+                )
+                tl.store(concat_pointer_matrix, concat_input, mask=concat_mask)
+
+                # Track actual candidates stored (bounded by SMEM_INPUT_SIZE)
+                thre_bin_sum = tl.minimum(thre_bin_sum + thre_bin_cur_sum, SMEM_INPUT_SIZE)
+                sum_val += cur_sum
+
+        round_num += 1
+
+    # Copy remaining candidates if needed
+    # Copy min(l_new_topk, thre_bin_sum) elements - we may have fewer candidates than needed
+    copy_count = tl.minimum(l_new_topk, thre_bin_sum)
+    if copy_count > 0:
+        ss = tl.cdiv(copy_count, BSS)
+        MAX_COPY_ITERS: tl.constexpr = (K + BSS - 1) // BSS
+        for s in range(MAX_COPY_ITERS):
+            if s < ss:
+                s_input_idx = s * BSS + tl.arange(0, BSS)
+                s_input_idx_mask = s_input_idx < copy_count
+                input_idx = tl.load(s_input_ids_base + s_input_idx, s_input_idx_mask, other=-1)
+                tl.store(indices_base + sum_val + tl.arange(0, BSS), input_idx, mask=s_input_idx_mask)
+                sum_val += BSS
+
+
+def top_k_per_row_decode(
+    logits: torch.Tensor,
+    next_n: int,
+    seq_lens: torch.Tensor,
+    indices: torch.Tensor,
+    num_rows: int,
+    stride0: int,
+    stride1: int,
+    top_k: int,
+) -> None:
+    """
+    Select top-k indices from each row of logits for speculative decoding.
+
+    Uses histogram-based radix select (O(n) algorithm) for efficient selection.
+
+    Args:
+        logits: Input logits tensor [num_rows, vocab_size], float32
+        next_n: Number of speculative tokens
+        seq_lens: Sequence lengths tensor [batch_size], int32
+        indices: Output indices tensor [num_rows, top_k], int32 (modified in-place)
+        num_rows: Number of rows to process
+        stride0: logits.stride(0)
+        stride1: logits.stride(1)
+        top_k: Number of top elements to select
+    """
+    assert logits.dtype == torch.float32, "logits must be float32"
+    assert seq_lens.dtype == torch.int32, "seq_lens must be int32"
+    assert indices.dtype == torch.int32, "indices must be int32"
+
+    vocab_size = logits.shape[1]
+    device = logits.device
+
+    # Fixed block sizes to avoid autotune LLVM issues
+    BS = 2048  # Block size for vocab iteration (increased for better parallelism)
+    BSS = 512  # Block size for candidate iteration (increased for better parallelism)
+    HISTOGRAM_SIZE = 256
+    # For worst case (e.g., 10LSBits data where all values have same high bits),
+    # all elements could become candidates. Use vocab_size as upper bound.
+    SMEM_INPUT_SIZE = min(vocab_size, 65536)  # Cap at 64K to limit memory usage
+
+    # Allocate temp buffer for candidates
+    s_input_ids = torch.zeros(
+        num_rows, SMEM_INPUT_SIZE, dtype=torch.int32, device=device
+    )
+
+    # Initialize indices to -1 (invalid marker)
+    indices.fill_(-1)
+
+    grid = (num_rows,)
+    with torch_device_fn.device(device):
+        kernel_topk_decode_histogram[grid](
+            logits,
+            indices,
+            s_input_ids,
+            seq_lens,
+            next_n,
+            stride0,
+            stride1,
+            vocab_size,
+            top_k,
+            HISTOGRAM_SIZE,
+            SMEM_INPUT_SIZE,
+            BS,
+            BSS,
+        )

--- a/src/flag_gems/fused/top_k_per_row_decode.py
+++ b/src/flag_gems/fused/top_k_per_row_decode.py
@@ -79,31 +79,47 @@ def kernel_topk_decode_histogram(
     TS = tl.cdiv(S, BS)
     for s in range(TS):
         input_idx = s * BS + tl.arange(0, BS)
-        input_mask = (input_idx < l_end_idx) & (input_idx >= l_start_idx) & (input_idx < S)
+        input_mask = (
+            (input_idx < l_end_idx) & (input_idx >= l_start_idx) & (input_idx < S)
+        )
         if stride1 == 1:
-            input_val = tl.load(s_base + input_idx, input_mask, other=float("-inf")).to(tl.float32)
+            input_val = tl.load(s_base + input_idx, input_mask, other=float("-inf")).to(
+                tl.float32
+            )
         else:
-            input_val = tl.load(s_base + input_idx * stride1, input_mask, other=float("-inf")).to(tl.float32)
+            input_val = tl.load(
+                s_base + input_idx * stride1, input_mask, other=float("-inf")
+            ).to(tl.float32)
         inval_uint8 = (convert_to_uint32(input_val) >> 24) & 0xFF
         s_histogram += inval_uint8.to(tl.int32).histogram(HISTOGRAM_SIZE)
 
     # Find threshold bin using suffix sum
     s_histogram = s_histogram.cumsum(0, reverse=True)
-    mv_idx = (tl.arange(1, HISTOGRAM_SIZE + 1) % HISTOGRAM_SIZE)
-    cond = (s_histogram > l_new_topk) & ((s_histogram.gather(mv_idx, 0) <= l_new_topk) | (mv_idx == 0))
+    mv_idx = tl.arange(1, HISTOGRAM_SIZE + 1) % HISTOGRAM_SIZE
+    cond = (s_histogram > l_new_topk) & (
+        (s_histogram.gather(mv_idx, 0) <= l_new_topk) | (mv_idx == 0)
+    )
     l_threshold_bin_id = cond.argmax(0)
-    l_new_topk -= tl.where(tl.arange(0, HISTOGRAM_SIZE) == l_threshold_bin_id + 1, s_histogram, 0).max(0)
+    l_new_topk -= tl.where(
+        tl.arange(0, HISTOGRAM_SIZE) == l_threshold_bin_id + 1, s_histogram, 0
+    ).max(0)
 
     # Partition elements: above threshold -> output, equal threshold -> candidates
     sum_val = 0
     thre_bin_sum = 0
     for s in range(TS):
         input_idx = s * BS + tl.arange(0, BS)
-        input_mask = (input_idx < l_end_idx) & (input_idx >= l_start_idx) & (input_idx < S)
+        input_mask = (
+            (input_idx < l_end_idx) & (input_idx >= l_start_idx) & (input_idx < S)
+        )
         if stride1 == 1:
-            input_val = tl.load(s_base + input_idx, input_mask, other=float("-inf")).to(tl.float32)
+            input_val = tl.load(s_base + input_idx, input_mask, other=float("-inf")).to(
+                tl.float32
+            )
         else:
-            input_val = tl.load(s_base + input_idx * stride1, input_mask, other=float("-inf")).to(tl.float32)
+            input_val = tl.load(
+                s_base + input_idx * stride1, input_mask, other=float("-inf")
+            ).to(tl.float32)
         inval_uint8 = (convert_to_uint32(input_val) >> 24) & 0xFF
 
         # Must AND with input_mask to exclude invalid positions
@@ -146,19 +162,33 @@ def kernel_topk_decode_histogram(
             if s < ss:
                 s_input_idx = s * BSS + tl.arange(0, BSS)
                 s_input_idx_mask = s_input_idx < thre_bin_sum
-                input_idx = tl.load(s_input_ids_base + s_input_idx, s_input_idx_mask, other=-1)
+                input_idx = tl.load(
+                    s_input_ids_base + s_input_idx, s_input_idx_mask, other=-1
+                )
                 if stride1 == 1:
-                    s_input = tl.load(s_base + input_idx, s_input_idx_mask, other=padding_num).to(tl.float32)
+                    s_input = tl.load(
+                        s_base + input_idx, s_input_idx_mask, other=padding_num
+                    ).to(tl.float32)
                 else:
-                    s_input = tl.load(s_base + input_idx * stride1, s_input_idx_mask, other=padding_num).to(tl.float32)
-                inval_int32 = (convert_to_uint32(s_input) >> (24 - round_num * 8)) & 0xFF
+                    s_input = tl.load(
+                        s_base + input_idx * stride1,
+                        s_input_idx_mask,
+                        other=padding_num,
+                    ).to(tl.float32)
+                inval_int32 = (
+                    convert_to_uint32(s_input) >> (24 - round_num * 8)
+                ) & 0xFF
                 s_histogram += inval_int32.to(tl.int32).histogram(HISTOGRAM_SIZE)
 
         s_histogram = s_histogram.cumsum(0, reverse=True)
-        mv_idx = (tl.arange(1, HISTOGRAM_SIZE + 1) % HISTOGRAM_SIZE)
-        cond = (s_histogram > l_new_topk) & ((s_histogram.gather(mv_idx, 0) <= l_new_topk) | (mv_idx == 0))
+        mv_idx = tl.arange(1, HISTOGRAM_SIZE + 1) % HISTOGRAM_SIZE
+        cond = (s_histogram > l_new_topk) & (
+            (s_histogram.gather(mv_idx, 0) <= l_new_topk) | (mv_idx == 0)
+        )
         l_threshold_bin_id = cond.argmax(0)
-        l_new_topk -= tl.where(tl.arange(0, HISTOGRAM_SIZE) == l_threshold_bin_id + 1, s_histogram, 0).max(0)
+        l_new_topk -= tl.where(
+            tl.arange(0, HISTOGRAM_SIZE) == l_threshold_bin_id + 1, s_histogram, 0
+        ).max(0)
         thre_bin_sum, old_thre_bin_sum = 0, thre_bin_sum
         old_ss = ss
 
@@ -166,17 +196,31 @@ def kernel_topk_decode_histogram(
             if s < old_ss:
                 s_input_idx = s * BSS + tl.arange(0, BSS)
                 s_input_idx_mask = s_input_idx < old_thre_bin_sum
-                input_idx = tl.load(s_input_ids_base + s_input_idx, s_input_idx_mask, other=-1)
+                input_idx = tl.load(
+                    s_input_ids_base + s_input_idx, s_input_idx_mask, other=-1
+                )
                 if stride1 == 1:
-                    s_input = tl.load(s_base + input_idx, s_input_idx_mask, other=padding_num).to(tl.float32)
+                    s_input = tl.load(
+                        s_base + input_idx, s_input_idx_mask, other=padding_num
+                    ).to(tl.float32)
                 else:
-                    s_input = tl.load(s_base + input_idx * stride1, s_input_idx_mask, other=padding_num).to(tl.float32)
-                inval_int32 = (convert_to_uint32(s_input) >> (24 - round_num * 8)) & 0xFF
+                    s_input = tl.load(
+                        s_base + input_idx * stride1,
+                        s_input_idx_mask,
+                        other=padding_num,
+                    ).to(tl.float32)
+                inval_int32 = (
+                    convert_to_uint32(s_input) >> (24 - round_num * 8)
+                ) & 0xFF
 
                 # Must AND with s_input_idx_mask to exclude invalid positions (padding values)
-                over_thre = (inval_int32.to(tl.int32) > l_threshold_bin_id) & s_input_idx_mask
+                over_thre = (
+                    inval_int32.to(tl.int32) > l_threshold_bin_id
+                ) & s_input_idx_mask
                 cur_sum = over_thre.to(tl.int32).sum(-1)
-                eq_thre = (inval_int32.to(tl.int32) == l_threshold_bin_id) & s_input_idx_mask
+                eq_thre = (
+                    inval_int32.to(tl.int32) == l_threshold_bin_id
+                ) & s_input_idx_mask
                 thre_bin_cur_sum = eq_thre.to(tl.int32).sum(-1)
 
                 topk_idx = over_thre.to(tl.int32).cumsum(-1)
@@ -196,7 +240,9 @@ def kernel_topk_decode_histogram(
                 tl.store(concat_pointer_matrix, concat_input, mask=concat_mask)
 
                 # Track actual candidates stored (bounded by SMEM_INPUT_SIZE)
-                thre_bin_sum = tl.minimum(thre_bin_sum + thre_bin_cur_sum, SMEM_INPUT_SIZE)
+                thre_bin_sum = tl.minimum(
+                    thre_bin_sum + thre_bin_cur_sum, SMEM_INPUT_SIZE
+                )
                 sum_val += cur_sum
 
         round_num += 1
@@ -211,8 +257,14 @@ def kernel_topk_decode_histogram(
             if s < ss:
                 s_input_idx = s * BSS + tl.arange(0, BSS)
                 s_input_idx_mask = s_input_idx < copy_count
-                input_idx = tl.load(s_input_ids_base + s_input_idx, s_input_idx_mask, other=-1)
-                tl.store(indices_base + sum_val + tl.arange(0, BSS), input_idx, mask=s_input_idx_mask)
+                input_idx = tl.load(
+                    s_input_ids_base + s_input_idx, s_input_idx_mask, other=-1
+                )
+                tl.store(
+                    indices_base + sum_val + tl.arange(0, BSS),
+                    input_idx,
+                    mask=s_input_idx_mask,
+                )
                 sum_val += BSS
 
 

--- a/src/flag_gems/patches/patch_vllm_all.py
+++ b/src/flag_gems/patches/patch_vllm_all.py
@@ -428,6 +428,23 @@ def custom_concat_and_cache_mla(
     )
 
 
+def custom_top_k_per_row_decode(
+    logits: torch.Tensor,
+    next_n: int,
+    seq_lens: torch.Tensor,
+    indices: torch.Tensor,
+    num_rows: int,
+    stride0: int,
+    stride1: int,
+    top_k: int,
+) -> None:
+    from flag_gems.fused.top_k_per_row_decode import top_k_per_row_decode
+
+    return top_k_per_row_decode(
+        logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k
+    )
+
+
 def custom_gems_flashattn_mla_forward_decode(
     self,
     q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
@@ -585,6 +602,7 @@ def apply_gems_patches_to_vllm(verbose=True):
     lib_patches = [
         ("_C", "silu_and_mul", custom_silu_and_mul),
         ("_C", "cutlass_scaled_mm", custom_cutlass_scaled_mm),
+        ("_C", "top_k_per_row_decode", custom_top_k_per_row_decode),
         ("_moe_C", "moe_align_block_size", custom_moe_align_block_size),
         ("_moe_C", "topk_softmax", custom_topk_softmax),
         ("_moe_C", "moe_sum", custom_moe_sum),

--- a/tests/test_vllm_ops.py
+++ b/tests/test_vllm_ops.py
@@ -233,3 +233,294 @@ def test_cutlass_scaled_mm(p):
         rtol, atol = 5e-1, 1.5e-1
 
     torch.testing.assert_close(c, output_ref, rtol=rtol, atol=atol)
+
+
+# ============================================================================
+# top_k_per_row_decode tests (converted from vLLM)
+# ============================================================================
+
+# Test parameters for top_k_per_row_decode
+TOP_K_VALUES = [2048, 3000]
+TOP_K_BATCH_SIZE = [1, 2, 2048]
+TOP_K_NEXT_N = [1, 8]
+TOP_K_DATA_GENERATION = ["random", "10LSBits"]
+
+
+def create_random_logits(
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    dtype: torch.dtype,
+    seed: int,
+    clean_logits: bool,
+    data_generation: str,
+) -> torch.Tensor:
+    """Create random logits tensor for testing."""
+    torch.manual_seed(seed)
+    device = flag_gems.device
+    # Generate logits with some structure to make testing more meaningful
+    if data_generation == "random":
+        logits = torch.randn(
+            row_starts.shape[0], max(row_ends), dtype=dtype, device=device
+        )
+    elif data_generation == "10LSBits":
+        top_22_bits_mask = 0xFFFFFC00
+        last_10_bits_mask = 0x000003FF
+        fixed_top_22_bits = 0x3F900000
+        # Generate random bits for the last 10 bits
+        random_bottom_bits = torch.randint(
+            0,
+            2**10,
+            (row_starts.shape[0], max(row_ends)),
+            dtype=torch.int32,
+            device=device,
+        )
+        # Combine: fixed top 22 bits with random last 10 bits
+        logits_bits = (fixed_top_22_bits & top_22_bits_mask) | (
+            random_bottom_bits & last_10_bits_mask
+        )
+        logits = logits_bits.view(dtype)
+    else:
+        raise ValueError(f"Unknown data_generation: {data_generation}")
+
+    if clean_logits:
+        for i, end in enumerate(row_ends):
+            logits[i, int(end):] = float("-inf")
+    return logits
+
+
+def compare_top_k_results(
+    logits: torch.Tensor,
+    gems_indices: torch.Tensor,
+    torch_indices: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    top_k: int,
+    tolerance: float = 1e-5,
+) -> bool:
+    """
+    Compare results from FlagGems top_k_per_row with torch.topk.
+    Both results should contain the same top-k elements (values, not necessarily indices).
+    """
+    num_rows = gems_indices.shape[0]
+
+    for row_idx in range(num_rows):
+        # Get valid elements using row boundaries
+        row_start = row_starts[row_idx].item()
+        row_end = row_ends[row_idx].item()
+        row_length = row_end - row_start
+        num_valid = min(top_k, row_length)
+        gems_row_indices = gems_indices[row_idx][:num_valid].cpu()
+        torch_row_indices = torch_indices[row_idx][:num_valid].cpu()
+
+        # Compare the sets of indices first
+        gems_set = set(gems_row_indices.tolist())
+        torch_set = set(torch_row_indices.tolist())
+        if gems_set == torch_set:
+            continue
+
+        # Any difference in elements, compare the values
+        logits_row = logits[row_idx]
+        gems_row_values = [logits_row[i] for i in gems_row_indices]
+        torch_row_values = [logits_row[i] for i in torch_row_indices]
+
+        gems_only_values, torch_only_values = [], []
+        for idx in gems_set - torch_set:
+            gems_pos = (gems_row_indices == idx).nonzero(as_tuple=True)[0]
+            gems_only_values.append(gems_row_values[gems_pos[0]])
+
+        for idx in torch_set - gems_set:
+            torch_pos = (torch_row_indices == idx).nonzero(as_tuple=True)[0]
+            torch_only_values.append(torch_row_values[torch_pos[0]])
+
+        if len(gems_only_values) != len(torch_only_values):
+            return False
+        if not torch.allclose(
+            torch.tensor(gems_only_values),
+            torch.tensor(torch_only_values),
+            rtol=tolerance,
+            atol=tolerance,
+        ):
+            return False
+
+    return True
+
+
+def _run_top_k_per_row_decode_test(
+    top_k: int,
+    batch_size: int,
+    next_n: int,
+    vocab_size: int,
+    clean_logits: bool,
+    data_generation: str,
+) -> None:
+    """
+    Helper function to run top_k_per_row_decode test with given parameters.
+    """
+    from flag_gems.fused.top_k_per_row_decode import top_k_per_row_decode
+
+    device = flag_gems.device
+
+    # Create test data
+    num_rows = batch_size * next_n
+    seq_lens = torch.randint(
+        low=next_n,
+        high=vocab_size,
+        size=(batch_size,),
+        dtype=torch.int32,
+        device=device,
+    )
+    row_starts = torch.zeros(num_rows, dtype=torch.int32, device=device)
+    row_indices = torch.arange(num_rows, device=device) // next_n
+    next_n_offset = torch.arange(num_rows, device=device) % next_n
+    row_ends = seq_lens[row_indices] - next_n + next_n_offset + 1
+    logits = create_random_logits(
+        row_starts, row_ends, torch.float32, 42, clean_logits, data_generation
+    )
+
+    # Create output tensors
+    indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
+
+    # Run FlagGems implementation
+    top_k_per_row_decode(
+        logits,
+        next_n,
+        seq_lens,
+        indices,
+        num_rows,
+        logits.stride(0),
+        logits.stride(1),
+        top_k,
+    )
+
+    torch.cuda.synchronize() if device == "cuda" else None
+
+    # Run reference implementation
+    torch_indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
+    for i in range(num_rows):
+        row_end = int(row_ends[i])
+        k_i = min(top_k, row_end)
+        idx = logits[i, :row_end].topk(k_i, dim=-1)[1]
+        torch_indices[i, :k_i] = idx
+
+    # Compare results
+    assert compare_top_k_results(
+        logits, indices, torch_indices, row_starts, row_ends, top_k
+    ), "FlagGems top_k_per_row_decode results don't match torch.topk"
+
+
+@pytest.mark.skipif(flag_gems.device != "cuda", reason="This test requires CUDA")
+@pytest.mark.top_k_per_row_decode
+@pytest.mark.parametrize("top_k", TOP_K_VALUES if not QUICK_MODE else [2048])
+@pytest.mark.parametrize("batch_size", TOP_K_BATCH_SIZE if not QUICK_MODE else [1, 32])
+@pytest.mark.parametrize("next_n", TOP_K_NEXT_N if not QUICK_MODE else [1])
+@pytest.mark.parametrize("clean_logits", [True, False] if not QUICK_MODE else [True])
+@pytest.mark.parametrize("data_generation", TOP_K_DATA_GENERATION if not QUICK_MODE else ["random"])
+@torch.inference_mode()
+def test_top_k_per_row_decode(
+    top_k: int,
+    batch_size: int,
+    next_n: int,
+    clean_logits: bool,
+    data_generation: str,
+) -> None:
+    """
+    Test top_k_per_row_decode with various parameter combinations.
+    Converted from vLLM's test_top_k_per_row.py.
+    """
+    torch.manual_seed(0)
+    vocab_size = 20000
+    _run_top_k_per_row_decode_test(
+        top_k, batch_size, next_n, vocab_size, clean_logits, data_generation
+    )
+
+
+@pytest.mark.skipif(flag_gems.device != "cuda", reason="This test requires CUDA")
+@pytest.mark.top_k_per_row_decode
+@pytest.mark.parametrize("clean_logits", [True, False])
+@torch.inference_mode()
+def test_top_k_per_row_decode_large_vocab_size(clean_logits: bool) -> None:
+    """
+    Test top_k_per_row_decode with large vocabulary size (300K).
+    """
+    torch.manual_seed(0)
+    top_k = 2048
+    batch_size = 2
+    next_n = 2
+    vocab_size = 300000
+    data_generation = "random"
+    _run_top_k_per_row_decode_test(
+        top_k, batch_size, next_n, vocab_size, clean_logits, data_generation
+    )
+
+
+@pytest.mark.skipif(flag_gems.device != "cuda", reason="This test requires CUDA")
+@pytest.mark.top_k_per_row_decode
+@pytest.mark.parametrize("clean_logits", [True, False])
+@torch.inference_mode()
+def test_deepseek_hybrid_topk_short_sequences(clean_logits: bool) -> None:
+    """
+    Test top_k_per_row_decode for short sequences (< 8192).
+    This is the portion of test_deepseek_hybrid_topk that uses top_k_per_row_decode.
+    (Long sequences use large_context_topk which is not in scope.)
+    """
+    from flag_gems.fused.top_k_per_row_decode import top_k_per_row_decode
+
+    device = flag_gems.device
+    top_k = 2048
+
+    # Test case: Short sequences (< 8192)
+    batch_size_short = 4
+    next_n = 1
+    num_rows_short = batch_size_short * next_n
+
+    # Create sequences with max length < 8192
+    torch.manual_seed(42)
+    seq_lens_short = torch.randint(
+        4000, 8000, (batch_size_short,), dtype=torch.int32, device=device
+    )
+
+    row_starts_short = torch.zeros(num_rows_short, dtype=torch.int32, device=device)
+    row_indices_short = torch.arange(num_rows_short, device=device) // next_n
+    next_n_offset_short = torch.arange(num_rows_short, device=device) % next_n
+    row_ends_short = (
+        seq_lens_short[row_indices_short] - next_n + next_n_offset_short + 1
+    )
+
+    logits_short = create_random_logits(
+        row_starts_short, row_ends_short, torch.float32, 42, clean_logits, "random"
+    )
+
+    indices_gems = torch.empty(
+        (num_rows_short, top_k), dtype=torch.int32, device=device
+    )
+
+    # Use FlagGems kernel for short sequences
+    top_k_per_row_decode(
+        logits_short,
+        next_n,
+        seq_lens_short,
+        indices_gems,
+        num_rows_short,
+        logits_short.stride(0),
+        logits_short.stride(1),
+        top_k,
+    )
+
+    # Reference implementation
+    torch_indices_short = torch.empty(
+        (num_rows_short, top_k), dtype=torch.int32, device=device
+    )
+    for i in range(num_rows_short):
+        row_end = int(row_ends_short[i])
+        k_i = min(top_k, row_end)
+        idx = logits_short[i, :row_end].topk(k_i, dim=-1)[1]
+        torch_indices_short[i, :k_i] = idx
+
+    assert compare_top_k_results(
+        logits_short,
+        indices_gems,
+        torch_indices_short,
+        row_starts_short,
+        row_ends_short,
+        top_k,
+    ), "top_k_per_row_decode kernel (short sequences) doesn't match torch.topk"

--- a/tests/test_vllm_ops.py
+++ b/tests/test_vllm_ops.py
@@ -284,7 +284,7 @@ def create_random_logits(
 
     if clean_logits:
         for i, end in enumerate(row_ends):
-            logits[i, int(end):] = float("-inf")
+            logits[i, int(end) :] = float("-inf")
     return logits
 
 
@@ -414,7 +414,9 @@ def _run_top_k_per_row_decode_test(
 @pytest.mark.parametrize("batch_size", TOP_K_BATCH_SIZE if not QUICK_MODE else [1, 32])
 @pytest.mark.parametrize("next_n", TOP_K_NEXT_N if not QUICK_MODE else [1])
 @pytest.mark.parametrize("clean_logits", [True, False] if not QUICK_MODE else [True])
-@pytest.mark.parametrize("data_generation", TOP_K_DATA_GENERATION if not QUICK_MODE else ["random"])
+@pytest.mark.parametrize(
+    "data_generation", TOP_K_DATA_GENERATION if not QUICK_MODE else ["random"]
+)
 @torch.inference_mode()
 def test_top_k_per_row_decode(
     top_k: int,


### PR DESCRIPTION
Implement histogram-based radix select O(n) algorithm for efficient top-k selection:
- Uses 256-bin histogram with 4-round refinement (8 bits per round)
- Handles boundary cases where valid_count < K
- Fixed block sizes to avoid Triton JIT non-determinism

### PR Category
Operator

### Type of Change
New Feature

### Description
Add `top_k_per_row_decode` operator for vLLM's speculative decoding phase. This operator selects top-k indices from each row of logits tensor using histogram-based radix select algorithm with O(n) complexity.

Key features:
- Float32 to uint32 order-preserving conversion for histogram binning
- 4-round refinement using 8 bits per round (32 bits total)
- Compile-time constant loop bounds to avoid Triton JIT non-determinism
- Proper handling of boundary cases (valid_count < K)

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
benchmark/test_vllm_perf.py::test_top_k_per_row_decode_benchmark
Operator: top_k_per_row_decode  Performance Test (dtype=small_rows, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.023840            0.073312               0.325          [torch.Size([32, 20000]), 1, torch.Size([32]), torch.Size([32, 10]), 32, 20000, 1, 10]
SUCCESS               0.071520            0.393888               0.182          [torch.Size([32, 128256]), 1, torch.Size([32]), torch.Size([32, 10]), 32, 128256, 1, 10]


Operator: top_k_per_row_decode  Performance Test (dtype=medium_rows, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.025472            0.082208               0.310          [torch.Size([128, 20000]), 1, torch.Size([128]), torch.Size([128, 10]), 128, 20000, 1, 10]
SUCCESS               0.099232            0.479104               0.207          [torch.Size([128, 128256]), 1, torch.Size([128]), torch.Size([128, 10]), 128, 128256, 1, 10]


Operator: top_k_per_row_decode  Performance Test (dtype=large_rows, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.114912            0.297376               0.386          [torch.Size([1024, 20000]), 1, torch.Size([1024]), torch.Size([1024, 10]), 1024, 20000, 1, 10]
SUCCESS               0.448560            1.784608               0.251          [torch.Size([1024, 128256]), 1, torch.Size([1024]), torch.Size([1024, 10]), 1024, 128256, 1, 10]
SUCCESS               0.209184            0.564560               0.371          [torch.Size([2048, 20000]), 1, torch.Size([2048]), torch.Size([2048, 10]), 2048, 20000, 1, 10]
SUCCESS               0.862688            3.403584               0.253          [torch.Size([2048, 128256]), 1, torch.Size([2048]), torch.Size([2048, 10]), 2048, 128256, 1, 10]
SUCCESS               0.395072            1.095808               0.361          [torch.Size([4096, 20000]), 1, torch.Size([4096]), torch.Size([4096, 10]), 4096, 20000, 1, 10]
SUCCESS               1.665696            6.525312               0.255          [torch.Size([4096, 128256]), 1, torch.Size([4096]), torch.Size([4096, 10]), 4096, 128256, 1, 10]
SUCCESS               0.761056            2.172624               0.350          [torch.Size([8192, 20000]), 1, torch.Size([8192]), torch.Size([8192, 10]), 8192, 20000, 1, 10]
SUCCESS               3.235440           12.814656               0.252          [torch.Size([8192, 128256]), 1, torch.Size([8192]), torch.Size([8192, 10]), 8192, 128256, 1, 10]
