### PR TITLE
【KernelGen】Add __or__ operator

### DIFF
--- a/benchmark/test_binary_pointwise_perf.py
+++ b/benchmark/test_binary_pointwise_perf.py
@@ -99,6 +99,7 @@ class ScalarBinaryPointwiseBenchmark(Benchmark):
             # Bitwise operations
             ("bitwise_and", torch.bitwise_and, INT_DTYPES + BOOL_DTYPES),
             ("bitwise_or", torch.bitwise_or, INT_DTYPES + BOOL_DTYPES),
+            ("dunder_or", lambda a, b: a | b, INT_DTYPES + BOOL_DTYPES),
             # Numerical Checks
             ("isclose", torch.isclose, FLOAT_DTYPES + INT_DTYPES),
             ("allclose", torch.allclose, FLOAT_DTYPES + INT_DTYPES),
@@ -135,6 +136,7 @@ def test_general_binary_pointwise_perf(op_name, torch_op, dtypes):
             # Bitwise operations
             ("bitwise_and_", lambda a, b: a.bitwise_and_(b), INT_DTYPES + BOOL_DTYPES),
             ("bitwise_or_", lambda a, b: a.bitwise_or_(b), INT_DTYPES + BOOL_DTYPES),
+            ("dunder_ior", lambda a, b: a.__ior__(b), INT_DTYPES + BOOL_DTYPES),
         ]
     ],
 )

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -28,6 +28,10 @@ def torch_ge(v):
 
 
 _FULL_CONFIG = (
+    ("__ior__.Scalar", bitwise_or_scalar_),
+    ("__ior__.Tensor", bitwise_or_tensor_),
+    ("__or__.Scalar", bitwise_or_scalar),
+    ("__or__.Tensor", bitwise_or_tensor),
     ("_assert_async", _assert_async),
     ("_flash_attention_forward", flash_attention_forward),
     (

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -2718,7 +2718,6 @@ def test_accuracy_dunder_or_scalar(shape, dtype):
     gems_assert_equal(res_out, ref_out)
 
 
-@pytest.mark.inplace
 @pytest.mark.dunder_ior
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", INT_DTYPES + BOOL_TYPES)

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -1127,13 +1127,11 @@ def test_accuracy_gelu_and_mul(shape, approximate, dtype):
     out_grad = torch.randn_like(res_out)
     ref_grad = to_reference(out_grad, True)
 
-    (ref_inp1_grad, ref_inp2_grad) = torch.autograd.grad(
+    ref_inp1_grad, ref_inp2_grad = torch.autograd.grad(
         ref_out, (ref_inp1, ref_inp2), ref_grad
     )
 
-    (res_inp1_grad, res_inp2_grad) = torch.autograd.grad(
-        res_out, (inp1, inp2), out_grad
-    )
+    res_inp1_grad, res_inp2_grad = torch.autograd.grad(res_out, (inp1, inp2), out_grad)
 
     gems_assert_close(res_out, ref_out, dtype)
     gems_assert_close(res_inp1_grad, ref_inp1_grad, dtype)
@@ -1706,13 +1704,11 @@ def test_accuracy_silu_and_mul(shape, dtype):
     out_grad = torch.randn_like(res_out)
     ref_grad = to_reference(out_grad, True)
 
-    (ref_inp1_grad, ref_inp2_grad) = torch.autograd.grad(
+    ref_inp1_grad, ref_inp2_grad = torch.autograd.grad(
         ref_out, (ref_inp1, ref_inp2), ref_grad
     )
 
-    (res_inp1_grad, res_inp2_grad) = torch.autograd.grad(
-        res_out, (inp1, inp2), out_grad
-    )
+    res_inp1_grad, res_inp2_grad = torch.autograd.grad(res_out, (inp1, inp2), out_grad)
 
     gems_assert_close(res_out, ref_out, dtype)
     gems_assert_close(res_inp1_grad, ref_inp1_grad, dtype)

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -2644,3 +2644,103 @@ def test_accuracy_atan2_out(shape, dtype):
         res_out = torch.ops.aten.atan2.out(x, y, out=res_out_buf)
 
     gems_assert_close(res_out, ref_out, dtype)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.dunder_or
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", INT_DTYPES + BOOL_TYPES)
+def test_accuracy_dunder_or(shape, dtype):
+    if dtype in BOOL_TYPES:
+        inp1 = torch.randint(0, 2, size=shape, dtype=dtype, device="cpu").to(
+            flag_gems.device
+        )
+        inp2 = torch.randint(0, 2, size=shape, dtype=dtype, device="cpu").to(
+            flag_gems.device
+        )
+    else:
+        inp1 = torch.randint(
+            low=-0x7FFF, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+        ).to(flag_gems.device)
+        inp2 = torch.randint(
+            low=-0x7FFF, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+        ).to(flag_gems.device)
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = ref_inp1 | ref_inp2
+    with flag_gems.use_gems():
+        res_out = inp1 | inp2
+
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.inplace
+@pytest.mark.dunder_ior
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", INT_DTYPES + BOOL_TYPES)
+def test_accuracy_dunder_ior(shape, dtype):
+    if dtype in BOOL_TYPES:
+        inp1 = torch.randint(0, 2, size=shape, dtype=dtype, device=flag_gems.device)
+        inp2 = torch.randint(0, 2, size=shape, dtype=dtype, device=flag_gems.device)
+    else:
+        inp1 = torch.randint(
+            low=-0x7FFF, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+        ).to(flag_gems.device)
+        inp2 = torch.randint(
+            low=-0x7FFF, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+        ).to(flag_gems.device)
+    ref_inp1 = to_reference(inp1.clone())
+    ref_inp2 = to_reference(inp2)
+
+    ref_inp1 |= ref_inp2
+    with flag_gems.use_gems():
+        inp1 |= inp2
+
+    gems_assert_equal(inp1, ref_inp1)
+
+
+@pytest.mark.dunder_or
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", INT_DTYPES + BOOL_TYPES)
+def test_accuracy_dunder_or_scalar(shape, dtype):
+    if dtype in BOOL_TYPES:
+        inp1 = torch.randint(0, 2, size=shape, dtype=dtype, device="cpu").to(
+            flag_gems.device
+        )
+        inp2 = bool(random.randint(0, 1))
+    else:
+        inp1 = torch.randint(
+            low=-0x7FFF, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+        ).to(flag_gems.device)
+        inp2 = 0x00FF
+    ref_inp1 = to_reference(inp1)
+
+    ref_out = ref_inp1 | inp2
+    with flag_gems.use_gems():
+        res_out = inp1 | inp2
+
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.inplace
+@pytest.mark.dunder_ior
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", INT_DTYPES + BOOL_TYPES)
+def test_accuracy_dunder_ior_scalar(shape, dtype):
+    if dtype in BOOL_TYPES:
+        inp1 = torch.randint(0, 2, size=shape, dtype=dtype, device=flag_gems.device)
+        inp2 = bool(random.randint(0, 1))
+    else:
+        inp1 = torch.randint(
+            low=-0x7FFF, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+        ).to(flag_gems.device)
+        inp2 = 0x00FF
+    ref_inp1 = to_reference(inp1.clone())
+
+    ref_inp1 |= inp2
+    with flag_gems.use_gems():
+        inp1 |= inp2
+
+    gems_assert_equal(inp1, ref_inp1)

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -2641,8 +2641,6 @@ def test_accuracy_atan2_out(shape, dtype):
 
     gems_assert_close(res_out, ref_out, dtype)
 
-    gems_assert_close(res_out, ref_out, dtype)
-
 
 @pytest.mark.dunder_or
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -2670,7 +2670,6 @@ def test_accuracy_dunder_or(shape, dtype):
     gems_assert_equal(res_out, ref_out)
 
 
-@pytest.mark.inplace
 @pytest.mark.dunder_ior
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", INT_DTYPES + BOOL_TYPES)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `__or__` operator implementation with Triton kernel.

- Implementation mode: `pointwise_dynamic`
- Accuracy test: 72/72 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bool**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 2.3673 | 2.5636 | 0.923 |
| [4096, 4096] | 0.0491 | 0.0494 | 0.993 |
| [1024, 1024, 1024] | 2.3659 | 2.4698 | 0.958 |

**torch.int16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 4.7504 | 4.6767 | 1.016 |
| [4096, 4096] | 0.0856 | 0.0855 | 1.001 |
| [1024, 1024, 1024] | 4.7489 | 4.6963 | 1.011 |

**torch.int32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 9.4788 | 9.3239 | 1.017 |
| [4096, 4096] | 0.1579 | 0.1584 | 0.997 |
| [1024, 1024, 1024] | 9.4756 | 9.3351 | 1.015 |

**Overall: median speedup = 1.001x, mean speedup = 0.992x** (9 data points)

---
_Generated by auto_gen tool with Claude Code_
