### PR TITLE
【KernelGen】Add cp_gather_indexer_k_quant_cache operator for KV cache gathering

### DIFF
--- a/benchmark/test_vllm_perf.py
+++ b/benchmark/test_vllm_perf.py
@@ -239,3 +239,119 @@ class CutlassScaledMMBenchmark(Benchmark):
 def test_cutlass_scaled_mm_benchmark():
     bench = CutlassScaledMMBenchmark()
     bench.run()
+
+
+# ============ cp_gather_indexer_k_quant_cache benchmark ============
+class CpGatherIndexerKQuantCacheBenchmark(Benchmark):
+    """Benchmark for cp_gather_indexer_k_quant_cache operator.
+
+    Compares FlagGems Triton implementation with vLLM CUDA implementation.
+    """
+
+    DEFAULT_METRICS = ["latency_base", "latency", "speedup"]
+
+    def __init__(self):
+        import vllm._custom_ops as ops
+
+        from flag_gems.fused.cp_gather_indexer_k_quant_cache import (
+            cp_gather_indexer_k_quant_cache,
+        )
+
+        super().__init__(
+            "cp_gather_indexer_k_quant_cache",
+            ops.cp_gather_indexer_k_quant_cache,
+            dtypes=["small_batch", "medium_batch", "large_batch"],
+        )
+        self.set_gems(cp_gather_indexer_k_quant_cache)
+
+    def set_shapes(self, shape_file_path=None):
+        # (batch_size, block_size, head_dim, num_blocks_per_seq, avg_seq_len)
+        # cache_stride = head_dim + 4 (4 bytes for float32 scale)
+        self.shapes = {
+            "small_batch": [
+                (1, 16, 128, 8, 113),
+                (4, 16, 128, 8, 68),
+                (8, 16, 256, 8, 86),
+            ],
+            "medium_batch": [
+                (16, 16, 128, 16, 154),
+                (32, 32, 256, 8, 148),
+                (64, 16, 512, 8, 81),
+            ],
+            "large_batch": [
+                (128, 16, 128, 16, 160),
+                (256, 32, 256, 4, 78),
+                (512, 16, 512, 4, 41),
+            ],
+        }
+
+    def get_input_iter(self, dtype):
+        shapes = self.shapes.get(dtype, [])
+        for batch_size, block_size, head_dim, num_blocks_per_seq, avg_seq_len in shapes:
+            device = flag_gems.device
+
+            # Calculate dimensions
+            cache_stride = head_dim + 4  # head_dim + 4 bytes for scale
+
+            # Generate random sequence lengths around avg_seq_len
+            max_seq_len = block_size * num_blocks_per_seq
+            seq_lens = torch.randint(
+                max(1, avg_seq_len - 20),
+                min(avg_seq_len + 20, max_seq_len) + 1,
+                (batch_size,),
+                device=device,
+                dtype=torch.int32,
+            )
+            num_tokens = int(seq_lens.sum().item())
+
+            # Calculate actual blocks needed
+            blocks_per_batch = (seq_lens + block_size - 1) // block_size
+            num_blocks = int(blocks_per_batch.sum().item())
+
+            # Create kv_cache: [num_blocks, block_size, cache_stride]
+            kv_cache = torch.zeros(
+                num_blocks,
+                block_size,
+                cache_stride,
+                dtype=torch.float8_e4m3fn,
+                device=device,
+            )
+
+            # Fill with random data
+            kv_cache[:, :, :head_dim] = to_fp8(
+                torch.randn(num_blocks, block_size, head_dim, device=device) * 0.1
+            )
+
+            # Create block_table: [batch_size, num_blocks_per_seq]
+            block_table = torch.zeros(
+                batch_size, num_blocks_per_seq, device=device, dtype=torch.int32
+            )
+            block_idx = 0
+            for i in range(batch_size):
+                n_blocks = int(blocks_per_batch[i].item())
+                block_table[i, :n_blocks] = torch.arange(
+                    block_idx, block_idx + n_blocks, device=device, dtype=torch.int32
+                )
+                block_idx += n_blocks
+
+            # Create cu_seq_lens: [batch_size + 1]
+            cu_seq_lens = torch.zeros(batch_size + 1, device=device, dtype=torch.int32)
+            cu_seq_lens[1:] = torch.cumsum(seq_lens, dim=0)
+
+            # Create output tensors
+            dst_k = torch.empty(
+                num_tokens, head_dim, dtype=torch.float8_e4m3fn, device=device
+            )
+            dst_scale = torch.empty(
+                num_tokens, 4, dtype=torch.float8_e4m3fn, device=device
+            )
+
+            yield (kv_cache, dst_k, dst_scale, block_table, cu_seq_lens)
+
+
+@pytest.mark.skipif(not VLLM_AVAILABLE, reason="requires vLLM")
+@pytest.mark.cp_gather_indexer_k_quant_cache
+@pytest.mark.performance
+def test_cp_gather_indexer_k_quant_cache_benchmark():
+    bench = CpGatherIndexerKQuantCacheBenchmark()
+    bench.run()

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -1,5 +1,8 @@
 from flag_gems.fused.apply_repetition_penalties import apply_repetition_penalties
 from flag_gems.fused.concat_and_cache_mla import concat_and_cache_mla
+from flag_gems.fused.cp_gather_indexer_k_quant_cache import (
+    cp_gather_indexer_k_quant_cache,
+)
 from flag_gems.fused.cross_entropy_loss import cross_entropy_loss
 from flag_gems.fused.cutlass_scaled_mm import cutlass_scaled_mm
 from flag_gems.fused.FLA import (
@@ -35,6 +38,7 @@ __all__ = [
     "apply_rotary_pos_emb",
     "chunk_gated_delta_rule_fwd",
     "concat_and_cache_mla",
+    "cp_gather_indexer_k_quant_cache",
     "cutlass_scaled_mm",
     "cross_entropy_loss",
     "dgeglu",

--- a/src/flag_gems/fused/cp_gather_indexer_k_quant_cache.py
+++ b/src/flag_gems/fused/cp_gather_indexer_k_quant_cache.py
@@ -1,0 +1,180 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.jit
+def _cp_gather_indexer_k_quant_cache_kernel(
+    kv_cache_value_ptr,
+    kv_cache_scale_ptr,
+    dst_k_ptr,
+    dst_scale_ptr,
+    block_table_ptr,
+    cu_seq_lens_ptr,
+    token_to_seq_ptr,
+    # strides
+    kv_cache_value_stride,
+    kv_cache_scale_stride,
+    block_table_stride,
+    # dims
+    cache_block_size,
+    # constexpr
+    HEAD_DIM: tl.constexpr,
+):
+    """
+    Gather quantized K cache data from paged KV cache.
+
+    Args:
+        kv_cache_value_ptr: [num_blocks, block_size * head_dim] - FP8 K values
+        kv_cache_scale_ptr: [num_blocks, block_size] - float32 scales (one per token)
+        dst_k_ptr: [num_tokens, head_dim] - destination for FP8 K data
+        dst_scale_ptr: [num_tokens] - destination for scales
+        block_table_ptr: [batch_size, num_blocks_per_seq] - block indices
+        cu_seq_lens_ptr: [batch_size + 1] - cumulative sequence lengths
+        token_to_seq_ptr: [num_tokens] - precomputed token to batch mapping
+    """
+    token_idx = tl.program_id(0)
+
+    # 1. Look up batch index from precomputed mapping
+    batch_idx = tl.load(token_to_seq_ptr + token_idx)
+
+    # 2. Calculate cache position
+    seq_start = tl.load(cu_seq_lens_ptr + batch_idx)
+    inbatch_seq_idx = token_idx - seq_start
+    block_table_idx = inbatch_seq_idx // cache_block_size
+    block_offset = inbatch_seq_idx % cache_block_size
+
+    # Load block index from block table
+    block_idx = tl.load(
+        block_table_ptr + batch_idx * block_table_stride + block_table_idx
+    )
+
+    # 3. Copy K data (vectorized)
+    # Layout: [num_blocks, block_size * head_dim]
+    src_cache_offset = block_idx * kv_cache_value_stride + block_offset * HEAD_DIM
+    dst_offset = token_idx * HEAD_DIM
+
+    offset = tl.arange(0, HEAD_DIM)
+    val = tl.load(kv_cache_value_ptr + src_cache_offset + offset)
+    tl.store(dst_k_ptr + dst_offset + offset, val)
+
+    # 4. Copy scale data
+    # Layout: [num_blocks, block_size]
+    src_scale_offset = block_idx * kv_cache_scale_stride + block_offset
+    scale_val = tl.load(kv_cache_scale_ptr + src_scale_offset)
+    tl.store(dst_scale_ptr + token_idx, scale_val)
+
+
+class CpGatherIndexerKQuantCache(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        kv_cache: torch.Tensor,
+        dst_k: torch.Tensor,
+        dst_scale: torch.Tensor,
+        block_table: torch.Tensor,
+        cu_seq_lens: torch.Tensor,
+    ):
+        """
+        Gather quantized K cache data from paged KV cache.
+
+        Args:
+            kv_cache: [num_blocks, block_size, cache_stride] - source cache
+                      cache_stride = head_dim + 4 (4 bytes for scale per token)
+            dst_k: [num_tokens, head_dim] - output FP8 K data
+            dst_scale: [num_tokens, ...] - output scales (viewed as float32)
+            block_table: [batch_size, num_blocks_per_seq] - block indices
+            cu_seq_lens: [batch_size + 1] - cumulative sequence lengths
+        """
+        num_tokens = dst_k.size(0)
+        head_dim = dst_k.size(1)
+        batch_size = block_table.size(0)
+        num_blocks = kv_cache.size(0)
+        cache_block_size = kv_cache.size(1)
+
+        device = dst_k.device
+
+        # Precompute token_to_seq mapping
+        # This maps each token index to its batch index
+        token_to_seq = torch.empty(num_tokens, dtype=torch.int32, device=device)
+        cu_seq_lens_cpu = cu_seq_lens.cpu()
+        for i in range(batch_size):
+            start = int(cu_seq_lens_cpu[i].item())
+            end = int(cu_seq_lens_cpu[i + 1].item())
+            token_to_seq[start:end] = i
+
+        # Split kv_cache into value and scale portions
+        # kv_cache: [num_blocks, block_size, head_dim + 4]
+        # Flatten to [num_blocks, block_size * (head_dim + 4)]
+        kv_cache_flat = kv_cache.view(num_blocks, -1)
+
+        # Value portion: first block_size * head_dim elements per block
+        kv_cache_value = kv_cache_flat[:, : cache_block_size * head_dim]
+
+        # Scale portion: remaining elements, viewed as float32
+        # [num_blocks, block_size * 4] bytes -> [num_blocks, block_size] floats
+        kv_cache_scale = kv_cache_flat[:, cache_block_size * head_dim :].view(
+            torch.float32
+        )
+
+        # Get strides
+        kv_cache_value_stride = kv_cache_value.stride(0)
+        kv_cache_scale_stride = kv_cache_scale.stride(0)
+        block_table_stride = block_table.stride(0)
+
+        grid = (num_tokens,)
+
+        # View dst_scale as float32
+        dst_scale_f32 = dst_scale.view(-1).view(torch.float32)
+
+        with torch_device_fn.device(device):
+            _cp_gather_indexer_k_quant_cache_kernel[grid](
+                kv_cache_value,
+                kv_cache_scale,
+                dst_k.view(-1),
+                dst_scale_f32,
+                block_table,
+                cu_seq_lens,
+                token_to_seq,
+                # strides
+                kv_cache_value_stride,
+                kv_cache_scale_stride,
+                block_table_stride,
+                # dims
+                cache_block_size,
+                # constexpr
+                HEAD_DIM=head_dim,
+            )
+
+        return None
+
+
+def cp_gather_indexer_k_quant_cache(
+    kv_cache: torch.Tensor,
+    dst_k: torch.Tensor,
+    dst_scale: torch.Tensor,
+    block_table: torch.Tensor,
+    cu_seq_lens: torch.Tensor,
+) -> None:
+    """
+    Gather quantized K cache data from paged KV cache.
+
+    Args:
+        kv_cache: [num_blocks, block_size, cache_stride] - source cache
+        dst_k: [num_tokens, head_dim] - output FP8 K data
+        dst_scale: [num_tokens, ...] - output scales
+        block_table: [batch_size, num_blocks_per_seq] - block indices
+        cu_seq_lens: [batch_size + 1] - cumulative sequence lengths
+    """
+    logger.debug("GEMS CP_GATHER_INDEXER_K_QUANT_CACHE")
+    return CpGatherIndexerKQuantCache.apply(
+        kv_cache, dst_k, dst_scale, block_table, cu_seq_lens
+    )

--- a/src/flag_gems/patches/patch_vllm_all.py
+++ b/src/flag_gems/patches/patch_vllm_all.py
@@ -435,9 +435,7 @@ def custom_cp_gather_indexer_k_quant_cache(
     block_table: torch.Tensor,
     cu_seq_lens: torch.Tensor,
 ) -> None:
-    from flag_gems.fused.cp_gather_indexer_k_quant_cache import (
-        cp_gather_indexer_k_quant_cache,
-    )
+    from flag_gems.fused import cp_gather_indexer_k_quant_cache
 
     return cp_gather_indexer_k_quant_cache(
         kv_cache, dst_k, dst_scale, block_table, cu_seq_lens

--- a/src/flag_gems/patches/patch_vllm_all.py
+++ b/src/flag_gems/patches/patch_vllm_all.py
@@ -428,6 +428,22 @@ def custom_concat_and_cache_mla(
     )
 
 
+def custom_cp_gather_indexer_k_quant_cache(
+    kv_cache: torch.Tensor,
+    dst_k: torch.Tensor,
+    dst_scale: torch.Tensor,
+    block_table: torch.Tensor,
+    cu_seq_lens: torch.Tensor,
+) -> None:
+    from flag_gems.fused.cp_gather_indexer_k_quant_cache import (
+        cp_gather_indexer_k_quant_cache,
+    )
+
+    return cp_gather_indexer_k_quant_cache(
+        kv_cache, dst_k, dst_scale, block_table, cu_seq_lens
+    )
+
+
 def custom_gems_flashattn_mla_forward_decode(
     self,
     q: torch.Tensor | tuple[torch.Tensor, torch.Tensor],
@@ -593,6 +609,11 @@ def apply_gems_patches_to_vllm(verbose=True):
         ("_C", "per_token_group_fp8_quant", custom_per_token_group_fp8_quant),
         ("_C", "apply_repetition_penalties_", custom_apply_repetition_penalties),
         ("_C_cache_ops", "concat_and_cache_mla", custom_concat_and_cache_mla),
+        (
+            "_C_cache_ops",
+            "cp_gather_indexer_k_quant_cache",
+            custom_cp_gather_indexer_k_quant_cache,
+        ),
     ]
     for lib_name, fn_name, fn in lib_patches:
         patch_vllm_lib(lib_name, fn_name, fn, dispatch_key, verbose)

--- a/tests/test_vllm_ops.py
+++ b/tests/test_vllm_ops.py
@@ -267,9 +267,7 @@ class CpGatherIndexerKQuantCacheTestKit:
     CpGatherIndexerKQuantCacheTestKit.get_test_params(),
 )
 def test_cp_gather_indexer_k_quant_cache(batch_size, max_seq_len, head_dim, block_size):
-    from flag_gems.fused.cp_gather_indexer_k_quant_cache import (
-        cp_gather_indexer_k_quant_cache,
-    )
+    from flag_gems.fused import cp_gather_indexer_k_quant_cache
 
     device = flag_gems.device
 

--- a/tests/test_vllm_ops.py
+++ b/tests/test_vllm_ops.py
@@ -233,3 +233,125 @@ def test_cutlass_scaled_mm(p):
         rtol, atol = 5e-1, 1.5e-1
 
     torch.testing.assert_close(c, output_ref, rtol=rtol, atol=atol)
+
+
+# ============ cp_gather_indexer_k_quant_cache tests ============
+class CpGatherIndexerKQuantCacheTestKit:
+    num_test_cases = 8 if QUICK_MODE else 16
+
+    @staticmethod
+    def _get_all_combinations():
+        # Test configurations: (batch_size, max_seq_len, head_dim, block_size)
+        configs = [
+            (1, 128, 64, 16),
+            (2, 256, 64, 16),
+            (4, 512, 128, 32),
+            (8, 256, 64, 16),
+            (16, 128, 64, 32),
+            (32, 64, 128, 16),
+            (4, 1024, 64, 64),
+            (8, 512, 128, 32),
+        ]
+        return configs
+
+    @classmethod
+    def get_test_params(cls):
+        all_configs = cls._get_all_combinations()
+        random.shuffle(all_configs)
+        return all_configs[: cls.num_test_cases]
+
+
+@pytest.mark.cp_gather_indexer_k_quant_cache
+@pytest.mark.parametrize(
+    "batch_size,max_seq_len,head_dim,block_size",
+    CpGatherIndexerKQuantCacheTestKit.get_test_params(),
+)
+def test_cp_gather_indexer_k_quant_cache(batch_size, max_seq_len, head_dim, block_size):
+    from flag_gems.fused.cp_gather_indexer_k_quant_cache import (
+        cp_gather_indexer_k_quant_cache,
+    )
+
+    device = flag_gems.device
+
+    # Generate random sequence lengths for each batch
+    seq_lens = torch.randint(
+        block_size, max_seq_len + 1, (batch_size,), device=device, dtype=torch.int32
+    )
+
+    # Create cumulative sequence lengths
+    cu_seq_lens = torch.zeros(batch_size + 1, device=device, dtype=torch.int32)
+    cu_seq_lens[1:] = torch.cumsum(seq_lens, dim=0)
+    num_tokens = int(cu_seq_lens[-1].item())
+
+    # Calculate number of blocks needed
+    num_blocks_per_seq = (max_seq_len + block_size - 1) // block_size
+    total_blocks = batch_size * num_blocks_per_seq
+
+    # cache_stride = head_dim + 4 (4 bytes for float32 scale per token)
+    cache_stride = head_dim + 4
+
+    # Create kv_cache: [num_blocks, block_size, cache_stride]
+    # FP8 data for K values, float32 scale packed at the end
+    kv_cache = torch.zeros(
+        total_blocks, block_size, cache_stride, dtype=torch.float8_e4m3fn, device=device
+    )
+
+    # Fill kv_cache with test data
+    for b in range(batch_size):
+        seq_len = int(seq_lens[b].item())
+        for pos in range(seq_len):
+            block_idx = b * num_blocks_per_seq + pos // block_size
+            block_offset = pos % block_size
+            # Fill K values with position-dependent data
+            kv_cache[block_idx, block_offset, :head_dim] = to_fp8(
+                torch.randn(head_dim, device=device) * 0.1
+            )
+            # Fill scale (last 4 bytes as float32)
+            scale_val = torch.tensor(
+                [0.5 + pos * 0.01], dtype=torch.float32, device=device
+            )
+            kv_cache[block_idx, block_offset, head_dim:] = scale_val.view(
+                torch.float8_e4m3fn
+            )
+
+    # Create block_table: [batch_size, num_blocks_per_seq]
+    block_table = torch.arange(total_blocks, device=device, dtype=torch.int32).view(
+        batch_size, num_blocks_per_seq
+    )
+
+    # Create output tensors
+    dst_k = torch.empty(num_tokens, head_dim, dtype=torch.float8_e4m3fn, device=device)
+    dst_scale = torch.empty(num_tokens, 1, dtype=torch.float8_e4m3fn, device=device)
+
+    # Call the function
+    cp_gather_indexer_k_quant_cache(
+        kv_cache, dst_k, dst_scale, block_table, cu_seq_lens
+    )
+
+    # Verify results by checking that data was gathered correctly
+    dst_scale_f32 = dst_scale.view(-1).view(torch.float32)
+
+    token_idx = 0
+    for b in range(batch_size):
+        seq_len = int(seq_lens[b].item())
+        for pos in range(seq_len):
+            block_idx = b * num_blocks_per_seq + pos // block_size
+            block_offset = pos % block_size
+
+            # Check K values match
+            expected_k = kv_cache[block_idx, block_offset, :head_dim]
+            actual_k = dst_k[token_idx]
+            assert torch.equal(
+                actual_k, expected_k
+            ), f"K mismatch at batch {b}, pos {pos}"
+
+            # Check scale matches
+            expected_scale = kv_cache[block_idx, block_offset, head_dim:].view(
+                torch.float32
+            )
+            actual_scale = dst_scale_f32[token_idx : token_idx + 1]
+            torch.testing.assert_close(
+                actual_scale, expected_scale, rtol=1e-5, atol=1e-5
+            )
+
+            token_idx += 1


### PR DESCRIPTION
Implement efficient gathering of quantized K cache data from paged KV cache.

### PR Category
Operator

### Type of Change
New Feature

### Description
Add `cp_gather_indexer_k_quant_cache` operator for gathering quantized K cache data from paged KV cache. This operator is used in vLLM's context parallelism for efficient KV cache operations.

Key features:
- Gathers FP8 K values and float32 scales from paged cache blocks
- Uses precomputed token-to-sequence mapping for efficient lookup
- Supports variable sequence lengths with cu_seq_lens
- Vectorized data copy for head_dim elements

Implementation details:
- Layout: kv_cache [num_blocks, block_size, head_dim + 4] (4 bytes for scale)
- Block table mapping for efficient cache block access
- Single kernel launch with num_tokens grid dimension

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
benchmark/test_vllm_perf.py::test_cp_gather_indexer_k_quant_cache_benchmark
Operator: cp_gather_indexer_k_quant_cache  Performance Test (dtype=small_batch, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007072            0.084896               0.083          [torch.Size([8, 16, 132]), torch.Size([127, 128]), torch.Size([127, 4]), torch.Size([1, 8]), torch.Size([2])]
SUCCESS               0.007136            0.115296               0.062          [torch.Size([19, 16, 132]), torch.Size([270, 128]), torch.Size([270, 4]), torch.Size([4, 8]), torch.Size([5])]
SUCCESS               0.007264            0.153248               0.047          [torch.Size([48, 16, 260]), torch.Size([690, 256]), torch.Size([690, 4]), torch.Size([8, 8]), torch.Size([9])]


Operator: cp_gather_indexer_k_quant_cache  Performance Test (dtype=medium_batch, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007808            0.232384               0.034          [torch.Size([157, 16, 132]), torch.Size([2388, 128]), torch.Size([2388, 4]), torch.Size([16, 16]), torch.Size([17])]
SUCCESS               0.009152            0.388000               0.024          [torch.Size([166, 32, 260]), torch.Size([4699, 256]), torch.Size([4699, 4]), torch.Size([32, 8]), torch.Size([33])]
SUCCESS               0.011072            0.699520               0.016          [torch.Size([350, 16, 516]), torch.Size([5107, 512]), torch.Size([5107, 4]), torch.Size([64, 8]), torch.Size([65])]


Operator: cp_gather_indexer_k_quant_cache  Performance Test (dtype=large_batch, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.012928            1.316864               0.010          [torch.Size([1332, 16, 132]), torch.Size([20394, 128]), torch.Size([20394, 4]), torch.Size([128, 16]), torch.Size([129])]
SUCCESS               0.021120            2.566368               0.008          [torch.Size([726, 32, 260]), torch.Size([19960, 256]), torch.Size([19960, 4]), torch.Size([256, 4]), torch.Size([257])]
SUCCESS               0.042080            5.048864               0.008          [torch.Size([1534, 16, 516]), torch.Size([20782, 512]), torch.Size([20782, 4]), torch.Size([512, 4]), torch.Size([513])]

PASSED