### PR TITLE
【KernelGen】Add hardtanh_backward operator

### DIFF
--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -246,6 +246,27 @@ def test_elu_backward_perf():
     bench.run()
 
 
+class HardtanhBackwardBenchmark(UnaryPointwiseBenchmark):
+    def get_input_iter(self, cur_dtype: torch.dtype) -> Generator:
+        for shape in self.shapes:
+            inp = generate_tensor_input(shape, cur_dtype, self.device)
+            grad_out = torch.randn_like(inp)
+            min_val = -1.0
+            max_val = 1.0
+
+            yield grad_out, inp, min_val, max_val
+
+
+@pytest.mark.hardtanh_backward
+def test_hardtanh_backward_perf():
+    bench = HardtanhBackwardBenchmark(
+        op_name="hardtanh_backward",
+        torch_op=torch.ops.aten.hardtanh_backward,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.run()
+
+
 class GluBenchmark(UnaryPointwiseBenchmark):
     # Glu test requires even numbers
     def set_more_shapes(self):

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -182,6 +182,7 @@ _FULL_CONFIG = (
     ("glu_backward", glu_backward),
     ("gt.Scalar", gt_scalar),
     ("gt.Tensor", gt),
+    ("hardtanh_backward", hardtanh_backward),
     ("hstack", hstack),
     ("index.Tensor", index),
     ("index_add", index_add),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -101,6 +101,7 @@ from flag_gems.ops.get_scheduler_metadata import get_scheduler_metadata
 from flag_gems.ops.glu import glu, glu_backward
 from flag_gems.ops.groupnorm import group_norm, group_norm_backward
 from flag_gems.ops.gt import gt, gt_scalar
+from flag_gems.ops.hardtanh_backward import hardtanh_backward
 from flag_gems.ops.hstack import hstack
 from flag_gems.ops.index import index
 from flag_gems.ops.index_add import index_add, index_add_
@@ -368,6 +369,7 @@ __all__ = [
     "group_norm_backward",
     "gt",
     "gt_scalar",
+    "hardtanh_backward",
     "hstack",
     "index",
     "index_add",

--- a/src/flag_gems/ops/hardtanh_backward.py
+++ b/src/flag_gems/ops/hardtanh_backward.py
@@ -1,0 +1,24 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(
+    is_tensor=[True, True, False, False], promotion_methods=[(0, 1, "DEFAULT")]
+)
+@triton.jit
+def hardtanh_backward_kernel(grad_output, self, min_val, max_val):
+    self_fp32 = self.to(tl.float32)
+    in_range = (self_fp32 > min_val) & (self_fp32 < max_val)
+    return tl.where(in_range, grad_output, 0)
+
+
+def hardtanh_backward(grad_output, self, min_val, max_val):
+    logger.debug("GEMS HARDTANH BACKWARD")
+    grad_input = hardtanh_backward_kernel(grad_output, self, min_val, max_val)
+    return grad_input

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -2166,3 +2166,22 @@ def test_accuracy_addcdiv(shape, dtype):
         res_out = torch.addcdiv(res_inp, t1, t2, value=v)
 
     gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.hardtanh_backward
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_hardtanh_backward(shape, dtype):
+    res_inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    res_grad = torch.randn_like(res_inp)
+    min_val = -1.0
+    max_val = 1.0
+
+    ref_inp = to_reference(res_inp, True)
+    ref_grad = to_reference(res_grad, True)
+
+    ref_in_grad = torch.ops.aten.hardtanh_backward(ref_grad, ref_inp, min_val, max_val)
+    with flag_gems.use_gems():
+        res_in_grad = torch.ops.aten.hardtanh_backward(res_grad, res_inp, min_val, max_val)
+
+    gems_assert_close(res_in_grad, ref_in_grad, dtype)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `hardtanh_backward` operator implementation with Triton kernel.

- Implementation mode: `pointwise_dynamic`
- Accuracy test: 18/18 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 4.7368 | 4.6906 | 1.010 |
| [64, 64] | 0.0074 | 0.0073 | 1.013 |
| [4096, 4096] | 0.0860 | 0.0865 | 0.994 |
| [64, 512, 512] | 0.0861 | 0.0860 | 1.002 |
| [1024, 1024, 1024] | 4.7398 | 4.6899 | 1.011 |
| [1024, 1] | 0.0068 | 0.0075 | 0.906 |
| [1024, 16] | 0.0076 | 0.0070 | 1.082 |
| [1024, 256] | 0.0088 | 0.0087 | 1.007 |
| [1024, 4096] | 0.0281 | 0.0280 | 1.002 |
| [1024, 65536] | 0.3061 | 0.3034 | 1.009 |
| [64, 64, 1] | 0.0079 | 0.0070 | 1.133 |
| [64, 64, 16] | 0.0073 | 0.0077 | 0.942 |
| [64, 64, 256] | 0.0126 | 0.0134 | 0.940 |
| [64, 64, 4096] | 0.0866 | 0.0862 | 1.004 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 4.7463 | 4.6758 | 1.015 |
| [64, 64] | 0.0070 | 0.0070 | 1.000 |
| [4096, 4096] | 0.0858 | 0.0865 | 0.993 |
| [64, 512, 512] | 0.0865 | 0.0865 | 1.000 |
| [1024, 1024, 1024] | 4.7477 | 4.6978 | 1.011 |
| [1024, 1] | 0.0067 | 0.0073 | 0.925 |
| [1024, 16] | 0.0081 | 0.0081 | 1.000 |
| [1024, 256] | 0.0091 | 0.0086 | 1.048 |
| [1024, 4096] | 0.0287 | 0.0280 | 1.026 |
| [1024, 65536] | 0.3052 | 0.3034 | 1.006 |
| [64, 64, 1] | 0.0079 | 0.0079 | 0.996 |
| [64, 64, 16] | 0.0073 | 0.0079 | 0.915 |
| [64, 64, 256] | 0.0133 | 0.0126 | 1.056 |
| [64, 64, 4096] | 0.0858 | 0.0864 | 0.992 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 9.4748 | 9.3407 | 1.014 |
| [64, 64] | 0.0070 | 0.0080 | 0.872 |
| [4096, 4096] | 0.1579 | 0.1577 | 1.001 |
| [64, 512, 512] | 0.1577 | 0.1582 | 0.996 |
| [1024, 1024, 1024] | 9.4724 | 9.3499 | 1.013 |
| [1024, 1] | 0.0070 | 0.0075 | 0.928 |
| [1024, 16] | 0.0075 | 0.0081 | 0.929 |
| [1024, 256] | 0.0099 | 0.0099 | 1.000 |
| [1024, 4096] | 0.0475 | 0.0475 | 1.001 |
| [1024, 65536] | 0.6017 | 0.5978 | 1.006 |
| [64, 64, 1] | 0.0075 | 0.0082 | 0.910 |
| [64, 64, 16] | 0.0081 | 0.0077 | 1.045 |
| [64, 64, 256] | 0.0174 | 0.0169 | 1.032 |
| [64, 64, 4096] | 0.1586 | 0.1584 | 1.001 |

**Overall: median speedup = 1.002x, mean speedup = 0.995x** (42 data points)

---
_Generated by auto_gen tool with Claude Code_
