### PR TITLE
【KernelGen】Add adaptive_max_pool2d_backward operator

### DIFF
--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -422,6 +422,56 @@ def test_perf_max_pool2d_backward():
     bench.run()
 
 
+def adaptive_max_pool2d_backward_input_fn(shape, dtype, device):
+    inp = generate_tensor_input(shape, dtype, device)
+    inp.requires_grad_(True)
+    # Common output size
+    output_size = (shape[-2] // 2, shape[-1] // 2)
+    output, indices = torch.nn.functional.adaptive_max_pool2d_with_indices(
+        inp, output_size
+    )
+    grad_output = torch.randn_like(output)
+    yield grad_output, inp, indices
+
+    if Config.bench_level == BenchLevel.COMPREHENSIVE:
+        # Output size 7x7 (common in ResNet)
+        if shape[-2] >= 14 and shape[-1] >= 14:
+            output_size = (7, 7)
+            output, indices = torch.nn.functional.adaptive_max_pool2d_with_indices(
+                inp, output_size
+            )
+            grad_output = torch.randn_like(output)
+            yield grad_output, inp, indices
+
+        # Output size 1x1 (global pooling)
+        output_size = (1, 1)
+        output, indices = torch.nn.functional.adaptive_max_pool2d_with_indices(
+            inp, output_size
+        )
+        grad_output = torch.randn_like(output)
+        yield grad_output, inp, indices
+
+
+class AdaptiveMaxPool2dBackwardBenchmark(GenericBenchmark4DOnly):
+    pass
+
+
+@pytest.mark.adaptive_max_pool2d_backward
+def test_perf_adaptive_max_pool2d_backward():
+    def torch_adaptive_max_pool2d_backward_wrapper(grad_output, input, indices):
+        return torch.ops.aten.adaptive_max_pool2d_backward(grad_output, input, indices)
+
+    bench = AdaptiveMaxPool2dBackwardBenchmark(
+        input_fn=adaptive_max_pool2d_backward_input_fn,
+        op_name="adaptive_max_pool2d_backward",
+        torch_op=torch_adaptive_max_pool2d_backward_wrapper,
+        dtypes=FLOAT_DTYPES,
+    )
+
+    bench.set_gems(flag_gems.adaptive_max_pool2d_backward)
+    bench.run()
+
+
 @pytest.mark.dot
 def test_perf_dot():
     def dot_input_fn(shape, dtype, device):

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -45,6 +45,7 @@ _FULL_CONFIG = (
     ("abs", abs),
     ("abs_", abs_),
     ("acos", acos),
+    ("adaptive_max_pool2d_backward", adaptive_max_pool2d_backward),
     ("add.Tensor", add),
     ("add_.Tensor", add_),
     ("addcdiv", addcdiv),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -1,5 +1,6 @@
 from flag_gems.ops.abs import abs, abs_
 from flag_gems.ops.acos import acos
+from flag_gems.ops.adaptive_max_pool2d_backward import adaptive_max_pool2d_backward
 from flag_gems.ops.add import add, add_
 from flag_gems.ops.addcdiv import addcdiv
 from flag_gems.ops.addcmul import addcmul
@@ -246,6 +247,7 @@ __all__ = [
     "abs",
     "abs_",
     "acos",
+    "adaptive_max_pool2d_backward",
     "add",
     "add_",
     "addcdiv",

--- a/src/flag_gems/ops/adaptive_max_pool2d_backward.py
+++ b/src/flag_gems/ops/adaptive_max_pool2d_backward.py
@@ -1,0 +1,121 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 512}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 1024}, num_warps=8),
+        triton.Config({"BLOCK_SIZE": 2048}, num_warps=8),
+    ],
+    key=["out_numel"],
+    reset_to_zero=["grad_input_ptr"],
+)
+@triton.jit
+def adaptive_max_pool2d_backward_kernel(
+    grad_output_ptr,
+    indices_ptr,
+    grad_input_ptr,
+    # Shape info
+    in_h,
+    in_w,
+    out_h,
+    out_w,
+    out_numel,
+    in_numel_per_nc,
+    # Strides for grad_output/indices (contiguous, so (N*C, out_h*out_w))
+    out_stride_nc,
+    # Tiling
+    BLOCK_SIZE: tl.constexpr,
+):
+    """
+    Each program processes a block of output elements.
+    For each output element, scatter its grad_output value to the position
+    indicated by the corresponding index in grad_input.
+    """
+    pid = tl.program_id(0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < out_numel
+
+    # Load grad_output and indices
+    grad_out_val = tl.load(grad_output_ptr + offsets, mask=mask, other=0.0)
+    indices_val = tl.load(indices_ptr + offsets, mask=mask, other=0)
+
+    # Calculate which (n*c) batch this output element belongs to
+    nc_idx = offsets // out_stride_nc
+
+    # Calculate the position in grad_input
+    # indices_val is the flat index within (in_h * in_w) spatial plane
+    grad_input_offset = nc_idx * in_numel_per_nc + indices_val
+
+    # Use atomic add since multiple output elements could map to the same input
+    # (though for adaptive_max_pool2d this shouldn't happen, but using atomic
+    # for correctness)
+    tl.atomic_add(grad_input_ptr + grad_input_offset, grad_out_val, mask=mask)
+
+
+def adaptive_max_pool2d_backward(
+    grad_output: torch.Tensor,
+    self: torch.Tensor,
+    indices: torch.Tensor,
+) -> torch.Tensor:
+    """
+    Backward pass for adaptive_max_pool2d.
+
+    Args:
+        grad_output: Gradient from the output, shape (N, C, out_H, out_W)
+        self: The original input tensor, shape (N, C, in_H, in_W)
+        indices: Indices of max values from forward pass, shape (N, C, out_H, out_W)
+
+    Returns:
+        grad_input: Gradient with respect to input, shape (N, C, in_H, in_W)
+    """
+    logger.debug("GEMS ADAPTIVE_MAX_POOL2D_BACKWARD")
+
+    grad_output = grad_output.contiguous()
+    indices = indices.contiguous()
+
+    # Get shapes
+    in_n, in_c, in_h, in_w = self.shape
+    out_h, out_w = grad_output.shape[2], grad_output.shape[3]
+
+    # Initialize grad_input with zeros
+    grad_input = torch.zeros(
+        (in_n, in_c, in_h, in_w),
+        device=grad_output.device,
+        dtype=torch.float32,
+    )
+
+    out_numel = grad_output.numel()
+    if out_numel == 0:
+        return grad_input.to(grad_output.dtype)
+
+    out_stride_nc = out_h * out_w
+    in_numel_per_nc = in_h * in_w
+
+    grid = lambda meta: (triton.cdiv(out_numel, meta["BLOCK_SIZE"]),)
+
+    adaptive_max_pool2d_backward_kernel[grid](
+        grad_output,
+        indices,
+        grad_input,
+        in_h,
+        in_w,
+        out_h,
+        out_w,
+        out_numel,
+        in_numel_per_nc,
+        out_stride_nc,
+    )
+
+    return grad_input.to(grad_output.dtype)

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -1476,6 +1476,59 @@ def test_accuracy_max_pool2d_backward(
     gems_assert_close(res_in_grad, ref_in_grad, dtype)
 
 
+# Adaptive max pool 2d backward configs
+# Format: (input_shape, output_size)
+ADAPTIVE_MAXPOOL2D_BACKWARD_CONFIGS = [
+    # Standard cases
+    ((2, 3, 8, 8), (4, 4)),
+    ((4, 16, 32, 32), (8, 8)),
+    ((1, 64, 56, 56), (7, 7)),
+    # Non-square output
+    ((2, 8, 16, 16), (4, 8)),
+    ((1, 3, 28, 28), (7, 14)),
+    # Single output element per channel
+    ((2, 4, 8, 8), (1, 1)),
+    # Output same as input (identity-like)
+    ((2, 3, 4, 4), (4, 4)),
+    # Large reduction
+    ((1, 8, 64, 64), (4, 4)),
+]
+
+
+@pytest.mark.adaptive_max_pool2d_backward
+@pytest.mark.parametrize("shape, output_size", ADAPTIVE_MAXPOOL2D_BACKWARD_CONFIGS)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_adaptive_max_pool2d_backward(shape, output_size, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    ref_inp = to_reference(inp, upcast=True)
+
+    # Forward pass to get output and indices (use reference to get consistent indices)
+    ref_out, ref_indices = torch.nn.functional.adaptive_max_pool2d_with_indices(
+        ref_inp, output_size
+    )
+
+    # Create gradient for backward
+    out_grad = torch.randn_like(ref_out, dtype=dtype, device=flag_gems.device)
+    ref_grad = to_reference(out_grad, upcast=True)
+
+    # Reference backward
+    ref_in_grad = torch.ops.aten.adaptive_max_pool2d_backward(
+        ref_grad, ref_inp, ref_indices
+    )
+
+    # Use the same indices (from reference) for FlagGems backward
+    # This ensures we test the backward kernel independently of forward differences
+    indices_on_device = ref_indices.to(device=flag_gems.device)
+
+    # FlagGems backward using same indices
+    with flag_gems.use_gems():
+        res_in_grad = torch.ops.aten.adaptive_max_pool2d_backward(
+            out_grad, inp, indices_on_device
+        )
+
+    gems_assert_close(res_in_grad, ref_in_grad, dtype)
+
+
 INDEX_PUT_SHAPE_ACC_FALSE = (
     ((2**28,), ((2**16,),), (2**16,), False),
     ((32, 32), ((8,), (8,)), (8,), False),


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `adaptive_max_pool2d_backward` operator implementation with Triton kernel.

- Implementation mode: `manual_kernel`
- Accuracy test: 24/24 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [64, 64, 2, 4] | 0.0159 | 0.0148 | 1.071 |
| [64, 64, 1, 1] | 0.0152 | 0.0143 | 1.063 |
| [256, 256, 2, 4] | 0.0770 | 0.0336 | 2.288 |
| [256, 256, 1, 1] | 0.0654 | 0.0252 | 2.596 |
| [1024, 1024, 2, 4] | 1.1263 | 0.5107 | 2.206 |
| [1024, 1024, 1, 1] | 0.8685 | 0.3289 | 2.640 |
| [4096, 4096, 2, 4] | 17.8347 | 7.9094 | 2.255 |
| [4096, 4096, 1, 1] | 13.6591 | 4.9896 | 2.738 |
| [1024, 65536, 2, 4] | 70.8219 | 31.5905 | 2.242 |
| [1024, 65536, 1, 1] | 54.5931 | 19.9182 | 2.741 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [64, 64, 2, 4] | 0.0189 | 0.0159 | 1.192 |
| [64, 64, 1, 1] | 0.0150 | 0.0143 | 1.054 |
| [256, 256, 2, 4] | 0.0743 | 0.0323 | 2.299 |
| [256, 256, 1, 1] | 0.0644 | 0.0265 | 2.428 |
| [1024, 1024, 2, 4] | 1.0602 | 0.5119 | 2.071 |
| [1024, 1024, 1, 1] | 0.8527 | 0.3288 | 2.593 |
| [4096, 4096, 2, 4] | 16.5988 | 7.9048 | 2.100 |
| [4096, 4096, 1, 1] | 13.4169 | 4.9908 | 2.688 |
| [1024, 65536, 2, 4] | 66.8392 | 31.5925 | 2.116 |
| [1024, 65536, 1, 1] | 53.6229 | 19.9217 | 2.692 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [64, 64, 2, 4] | 0.0135 | 0.0117 | 1.156 |
| [64, 64, 1, 1] | 0.0132 | 0.0112 | 1.186 |
| [256, 256, 2, 4] | 0.0642 | 0.0268 | 2.398 |
| [256, 256, 1, 1] | 0.0639 | 0.0185 | 3.461 |
| [1024, 1024, 2, 4] | 0.8749 | 0.3675 | 2.381 |
| [1024, 1024, 1, 1] | 0.8744 | 0.1844 | 4.741 |
| [4096, 4096, 2, 4] | 13.8325 | 5.6911 | 2.431 |
| [4096, 4096, 1, 1] | 13.8339 | 2.6347 | 5.251 |
| [1024, 65536, 2, 4] | 55.3045 | 22.7376 | 2.432 |
| [1024, 65536, 1, 1] | 55.3052 | 10.4835 | 5.275 |

**Overall: median speedup = 2.389x, mean speedup = 2.459x** (30 data points)

---
_Generated by auto_gen tool with Claude Code_
