### PR TITLE
【KernelGen】Add _scaled_dot_product_flash_attention operator

### DIFF
--- a/benchmark/test_attention_perf.py
+++ b/benchmark/test_attention_perf.py
@@ -700,3 +700,62 @@ def test_perf_reshape_and_cache_flash():
     )
     bench.set_gems(flag_gems.reshape_and_cache_flash)
     bench.run()
+
+
+class ScaledDotProductFlashAttentionBenchmark(GenericBenchmark):
+    """
+    benchmark for _scaled_dot_product_flash_attention
+    """
+
+    def set_shapes(self, shape_file_path=None):
+        # Shapes for attention: (batch, num_heads, seq_len, head_size)
+        self.shapes = [
+            (1, 8, 64, 64),
+            (2, 8, 128, 64),
+            (2, 16, 256, 64),
+            (4, 8, 512, 64),
+            (2, 32, 1024, 64),
+            (1, 8, 2048, 128),
+        ]
+
+    def set_more_shapes(self):
+        # self.shapes is a list of tuples, each containing four elements:
+        # (batch, num_heads, seq_len, head_size).
+        return None
+
+
+@pytest.mark.scaled_dot_product_flash_attention
+@pytest.mark.parametrize("is_causal", [True, False])
+def test_perf_scaled_dot_product_flash_attention(is_causal):
+    def scaled_dot_product_flash_attention_kwargs(shape, dtype, device):
+        batch, num_heads, seq_len, head_size = shape
+        query = torch.randn(shape, device=device, dtype=dtype)
+        key = torch.randn(shape, device=device, dtype=dtype)
+        value = torch.randn(shape, device=device, dtype=dtype)
+        yield query, key, value, 0.0, is_causal, False
+
+    def torch_scaled_dot_product_flash_attention(
+        query, key, value, dropout_p, is_causal, return_debug_mask
+    ):
+        return torch.ops.aten._scaled_dot_product_flash_attention(
+            query, key, value, dropout_p, is_causal, return_debug_mask, scale=None
+        )
+
+    def gems_scaled_dot_product_flash_attention(
+        query, key, value, dropout_p, is_causal, return_debug_mask
+    ):
+        return flag_gems.ops._scaled_dot_product_flash_attention(
+            query, key, value, dropout_p, is_causal, return_debug_mask, scale=None
+        )
+
+    bench = ScaledDotProductFlashAttentionBenchmark(
+        op_name="_scaled_dot_product_flash_attention",
+        input_fn=scaled_dot_product_flash_attention_kwargs,
+        torch_op=torch_scaled_dot_product_flash_attention,
+        dtypes=[
+            torch.float16,
+            torch.bfloat16,
+        ],
+    )
+    bench.set_gems(gems_scaled_dot_product_flash_attention)
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -31,6 +31,7 @@ _FULL_CONFIG = (
     ("_flash_attention_forward", flash_attention_forward),
     ("_log_softmax", log_softmax),
     ("_log_softmax_backward_data", log_softmax_backward),
+    ("_scaled_dot_product_flash_attention", _scaled_dot_product_flash_attention),
     ("_softmax", softmax),
     ("_softmax_backward_data", softmax_backward),
     (

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -59,6 +59,9 @@ from flag_gems.ops.conv1d import conv1d
 from flag_gems.ops.conv2d import conv2d
 from flag_gems.ops.conv3d import conv3d
 from flag_gems.ops.conv_depthwise2d import _conv_depthwise2d
+from flag_gems.ops._scaled_dot_product_flash_attention import (
+    _scaled_dot_product_flash_attention,
+)
 from flag_gems.ops.copy import copy, copy_
 from flag_gems.ops.cos import cos, cos_
 from flag_gems.ops.count_nonzero import count_nonzero
@@ -241,6 +244,7 @@ from flag_gems.ops.zeros_like import zeros_like
 
 __all__ = [
     "_conv_depthwise2d",
+    "_scaled_dot_product_flash_attention",
     "_unique2",
     "_upsample_bicubic2d_aa",
     "abs",

--- a/src/flag_gems/ops/_scaled_dot_product_flash_attention.py
+++ b/src/flag_gems/ops/_scaled_dot_product_flash_attention.py
@@ -1,0 +1,97 @@
+import logging
+import math
+
+import torch
+
+from flag_gems.ops.attention import scaled_dot_product_attention_forward
+
+logger = logging.getLogger(__name__)
+
+# ln(2) constant for converting log2 to natural log
+LN2 = math.log(2)
+
+
+def _scaled_dot_product_flash_attention(
+    query,
+    key,
+    value,
+    dropout_p=0.0,
+    is_causal=False,
+    return_debug_mask=False,
+    *,
+    scale=None,
+):
+    """
+    FlagGems implementation of scaled dot product flash attention.
+
+    This wraps the scaled_dot_product_attention_forward function to match the PyTorch
+    _scaled_dot_product_flash_attention aten op signature.
+
+    Args:
+        query: (batch, num_heads, seq_len_q, head_dim)
+        key: (batch, num_heads, seq_len_k, head_dim)
+        value: (batch, num_heads, seq_len_k, head_dim)
+        dropout_p: Dropout probability (default: 0.0)
+        is_causal: Whether to apply causal masking (default: False)
+        return_debug_mask: Whether to return debug attention mask (default: False)
+        scale: Optional scale factor (default: None, uses 1/sqrt(head_dim))
+
+    Returns:
+        Tuple of 9 outputs:
+        - output: (batch, num_heads, seq_len_q, head_dim)
+        - logsumexp: (batch, num_heads, seq_len_q)
+        - cum_seq_q: None (not used for non-varlen)
+        - cum_seq_k: None (not used for non-varlen)
+        - max_q: seq_len_q
+        - max_k: seq_len_k
+        - philox_seed: RNG seed tensor (scalar on CPU)
+        - philox_offset: RNG offset tensor (scalar on CPU)
+        - debug_attn_mask: Empty tensor or debug mask
+    """
+    logger.debug("GEMS _SCALED_DOT_PRODUCT_FLASH_ATTENTION")
+
+    # Get sequence lengths
+    seq_len_q = query.shape[2]
+    seq_len_k = key.shape[2]
+
+    # Call scaled_dot_product_attention_forward
+    # Returns: (output, logsumexp)
+    # Note: The logsumexp is in log2 space, need to convert to natural log
+    out, lse = scaled_dot_product_attention_forward(
+        query,
+        key,
+        value,
+        attn_mask=None,
+        dropout_p=dropout_p,
+        is_causal=is_causal,
+        scale=scale,
+        enable_gqa=False,
+    )
+
+    # Convert logsumexp from log2 to natural log (multiply by ln(2))
+    # The internal implementation uses log2 for numerical stability
+    if lse is not None:
+        lse = lse * LN2
+
+    # Create placeholder philox tensors for RNG state
+    # These are used for reproducibility with dropout, but since we don't support dropout yet,
+    # we just create placeholder values
+    philox_seed = torch.tensor(0, dtype=torch.int64, device="cpu")
+    philox_offset = torch.tensor(0, dtype=torch.int64, device="cpu")
+
+    # Create empty debug mask tensor
+    debug_mask = torch.empty(0, dtype=query.dtype, device=query.device)
+
+    # Return 9 outputs matching the aten op signature
+    # cum_seq_q and cum_seq_k are None for non-varlen attention
+    return (
+        out,
+        lse,
+        None,  # cum_seq_q
+        None,  # cum_seq_k
+        seq_len_q,  # max_q
+        seq_len_k,  # max_k
+        philox_seed,
+        philox_offset,
+        debug_mask,
+    )

--- a/tests/test_attention_ops.py
+++ b/tests/test_attention_ops.py
@@ -1771,3 +1771,164 @@ def test_scheduler_metadata_correctness(
         )
 
     gems_assert_close(gems_metadata, ref_metadata, dtype=torch.int32)
+
+
+# Test shapes for _scaled_dot_product_flash_attention
+SDPA_FLASH_SHAPES = [
+    # (batch, num_heads, seq_len, head_dim)
+    (1, 8, 64, 32),
+    (2, 8, 64, 64),
+    (2, 16, 128, 64),
+    (4, 8, 256, 32),
+    (2, 8, 512, 64),
+    (1, 32, 1024, 64),
+    (2, 8, 2048, 128),
+]
+
+
+@pytest.mark.scaled_dot_product_flash_attention
+@pytest.mark.parametrize(
+    "batch, num_heads, seq_len, head_dim",
+    SDPA_FLASH_SHAPES,
+)
+@pytest.mark.parametrize("is_causal", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_accuracy_scaled_dot_product_flash_attention(
+    batch, num_heads, seq_len, head_dim, is_causal, dtype
+):
+    """Test accuracy of _scaled_dot_product_flash_attention operator."""
+    if TO_CPU:
+        pytest.skip("Skipping test in CPU mode.")
+
+    device = torch_device_fn.current_device()
+
+    # Create input tensors
+    query = torch.randn(
+        batch, num_heads, seq_len, head_dim, dtype=dtype, device=device
+    )
+    key = torch.randn(
+        batch, num_heads, seq_len, head_dim, dtype=dtype, device=device
+    )
+    value = torch.randn(
+        batch, num_heads, seq_len, head_dim, dtype=dtype, device=device
+    )
+
+    # Reference implementation (native PyTorch)
+    ref_query = to_reference(query)
+    ref_key = to_reference(key)
+    ref_value = to_reference(value)
+
+    ref_result = torch.ops.aten._scaled_dot_product_flash_attention(
+        ref_query, ref_key, ref_value, 0.0, is_causal, False, scale=None
+    )
+
+    # FlagGems implementation
+    with flag_gems.use_gems():
+        gems_result = torch.ops.aten._scaled_dot_product_flash_attention(
+            query, key, value, 0.0, is_causal, False, scale=None
+        )
+
+    # Check output tensor (index 0) with larger tolerance for attention operations
+    # Flash attention implementations can have small numerical differences
+    gems_assert_close(gems_result[0], ref_result[0], dtype, atol=0.01)
+
+    # Check logsumexp tensor (index 1)
+    gems_assert_close(gems_result[1], ref_result[1], dtype=torch.float32, atol=0.01)
+
+
+@pytest.mark.scaled_dot_product_flash_attention
+@pytest.mark.parametrize(
+    "batch, num_heads, seq_len_q, seq_len_k, head_dim",
+    [
+        # Different q and k sequence lengths
+        (2, 8, 64, 128, 64),
+        (2, 8, 128, 64, 64),
+        (1, 16, 256, 512, 32),
+        (2, 8, 512, 256, 64),
+    ],
+)
+@pytest.mark.parametrize("is_causal", [False])  # Causal requires seq_len_q >= seq_len_k
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_accuracy_scaled_dot_product_flash_attention_nonsquare(
+    batch, num_heads, seq_len_q, seq_len_k, head_dim, is_causal, dtype
+):
+    """Test accuracy of _scaled_dot_product_flash_attention with different q/k sequence lengths."""
+    if TO_CPU:
+        pytest.skip("Skipping test in CPU mode.")
+
+    device = torch_device_fn.current_device()
+
+    # Create input tensors with different sequence lengths
+    query = torch.randn(
+        batch, num_heads, seq_len_q, head_dim, dtype=dtype, device=device
+    )
+    key = torch.randn(
+        batch, num_heads, seq_len_k, head_dim, dtype=dtype, device=device
+    )
+    value = torch.randn(
+        batch, num_heads, seq_len_k, head_dim, dtype=dtype, device=device
+    )
+
+    # Reference implementation (native PyTorch)
+    ref_query = to_reference(query)
+    ref_key = to_reference(key)
+    ref_value = to_reference(value)
+
+    ref_result = torch.ops.aten._scaled_dot_product_flash_attention(
+        ref_query, ref_key, ref_value, 0.0, is_causal, False, scale=None
+    )
+
+    # FlagGems implementation
+    with flag_gems.use_gems():
+        gems_result = torch.ops.aten._scaled_dot_product_flash_attention(
+            query, key, value, 0.0, is_causal, False, scale=None
+        )
+
+    # Check output tensor (index 0) with larger tolerance for attention operations
+    gems_assert_close(gems_result[0], ref_result[0], dtype, atol=0.01)
+
+    # Check logsumexp tensor (index 1)
+    gems_assert_close(gems_result[1], ref_result[1], dtype=torch.float32, atol=0.01)
+
+
+@pytest.mark.scaled_dot_product_flash_attention
+@pytest.mark.parametrize("scale", [None, 0.1, 0.5])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_accuracy_scaled_dot_product_flash_attention_with_scale(scale, dtype):
+    """Test accuracy of _scaled_dot_product_flash_attention with custom scale."""
+    if TO_CPU:
+        pytest.skip("Skipping test in CPU mode.")
+
+    device = torch_device_fn.current_device()
+    batch, num_heads, seq_len, head_dim = 2, 8, 64, 64
+
+    query = torch.randn(
+        batch, num_heads, seq_len, head_dim, dtype=dtype, device=device
+    )
+    key = torch.randn(
+        batch, num_heads, seq_len, head_dim, dtype=dtype, device=device
+    )
+    value = torch.randn(
+        batch, num_heads, seq_len, head_dim, dtype=dtype, device=device
+    )
+
+    # Reference implementation
+    ref_query = to_reference(query)
+    ref_key = to_reference(key)
+    ref_value = to_reference(value)
+
+    ref_result = torch.ops.aten._scaled_dot_product_flash_attention(
+        ref_query, ref_key, ref_value, 0.0, False, False, scale=scale
+    )
+
+    # FlagGems implementation
+    with flag_gems.use_gems():
+        gems_result = torch.ops.aten._scaled_dot_product_flash_attention(
+            query, key, value, 0.0, False, False, scale=scale
+        )
+
+    # Check output tensor with larger tolerance for attention operations
+    gems_assert_close(gems_result[0], ref_result[0], dtype, atol=0.01)
+
+    # Check logsumexp tensor
+    gems_assert_close(gems_result[1], ref_result[1], dtype=torch.float32, atol=0.01)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `_scaled_dot_product_flash_attention` operator implementation with Triton kernel.

- Implementation mode: `N/A`
- Accuracy test: 7/7 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1, 8, 64, 64]) | 0.0142 | 0.0129 | 1.099 |
| torch.Size([2, 8, 128, 64]) | 0.0133 | 0.0155 | 0.863 |
| torch.Size([2, 16, 256, 64]) | 0.0199 | 0.0214 | 0.930 |
| torch.Size([4, 8, 512, 64]) | 0.0353 | 0.0366 | 0.963 |
| torch.Size([2, 32, 1024, 64]) | 0.0961 | 0.1074 | 0.895 |
| torch.Size([1, 8, 2048, 128]) | 0.1356 | 0.1725 | 0.786 |
| torch.Size([1, 8, 64, 64]) | 0.0136 | 0.0126 | 1.076 |
| torch.Size([2, 8, 128, 64]) | 0.0132 | 0.0142 | 0.930 |
| torch.Size([2, 16, 256, 64]) | 0.0180 | 0.0202 | 0.892 |
| torch.Size([4, 8, 512, 64]) | 0.0328 | 0.0352 | 0.930 |
| torch.Size([2, 32, 1024, 64]) | 0.1173 | 0.1439 | 0.815 |
| torch.Size([1, 8, 2048, 128]) | 0.1523 | 0.1758 | 0.866 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1, 8, 64, 64]) | 0.0173 | 0.0161 | 1.076 |
| torch.Size([2, 8, 128, 64]) | 0.0167 | 0.0155 | 1.076 |
| torch.Size([2, 16, 256, 64]) | 0.0190 | 0.0225 | 0.846 |
| torch.Size([4, 8, 512, 64]) | 0.0353 | 0.0367 | 0.962 |
| torch.Size([2, 32, 1024, 64]) | 0.0955 | 0.1064 | 0.897 |
| torch.Size([1, 8, 2048, 128]) | 0.1364 | 0.1636 | 0.833 |
| torch.Size([1, 8, 64, 64]) | 0.0140 | 0.0127 | 1.104 |
| torch.Size([2, 8, 128, 64]) | 0.0132 | 0.0142 | 0.926 |
| torch.Size([2, 16, 256, 64]) | 0.0181 | 0.0202 | 0.895 |
| torch.Size([4, 8, 512, 64]) | 0.0328 | 0.0353 | 0.930 |
| torch.Size([2, 32, 1024, 64]) | 0.1176 | 0.1446 | 0.813 |
| torch.Size([1, 8, 2048, 128]) | 0.1522 | 0.1758 | 0.865 |

**Overall: median speedup = 0.911x, mean speedup = 0.928x** (24 data points)

---
_Generated by auto_gen tool with Claude Code_
