### PR TITLE
【KernelGen】Add hardsigmoid_backward operator

### DIFF
--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -370,3 +370,21 @@ def test_perf_repetition_penalty():
     )
     bench.set_gems(flag_gems.apply_repetition_penalties)
     bench.run()
+
+
+class HardsigmoidBackwardBenchmark(UnaryPointwiseBenchmark):
+    def get_input_iter(self, cur_dtype: torch.dtype) -> Generator:
+        for shape in self.shapes:
+            inp = generate_tensor_input(shape, cur_dtype, self.device)
+            grad_out = torch.randn_like(inp)
+            yield grad_out, inp
+
+
+@pytest.mark.hardsigmoid_backward
+def test_hardsigmoid_backward_perf():
+    bench = HardsigmoidBackwardBenchmark(
+        op_name="hardsigmoid_backward",
+        torch_op=torch.ops.aten.hardsigmoid_backward,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -182,6 +182,7 @@ _FULL_CONFIG = (
     ("glu_backward", glu_backward),
     ("gt.Scalar", gt_scalar),
     ("gt.Tensor", gt),
+    ("hardsigmoid_backward", hardsigmoid_backward),
     ("hstack", hstack),
     ("index.Tensor", index),
     ("index_add", index_add),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -101,6 +101,7 @@ from flag_gems.ops.get_scheduler_metadata import get_scheduler_metadata
 from flag_gems.ops.glu import glu, glu_backward
 from flag_gems.ops.groupnorm import group_norm, group_norm_backward
 from flag_gems.ops.gt import gt, gt_scalar
+from flag_gems.ops.hardsigmoid_backward import hardsigmoid_backward
 from flag_gems.ops.hstack import hstack
 from flag_gems.ops.index import index
 from flag_gems.ops.index_add import index_add, index_add_
@@ -368,6 +369,7 @@ __all__ = [
     "group_norm_backward",
     "gt",
     "gt_scalar",
+    "hardsigmoid_backward",
     "hstack",
     "index",
     "index_add",

--- a/src/flag_gems/ops/hardsigmoid_backward.py
+++ b/src/flag_gems/ops/hardsigmoid_backward.py
@@ -1,0 +1,30 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def hardsigmoid_backward_kernel(grad_output, self):
+    # hardsigmoid(x) = clamp(x/6 + 0.5, 0, 1)
+    # derivative: 0 if self <= -3 or self >= 3, else 1/6
+    self_fp32 = self.to(tl.float32)
+    grad_output_fp32 = grad_output.to(tl.float32)
+
+    # Compute mask: True if -3 < self < 3
+    in_range = (self_fp32 > -3.0) & (self_fp32 < 3.0)
+
+    # Apply gradient: grad_output / 6 if in range, else 0
+    grad_input = tl.where(in_range, grad_output_fp32 / 6.0, 0.0)
+
+    return grad_input
+
+
+def hardsigmoid_backward(grad_output, self):
+    logger.debug("GEMS HARDSIGMOID_BACKWARD")
+    return hardsigmoid_backward_kernel(grad_output, self)

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -1769,3 +1769,20 @@ def test_accuracy_ceil_out(shape, dtype):
         torch.ceil(inp, out=out)
 
     gems_assert_equal(out, ref_out)
+
+
+@pytest.mark.hardsigmoid_backward
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_hardsigmoid_backward(shape, dtype):
+    res_inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    res_grad = torch.randn_like(res_inp)
+
+    ref_inp = to_reference(res_inp, True)
+    ref_grad = to_reference(res_grad, True)
+
+    ref_in_grad = torch.ops.aten.hardsigmoid_backward(ref_grad, ref_inp)
+    with flag_gems.use_gems():
+        res_in_grad = torch.ops.aten.hardsigmoid_backward(res_grad, res_inp)
+
+    gems_assert_close(res_in_grad, ref_in_grad, dtype)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `hardsigmoid_backward` operator implementation with Triton kernel.

- Implementation mode: `pointwise_dynamic`
- Accuracy test: 18/18 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 4.7422 | 4.6933 | 1.010 |
| [64, 64] | 0.0072 | 0.0069 | 1.032 |
| [4096, 4096] | 0.0868 | 0.0859 | 1.011 |
| [64, 512, 512] | 0.0869 | 0.0858 | 1.013 |
| [1024, 1024, 1024] | 4.7398 | 4.6985 | 1.009 |
| [1024, 1] | 0.0074 | 0.0075 | 0.996 |
| [1024, 16] | 0.0071 | 0.0072 | 0.996 |
| [1024, 256] | 0.0091 | 0.0088 | 1.029 |
| [1024, 4096] | 0.0291 | 0.0281 | 1.035 |
| [1024, 65536] | 0.3056 | 0.3033 | 1.008 |
| [64, 64, 1] | 0.0072 | 0.0074 | 0.966 |
| [64, 64, 16] | 0.0074 | 0.0085 | 0.872 |
| [64, 64, 256] | 0.0128 | 0.0134 | 0.955 |
| [64, 64, 4096] | 0.0867 | 0.0858 | 1.010 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 4.7469 | 4.6720 | 1.016 |
| [64, 64] | 0.0071 | 0.0081 | 0.878 |
| [4096, 4096] | 0.0868 | 0.0859 | 1.011 |
| [64, 512, 512] | 0.0859 | 0.0858 | 1.001 |
| [1024, 1024, 1024] | 4.7450 | 4.6558 | 1.019 |
| [1024, 1] | 0.0069 | 0.0069 | 1.005 |
| [1024, 16] | 0.0072 | 0.0072 | 1.000 |
| [1024, 256] | 0.0101 | 0.0091 | 1.113 |
| [1024, 4096] | 0.0282 | 0.0281 | 1.002 |
| [1024, 65536] | 0.3063 | 0.3041 | 1.007 |
| [64, 64, 1] | 0.0074 | 0.0069 | 1.069 |
| [64, 64, 16] | 0.0074 | 0.0074 | 1.004 |
| [64, 64, 256] | 0.0128 | 0.0135 | 0.948 |
| [64, 64, 4096] | 0.0859 | 0.0858 | 1.001 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 9.4811 | 9.3369 | 1.015 |
| [64, 64] | 0.0072 | 0.0077 | 0.933 |
| [4096, 4096] | 0.1589 | 0.1579 | 1.007 |
| [64, 512, 512] | 0.1587 | 0.1577 | 1.006 |
| [1024, 1024, 1024] | 9.4768 | 9.3268 | 1.016 |
| [1024, 1] | 0.0069 | 0.0069 | 1.000 |
| [1024, 16] | 0.0072 | 0.0076 | 0.945 |
| [1024, 256] | 0.0107 | 0.0106 | 1.015 |
| [1024, 4096] | 0.0476 | 0.0482 | 0.989 |
| [1024, 65536] | 0.6017 | 0.5974 | 1.007 |
| [64, 64, 1] | 0.0072 | 0.0082 | 0.872 |
| [64, 64, 16] | 0.0089 | 0.0077 | 1.158 |
| [64, 64, 256] | 0.0168 | 0.0176 | 0.956 |
| [64, 64, 4096] | 0.1580 | 0.1586 | 0.997 |

**Overall: median speedup = 1.006x, mean speedup = 0.998x** (42 data points)

---
_Generated by auto_gen tool with Claude Code_
