### PR TITLE
【KernelGen】Add _scaled_dot_product_efficient_attention operator

### DIFF
--- a/benchmark/test_attention_perf.py
+++ b/benchmark/test_attention_perf.py
@@ -700,3 +700,65 @@ def test_perf_reshape_and_cache_flash():
     )
     bench.set_gems(flag_gems.reshape_and_cache_flash)
     bench.run()
+
+
+class ScaledDotProductEfficientAttentionBenchmark(GenericBenchmark):
+    """
+    benchmark for _scaled_dot_product_efficient_attention
+    """
+
+    DEFAULT_SHAPES = [
+        # (batch, num_heads, seq_len, head_size)
+        (2, 4, 128, 64),
+        (2, 8, 256, 64),
+        (4, 8, 512, 64),
+        (2, 8, 1024, 64),
+        (1, 4, 2048, 128),
+    ]
+    DEFAULT_SHAPE_DESC = "batch, num_heads, seq_len, head_size"
+
+    def set_shapes(self, shape_file_path=None):
+        # Override to always use our attention-specific shapes
+        self.shapes = self.DEFAULT_SHAPES
+        self.shape_desc = self.DEFAULT_SHAPE_DESC
+
+    def set_more_shapes(self):
+        # Return None to use only DEFAULT_SHAPES
+        return None
+
+
+@pytest.mark.scaled_dot_product_efficient_attention
+@pytest.mark.parametrize("is_causal", [False, True])
+def test_perf_scaled_dot_product_efficient_attention(is_causal):
+    def input_kwargs(shape, dtype, device):
+        query = torch.randn(shape, device=device, dtype=dtype)
+        key = torch.randn(shape, device=device, dtype=dtype)
+        value = torch.randn(shape, device=device, dtype=dtype)
+        # attn_bias, compute_log_sumexp, dropout_p, is_causal, scale
+        yield query, key, value, None, True, 0.0, is_causal, {"scale": None}
+
+    def torch_sdpa_efficient(
+        query, key, value, attn_bias, compute_log_sumexp, dropout_p, is_causal, **kwargs
+    ):
+        return torch._scaled_dot_product_efficient_attention(
+            query, key, value, attn_bias, compute_log_sumexp, dropout_p, is_causal, **kwargs
+        )
+
+    def gems_sdpa_efficient(
+        query, key, value, attn_bias, compute_log_sumexp, dropout_p, is_causal, **kwargs
+    ):
+        return flag_gems._scaled_dot_product_efficient_attention(
+            query, key, value, attn_bias, compute_log_sumexp, dropout_p, is_causal, **kwargs
+        )
+
+    bench = ScaledDotProductEfficientAttentionBenchmark(
+        op_name="_scaled_dot_product_efficient_attention",
+        input_fn=input_kwargs,
+        torch_op=torch_sdpa_efficient,
+        dtypes=[
+            torch.float16,
+            torch.bfloat16,
+        ],
+    )
+    bench.set_gems(gems_sdpa_efficient)
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -31,6 +31,7 @@ _FULL_CONFIG = (
     ("_flash_attention_forward", flash_attention_forward),
     ("_log_softmax", log_softmax),
     ("_log_softmax_backward_data", log_softmax_backward),
+    ("_scaled_dot_product_efficient_attention", _scaled_dot_product_efficient_attention),
     ("_softmax", softmax),
     ("_softmax_backward_data", softmax_backward),
     (

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -193,6 +193,9 @@ from flag_gems.ops.resolve_conj import resolve_conj
 from flag_gems.ops.resolve_neg import resolve_neg
 from flag_gems.ops.rms_norm import rms_norm, rms_norm_backward, rms_norm_forward
 from flag_gems.ops.rsqrt import rsqrt, rsqrt_
+from flag_gems.ops._scaled_dot_product_efficient_attention import (
+    _scaled_dot_product_efficient_attention,
+)
 from flag_gems.ops.scaled_softmax import scaled_softmax_backward, scaled_softmax_forward
 from flag_gems.ops.scatter import scatter, scatter_
 from flag_gems.ops.scatter_add_ import scatter_add_
@@ -241,6 +244,7 @@ from flag_gems.ops.zeros_like import zeros_like
 
 __all__ = [
     "_conv_depthwise2d",
+    "_scaled_dot_product_efficient_attention",
     "_unique2",
     "_upsample_bicubic2d_aa",
     "abs",

--- a/src/flag_gems/ops/_scaled_dot_product_efficient_attention.py
+++ b/src/flag_gems/ops/_scaled_dot_product_efficient_attention.py
@@ -1,0 +1,84 @@
+import logging
+import math
+
+import torch
+
+from flag_gems.ops.attention import scaled_dot_product_attention_forward
+
+logger = logging.getLogger(__name__)
+
+
+def _scaled_dot_product_efficient_attention(
+    query,
+    key,
+    value,
+    attn_bias=None,
+    compute_log_sumexp=True,
+    dropout_p=0.0,
+    is_causal=False,
+    *,
+    scale=None,
+):
+    """
+    Scaled dot product efficient attention implementation.
+
+    Args:
+        query: (batch, num_heads, seq_len, head_dim)
+        key: (batch, num_heads, seq_len, head_dim)
+        value: (batch, num_heads, seq_len, head_dim)
+        attn_bias: Optional attention bias tensor (batch, num_heads, seq_len, seq_len)
+        compute_log_sumexp: Whether to compute and return log_sumexp
+        dropout_p: Dropout probability (default 0.0)
+        is_causal: Whether to apply causal masking (default False)
+        scale: Optional scale factor for attention scores
+
+    Returns:
+        Tuple of (output, log_sumexp, philox_seed, philox_offset)
+        - output: (batch, num_heads, seq_len, head_dim)
+        - log_sumexp: (batch, num_heads, seq_len) if compute_log_sumexp else empty
+        - philox_seed: Scalar tensor for dropout random seed
+        - philox_offset: Scalar tensor for dropout random offset
+    """
+    logger.debug("GEMS _SCALED_DOT_PRODUCT_EFFICIENT_ATTENTION")
+
+    # Compute scale if not provided
+    head_dim = query.shape[-1]
+    if scale is None:
+        sm_scale = 1.0 / math.sqrt(head_dim)
+    else:
+        sm_scale = scale
+
+    # Call the existing forward implementation
+    # The existing implementation uses attn_mask parameter which is equivalent to attn_bias
+    output, M = scaled_dot_product_attention_forward(
+        query,
+        key,
+        value,
+        attn_mask=attn_bias,
+        dropout_p=dropout_p,
+        is_causal=is_causal,
+        scale=sm_scale,
+        enable_gqa=False,
+    )
+
+    # Handle log_sumexp output
+    # M is computed as m_i + log2(l_i) in the kernel, we need to convert to natural log
+    # M = m_i + log2(l_i), where m_i is max(qk_scale * qk * log2(e))
+    # The actual log_sumexp in natural log is: M / log2(e)
+    LN2 = math.log(2)
+    if compute_log_sumexp:
+        # Convert from log2 to natural log
+        log_sumexp = M * LN2
+    else:
+        # Return empty tensor when compute_log_sumexp is False
+        batch, num_heads, seq_len = M.shape
+        log_sumexp = torch.empty(
+            (batch, num_heads, 0), dtype=torch.float32, device=query.device
+        )
+
+    # Create philox seed and offset tensors for dropout
+    # Since we currently only support dropout_p=0.0, these are placeholder values
+    philox_seed = torch.tensor(0, dtype=torch.int64, device=query.device)
+    philox_offset = torch.tensor(0, dtype=torch.int64, device=query.device)
+
+    return output, log_sumexp, philox_seed, philox_offset

--- a/tests/test_attention_ops.py
+++ b/tests/test_attention_ops.py
@@ -1771,3 +1771,227 @@ def test_scheduler_metadata_correctness(
         )
 
     gems_assert_close(gems_metadata, ref_metadata, dtype=torch.int32)
+
+
+# Test cases for _scaled_dot_product_efficient_attention
+SDPA_EFFICIENT_SHAPES = [
+    # (batch, num_heads, seq_len, head_dim)
+    (2, 4, 128, 64),
+    (2, 8, 256, 64),
+    (1, 4, 512, 128),
+    (4, 8, 64, 32),
+]
+
+
+@pytest.mark.scaled_dot_product_efficient_attention
+@pytest.mark.parametrize(
+    "batch, num_heads, seq_len, head_dim",
+    SDPA_EFFICIENT_SHAPES,
+)
+@pytest.mark.parametrize("is_causal", [False, True])
+@pytest.mark.parametrize("compute_log_sumexp", [True, False])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_accuracy_scaled_dot_product_efficient_attention(
+    batch,
+    num_heads,
+    seq_len,
+    head_dim,
+    is_causal,
+    compute_log_sumexp,
+    dtype,
+):
+    """Test _scaled_dot_product_efficient_attention accuracy against PyTorch."""
+    device = torch_device_fn.current_device()
+
+    # Create input tensors
+    q = torch.randn(
+        batch, num_heads, seq_len, head_dim, dtype=dtype, device=device
+    ).uniform_(-0.05, 0.05)
+    k = torch.randn(
+        batch, num_heads, seq_len, head_dim, dtype=dtype, device=device
+    ).uniform_(-0.05, 0.05)
+    v = torch.randn(
+        batch, num_heads, seq_len, head_dim, dtype=dtype, device=device
+    ).uniform_(-0.05, 0.05)
+
+    ref_q = to_reference(q)
+    ref_k = to_reference(k)
+    ref_v = to_reference(v)
+
+    # Reference: PyTorch implementation
+    ref_out, ref_logsumexp, ref_seed, ref_offset = (
+        torch._scaled_dot_product_efficient_attention(
+            ref_q,
+            ref_k,
+            ref_v,
+            None,  # attn_bias
+            compute_log_sumexp,
+            0.0,  # dropout_p
+            is_causal,
+            scale=None,
+        )
+    )
+
+    # Test: FlagGems implementation
+    with flag_gems.use_gems():
+        gems_out, gems_logsumexp, gems_seed, gems_offset = (
+            torch._scaled_dot_product_efficient_attention(
+                q,
+                k,
+                v,
+                None,  # attn_bias
+                compute_log_sumexp,
+                0.0,  # dropout_p
+                is_causal,
+                scale=None,
+            )
+        )
+
+    # Check output
+    gems_assert_close(gems_out, ref_out, dtype)
+
+    # Check logsumexp if computed
+    if compute_log_sumexp:
+        gems_assert_close(gems_logsumexp, ref_logsumexp, dtype=torch.float32)
+
+
+@pytest.mark.scaled_dot_product_efficient_attention
+@pytest.mark.parametrize(
+    "batch, num_heads, seq_len, head_dim",
+    [(2, 4, 128, 64), (1, 8, 256, 64)],
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_accuracy_scaled_dot_product_efficient_attention_with_bias(
+    batch,
+    num_heads,
+    seq_len,
+    head_dim,
+    dtype,
+):
+    """Test _scaled_dot_product_efficient_attention with attention bias."""
+    device = torch_device_fn.current_device()
+
+    # Create input tensors
+    q = torch.randn(
+        batch, num_heads, seq_len, head_dim, dtype=dtype, device=device
+    ).uniform_(-0.05, 0.05)
+    k = torch.randn(
+        batch, num_heads, seq_len, head_dim, dtype=dtype, device=device
+    ).uniform_(-0.05, 0.05)
+    v = torch.randn(
+        batch, num_heads, seq_len, head_dim, dtype=dtype, device=device
+    ).uniform_(-0.05, 0.05)
+    attn_bias = torch.randn(
+        batch, num_heads, seq_len, seq_len, dtype=dtype, device=device
+    ).uniform_(-0.1, 0.1)
+
+    ref_q = to_reference(q)
+    ref_k = to_reference(k)
+    ref_v = to_reference(v)
+    ref_attn_bias = to_reference(attn_bias)
+
+    # Reference: PyTorch implementation
+    ref_out, ref_logsumexp, ref_seed, ref_offset = (
+        torch._scaled_dot_product_efficient_attention(
+            ref_q,
+            ref_k,
+            ref_v,
+            ref_attn_bias,
+            True,  # compute_log_sumexp
+            0.0,  # dropout_p
+            False,  # is_causal
+            scale=None,
+        )
+    )
+
+    # Test: FlagGems implementation
+    with flag_gems.use_gems():
+        gems_out, gems_logsumexp, gems_seed, gems_offset = (
+            torch._scaled_dot_product_efficient_attention(
+                q,
+                k,
+                v,
+                attn_bias,
+                True,  # compute_log_sumexp
+                0.0,  # dropout_p
+                False,  # is_causal
+                scale=None,
+            )
+        )
+
+    # Check output with relaxed tolerance for attention with bias
+    # Attention operations with bias can have slightly higher numerical variance
+    atol = 2e-4 if dtype == torch.bfloat16 else 2e-4
+    rtol = 0.05 if dtype == torch.bfloat16 else 0.05
+    torch.testing.assert_close(gems_out, ref_out.to(dtype), atol=atol, rtol=rtol)
+
+    # Check logsumexp with relaxed tolerance
+    torch.testing.assert_close(
+        gems_logsumexp, ref_logsumexp.to(torch.float32), atol=1e-3, rtol=0.01
+    )
+
+
+@pytest.mark.scaled_dot_product_efficient_attention
+@pytest.mark.parametrize(
+    "batch, num_heads, seq_len, head_dim",
+    [(2, 4, 128, 64)],
+)
+@pytest.mark.parametrize("scale", [0.1, 0.5, 1.0])
+@pytest.mark.parametrize("dtype", [torch.float16])
+def test_accuracy_scaled_dot_product_efficient_attention_with_scale(
+    batch,
+    num_heads,
+    seq_len,
+    head_dim,
+    scale,
+    dtype,
+):
+    """Test _scaled_dot_product_efficient_attention with custom scale."""
+    device = torch_device_fn.current_device()
+
+    # Create input tensors
+    q = torch.randn(
+        batch, num_heads, seq_len, head_dim, dtype=dtype, device=device
+    ).uniform_(-0.05, 0.05)
+    k = torch.randn(
+        batch, num_heads, seq_len, head_dim, dtype=dtype, device=device
+    ).uniform_(-0.05, 0.05)
+    v = torch.randn(
+        batch, num_heads, seq_len, head_dim, dtype=dtype, device=device
+    ).uniform_(-0.05, 0.05)
+
+    ref_q = to_reference(q)
+    ref_k = to_reference(k)
+    ref_v = to_reference(v)
+
+    # Reference: PyTorch implementation
+    ref_out, ref_logsumexp, ref_seed, ref_offset = (
+        torch._scaled_dot_product_efficient_attention(
+            ref_q,
+            ref_k,
+            ref_v,
+            None,
+            True,  # compute_log_sumexp
+            0.0,  # dropout_p
+            False,  # is_causal
+            scale=scale,
+        )
+    )
+
+    # Test: FlagGems implementation
+    with flag_gems.use_gems():
+        gems_out, gems_logsumexp, gems_seed, gems_offset = (
+            torch._scaled_dot_product_efficient_attention(
+                q,
+                k,
+                v,
+                None,
+                True,  # compute_log_sumexp
+                0.0,  # dropout_p
+                False,  # is_causal
+                scale=scale,
+            )
+        )
+
+    # Check output
+    gems_assert_close(gems_out, ref_out, dtype)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `_scaled_dot_product_efficient_attention` operator implementation with Triton kernel.

- Implementation mode: `manual_kernel`
- Accuracy test: 39/39 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [2, 4, 128, 64] | 0.0156 | 0.0697 | 0.225 |
| [2, 8, 256, 64] | 0.0221 | 0.0731 | 0.303 |
| [4, 8, 512, 64] | 0.0483 | 0.0917 | 0.527 |
| [2, 8, 1024, 64] | 0.0852 | 0.1104 | 0.772 |
| [1, 4, 2048, 128] | 0.1432 | 0.1684 | 0.850 |
| [2, 4, 128, 64] | 0.0153 | 0.0714 | 0.215 |
| [2, 8, 256, 64] | 0.0234 | 0.0745 | 0.314 |
| [4, 8, 512, 64] | 0.0484 | 0.0932 | 0.520 |
| [2, 8, 1024, 64] | 0.0827 | 0.1120 | 0.738 |
| [1, 4, 2048, 128] | 0.1252 | 0.1916 | 0.653 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [2, 4, 128, 64] | 0.0190 | 0.0749 | 0.254 |
| [2, 8, 256, 64] | 0.0280 | 0.0726 | 0.386 |
| [4, 8, 512, 64] | 0.0483 | 0.0916 | 0.527 |
| [2, 8, 1024, 64] | 0.0845 | 0.1167 | 0.724 |
| [1, 4, 2048, 128] | 0.1431 | 0.1684 | 0.850 |
| [2, 4, 128, 64] | 0.0158 | 0.0712 | 0.221 |
| [2, 8, 256, 64] | 0.0233 | 0.0748 | 0.312 |
| [4, 8, 512, 64] | 0.0483 | 0.0936 | 0.516 |
| [2, 8, 1024, 64] | 0.0825 | 0.1164 | 0.709 |
| [1, 4, 2048, 128] | 0.1250 | 0.1847 | 0.677 |

**Overall: median speedup = 0.524x, mean speedup = 0.515x** (20 data points)

---
_Generated by auto_gen tool with Claude Code_
