### PR TITLE
【KernelGen】Add _fft_c2c operator

### DIFF
--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -821,3 +821,54 @@ def test_perf_moe_align_block_size():
 
     bench.set_gems(gems_op)
     bench.run()
+
+
+# FFT Benchmark
+COMPLEX_DTYPES = [torch.complex64]
+
+
+class FFTBenchmark(Benchmark):
+    """Benchmark for _fft_c2c operation."""
+
+    def set_shapes(self, shape_file_path=None):
+        # Power-of-2 sizes for optimal performance
+        fft_shapes = [
+            (64,),
+            (128,),
+            (256,),
+            (512,),
+            (1024,),
+            (2048,),
+            (4096,),
+            (8, 512),
+            (16, 256),
+            (32, 128),
+            (64, 64),
+            (8, 8, 64),
+            (4, 16, 128),
+        ]
+        self.shapes = fft_shapes
+
+    def get_input_iter(self, cur_dtype):
+        for shape in self.shapes:
+            yield from self.fft_input_fn(shape, cur_dtype, self.device)
+
+    def fft_input_fn(self, shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=device)
+        # Forward FFT on last dimension
+        yield (inp, [-1], 0, True)
+
+
+@pytest.mark.fft_c2c
+def test_perf_fft_c2c():
+    def torch_op(inp, dim, normalization, forward):
+        return torch.fft.fft(inp, dim=dim[0], norm=None)
+
+    # Use torch.fft.fft with gems context to call our implementation
+    bench = FFTBenchmark(
+        op_name="_fft_c2c",
+        torch_op=torch_op,
+        dtypes=COMPLEX_DTYPES,
+    )
+    # Don't set gems_op directly; use_gems context will be used
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -28,6 +28,7 @@ def torch_ge(v):
 
 
 _FULL_CONFIG = (
+    ("_fft_c2c", _fft_c2c),
     ("_flash_attention_forward", flash_attention_forward),
     ("_log_softmax", log_softmax),
     ("_log_softmax_backward_data", log_softmax_backward),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -1,3 +1,4 @@
+from flag_gems.ops._fft_c2c import _fft_c2c
 from flag_gems.ops.abs import abs, abs_
 from flag_gems.ops.acos import acos
 from flag_gems.ops.add import add, add_
@@ -241,6 +242,7 @@ from flag_gems.ops.zeros_like import zeros_like
 
 __all__ = [
     "_conv_depthwise2d",
+    "_fft_c2c",
     "_unique2",
     "_upsample_bicubic2d_aa",
     "abs",

--- a/src/flag_gems/ops/_fft_c2c.py
+++ b/src/flag_gems/ops/_fft_c2c.py
@@ -1,0 +1,338 @@
+import logging
+import math
+from typing import List
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+def is_power_of_2(n: int) -> bool:
+    """Check if n is a power of 2."""
+    return n > 0 and (n & (n - 1)) == 0
+
+
+@libentry()
+@triton.jit
+def bit_reversal_permutation_kernel(
+    in_real_ptr,
+    in_imag_ptr,
+    out_real_ptr,
+    out_imag_ptr,
+    batch_stride,
+    n,
+    log2_n: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Perform bit-reversal permutation for FFT."""
+    batch_id = tl.program_id(0)
+    block_id = tl.program_id(1)
+
+    batch_offset = batch_id * batch_stride
+
+    offsets = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n
+
+    # Compute bit-reversed indices
+    rev_idx = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+    temp_idx = offsets.to(tl.int32)
+    for _ in range(log2_n):
+        rev_idx = (rev_idx << 1) | (temp_idx & 1)
+        temp_idx = temp_idx >> 1
+
+    # Load from original positions
+    in_real = tl.load(in_real_ptr + batch_offset + offsets, mask=mask, other=0.0)
+    in_imag = tl.load(in_imag_ptr + batch_offset + offsets, mask=mask, other=0.0)
+
+    # Store to bit-reversed positions
+    tl.store(out_real_ptr + batch_offset + rev_idx, in_real, mask=mask)
+    tl.store(out_imag_ptr + batch_offset + rev_idx, in_imag, mask=mask)
+
+
+@libentry()
+@triton.jit
+def fft_butterfly_stage_kernel(
+    real_ptr,
+    imag_ptr,
+    twiddle_real_ptr,
+    twiddle_imag_ptr,
+    batch_stride,
+    n,
+    half_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Single butterfly stage of FFT."""
+    batch_id = tl.program_id(0)
+    block_id = tl.program_id(1)
+
+    batch_offset = batch_id * batch_stride
+    step = half_size * 2
+
+    # Each thread handles one butterfly pair
+    offsets = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    pair_idx = offsets  # Index of butterfly pair within batch
+
+    # Total number of butterfly pairs
+    num_pairs = n // 2
+    mask = pair_idx < num_pairs
+
+    # Calculate which group and position within group
+    group = pair_idx // half_size
+    pos_in_group = pair_idx % half_size
+
+    # Upper and lower indices
+    upper_idx = group * step + pos_in_group
+    lower_idx = upper_idx + half_size
+
+    # Twiddle factor index
+    tw_idx = pos_in_group * (n // step)
+
+    # Load upper and lower values
+    upper_real = tl.load(real_ptr + batch_offset + upper_idx, mask=mask, other=0.0)
+    upper_imag = tl.load(imag_ptr + batch_offset + upper_idx, mask=mask, other=0.0)
+    lower_real = tl.load(real_ptr + batch_offset + lower_idx, mask=mask, other=0.0)
+    lower_imag = tl.load(imag_ptr + batch_offset + lower_idx, mask=mask, other=0.0)
+
+    # Load twiddle factors
+    tw_real = tl.load(twiddle_real_ptr + tw_idx, mask=mask, other=1.0)
+    tw_imag = tl.load(twiddle_imag_ptr + tw_idx, mask=mask, other=0.0)
+
+    # Complex multiplication: lower * twiddle
+    prod_real = lower_real * tw_real - lower_imag * tw_imag
+    prod_imag = lower_real * tw_imag + lower_imag * tw_real
+
+    # Butterfly operation
+    new_upper_real = upper_real + prod_real
+    new_upper_imag = upper_imag + prod_imag
+    new_lower_real = upper_real - prod_real
+    new_lower_imag = upper_imag - prod_imag
+
+    # Store results
+    tl.store(real_ptr + batch_offset + upper_idx, new_upper_real, mask=mask)
+    tl.store(imag_ptr + batch_offset + upper_idx, new_upper_imag, mask=mask)
+    tl.store(real_ptr + batch_offset + lower_idx, new_lower_real, mask=mask)
+    tl.store(imag_ptr + batch_offset + lower_idx, new_lower_imag, mask=mask)
+
+
+@libentry()
+@triton.jit
+def fft_normalize_kernel(
+    real_ptr,
+    imag_ptr,
+    scale,
+    numel,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Apply normalization scaling to FFT output."""
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < numel
+
+    real_val = tl.load(real_ptr + offsets, mask=mask, other=0.0)
+    imag_val = tl.load(imag_ptr + offsets, mask=mask, other=0.0)
+
+    tl.store(real_ptr + offsets, real_val * scale, mask=mask)
+    tl.store(imag_ptr + offsets, imag_val * scale, mask=mask)
+
+
+def compute_twiddle_factors(n: int, inverse: bool, device: torch.device) -> torch.Tensor:
+    """
+    Compute twiddle factors for FFT.
+    W_n^k = exp(-2*pi*i*k/n) for forward FFT
+    W_n^k = exp(2*pi*i*k/n) for inverse FFT
+    """
+    sign = 1.0 if inverse else -1.0
+    k = torch.arange(n // 2, device=device, dtype=torch.float32)
+    angle = sign * 2.0 * math.pi * k / n
+    twiddle = torch.complex(torch.cos(angle), torch.sin(angle))
+    return twiddle
+
+
+def fft_1d_triton(
+    x: torch.Tensor,
+    inverse: bool = False,
+    normalization: int = 0,
+) -> torch.Tensor:
+    """
+    1D FFT using Triton with multi-stage butterfly approach.
+    Only supports power-of-2 sizes.
+    """
+    original_shape = x.shape
+    n = x.shape[-1]
+
+    if not is_power_of_2(n):
+        raise ValueError(f"FFT size must be power of 2, got {n}")
+
+    # Flatten batch dimensions
+    batch_size = x.numel() // n
+    x_flat = x.reshape(batch_size, n)
+
+    # Separate real and imaginary parts (use float32 for computation)
+    if x.dtype == torch.complex64:
+        compute_dtype = torch.float32
+    else:  # complex128
+        compute_dtype = torch.float64
+
+    x_real = x_flat.real.to(compute_dtype).contiguous()
+    x_imag = x_flat.imag.to(compute_dtype).contiguous()
+
+    # Allocate output buffers
+    out_real = torch.empty_like(x_real)
+    out_imag = torch.empty_like(x_imag)
+
+    log2_n = int(math.log2(n))
+    BLOCK_SIZE = min(1024, n)
+
+    with torch_device_fn.device(x.device):
+        # Step 1: Bit-reversal permutation
+        grid_perm = (batch_size, triton.cdiv(n, BLOCK_SIZE))
+        bit_reversal_permutation_kernel[grid_perm](
+            x_real,
+            x_imag,
+            out_real,
+            out_imag,
+            n,  # batch_stride
+            n,
+            log2_n,
+            BLOCK_SIZE,
+        )
+
+        # Compute twiddle factors
+        twiddle = compute_twiddle_factors(n, inverse, x.device)
+        twiddle_real = twiddle.real.to(compute_dtype).contiguous()
+        twiddle_imag = twiddle.imag.to(compute_dtype).contiguous()
+
+        # Step 2: Butterfly stages
+        num_pairs = n // 2
+        half_size = 1
+        for _ in range(log2_n):
+            grid_butterfly = (batch_size, triton.cdiv(num_pairs, BLOCK_SIZE))
+            fft_butterfly_stage_kernel[grid_butterfly](
+                out_real,
+                out_imag,
+                twiddle_real,
+                twiddle_imag,
+                n,  # batch_stride
+                n,
+                half_size,
+                BLOCK_SIZE,
+            )
+            half_size *= 2
+
+        # Step 3: Apply normalization
+        # normalization=0 (backward): inverse gets 1/N, forward gets 1
+        # normalization=1 (ortho): both get 1/sqrt(N)
+        # normalization=2 (forward): forward gets 1/N, inverse gets 1
+        if normalization == 0:  # backward normalization
+            scale = 1.0 / n if inverse else 1.0
+        elif normalization == 1:  # ortho normalization
+            scale = 1.0 / math.sqrt(n)
+        elif normalization == 2:  # forward normalization
+            scale = 1.0 / n if not inverse else 1.0
+        else:
+            scale = 1.0
+
+        if scale != 1.0:
+            numel = batch_size * n
+            grid_norm = (triton.cdiv(numel, BLOCK_SIZE),)
+            fft_normalize_kernel[grid_norm](
+                out_real,
+                out_imag,
+                scale,
+                numel,
+                BLOCK_SIZE,
+            )
+
+    # Combine real and imaginary parts
+    output = torch.complex(out_real, out_imag)
+    output = output.reshape(original_shape)
+
+    # Convert back to original dtype if needed
+    if output.dtype != x.dtype:
+        output = output.to(x.dtype)
+
+    return output
+
+
+def _fft_c2c_single_dim(
+    x: torch.Tensor,
+    dim: int,
+    normalization: int,
+    forward: bool,
+) -> torch.Tensor:
+    """
+    FFT along a single dimension.
+    Uses Triton for power-of-2 sizes, torch.fft for other sizes.
+    """
+    n = x.shape[dim]
+    inverse = not forward
+
+    # Move FFT dimension to last
+    if dim != -1 and dim != x.ndim - 1:
+        x = x.movedim(dim, -1)
+        moved = True
+    else:
+        moved = False
+
+    # Use Triton implementation for power-of-2 sizes
+    if is_power_of_2(n) and n >= 2:
+        result = fft_1d_triton(x, inverse=inverse, normalization=normalization)
+    else:
+        # Fall back to torch.fft for non-power-of-2 sizes
+        # This avoids recursion since torch.fft.fft/ifft use a different code path
+        norm_map = {0: None, 1: "ortho", 2: "forward"}
+        norm_str = norm_map.get(normalization, None)
+        if forward:
+            result = torch.fft.fft(x, dim=-1, norm=norm_str)
+        else:
+            result = torch.fft.ifft(x, dim=-1, norm=norm_str)
+
+    # Move dimension back
+    if moved:
+        result = result.movedim(-1, dim)
+
+    return result
+
+
+def _fft_c2c(
+    self: torch.Tensor,
+    dim: List[int],
+    normalization: int,
+    forward: bool,
+) -> torch.Tensor:
+    """
+    Complex-to-complex FFT.
+
+    Args:
+        self: Input complex tensor
+        dim: Dimensions along which to compute FFT
+        normalization: 0 = no normalization, 1 = ortho, 2 = forward
+        forward: True for forward FFT, False for inverse FFT
+
+    Returns:
+        Complex tensor with FFT applied
+    """
+    logger.debug("GEMS _FFT_C2C")
+
+    # Ensure input is complex
+    if not self.is_complex():
+        self = torch.complex(self, torch.zeros_like(self))
+
+    # Make contiguous
+    self = self.contiguous()
+
+    # Normalize dimensions
+    ndim = self.ndim
+    dim = [(d % ndim) for d in dim]
+
+    # Apply FFT along each dimension
+    result = self
+    for d in dim:
+        result = _fft_c2c_single_dim(result, d, normalization, forward)
+
+    return result

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -1890,3 +1890,71 @@ def test_accuracy_moe_align_block_size(
     gems_assert_close(
         num_tokens_post_pad, to_reference(num_tokens_post_pad_vllm), dtype=dtype
     )
+
+
+# FFT test shapes and dtypes
+FFT_SHAPES = [(8,), (16,), (32,), (64,), (4, 8), (4, 16), (8, 8), (2, 4, 8)]
+# Only use complex64 which is supported by gems_assert_close
+FFT_COMPLEX_DTYPES = [torch.complex64]
+
+
+@pytest.mark.fft_c2c
+@pytest.mark.parametrize("shape", FFT_SHAPES)
+@pytest.mark.parametrize("dtype", FFT_COMPLEX_DTYPES)
+def test_accuracy__fft_c2c_forward(shape, dtype):
+    """Test forward FFT accuracy."""
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    # Use torch.fft.fft for reference (works on GPU and CPU)
+    ref_out = torch.fft.fft(inp, dim=-1, norm=None)
+    with flag_gems.use_gems():
+        res_out = torch._fft_c2c(inp, [-1], 0, True)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.fft_c2c
+@pytest.mark.parametrize("shape", FFT_SHAPES)
+@pytest.mark.parametrize("dtype", FFT_COMPLEX_DTYPES)
+def test_accuracy__fft_c2c_inverse(shape, dtype):
+    """Test inverse FFT accuracy."""
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    # Use torch.fft.ifft for reference
+    ref_out = torch.fft.ifft(inp, dim=-1, norm=None)
+    with flag_gems.use_gems():
+        res_out = torch._fft_c2c(inp, [-1], 0, False)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.fft_c2c
+@pytest.mark.parametrize("shape", [(8, 8), (16, 16), (4, 8, 8)])
+@pytest.mark.parametrize("dtype", FFT_COMPLEX_DTYPES)
+def test_accuracy__fft_c2c_2d(shape, dtype):
+    """Test 2D FFT accuracy."""
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    # Use torch.fft.fftn for reference on last two dimensions
+    ref_out = torch.fft.fftn(inp, dim=(-2, -1), norm=None)
+    with flag_gems.use_gems():
+        res_out = torch._fft_c2c(inp, [-2, -1], 0, True)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.fft_c2c
+@pytest.mark.parametrize("norm_mode", [(0, None), (1, "ortho"), (2, "forward")])
+@pytest.mark.parametrize("dtype", FFT_COMPLEX_DTYPES)
+def test_accuracy__fft_c2c_normalization(norm_mode, dtype):
+    """Test FFT with different normalization modes."""
+    shape = (4, 16)
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    norm_int, norm_str = norm_mode
+
+    ref_out = torch.fft.fft(inp, dim=-1, norm=norm_str)
+    with flag_gems.use_gems():
+        res_out = torch._fft_c2c(inp, [-1], norm_int, True)
+
+    gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `_fft_c2c` operator implementation with Triton kernel.

- Implementation mode: `N/A`
- Accuracy test: 14/14 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.complex64**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([64]) | 0.0091 | 0.8760 | 0.010 |
| torch.Size([128]) | 0.0101 | 0.9292 | 0.011 |
| torch.Size([256]) | 0.0099 | 0.9086 | 0.011 |
| torch.Size([512]) | 0.0108 | 0.9308 | 0.012 |
| torch.Size([1024]) | 0.0100 | 0.9787 | 0.010 |
| torch.Size([2048]) | 0.0117 | 0.9895 | 0.012 |
| torch.Size([4096]) | 0.0128 | 1.0322 | 0.012 |
| torch.Size([8, 512]) | 0.0084 | 1.0273 | 0.008 |
| torch.Size([16, 256]) | 0.0077 | 0.9118 | 0.008 |
| torch.Size([32, 128]) | 0.0085 | 0.8851 | 0.010 |
| torch.Size([64, 64]) | 0.0094 | 0.8672 | 0.011 |
| torch.Size([8, 8, 64]) | 0.0084 | 0.8827 | 0.009 |
| torch.Size([4, 16, 128]) | 0.0082 | 0.8831 | 0.009 |

**Overall: median speedup = 0.010x, mean speedup = 0.010x** (13 data points)

---
_Generated by auto_gen tool with Claude Code_
