### PR TITLE
【KernelGen】Add leaky_relu_backward operator

### DIFF
--- a/benchmark/test_generic_pointwise_perf.py
+++ b/benchmark/test_generic_pointwise_perf.py
@@ -63,6 +63,12 @@ def threshold_input_fn(shape, cur_dtype, device):
     yield inp1, 3.14, 2.71
 
 
+def leaky_relu_backward_input_fn(shape, cur_dtype, device):
+    grad_output = generate_tensor_input(shape, cur_dtype, device)
+    self = generate_tensor_input(shape, cur_dtype, device)
+    yield grad_output, self, 0.01, False
+
+
 def addcmul_input_fn(shape, cur_dtype, device):
     inp1 = generate_tensor_input(shape, cur_dtype, device)
     inp2 = generate_tensor_input(shape, cur_dtype, device)
@@ -117,6 +123,13 @@ def addcdiv_input_fn(shape, cur_dtype, device):
             threshold_input_fn,
             FLOAT_DTYPES,
             marks=pytest.mark.threshold,
+        ),
+        pytest.param(
+            "leaky_relu_backward",
+            torch.ops.aten.leaky_relu_backward,
+            leaky_relu_backward_input_fn,
+            FLOAT_DTYPES,
+            marks=pytest.mark.leaky_relu_backward,
         ),
         pytest.param(
             "addcmul",

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -197,6 +197,7 @@ _FULL_CONFIG = (
     ("isinf", isinf),
     ("isnan", isnan),
     ("kron", kron),
+    ("leaky_relu_backward", leaky_relu_backward),
     ("le.Scalar", le_scalar),
     ("le.Tensor", le),
     ("lerp.Scalar", lerp_scalar),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -113,6 +113,7 @@ from flag_gems.ops.isinf import isinf
 from flag_gems.ops.isnan import isnan
 from flag_gems.ops.kron import kron
 from flag_gems.ops.layernorm import layer_norm, layer_norm_backward
+from flag_gems.ops.leaky_relu_backward import leaky_relu_backward
 from flag_gems.ops.le import le, le_scalar
 from flag_gems.ops.lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tensor_
 from flag_gems.ops.linspace import linspace
@@ -383,6 +384,7 @@ __all__ = [
     "kron",
     "layer_norm",
     "layer_norm_backward",
+    "leaky_relu_backward",
     "le",
     "le_scalar",
     "lerp_scalar",

--- a/src/flag_gems/ops/leaky_relu_backward.py
+++ b/src/flag_gems/ops/leaky_relu_backward.py
@@ -1,0 +1,27 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(is_tensor=[True, True, False, False], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def leaky_relu_backward_kernel(grad_output, self, negative_slope, self_is_result):
+    grad_output_fp32 = grad_output.to(tl.float32)
+    self_fp32 = self.to(tl.float32)
+    # For leaky_relu_backward:
+    # - If self > 0: gradient = grad_output * 1.0
+    # - If self <= 0: gradient = grad_output * negative_slope
+    # The self_is_result flag indicates whether self is the output of forward pass.
+    # The logic is the same since we check > 0 in both cases.
+    return tl.where(self_fp32 > 0, grad_output_fp32, grad_output_fp32 * negative_slope)
+
+
+def leaky_relu_backward(grad_output, self, negative_slope, self_is_result):
+    logger.debug("GEMS LEAKY_RELU_BACKWARD")
+    grad_input = leaky_relu_backward_kernel(grad_output, self, negative_slope, self_is_result)
+    return grad_input

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -1953,6 +1953,24 @@ def test_accuracy_threshold_backward(shape, dtype):
     gems_assert_close(res_in_grad, ref_in_grad, dtype)
 
 
+@pytest.mark.leaky_relu_backward
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_leaky_relu_backward(shape, dtype):
+    res_inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    res_grad = torch.randn_like(res_inp)
+    negative_slope = 0.01
+
+    ref_inp = to_reference(res_inp, True)
+    ref_grad = to_reference(res_grad, True)
+
+    ref_in_grad = torch.ops.aten.leaky_relu_backward(ref_grad, ref_inp, negative_slope, False)
+    with flag_gems.use_gems():
+        res_in_grad = torch.ops.aten.leaky_relu_backward(res_grad, res_inp, negative_slope, False)
+
+    gems_assert_close(res_in_grad, ref_in_grad, dtype)
+
+
 @pytest.mark.polar
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", [torch.float32])


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `leaky_relu_backward` operator implementation with Triton kernel.

- Implementation mode: `N/A`
- Accuracy test: 18/18 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1073741824]) | 4.7461 | 4.6714 | 1.016 |
| torch.Size([64, 64]) | 0.0068 | 0.0068 | 1.000 |
| torch.Size([4096, 4096]) | 0.0857 | 0.0856 | 1.002 |
| torch.Size([64, 512, 512]) | 0.0857 | 0.0862 | 0.994 |
| torch.Size([1024, 1024, 1024]) | 4.7463 | 4.6791 | 1.014 |
| torch.Size([268435456]) | 1.1919 | 1.1847 | 1.006 |
| torch.Size([10000, 1]) | 0.0073 | 0.0069 | 1.051 |
| torch.Size([10000, 256]) | 0.0211 | 0.0202 | 1.043 |
| torch.Size([10000, 65536]) | 2.8992 | 2.8691 | 1.010 |
| torch.Size([100, 1, 100]) | 0.0069 | 0.0069 | 1.000 |
| torch.Size([100, 256, 100]) | 0.0209 | 0.0202 | 1.033 |
| torch.Size([100, 65536, 100]) | 2.9000 | 2.8713 | 1.010 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1073741824]) | 4.7464 | 4.6711 | 1.016 |
| torch.Size([64, 64]) | 0.0068 | 0.0079 | 0.854 |
| torch.Size([4096, 4096]) | 0.0865 | 0.0856 | 1.010 |
| torch.Size([64, 512, 512]) | 0.0863 | 0.0855 | 1.010 |
| torch.Size([1024, 1024, 1024]) | 4.7486 | 4.6676 | 1.017 |
| torch.Size([268435456]) | 1.1921 | 1.1844 | 1.006 |
| torch.Size([10000, 1]) | 0.0069 | 0.0069 | 1.000 |
| torch.Size([10000, 256]) | 0.0210 | 0.0210 | 1.002 |
| torch.Size([10000, 65536]) | 2.9003 | 2.8696 | 1.011 |
| torch.Size([100, 1, 100]) | 0.0074 | 0.0069 | 1.060 |
| torch.Size([100, 256, 100]) | 0.0203 | 0.0211 | 0.964 |
| torch.Size([100, 65536, 100]) | 2.9010 | 2.8690 | 1.011 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1073741824]) | 9.4789 | 9.3362 | 1.015 |
| torch.Size([64, 64]) | 0.0073 | 0.0074 | 0.991 |
| torch.Size([4096, 4096]) | 0.1579 | 0.1584 | 0.997 |
| torch.Size([64, 512, 512]) | 0.1583 | 0.1581 | 1.001 |
| torch.Size([1024, 1024, 1024]) | 9.4776 | 9.3302 | 1.016 |
| torch.Size([268435456]) | 2.3783 | 2.3510 | 1.012 |
| torch.Size([10000, 1]) | 0.0078 | 0.0069 | 1.129 |
| torch.Size([10000, 256]) | 0.0313 | 0.0314 | 0.996 |
| torch.Size([10000, 65536]) | 5.7924 | 5.7167 | 1.013 |
| torch.Size([100, 1, 100]) | 0.0083 | 0.0069 | 1.189 |
| torch.Size([100, 256, 100]) | 0.0312 | 0.0323 | 0.967 |
| torch.Size([100, 65536, 100]) | 5.7936 | 5.7159 | 1.014 |

**Overall: median speedup = 1.010x, mean speedup = 1.013x** (36 data points)

---
_Generated by auto_gen tool with Claude Code_
