### PR TITLE
【KernelGen】Add _fft_c2r operator

### DIFF
--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -821,3 +821,58 @@ def test_perf_moe_align_block_size():
 
     bench.set_gems(gems_op)
     bench.run()
+
+
+# ============== FFT C2R Benchmark ==============
+class FFTC2RBenchmark(Benchmark):
+    """Benchmark for _fft_c2r (complex-to-real FFT)."""
+
+    def __init__(self, op_name, torch_op, dtypes):
+        super().__init__(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
+
+    def set_shapes(self, shape_file_path=None):
+        # Shapes represent the output real size of the FFT transform
+        # Shapes: (batch_size, fft_size)
+        fft_c2r_shapes = [
+            (1, 16),
+            (1, 32),
+            (1, 64),
+            (1, 128),
+            (1, 256),
+            (4, 16),
+            (4, 32),
+            (4, 64),
+            (4, 128),
+            (16, 64),
+            (16, 128),
+            (16, 256),
+            (64, 64),
+            (64, 128),
+            (128, 128),
+        ]
+        self.shapes = fft_c2r_shapes
+
+    def get_input_iter(self, cur_dtype):
+        for shape in self.shapes:
+            yield from self._fft_c2r_input_fn(shape, cur_dtype, self.device)
+
+    def _fft_c2r_input_fn(self, shape, dtype, device):
+        batch_size, fft_size = shape
+        # Create real input, compute rfft to get complex input
+        real_inp = torch.randn(batch_size, fft_size, dtype=torch.float32, device=device)
+        complex_inp = torch.fft.rfft(real_inp, dim=-1)
+        # Parameters for _fft_c2r
+        dim = [1]
+        normalization = 2  # backward norm
+        last_dim_size = fft_size
+        yield complex_inp, dim, normalization, last_dim_size
+
+
+@pytest.mark.fft_c2r
+def test_perf_fft_c2r():
+    bench = FFTC2RBenchmark(
+        op_name="_fft_c2r",
+        torch_op=torch._fft_c2r,
+        dtypes=[torch.float32],
+    )
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -28,6 +28,7 @@ def torch_ge(v):
 
 
 _FULL_CONFIG = (
+    ("_fft_c2r", _fft_c2r),
     ("_flash_attention_forward", flash_attention_forward),
     ("_log_softmax", log_softmax),
     ("_log_softmax_backward_data", log_softmax_backward),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -59,6 +59,7 @@ from flag_gems.ops.conv1d import conv1d
 from flag_gems.ops.conv2d import conv2d
 from flag_gems.ops.conv3d import conv3d
 from flag_gems.ops.conv_depthwise2d import _conv_depthwise2d
+from flag_gems.ops._fft_c2r import _fft_c2r
 from flag_gems.ops.copy import copy, copy_
 from flag_gems.ops.cos import cos, cos_
 from flag_gems.ops.count_nonzero import count_nonzero
@@ -241,6 +242,7 @@ from flag_gems.ops.zeros_like import zeros_like
 
 __all__ = [
     "_conv_depthwise2d",
+    "_fft_c2r",
     "_unique2",
     "_upsample_bicubic2d_aa",
     "abs",

--- a/src/flag_gems/ops/_fft_c2r.py
+++ b/src/flag_gems/ops/_fft_c2r.py
@@ -1,0 +1,226 @@
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_M": 1, "BLOCK_N": 256}),
+        triton.Config({"BLOCK_M": 1, "BLOCK_N": 512}),
+        triton.Config({"BLOCK_M": 1, "BLOCK_N": 1024}),
+        triton.Config({"BLOCK_M": 4, "BLOCK_N": 64}),
+        triton.Config({"BLOCK_M": 4, "BLOCK_N": 128}),
+        triton.Config({"BLOCK_M": 4, "BLOCK_N": 256}),
+        triton.Config({"BLOCK_M": 8, "BLOCK_N": 64}),
+        triton.Config({"BLOCK_M": 8, "BLOCK_N": 128}),
+    ],
+    key=["N", "K"],
+)
+@triton.jit
+def _fft_c2r_kernel(
+    input_real_ptr,
+    input_imag_ptr,
+    output_ptr,
+    M,  # batch size (product of all dims except the transform dim)
+    N,  # output size (last_dim_size)
+    K,  # input complex size (N // 2 + 1)
+    normalization: tl.constexpr,  # 0: none, 1: by_root_n, 2: by_n
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """
+    Compute irfft (complex-to-real FFT) using DFT matrix multiplication.
+
+    For each output element x[n], compute:
+    x[n] = X[0].real
+         + 2 * sum_{k=1}^{K-2} [X[k].real * cos(2*pi*k*n/N) - X[k].imag * sin(2*pi*k*n/N)]
+         + X[K-1].real * cos(pi*n)  (only if N is even)
+
+    Then apply normalization factor based on normalization mode.
+    """
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    m_offsets = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    n_offsets = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    m_mask = m_offsets < M
+    n_mask = n_offsets < N
+    mask = m_mask[:, None] & n_mask[None, :]
+
+    # Precompute 2*pi/N
+    two_pi_over_N = 2.0 * 3.141592653589793 / N
+
+    # Initialize accumulator
+    acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+
+    # k = 0 term: X[0].real (no phase factor)
+    x0_real_offset = m_offsets * K
+    x0_real = tl.load(input_real_ptr + x0_real_offset, mask=m_mask, other=0.0)
+    acc += x0_real[:, None]
+
+    # k = 1 to K-2 terms: contribute twice due to conjugate symmetry
+    for k in range(1, K - 1 if K > 1 else 1):
+        # Load X[k].real and X[k].imag
+        xk_offset = m_offsets * K + k
+        xk_real = tl.load(input_real_ptr + xk_offset, mask=m_mask, other=0.0)
+        xk_imag = tl.load(input_imag_ptr + xk_offset, mask=m_mask, other=0.0)
+
+        # Compute phase: 2*pi*k*n/N
+        phase = k * two_pi_over_N * n_offsets.to(tl.float32)
+        cos_phase = tl.cos(phase)
+        sin_phase = tl.sin(phase)
+
+        # Contribution: 2 * [X[k].real * cos - X[k].imag * sin]
+        contrib = 2.0 * (xk_real[:, None] * cos_phase[None, :] - xk_imag[:, None] * sin_phase[None, :])
+        acc += contrib
+
+    # k = K-1 term (Nyquist frequency, only if N is even)
+    # If N is even, K = N//2 + 1, and X[K-1] corresponds to Nyquist
+    # cos(pi*n) = (-1)^n
+    if K > 1:
+        xk_offset = m_offsets * K + (K - 1)
+        xk_real = tl.load(input_real_ptr + xk_offset, mask=m_mask, other=0.0)
+
+        # For Nyquist frequency: phase = pi * n, cos(pi*n) = (-1)^n
+        # If N is even, include this term; if N is odd, K-1 is not exactly at Nyquist
+        # and should be handled like regular terms
+        is_even = (N % 2) == 0
+        if is_even:
+            # cos(pi * n) = (-1)^n
+            n_mod2 = n_offsets % 2
+            cos_nyquist = tl.where(n_mod2 == 0, 1.0, -1.0)
+            acc += xk_real[:, None] * cos_nyquist[None, :]
+        else:
+            # N is odd, treat K-1 like a regular term with factor 2
+            xk_imag = tl.load(input_imag_ptr + xk_offset, mask=m_mask, other=0.0)
+            k_last = K - 1
+            phase = k_last * two_pi_over_N * n_offsets.to(tl.float32)
+            cos_phase = tl.cos(phase)
+            sin_phase = tl.sin(phase)
+            contrib = 2.0 * (xk_real[:, None] * cos_phase[None, :] - xk_imag[:, None] * sin_phase[None, :])
+            acc += contrib
+
+    # Apply normalization
+    if normalization == 2:  # by_n (backward norm in torch.fft)
+        acc = acc / N
+    elif normalization == 1:  # by_root_n (ortho norm)
+        acc = acc / tl.sqrt(N.to(tl.float32))
+    # normalization == 0: no normalization (forward norm - multiply by nothing extra)
+
+    # Store result
+    output_offset = m_offsets[:, None] * N + n_offsets[None, :]
+    tl.store(output_ptr + output_offset, acc, mask=mask)
+
+
+def _fft_c2r(input, dim, normalization, last_dim_size):
+    """
+    Compute the inverse real FFT (complex-to-real).
+
+    Args:
+        input: Complex input tensor from rfft
+        dim: List of dimensions to transform (only single dimension supported)
+        normalization: Normalization mode (0: none, 1: ortho, 2: backward)
+        last_dim_size: Size of the output along the transform dimension
+
+    Returns:
+        Real tensor with the inverse FFT result
+    """
+    logger.debug("GEMS _FFT_C2R")
+
+    # Currently only support single dimension transform
+    assert len(dim) == 1, "Only single dimension transform is supported"
+    transform_dim = dim[0]
+
+    # Normalize negative dimension
+    ndim = input.ndim
+    if transform_dim < 0:
+        transform_dim = ndim + transform_dim
+
+    # Get input shape info
+    input_shape = list(input.shape)
+    K = input_shape[transform_dim]  # Complex input size
+    N = last_dim_size  # Output real size
+
+    # Ensure input is contiguous
+    input = input.contiguous()
+
+    # Compute batch size M (product of all dims except transform dim)
+    # and move transform dim to last position
+    if transform_dim != ndim - 1:
+        # Permute to move transform dim to last
+        perm = list(range(ndim))
+        perm.remove(transform_dim)
+        perm.append(transform_dim)
+        input = input.permute(perm)
+        output_shape = [input_shape[i] for i in perm[:-1]] + [N]
+        inverse_perm = [0] * ndim
+        for i, p in enumerate(perm):
+            inverse_perm[p] = i
+    else:
+        output_shape = input_shape[:-1] + [N]
+        inverse_perm = None
+
+    # Make contiguous after permute
+    input = input.contiguous()
+
+    # Compute batch size
+    M = 1
+    for i in range(ndim - 1):
+        M *= input.shape[i]
+
+    # Get real and imaginary parts
+    # Complex tensor is stored as [..., 2] where last dim is [real, imag]
+    input_real = torch.view_as_real(input)
+    input_real_part = input_real[..., 0].contiguous()
+    input_imag_part = input_real[..., 1].contiguous()
+
+    # Reshape to 2D for kernel: [M, K]
+    input_real_flat = input_real_part.view(M, K)
+    input_imag_flat = input_imag_part.view(M, K)
+
+    # Determine output dtype based on input complex dtype
+    if input.dtype == torch.complex64:
+        out_dtype = torch.float32
+    elif input.dtype == torch.complex128:
+        out_dtype = torch.float64
+    else:
+        out_dtype = torch.float32
+
+    # Allocate output
+    output_flat = torch.empty((M, N), dtype=out_dtype, device=input.device)
+
+    # Launch kernel
+    grid = lambda meta: (
+        triton.cdiv(M, meta["BLOCK_M"]),
+        triton.cdiv(N, meta["BLOCK_N"]),
+    )
+
+    with torch_device_fn.device(input.device):
+        _fft_c2r_kernel[grid](
+            input_real_flat,
+            input_imag_flat,
+            output_flat,
+            M,
+            N,
+            K,
+            normalization,
+        )
+
+    # Reshape output
+    output = output_flat.view(output_shape)
+
+    # Permute back if needed
+    if inverse_perm is not None:
+        output = output.permute(inverse_perm)
+
+    return output.contiguous()

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -1890,3 +1890,118 @@ def test_accuracy_moe_align_block_size(
     gems_assert_close(
         num_tokens_post_pad, to_reference(num_tokens_post_pad_vllm), dtype=dtype
     )
+
+
+# ============== FFT C2R Tests ==============
+FFT_SHAPES = [(8,), (16,), (32,), (64,), (128,)] if not QUICK_MODE else [(16,)]
+FFT_BATCH_SHAPES = (
+    [(4, 8), (2, 3, 16), (2, 4, 32)]
+    if not QUICK_MODE
+    else [(4, 16)]
+)
+FFT_NORMALIZATIONS = [0, 1, 2]  # 0: none, 1: ortho, 2: backward
+
+
+def fft_assert_close(res, ref, dtype):
+    """Custom assertion for FFT with relaxed tolerance for larger transforms."""
+    res = res.to(dtype)
+    ref = ref.to(dtype)
+    # FFT accumulates numerical errors, use relaxed tolerance
+    # For larger transforms, error grows as O(N * log(N))
+    torch.testing.assert_close(res, ref, atol=5e-3, rtol=5e-4)
+
+
+@pytest.mark.fft_c2r
+@pytest.mark.parametrize("shape", FFT_SHAPES)
+@pytest.mark.parametrize("normalization", FFT_NORMALIZATIONS)
+def test_accuracy__fft_c2r_1d(shape, normalization):
+    """Test _fft_c2r for 1D inputs."""
+    inp = torch.randn(shape, dtype=torch.float32, device=device)
+    # Compute rfft to get complex input
+    inp_fft = torch.fft.rfft(inp).to(torch.complex64)
+    inp_fft = inp_fft.unsqueeze(0)  # Add batch dim for _fft_c2r
+
+    ref_inp = to_reference(inp_fft)
+    ref_out = torch._fft_c2r(ref_inp, dim=[1], normalization=normalization, last_dim_size=shape[0])
+
+    with flag_gems.use_gems():
+        res_out = torch._fft_c2r(inp_fft, dim=[1], normalization=normalization, last_dim_size=shape[0])
+
+    fft_assert_close(res_out, ref_out, torch.float32)
+
+
+@pytest.mark.fft_c2r
+@pytest.mark.parametrize("shape", FFT_BATCH_SHAPES)
+@pytest.mark.parametrize("normalization", FFT_NORMALIZATIONS)
+def test_accuracy__fft_c2r_batch(shape, normalization):
+    """Test _fft_c2r for batched inputs with transform on last dimension."""
+    inp = torch.randn(shape, dtype=torch.float32, device=device)
+    last_dim_size = shape[-1]
+    transform_dim = len(shape) - 1
+
+    # Compute rfft to get complex input
+    inp_fft = torch.fft.rfft(inp, dim=-1).to(torch.complex64)
+
+    ref_inp = to_reference(inp_fft)
+    ref_out = torch._fft_c2r(ref_inp, dim=[transform_dim], normalization=normalization, last_dim_size=last_dim_size)
+
+    with flag_gems.use_gems():
+        res_out = torch._fft_c2r(inp_fft, dim=[transform_dim], normalization=normalization, last_dim_size=last_dim_size)
+
+    fft_assert_close(res_out, ref_out, torch.float32)
+
+
+@pytest.mark.fft_c2r
+def test_accuracy__fft_c2r_non_last_dim():
+    """Test _fft_c2r for transform on non-last dimension."""
+    shape = (16, 4)
+    inp = torch.randn(shape, dtype=torch.float32, device=device)
+    last_dim_size = shape[0]
+
+    # Compute rfft on dim=0
+    inp_fft = torch.fft.rfft(inp, dim=0).to(torch.complex64)
+
+    ref_inp = to_reference(inp_fft)
+    ref_out = torch._fft_c2r(ref_inp, dim=[0], normalization=2, last_dim_size=last_dim_size)
+
+    with flag_gems.use_gems():
+        res_out = torch._fft_c2r(inp_fft, dim=[0], normalization=2, last_dim_size=last_dim_size)
+
+    fft_assert_close(res_out, ref_out, torch.float32)
+
+
+@pytest.mark.fft_c2r
+def test_accuracy__fft_c2r_middle_dim():
+    """Test _fft_c2r for transform on middle dimension."""
+    shape = (2, 16, 4)
+    inp = torch.randn(shape, dtype=torch.float32, device=device)
+    last_dim_size = shape[1]
+
+    # Compute rfft on dim=1
+    inp_fft = torch.fft.rfft(inp, dim=1).to(torch.complex64)
+
+    ref_inp = to_reference(inp_fft)
+    ref_out = torch._fft_c2r(ref_inp, dim=[1], normalization=2, last_dim_size=last_dim_size)
+
+    with flag_gems.use_gems():
+        res_out = torch._fft_c2r(inp_fft, dim=[1], normalization=2, last_dim_size=last_dim_size)
+
+    fft_assert_close(res_out, ref_out, torch.float32)
+
+
+@pytest.mark.fft_c2r
+def test_accuracy__fft_c2r_odd_size():
+    """Test _fft_c2r for odd-sized transform dimension."""
+    shape = (4, 15)  # 15 is odd
+    inp = torch.randn(shape, dtype=torch.float32, device=device)
+    last_dim_size = shape[-1]
+
+    inp_fft = torch.fft.rfft(inp, dim=-1).to(torch.complex64)
+
+    ref_inp = to_reference(inp_fft)
+    ref_out = torch._fft_c2r(ref_inp, dim=[1], normalization=2, last_dim_size=last_dim_size)
+
+    with flag_gems.use_gems():
+        res_out = torch._fft_c2r(inp_fft, dim=[1], normalization=2, last_dim_size=last_dim_size)
+
+    fft_assert_close(res_out, ref_out, torch.float32)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `_fft_c2r` operator implementation with Triton kernel.

- Implementation mode: `N/A`
- Accuracy test: 22/22 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1, 9]) | 0.0143 | 0.1088 | 0.131 |
| torch.Size([1, 17]) | 0.0127 | 0.1068 | 0.119 |
| torch.Size([1, 33]) | 0.0120 | 0.1073 | 0.112 |
| torch.Size([1, 65]) | 0.0127 | 0.1053 | 0.120 |
| torch.Size([1, 129]) | 0.0120 | 0.1091 | 0.110 |
| torch.Size([4, 9]) | 0.0131 | 0.1099 | 0.119 |
| torch.Size([4, 17]) | 0.0125 | 0.1108 | 0.113 |
| torch.Size([4, 33]) | 0.0119 | 0.1118 | 0.106 |
| torch.Size([4, 65]) | 0.0126 | 0.1076 | 0.117 |
| torch.Size([16, 33]) | 0.0141 | 0.1089 | 0.129 |
| torch.Size([16, 65]) | 0.0149 | 0.1082 | 0.138 |
| torch.Size([16, 129]) | 0.0171 | 0.1119 | 0.153 |
| torch.Size([64, 33]) | 0.0125 | 0.1070 | 0.117 |
| torch.Size([64, 65]) | 0.0163 | 0.1155 | 0.141 |
| torch.Size([128, 65]) | 0.0138 | 0.1124 | 0.122 |

**Overall: median speedup = 0.119x, mean speedup = 0.123x** (15 data points)

---
_Generated by auto_gen tool with Claude Code_
