### PR TITLE
【KernelGen】Add top_k_per_row_prefill operator for vLLM speculative decoding

### DIFF
--- a/benchmark/test_vllm_perf.py
+++ b/benchmark/test_vllm_perf.py
@@ -239,3 +239,92 @@ class CutlassScaledMMBenchmark(Benchmark):
 def test_cutlass_scaled_mm_benchmark():
     bench = CutlassScaledMMBenchmark()
     bench.run()
+
+
+# ============ top_k_per_row_prefill benchmark ============
+class TopKPerRowPrefillBenchmark(Benchmark):
+    """Benchmark for top_k_per_row_prefill operator.
+
+    Compares FlagGems Triton implementation with vLLM CUDA implementation.
+    Uses histogram-based radix select O(n) algorithm.
+    """
+
+    DEFAULT_METRICS = ["latency_base", "latency", "speedup"]
+
+    def __init__(self):
+        # Must import vllm._C first to register torch.ops._C.top_k_per_row_prefill
+        import vllm._C  # noqa: F401
+
+        from flag_gems.fused.top_k_per_row_prefill import top_k_per_row_prefill
+
+        def vllm_top_k_per_row_prefill(
+            logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+        ):
+            torch.ops._C.top_k_per_row_prefill(
+                logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+            )
+
+        super().__init__(
+            "top_k_per_row_prefill",
+            vllm_top_k_per_row_prefill,
+            dtypes=["small_rows", "medium_rows", "large_rows"],
+        )
+        self.set_gems(top_k_per_row_prefill)
+
+    def set_shapes(self, shape_file_path=None):
+        # (num_rows, vocab_size, top_k)
+        self.shapes = {
+            "small_rows": [
+                (32, 20000, 2048),
+                (128, 20000, 2048),
+            ],
+            "medium_rows": [
+                (1024, 20000, 2048),
+                (2048, 20000, 2048),
+            ],
+            "large_rows": [
+                (4096, 20000, 2048),
+                (8192, 20000, 2048),
+            ],
+        }
+
+    def get_input_iter(self, dtype):
+        shapes = self.shapes.get(dtype, [])
+        for num_rows, vocab_size, top_k in shapes:
+            device = flag_gems.device
+
+            # Create logits tensor
+            logits = torch.randn(
+                num_rows, vocab_size, dtype=torch.float32, device=device
+            )
+
+            # Create row_starts and row_ends - each row uses full vocab
+            row_starts = torch.zeros(num_rows, dtype=torch.int32, device=device)
+            row_ends = torch.full(
+                (num_rows,), vocab_size, dtype=torch.int32, device=device
+            )
+
+            # Create output indices tensor
+            indices = torch.empty(num_rows, top_k, dtype=torch.int32, device=device)
+
+            stride0 = logits.stride(0)
+            stride1 = logits.stride(1)
+
+            yield (
+                logits,
+                row_starts,
+                row_ends,
+                indices,
+                num_rows,
+                stride0,
+                stride1,
+                top_k,
+            )
+
+
+@pytest.mark.skipif(not VLLM_AVAILABLE, reason="requires vLLM")
+@pytest.mark.top_k_per_row_prefill
+@pytest.mark.performance
+def test_top_k_per_row_prefill_benchmark():
+    bench = TopKPerRowPrefillBenchmark()
+    bench.run()

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -27,6 +27,7 @@ from flag_gems.fused.rwkv_mm_sparsity import rwkv_mm_sparsity
 from flag_gems.fused.silu_and_mul import silu_and_mul, silu_and_mul_out
 from flag_gems.fused.skip_layernorm import skip_layer_norm
 from flag_gems.fused.swiglu import dswiglu, swiglu
+from flag_gems.fused.top_k_per_row_prefill import top_k_per_row_prefill
 from flag_gems.fused.topk_softmax import topk_softmax
 from flag_gems.fused.weight_norm import weight_norm
 
@@ -60,6 +61,7 @@ __all__ = [
     "silu_and_mul_out",
     "skip_layer_norm",
     "swiglu",
+    "top_k_per_row_prefill",
     "topk_softmax",
     "weight_norm",
 ]

--- a/src/flag_gems/fused/top_k_per_row_prefill.py
+++ b/src/flag_gems/fused/top_k_per_row_prefill.py
@@ -1,0 +1,334 @@
+"""
+top_k_per_row_prefill: Triton implementation for vLLM's top_k_per_row_prefill kernel.
+
+Uses histogram-based radix select (O(n) algorithm) for efficient top-k selection.
+Based on top_k_per_row_decode implementation.
+"""
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+
+
+@triton.jit
+def convert_to_uint32(x):
+    """Convert float32 to uint32 for histogram binning, preserving order."""
+    bits_uint = x.cast(dtype=tl.uint32, bitcast=True)
+    bits_uint = tl.where(
+        x < 0,
+        ~bits_uint & tl.cast((0xFFFFFFFF), tl.uint32, bitcast=True),
+        bits_uint | tl.cast((0x80000000), tl.uint32, bitcast=True),
+    )
+    return bits_uint
+
+
+@triton.jit
+def kernel_topk_prefill_histogram(
+    inputs,  # (num_rows, vocab_size) logits
+    indices,  # (num_rows, K) output topk indices
+    s_input_ids,  # Temp buffer for candidates
+    row_starts,  # (num_rows,) start indices
+    row_ends,  # (num_rows,) end indices
+    stride0,  # logits.stride(0)
+    stride1,  # logits.stride(1)
+    S: tl.constexpr,  # vocab_size
+    K: tl.constexpr,  # top_k
+    HISTOGRAM_SIZE: tl.constexpr,
+    SMEM_INPUT_SIZE: tl.constexpr,
+    BS: tl.constexpr,  # block size for vocab iteration
+    BSS: tl.constexpr,  # block size for candidate iteration
+):
+    """
+    Histogram-based radix select for top-k selection (prefill version).
+    Uses O(n) algorithm with 256-bin histogram and multi-round refinement.
+    """
+    row_idx = tl.program_id(0)
+
+    # Load row boundaries directly from arrays
+    l_start_idx = tl.load(row_starts + row_idx)
+    l_end_idx = tl.load(row_ends + row_idx)
+    l_end_idx = tl.minimum(l_end_idx, S)
+    l_end_idx = tl.maximum(l_end_idx, 0)
+    l_start_idx = tl.maximum(l_start_idx, 0)
+    l_start_idx = tl.minimum(l_start_idx, l_end_idx)
+
+    # Calculate valid element count and actual k to select
+    valid_count = l_end_idx - l_start_idx
+    actual_k = tl.minimum(K, valid_count)
+
+    # Block base pointer definitions
+    s_base = inputs + row_idx * stride0
+    indices_base = indices + row_idx * K
+    s_input_ids_base = s_input_ids + row_idx * SMEM_INPUT_SIZE
+
+    # Early exit if no valid elements
+    if valid_count <= 0:
+        return
+
+    # Histogram initialization
+    s_histogram = tl.zeros([HISTOGRAM_SIZE], dtype=tl.int32)
+
+    # Record how many positions remain to fill the topk array
+    l_new_topk = actual_k
+
+    # Round 0: Build histogram using uint32 high 8 bits
+    TS = tl.cdiv(S, BS)
+    for s in range(TS):
+        input_idx = s * BS + tl.arange(0, BS)
+        input_mask = (
+            (input_idx < l_end_idx) & (input_idx >= l_start_idx) & (input_idx < S)
+        )
+        if stride1 == 1:
+            input_val = tl.load(s_base + input_idx, input_mask, other=float("-inf")).to(
+                tl.float32
+            )
+        else:
+            input_val = tl.load(
+                s_base + input_idx * stride1, input_mask, other=float("-inf")
+            ).to(tl.float32)
+        inval_uint8 = (convert_to_uint32(input_val) >> 24) & 0xFF
+        s_histogram += inval_uint8.to(tl.int32).histogram(HISTOGRAM_SIZE)
+
+    # Find threshold bin using suffix sum
+    s_histogram = s_histogram.cumsum(0, reverse=True)
+    mv_idx = tl.arange(1, HISTOGRAM_SIZE + 1) % HISTOGRAM_SIZE
+    cond = (s_histogram > l_new_topk) & (
+        (s_histogram.gather(mv_idx, 0) <= l_new_topk) | (mv_idx == 0)
+    )
+    l_threshold_bin_id = cond.argmax(0)
+    l_new_topk -= tl.where(
+        tl.arange(0, HISTOGRAM_SIZE) == l_threshold_bin_id + 1, s_histogram, 0
+    ).max(0)
+
+    # Partition elements: above threshold -> output, equal threshold -> candidates
+    sum_val = 0
+    thre_bin_sum = 0
+    for s in range(TS):
+        input_idx = s * BS + tl.arange(0, BS)
+        input_mask = (
+            (input_idx < l_end_idx) & (input_idx >= l_start_idx) & (input_idx < S)
+        )
+        if stride1 == 1:
+            input_val = tl.load(s_base + input_idx, input_mask, other=float("-inf")).to(
+                tl.float32
+            )
+        else:
+            input_val = tl.load(
+                s_base + input_idx * stride1, input_mask, other=float("-inf")
+            ).to(tl.float32)
+        inval_uint8 = (convert_to_uint32(input_val) >> 24) & 0xFF
+
+        # Must AND with input_mask to exclude invalid positions
+        over_thre = (inval_uint8.to(tl.int32) > l_threshold_bin_id) & input_mask
+        cur_sum = over_thre.to(tl.int32).sum(-1)
+        eq_thre = (inval_uint8.to(tl.int32) == l_threshold_bin_id) & input_mask
+        thre_bin_cur_sum = eq_thre.to(tl.int32).sum(-1)
+
+        topk_idx = over_thre.to(tl.int32).cumsum(-1)
+        thre_bin_idx = eq_thre.to(tl.int32).cumsum(-1)
+
+        # Bound check for candidate storage to avoid buffer overflow
+        candidate_write_pos = thre_bin_sum + thre_bin_idx - 1
+        eq_thre_bounded = eq_thre & (candidate_write_pos < SMEM_INPUT_SIZE)
+
+        concat_mask = tl.cat(over_thre, eq_thre_bounded, True)
+        concat_input = tl.cat(input_idx, input_idx, True)
+        concat_pointer_matrix = tl.cat(
+            indices_base + sum_val + topk_idx - 1,
+            s_input_ids_base + candidate_write_pos,
+            True,
+        )
+        tl.store(concat_pointer_matrix, concat_input, mask=concat_mask)
+
+        # Track actual candidates stored (bounded by SMEM_INPUT_SIZE)
+        thre_bin_sum = tl.minimum(thre_bin_sum + thre_bin_cur_sum, SMEM_INPUT_SIZE)
+        sum_val += cur_sum
+
+    # Subsequent rounds: refine using more bits (23-16, 15-8, 7-0)
+    # Use fixed max iterations to avoid dynamic loop bound issues in Triton JIT
+    MAX_CAND_ITERS: tl.constexpr = (SMEM_INPUT_SIZE + BSS - 1) // BSS
+
+    round_num = 1
+    while round_num < 4 and l_new_topk > 0:
+        ss = tl.cdiv(thre_bin_sum, BSS)
+        s_histogram = tl.zeros([HISTOGRAM_SIZE], dtype=tl.int32)
+        padding_num = 0.0
+
+        for s in range(MAX_CAND_ITERS):
+            if s < ss:
+                s_input_idx = s * BSS + tl.arange(0, BSS)
+                s_input_idx_mask = s_input_idx < thre_bin_sum
+                input_idx = tl.load(
+                    s_input_ids_base + s_input_idx, s_input_idx_mask, other=-1
+                )
+                if stride1 == 1:
+                    s_input = tl.load(
+                        s_base + input_idx, s_input_idx_mask, other=padding_num
+                    ).to(tl.float32)
+                else:
+                    s_input = tl.load(
+                        s_base + input_idx * stride1,
+                        s_input_idx_mask,
+                        other=padding_num,
+                    ).to(tl.float32)
+                inval_int32 = (
+                    convert_to_uint32(s_input) >> (24 - round_num * 8)
+                ) & 0xFF
+                s_histogram += inval_int32.to(tl.int32).histogram(HISTOGRAM_SIZE)
+
+        s_histogram = s_histogram.cumsum(0, reverse=True)
+        mv_idx = tl.arange(1, HISTOGRAM_SIZE + 1) % HISTOGRAM_SIZE
+        cond = (s_histogram > l_new_topk) & (
+            (s_histogram.gather(mv_idx, 0) <= l_new_topk) | (mv_idx == 0)
+        )
+        l_threshold_bin_id = cond.argmax(0)
+        l_new_topk -= tl.where(
+            tl.arange(0, HISTOGRAM_SIZE) == l_threshold_bin_id + 1, s_histogram, 0
+        ).max(0)
+        thre_bin_sum, old_thre_bin_sum = 0, thre_bin_sum
+        old_ss = ss
+
+        for s in range(MAX_CAND_ITERS):
+            if s < old_ss:
+                s_input_idx = s * BSS + tl.arange(0, BSS)
+                s_input_idx_mask = s_input_idx < old_thre_bin_sum
+                input_idx = tl.load(
+                    s_input_ids_base + s_input_idx, s_input_idx_mask, other=-1
+                )
+                if stride1 == 1:
+                    s_input = tl.load(
+                        s_base + input_idx, s_input_idx_mask, other=padding_num
+                    ).to(tl.float32)
+                else:
+                    s_input = tl.load(
+                        s_base + input_idx * stride1,
+                        s_input_idx_mask,
+                        other=padding_num,
+                    ).to(tl.float32)
+                inval_int32 = (
+                    convert_to_uint32(s_input) >> (24 - round_num * 8)
+                ) & 0xFF
+
+                # Must AND with s_input_idx_mask to exclude invalid positions (padding values)
+                over_thre = (
+                    inval_int32.to(tl.int32) > l_threshold_bin_id
+                ) & s_input_idx_mask
+                cur_sum = over_thre.to(tl.int32).sum(-1)
+                eq_thre = (
+                    inval_int32.to(tl.int32) == l_threshold_bin_id
+                ) & s_input_idx_mask
+                thre_bin_cur_sum = eq_thre.to(tl.int32).sum(-1)
+
+                topk_idx = over_thre.to(tl.int32).cumsum(-1)
+                thre_bin_idx = eq_thre.to(tl.int32).cumsum(-1)
+
+                # Bound check for candidate storage to avoid buffer overflow
+                candidate_write_pos = thre_bin_sum + thre_bin_idx - 1
+                eq_thre_bounded = eq_thre & (candidate_write_pos < SMEM_INPUT_SIZE)
+
+                concat_mask = tl.cat(over_thre, eq_thre_bounded, True)
+                concat_input = tl.cat(input_idx, input_idx, True)
+                concat_pointer_matrix = tl.cat(
+                    indices_base + sum_val + topk_idx - 1,
+                    s_input_ids_base + candidate_write_pos,
+                    True,
+                )
+                tl.store(concat_pointer_matrix, concat_input, mask=concat_mask)
+
+                # Track actual candidates stored (bounded by SMEM_INPUT_SIZE)
+                thre_bin_sum = tl.minimum(
+                    thre_bin_sum + thre_bin_cur_sum, SMEM_INPUT_SIZE
+                )
+                sum_val += cur_sum
+
+        round_num += 1
+
+    # Copy remaining candidates if needed
+    # Copy min(l_new_topk, thre_bin_sum) elements - we may have fewer candidates than needed
+    copy_count = tl.minimum(l_new_topk, thre_bin_sum)
+    if copy_count > 0:
+        ss = tl.cdiv(copy_count, BSS)
+        MAX_COPY_ITERS: tl.constexpr = (K + BSS - 1) // BSS
+        for s in range(MAX_COPY_ITERS):
+            if s < ss:
+                s_input_idx = s * BSS + tl.arange(0, BSS)
+                s_input_idx_mask = s_input_idx < copy_count
+                input_idx = tl.load(
+                    s_input_ids_base + s_input_idx, s_input_idx_mask, other=-1
+                )
+                tl.store(
+                    indices_base + sum_val + tl.arange(0, BSS),
+                    input_idx,
+                    mask=s_input_idx_mask,
+                )
+                sum_val += BSS
+
+
+def top_k_per_row_prefill(
+    logits: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    indices: torch.Tensor,
+    num_rows: int,
+    stride0: int,
+    stride1: int,
+    top_k: int,
+) -> None:
+    """
+    Select top-k indices from each row of logits for prefill phase.
+
+    Uses histogram-based radix select (O(n) algorithm) for efficient selection.
+
+    Args:
+        logits: Input logits tensor [num_rows, vocab_size], float32
+        row_starts: Start indices for each row [num_rows], int32
+        row_ends: End indices for each row [num_rows], int32
+        indices: Output indices tensor [num_rows, top_k], int32 (modified in-place)
+        num_rows: Number of rows
+        stride0: logits.stride(0)
+        stride1: logits.stride(1)
+        top_k: Number of top elements to select
+    """
+    assert logits.dtype == torch.float32, "logits must be float32"
+    assert row_starts.dtype == torch.int32, "row_starts must be int32"
+    assert row_ends.dtype == torch.int32, "row_ends must be int32"
+    assert indices.dtype == torch.int32, "indices must be int32"
+
+    vocab_size = logits.shape[1]
+    device = logits.device
+
+    # Fixed block sizes to avoid autotune LLVM issues
+    BS = 1024  # Block size for vocab iteration
+    BSS = 256  # Block size for candidate iteration
+    HISTOGRAM_SIZE = 256
+    # For worst case (e.g., 10LSBits data where all values have same high bits),
+    # all elements could become candidates. Use vocab_size as upper bound.
+    SMEM_INPUT_SIZE = min(vocab_size, 65536)  # Cap at 64K to limit memory usage
+
+    # Allocate temp buffer for candidates
+    s_input_ids = torch.zeros(
+        num_rows, SMEM_INPUT_SIZE, dtype=torch.int32, device=device
+    )
+
+    # Initialize indices to -1 (invalid marker)
+    indices.fill_(-1)
+
+    grid = (num_rows,)
+    with torch_device_fn.device(device):
+        kernel_topk_prefill_histogram[grid](
+            logits,
+            indices,
+            s_input_ids,
+            row_starts,
+            row_ends,
+            stride0,
+            stride1,
+            vocab_size,
+            top_k,
+            HISTOGRAM_SIZE,
+            SMEM_INPUT_SIZE,
+            BS,
+            BSS,
+        )

--- a/src/flag_gems/patches/patch_vllm_all.py
+++ b/src/flag_gems/patches/patch_vllm_all.py
@@ -428,6 +428,23 @@ def custom_concat_and_cache_mla(
     )
 
 
+def custom_top_k_per_row_prefill(
+    logits: torch.Tensor,
+    row_starts: torch.Tensor,
+    row_ends: torch.Tensor,
+    indices: torch.Tensor,
+    num_rows: int,
+    stride0: int,
+    stride1: int,
+    top_k: int,
+) -> None:
+    from flag_gems.fused.top_k_per_row_prefill import top_k_per_row_prefill
+
+    return top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+    )
+
+
 def custom_gems_flashattn_mla_forward_decode(
     self,
     q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
@@ -585,6 +602,7 @@ def apply_gems_patches_to_vllm(verbose=True):
     lib_patches = [
         ("_C", "silu_and_mul", custom_silu_and_mul),
         ("_C", "cutlass_scaled_mm", custom_cutlass_scaled_mm),
+        ("_C", "top_k_per_row_prefill", custom_top_k_per_row_prefill),
         ("_moe_C", "moe_align_block_size", custom_moe_align_block_size),
         ("_moe_C", "topk_softmax", custom_topk_softmax),
         ("_moe_C", "moe_sum", custom_moe_sum),

--- a/tests/test_vllm_ops.py
+++ b/tests/test_vllm_ops.py
@@ -233,3 +233,91 @@ def test_cutlass_scaled_mm(p):
         rtol, atol = 5e-1, 1.5e-1
 
     torch.testing.assert_close(c, output_ref, rtol=rtol, atol=atol)
+
+
+# ============ top_k_per_row_prefill tests ============
+class TopKPerRowPrefillTestKit:
+    num_test_cases = 8 if QUICK_MODE else 16
+
+    @staticmethod
+    def _get_all_combinations():
+        # Test various row configurations
+        row_configs = [
+            # (num_rows, vocab_size, top_k)
+            (1, 32000, 10),
+            (4, 32000, 10),
+            (8, 128256, 10),
+            (16, 32000, 5),
+            (32, 128256, 10),
+            (64, 32000, 10),
+            (128, 128256, 5),
+            (256, 32000, 10),
+        ]
+        return row_configs
+
+    @classmethod
+    def get_test_params(cls):
+        all_combinations = cls._get_all_combinations()
+        random.shuffle(all_combinations)
+        return all_combinations[: cls.num_test_cases]
+
+
+@pytest.mark.top_k_per_row_prefill
+@pytest.mark.parametrize(
+    "num_rows,vocab_size,top_k", TopKPerRowPrefillTestKit.get_test_params()
+)
+def test_top_k_per_row_prefill(num_rows, vocab_size, top_k):
+    from flag_gems.fused.top_k_per_row_prefill import top_k_per_row_prefill
+
+    # Generate random row lengths (variable length rows)
+    min_len = vocab_size // 2
+    max_len = vocab_size
+    row_lengths = torch.randint(
+        min_len, max_len + 1, (num_rows,), device=flag_gems.device
+    )
+
+    # Create row_starts and row_ends
+    row_starts = torch.zeros(num_rows, dtype=torch.int32, device=flag_gems.device)
+    row_ends = row_lengths.to(torch.int32)
+
+    # Total elements
+    total_elements = int(row_lengths.sum().item())
+
+    # Create logits tensor (flattened for all rows)
+    logits = torch.randn(total_elements, dtype=torch.float32, device=flag_gems.device)
+
+    # Output indices tensor
+    indices = torch.empty(num_rows * top_k, dtype=torch.int64, device=flag_gems.device)
+
+    stride0 = top_k
+    stride1 = 1
+
+    # Call the function
+    top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+    )
+
+    # Verify results using PyTorch reference
+    indices_result = indices.view(num_rows, top_k)
+    offset = 0
+    for row_idx in range(num_rows):
+        row_len = int(row_lengths[row_idx].item())
+        row_logits = logits[offset : offset + row_len]
+
+        # Get reference top-k
+        _, ref_indices = torch.topk(row_logits, min(top_k, row_len), dim=0)
+
+        # Get actual indices for this row
+        actual_indices = indices_result[row_idx]
+
+        # Check that actual indices are valid and point to top values
+        actual_values = row_logits[actual_indices]
+        ref_values = row_logits[ref_indices]
+
+        # The top-k values should match (not necessarily the indices due to ties)
+        actual_sorted = torch.sort(actual_values, descending=True)[0]
+        ref_sorted = torch.sort(ref_values, descending=True)[0]
+
+        torch.testing.assert_close(actual_sorted, ref_sorted, rtol=1e-5, atol=1e-5)
+
+        offset += row_len


### PR DESCRIPTION
Implement per-row top-k selection for prefill phase using Triton kernels.

### PR Category
Operator

### Type of Change
New Feature

### Description
Add `top_k_per_row_prefill` operator for vLLM's speculative decoding prefill phase. This operator selects top-k indices from variable-length rows of logits tensor.

Key features:
- Supports variable-length rows with row_starts and row_ends parameters
- Uses radix-based histogram algorithm for efficient O(n) selection
- Float32 to uint32 order-preserving conversion for histogram binning
- 4-round refinement using 8 bits per round (32 bits total)
- Handles boundary cases properly (valid_count < K)

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
benchmark/test_vllm_perf.py::test_top_k_per_row_prefill_benchmark
Operator: top_k_per_row_prefill  Performance Test (dtype=small_rows, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.021664            0.126848               0.171          [torch.Size([32, 20000]), torch.Size([32]), torch.Size([32]), torch.Size([32, 2048]), 32, 20000, 1, 2048]
SUCCESS               0.023072            0.130240               0.177          [torch.Size([128, 20000]), torch.Size([128]), torch.Size([128]), torch.Size([128, 2048]), 128, 20000, 1, 2048]


Operator: top_k_per_row_prefill  Performance Test (dtype=medium_rows, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.085472            0.441920               0.193          [torch.Size([1024, 20000]), torch.Size([1024]), torch.Size([1024]), torch.Size([1024, 2048]), 1024, 20000, 1, 2048]
SUCCESS               0.146240            0.834176               0.175          [torch.Size([2048, 20000]), torch.Size([2048]), torch.Size([2048]), torch.Size([2048, 2048]), 2048, 20000, 1, 2048]


Operator: top_k_per_row_prefill  Performance Test (dtype=large_rows, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.256960            1.562352               0.164          [torch.Size([4096, 20000]), torch.Size([4096]), torch.Size([4096]), torch.Size([4096, 2048]), 4096, 20000, 1, 2048]
SUCCESS               0.478496            3.028256               0.158          [torch.Size([8192, 20000]), torch.Size([8192]), torch.Size([8192]), torch.Size([8192, 2048]), 8192, 20000, 1, 2048]

PASSED