### PR TITLE
【KernelGen】Add mish_backward operator

### DIFF
--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -246,6 +246,24 @@ def test_elu_backward_perf():
     bench.run()
 
 
+class MishBackwardBenchmark(UnaryPointwiseBenchmark):
+    def get_input_iter(self, cur_dtype: torch.dtype) -> Generator:
+        for shape in self.shapes:
+            inp = generate_tensor_input(shape, cur_dtype, self.device)
+            grad_out = torch.randn_like(inp)
+            yield grad_out, inp
+
+
+@pytest.mark.mish_backward
+def test_mish_backward_perf():
+    bench = MishBackwardBenchmark(
+        op_name="mish_backward",
+        torch_op=torch.ops.aten.mish_backward,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.run()
+
+
 class GluBenchmark(UnaryPointwiseBenchmark):
     # Glu test requires even numbers
     def set_more_shapes(self):

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -233,6 +233,7 @@ _FULL_CONFIG = (
     ("min", min),
     ("min.dim", min_dim),
     ("minimum", minimum),
+    ("mish_backward", mish_backward),
     ("mm", mm),
     ("mm.out", mm_out),
     ("mse_loss", mse_loss),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -137,6 +137,7 @@ from flag_gems.ops.maximum import maximum
 from flag_gems.ops.mean import mean, mean_dim
 from flag_gems.ops.min import min, min_dim
 from flag_gems.ops.minimum import minimum
+from flag_gems.ops.mish_backward import mish_backward
 from flag_gems.ops.mm import mm, mm_out
 from flag_gems.ops.mse_loss import mse_loss
 from flag_gems.ops.mul import mul, mul_
@@ -418,6 +419,7 @@ __all__ = [
     "min",
     "min_dim",
     "minimum",
+    "mish_backward",
     "mm",
     "mm_out",
     "mse_loss",

--- a/src/flag_gems/ops/mish_backward.py
+++ b/src/flag_gems/ops/mish_backward.py
@@ -1,0 +1,40 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
+
+tanh = tl_extra_shim.tanh
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def mish_backward_kernel(x, dy):
+    # mish(x) = x * tanh(softplus(x))
+    # mish'(x) = tanh(softplus(x)) + x * sigmoid(x) * (1 - tanh^2(softplus(x)))
+    x_fp32 = x.to(tl.float32)
+    dy_fp32 = dy.to(tl.float32)
+
+    # softplus(x) = ln(1 + exp(x))
+    sp = tl.log(1.0 + tl.exp(x_fp32))
+
+    # tanh(softplus(x))
+    t = tanh(sp)
+
+    # sigmoid(x) = 1 / (1 + exp(-x))
+    sig = 1.0 / (1.0 + tl.exp(-x_fp32))
+
+    # mish'(x) = t + x * sig * (1 - t^2)
+    grad = t + x_fp32 * sig * (1.0 - t * t)
+
+    dx = dy_fp32 * grad
+    return dx
+
+
+def mish_backward(grad_output, self):
+    logger.debug("GEMS MISH_BACKWARD")
+    grad_input = mish_backward_kernel(self, grad_output)
+    return grad_input

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -1769,3 +1769,20 @@ def test_accuracy_ceil_out(shape, dtype):
         torch.ceil(inp, out=out)
 
     gems_assert_equal(out, ref_out)
+
+
+@pytest.mark.mish_backward
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_mish_backward(shape, dtype):
+    res_inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    res_grad = torch.randn_like(res_inp)
+
+    ref_inp = to_reference(res_inp, True)
+    ref_grad = to_reference(res_grad, True)
+
+    ref_in_grad = torch.ops.aten.mish_backward(ref_grad, ref_inp)
+    with flag_gems.use_gems():
+        res_in_grad = torch.ops.aten.mish_backward(res_grad, res_inp)
+
+    gems_assert_close(res_in_grad, ref_in_grad, dtype)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `mish_backward` operator implementation with Triton kernel.

- Implementation mode: `pointwise_dynamic`
- Accuracy test: 18/18 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 6.4998 | 5.2133 | 1.247 |
| [64, 64] | 0.0079 | 0.0075 | 1.056 |
| [4096, 4096] | 0.1121 | 0.0892 | 1.258 |
| [64, 512, 512] | 0.1122 | 0.0897 | 1.251 |
| [1024, 1024, 1024] | 6.5664 | 5.2336 | 1.255 |
| [1024, 1] | 0.0083 | 0.0074 | 1.126 |
| [1024, 16] | 0.0085 | 0.0077 | 1.113 |
| [1024, 256] | 0.0103 | 0.0098 | 1.046 |
| [1024, 4096] | 0.0355 | 0.0295 | 1.203 |
| [1024, 65536] | 0.4166 | 0.3292 | 1.265 |
| [64, 64, 1] | 0.0079 | 0.0086 | 0.915 |
| [64, 64, 16] | 0.0087 | 0.0085 | 1.026 |
| [64, 64, 256] | 0.0171 | 0.0153 | 1.119 |
| [64, 64, 4096] | 0.1113 | 0.0902 | 1.234 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 6.5612 | 5.2107 | 1.259 |
| [64, 64] | 0.0083 | 0.0075 | 1.111 |
| [4096, 4096] | 0.1124 | 0.0900 | 1.249 |
| [64, 512, 512] | 0.1128 | 0.0904 | 1.248 |
| [1024, 1024, 1024] | 6.6300 | 5.2075 | 1.273 |
| [1024, 1] | 0.0077 | 0.0073 | 1.057 |
| [1024, 16] | 0.0085 | 0.0083 | 1.031 |
| [1024, 256] | 0.0103 | 0.0102 | 1.009 |
| [1024, 4096] | 0.0365 | 0.0295 | 1.238 |
| [1024, 65536] | 0.4205 | 0.3306 | 1.272 |
| [64, 64, 1] | 0.0079 | 0.0075 | 1.064 |
| [64, 64, 16] | 0.0088 | 0.0093 | 0.948 |
| [64, 64, 256] | 0.0171 | 0.0152 | 1.126 |
| [64, 64, 4096] | 0.1127 | 0.0903 | 1.248 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 9.4620 | 9.3414 | 1.013 |
| [64, 64] | 0.0085 | 0.0076 | 1.109 |
| [4096, 4096] | 0.1618 | 0.1603 | 1.009 |
| [64, 512, 512] | 0.1615 | 0.1594 | 1.013 |
| [1024, 1024, 1024] | 9.4636 | 9.3435 | 1.013 |
| [1024, 1] | 0.0079 | 0.0075 | 1.056 |
| [1024, 16] | 0.0087 | 0.0077 | 1.129 |
| [1024, 256] | 0.0114 | 0.0118 | 0.959 |
| [1024, 4096] | 0.0510 | 0.0493 | 1.034 |
| [1024, 65536] | 0.6043 | 0.5999 | 1.007 |
| [64, 64, 1] | 0.0080 | 0.0077 | 1.038 |
| [64, 64, 16] | 0.0088 | 0.0084 | 1.053 |
| [64, 64, 256] | 0.0197 | 0.0190 | 1.039 |
| [64, 64, 4096] | 0.1617 | 0.1603 | 1.009 |

**Overall: median speedup = 1.087x, mean speedup = 1.113x** (42 data points)

---
_Generated by auto_gen tool with Claude Code_
