### PR TITLE
【KernelGen】Add _fused_rms_norm operator

### DIFF
--- a/benchmark/test_norm_perf.py
+++ b/benchmark/test_norm_perf.py
@@ -257,3 +257,33 @@ def test_perf_rms_norm():
         torch_op=torch.nn.functional.rms_norm,
     )
     bench.run()
+
+
+@pytest.mark.fused_rms_norm_internal
+def test_perf_fused_rms_norm():
+    """Benchmark for _fused_rms_norm which returns (output, inv_rms)."""
+
+    def _torch_fused_rms_norm(x, normalized_shape, weight=None, eps=1e-5):
+        """Reference implementation for comparison."""
+        upcast_x = x.to(torch.float32)
+        variance = upcast_x.pow(2).mean(-1, keepdim=True)
+        inv_rms = torch.rsqrt(variance + eps)
+        hidden_states = upcast_x * inv_rms
+        hidden_states = hidden_states.to(x.dtype)
+        if weight is not None:
+            return weight * hidden_states, inv_rms.squeeze(-1)
+        return hidden_states, inv_rms.squeeze(-1)
+
+    def fused_rms_norm_input_fn(shape, dtype, device):
+        M, N = shape
+        inp = torch.randn(shape, dtype=dtype, device=device)
+        weight = torch.randn(N, dtype=dtype, device=device)
+        yield inp, (N,), weight
+
+    bench = GenericBenchmark2DOnly(
+        input_fn=fused_rms_norm_input_fn,
+        op_name="_fused_rms_norm",
+        torch_op=_torch_fused_rms_norm,
+    )
+    bench.set_gems(flag_gems._fused_rms_norm)
+    bench.run()

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -60,6 +60,11 @@ from flag_gems.ops.conv2d import conv2d
 from flag_gems.ops.conv3d import conv3d
 from flag_gems.ops.conv_depthwise2d import _conv_depthwise2d
 from flag_gems.ops.copy import copy, copy_
+from flag_gems.ops._fused_rms_norm import (
+    _fused_rms_norm,
+    _fused_rms_norm_backward,
+    _fused_rms_norm_forward,
+)
 from flag_gems.ops.cos import cos, cos_
 from flag_gems.ops.count_nonzero import count_nonzero
 from flag_gems.ops.cummax import cummax
@@ -241,6 +246,9 @@ from flag_gems.ops.zeros_like import zeros_like
 
 __all__ = [
     "_conv_depthwise2d",
+    "_fused_rms_norm",
+    "_fused_rms_norm_backward",
+    "_fused_rms_norm_forward",
     "_unique2",
     "_upsample_bicubic2d_aa",
     "abs",

--- a/src/flag_gems/ops/_fused_rms_norm.py
+++ b/src/flag_gems/ops/_fused_rms_norm.py
@@ -1,0 +1,369 @@
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.jit(do_not_specialize=["eps"])
+def _fused_rms_norm_kernel(
+    out_ptr,  # pointer to the output
+    INV_RMS,  # pointer to inverse rms
+    in_ptr,  # pointer to the input
+    w_ptr,  # pointer to the weights
+    y_stride_r,
+    y_stride_c,
+    x_stride_r,  # how much to increase the pointer when moving by 1 row
+    x_stride_c,  # how much to increase the pointer when moving by 1 col
+    N,  # number of columns in X
+    eps,  # epsilon to avoid division by zero
+    BLOCK_SIZE: tl.constexpr,
+):
+    if tl.constexpr(in_ptr.dtype.element_ty == tl.float16) or tl.constexpr(
+        in_ptr.dtype.element_ty == tl.bfloat16
+    ):
+        cdtype = tl.float32
+    else:
+        cdtype = in_ptr.dtype.element_ty
+
+    pid = tle.program_id(0)
+    out_ptr += pid * y_stride_r
+    in_ptr += pid * x_stride_r
+
+    mask = tl.arange(0, BLOCK_SIZE) < N
+    cols = tl.arange(0, BLOCK_SIZE)
+    x = tl.load(in_ptr + cols * x_stride_c, mask, other=0.0).to(cdtype)
+
+    var = tl.sum(x * x, axis=0) / N
+    rrms = 1 / tl.sqrt(var + eps)
+
+    w = tl.load(w_ptr + tl.arange(0, BLOCK_SIZE), mask=mask, other=0.0)
+    y = (x * rrms * w).to(cdtype)
+    tl.store(out_ptr + cols * y_stride_c, y, mask=mask)
+    tl.store(INV_RMS + pid, rrms)
+
+
+@libentry()
+@triton.jit(do_not_specialize=["eps"])
+def _fused_rms_norm_kernel_no_weight(
+    out_ptr,  # pointer to the output
+    INV_RMS,  # pointer to inverse rms
+    in_ptr,  # pointer to the input
+    y_stride_r,
+    y_stride_c,
+    x_stride_r,  # how much to increase the pointer when moving by 1 row
+    x_stride_c,  # how much to increase the pointer when moving by 1 col
+    N,  # number of columns in X
+    eps,  # epsilon to avoid division by zero
+    BLOCK_SIZE: tl.constexpr,
+):
+    if tl.constexpr(in_ptr.dtype.element_ty == tl.float16) or tl.constexpr(
+        in_ptr.dtype.element_ty == tl.bfloat16
+    ):
+        cdtype = tl.float32
+    else:
+        cdtype = in_ptr.dtype.element_ty
+
+    pid = tle.program_id(0)
+    out_ptr += pid * y_stride_r
+    in_ptr += pid * x_stride_r
+
+    mask = tl.arange(0, BLOCK_SIZE) < N
+    cols = tl.arange(0, BLOCK_SIZE)
+    x = tl.load(in_ptr + cols * x_stride_c, mask, other=0.0).to(cdtype)
+
+    var = tl.sum(x * x, axis=0) / N
+    rrms = 1 / tl.sqrt(var + eps)
+
+    y = (x * rrms).to(cdtype)
+    tl.store(out_ptr + cols * y_stride_c, y, mask=mask)
+    tl.store(INV_RMS + pid, rrms)
+
+
+def _fused_rms_norm_forward(x, normalized_shape, weight=None, eps=1e-5):
+    """
+    Fused RMS normalization forward pass.
+
+    Args:
+        x: Input tensor
+        normalized_shape: Shape of the normalization dimensions (from the right)
+        weight: Optional weight tensor for scaling
+        eps: Epsilon for numerical stability
+
+    Returns:
+        tuple: (output, inv_rms) where inv_rms is 1/sqrt(mean(x^2) + eps)
+    """
+    logger.debug("GEMS _FUSED_RMS_NORM FORWARD")
+    dim = x.ndim - len(normalized_shape)
+    M = math.prod(x.shape[:dim])
+    N = math.prod(normalized_shape)
+
+    BLOCK_SIZE = triton.next_power_of_2(N)
+    x = x.contiguous()
+    y = torch.empty_like(x)
+    inv_rms = torch.empty((M,), device=x.device, dtype=torch.float32)
+
+    with torch_device_fn.device(x.device):
+        if weight is not None:
+            weight = weight.contiguous()
+            _fused_rms_norm_kernel[M,](
+                y, inv_rms, x, weight, N, 1, N, 1, N, eps, BLOCK_SIZE
+            )
+        else:
+            _fused_rms_norm_kernel_no_weight[M,](
+                y, inv_rms, x, N, 1, N, 1, N, eps, BLOCK_SIZE
+            )
+
+    return y, inv_rms
+
+
+@libentry()
+@triton.jit(do_not_specialize=["eps"])
+def _fused_rms_norm_grad_dx_kernel(
+    X,  # pointer to the input
+    DY,
+    INV_RMS,  # pointer to inverse rms
+    DX,  # pointer to the output
+    W,  # pointer to the weights
+    dx_stride_r,
+    dx_stride_c,
+    x_stride_r,  # how much to increase the pointer when moving by 1 row
+    x_stride_c,  # how much to increase the pointer when moving by 1 col
+    N,  # number of columns in X
+    eps,  # epsilon to avoid division by zero
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tle.program_id(0)
+    DX += pid * dx_stride_r
+    X += pid * x_stride_r
+    DY += pid * x_stride_r
+    INV_RMS += pid
+
+    mask = tl.arange(0, BLOCK_SIZE) < N
+    cols = tl.arange(0, BLOCK_SIZE)
+    x = tl.load(X + cols * x_stride_c, mask, other=0.0).to(tl.float32)
+    inv_rms = tl.load(INV_RMS).to(tl.float32)
+    dy = tl.load(DY + cols * x_stride_c, mask, other=0.0).to(tl.float32)
+    w = tl.load(W + tl.arange(0, BLOCK_SIZE), mask=mask, other=0.0)
+
+    dy = dy * w
+
+    normalized_buf = x * inv_rms
+    row_sum_stats = tl.sum(normalized_buf * dy, axis=0)
+
+    norm_val = normalized_buf / N
+    dx = (dy - norm_val * row_sum_stats) * inv_rms
+
+    tl.store(DX + cols * dx_stride_c, dx, mask=mask)
+
+
+@libentry()
+@triton.jit(do_not_specialize=["eps"])
+def _fused_rms_norm_grad_dx_kernel_no_weight(
+    X,  # pointer to the input
+    DY,
+    INV_RMS,  # pointer to inverse rms
+    DX,  # pointer to the output
+    dx_stride_r,
+    dx_stride_c,
+    x_stride_r,  # how much to increase the pointer when moving by 1 row
+    x_stride_c,  # how much to increase the pointer when moving by 1 col
+    N,  # number of columns in X
+    eps,  # epsilon to avoid division by zero
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tle.program_id(0)
+    DX += pid * dx_stride_r
+    X += pid * x_stride_r
+    DY += pid * x_stride_r
+    INV_RMS += pid
+
+    mask = tl.arange(0, BLOCK_SIZE) < N
+    cols = tl.arange(0, BLOCK_SIZE)
+    x = tl.load(X + cols * x_stride_c, mask, other=0.0).to(tl.float32)
+    inv_rms = tl.load(INV_RMS).to(tl.float32)
+    dy = tl.load(DY + cols * x_stride_c, mask, other=0.0).to(tl.float32)
+
+    normalized_buf = x * inv_rms
+    row_sum_stats = tl.sum(normalized_buf * dy, axis=0)
+
+    norm_val = normalized_buf / N
+    dx = (dy - norm_val * row_sum_stats) * inv_rms
+
+    tl.store(DX + cols * dx_stride_c, dx, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _fused_rms_norm_grad_dw_kernel(
+    X,  # pointer to the input
+    DY,
+    INV_RMS,  # pointer to inverse rms
+    DW,  # pointer to the output
+    dx_stride_r,
+    dx_stride_c,
+    x_stride_r,  # how much to increase the pointer when moving by 1 row
+    x_stride_c,  # how much to increase the pointer when moving by 1 col
+    M,  # number of rows in X
+    N,  # number of columns in X
+    ROW_BLOCK_SIZE: tl.constexpr,
+    COL_BLOCK_SIZE: tl.constexpr,
+):
+    row_pid = tle.program_id(0)
+    col_pid = tle.program_id(1)
+
+    row_start = row_pid * ROW_BLOCK_SIZE
+    col_start = col_pid * COL_BLOCK_SIZE
+
+    offset = row_start * x_stride_r + col_start * x_stride_c
+    X += offset
+    DY += offset
+    INV_RMS += row_start
+
+    rows = tl.arange(0, ROW_BLOCK_SIZE)
+    cols = tl.arange(0, COL_BLOCK_SIZE)
+
+    row_mask = (row_start + rows) < M
+    col_mask = (col_start + cols) < N
+
+    x = tl.load(
+        X + rows[:, None] * x_stride_r + cols[None, :] * x_stride_c,
+        row_mask[:, None] & col_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+    inv_rms = tl.load(INV_RMS + rows, row_mask, other=0.0).to(tl.float32)
+    dy = tl.load(
+        DY + rows[:, None] * x_stride_r + cols[None, :] * x_stride_c,
+        row_mask[:, None] & col_mask[None, :],
+        other=0.0,
+    ).to(tl.float32)
+
+    d_weight = x * dy * inv_rms[:, None]
+    # Sum over rows (axis=0) - masked rows are 0 (from other=0.0 in load), so sum is correct
+    # The mask ensures invalid rows contribute 0 to the sum
+    partial_dweight_sum = tl.sum(d_weight, axis=0)
+
+    tl.store(
+        DW + row_pid * N + col_start + cols,
+        partial_dweight_sum,
+        mask=col_mask,
+    )
+
+
+def _fused_rms_norm_backward(dy, x, inv_rms, normalized_shape, weight=None, eps=1e-5):
+    """
+    Fused RMS normalization backward pass.
+
+    Args:
+        dy: Gradient of the output
+        x: Input tensor from forward pass
+        inv_rms: Inverse RMS from forward pass
+        normalized_shape: Shape of the normalization dimensions
+        weight: Optional weight tensor
+        eps: Epsilon for numerical stability
+
+    Returns:
+        tuple: (dx, dw) gradients for input and weight (dw is None if weight is None)
+    """
+    logger.debug("GEMS _FUSED_RMS_NORM BACKWARD")
+    dim = x.ndim - len(normalized_shape)
+    M = math.prod(x.shape[:dim])
+    N = math.prod(normalized_shape)
+
+    BLOCK_SIZE = triton.next_power_of_2(N)
+    x = x.contiguous()
+    dy = dy.contiguous()
+    dx = torch.empty_like(x)
+
+    with torch_device_fn.device(x.device):
+        if weight is not None:
+            weight = weight.contiguous()
+            _fused_rms_norm_grad_dx_kernel[M,](
+                x, dy, inv_rms, dx, weight, N, 1, N, 1, N, eps, BLOCK_SIZE
+            )
+        else:
+            _fused_rms_norm_grad_dx_kernel_no_weight[M,](
+                x, dy, inv_rms, dx, N, 1, N, 1, N, eps, BLOCK_SIZE
+            )
+
+    dw = None
+    if weight is not None:
+        ROW_BLOCK_SIZE = 16
+        COL_BLOCK_SIZE = 256
+        row_block_num = triton.cdiv(M, ROW_BLOCK_SIZE)
+        col_block_num = triton.cdiv(N, COL_BLOCK_SIZE)
+
+        partial_buffer = torch.empty(
+            (row_block_num, N), dtype=torch.float32, device=x.device
+        )
+
+        with torch_device_fn.device(x.device):
+            _fused_rms_norm_grad_dw_kernel[row_block_num, col_block_num](
+                x,
+                dy,
+                inv_rms,
+                partial_buffer,
+                N,
+                1,
+                N,
+                1,
+                M,
+                N,
+                ROW_BLOCK_SIZE,
+                COL_BLOCK_SIZE,
+            )
+            dw = (
+                torch.sum(partial_buffer, dim=0, dtype=torch.float32)
+                .to(x.dtype)
+                .reshape(-1)
+            )
+
+    return dx, dw
+
+
+class _FusedRmsNorm(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, x, normalized_shape, weight, eps=1e-5):
+        y, inv_rms = _fused_rms_norm_forward(x, normalized_shape, weight, eps)
+        ctx.save_for_backward(x, inv_rms, weight)
+        ctx.normalized_shape = normalized_shape
+        ctx.eps = eps
+        return y, inv_rms
+
+    @staticmethod
+    def backward(ctx, dy, d_inv_rms):
+        x, inv_rms, weight = ctx.saved_tensors
+        normalized_shape = ctx.normalized_shape
+        eps = ctx.eps
+
+        dx, dw = _fused_rms_norm_backward(dy, x, inv_rms, normalized_shape, weight, eps)
+        return dx, None, dw, None
+
+
+def _fused_rms_norm(x, normalized_shape, weight=None, eps=1e-5):
+    """
+    Fused RMS normalization that returns both output and inverse RMS.
+
+    This is useful for efficient backward computation as the inverse RMS
+    is computed during forward pass and reused in backward.
+
+    Args:
+        x: Input tensor of shape (*, normalized_shape)
+        normalized_shape: List of integers specifying the shape to normalize over
+        weight: Optional learnable weight tensor of shape normalized_shape
+        eps: Small constant for numerical stability (default: 1e-5)
+
+    Returns:
+        tuple: (output, inv_rms) where:
+            - output: Normalized tensor of same shape as input
+            - inv_rms: Inverse RMS tensor of shape (M,) where M = prod(x.shape[:-len(normalized_shape)])
+    """
+    return _FusedRmsNorm.apply(x, normalized_shape, weight, eps)

--- a/tests/test_norm_ops.py
+++ b/tests/test_norm_ops.py
@@ -632,6 +632,97 @@ def test_accuracy_fused_add_rms_norm(shape, dtype):
     gems_assert_close(res_new_residual, ref_new_residual, dtype)
 
 
+@pytest.mark.fused_rms_norm_internal
+@pytest.mark.parametrize("shape", REDUCTION_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy__fused_rms_norm(shape, dtype):
+    N = shape[1]
+    layer_shape = [
+        N,
+    ]
+    np.random.seed(0)
+    np_inp = np.random.uniform(-0.1, 0.1, shape[:2]).astype(np.float32)
+    np_grad = np.random.uniform(-0.01, 0.01, shape[:2]).astype(np.float32)
+    np_weight = np.random.uniform(-0.1, 0.1, layer_shape).astype(np.float32)
+
+    inp = torch.tensor(np_inp, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    weight = torch.tensor(
+        np_weight, dtype=dtype, device=flag_gems.device, requires_grad=True
+    )
+
+    eps = 1e-5
+
+    ref_inp = to_reference(inp)
+    ref_weight = to_reference(weight)
+
+    def _torch_rms_norm(x, weight, eps):
+        upcast_x = x.to(torch.float32)
+        variance = upcast_x.pow(2).mean(-1, keepdim=True)
+        inv_rms = torch.rsqrt(variance + eps)
+        hidden_states = upcast_x * inv_rms.to(torch.float32)
+        hidden_states = hidden_states.to(x.dtype)
+        return weight * hidden_states, inv_rms.squeeze(-1)
+
+    ref_out, ref_inv_rms = _torch_rms_norm(ref_inp, weight=ref_weight, eps=eps)
+    res_out, res_inv_rms = flag_gems._fused_rms_norm(
+        inp, list(layer_shape), weight=weight, eps=eps
+    )
+
+    # Check forward outputs
+    gems_assert_close(res_out, ref_out, dtype)
+    gems_assert_close(res_inv_rms, ref_inv_rms, torch.float32)
+
+    # Check backward
+    res_grad = torch.tensor(
+        np_grad, dtype=dtype, device=flag_gems.device, requires_grad=True
+    )
+    ref_grad = to_reference(res_grad)
+
+    res_in_grad, res_weight_grad = torch.autograd.grad(
+        res_out, (inp, weight), res_grad
+    )
+    ref_in_grad, ref_weight_grad = torch.autograd.grad(
+        ref_out, (ref_inp, ref_weight), ref_grad
+    )
+
+    gems_assert_close(res_in_grad, ref_in_grad, dtype)
+    gems_assert_close(res_weight_grad, ref_weight_grad, dtype, reduce_dim=N)
+
+
+@pytest.mark.fused_rms_norm_internal
+@pytest.mark.parametrize("shape", REDUCTION_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy__fused_rms_norm_no_weight(shape, dtype):
+    """Test _fused_rms_norm without weight parameter."""
+    N = shape[1]
+    layer_shape = [
+        N,
+    ]
+    np.random.seed(0)
+    np_inp = np.random.uniform(-0.1, 0.1, shape[:2]).astype(np.float32)
+
+    inp = torch.tensor(np_inp, dtype=dtype, device=flag_gems.device)
+    eps = 1e-5
+
+    ref_inp = to_reference(inp)
+
+    def _torch_rms_norm_no_weight(x, eps):
+        upcast_x = x.to(torch.float32)
+        variance = upcast_x.pow(2).mean(-1, keepdim=True)
+        inv_rms = torch.rsqrt(variance + eps)
+        hidden_states = upcast_x * inv_rms.to(torch.float32)
+        hidden_states = hidden_states.to(x.dtype)
+        return hidden_states, inv_rms.squeeze(-1)
+
+    ref_out, ref_inv_rms = _torch_rms_norm_no_weight(ref_inp, eps=eps)
+    res_out, res_inv_rms = flag_gems._fused_rms_norm(
+        inp, list(layer_shape), weight=None, eps=eps
+    )
+
+    gems_assert_close(res_out, ref_out, dtype)
+    gems_assert_close(res_inv_rms, ref_inv_rms, torch.float32)
+
+
 @pytest.mark.vector_norm
 @pytest.mark.parametrize("shape", REDUCTION_SHAPES)
 @pytest.mark.parametrize(


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `_fused_rms_norm` operator implementation with Triton kernel.

- Implementation mode: `manual_kernel`
- Accuracy test: 18/18 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [64, 64] | 0.0339 | 0.0081 | 4.165 |
| [256, 256] | 0.0348 | 0.0078 | 4.437 |
| [1024, 1024] | 0.0535 | 0.0118 | 4.519 |
| [4096, 4096] | 0.5250 | 0.0581 | 9.029 |
| [1024, 65536] | 1.9448 | 1.5310 | 1.270 |
| [10000, 1] | 0.0340 | 0.0144 | 2.360 |
| [10000, 256] | 0.0756 | 0.0182 | 4.146 |
| [10000, 65536] | 18.5780 | 14.7820 | 1.257 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [64, 64] | 0.0417 | 0.0094 | 4.435 |
| [256, 256] | 0.0364 | 0.0079 | 4.581 |
| [1024, 1024] | 0.0530 | 0.0116 | 4.584 |
| [4096, 4096] | 0.5208 | 0.0581 | 8.966 |
| [1024, 65536] | 1.9395 | 1.2656 | 1.532 |
| [10000, 1] | 0.0335 | 0.0148 | 2.259 |
| [10000, 256] | 0.0753 | 0.0172 | 4.367 |
| [10000, 65536] | 18.5248 | 12.2558 | 1.512 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [64, 64] | 0.0245 | 0.0086 | 2.844 |
| [256, 256] | 0.0261 | 0.0090 | 2.890 |
| [1024, 1024] | 0.0397 | 0.0137 | 2.906 |
| [4096, 4096] | 0.3799 | 0.1075 | 3.535 |
| [1024, 65536] | 1.4006 | 2.5691 | 0.545 |
| [10000, 1] | 0.0237 | 0.0148 | 1.597 |
| [10000, 256] | 0.0611 | 0.0232 | 2.629 |
| [10000, 65536] | 13.3215 | 25.4208 | 0.524 |

**Overall: median speedup = 2.898x, mean speedup = 3.370x** (24 data points)

---
_Generated by auto_gen tool with Claude Code_
