### PR TITLE
【KernelGen】Add mish operator

### DIFF
--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -63,6 +63,7 @@ forward_operations = [
     ("softplus", torch.nn.functional.softplus, FLOAT_DTYPES),
     ("sigmoid", torch.sigmoid, FLOAT_DTYPES),
     ("log_sigmoid", torch.nn.functional.logsigmoid, FLOAT_DTYPES),
+    ("mish", torch.nn.functional.mish, FLOAT_DTYPES),
     ("silu", torch.nn.functional.silu, FLOAT_DTYPES),
     # Trigonometric operations
     ("cos", torch.cos, FLOAT_DTYPES),
@@ -117,6 +118,7 @@ forward_inplace_operations = [
     ("celu_", torch.nn.functional.celu_, FLOAT_DTYPES),
     ("elu_", torch.nn.functional.elu_, FLOAT_DTYPES),
     ("gelu_", torch.ops.aten.gelu_.default, FLOAT_DTYPES),
+    ("mish_", lambda a: torch.nn.functional.mish(a, inplace=True), FLOAT_DTYPES),
     ("relu_", torch.relu_, FLOAT_DTYPES),
     ("sigmoid_", torch.sigmoid_, FLOAT_DTYPES),
     ("silu_", lambda a: torch.nn.functional.silu(a, inplace=True), FLOAT_DTYPES),

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -233,6 +233,8 @@ _FULL_CONFIG = (
     ("min", min),
     ("min.dim", min_dim),
     ("minimum", minimum),
+    ("mish", mish),
+    ("mish_", mish_),
     ("mm", mm),
     ("mm.out", mm_out),
     ("mse_loss", mse_loss),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -137,6 +137,7 @@ from flag_gems.ops.maximum import maximum
 from flag_gems.ops.mean import mean, mean_dim
 from flag_gems.ops.min import min, min_dim
 from flag_gems.ops.minimum import minimum
+from flag_gems.ops.mish import mish, mish_
 from flag_gems.ops.mm import mm, mm_out
 from flag_gems.ops.mse_loss import mse_loss
 from flag_gems.ops.mul import mul, mul_
@@ -418,6 +419,8 @@ __all__ = [
     "min",
     "min_dim",
     "minimum",
+    "mish",
+    "mish_",
     "mm",
     "mm_out",
     "mse_loss",

--- a/src/flag_gems/ops/mish.py
+++ b/src/flag_gems/ops/mish.py
@@ -1,0 +1,31 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
+
+_tanh = tl_extra_shim.tanh
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=[(0, "DEFAULT")])
+@triton.jit
+def mish_forward(x):
+    x_fp32 = x.to(tl.float32)
+    # mish(x) = x * tanh(softplus(x)) = x * tanh(log(1 + exp(x)))
+    softplus_x = tl.log(1.0 + tl.exp(x_fp32))
+    y = x_fp32 * _tanh(softplus_x)
+    return y
+
+
+def mish(self):
+    logger.debug("GEMS MISH")
+    output = mish_forward(self)
+    return output
+
+
+def mish_(A):
+    logger.debug("GEMS MISH_")
+    out = mish_forward(A, out0=A)
+    return out

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -923,6 +923,35 @@ def test_accuracy_silu_(shape, dtype):
     gems_assert_close(res_out, ref_out, dtype)
 
 
+@pytest.mark.mish
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_mish(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+
+    ref_out = torch.nn.functional.mish(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.mish(inp)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.inplace
+@pytest.mark.mish_
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_mish_(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp.clone(), True)
+
+    ref_out = torch.nn.functional.mish(ref_inp, inplace=True)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.mish(inp, inplace=True)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
 @pytest.mark.sin
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `mish` operator implementation with Triton kernel.

- Implementation mode: `pointwise_dynamic`
- Accuracy test: 36/36 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 4.4995 | 3.9356 | 1.143 |
| [64, 64] | 0.0076 | 0.0079 | 0.960 |
| [4096, 4096] | 0.0800 | 0.0692 | 1.156 |
| [64, 512, 512] | 0.0795 | 0.0692 | 1.148 |
| [1024, 1024, 1024] | 4.4996 | 3.9357 | 1.143 |
| [1024, 1] | 0.0076 | 0.0077 | 0.988 |
| [1024, 16] | 0.0078 | 0.0076 | 1.030 |
| [1024, 256] | 0.0089 | 0.0087 | 1.030 |
| [1024, 4096] | 0.0266 | 0.0233 | 1.140 |
| [1024, 65536] | 0.2901 | 0.2528 | 1.148 |
| [64, 64, 1] | 0.0080 | 0.0077 | 1.041 |
| [64, 64, 16] | 0.0079 | 0.0083 | 0.953 |
| [64, 64, 256] | 0.0134 | 0.0132 | 1.010 |
| [64, 64, 4096] | 0.0790 | 0.0698 | 1.132 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 4.5051 | 3.9349 | 1.145 |
| [64, 64] | 0.0082 | 0.0076 | 1.067 |
| [4096, 4096] | 0.0801 | 0.0691 | 1.159 |
| [64, 512, 512] | 0.0791 | 0.0691 | 1.146 |
| [1024, 1024, 1024] | 4.5052 | 3.9343 | 1.145 |
| [1024, 1] | 0.0076 | 0.0076 | 0.992 |
| [1024, 16] | 0.0078 | 0.0079 | 0.984 |
| [1024, 256] | 0.0094 | 0.0092 | 1.024 |
| [1024, 4096] | 0.0262 | 0.0239 | 1.098 |
| [1024, 65536] | 0.2898 | 0.2528 | 1.146 |
| [64, 64, 1] | 0.0082 | 0.0073 | 1.122 |
| [64, 64, 16] | 0.0084 | 0.0082 | 1.019 |
| [64, 64, 256] | 0.0129 | 0.0131 | 0.985 |
| [64, 64, 4096] | 0.0790 | 0.0701 | 1.127 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 6.1943 | 6.2697 | 0.988 |
| [64, 64] | 0.0076 | 0.0073 | 1.035 |
| [4096, 4096] | 0.1089 | 0.1064 | 1.023 |
| [64, 512, 512] | 0.1084 | 0.1062 | 1.021 |
| [1024, 1024, 1024] | 6.1940 | 6.2784 | 0.987 |
| [1024, 1] | 0.0076 | 0.0076 | 0.992 |
| [1024, 16] | 0.0078 | 0.0076 | 1.034 |
| [1024, 256] | 0.0104 | 0.0104 | 1.003 |
| [1024, 4096] | 0.0332 | 0.0327 | 1.017 |
| [1024, 65536] | 0.3988 | 0.3976 | 1.003 |
| [64, 64, 1] | 0.0082 | 0.0078 | 1.045 |
| [64, 64, 16] | 0.0091 | 0.0079 | 1.150 |
| [64, 64, 256] | 0.0151 | 0.0140 | 1.085 |
| [64, 64, 4096] | 0.1084 | 0.1072 | 1.011 |

**Overall: median speedup = 1.034x, mean speedup = 1.061x** (42 data points)

---
_Generated by auto_gen tool with Claude Code_
