### PR TITLE
【KernelGen】Add bernoulli_ operator

### DIFF
--- a/benchmark/test_distribution_perf.py
+++ b/benchmark/test_distribution_perf.py
@@ -18,6 +18,12 @@ def normal_inplace_input_fn(shape, cur_dtype, device):
     yield self, loc, scale
 
 
+def bernoulli__input_fn(shape, cur_dtype, device):
+    self = torch.randn(shape, dtype=cur_dtype, device=device)
+    p = 0.5
+    yield self, p
+
+
 @pytest.mark.parametrize(
     "op_name, torch_op, input_fn",
     [
@@ -44,6 +50,12 @@ def normal_inplace_input_fn(shape, cur_dtype, device):
             torch.Tensor.exponential_,
             unary_input_fn,
             marks=pytest.mark.exponential_,
+        ),
+        pytest.param(
+            "bernoulli_",
+            torch.Tensor.bernoulli_,
+            bernoulli__input_fn,
+            marks=pytest.mark.bernoulli_,
         ),
     ],
 )

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -92,6 +92,7 @@ _FULL_CONFIG = (
     ("avg_pool2d", avg_pool2d),
     ("avg_pool2d_backward", avg_pool2d_backward),
     ("baddbmm", baddbmm),
+    ("bernoulli_.float", bernoulli_),
     ("bincount", bincount),
     ("bitwise_and.Scalar", bitwise_and_scalar),
     ("bitwise_and.Scalar_Tensor", bitwise_and_scalar_tensor),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -40,6 +40,7 @@ from flag_gems.ops.attention import (
 from flag_gems.ops.avg_pool2d import avg_pool2d, avg_pool2d_backward
 from flag_gems.ops.baddbmm import baddbmm
 from flag_gems.ops.batch_norm import batch_norm, batch_norm_backward
+from flag_gems.ops.bernoulli_ import bernoulli_
 from flag_gems.ops.bitwise_and import (
     bitwise_and_scalar,
     bitwise_and_scalar_,
@@ -372,6 +373,7 @@ __all__ = [
     "baddbmm",
     "batch_norm",
     "batch_norm_backward",
+    "bernoulli_",
     "bitwise_and_scalar",
     "bitwise_and_scalar_",
     "bitwise_and_scalar_tensor",

--- a/src/flag_gems/ops/bernoulli_.py
+++ b/src/flag_gems/ops/bernoulli_.py
@@ -1,0 +1,73 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils.random_utils import (
+    philox_backend_seed_offset,
+    uint_to_uniform_float,
+)
+from flag_gems.utils.shape_utils import volume
+
+logger = logging.getLogger(__name__)
+
+
+@triton.heuristics(runtime.get_heuristic_config("uniform"))
+@triton.jit(do_not_specialize=["philox_seed", "philox_offset", "p"])
+def bernoulli_kernel(
+    out_ptr,
+    N,
+    p,
+    philox_seed,
+    philox_offset,
+    BLOCK: tl.constexpr,
+):
+    philox_seed = philox_seed.to(tl.int64)
+    philox_offset = philox_offset.to(tl.int64)
+    c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
+    c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
+    i4 = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    c0 += i4
+    _O = c0 * 0
+    r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, _O, _O)
+
+    # Convert random uint32 to uniform float in [0, 1)
+    u0 = uint_to_uniform_float(r0)
+    u1 = uint_to_uniform_float(r1)
+    u2 = uint_to_uniform_float(r2)
+    u3 = uint_to_uniform_float(r3)
+
+    # Bernoulli sampling: output 1.0 if random < p, else 0.0
+    y0 = tl.where(u0 < p, 1.0, 0.0)
+    y1 = tl.where(u1 < p, 1.0, 0.0)
+    y2 = tl.where(u2 < p, 1.0, 0.0)
+    y3 = tl.where(u3 < p, 1.0, 0.0)
+
+    off_0 = tl.program_id(0) * BLOCK * 4 + tl.arange(0, BLOCK)
+    off_1 = off_0 + BLOCK
+    off_2 = off_1 + BLOCK
+    off_3 = off_2 + BLOCK
+
+    tl.store(out_ptr + off_0, y0, mask=off_0 < N, eviction_policy="evict_first")
+    tl.store(out_ptr + off_1, y1, mask=off_1 < N, eviction_policy="evict_first")
+    tl.store(out_ptr + off_2, y2, mask=off_2 < N, eviction_policy="evict_first")
+    tl.store(out_ptr + off_3, y3, mask=off_3 < N, eviction_policy="evict_first")
+
+
+UNROLL = 4
+
+
+def bernoulli_(self, p=0.5, *, generator=None):
+    logger.debug("GEMS BERNOULLI_")
+    N = volume(self.shape)
+    grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK"] * UNROLL),)
+
+    increment = triton.cdiv(N, UNROLL)
+    philox_seed, philox_offset = philox_backend_seed_offset(
+        increment, generator=generator
+    )
+    with torch_device_fn.device(self.device):
+        bernoulli_kernel[grid_fn](self, N, p, philox_seed, philox_offset)
+    return self

--- a/tests/test_distribution_ops.py
+++ b/tests/test_distribution_ops.py
@@ -107,6 +107,42 @@ def test_accuracy_fast_exponential_(shape, dtype):
     assert torch.abs(var_res - var_ref) < var_tol
 
 
+@pytest.mark.bernoulli_
+@pytest.mark.parametrize("shape", DISTRIBUTION_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_bernoulli_(shape, dtype):
+    x = torch.empty(size=shape, dtype=dtype, device=flag_gems.device)
+    p = 0.5
+    with flag_gems.use_gems():
+        x.bernoulli_(p)
+    # Check that all values are 0 or 1
+    assert ((x == 0) | (x == 1)).all()
+    # Check that the mean is approximately p (statistical test)
+    mean = x.float().mean().item()
+    assert abs(mean - p) < 0.1
+
+
+@pytest.mark.bernoulli_
+@pytest.mark.parametrize("shape", DISTRIBUTION_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("p", [0.0, 0.3, 0.7, 1.0])
+def test_accuracy_bernoulli_various_p(shape, dtype, p):
+    x = torch.empty(size=shape, dtype=dtype, device=flag_gems.device)
+    with flag_gems.use_gems():
+        x.bernoulli_(p)
+    # Check that all values are 0 or 1
+    assert ((x == 0) | (x == 1)).all()
+    # Check boundary cases
+    if p == 0.0:
+        assert (x == 0).all()
+    elif p == 1.0:
+        assert (x == 1).all()
+    else:
+        # Check that the mean is approximately p
+        mean = x.float().mean().item()
+        assert abs(mean - p) < 0.15
+
+
 @pytest.mark.multinomial
 @pytest.mark.parametrize("shape", [(1024, 10)])
 @pytest.mark.parametrize("dtype", [torch.float16, torch.float32])


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `bernoulli_` operator implementation with Triton kernel.

- Implementation mode: `N/A`
- Accuracy test: 15/15 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1073741824]) | 2.6896 | 2.0329 | 1.323 |
| torch.Size([64, 64]) | 0.0072 | 0.0072 | 1.000 |
| torch.Size([4096, 4096]) | 0.0510 | 0.0395 | 1.291 |
| torch.Size([64, 512, 512]) | 0.0510 | 0.0385 | 1.323 |
| torch.Size([1024, 1024, 1024]) | 2.6893 | 2.0334 | 1.323 |
| torch.Size([268435456]) | 0.6802 | 0.5135 | 1.325 |
| torch.Size([10000, 1]) | 0.0077 | 0.0072 | 1.071 |
| torch.Size([10000, 256]) | 0.0155 | 0.0120 | 1.293 |
| torch.Size([10000, 65536]) | 1.6443 | 1.2443 | 1.322 |
| torch.Size([100, 1, 100]) | 0.0077 | 0.0072 | 1.071 |
| torch.Size([100, 256, 100]) | 0.0158 | 0.0123 | 1.281 |
| torch.Size([100, 65536, 100]) | 1.6442 | 1.2435 | 1.322 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1073741824]) | 2.6885 | 2.0165 | 1.333 |
| torch.Size([64, 64]) | 0.0072 | 0.0072 | 1.004 |
| torch.Size([4096, 4096]) | 0.0510 | 0.0384 | 1.329 |
| torch.Size([64, 512, 512]) | 0.0513 | 0.0394 | 1.304 |
| torch.Size([1024, 1024, 1024]) | 2.6885 | 2.0175 | 1.333 |
| torch.Size([268435456]) | 0.6800 | 0.5098 | 1.334 |
| torch.Size([10000, 1]) | 0.0084 | 0.0082 | 1.019 |
| torch.Size([10000, 256]) | 0.0155 | 0.0117 | 1.323 |
| torch.Size([10000, 65536]) | 1.6449 | 1.2340 | 1.333 |
| torch.Size([100, 1, 100]) | 0.0072 | 0.0075 | 0.957 |
| torch.Size([100, 256, 100]) | 0.0158 | 0.0120 | 1.316 |
| torch.Size([100, 65536, 100]) | 1.6443 | 1.2342 | 1.332 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1073741824]) | 3.0572 | 2.7725 | 1.103 |
| torch.Size([64, 64]) | 0.0069 | 0.0075 | 0.931 |
| torch.Size([4096, 4096]) | 0.0582 | 0.0503 | 1.156 |
| torch.Size([64, 512, 512]) | 0.0573 | 0.0504 | 1.137 |
| torch.Size([1024, 1024, 1024]) | 3.0604 | 2.7711 | 1.104 |
| torch.Size([268435456]) | 0.7695 | 0.6982 | 1.102 |
| torch.Size([10000, 1]) | 0.0075 | 0.0075 | 1.009 |
| torch.Size([10000, 256]) | 0.0156 | 0.0135 | 1.162 |
| torch.Size([10000, 65536]) | 1.8705 | 1.6951 | 1.103 |
| torch.Size([100, 1, 100]) | 0.0081 | 0.0075 | 1.090 |
| torch.Size([100, 256, 100]) | 0.0157 | 0.0142 | 1.108 |
| torch.Size([100, 65536, 100]) | 1.8733 | 1.6950 | 1.105 |

**Overall: median speedup = 1.221x, mean speedup = 1.194x** (36 data points)

---
_Generated by auto_gen tool with Claude Code_
