### PR TITLE
【KernelGen】Add hardswish_backward operator

### DIFF
--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -246,6 +246,24 @@ def test_elu_backward_perf():
     bench.run()
 
 
+class HardswishBackwardBenchmark(UnaryPointwiseBenchmark):
+    def get_input_iter(self, cur_dtype: torch.dtype) -> Generator:
+        for shape in self.shapes:
+            inp = generate_tensor_input(shape, cur_dtype, self.device)
+            grad_out = torch.randn_like(inp)
+            yield grad_out, inp
+
+
+@pytest.mark.hardswish_backward
+def test_hardswish_backward_perf():
+    bench = HardswishBackwardBenchmark(
+        op_name="hardswish_backward",
+        torch_op=torch.ops.aten.hardswish_backward,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.run()
+
+
 class GluBenchmark(UnaryPointwiseBenchmark):
     # Glu test requires even numbers
     def set_more_shapes(self):

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -182,6 +182,7 @@ _FULL_CONFIG = (
     ("glu_backward", glu_backward),
     ("gt.Scalar", gt_scalar),
     ("gt.Tensor", gt),
+    ("hardswish_backward", hardswish_backward),
     ("hstack", hstack),
     ("index.Tensor", index),
     ("index_add", index_add),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -101,6 +101,7 @@ from flag_gems.ops.get_scheduler_metadata import get_scheduler_metadata
 from flag_gems.ops.glu import glu, glu_backward
 from flag_gems.ops.groupnorm import group_norm, group_norm_backward
 from flag_gems.ops.gt import gt, gt_scalar
+from flag_gems.ops.hardswish_backward import hardswish_backward
 from flag_gems.ops.hstack import hstack
 from flag_gems.ops.index import index
 from flag_gems.ops.index_add import index_add, index_add_
@@ -368,6 +369,7 @@ __all__ = [
     "group_norm_backward",
     "gt",
     "gt_scalar",
+    "hardswish_backward",
     "hstack",
     "index",
     "index_add",

--- a/src/flag_gems/ops/hardswish_backward.py
+++ b/src/flag_gems/ops/hardswish_backward.py
@@ -1,0 +1,35 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def hardswish_backward_kernel(grad_output, self):
+    # hardswish(x) = x * clamp(x + 3, 0, 6) / 6
+    # gradient (using strict inequalities for boundary continuity):
+    #   if x < -3: 0
+    #   if x > 3:  grad_output
+    #   else:      grad_output * (2*x + 3) / 6
+    grad_fp32 = grad_output.to(tl.float32)
+    x_fp32 = self.to(tl.float32)
+
+    lower = x_fp32 < -3.0
+    upper = x_fp32 > 3.0
+
+    grad_input = tl.where(
+        lower,
+        0.0,
+        tl.where(upper, grad_fp32, grad_fp32 * (2.0 * x_fp32 + 3.0) / 6.0),
+    )
+    return grad_input
+
+
+def hardswish_backward(grad_output, self):
+    logger.debug("GEMS HARDSWISH_BACKWARD")
+    return hardswish_backward_kernel(grad_output, self)

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -1769,3 +1769,20 @@ def test_accuracy_ceil_out(shape, dtype):
         torch.ceil(inp, out=out)
 
     gems_assert_equal(out, ref_out)
+
+
+@pytest.mark.hardswish_backward
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_hardswish_backward(shape, dtype):
+    res_inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    res_grad = torch.randn_like(res_inp)
+
+    ref_inp = to_reference(res_inp, True)
+    ref_grad = to_reference(res_grad, True)
+
+    ref_in_grad = torch.ops.aten.hardswish_backward(ref_grad, ref_inp)
+    with flag_gems.use_gems():
+        res_in_grad = torch.ops.aten.hardswish_backward(res_grad, res_inp)
+
+    gems_assert_close(res_in_grad, ref_in_grad, dtype)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `hardswish_backward` operator implementation with Triton kernel.

- Implementation mode: `pointwise_dynamic`
- Accuracy test: 18/18 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 4.7174 | 4.6560 | 1.013 |
| [64, 64] | 0.0085 | 0.0074 | 1.147 |
| [4096, 4096] | 0.0869 | 0.0859 | 1.013 |
| [64, 512, 512] | 0.0878 | 0.0865 | 1.015 |
| [1024, 1024, 1024] | 4.7183 | 4.6550 | 1.014 |
| [1024, 1] | 0.0071 | 0.0068 | 1.038 |
| [1024, 16] | 0.0076 | 0.0082 | 0.922 |
| [1024, 256] | 0.0094 | 0.0087 | 1.081 |
| [1024, 4096] | 0.0295 | 0.0281 | 1.051 |
| [1024, 65536] | 0.3069 | 0.3033 | 1.012 |
| [64, 64, 1] | 0.0083 | 0.0071 | 1.176 |
| [64, 64, 16] | 0.0081 | 0.0073 | 1.114 |
| [64, 64, 256] | 0.0132 | 0.0127 | 1.040 |
| [64, 64, 4096] | 0.0876 | 0.0864 | 1.014 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 4.7182 | 4.6744 | 1.009 |
| [64, 64] | 0.0078 | 0.0071 | 1.100 |
| [4096, 4096] | 0.0870 | 0.0866 | 1.004 |
| [64, 512, 512] | 0.0879 | 0.0860 | 1.022 |
| [1024, 1024, 1024] | 4.7179 | 4.6589 | 1.013 |
| [1024, 1] | 0.0071 | 0.0068 | 1.033 |
| [1024, 16] | 0.0075 | 0.0071 | 1.059 |
| [1024, 256] | 0.0090 | 0.0096 | 0.930 |
| [1024, 4096] | 0.0289 | 0.0290 | 0.997 |
| [1024, 65536] | 0.3062 | 0.3042 | 1.007 |
| [64, 64, 1] | 0.0073 | 0.0078 | 0.935 |
| [64, 64, 16] | 0.0078 | 0.0078 | 0.996 |
| [64, 64, 256] | 0.0138 | 0.0134 | 1.031 |
| [64, 64, 4096] | 0.0876 | 0.0865 | 1.013 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 9.4598 | 9.3271 | 1.014 |
| [64, 64] | 0.0078 | 0.0075 | 1.052 |
| [4096, 4096] | 0.1592 | 0.1586 | 1.003 |
| [64, 512, 512] | 0.1590 | 0.1583 | 1.004 |
| [1024, 1024, 1024] | 9.4654 | 9.3261 | 1.015 |
| [1024, 1] | 0.0073 | 0.0074 | 0.987 |
| [1024, 16] | 0.0075 | 0.0071 | 1.059 |
| [1024, 256] | 0.0103 | 0.0105 | 0.976 |
| [1024, 4096] | 0.0485 | 0.0476 | 1.021 |
| [1024, 65536] | 0.6024 | 0.5980 | 1.007 |
| [64, 64, 1] | 0.0073 | 0.0071 | 1.032 |
| [64, 64, 16] | 0.0080 | 0.0087 | 0.923 |
| [64, 64, 256] | 0.0181 | 0.0167 | 1.080 |
| [64, 64, 4096] | 0.1585 | 0.1577 | 1.005 |

**Overall: median speedup = 1.014x, mean speedup = 1.023x** (42 data points)

---
_Generated by auto_gen tool with Claude Code_
