### PR TITLE
【KernelGen】Add logsumexp operator

### DIFF
--- a/benchmark/test_logsumexp.py
+++ b/benchmark/test_logsumexp.py
@@ -1,0 +1,20 @@
+import pytest
+import torch
+
+from . import base, consts, utils
+
+
+def _input_fn(shape, dtype, device):
+    inp = utils.generate_tensor_input(shape, dtype, device)
+    yield inp, 1
+
+
+@pytest.mark.logsumexp
+def test_logsumexp():
+    bench = base.GenericBenchmark(
+        input_fn=_input_fn,
+        op_name="logsumexp",
+        torch_op=torch.logsumexp,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/benchmark/test_logsumexp.py
+++ b/benchmark/test_logsumexp.py
@@ -11,7 +11,7 @@ def _input_fn(shape, dtype, device):
 
 @pytest.mark.logsumexp
 def test_logsumexp():
-    bench = base.GenericBenchmark(
+    bench = base.GenericBenchmarkExcluse1D(
         input_fn=_input_fn,
         op_name="logsumexp",
         torch_op=torch.logsumexp,

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -302,6 +302,7 @@ _FULL_CONFIG = (
     ("logit.out", logit_out),
     ("logit_", logit_),
     ("logspace", logspace),
+    ("logsumexp", logsumexp),
     ("lt.Scalar", lt_scalar),
     ("lt.Tensor", lt),
     ("margin_ranking_loss", margin_ranking_loss),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -190,6 +190,7 @@ from flag_gems.ops.logical_xor import logical_xor
 from flag_gems.ops.logit import logit, logit_out
 from flag_gems.ops.logit_ import logit_
 from flag_gems.ops.logspace import logspace
+from flag_gems.ops.logsumexp import logsumexp
 from flag_gems.ops.lt import lt, lt_scalar
 from flag_gems.ops.margin_ranking_loss import margin_ranking_loss
 from flag_gems.ops.masked_fill import masked_fill, masked_fill_
@@ -599,6 +600,7 @@ __all__ = [
     "logit_out",
     "logit_",
     "logspace",
+    "logsumexp",
     "lt",
     "lt_scalar",
     "margin_ranking_loss",

--- a/src/flag_gems/ops/logsumexp.py
+++ b/src/flag_gems/ops/logsumexp.py
@@ -1,0 +1,189 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.heuristics(runtime.get_heuristic_config("softmax_non_inner"))
+@triton.jit
+def logsumexp_kernel_non_inner(
+    output_ptr,
+    input_ptr,
+    M,
+    N,
+    K,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    """Kernel for logsumexp when reduction dimension is not the innermost."""
+    pid_m = tle.program_id(0)
+    pid_k = tle.program_id(1)
+
+    k_offsets = pid_k * TILE_K + tl.arange(0, TILE_K)[None, :]
+
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)[:, None]
+        inp_offset = pid_m * N * K + n_offsets * K + k_offsets
+        mask = (n_offsets < N) & (k_offsets < K)
+        input_ptrs = input_ptr + inp_offset
+        inp = tl.load(input_ptrs, mask=mask, other=-float("inf")).to(tl.float32)
+        m = tl.max(inp, axis=0, keep_dims=True)
+        # Handle case where entire column is -inf
+        safe_m = tl.where(m == float("-inf"), tl.zeros_like(m), m)
+        e = tl.exp(inp - safe_m)
+        z = tl.sum(e, axis=0, keep_dims=True)
+        out = safe_m + tl.log(z)
+        # If all inputs were -inf, result should be -inf
+        out = tl.where(m == float("-inf"), m, out)
+        out_offset = pid_m * K + k_offsets
+        output_ptrs = output_ptr + out_offset
+        tl.store(output_ptrs, out, mask=k_offsets < K)
+    else:
+        m = tl.full([TILE_N, TILE_K], value=float("-inf"), dtype=tl.float32)
+        z = tl.full([TILE_N, TILE_K], value=0.0, dtype=tl.float32)
+
+        for start_n in range(0, N, TILE_N):
+            n_offsets = start_n + tl.arange(0, TILE_N)[:, None]
+            inp_offsets = pid_m * N * K + n_offsets * K + k_offsets
+            mask = (n_offsets < N) & (k_offsets < K)
+            inp = tl.load(input_ptr + inp_offsets, mask=mask, other=-float("inf")).to(
+                tl.float32
+            )
+            m_new = tl.maximum(m, inp)
+            all_neg_inf = m_new == float("-inf")
+            z = tl.where(all_neg_inf, z, z * tl.exp(m - m_new) + tl.exp(inp - m_new))
+            m = m_new
+
+        m_reduced = tl.max(m, axis=0, keep_dims=True)
+        z = tl.sum(z * tl.exp(m - m_reduced), axis=0, keep_dims=True)
+        m = m_reduced
+        # Handle case where all inputs were -inf
+        out = tl.where(m == float("-inf"), m, m + tl.log(z))
+        out_offset = pid_m * K + k_offsets
+        output_ptrs = output_ptr + out_offset
+        tl.store(output_ptrs, out, mask=k_offsets < K)
+
+
+@libentry()
+@triton.heuristics(runtime.get_heuristic_config("softmax_inner"))
+@triton.jit
+def logsumexp_kernel_inner(
+    output_ptr,
+    input_ptr,
+    M,
+    N,
+    TILE_N: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    """Kernel for logsumexp when reduction dimension is the innermost."""
+    pid_m = tle.program_id(0)
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)
+        offset = pid_m * N + n_offsets
+        input_ptrs = input_ptr + offset
+        mask = n_offsets < N
+        inp = tl.load(input_ptrs, mask=mask, other=-float("inf")).to(tl.float32)
+        m = tl.max(inp, axis=0)
+        # Handle case where all inputs are -inf
+        safe_m = tl.where(m == float("-inf"), 0.0, m)
+        e = tl.exp(inp - safe_m)
+        z = tl.sum(e, axis=0)
+        out = safe_m + tl.log(z)
+        # If all inputs were -inf, result should be -inf
+        out = tl.where(m == float("-inf"), m, out)
+        output_ptrs = output_ptr + pid_m
+        tl.store(output_ptrs, out)
+    else:
+        m = tl.full([TILE_N], value=float("-inf"), dtype=tl.float32)
+        z = tl.full([TILE_N], value=0.0, dtype=tl.float32)
+        input_ptr += pid_m * N
+
+        for start_n in range(0, N, TILE_N):
+            n_offsets = start_n + tl.arange(0, TILE_N)
+            mask = n_offsets < N
+            inp = tl.load(input_ptr + n_offsets, mask=mask, other=-float("inf")).to(
+                tl.float32
+            )
+            m_new = tl.maximum(m, inp)
+            all_neg_inf = m_new == float("-inf")
+            z = tl.where(all_neg_inf, z, z * tl.exp(m - m_new) + tl.exp(inp - m_new))
+            m = m_new
+
+        m_reduced = tl.max(m, axis=0)
+        z = tl.sum(z * tl.exp(m - m_reduced), axis=0)
+        m = m_reduced
+        # Handle case where all inputs were -inf
+        out = tl.where(m == float("-inf"), m, m + tl.log(z))
+        output_ptrs = output_ptr + pid_m
+        tl.store(output_ptrs, out)
+
+
+def logsumexp(inp, dim, keepdim=False):
+    logger.debug("GEMS LOGSUMEXP")
+
+    if isinstance(dim, (list, tuple)):
+        # Handle multi-dimensional reduction
+        if len(dim) == 0:
+            # Empty dim list means no reduction, just return the input
+            return inp.clone()
+        if len(dim) == 1:
+            dim = dim[0]
+        else:
+            # For multiple dims, reduce sequentially
+            # Sort dims in descending order to handle dimension shifts correctly
+            sorted_dims = sorted([d % inp.ndim for d in dim], reverse=True)
+            result = inp
+            for d in sorted_dims:
+                result = logsumexp(result, d, keepdim=True)
+            if not keepdim:
+                # Remove the reduced dimensions
+                for d in sorted(sorted_dims, reverse=True):
+                    result = result.squeeze(d)
+            return result
+
+    assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
+    dim = dim % inp.ndim
+    M = 1
+    N = inp.shape[dim]
+    for i in range(dim):
+        M *= inp.shape[i]
+    inp = inp.contiguous()
+    K = inp.numel() // M // N
+
+    # Output shape with reduction dimension set to 1
+    shape = list(inp.shape)
+    shape[dim] = 1
+    out = torch.empty(shape, dtype=inp.dtype, device=inp.device)
+
+    with torch_device_fn.device(inp.device):
+        if K > 1:
+            grid = lambda meta: (M, triton.cdiv(K, meta["TILE_K"]), 1)
+            logsumexp_kernel_non_inner[grid](
+                out,
+                inp,
+                M,
+                N,
+                K,
+            )
+        else:
+            grid = (M, 1, 1)
+            logsumexp_kernel_inner[grid](
+                out,
+                inp,
+                M,
+                N,
+            )
+
+    if not keepdim:
+        out = out.squeeze(dim=dim)
+    return out

--- a/tests/test_logsumexp.py
+++ b/tests/test_logsumexp.py
@@ -1,0 +1,30 @@
+import pytest
+import torch
+
+import flag_gems
+
+from .accuracy_utils import (
+    FLOAT_DTYPES,
+    REDUCTION_SHAPES,
+    gems_assert_close,
+    to_reference,
+)
+from .conftest import QUICK_MODE
+
+DIM_LIST = [0] if QUICK_MODE else [0, 1]
+
+
+@pytest.mark.logsumexp
+@pytest.mark.parametrize("shape", REDUCTION_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("dim", DIM_LIST)
+@pytest.mark.parametrize("keepdim", [True, False])
+def test_accuracy_logsumexp(shape, dtype, dim, keepdim):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp)
+
+    ref_out = torch.logsumexp(ref_inp, dim=dim, keepdim=keepdim)
+    with flag_gems.use_gems():
+        res_out = torch.logsumexp(inp, dim=dim, keepdim=keepdim)
+
+    gems_assert_close(res_out, ref_out, dtype, reduce_dim=shape[dim], atol=5e-3)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `logsumexp` operator implementation with Triton kernel.

- Implementation mode: `N/A`
- Accuracy test: 36/36 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([64, 64]) | 0.0359 | 0.0076 | 4.730 |
| torch.Size([256, 256]) | 0.0373 | 0.0083 | 4.519 |
| torch.Size([1024, 1024]) | 0.0484 | 0.0115 | 4.223 |
| torch.Size([4096, 4096]) | 0.2187 | 0.0467 | 4.680 |
| torch.Size([1024, 65536]) | 0.7471 | 0.1287 | 5.805 |
| torch.Size([10000, 1]) | 0.0381 | 0.0153 | 2.492 |
| torch.Size([10000, 256]) | 0.0609 | 0.0194 | 3.147 |
| torch.Size([10000, 65536]) | 6.6176 | 0.9506 | 6.961 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([64, 64]) | 0.0448 | 0.0089 | 5.040 |
| torch.Size([256, 256]) | 0.0370 | 0.0084 | 4.433 |
| torch.Size([1024, 1024]) | 0.0471 | 0.0109 | 4.304 |
| torch.Size([4096, 4096]) | 0.2161 | 0.0466 | 4.636 |
| torch.Size([1024, 65536]) | 0.7437 | 0.1271 | 5.851 |
| torch.Size([10000, 1]) | 0.0383 | 0.0153 | 2.502 |
| torch.Size([10000, 256]) | 0.0598 | 0.0188 | 3.179 |
| torch.Size([10000, 65536]) | 6.5999 | 0.9473 | 6.967 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([64, 64]) | 0.0348 | 0.0076 | 4.582 |
| torch.Size([256, 256]) | 0.0365 | 0.0083 | 4.392 |
| torch.Size([1024, 1024]) | 0.0477 | 0.0135 | 3.527 |
| torch.Size([4096, 4096]) | 0.3537 | 0.0737 | 4.799 |
| torch.Size([1024, 65536]) | 1.2220 | 0.2185 | 5.592 |
| torch.Size([10000, 1]) | 0.0365 | 0.0154 | 2.375 |
| torch.Size([10000, 256]) | 0.0650 | 0.0204 | 3.188 |
| torch.Size([10000, 65536]) | 11.3369 | 1.8290 | 6.198 |

**Overall: median speedup = 4.550x, mean speedup = 4.505x** (24 data points)

---
_Generated by auto_gen tool with Claude Code_
