### PR TITLE
【KernelGen】Add index_select_backward operator

### DIFF
--- a/benchmark/test_select_and_slice_perf.py
+++ b/benchmark/test_select_and_slice_perf.py
@@ -78,6 +78,62 @@ def index_select_gbps(bench_fn_args, latency):
     return io_amount * 1e-9 / (latency * 1e-3)
 
 
+def index_select_backward_input_fn(shape, cur_dtype, device):
+    # Create input tensor to determine shapes
+    inp = generate_tensor_input(shape, cur_dtype, device)
+    threshold = 0.1
+    dim = 0
+    index_size = inp.size(dim)
+    from math import floor
+
+    index_len = max(1, floor(index_size * threshold))
+    index = torch.randint(0, index_size, [index_len], device=device)
+
+    # Create gradient tensor with output shape of index_select
+    grad_shape = list(shape)
+    grad_shape[dim] = index_len
+    grad = torch.randn(grad_shape, dtype=cur_dtype, device=device)
+
+    yield grad, list(shape), dim, index
+
+
+def index_select_backward_gbps(bench_fn_args, latency):
+    grad = bench_fn_args[0]
+    self_sizes = bench_fn_args[1]
+    # IO: read grad + write output (of size self_sizes)
+    grad_bytes = shape_utils.size_in_bytes(grad)
+    output_bytes = grad.element_size()
+    for s in self_sizes:
+        output_bytes *= s
+    io_amount = grad_bytes + output_bytes
+    return io_amount * 1e-9 / (latency * 1e-3)
+
+
+@pytest.mark.index_select_backward
+@pytest.mark.parametrize(
+    "op_name, torch_op, input_fn, gbps_fn, dtypes",
+    [
+        pytest.param(
+            "index_select_backward",
+            torch.ops.aten.index_select_backward,
+            index_select_backward_input_fn,
+            index_select_backward_gbps,
+            FLOAT_DTYPES,
+            marks=pytest.mark.index_select_backward,
+        ),
+    ],
+)
+def test_perf_index_select_backward(op_name, torch_op, input_fn, gbps_fn, dtypes):
+    bench = TensorSelectBenchmark(
+        input_fn=input_fn,
+        op_name=op_name,
+        torch_op=torch_op,
+        dtypes=dtypes,
+        get_gbps=gbps_fn,
+    )
+    bench.run()
+
+
 @pytest.mark.index_select
 @pytest.mark.parametrize(
     "op_name, torch_op, input_fn, gbps_fn, dtypes",

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -189,6 +189,7 @@ _FULL_CONFIG = (
     ("index_put", index_put),
     ("index_put_", index_put_),
     ("index_select", index_select),
+    ("index_select_backward", index_select_backward),
     ("isclose", isclose),
     ("isfinite", isfinite),
     ("isin.Scalar_Tensor", isin),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -106,6 +106,7 @@ from flag_gems.ops.index import index
 from flag_gems.ops.index_add import index_add, index_add_
 from flag_gems.ops.index_put import index_put, index_put_
 from flag_gems.ops.index_select import index_select
+from flag_gems.ops.index_select_backward import index_select_backward
 from flag_gems.ops.isclose import allclose, isclose
 from flag_gems.ops.isfinite import isfinite
 from flag_gems.ops.isin import isin
@@ -375,6 +376,7 @@ __all__ = [
     "index_put",
     "index_put_",
     "index_select",
+    "index_select_backward",
     "isclose",
     "isfinite",
     "isin",

--- a/src/flag_gems/ops/index_select_backward.py
+++ b/src/flag_gems/ops/index_select_backward.py
@@ -1,0 +1,139 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.heuristics(runtime.get_heuristic_config("index_select"))
+@triton.jit
+def index_select_backward_kernel(
+    grad_inp,
+    grad_out,
+    index,
+    M,  # outer_size
+    N,  # src_dim_size (required by heuristics)
+    inner_size,
+    index_len,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """
+    Backward kernel for index_select.
+    Scatters gradients from grad_out back to grad_inp at positions specified by index.
+
+    Memory layout (for contiguous tensors):
+    - grad_out has shape [outer, index_len, inner] when viewed as 3D
+    - grad_inp has shape [outer, N, inner] when viewed as 3D
+
+    Args:
+        grad_inp: Output gradient tensor - target to scatter to
+        grad_out: Input gradient tensor - source of gradients
+        index: Indices tensor (1D)
+        M: Product of dimensions before dim (outer_size)
+        N: Original size at dim (src_dim_size)
+        inner_size: Product of dimensions after dim
+        index_len: Number of indices (size of grad_out at dim)
+    """
+    # Each program handles a block of (outer_idx, index_idx) pairs
+    pid_outer = tle.program_id(axis=0)
+    pid_idx = tle.program_id(axis=1)
+
+    outer_offsets = pid_outer * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+    idx_offsets = pid_idx * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    outer_mask = outer_offsets < M
+    idx_mask = idx_offsets < index_len
+    combined_mask = outer_mask and idx_mask
+
+    # Load indices
+    indices = tl.load(index + idx_offsets, mask=idx_mask, other=0)
+    valid_lower = indices >= 0
+    valid_upper = indices < N
+    index_valid_mask = valid_lower & valid_upper
+    final_mask = combined_mask & index_valid_mask
+
+    # For each inner position, scatter gradients
+    for inner_idx in range(inner_size):
+        # grad_out offset: outer * (index_len * inner_size) + idx * inner_size + inner
+        grad_out_base = outer_offsets * (index_len * inner_size) + idx_offsets[None, :] * inner_size + inner_idx
+
+        # grad_inp offset: outer * (N * inner_size) + indices * inner_size + inner
+        grad_inp_base = outer_offsets * (N * inner_size) + indices[None, :] * inner_size + inner_idx
+
+        grad_values = tl.load(grad_out + grad_out_base, mask=final_mask, other=0.0)
+        tl.atomic_add(grad_inp + grad_inp_base, grad_values, mask=final_mask, sem="relaxed")
+
+
+def index_select_backward(grad, self_sizes, dim, index):
+    """
+    Backward pass for index_select.
+
+    Args:
+        grad: Gradient tensor from the forward output
+        self_sizes: List of sizes of the original input tensor
+        dim: Dimension along which index_select was performed
+        index: Indices used in the forward pass
+
+    Returns:
+        Gradient tensor with shape self_sizes
+    """
+    logger.debug("GEMS INDEX SELECT BACKWARD")
+
+    ndim = len(self_sizes)
+    assert dim >= -ndim and dim < ndim, "Invalid dim"
+    assert index.ndim <= 1, "Index should have dimension 1 or 0"
+
+    if index.ndim == 0:
+        index = index.unsqueeze(0)
+    dim = dim % ndim
+    index_len = index.numel()
+
+    # Handle fp16/bf16 by computing in fp32
+    compute_dtype = grad.dtype
+    if grad.dtype in (torch.float16, torch.bfloat16):
+        compute_dtype = torch.float32
+
+    # Create output tensor initialized to zeros
+    grad_inp = torch.zeros(
+        self_sizes, dtype=compute_dtype, device=grad.device
+    )
+
+    # Make grad contiguous for the kernel
+    grad_contig = grad.contiguous()
+
+    # Compute M (outer_size) = product of dims before dim
+    M = 1
+    for i in range(dim):
+        M *= self_sizes[i]
+
+    # Compute inner_size = product of dims after dim
+    inner_size = 1
+    for i in range(dim + 1, ndim):
+        inner_size *= self_sizes[i]
+
+    # N = original size at dim
+    N = self_sizes[dim]
+
+    grid = lambda meta: (
+        triton.cdiv(M, meta["BLOCK_M"]),
+        triton.cdiv(index_len, meta["BLOCK_N"]),
+    )
+
+    index_select_backward_kernel[grid](
+        grad_inp, grad_contig, index,
+        M, N, inner_size, index_len
+    )
+
+    # Convert back to original dtype if needed
+    if grad.dtype in (torch.float16, torch.bfloat16):
+        grad_inp = grad_inp.to(grad.dtype)
+
+    return grad_inp

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -1250,6 +1250,72 @@ def test_accuracy_index_select(shape, dim, dtype):
     gems_assert_equal(res_out, ref_out)
 
 
+@pytest.mark.index_select_backward
+@pytest.mark.parametrize("shape", REDUCTION_SHAPES)
+@pytest.mark.parametrize("dim", DIM_LIST)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_index_select_backward(shape, dim, dtype):
+    from math import floor
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    dim = dim % len(shape)
+    index_size = inp.size(dim)
+
+    index = torch.randint(
+        0, index_size, [floor(index_size * 0.8)], device=flag_gems.device
+    )
+
+    # Perform forward pass to get the output shape
+    out = torch.index_select(inp, dim, index)
+    grad = torch.randn_like(out)
+
+    ref_grad = to_reference(grad, upcast=True)
+    ref_out = torch.ops.aten.index_select_backward(
+        ref_grad, list(inp.shape), dim, to_reference(index)
+    )
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.index_select_backward(
+            grad, list(inp.shape), dim, index
+        )
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.index_select_backward
+@pytest.mark.parametrize("shape", REDUCTION_SHAPES)
+@pytest.mark.parametrize("dim", DIM_LIST)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_index_select_backward_with_duplicates(shape, dim, dtype):
+    """Test index_select_backward with duplicate indices to verify gradient accumulation."""
+    from math import floor
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    dim = dim % len(shape)
+    index_size = inp.size(dim)
+
+    # Create index with intentional duplicates
+    num_indices = max(2, floor(index_size * 0.8))
+    index = torch.randint(
+        0, max(1, index_size // 2), [num_indices], device=flag_gems.device
+    )
+
+    # Create gradient tensor matching the output shape of index_select
+    out_shape = list(shape)
+    out_shape[dim] = num_indices
+    grad = torch.randn(out_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_grad = to_reference(grad, upcast=True)
+    ref_out = torch.ops.aten.index_select_backward(
+        ref_grad, list(inp.shape), dim, to_reference(index)
+    )
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.index_select_backward(
+            grad, list(inp.shape), dim, index
+        )
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
 @pytest.mark.masked_select
 @pytest.mark.parametrize("threshold, shape", THRESHOLD_SHAPE)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `index_select_backward` operator implementation with Triton kernel.

- Implementation mode: `manual_kernel`
- Accuracy test: 36/36 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [6, 64] | 0.0199 | 0.0939 | 0.212 |
| [25, 256] | 0.0124 | 0.0655 | 0.189 |
| [102, 1024] | 0.0161 | 0.1946 | 0.083 |
| [409, 4096] | 0.0774 | 2.3521 | 0.033 |
| [102, 65536] | 0.2875 | 11.4069 | 0.025 |
| [1000, 256] | 0.0227 | 0.3063 | 0.074 |
| [1000, 65536] | 2.6803 | 73.1104 | 0.037 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [6, 64] | 0.0213 | 0.0643 | 0.332 |
| [25, 256] | 0.0119 | 0.0697 | 0.171 |
| [102, 1024] | 0.0138 | 0.1836 | 0.075 |
| [409, 4096] | 0.0677 | 2.3519 | 0.029 |
| [102, 65536] | 0.2299 | 12.4672 | 0.018 |
| [1000, 256] | 0.0196 | 0.3106 | 0.063 |
| [1000, 65536] | 2.1627 | 72.5396 | 0.030 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [6, 64] | 0.0150 | 0.0159 | 0.940 |
| [25, 256] | 0.0110 | 0.0404 | 0.272 |
| [102, 1024] | 0.0143 | 0.1926 | 0.074 |
| [409, 4096] | 0.0775 | 2.2457 | 0.034 |
| [102, 65536] | 0.2641 | 11.8878 | 0.022 |
| [1000, 256] | 0.0209 | 0.3011 | 0.069 |
| [1000, 65536] | 2.4785 | 74.8329 | 0.033 |

**Overall: median speedup = 0.069x, mean speedup = 0.134x** (21 data points)

---
_Generated by auto_gen tool with Claude Code_
