### PR TITLE
[KUNLUNXIN] update bmm implement

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/bmm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/bmm.py
@@ -175,21 +175,5 @@ def bmm_out(A, B, out):
         batch,
     )
     with torch_device_fn.device(A.device):
-        bmm_kernel[grid_fn](
-            A,
-            B,
-            out,
-            M,
-            N,
-            K,
-            A.stride(0),
-            A.stride(1),
-            A.stride(2),
-            B.stride(0),
-            B.stride(1),
-            B.stride(2),
-            out.stride(0),
-            out.stride(1),
-            out.stride(2),
-        )
+        bmm_kernel[grid_fn](A, B, out, M, N, K)
     return out


### PR DESCRIPTION
**Summary**
- Fixes Kunlunxin `bmm_out` call signature to match `bmm_kernel`, avoiding duplicate constexpr binding errors (e.g., `TILE_M`).
- Removes unintended stride arguments that are not accepted by the kernel.

**Why**
- `bmm_out` was passing extra parameters, leading to a runtime `TypeError` during JIT binding in tests.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
