### PR TITLE
【KernelGen】Add _efficient_attention_forward operator

### DIFF
--- a/benchmark/test_attention_perf.py
+++ b/benchmark/test_attention_perf.py
@@ -700,3 +700,84 @@ def test_perf_reshape_and_cache_flash():
     )
     bench.set_gems(flag_gems.reshape_and_cache_flash)
     bench.run()
+
+
+class EfficientAttentionBenchmark(Benchmark):
+    """
+    benchmark for _efficient_attention_forward
+    """
+
+    def __init__(self, custom_mask_type, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.custom_mask_type = custom_mask_type
+
+    def set_shapes(self, shape_file_path=None):
+        # (batch, seq_len, num_heads, head_size)
+        self.shapes = [
+            (2, 256, 8, 64),
+            (2, 512, 8, 64),
+            (2, 1024, 8, 64),
+            (4, 512, 8, 64),
+            (4, 1024, 16, 64),
+            (2, 2048, 8, 64),
+            (2, 512, 8, 128),
+        ]
+
+    def get_input_iter(self, cur_dtype):
+        for shape in self.shapes:
+            yield self.efficient_attention_input_fn(shape, cur_dtype, self.device)
+
+    def efficient_attention_input_fn(self, shape, dtype, device):
+        # shape is (batch, seq_len, num_heads, head_size)
+        batch, seq_len, num_heads, head_size = shape
+        # Input shape for _efficient_attention_forward: (batch, seq_len, num_heads, head_dim)
+        query = torch.randn(batch, seq_len, num_heads, head_size, device=device, dtype=dtype)
+        key = torch.randn(batch, seq_len, num_heads, head_size, device=device, dtype=dtype)
+        value = torch.randn(batch, seq_len, num_heads, head_size, device=device, dtype=dtype)
+        return (
+            query,
+            key,
+            value,
+            None,  # bias
+            None,  # cu_seqlens_q
+            None,  # cu_seqlens_k
+            None,  # max_seqlen_q
+            None,  # max_seqlen_k
+            0.0,   # dropout_p
+            self.custom_mask_type,  # custom_mask_type
+            False,  # compute_log_sumexp
+        )
+
+
+@pytest.mark.efficient_attention_forward
+@pytest.mark.parametrize("custom_mask_type", [0, 1])  # 0=no mask, 1=causal
+def test_perf_efficient_attention_forward(custom_mask_type):
+    def torch_efficient_attention(
+        query, key, value, bias, cu_seqlens_q, cu_seqlens_k,
+        max_seqlen_q, max_seqlen_k, dropout_p, custom_mask_type, compute_log_sumexp
+    ):
+        return torch.ops.aten._efficient_attention_forward(
+            query, key, value, bias, cu_seqlens_q, cu_seqlens_k,
+            max_seqlen_q, max_seqlen_k, dropout_p, custom_mask_type, compute_log_sumexp
+        )
+
+    def gems_efficient_attention(
+        query, key, value, bias, cu_seqlens_q, cu_seqlens_k,
+        max_seqlen_q, max_seqlen_k, dropout_p, custom_mask_type, compute_log_sumexp
+    ):
+        return flag_gems._efficient_attention_forward(
+            query, key, value, bias, cu_seqlens_q, cu_seqlens_k,
+            max_seqlen_q, max_seqlen_k, dropout_p, custom_mask_type, compute_log_sumexp
+        )
+
+    bench = EfficientAttentionBenchmark(
+        custom_mask_type=custom_mask_type,
+        op_name="efficient_attention_forward",
+        torch_op=torch_efficient_attention,
+        dtypes=[
+            torch.float16,
+            torch.bfloat16,
+        ],
+    )
+    bench.set_gems(gems_efficient_attention)
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -28,6 +28,7 @@ def torch_ge(v):
 
 
 _FULL_CONFIG = (
+    ("_efficient_attention_forward", _efficient_attention_forward),
     ("_flash_attention_forward", flash_attention_forward),
     ("_log_softmax", log_softmax),
     ("_log_softmax_backward_data", log_softmax_backward),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -1,3 +1,4 @@
+from flag_gems.ops._efficient_attention_forward import _efficient_attention_forward
 from flag_gems.ops.abs import abs, abs_
 from flag_gems.ops.acos import acos
 from flag_gems.ops.add import add, add_
@@ -241,6 +242,7 @@ from flag_gems.ops.zeros_like import zeros_like
 
 __all__ = [
     "_conv_depthwise2d",
+    "_efficient_attention_forward",
     "_unique2",
     "_upsample_bicubic2d_aa",
     "abs",

--- a/src/flag_gems/ops/_efficient_attention_forward.py
+++ b/src/flag_gems/ops/_efficient_attention_forward.py
@@ -1,0 +1,126 @@
+import logging
+
+import torch
+
+from flag_gems.ops.attention import scaled_dot_product_attention_forward
+
+logger = logging.getLogger(__name__)
+
+
+def _efficient_attention_forward(
+    query,
+    key,
+    value,
+    bias=None,
+    cu_seqlens_q=None,
+    cu_seqlens_k=None,
+    max_seqlen_q=None,
+    max_seqlen_k=None,
+    dropout_p=0.0,
+    custom_mask_type=0,
+    compute_log_sumexp=False,
+    *,
+    scale=None,
+    seqlen_k=None,
+    window_size=None,
+):
+    """
+    Memory-efficient attention forward pass (xFormers style).
+
+    Args:
+        query: (batch, seq_q, num_heads, head_dim)
+        key: (batch, seq_k, num_heads, head_dim)
+        value: (batch, seq_k, num_heads, head_dim)
+        bias: Optional attention bias (batch, num_heads, seq_q, seq_k)
+        cu_seqlens_q: Cumulative sequence lengths for query (for variable length)
+        cu_seqlens_k: Cumulative sequence lengths for key (for variable length)
+        max_seqlen_q: Maximum sequence length for query
+        max_seqlen_k: Maximum sequence length for key
+        dropout_p: Dropout probability (must be 0.0 currently)
+        custom_mask_type: 0=no mask, 1=causal, 2=upper triangular (not supported)
+        compute_log_sumexp: Whether to compute and return logsumexp
+        scale: Scale factor for attention scores (default: 1/sqrt(head_dim))
+        seqlen_k: Per-batch sequence lengths for key
+        window_size: Sliding window size (not supported)
+
+    Returns:
+        Tuple of (output, logsumexp, philox_seed, philox_offset,
+                  max_seqlen_batch_q, max_seqlen_batch_k)
+    """
+    logger.debug("GEMS _EFFICIENT_ATTENTION_FORWARD")
+
+    # Validate inputs
+    assert cu_seqlens_q is None and cu_seqlens_k is None, (
+        "Variable length attention (cu_seqlens) is not supported yet"
+    )
+    assert custom_mask_type in (0, 1), (
+        f"custom_mask_type={custom_mask_type} not supported, only 0 (no mask) and 1 (causal) are supported"
+    )
+    assert window_size is None, "Sliding window attention is not supported yet"
+
+    # Input shape: (batch, seq_len, num_heads, head_dim)
+    # Need to transpose to (batch, num_heads, seq_len, head_dim) for the kernel
+    batch_size, seq_q, num_heads, head_dim = query.shape
+    _, seq_k, _, _ = key.shape
+
+    # Transpose: (batch, seq_len, heads, head_dim) -> (batch, heads, seq_len, head_dim)
+    query_t = query.transpose(1, 2).contiguous()
+    key_t = key.transpose(1, 2).contiguous()
+    value_t = value.transpose(1, 2).contiguous()
+
+    # Handle bias - it should be (batch, num_heads, seq_q, seq_k)
+    # The FlagGems kernel applies the mask after converting QK^T to log2 space,
+    # so we need to scale the bias by log2(e) for correct behavior
+    LOG2E = 1.44269504
+    attn_mask = None
+    if bias is not None:
+        attn_mask = bias * LOG2E
+
+    # Determine if causal mask is needed
+    is_causal = custom_mask_type == 1
+
+    # Call the underlying attention implementation
+    output_t, M = scaled_dot_product_attention_forward(
+        query_t,
+        key_t,
+        value_t,
+        attn_mask=attn_mask,
+        dropout_p=dropout_p,
+        is_causal=is_causal,
+        scale=scale,
+        enable_gqa=False,
+    )
+
+    # Transpose output back: (batch, heads, seq_len, head_dim) -> (batch, seq_len, heads, head_dim)
+    output = output_t.transpose(1, 2).contiguous()
+
+    # Prepare logsumexp output
+    if compute_log_sumexp:
+        # M has shape (batch, num_heads, seq_q)
+        # Need to convert from log2 space to natural log space
+        # M is stored as log2(sum(exp(x))) so we need to multiply by ln(2) to get natural log
+        logsumexp = M * 0.6931471824645996  # ln(2)
+    else:
+        # Return empty tensor when not computing logsumexp
+        logsumexp = torch.empty(
+            (batch_size, num_heads, 0),
+            device=query.device,
+            dtype=torch.float32,
+        )
+
+    # Create dummy philox state tensors (we don't support dropout)
+    philox_seed = torch.tensor(0, device=query.device, dtype=torch.int64)
+    philox_offset = torch.tensor(0, device=query.device, dtype=torch.int64)
+
+    # Return max sequence lengths
+    max_seqlen_batch_q = seq_q
+    max_seqlen_batch_k = seq_k
+
+    return (
+        output,
+        logsumexp,
+        philox_seed,
+        philox_offset,
+        max_seqlen_batch_q,
+        max_seqlen_batch_k,
+    )

--- a/tests/test_attention_ops.py
+++ b/tests/test_attention_ops.py
@@ -1771,3 +1771,192 @@ def test_scheduler_metadata_correctness(
         )
 
     gems_assert_close(gems_metadata, ref_metadata, dtype=torch.int32)
+
+
+@pytest.mark.efficient_attention_forward
+@pytest.mark.parametrize(
+    "batch, num_heads, seq_q, seq_k, head_size",
+    [
+        (2, 4, 64, 64, 64),
+        (2, 4, 128, 128, 64),
+        (2, 8, 256, 256, 32),
+        (1, 4, 512, 512, 64),
+        (2, 4, 128, 256, 64),
+        (2, 4, 256, 128, 64),
+        (2, 4, 64, 64, 128),
+    ],
+)
+@pytest.mark.parametrize("custom_mask_type", [0, 1])  # 0=no mask, 1=causal
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_efficient_attention_forward(
+    batch, num_heads, seq_q, seq_k, head_size, custom_mask_type, dtype
+):
+    """Test _efficient_attention_forward operator."""
+    device = torch_device_fn.current_device()
+
+    # Input shape for _efficient_attention_forward: (batch, seq_len, heads, head_dim)
+    query = torch.randn(batch, seq_q, num_heads, head_size, device=device, dtype=dtype)
+    key = torch.randn(batch, seq_k, num_heads, head_size, device=device, dtype=dtype)
+    value = torch.randn(batch, seq_k, num_heads, head_size, device=device, dtype=dtype)
+
+    ref_query = to_reference(query)
+    ref_key = to_reference(key)
+    ref_value = to_reference(value)
+
+    # Call PyTorch reference
+    ref_out = torch.ops.aten._efficient_attention_forward(
+        ref_query,
+        ref_key,
+        ref_value,
+        None,  # bias
+        None,  # cu_seqlens_q
+        None,  # cu_seqlens_k
+        None,  # max_seqlen_q
+        None,  # max_seqlen_k
+        0.0,  # dropout_p
+        custom_mask_type,
+        False,  # compute_log_sumexp
+    )
+
+    # Call FlagGems implementation
+    with flag_gems.use_gems():
+        gems_out = torch.ops.aten._efficient_attention_forward(
+            query,
+            key,
+            value,
+            None,  # bias
+            None,  # cu_seqlens_q
+            None,  # cu_seqlens_k
+            None,  # max_seqlen_q
+            None,  # max_seqlen_k
+            0.0,  # dropout_p
+            custom_mask_type,
+            False,  # compute_log_sumexp
+        )
+
+    # Compare output tensors - use larger atol for attention due to numerical differences
+    gems_assert_close(gems_out[0], ref_out[0], dtype, atol=5e-3)
+
+
+@pytest.mark.efficient_attention_forward
+@pytest.mark.parametrize(
+    "batch, num_heads, seq_q, seq_k, head_size",
+    [
+        (2, 4, 64, 64, 64),
+        (2, 4, 128, 128, 64),
+        (1, 4, 256, 256, 64),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_efficient_attention_forward_with_bias(
+    batch, num_heads, seq_q, seq_k, head_size, dtype
+):
+    """Test _efficient_attention_forward operator with bias."""
+    device = torch_device_fn.current_device()
+
+    # Input shape for _efficient_attention_forward: (batch, seq_len, heads, head_dim)
+    query = torch.randn(batch, seq_q, num_heads, head_size, device=device, dtype=dtype)
+    key = torch.randn(batch, seq_k, num_heads, head_size, device=device, dtype=dtype)
+    value = torch.randn(batch, seq_k, num_heads, head_size, device=device, dtype=dtype)
+    bias = torch.randn(batch, num_heads, seq_q, seq_k, device=device, dtype=dtype)
+
+    ref_query = to_reference(query)
+    ref_key = to_reference(key)
+    ref_value = to_reference(value)
+    ref_bias = to_reference(bias)
+
+    # Call PyTorch reference
+    ref_out = torch.ops.aten._efficient_attention_forward(
+        ref_query,
+        ref_key,
+        ref_value,
+        ref_bias,  # bias
+        None,  # cu_seqlens_q
+        None,  # cu_seqlens_k
+        None,  # max_seqlen_q
+        None,  # max_seqlen_k
+        0.0,  # dropout_p
+        0,  # custom_mask_type (no causal mask when bias is used)
+        False,  # compute_log_sumexp
+    )
+
+    # Call FlagGems implementation
+    with flag_gems.use_gems():
+        gems_out = torch.ops.aten._efficient_attention_forward(
+            query,
+            key,
+            value,
+            bias,  # bias
+            None,  # cu_seqlens_q
+            None,  # cu_seqlens_k
+            None,  # max_seqlen_q
+            None,  # max_seqlen_k
+            0.0,  # dropout_p
+            0,  # custom_mask_type
+            False,  # compute_log_sumexp
+        )
+
+    # Compare output tensors - use larger atol for attention due to numerical differences
+    gems_assert_close(gems_out[0], ref_out[0], dtype, atol=5e-3)
+
+
+@pytest.mark.efficient_attention_forward
+@pytest.mark.parametrize(
+    "batch, num_heads, seq_q, seq_k, head_size",
+    [
+        (2, 4, 64, 64, 64),
+        (2, 4, 128, 128, 64),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_efficient_attention_forward_logsumexp(
+    batch, num_heads, seq_q, seq_k, head_size, dtype
+):
+    """Test _efficient_attention_forward operator with compute_log_sumexp=True."""
+    device = torch_device_fn.current_device()
+
+    # Input shape for _efficient_attention_forward: (batch, seq_len, heads, head_dim)
+    query = torch.randn(batch, seq_q, num_heads, head_size, device=device, dtype=dtype)
+    key = torch.randn(batch, seq_k, num_heads, head_size, device=device, dtype=dtype)
+    value = torch.randn(batch, seq_k, num_heads, head_size, device=device, dtype=dtype)
+
+    ref_query = to_reference(query)
+    ref_key = to_reference(key)
+    ref_value = to_reference(value)
+
+    # Call PyTorch reference
+    ref_out = torch.ops.aten._efficient_attention_forward(
+        ref_query,
+        ref_key,
+        ref_value,
+        None,  # bias
+        None,  # cu_seqlens_q
+        None,  # cu_seqlens_k
+        None,  # max_seqlen_q
+        None,  # max_seqlen_k
+        0.0,  # dropout_p
+        0,  # custom_mask_type
+        True,  # compute_log_sumexp
+    )
+
+    # Call FlagGems implementation
+    with flag_gems.use_gems():
+        gems_out = torch.ops.aten._efficient_attention_forward(
+            query,
+            key,
+            value,
+            None,  # bias
+            None,  # cu_seqlens_q
+            None,  # cu_seqlens_k
+            None,  # max_seqlen_q
+            None,  # max_seqlen_k
+            0.0,  # dropout_p
+            0,  # custom_mask_type
+            True,  # compute_log_sumexp
+        )
+
+    # Compare output tensors - use larger atol for attention due to numerical differences
+    gems_assert_close(gems_out[0], ref_out[0], dtype, atol=5e-3)
+    # Compare logsumexp - shape may differ slightly but values should be close
+    if gems_out[1].numel() > 0 and ref_out[1].numel() > 0:
+        gems_assert_close(gems_out[1], ref_out[1], torch.float32, atol=5e-3)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `_efficient_attention_forward` operator implementation with Triton kernel.

- Implementation mode: `manual_kernel`
- Accuracy test: 38/38 passed

> **Note**: This operator has known flaky accuracy tests that may need tolerance adjustment.

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [2, 256, 8, 64] | 0.0230 | 0.0984 | 0.233 |
| [2, 512, 8, 64] | 0.0418 | 0.1116 | 0.374 |
| [2, 1024, 8, 64] | 0.0846 | 0.1492 | 0.567 |
| [4, 512, 8, 64] | 0.0492 | 0.1302 | 0.378 |
| [4, 1024, 16, 64] | 0.2415 | 0.2940 | 0.821 |
| [2, 2048, 8, 64] | 0.2888 | 0.2570 | 1.124 |
| [2, 512, 8, 128] | 0.0455 | 0.1369 | 0.332 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [2, 256, 8, 64] | 0.0291 | 0.1084 | 0.268 |
| [2, 512, 8, 64] | 0.0411 | 0.1116 | 0.368 |
| [2, 1024, 8, 64] | 0.0853 | 0.1494 | 0.571 |
| [4, 512, 8, 64] | 0.0485 | 0.1304 | 0.372 |
| [4, 1024, 16, 64] | 0.2422 | 0.2935 | 0.825 |
| [2, 2048, 8, 64] | 0.2894 | 0.2556 | 1.132 |
| [2, 512, 8, 128] | 0.0455 | 0.1367 | 0.333 |

**Overall: median speedup = 0.376x, mean speedup = 0.550x** (14 data points)

---
_Generated by auto_gen tool with Claude Code_
