### PR TITLE
【KernelGen】Add _scaled_dot_product_cudnn_attention operator

### DIFF
--- a/benchmark/test_attention_perf.py
+++ b/benchmark/test_attention_perf.py
@@ -700,3 +700,58 @@ def test_perf_reshape_and_cache_flash():
     )
     bench.set_gems(flag_gems.reshape_and_cache_flash)
     bench.run()
+
+
+@pytest.mark.skipif(vendor_name == "kunlunxin", reason="RESULT TODOFIX")
+@pytest.mark.scaled_dot_product_cudnn_attention
+@pytest.mark.parametrize("is_causal", [True, False])
+def test_perf_scaled_dot_product_cudnn_attention(is_causal):
+    """Benchmark for _scaled_dot_product_cudnn_attention."""
+
+    def scaled_dot_product_cudnn_attention_kwargs(shape, dtype, device):
+        query = torch.randn(shape, device=device, dtype=dtype)
+        key = torch.randn(shape, device=device, dtype=dtype)
+        value = torch.randn(shape, device=device, dtype=dtype)
+        head_size = shape[-1]
+        scale = 1.0 / (head_size ** 0.5)
+        yield query, key, value, None, True, 0.0, is_causal, False, scale
+
+    def torch_cudnn_attention(
+        query, key, value, attn_bias=None, compute_log_sumexp=True,
+        dropout_p=0.0, is_causal=False, return_debug_mask=False, scale=None
+    ):
+        # Use PyTorch's scaled_dot_product_attention as reference
+        return torch.nn.functional.scaled_dot_product_attention(
+            query, key, value,
+            attn_mask=attn_bias,
+            dropout_p=dropout_p,
+            is_causal=is_causal,
+            scale=scale,
+        )
+
+    def gems_cudnn_attention(
+        query, key, value, attn_bias=None, compute_log_sumexp=True,
+        dropout_p=0.0, is_causal=False, return_debug_mask=False, scale=None
+    ):
+        result = flag_gems.ops._scaled_dot_product_cudnn_attention(
+            query, key, value,
+            attn_bias=attn_bias,
+            compute_log_sumexp=compute_log_sumexp,
+            dropout_p=dropout_p,
+            is_causal=is_causal,
+            return_debug_mask=return_debug_mask,
+            scale=scale,
+        )
+        return result[0]  # Return only the output tensor
+
+    bench = AttentionBenchmark(
+        op_name="_scaled_dot_product_cudnn_attention",
+        input_fn=scaled_dot_product_cudnn_attention_kwargs,
+        torch_op=torch_cudnn_attention,
+        dtypes=[
+            torch.float16,
+            torch.bfloat16,
+        ],
+    )
+    bench.set_gems(gems_cudnn_attention)
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -31,6 +31,7 @@ _FULL_CONFIG = (
     ("_flash_attention_forward", flash_attention_forward),
     ("_log_softmax", log_softmax),
     ("_log_softmax_backward_data", log_softmax_backward),
+    ("_scaled_dot_product_cudnn_attention", _scaled_dot_product_cudnn_attention),
     ("_softmax", softmax),
     ("_softmax_backward_data", softmax_backward),
     (

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -1,3 +1,6 @@
+from flag_gems.ops._scaled_dot_product_cudnn_attention import (
+    _scaled_dot_product_cudnn_attention,
+)
 from flag_gems.ops.abs import abs, abs_
 from flag_gems.ops.acos import acos
 from flag_gems.ops.add import add, add_
@@ -241,6 +244,7 @@ from flag_gems.ops.zeros_like import zeros_like
 
 __all__ = [
     "_conv_depthwise2d",
+    "_scaled_dot_product_cudnn_attention",
     "_unique2",
     "_upsample_bicubic2d_aa",
     "abs",

--- a/src/flag_gems/ops/_scaled_dot_product_cudnn_attention.py
+++ b/src/flag_gems/ops/_scaled_dot_product_cudnn_attention.py
@@ -1,0 +1,106 @@
+import logging
+
+import torch
+
+from flag_gems.ops.attention import scaled_dot_product_attention_forward
+
+logger = logging.getLogger(__name__)
+
+
+def _scaled_dot_product_cudnn_attention(
+    query,
+    key,
+    value,
+    attn_bias=None,
+    compute_log_sumexp=True,
+    dropout_p=0.0,
+    is_causal=False,
+    return_debug_mask=False,
+    *,
+    scale=None,
+):
+    """
+    Scaled dot product attention using FlagGems Triton kernels.
+
+    This function wraps the FlagGems attention implementation to provide
+    the same interface as torch._scaled_dot_product_cudnn_attention.
+
+    Args:
+        query: Query tensor of shape (batch, num_heads, seq_len_q, head_dim)
+        key: Key tensor of shape (batch, num_heads, seq_len_k, head_dim)
+        value: Value tensor of shape (batch, num_heads, seq_len_k, head_dim)
+        attn_bias: Optional attention bias tensor
+        compute_log_sumexp: Whether to compute and return log-sum-exp values
+        dropout_p: Dropout probability (currently must be 0.0)
+        is_causal: Whether to apply causal masking
+        return_debug_mask: Whether to return debug attention mask
+        scale: Optional scale factor for attention scores
+
+    Returns:
+        tuple: (output, logsumexp, cum_seq_q, cum_seq_k, max_q, max_k,
+                philox_seed, philox_offset, debug_attn_mask)
+    """
+    logger.debug("GEMS _SCALED_DOT_PRODUCT_CUDNN_ATTENTION")
+
+    # Convert attn_bias to attn_mask if provided
+    attn_mask = attn_bias
+
+    # Call the existing FlagGems attention forward implementation
+    output, M = scaled_dot_product_attention_forward(
+        query,
+        key,
+        value,
+        attn_mask=attn_mask,
+        dropout_p=dropout_p,
+        is_causal=is_causal,
+        scale=scale,
+        enable_gqa=False,
+    )
+
+    # Compute logsumexp from M if needed
+    # M is already the log-sum-exp values from the attention computation
+    if compute_log_sumexp:
+        # M has shape (batch, num_heads, seq_len_q)
+        logsumexp = M
+    else:
+        logsumexp = torch.empty(0, device=query.device, dtype=torch.float32)
+
+    # Create placeholder tensors for cumulative sequence lengths
+    # These are used for variable-length sequences, which we don't handle here
+    cum_seq_q = torch.empty(0, device=query.device, dtype=torch.int32)
+    cum_seq_k = torch.empty(0, device=query.device, dtype=torch.int32)
+
+    # Get max sequence lengths
+    max_q = query.shape[2]
+    max_k = key.shape[2]
+
+    # Philox seed and offset for dropout (currently not used as dropout_p must be 0)
+    philox_seed = torch.empty((), device=query.device, dtype=torch.int64)
+    philox_offset = torch.empty((), device=query.device, dtype=torch.int64)
+
+    # Debug attention mask
+    if return_debug_mask:
+        # Create a debug mask of the appropriate shape
+        batch = query.shape[0]
+        num_heads = query.shape[1]
+        seq_len_q = query.shape[2]
+        seq_len_k = key.shape[2]
+        debug_attn_mask = torch.zeros(
+            (batch, num_heads, seq_len_q, seq_len_k),
+            device=query.device,
+            dtype=query.dtype,
+        )
+    else:
+        debug_attn_mask = torch.empty(0, device=query.device, dtype=query.dtype)
+
+    return (
+        output,
+        logsumexp,
+        cum_seq_q,
+        cum_seq_k,
+        max_q,
+        max_k,
+        philox_seed,
+        philox_offset,
+        debug_attn_mask,
+    )

--- a/tests/test_attention_ops.py
+++ b/tests/test_attention_ops.py
@@ -1771,3 +1771,145 @@ def test_scheduler_metadata_correctness(
         )
 
     gems_assert_close(gems_metadata, ref_metadata, dtype=torch.int32)
+
+
+# Test for _scaled_dot_product_cudnn_attention
+@pytest.mark.scaled_dot_product_cudnn_attention
+@pytest.mark.parametrize(
+    "batch, num_head, q_seq_len, kv_seq_len, head_size",
+    [
+        (1, 4, 64, 64, 64),
+        (2, 8, 128, 128, 64),
+        (4, 4, 256, 256, 128),
+        (1, 8, 512, 512, 64),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("is_causal", [False, True])
+def test_accuracy__scaled_dot_product_cudnn_attention(
+    batch, num_head, q_seq_len, kv_seq_len, head_size, dtype, is_causal
+):
+    """Test _scaled_dot_product_cudnn_attention accuracy against reference implementation."""
+    if TO_CPU:
+        pytest.skip("Skipping attention test in CPU mode.")
+
+    init_seed(42)
+
+    # Create input tensors in the format expected by scaled_dot_product_cudnn_attention
+    # Shape: (batch, num_heads, seq_len, head_dim)
+    q = torch.randn(batch, num_head, q_seq_len, head_size, dtype=dtype, device=device)
+    k = torch.randn(batch, num_head, kv_seq_len, head_size, dtype=dtype, device=device)
+    v = torch.randn(batch, num_head, kv_seq_len, head_size, dtype=dtype, device=device)
+
+    # Compute scale
+    scale = 1.0 / (head_size ** 0.5)
+
+    # Reference using torch.nn.functional.scaled_dot_product_attention
+    ref_q = to_reference(q)
+    ref_k = to_reference(k)
+    ref_v = to_reference(v)
+
+    # Use PyTorch's SDPA as reference
+    ref_out = torch.nn.functional.scaled_dot_product_attention(
+        ref_q, ref_k, ref_v,
+        attn_mask=None,
+        dropout_p=0.0,
+        is_causal=is_causal,
+        scale=scale,
+    )
+
+    # Test FlagGems implementation
+    with flag_gems.use_gems():
+        (
+            gems_out,
+            logsumexp,
+            cum_seq_q,
+            cum_seq_k,
+            max_q,
+            max_k,
+            philox_seed,
+            philox_offset,
+            debug_attn_mask,
+        ) = torch._scaled_dot_product_cudnn_attention(
+            q, k, v,
+            attn_bias=None,
+            compute_log_sumexp=True,
+            dropout_p=0.0,
+            is_causal=is_causal,
+            return_debug_mask=False,
+            scale=scale,
+        )
+
+    # Use relaxed tolerance for attention (atol=5e-2 for attention operations)
+    gems_assert_close(gems_out, ref_out, dtype, atol=5e-2)
+
+    # Verify returned tensor shapes
+    assert gems_out.shape == q.shape
+    assert logsumexp.shape == (batch, num_head, q_seq_len)
+    assert max_q == q_seq_len
+    assert max_k == kv_seq_len
+
+
+@pytest.mark.scaled_dot_product_cudnn_attention
+@pytest.mark.parametrize(
+    "batch, num_head, q_seq_len, kv_seq_len, head_size",
+    [
+        (2, 4, 64, 64, 64),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float16])
+def test_accuracy__scaled_dot_product_cudnn_attention_with_attn_bias(
+    batch, num_head, q_seq_len, kv_seq_len, head_size, dtype
+):
+    """Test _scaled_dot_product_cudnn_attention with attention bias."""
+    if TO_CPU:
+        pytest.skip("Skipping attention test in CPU mode.")
+
+    init_seed(42)
+
+    q = torch.randn(batch, num_head, q_seq_len, head_size, dtype=dtype, device=device)
+    k = torch.randn(batch, num_head, kv_seq_len, head_size, dtype=dtype, device=device)
+    v = torch.randn(batch, num_head, kv_seq_len, head_size, dtype=dtype, device=device)
+
+    # Create attention bias
+    attn_bias = torch.randn(batch, num_head, q_seq_len, kv_seq_len, dtype=dtype, device=device) * 0.1
+
+    scale = 1.0 / (head_size ** 0.5)
+
+    ref_q = to_reference(q)
+    ref_k = to_reference(k)
+    ref_v = to_reference(v)
+    ref_bias = to_reference(attn_bias)
+
+    # Reference using SDPA with attn_mask as bias
+    ref_out = torch.nn.functional.scaled_dot_product_attention(
+        ref_q, ref_k, ref_v,
+        attn_mask=ref_bias,
+        dropout_p=0.0,
+        is_causal=False,
+        scale=scale,
+    )
+
+    with flag_gems.use_gems():
+        (
+            gems_out,
+            logsumexp,
+            cum_seq_q,
+            cum_seq_k,
+            max_q,
+            max_k,
+            philox_seed,
+            philox_offset,
+            debug_attn_mask,
+        ) = torch._scaled_dot_product_cudnn_attention(
+            q, k, v,
+            attn_bias=attn_bias,
+            compute_log_sumexp=True,
+            dropout_p=0.0,
+            is_causal=False,
+            return_debug_mask=False,
+            scale=scale,
+        )
+
+    # Use relaxed tolerance for attention (atol=5e-2 for attention operations)
+    gems_assert_close(gems_out, ref_out, dtype, atol=5e-2)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `_scaled_dot_product_cudnn_attention` operator implementation with Triton kernel.

- Implementation mode: `N/A`
- Accuracy test: 1/1 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([4, 32, 1024, 64]) | 0.1549 | 0.1790 | 0.865 |
| torch.Size([4, 32, 1024, 128]) | 0.2669 | 0.3231 | 0.826 |
| torch.Size([4, 32, 2048, 128]) | 0.8314 | 1.0020 | 0.830 |
| torch.Size([4, 32, 4096, 128]) | 2.9840 | 3.6284 | 0.822 |
| torch.Size([4, 32, 8192, 128]) | 11.2220 | 13.7461 | 0.816 |
| torch.Size([4, 32, 1024, 64]) | 0.2184 | 0.2581 | 0.846 |
| torch.Size([4, 32, 1024, 128]) | 0.3748 | 0.4568 | 0.821 |
| torch.Size([4, 32, 2048, 128]) | 1.4193 | 1.6048 | 0.884 |
| torch.Size([4, 32, 4096, 128]) | 5.4039 | 6.1788 | 0.875 |
| torch.Size([4, 32, 8192, 128]) | 21.3753 | 26.7810 | 0.798 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([4, 32, 1024, 64]) | 0.1926 | 0.1748 | 1.102 |
| torch.Size([4, 32, 1024, 128]) | 0.2669 | 0.3150 | 0.847 |
| torch.Size([4, 32, 2048, 128]) | 0.8439 | 1.0120 | 0.834 |
| torch.Size([4, 32, 4096, 128]) | 3.0062 | 3.6591 | 0.822 |
| torch.Size([4, 32, 8192, 128]) | 11.4342 | 13.8259 | 0.827 |
| torch.Size([4, 32, 1024, 64]) | 0.2192 | 0.2586 | 0.848 |
| torch.Size([4, 32, 1024, 128]) | 0.3771 | 0.4380 | 0.861 |
| torch.Size([4, 32, 2048, 128]) | 1.4610 | 1.6075 | 0.909 |
| torch.Size([4, 32, 4096, 128]) | 5.5175 | 6.2390 | 0.884 |
| torch.Size([4, 32, 8192, 128]) | 21.6544 | 24.5730 | 0.881 |

**Overall: median speedup = 0.847x, mean speedup = 0.860x** (20 data points)

---
_Generated by auto_gen tool with Claude Code_
