### PR TITLE
【KernelGen】Add log1p operator

### DIFF
--- a/benchmark/test_log1p.py
+++ b/benchmark/test_log1p.py
@@ -1,6 +1,15 @@
 import pytest
+import torch
 
 from . import base, consts
+
+
+@pytest.mark.log1p
+def test_log1p():
+    bench = base.UnaryPointwiseBenchmark(
+        op_name="log1p", torch_op=torch.log1p, dtypes=consts.FLOAT_DTYPES
+    )
+    bench.run()
 
 
 @pytest.mark.log1p_

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -3448,6 +3448,18 @@ ops:
       - Math
     stages:
       - beta: '5.1'
+  - id: log1p
+    description: |
+      Computes the natural logarithm of `1+x(y_i=log_e(x_i+1))` for each element in the input tensor.
+    for:
+      - log1p
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - Math
+    stages:
+      - beta: '5.0'
   - id: log1p_
     description: |
       Computes the natural logarithm of `1+x(y_i=log_e(x_i+1))` for each element in the input tensor in-place.

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -313,6 +313,7 @@ _FULL_CONFIG = (
     ("log10", log10),
     ("log10_", log10_),
     ("log10.out", log10_out),
+    ("log1p", log1p),
     ("log1p_", log1p_),
     ("log_sigmoid", log_sigmoid),
     ("logaddexp", logaddexp),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -197,6 +197,7 @@ from flag_gems.ops.lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tens
 from flag_gems.ops.lift_fresh_copy import lift_fresh_copy, lift_fresh_copy_out
 from flag_gems.ops.linspace import linspace
 from flag_gems.ops.log import log
+from flag_gems.ops.log1p import log1p
 from flag_gems.ops.log1p_ import log1p_
 from flag_gems.ops.log10 import log10, log10_, log10_out
 from flag_gems.ops.log_sigmoid import log_sigmoid
@@ -659,6 +660,8 @@ __all__ = [
     "log_softmax_backward",
     "log_softmax_backward_out",
     "log_softmax_out",
+    "log1p",
+    "log1p_",
     "logaddexp",
     "logaddexp_out",
     "logical_and",

--- a/src/flag_gems/ops/log1p.py
+++ b/src/flag_gems/ops/log1p.py
@@ -1,0 +1,19 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
+@triton.jit
+def log1p_func(x):
+    return tl.log(1.0 + x.to(tl.float32)).to(x.dtype)
+
+
+def log1p(A):
+    logger.debug("GEMS LOG1P")
+    return log1p_func(A)

--- a/tests/test_log1p.py
+++ b/tests/test_log1p.py
@@ -6,6 +6,19 @@ import flag_gems
 from . import accuracy_utils as utils
 
 
+@pytest.mark.log1p
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_log1p(shape, dtype):
+    torch.manual_seed(0)
+    inp = torch.rand(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp)
+    ref_out = torch.log1p(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.log1p(inp)
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
 @pytest.mark.log1p_
 @pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `log1p` operator implementation with Triton kernel.

- Implementation mode: `N/A`
- Accuracy test: 18/18 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1073741824]) | 3.3379 | 3.2321 | 1.033 |
| torch.Size([64, 64]) | 0.0076 | 0.0068 | 1.122 |
| torch.Size([4096, 4096]) | 0.0628 | 0.0583 | 1.078 |
| torch.Size([64, 512, 512]) | 0.0619 | 0.0587 | 1.055 |
| torch.Size([1024, 1024, 1024]) | 3.3389 | 3.2316 | 1.033 |
| torch.Size([1024, 1]) | 0.0073 | 0.0079 | 0.919 |
| torch.Size([1024, 16]) | 0.0083 | 0.0082 | 1.012 |
| torch.Size([1024, 256]) | 0.0086 | 0.0081 | 1.071 |
| torch.Size([1024, 4096]) | 0.0221 | 0.0201 | 1.097 |
| torch.Size([1024, 65536]) | 0.2172 | 0.2088 | 1.040 |
| torch.Size([64, 64, 1]) | 0.0074 | 0.0068 | 1.085 |
| torch.Size([64, 64, 16]) | 0.0076 | 0.0073 | 1.035 |
| torch.Size([64, 64, 256]) | 0.0112 | 0.0109 | 1.023 |
| torch.Size([64, 64, 4096]) | 0.0629 | 0.0588 | 1.069 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1073741824]) | 3.3409 | 3.2281 | 1.035 |
| torch.Size([64, 64]) | 0.0070 | 0.0074 | 0.957 |
| torch.Size([4096, 4096]) | 0.0623 | 0.0588 | 1.061 |
| torch.Size([64, 512, 512]) | 0.0620 | 0.0586 | 1.057 |
| torch.Size([1024, 1024, 1024]) | 3.3427 | 3.2263 | 1.036 |
| torch.Size([1024, 1]) | 0.0074 | 0.0080 | 0.920 |
| torch.Size([1024, 16]) | 0.0073 | 0.0070 | 1.036 |
| torch.Size([1024, 256]) | 0.0083 | 0.0081 | 1.028 |
| torch.Size([1024, 4096]) | 0.0216 | 0.0201 | 1.075 |
| torch.Size([1024, 65536]) | 0.2183 | 0.2088 | 1.045 |
| torch.Size([64, 64, 1]) | 0.0070 | 0.0068 | 1.033 |
| torch.Size([64, 64, 16]) | 0.0076 | 0.0073 | 1.035 |
| torch.Size([64, 64, 256]) | 0.0112 | 0.0115 | 0.972 |
| torch.Size([64, 64, 4096]) | 0.0620 | 0.0587 | 1.058 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1073741824]) | 6.1727 | 6.2751 | 0.984 |
| torch.Size([64, 64]) | 0.0070 | 0.0079 | 0.891 |
| torch.Size([4096, 4096]) | 0.1060 | 0.1065 | 0.995 |
| torch.Size([64, 512, 512]) | 0.1060 | 0.1066 | 0.995 |
| torch.Size([1024, 1024, 1024]) | 6.1743 | 6.2762 | 0.984 |
| torch.Size([1024, 1]) | 0.0074 | 0.0080 | 0.928 |
| torch.Size([1024, 16]) | 0.0082 | 0.0071 | 1.163 |
| torch.Size([1024, 256]) | 0.0100 | 0.0094 | 1.068 |
| torch.Size([1024, 4096]) | 0.0316 | 0.0321 | 0.985 |
| torch.Size([1024, 65536]) | 0.3945 | 0.3956 | 0.997 |
| torch.Size([64, 64, 1]) | 0.0074 | 0.0070 | 1.055 |
| torch.Size([64, 64, 16]) | 0.0076 | 0.0078 | 0.963 |
| torch.Size([64, 64, 256]) | 0.0140 | 0.0138 | 1.016 |
| torch.Size([64, 64, 4096]) | 0.1059 | 0.1059 | 1.000 |

**Overall: median speedup = 1.034x, mean speedup = 1.025x** (42 data points)

---
_Generated by auto_gen tool with Claude Code_
