### PR TITLE
【KernelGen】Add clip operator

### DIFF
--- a/benchmark/test_clip_perf.py
+++ b/benchmark/test_clip_perf.py
@@ -1,0 +1,37 @@
+import pytest
+import torch
+
+from benchmark.attri_util import FLOAT_DTYPES
+from benchmark.conftest import BenchLevel, Config
+from benchmark.performance_utils import GenericBenchmark, generate_tensor_input
+
+
+def clip_input_fn(shape, cur_dtype, device):
+    inp = generate_tensor_input(shape, cur_dtype, device)
+    yield inp, -0.5, 0.5
+    if Config.bench_level == BenchLevel.COMPREHENSIVE:
+        yield inp, None, 0.5
+        yield inp, -0.5, None
+
+
+@pytest.mark.clip
+def test_clip():
+    bench = GenericBenchmark(
+        input_fn=clip_input_fn,
+        op_name="clip",
+        torch_op=torch.clip,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.clip_
+def test_clip_inplace():
+    bench = GenericBenchmark(
+        input_fn=clip_input_fn,
+        op_name="clip_",
+        torch_op=torch.clip_,
+        dtypes=FLOAT_DTYPES,
+        is_inplace=True,
+    )
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -129,6 +129,8 @@ _FULL_CONFIG = (
     ("clamp_", clamp_),
     ("clamp_.Tensor", clamp_tensor_),
     ("clamp_min_", clamp_min_),
+    ("clip", clip),
+    ("clip_", clip_),
     ("conj_physical", conj_physical),
     ("constant_pad_nd", constant_pad_nd),
     # ("contiguous", contiguous),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -71,6 +71,7 @@ from flag_gems.ops.clamp import (
     clamp_tensor,
     clamp_tensor_,
 )
+from flag_gems.ops.clip import clip, clip_
 from flag_gems.ops.conj_physical import conj_physical
 from flag_gems.ops.contiguous import contiguous
 from flag_gems.ops.conv1d import conv1d
@@ -410,6 +411,8 @@ __all__ = [
     "clamp_min_",
     "clamp_tensor",
     "clamp_tensor_",
+    "clip",
+    "clip_",
     "constant_pad_nd",
     "contiguous",
     "conv1d",

--- a/src/flag_gems/ops/clip.py
+++ b/src/flag_gems/ops/clip.py
@@ -1,0 +1,52 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(
+    is_tensor=[True, False, False], promotion_methods=[(0, 1, 2, "DEFAULT")]
+)
+@triton.jit
+def clip_func(x, mini, maxi):
+    return tl.minimum(maxi, tl.maximum(mini, x.to(tl.float32)))
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def clip_func_min(x, mini):
+    return tl.maximum(mini, x.to(tl.float32))
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def clip_func_max(x, maxi):
+    return tl.minimum(maxi, x.to(tl.float32))
+
+
+def clip(A, mini=None, maxi=None):
+    logger.debug("GEMS CLIP")
+    if mini is None and maxi is None:
+        raise ValueError("At least one of mini or maxi must not be None")
+    elif mini is None:
+        return clip_func_max(A, maxi)
+    elif maxi is None:
+        return clip_func_min(A, mini)
+    else:
+        return clip_func(A, mini, maxi)
+
+
+def clip_(A, mini=None, maxi=None):
+    logger.debug("GEMS CLIP_")
+    if mini is None and maxi is None:
+        raise ValueError("At least one of mini or maxi must not be None")
+    elif mini is None:
+        return clip_func_max(A, maxi, out0=A)
+    elif maxi is None:
+        return clip_func_min(A, mini, out0=A)
+    else:
+        return clip_func(A, mini, maxi, out0=A)

--- a/tests/test_clip.py
+++ b/tests/test_clip.py
@@ -1,0 +1,55 @@
+import pytest
+import torch
+
+import flag_gems
+
+from .accuracy_utils import (
+    FLOAT_DTYPES,
+    POINTWISE_SHAPES,
+    SCALARS,
+    gems_assert_equal,
+    to_reference,
+)
+
+
+@pytest.mark.clip
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("maxi", SCALARS)
+@pytest.mark.parametrize("mini", SCALARS)
+@pytest.mark.parametrize("isnone", [None, "max", "min"])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_clip(shape, maxi, mini, isnone, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    if isnone == "min":
+        mini = None
+    elif isnone == "max":
+        maxi = None
+    ref_inp = to_reference(inp)
+
+    ref_out = torch.clip(ref_inp, min=mini, max=maxi)
+    with flag_gems.use_gems():
+        res_out = torch.clip(inp, min=mini, max=maxi)
+
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.inplace
+@pytest.mark.clip_
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("maxi", SCALARS)
+@pytest.mark.parametrize("mini", SCALARS)
+@pytest.mark.parametrize("isnone", [None, "max", "min"])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_clip_(shape, maxi, mini, isnone, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    if isnone == "min":
+        mini = None
+    elif isnone == "max":
+        maxi = None
+    ref_inp = to_reference(inp.clone())
+
+    ref_out = torch.clip_(ref_inp, min=mini, max=maxi)
+    with flag_gems.use_gems():
+        res_out = torch.clip_(inp, min=mini, max=maxi)
+
+    gems_assert_equal(res_out, ref_out)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `clip` operator implementation with Triton kernel.

- Implementation mode: `pointwise_dynamic`
- Accuracy test: 864/864 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 3.1074 | 3.1816 | 0.977 |
| [64, 64] | 0.0071 | 0.0071 | 1.005 |
| [4096, 4096] | 0.0580 | 0.0577 | 1.006 |
| [64, 512, 512] | 0.0578 | 0.0569 | 1.016 |
| [1024, 1024, 1024] | 3.1074 | 3.1818 | 0.977 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 3.1019 | 3.1858 | 0.974 |
| [64, 64] | 0.0072 | 0.0071 | 1.013 |
| [4096, 4096] | 0.0578 | 0.0571 | 1.013 |
| [64, 512, 512] | 0.0578 | 0.0577 | 1.002 |
| [1024, 1024, 1024] | 3.1011 | 3.1844 | 0.974 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 6.1976 | 6.2743 | 0.988 |
| [64, 64] | 0.0079 | 0.0067 | 1.187 |
| [4096, 4096] | 0.1064 | 0.1055 | 1.008 |
| [64, 512, 512] | 0.1063 | 0.1064 | 0.999 |
| [1024, 1024, 1024] | 6.1956 | 6.2729 | 0.988 |

**Overall: median speedup = 1.002x, mean speedup = 1.008x** (15 data points)

---
_Generated by auto_gen tool with Claude Code_
