### PR TITLE
【KernelGen】Add _adaptive_avg_pool2d_backward operator

### DIFF
--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -422,6 +422,50 @@ def test_perf_max_pool2d_backward():
     bench.run()
 
 
+def adaptive_avg_pool2d_backward_input_fn(shape, dtype, device):
+    """Generate inputs for _adaptive_avg_pool2d_backward benchmark."""
+    inp = generate_tensor_input(shape, dtype, device)
+    # Common output sizes for adaptive pooling
+    output_sizes = [(7, 7)]  # Global pooling to 7x7 (common in ResNet)
+    if Config.bench_level == BenchLevel.COMPREHENSIVE:
+        output_sizes.extend([
+            (1, 1),  # Global average pooling
+            (4, 4),
+        ])
+
+    for output_size in output_sizes:
+        if output_size[0] <= shape[-2] and output_size[1] <= shape[-1]:
+            # Compute forward to get grad_output shape
+            forward_out = torch.nn.functional.adaptive_avg_pool2d(inp, output_size)
+            grad_output = torch.randn_like(forward_out)
+            yield grad_output, inp
+
+
+class AdaptiveAvgPool2dBackwardBenchmark(GenericBenchmark):
+    def get_input_iter(self, cur_dtype) -> Generator:
+        shapes_4d = [
+            (4, 3, 224, 224),  # Typical input image size
+            (16, 64, 56, 56),  # Early ResNet layer output
+            (32, 128, 28, 28),  # Mid ResNet layer output
+            (64, 256, 14, 14),  # Later ResNet layer output
+            (128, 512, 7, 7),  # Final ResNet layer output
+        ]
+
+        for shape in shapes_4d:
+            yield from self.input_fn(shape, cur_dtype, self.device)
+
+
+@pytest.mark.adaptive_avg_pool2d_backward
+def test_perf_adaptive_avg_pool2d_backward():
+    bench = AdaptiveAvgPool2dBackwardBenchmark(
+        input_fn=adaptive_avg_pool2d_backward_input_fn,
+        op_name="adaptive_avg_pool2d_backward",
+        torch_op=torch.ops.aten._adaptive_avg_pool2d_backward,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.run()
+
+
 @pytest.mark.dot
 def test_perf_dot():
     def dot_input_fn(shape, dtype, device):

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -28,6 +28,7 @@ def torch_ge(v):
 
 
 _FULL_CONFIG = (
+    ("_adaptive_avg_pool2d_backward", _adaptive_avg_pool2d_backward),
     ("_flash_attention_forward", flash_attention_forward),
     ("_log_softmax", log_softmax),
     ("_log_softmax_backward_data", log_softmax_backward),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -1,3 +1,4 @@
+from flag_gems.ops._adaptive_avg_pool2d_backward import _adaptive_avg_pool2d_backward
 from flag_gems.ops.abs import abs, abs_
 from flag_gems.ops.acos import acos
 from flag_gems.ops.add import add, add_
@@ -240,6 +241,7 @@ from flag_gems.ops.zeros import zero_, zeros
 from flag_gems.ops.zeros_like import zeros_like
 
 __all__ = [
+    "_adaptive_avg_pool2d_backward",
     "_conv_depthwise2d",
     "_unique2",
     "_upsample_bicubic2d_aa",

--- a/src/flag_gems/ops/_adaptive_avg_pool2d_backward.py
+++ b/src/flag_gems/ops/_adaptive_avg_pool2d_backward.py
@@ -1,0 +1,210 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_H": 16, "BLOCK_W": 16}, num_stages=4, num_warps=4),
+        triton.Config({"BLOCK_H": 32, "BLOCK_W": 16}, num_stages=3, num_warps=4),
+        triton.Config({"BLOCK_H": 16, "BLOCK_W": 32}, num_stages=3, num_warps=4),
+        triton.Config({"BLOCK_H": 32, "BLOCK_W": 32}, num_stages=2, num_warps=8),
+        triton.Config({"BLOCK_H": 8, "BLOCK_W": 8}, num_stages=5, num_warps=2),
+        triton.Config({"BLOCK_H": 8, "BLOCK_W": 16}, num_stages=5, num_warps=2),
+        triton.Config({"BLOCK_H": 16, "BLOCK_W": 8}, num_stages=5, num_warps=2),
+    ],
+    key=["in_h", "in_w", "out_h", "out_w"],
+)
+@triton.jit
+def _adaptive_avg_pool2d_backward_kernel(
+    grad_output_ptr,
+    grad_input_ptr,
+    # Input/Output shapes
+    in_c,
+    in_h,
+    in_w,
+    out_h,
+    out_w,
+    # Strides for grad_output
+    out_stride_n,
+    out_stride_c,
+    out_stride_h,
+    out_stride_w,
+    # Strides for grad_input
+    in_stride_n,
+    in_stride_c,
+    in_stride_h,
+    in_stride_w,
+    # Tiling meta-parameters
+    BLOCK_H: tl.constexpr,
+    BLOCK_W: tl.constexpr,
+):
+    """
+    Backward kernel for adaptive average pooling 2D.
+
+    For each input position (ih, iw), we need to find all output positions (oh, ow)
+    whose pooling window includes (ih, iw), and accumulate:
+        grad_input[ih, iw] += grad_output[oh, ow] / window_size
+
+    The adaptive pooling window boundaries are computed as:
+        start_h(oh) = (oh * in_h) // out_h
+        end_h(oh) = ((oh + 1) * in_h + out_h - 1) // out_h
+    """
+    pid_nc = tl.program_id(0)
+    pid_hw = tl.program_id(1)
+
+    num_w_blocks = tl.cdiv(in_w, BLOCK_W)
+
+    h_block_idx = pid_hw // num_w_blocks
+    w_block_idx = pid_hw % num_w_blocks
+    n_idx = pid_nc // in_c
+    c_idx = pid_nc % in_c
+
+    # Input positions for this block
+    h_in_offsets = h_block_idx * BLOCK_H + tl.arange(0, BLOCK_H)
+    w_in_offsets = w_block_idx * BLOCK_W + tl.arange(0, BLOCK_W)
+
+    # Compute base pointers
+    grad_output_base = grad_output_ptr + n_idx * out_stride_n + c_idx * out_stride_c
+    grad_input_base = grad_input_ptr + n_idx * in_stride_n + c_idx * in_stride_c
+
+    # Accumulator for gradients
+    grad_acc = tl.zeros((BLOCK_H, BLOCK_W), dtype=tl.float32)
+
+    # Cast dimensions to int64 for safe integer arithmetic
+    in_h_i64 = tl.full((), in_h, dtype=tl.int64)
+    in_w_i64 = tl.full((), in_w, dtype=tl.int64)
+    out_h_i64 = tl.full((), out_h, dtype=tl.int64)
+    out_w_i64 = tl.full((), out_w, dtype=tl.int64)
+
+    h_in_i64 = h_in_offsets.to(tl.int64)
+    w_in_i64 = w_in_offsets.to(tl.int64)
+
+    # For each output position, check if it includes our input position
+    for oh in range(out_h):
+        oh_i64 = tl.full((), oh, dtype=tl.int64)
+
+        # Compute height window boundaries for this output row
+        # start_h = (oh * in_h) // out_h
+        # end_h = ((oh + 1) * in_h + out_h - 1) // out_h
+        start_h = (oh_i64 * in_h_i64) // out_h_i64
+        end_h = ((oh_i64 + 1) * in_h_i64 + out_h_i64 - 1) // out_h_i64
+
+        # Check if input height positions are in this window
+        h_in_window = (h_in_i64[:, None] >= start_h) & (h_in_i64[:, None] < end_h)
+
+        for ow in range(out_w):
+            ow_i64 = tl.full((), ow, dtype=tl.int64)
+
+            # Compute width window boundaries for this output column
+            start_w = (ow_i64 * in_w_i64) // out_w_i64
+            end_w = ((ow_i64 + 1) * in_w_i64 + out_w_i64 - 1) // out_w_i64
+
+            # Check if input width positions are in this window
+            w_in_window = (w_in_i64[None, :] >= start_w) & (w_in_i64[None, :] < end_w)
+
+            # Combined mask: input position is in this output's window
+            in_window = h_in_window & w_in_window
+
+            # Compute window size for this output position
+            window_h = end_h - start_h
+            window_w = end_w - start_w
+            window_size = (window_h * window_w).to(tl.float32)
+
+            # Load gradient from output
+            grad_out_ptr = (
+                grad_output_base + oh * out_stride_h + ow * out_stride_w
+            )
+            grad_out_val = tl.load(grad_out_ptr)
+            grad_out_val = grad_out_val.to(tl.float32)
+
+            # Add contribution: grad_output / window_size for positions in window
+            grad_contribution = grad_out_val / window_size
+            grad_acc += tl.where(in_window, grad_contribution, 0.0)
+
+    # Store accumulated gradients
+    in_write_mask = (h_in_offsets[:, None] < in_h) & (w_in_offsets[None, :] < in_w)
+    grad_input_store_ptr = (
+        grad_input_base
+        + h_in_offsets[:, None] * in_stride_h
+        + w_in_offsets[None, :] * in_stride_w
+    )
+    tl.store(
+        grad_input_store_ptr,
+        grad_acc.to(grad_input_ptr.type.element_ty),
+        mask=in_write_mask,
+    )
+
+
+def _adaptive_avg_pool2d_backward(
+    grad_output: torch.Tensor,
+    self: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Compute the backward pass for adaptive average pooling 2D.
+
+    Args:
+        grad_output: Gradient with respect to the output of adaptive_avg_pool2d.
+                    Shape: (N, C, out_H, out_W) or (C, out_H, out_W)
+        self: The input tensor from the forward pass.
+              Shape: (N, C, in_H, in_W) or (C, in_H, in_W)
+
+    Returns:
+        grad_input: Gradient with respect to the input.
+                   Shape: same as self
+    """
+    logger.debug("GEMS _ADAPTIVE_AVG_POOL2D_BACKWARD")
+
+    # Handle 3D input (C, H, W) by adding batch dimension
+    input_is_3d = self.dim() == 3
+    if input_is_3d:
+        grad_output = grad_output.unsqueeze(0)
+        self = self.unsqueeze(0)
+
+    grad_output = grad_output.contiguous()
+
+    in_n, in_c, in_h, in_w = self.shape
+    out_h, out_w = grad_output.shape[2], grad_output.shape[3]
+
+    # Create output tensor (same shape as input)
+    grad_input = torch.empty_like(self, dtype=self.dtype)
+
+    if grad_output.numel() == 0 or self.numel() == 0:
+        if input_is_3d:
+            return grad_input.squeeze(0)
+        return grad_input
+
+    grid = lambda meta: (
+        in_n * in_c,
+        triton.cdiv(in_h, meta["BLOCK_H"]) * triton.cdiv(in_w, meta["BLOCK_W"]),
+    )
+
+    _adaptive_avg_pool2d_backward_kernel[grid](
+        grad_output,
+        grad_input,
+        in_c,
+        in_h,
+        in_w,
+        out_h,
+        out_w,
+        grad_output.stride(0),
+        grad_output.stride(1),
+        grad_output.stride(2),
+        grad_output.stride(3),
+        grad_input.stride(0),
+        grad_input.stride(1),
+        grad_input.stride(2),
+        grad_input.stride(3),
+    )
+
+    if input_is_3d:
+        return grad_input.squeeze(0)
+
+    return grad_input

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -2201,3 +2201,70 @@ def test_accuracy_masked_scatter_(shape, dtype, threshold):
         inp.masked_scatter_(mask, src)
 
     gems_assert_equal(inp, ref_inp)
+
+
+# Adaptive average pooling 2D backward configurations
+# (input_shape, output_size)
+ADAPTIVE_AVGPOOL2D_BACKWARD_CONFIGS = [
+    # Basic cases with even division
+    ((2, 3, 8, 8), (4, 4)),
+    ((1, 1, 16, 16), (8, 8)),
+    # Non-even division (different window sizes)
+    ((2, 4, 7, 7), (3, 3)),
+    ((1, 3, 10, 10), (4, 4)),
+    # Non-square input and output
+    ((2, 3, 8, 12), (4, 6)),
+    ((1, 2, 15, 10), (5, 4)),
+    # Larger input to smaller output
+    ((1, 64, 56, 56), (7, 7)),
+    # Same size (no pooling)
+    ((2, 3, 4, 4), (4, 4)),
+    # Upsampling case (output larger than input)
+    ((1, 1, 4, 4), (8, 8)),
+    # Single channel, single batch
+    ((1, 1, 6, 6), (2, 2)),
+]
+
+
+@pytest.mark.adaptive_avg_pool2d_backward
+@pytest.mark.parametrize("shape, output_size", ADAPTIVE_AVGPOOL2D_BACKWARD_CONFIGS)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy__adaptive_avg_pool2d_backward(shape, output_size, dtype):
+    """Test _adaptive_avg_pool2d_backward accuracy."""
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    ref_inp = to_reference(inp, True)
+
+    # Compute forward pass to get the output shape
+    ref_out = torch.nn.functional.adaptive_avg_pool2d(ref_inp, output_size)
+    out_grad = torch.randn_like(ref_out, dtype=dtype, device=flag_gems.device)
+    ref_out_grad = to_reference(out_grad, True)
+
+    # Compute reference backward
+    ref_inp_grad = torch.ops.aten._adaptive_avg_pool2d_backward(ref_out_grad, ref_inp)
+
+    # Compute FlagGems backward
+    with flag_gems.use_gems():
+        res_inp_grad = torch.ops.aten._adaptive_avg_pool2d_backward(out_grad, inp)
+
+    gems_assert_close(res_inp_grad, ref_inp_grad, dtype)
+
+
+@pytest.mark.adaptive_avg_pool2d_backward
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy__adaptive_avg_pool2d_backward_3d_input(dtype):
+    """Test _adaptive_avg_pool2d_backward with 3D input (C, H, W)."""
+    # 3D input without batch dimension
+    inp = torch.randn((3, 8, 8), dtype=dtype, device=flag_gems.device, requires_grad=True)
+    ref_inp = to_reference(inp, True)
+    output_size = (4, 4)
+
+    ref_out = torch.nn.functional.adaptive_avg_pool2d(ref_inp, output_size)
+    out_grad = torch.randn_like(ref_out, dtype=dtype, device=flag_gems.device)
+    ref_out_grad = to_reference(out_grad, True)
+
+    ref_inp_grad = torch.ops.aten._adaptive_avg_pool2d_backward(ref_out_grad, ref_inp)
+
+    with flag_gems.use_gems():
+        res_inp_grad = torch.ops.aten._adaptive_avg_pool2d_backward(out_grad, inp)
+
+    gems_assert_close(res_inp_grad, ref_inp_grad, dtype)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `_adaptive_avg_pool2d_backward` operator implementation with Triton kernel.

- Implementation mode: `N/A`
- Accuracy test: 33/33 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([4, 3, 7, 7]) | 0.7338 | 0.0535 | 13.722 |
| torch.Size([4, 3, 1, 1]) | 29.2549 | 0.0079 | 3701.276 |
| torch.Size([4, 3, 4, 4]) | 2.1617 | 0.0283 | 76.416 |
| torch.Size([16, 64, 7, 7]) | 0.1292 | 0.2470 | 0.523 |
| torch.Size([16, 64, 1, 1]) | 4.1273 | 0.0177 | 233.231 |
| torch.Size([16, 64, 4, 4]) | 0.3021 | 0.1372 | 2.201 |
| torch.Size([32, 128, 7, 7]) | 0.1113 | 0.3014 | 0.369 |
| torch.Size([32, 128, 1, 1]) | 1.5205 | 0.0171 | 89.148 |
| torch.Size([32, 128, 4, 4]) | 0.1937 | 0.1362 | 1.422 |
| torch.Size([64, 256, 7, 7]) | 0.1747 | 0.4310 | 0.405 |
| torch.Size([64, 256, 1, 1]) | 0.8324 | 0.0232 | 35.930 |
| torch.Size([64, 256, 4, 4]) | 0.2854 | 0.2624 | 1.088 |
| torch.Size([128, 512, 7, 7]) | 0.3803 | 0.7005 | 0.543 |
| torch.Size([128, 512, 1, 1]) | 0.8132 | 0.0562 | 14.464 |
| torch.Size([128, 512, 4, 4]) | 1.1231 | 0.3292 | 3.411 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([4, 3, 7, 7]) | 0.6353 | 0.0540 | 11.761 |
| torch.Size([4, 3, 1, 1]) | 24.5913 | 0.0081 | 3037.466 |
| torch.Size([4, 3, 4, 4]) | 1.8587 | 0.0283 | 65.706 |
| torch.Size([16, 64, 7, 7]) | 0.1207 | 0.2469 | 0.489 |
| torch.Size([16, 64, 1, 1]) | 3.5035 | 0.0162 | 215.945 |
| torch.Size([16, 64, 4, 4]) | 0.2644 | 0.1354 | 1.953 |
| torch.Size([32, 128, 7, 7]) | 0.1026 | 0.3026 | 0.339 |
| torch.Size([32, 128, 1, 1]) | 1.2974 | 0.0168 | 77.227 |
| torch.Size([32, 128, 4, 4]) | 0.1740 | 0.1357 | 1.282 |
| torch.Size([64, 256, 7, 7]) | 0.1379 | 0.4313 | 0.320 |
| torch.Size([64, 256, 1, 1]) | 0.7163 | 0.0241 | 29.766 |
| torch.Size([64, 256, 4, 4]) | 0.2147 | 0.2624 | 0.818 |
| torch.Size([128, 512, 7, 7]) | 0.3335 | 0.6956 | 0.480 |
| torch.Size([128, 512, 1, 1]) | 0.7115 | 0.0552 | 12.897 |
| torch.Size([128, 512, 4, 4]) | 0.7657 | 0.3280 | 2.335 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([4, 3, 7, 7]) | 0.0516 | 0.0538 | 0.959 |
| torch.Size([4, 3, 1, 1]) | 0.3623 | 0.0079 | 45.834 |
| torch.Size([4, 3, 4, 4]) | 0.0515 | 0.0281 | 1.834 |
| torch.Size([16, 64, 7, 7]) | 0.0820 | 0.2462 | 0.333 |
| torch.Size([16, 64, 1, 1]) | 0.1492 | 0.0163 | 9.141 |
| torch.Size([16, 64, 4, 4]) | 0.1027 | 0.1355 | 0.758 |
| torch.Size([32, 128, 7, 7]) | 0.0548 | 0.3007 | 0.182 |
| torch.Size([32, 128, 1, 1]) | 0.0839 | 0.0163 | 5.141 |
| torch.Size([32, 128, 4, 4]) | 0.0752 | 0.1361 | 0.553 |
| torch.Size([64, 256, 7, 7]) | 0.0804 | 0.4292 | 0.187 |
| torch.Size([64, 256, 1, 1]) | 0.0756 | 0.0240 | 3.156 |
| torch.Size([64, 256, 4, 4]) | 0.0720 | 0.2626 | 0.274 |
| torch.Size([128, 512, 7, 7]) | 0.2444 | 0.6964 | 0.351 |
| torch.Size([128, 512, 1, 1]) | 0.0952 | 0.0552 | 1.724 |
| torch.Size([128, 512, 4, 4]) | 0.1722 | 0.3272 | 0.526 |

**Overall: median speedup = 1.834x, mean speedup = 171.197x** (45 data points)

---
_Generated by auto_gen tool with Claude Code_
