### PR TITLE
【KernelGen】Add convolution_backward operator

### DIFF
--- a/benchmark/core_shapes.yaml
+++ b/benchmark/core_shapes.yaml
@@ -207,6 +207,14 @@ Conv3DBenchmark:
     - [16, 32, 12, 12, 12, 24, 3, 3, 3, 1, 2, 1]  # smaller input, different padding
   shape_desc: "N, C_in, D, H, W, C_out, K_d, K_h, K_w, stride, padding, groups"
 
+ConvolutionBackwardBenchmark:
+  shapes:
+    - [2, 64, 56, 56, 64, 3, 3, 1, 1, 1]
+    - [4, 128, 28, 28, 128, 3, 3, 1, 1, 1]
+    - [8, 256, 14, 14, 256, 3, 3, 1, 1, 1]
+    - [16, 512, 7, 7, 512, 3, 3, 1, 1, 1]
+  shape_desc: "N, C_in, H, W, C_out, K_h, K_w, stride, padding, groups"
+
 AttentionBenchmark:
   shapes:
     - [4, 32, 1024, 64]

--- a/benchmark/test_convolution_perf.py
+++ b/benchmark/test_convolution_perf.py
@@ -168,3 +168,92 @@ def test_perf_conv3d():
     )
     bench.set_gems(flag_gems.conv3d)
     bench.run()
+
+
+class ConvolutionBackwardBenchmark(GenericBenchmark):
+    def set_more_shapes(self):
+        return [
+            # (batch, in_c, h, w, out_c, kh, kw, stride, padding, groups)
+            (2, 64, 56, 56, 64, 3, 3, 1, 1, 1),
+            (4, 128, 28, 28, 128, 3, 3, 1, 1, 1),
+            (8, 256, 14, 14, 256, 3, 3, 1, 1, 1),
+            (16, 512, 7, 7, 512, 3, 3, 1, 1, 1),
+        ]
+
+
+@pytest.mark.convolution_backward
+def test_perf_convolution_backward():
+    def convolution_backward_input_fn(shape, dtype, device):
+        (
+            batch,
+            input_c,
+            input_h,
+            input_w,
+            out_c,
+            kernel_h,
+            kernel_w,
+            stride,
+            padding,
+            groups,
+        ) = shape
+        input_shape = (batch, input_c, input_h, input_w)
+        weight_shape = (out_c, input_c // groups, kernel_h, kernel_w)
+        input = torch.randn(size=input_shape, device=device, dtype=dtype)
+        weight = torch.randn(size=weight_shape, device=device, dtype=dtype)
+
+        # Forward pass to get output shape
+        output = torch.nn.functional.conv2d(
+            input, weight, bias=None, stride=stride, padding=padding, groups=groups
+        )
+        grad_output = torch.randn_like(output)
+
+        yield {
+            "grad_output": grad_output,
+            "input": input,
+            "weight": weight,
+            "bias_sizes": None,
+            "stride": [stride, stride],
+            "padding": [padding, padding],
+            "dilation": [1, 1],
+            "transposed": False,
+            "output_padding": [0, 0],
+            "groups": groups,
+            "output_mask": [True, True, False],
+        },
+
+    def torch_convolution_backward(
+        grad_output,
+        input,
+        weight,
+        bias_sizes,
+        stride,
+        padding,
+        dilation,
+        transposed,
+        output_padding,
+        groups,
+        output_mask,
+    ):
+        return torch.ops.aten.convolution_backward.default(
+            grad_output,
+            input,
+            weight,
+            bias_sizes,
+            stride,
+            padding,
+            dilation,
+            transposed,
+            output_padding,
+            groups,
+            output_mask,
+        )
+
+    torch.backends.cudnn.allow_tf32 = False
+    bench = ConvolutionBackwardBenchmark(
+        input_fn=convolution_backward_input_fn,
+        op_name="convolution_backward",
+        torch_op=torch_convolution_backward,
+        dtypes=[torch.float16, torch.float32],
+    )
+    bench.set_gems(flag_gems.convolution_backward)
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -109,6 +109,7 @@ _FULL_CONFIG = (
     ("conv2d.padding", conv2d),
     ("conv3d", conv3d),
     ("conv3d.padding", conv3d),
+    ("convolution_backward", convolution_backward),
     (
         "copy_",
         copy_,

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -58,6 +58,7 @@ from flag_gems.ops.contiguous import contiguous
 from flag_gems.ops.conv1d import conv1d
 from flag_gems.ops.conv2d import conv2d
 from flag_gems.ops.conv3d import conv3d
+from flag_gems.ops.convolution_backward import convolution_backward
 from flag_gems.ops.conv_depthwise2d import _conv_depthwise2d
 from flag_gems.ops.copy import copy, copy_
 from flag_gems.ops.cos import cos, cos_
@@ -308,6 +309,7 @@ __all__ = [
     "conv1d",
     "conv2d",
     "conv3d",
+    "convolution_backward",
     "copy",
     "copy_",
     "cos",

--- a/src/flag_gems/ops/convolution_backward.py
+++ b/src/flag_gems/ops/convolution_backward.py
@@ -1,0 +1,272 @@
+import logging
+from typing import List, Optional, Tuple
+
+import torch
+import triton
+
+from flag_gems import runtime
+from flag_gems.ops.conv2d import (
+    conv2d_backward_kernel_weight,
+    conv2d_forward_kernel,
+    conv2d_output_size,
+)
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+def _conv2d_backward(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias_sizes: Optional[List[int]],
+    stride: List[int],
+    padding: List[int],
+    dilation: List[int],
+    groups: int,
+    output_mask: List[bool],
+) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
+    """
+    Compute the backward pass for 2D convolution using Triton kernels.
+    """
+    device = input.device
+    dtype = input.dtype
+
+    stride_height, stride_width = stride[0], stride[1]
+    padding_height, padding_width = padding[0], padding[1]
+    dilation_height, dilation_width = dilation[0], dilation[1]
+
+    in_n, in_c, input_height, input_width = input.shape
+    out_c, weight_c, weight_height, weight_width = weight.shape
+
+    out_height = grad_output.shape[2]
+    out_width = grad_output.shape[3]
+
+    grad_input = None
+    grad_weight = None
+    grad_bias = None
+
+    # Compute grad_input if requested
+    if output_mask[0]:
+        # Compute gradient w.r.t. input using transposed convolution
+        revert_padding_height = dilation_height * (weight_height - 1) - padding_height
+        revert_padding_width = dilation_width * (weight_width - 1) - padding_width
+
+        # Flip and transpose weight for backward pass
+        revert_weight = weight.clone()
+        revert_weight = torch.flip(revert_weight, dims=[2, 3]).contiguous()
+
+        out_c_per_group = out_c // groups
+        if groups != 1:
+            revert_weight = revert_weight.reshape(
+                groups, out_c_per_group, weight_c, weight_height, weight_width
+            )
+            revert_weight = revert_weight.transpose(1, 2)
+            revert_weight = revert_weight.reshape(
+                groups * weight_c, out_c_per_group, weight_height, weight_width
+            ).contiguous()
+        else:
+            revert_weight = revert_weight.transpose(0, 1).contiguous()
+
+        # Handle strided convolution by dilating grad_output
+        new_out_height = out_height + (stride_height - 1) * (out_height - 1)
+        new_out_width = out_width + (stride_width - 1) * (out_width - 1)
+
+        if stride_height > 1 or stride_width > 1:
+            new_out = torch.zeros(
+                in_n,
+                out_c,
+                new_out_height,
+                new_out_width,
+                device=device,
+                dtype=dtype,
+            )
+            # Copy grad_output to dilated positions
+            for i in range(out_height):
+                for j in range(out_width):
+                    new_out[:, :, i * stride_height, j * stride_width] = grad_output[
+                        :, :, i, j
+                    ]
+        else:
+            new_out = grad_output
+
+        # Allocate output for grad_input
+        grad_input = torch.zeros(
+            in_n,
+            in_c,
+            input_height,
+            input_width,
+            dtype=torch.float32,
+            device=device,
+        )
+
+        # Use forward kernel with transposed weights to compute grad_input
+        grid = lambda META: (
+            triton.cdiv(
+                in_n * input_height * input_width, META["BLOCK_NI_HO_WO"]
+            ),
+            triton.cdiv(weight_c, META["BLOCK_CO"]),
+            groups,
+        )
+
+        bias_zero = torch.zeros(in_c, device=device, dtype=dtype)
+
+        conv2d_forward_kernel[grid](
+            new_out,
+            revert_weight,
+            grad_input,
+            bias_zero,
+            in_n,
+            new_out_height,
+            new_out_width,
+            in_c,
+            input_height,
+            input_width,
+            *new_out.stride(),
+            *revert_weight.stride(),
+            *grad_input.stride(),
+            out_c_per_group,
+            weight_height,
+            weight_width,
+            1,
+            1,
+            revert_padding_height,
+            revert_padding_width,
+            dilation_height,
+            dilation_width,
+            groups=groups,
+        )
+
+        grad_input = grad_input.to(dtype)
+
+    # Compute grad_weight if requested
+    if output_mask[1]:
+        out_c_per_group = out_c // groups
+        grad_weight = torch.zeros(
+            out_c,
+            weight_c,
+            weight_height,
+            weight_width,
+            dtype=dtype,
+            device=device,
+        )
+
+        grid_weight = lambda meta: (
+            triton.cdiv(
+                weight_c * weight_height * weight_width, meta["BLOCK_CI_HK_WK"]
+            ),
+            groups,
+            triton.cdiv(out_c_per_group, meta["BLOCK_CO"]),
+        )
+
+        conv2d_backward_kernel_weight[grid_weight](
+            input,
+            grad_output,
+            grad_weight,
+            *input.stride(),
+            *weight.stride(),
+            *grad_output.stride(),
+            input_height,
+            input_width,
+            weight_height,
+            weight_width,
+            weight_c,
+            in_n,
+            stride_height,
+            stride_width,
+            out_height,
+            out_width,
+            out_c_per_group,
+            padding_height,
+            padding_width,
+            dilation_height,
+            dilation_width,
+        )
+
+    # Compute grad_bias if requested
+    if output_mask[2] and bias_sizes is not None:
+        grad_bias = grad_output.sum(dim=(0, 2, 3))
+
+    return grad_input, grad_weight, grad_bias
+
+
+def convolution_backward(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    weight: torch.Tensor,
+    bias_sizes: Optional[List[int]],
+    stride: List[int],
+    padding: List[int],
+    dilation: List[int],
+    transposed: bool,
+    output_padding: List[int],
+    groups: int,
+    output_mask: List[bool],
+) -> Tuple[Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
+    """
+    Compute the backward pass for convolution operations.
+
+    This function computes gradients with respect to input, weight, and bias
+    for convolution operations based on the output_mask.
+
+    Args:
+        grad_output: Gradient of the output tensor
+        input: Original input tensor
+        weight: Convolution weight tensor
+        bias_sizes: Size of bias (or None if no bias)
+        stride: Convolution stride
+        padding: Convolution padding
+        dilation: Convolution dilation
+        transposed: Whether this is a transposed convolution
+        output_padding: Output padding for transposed convolution
+        groups: Number of groups for grouped convolution
+        output_mask: Boolean list [compute_grad_input, compute_grad_weight, compute_grad_bias]
+
+    Returns:
+        Tuple of (grad_input, grad_weight, grad_bias)
+    """
+    logger.debug("GEMS CONVOLUTION_BACKWARD")
+
+    # Determine convolution dimension from input shape
+    # input shape: [N, C, ...spatial dims...]
+    spatial_dims = input.ndim - 2
+
+    # Currently only support 2D non-transposed convolution with Triton kernels
+    # For other cases, fall back to native PyTorch implementation
+    use_triton = (
+        spatial_dims == 2
+        and not transposed
+        and all(op == 0 for op in output_padding)
+        and input.is_cuda
+        and grad_output.is_cuda
+        and weight.is_cuda
+    )
+
+    if use_triton:
+        return _conv2d_backward(
+            grad_output,
+            input,
+            weight,
+            bias_sizes,
+            stride,
+            padding,
+            dilation,
+            groups,
+            output_mask,
+        )
+    else:
+        # Fall back to native PyTorch for unsupported cases
+        # (1D, 3D, transposed convolution, etc.)
+        return torch.ops.aten.convolution_backward.default(
+            grad_output,
+            input,
+            weight,
+            bias_sizes,
+            stride,
+            padding,
+            dilation,
+            transposed,
+            output_padding,
+            groups,
+            output_mask,
+        )

--- a/tests/test_convolution_ops.py
+++ b/tests/test_convolution_ops.py
@@ -434,3 +434,161 @@ def test_accuracy_depthwise2d(
         inp, weight, kernel, bias=None, stride=stride, padding=padding, dilation=1
     )
     gems_assert_close(res_out, ref_out, dtype)
+
+
+# Test shapes for convolution_backward
+SHAPE_CONV_BACKWARD = [
+    ((2, 3, 8, 8), (4, 3, 3, 3)),  # batch=2, in_ch=3, out_ch=4, 3x3 kernel
+    ((1, 2, 5, 5), (1, 2, 3, 3)),  # batch=1, in_ch=2, out_ch=1, 3x3 kernel
+    ((4, 8, 16, 16), (16, 8, 3, 3)),  # larger batch and channels
+]
+
+
+@pytest.mark.convolution_backward
+@pytest.mark.parametrize("input_shape, weight_shape", SHAPE_CONV_BACKWARD)
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("padding", [0, 1])
+@pytest.mark.parametrize("dilation", [1])
+@pytest.mark.parametrize("groups", [1])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+@pytest.mark.parametrize("bias", [True, False])
+def test_accuracy_convolution_backward(
+    input_shape, weight_shape, stride, padding, dilation, groups, dtype, bias
+):
+    """Test convolution_backward accuracy against PyTorch reference implementation."""
+    torch.backends.cudnn.allow_tf32 = False
+
+    # Create input and weight tensors
+    input = torch.randn(input_shape, dtype=dtype, device=flag_gems.device)
+    weight = torch.randn(weight_shape, dtype=dtype, device=flag_gems.device)
+
+    # Forward pass to determine output shape
+    output = torch.nn.functional.conv2d(
+        input, weight, bias=None, stride=stride, padding=padding, dilation=dilation
+    )
+
+    # Create grad_output
+    grad_output = torch.randn_like(output)
+
+    # Determine bias_sizes
+    bias_sizes = [weight_shape[0]] if bias else None
+
+    # Reference implementation
+    ref_input = to_reference(input)
+    ref_weight = to_reference(weight)
+    ref_grad_output = to_reference(grad_output)
+
+    ref_grad_input, ref_grad_weight, ref_grad_bias = (
+        torch.ops.aten.convolution_backward.default(
+            ref_grad_output,
+            ref_input,
+            ref_weight,
+            bias_sizes=bias_sizes,
+            stride=[stride, stride],
+            padding=[padding, padding],
+            dilation=[dilation, dilation],
+            transposed=False,
+            output_padding=[0, 0],
+            groups=groups,
+            output_mask=[True, True, bias],
+        )
+    )
+
+    # FlagGems implementation
+    with flag_gems.use_gems():
+        res_grad_input, res_grad_weight, res_grad_bias = (
+            torch.ops.aten.convolution_backward(
+                grad_output,
+                input,
+                weight,
+                bias_sizes=bias_sizes,
+                stride=[stride, stride],
+                padding=[padding, padding],
+                dilation=[dilation, dilation],
+                transposed=False,
+                output_padding=[0, 0],
+                groups=groups,
+                output_mask=[True, True, bias],
+            )
+        )
+
+    # Check grad_input
+    gems_assert_close(res_grad_input, ref_grad_input, dtype, reduce_dim=weight_shape[2])
+
+    # Check grad_weight
+    gems_assert_close(
+        res_grad_weight, ref_grad_weight, dtype, reduce_dim=weight_shape[0]
+    )
+
+    # Check grad_bias if applicable
+    if bias:
+        gems_assert_close(res_grad_bias, ref_grad_bias, dtype)
+
+
+@pytest.mark.convolution_backward
+@pytest.mark.parametrize(
+    "input_shape, weight_shape, groups",
+    [
+        ((4, 8, 8, 8), (8, 4, 3, 3), 2),  # groups=2
+    ],
+)
+@pytest.mark.parametrize("stride", [1])
+@pytest.mark.parametrize("padding", [1])
+@pytest.mark.parametrize("dtype", [torch.float32])
+def test_accuracy_convolution_backward_groups(
+    input_shape, weight_shape, groups, stride, padding, dtype
+):
+    """Test convolution_backward with group convolution."""
+    torch.backends.cudnn.allow_tf32 = False
+
+    input = torch.randn(input_shape, dtype=dtype, device=flag_gems.device)
+    weight = torch.randn(weight_shape, dtype=dtype, device=flag_gems.device)
+
+    # Forward pass to determine output shape
+    output = torch.nn.functional.conv2d(
+        input, weight, bias=None, stride=stride, padding=padding, groups=groups
+    )
+
+    grad_output = torch.randn_like(output)
+
+    ref_input = to_reference(input)
+    ref_weight = to_reference(weight)
+    ref_grad_output = to_reference(grad_output)
+
+    ref_grad_input, ref_grad_weight, ref_grad_bias = (
+        torch.ops.aten.convolution_backward.default(
+            ref_grad_output,
+            ref_input,
+            ref_weight,
+            bias_sizes=None,
+            stride=[stride, stride],
+            padding=[padding, padding],
+            dilation=[1, 1],
+            transposed=False,
+            output_padding=[0, 0],
+            groups=groups,
+            output_mask=[True, True, False],
+        )
+    )
+
+    with flag_gems.use_gems():
+        res_grad_input, res_grad_weight, res_grad_bias = (
+            torch.ops.aten.convolution_backward(
+                grad_output,
+                input,
+                weight,
+                bias_sizes=None,
+                stride=[stride, stride],
+                padding=[padding, padding],
+                dilation=[1, 1],
+                transposed=False,
+                output_padding=[0, 0],
+                groups=groups,
+                output_mask=[True, True, False],
+            )
+        )
+
+    gems_assert_close(res_grad_input, ref_grad_input, dtype, reduce_dim=weight_shape[2])
+    gems_assert_close(
+        res_grad_weight, ref_grad_weight, dtype, reduce_dim=weight_shape[0]
+    )


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `convolution_backward` operator implementation with Triton kernel.

- Implementation mode: `manual_kernel`
- Accuracy test: 49/49 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [2, 64, 56, 56] | 0.0770 | 1.4310 | 0.054 |
| [4, 128, 28, 28] | 0.0660 | 0.4910 | 0.133 |
| [8, 256, 14, 14] | 0.0780 | 0.3620 | 0.215 |
| [16, 512, 7, 7] | 0.1260 | 0.4690 | 0.269 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [2, 64, 56, 56] | 0.1120 | 9.2200 | 0.012 |
| [4, 128, 28, 28] | 0.1340 | 4.6610 | 0.029 |
| [8, 256, 14, 14] | 0.2060 | 2.5020 | 0.082 |
| [16, 512, 7, 7] | 0.4690 | 2.0990 | 0.223 |

**Overall: median speedup = 0.108x, mean speedup = 0.127x** (8 data points)

---
_Generated by auto_gen tool with Claude Code_
