### PR TITLE
Add runner ssh key to image-builder

### DIFF
--- a/.github/workflows/image-builder.yaml
+++ b/.github/workflows/image-builder.yaml
@@ -80,3 +80,4 @@ jobs:
     secrets:
       REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
       CONTAINER_REGISTRY: ${{ secrets.CONTAINER_REGISTRY }}
+      RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

Add missing RUNNER_SSH_KEY to the container image building CI job and rename to workflow file to better reflect its purpose.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
