### PR TITLE
【KernelGen】Add max_pool2d_with_indices_backward operator

### DIFF
--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -422,6 +422,34 @@ def test_perf_max_pool2d_backward():
     bench.run()
 
 
+@pytest.mark.max_pool2d_with_indices_backward
+def test_perf_max_pool2d_with_indices_backward():
+    def max_pool2d_with_indices_backward_input_fn(shape, dtype, device):
+        for forward_args in max_pool2d_input_fn(shape, dtype, device):
+            inp, params = forward_args
+            output, indices = torch.ops.aten.max_pool2d_with_indices(
+                inp,
+                params["kernel_size"],
+                params["stride"],
+                params["padding"],
+                params["dilation"],
+                params["ceil_mode"],
+            )
+            grad_output = torch.randn_like(output)
+            yield grad_output, inp, params["kernel_size"], params["stride"], params[
+                "padding"
+            ], params["dilation"], params["ceil_mode"], indices
+
+    bench = MaxPool2dBenchmark(
+        input_fn=max_pool2d_with_indices_backward_input_fn,
+        op_name="max_pool2d_with_indices_backward",
+        torch_op=torch.ops.aten.max_pool2d_with_indices_backward,
+        dtypes=FLOAT_DTYPES,
+        is_backward=False,
+    )
+    bench.run()
+
+
 @pytest.mark.dot
 def test_perf_dot():
     def dot_input_fn(shape, dtype, device):

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -227,6 +227,7 @@ _FULL_CONFIG = (
     ("max.dim", max_dim),
     ("maximum", maximum),
     ("max_pool2d_with_indices", max_pool2d_with_indices),
+    ("max_pool2d_with_indices_backward", max_pool2d_with_indices_backward),
     ("max_pool2d_backward", max_pool2d_backward),
     ("mean", mean),
     ("mean.dim", mean_dim),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -132,6 +132,7 @@ from flag_gems.ops.max import max, max_dim
 from flag_gems.ops.max_pool2d_with_indices import (
     max_pool2d_backward,
     max_pool2d_with_indices,
+    max_pool2d_with_indices_backward,
 )
 from flag_gems.ops.maximum import maximum
 from flag_gems.ops.mean import mean, mean_dim
@@ -411,6 +412,7 @@ __all__ = [
     "max",
     "max_dim",
     "max_pool2d_with_indices",
+    "max_pool2d_with_indices_backward",
     "max_pool2d_backward",
     "maximum",
     "mean",

--- a/src/flag_gems/ops/max_pool2d_with_indices.py
+++ b/src/flag_gems/ops/max_pool2d_with_indices.py
@@ -339,7 +339,7 @@ def max_pool2d_backward(
     dilation,
     ceil_mode,
 ):
-    logger.debug("GEMS MAX_POOL2D BACKWARD")
+    logger.debug("GEMS MAX_POOL2D_BACKWARD")
     grad_output = grad_output.contiguous()
     indices = indices.contiguous()
 
@@ -394,3 +394,20 @@ def max_pool2d_backward(
     )
 
     return grad_input.to(grad_output.dtype)
+
+
+def max_pool2d_with_indices_backward(
+    grad_output: torch.Tensor,
+    self: torch.Tensor,
+    kernel_size,
+    stride,
+    padding,
+    dilation,
+    ceil_mode: bool,
+    indices: torch.Tensor,
+):
+    """Wrapper matching the aten::max_pool2d_with_indices_backward schema."""
+    logger.debug("GEMS MAX_POOL2D_WITH_INDICES_BACKWARD")
+    return max_pool2d_backward(
+        grad_output, self, indices, kernel_size, stride, padding, dilation, ceil_mode
+    )

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -1476,6 +1476,67 @@ def test_accuracy_max_pool2d_backward(
     gems_assert_close(res_in_grad, ref_in_grad, dtype)
 
 
+@pytest.mark.max_pool2d_with_indices_backward
+@pytest.mark.parametrize(
+    "shape, kernel_size, stride, padding, dilation, ceil_mode", MAXPOOL2D_CONFIGS
+)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_max_pool2d_with_indices_backward(
+    shape, kernel_size, stride, padding, dilation, ceil_mode, dtype
+):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, upcast=True)
+
+    # Run forward to get indices
+    ref_out, ref_indices = torch.ops.aten.max_pool2d_with_indices(
+        ref_inp,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+    )
+    res_out, res_indices = torch.ops.aten.max_pool2d_with_indices(
+        inp,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+    )
+
+    # Create gradient
+    out_grad = torch.randn_like(res_out, device=flag_gems.device)
+    ref_grad = to_reference(out_grad, upcast=True)
+
+    # Reference backward (without flag_gems)
+    ref_in_grad = torch.ops.aten.max_pool2d_with_indices_backward(
+        ref_grad,
+        ref_inp,
+        kernel_size,
+        stride,
+        padding,
+        dilation,
+        ceil_mode,
+        ref_indices,
+    )
+
+    # FlagGems backward
+    with flag_gems.use_gems():
+        res_in_grad = torch.ops.aten.max_pool2d_with_indices_backward(
+            out_grad,
+            inp,
+            kernel_size,
+            stride,
+            padding,
+            dilation,
+            ceil_mode,
+            res_indices,
+        )
+
+    gems_assert_close(res_in_grad, ref_in_grad, dtype)
+
+
 INDEX_PUT_SHAPE_ACC_FALSE = (
     ((2**28,), ((2**16,),), (2**16,), False),
     ((32, 32), ((8,), (8,)), (8,), False),


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `max_pool2d_with_indices_backward` operator implementation with Triton kernel.

- Implementation mode: `manual_kernel`
- Accuracy test: 21/21 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [4, 3, 224, 224] | 0.0278 | 0.0845 | 0.329 |
| [4, 3, 224, 224] (non-square) | 0.0300 | 0.0828 | 0.362 |
| [4, 3, 224, 224] (dilation=2) | 0.0426 | 0.0782 | 0.545 |
| [4, 3, 224, 224] (ceil_mode) | 0.0286 | 0.0800 | 0.357 |
| [16, 64, 56, 56] | 0.0887 | 0.0994 | 0.892 |
| [16, 64, 56, 56] (non-square) | 0.1014 | 0.1286 | 0.789 |
| [16, 64, 56, 56] (dilation=2) | 0.1585 | 0.1055 | 1.502 |
| [16, 64, 56, 56] (ceil_mode) | 0.0892 | 0.1002 | 0.890 |
| [32, 128, 28, 28] | 0.0901 | 0.1088 | 0.829 |
| [32, 128, 28, 28] (non-square) | 0.1082 | 0.1396 | 0.775 |
| [32, 128, 28, 28] (dilation=2) | 0.1621 | 0.1092 | 1.485 |
| [32, 128, 28, 28] (ceil_mode) | 0.0927 | 0.1090 | 0.851 |
| [64, 256, 14, 14] | 0.0962 | 0.1098 | 0.876 |
| [64, 256, 14, 14] (non-square) | 0.1161 | 0.1429 | 0.812 |
| [64, 256, 14, 14] (dilation=2) | 0.1653 | 0.1004 | 1.648 |
| [64, 256, 14, 14] (ceil_mode) | 0.0996 | 0.1084 | 0.919 |
| [128, 512, 7, 7] | 0.1281 | 0.3487 | 0.367 |
| [128, 512, 7, 7] (non-square) | 0.1516 | 0.4812 | 0.315 |
| [128, 512, 7, 7] (dilation=2) | 0.2104 | 0.3032 | 0.694 |
| [128, 512, 7, 7] (ceil_mode) | 0.1281 | 0.3500 | 0.366 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [4, 3, 224, 224] | 0.0329 | 0.0960 | 0.343 |
| [4, 3, 224, 224] (non-square) | 0.0307 | 0.0778 | 0.395 |
| [4, 3, 224, 224] (dilation=2) | 0.0426 | 0.0817 | 0.521 |
| [4, 3, 224, 224] (ceil_mode) | 0.0284 | 0.0781 | 0.364 |
| [16, 64, 56, 56] | 0.0886 | 0.1013 | 0.875 |
| [16, 64, 56, 56] (non-square) | 0.1013 | 0.1314 | 0.771 |
| [16, 64, 56, 56] (dilation=2) | 0.1577 | 0.1073 | 1.470 |
| [16, 64, 56, 56] (ceil_mode) | 0.0892 | 0.1007 | 0.886 |
| [32, 128, 28, 28] | 0.0901 | 0.1098 | 0.821 |
| [32, 128, 28, 28] (non-square) | 0.1080 | 0.1431 | 0.755 |
| [32, 128, 28, 28] (dilation=2) | 0.1615 | 0.1122 | 1.440 |
| [32, 128, 28, 28] (ceil_mode) | 0.0926 | 0.1120 | 0.827 |
| [64, 256, 14, 14] | 0.0963 | 0.1094 | 0.880 |
| [64, 256, 14, 14] (non-square) | 0.1159 | 0.1447 | 0.801 |
| [64, 256, 14, 14] (dilation=2) | 0.1644 | 0.1015 | 1.620 |
| [64, 256, 14, 14] (ceil_mode) | 0.0997 | 0.1094 | 0.911 |
| [128, 512, 7, 7] | 0.1282 | 0.3534 | 0.363 |
| [128, 512, 7, 7] (non-square) | 0.1513 | 0.4856 | 0.312 |
| [128, 512, 7, 7] (dilation=2) | 0.2097 | 0.3090 | 0.679 |
| [128, 512, 7, 7] (ceil_mode) | 0.1279 | 0.3532 | 0.362 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [4, 3, 224, 224] | 0.0290 | 0.0240 | 1.208 |
| [4, 3, 224, 224] (non-square) | 0.0316 | 0.0337 | 0.940 |
| [4, 3, 224, 224] (dilation=2) | 0.0449 | 0.0291 | 1.542 |
| [4, 3, 224, 224] (ceil_mode) | 0.0296 | 0.0237 | 1.247 |
| [16, 64, 56, 56] | 0.0952 | 0.0880 | 1.082 |
| [16, 64, 56, 56] (non-square) | 0.1073 | 0.1173 | 0.915 |
| [16, 64, 56, 56] (dilation=2) | 0.1649 | 0.0975 | 1.692 |
| [16, 64, 56, 56] (ceil_mode) | 0.0961 | 0.0890 | 1.080 |
| [32, 128, 28, 28] | 0.0957 | 0.0972 | 0.984 |
| [32, 128, 28, 28] (non-square) | 0.1128 | 0.1270 | 0.888 |
| [32, 128, 28, 28] (dilation=2) | 0.1669 | 0.1004 | 1.663 |
| [32, 128, 28, 28] (ceil_mode) | 0.0984 | 0.0976 | 1.008 |
| [64, 256, 14, 14] | 0.1011 | 0.0962 | 1.051 |
| [64, 256, 14, 14] (non-square) | 0.1203 | 0.1303 | 0.923 |
| [64, 256, 14, 14] (dilation=2) | 0.1679 | 0.0884 | 1.899 |
| [64, 256, 14, 14] (ceil_mode) | 0.1050 | 0.0965 | 1.088 |
| [128, 512, 7, 7] | 0.1321 | 0.3233 | 0.408 |
| [128, 512, 7, 7] (non-square) | 0.1558 | 0.4447 | 0.350 |
| [128, 512, 7, 7] (dilation=2) | 0.2122 | 0.2748 | 0.772 |
| [128, 512, 7, 7] (ceil_mode) | 0.1321 | 0.3233 | 0.408 |

**Overall: median speedup = 0.863x, mean speedup = 0.869x** (60 data points)

---
_Generated by auto_gen tool with Claude Code_
