### PR TITLE
【KernelGen】Add new_full operator

### DIFF
--- a/benchmark/test_tensor_constructor_perf.py
+++ b/benchmark/test_tensor_constructor_perf.py
@@ -9,15 +9,9 @@ import torch.nn.functional as F
 
 import flag_gems
 from benchmark.attri_util import FLOAT_DTYPES, BenchLevel
-from benchmark.performance_utils import (
-    Benchmark,
-    Config,
-    GenericBenchmark,
-    SkipVersion,
-    generate_tensor_input,
-    unary_input_fn,
-    vendor_name,
-)
+from benchmark.performance_utils import (Benchmark, Config, GenericBenchmark,
+                                         SkipVersion, generate_tensor_input,
+                                         unary_input_fn, vendor_name)
 
 
 def generic_constructor_input_fn(shape, dtype, device):
@@ -160,7 +154,11 @@ tensor_constructor_operations = [
     ("masked_fill", torch.masked_fill, masked_fill_input_fn),
     ("full", torch.full, full_input_fn),
     ("full_like", torch.full_like, full_like_input_fn),
-    ("new_full", lambda inp, size, fill_value: inp.new_full(size, fill_value), new_full_input_fn),
+    (
+        "new_full",
+        lambda inp, size, fill_value: inp.new_full(size, fill_value),
+        new_full_input_fn,
+    ),
     # arange
     ("arange", torch.arange, arange_input_fn),
     # linspace

--- a/benchmark/test_tensor_constructor_perf.py
+++ b/benchmark/test_tensor_constructor_perf.py
@@ -40,6 +40,11 @@ def full_like_input_fn(shape, dtype, device):
     yield {"input": inp, "fill_value": 3.1415926},
 
 
+def new_full_input_fn(shape, dtype, device):
+    inp = torch.randn((4, 4), dtype=dtype, device=device)
+    yield inp, shape, 3.1415926,
+
+
 def fill_input_fn(shape, dtype, device):
     input = torch.empty(shape, dtype=dtype, device=device)
     yield input, 3.14159,
@@ -155,6 +160,7 @@ tensor_constructor_operations = [
     ("masked_fill", torch.masked_fill, masked_fill_input_fn),
     ("full", torch.full, full_input_fn),
     ("full_like", torch.full_like, full_like_input_fn),
+    ("new_full", lambda inp, size, fill_value: inp.new_full(size, fill_value), new_full_input_fn),
     # arange
     ("arange", torch.arange, arange_input_fn),
     # linspace

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -287,6 +287,7 @@ _FULL_CONFIG = (
     ("ne.Tensor", ne),
     ("neg", neg),
     ("neg_", neg_),
+    ("new_full", new_full),
     ("nll_loss_backward", nll_loss_backward),
     ("nll_loss_forward", nll_loss_forward),
     ("nll_loss2d_backward", nll_loss2d_backward),

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -8,7 +8,8 @@ from flag_gems import runtime
 from flag_gems.config import aten_patch_list, resolve_user_setting
 from flag_gems.experimental_ops import *  # noqa: F403
 from flag_gems.fused import *  # noqa: F403
-from flag_gems.logging_utils import setup_flaggems_logging, teardown_flaggems_logging
+from flag_gems.logging_utils import (setup_flaggems_logging,
+                                     teardown_flaggems_logging)
 from flag_gems.modules import *  # noqa: F403
 from flag_gems.ops import *  # noqa: F403
 from flag_gems.patches import *  # noqa: F403

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -1,6 +1,5 @@
-from flag_gems.ops._functional_sym_constrain_range_for_size import (
-    _functional_sym_constrain_range_for_size,
-)
+from flag_gems.ops._functional_sym_constrain_range_for_size import \
+    _functional_sym_constrain_range_for_size
 from flag_gems.ops._safe_softmax import _safe_softmax
 from flag_gems.ops._upsample_nearest_exact1d import _upsample_nearest_exact1d
 from flag_gems.ops.abs import abs, abs_
@@ -25,46 +24,30 @@ from flag_gems.ops.argmax import argmax
 from flag_gems.ops.argmin import argmin
 from flag_gems.ops.asinh_ import asinh_
 from flag_gems.ops.atan import atan, atan_
-from flag_gems.ops.attention import (
-    ScaleDotProductAttention,
-    flash_attention_forward,
-    flash_attn_varlen_func,
-    scaled_dot_product_attention,
-    scaled_dot_product_attention_backward,
-    scaled_dot_product_attention_forward,
-)
+from flag_gems.ops.attention import (ScaleDotProductAttention,
+                                     flash_attention_forward,
+                                     flash_attn_varlen_func,
+                                     scaled_dot_product_attention,
+                                     scaled_dot_product_attention_backward,
+                                     scaled_dot_product_attention_forward)
 from flag_gems.ops.avg_pool2d import avg_pool2d, avg_pool2d_backward
 from flag_gems.ops.baddbmm import baddbmm
 from flag_gems.ops.batch_norm import batch_norm, batch_norm_backward
-from flag_gems.ops.bitwise_and import (
-    bitwise_and_scalar,
-    bitwise_and_scalar_,
-    bitwise_and_scalar_tensor,
-    bitwise_and_tensor,
-    bitwise_and_tensor_,
-)
+from flag_gems.ops.bitwise_and import (bitwise_and_scalar, bitwise_and_scalar_,
+                                       bitwise_and_scalar_tensor,
+                                       bitwise_and_tensor, bitwise_and_tensor_)
 from flag_gems.ops.bitwise_left_shift import bitwise_left_shift
 from flag_gems.ops.bitwise_not import bitwise_not, bitwise_not_
-from flag_gems.ops.bitwise_or import (
-    bitwise_or_scalar,
-    bitwise_or_scalar_,
-    bitwise_or_scalar_tensor,
-    bitwise_or_tensor,
-    bitwise_or_tensor_,
-)
+from flag_gems.ops.bitwise_or import (bitwise_or_scalar, bitwise_or_scalar_,
+                                      bitwise_or_scalar_tensor,
+                                      bitwise_or_tensor, bitwise_or_tensor_)
 from flag_gems.ops.bitwise_right_shift import bitwise_right_shift
 from flag_gems.ops.bmm import bmm, bmm_out
 from flag_gems.ops.cat import cat
 from flag_gems.ops.ceil import ceil, ceil_, ceil_out
 from flag_gems.ops.celu import celu, celu_
-from flag_gems.ops.clamp import (
-    clamp,
-    clamp_,
-    clamp_min,
-    clamp_min_,
-    clamp_tensor,
-    clamp_tensor_,
-)
+from flag_gems.ops.clamp import (clamp, clamp_, clamp_min, clamp_min_,
+                                 clamp_tensor, clamp_tensor_)
 from flag_gems.ops.contiguous import contiguous
 from flag_gems.ops.conv1d import conv1d
 from flag_gems.ops.conv2d import conv2d
@@ -80,17 +63,9 @@ from flag_gems.ops.diag import diag
 from flag_gems.ops.diag_embed import diag_embed
 from flag_gems.ops.diagonal import diagonal_backward
 from flag_gems.ops.digamma_ import digamma_
-from flag_gems.ops.div import (
-    div_mode,
-    div_mode_,
-    floor_divide,
-    floor_divide_,
-    remainder,
-    remainder_,
-    true_divide,
-    true_divide_,
-    true_divide_out,
-)
+from flag_gems.ops.div import (div_mode, div_mode_, floor_divide,
+                               floor_divide_, remainder, remainder_,
+                               true_divide, true_divide_, true_divide_out)
 from flag_gems.ops.dot import dot
 from flag_gems.ops.dropout import dropout, dropout_backward
 from flag_gems.ops.elu import elu, elu_, elu_backward
@@ -103,14 +78,8 @@ from flag_gems.ops.exp2 import exp2, exp2_
 from flag_gems.ops.exponential_ import exponential_
 from flag_gems.ops.eye import eye
 from flag_gems.ops.eye_m import eye_m
-from flag_gems.ops.fill import (
-    fill_scalar,
-    fill_scalar_,
-    fill_scalar_out,
-    fill_tensor,
-    fill_tensor_,
-    fill_tensor_out,
-)
+from flag_gems.ops.fill import (fill_scalar, fill_scalar_, fill_scalar_out,
+                                fill_tensor, fill_tensor_, fill_tensor_out)
 from flag_gems.ops.flip import flip
 from flag_gems.ops.floor_ import floor_
 from flag_gems.ops.fmin import fmin, fmin_out
@@ -141,7 +110,8 @@ from flag_gems.ops.isnan import isnan
 from flag_gems.ops.kron import kron
 from flag_gems.ops.layernorm import layer_norm, layer_norm_backward
 from flag_gems.ops.le import le, le_scalar
-from flag_gems.ops.lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tensor_
+from flag_gems.ops.lerp import (lerp_scalar, lerp_scalar_, lerp_tensor,
+                                lerp_tensor_)
 from flag_gems.ops.lift_fresh_copy import lift_fresh_copy, lift_fresh_copy_out
 from flag_gems.ops.linspace import linspace
 from flag_gems.ops.log import log
@@ -161,10 +131,8 @@ from flag_gems.ops.masked_fill import masked_fill, masked_fill_
 from flag_gems.ops.masked_scatter import masked_scatter, masked_scatter_
 from flag_gems.ops.masked_select import masked_select
 from flag_gems.ops.max import max, max_dim
-from flag_gems.ops.max_pool2d_with_indices import (
-    max_pool2d_backward,
-    max_pool2d_with_indices,
-)
+from flag_gems.ops.max_pool2d_with_indices import (max_pool2d_backward,
+                                                   max_pool2d_with_indices)
 from flag_gems.ops.maximum import maximum
 from flag_gems.ops.mean import mean, mean_dim
 from flag_gems.ops.min import min, min_dim
@@ -177,38 +145,24 @@ from flag_gems.ops.mv import mv
 from flag_gems.ops.nan_to_num import nan_to_num
 from flag_gems.ops.ne import ne, ne_scalar
 from flag_gems.ops.neg import neg, neg_
-from flag_gems.ops.nll_loss_nd import nll_loss_nd_backward, nll_loss_nd_forward
 from flag_gems.ops.new_full import new_full
-from flag_gems.ops.nllloss import (
-    nll_loss2d_backward,
-    nll_loss2d_forward,
-    nll_loss_backward,
-    nll_loss_forward,
-)
+from flag_gems.ops.nll_loss_nd import nll_loss_nd_backward, nll_loss_nd_forward
+from flag_gems.ops.nllloss import (nll_loss2d_backward, nll_loss2d_forward,
+                                   nll_loss_backward, nll_loss_forward)
 from flag_gems.ops.nonzero import nonzero
-from flag_gems.ops.normal import (
-    normal_,
-    normal_float_tensor,
-    normal_tensor_float,
-    normal_tensor_tensor,
-)
+from flag_gems.ops.normal import (normal_, normal_float_tensor,
+                                  normal_tensor_float, normal_tensor_tensor)
 from flag_gems.ops.one_hot import one_hot
 from flag_gems.ops.ones import ones
 from flag_gems.ops.ones_like import ones_like
 from flag_gems.ops.pad import constant_pad_nd, pad
-from flag_gems.ops.per_token_group_quant_fp8 import (
-    SUPPORTED_FP8_DTYPE,
-    per_token_group_quant_fp8,
-)
+from flag_gems.ops.per_token_group_quant_fp8 import (SUPPORTED_FP8_DTYPE,
+                                                     per_token_group_quant_fp8)
 from flag_gems.ops.pixel_unshuffle import pixel_unshuffle, pixel_unshuffle_out
 from flag_gems.ops.polar import polar
-from flag_gems.ops.pow import (
-    pow_scalar,
-    pow_tensor_scalar,
-    pow_tensor_scalar_,
-    pow_tensor_tensor,
-    pow_tensor_tensor_,
-)
+from flag_gems.ops.pow import (pow_scalar, pow_tensor_scalar,
+                               pow_tensor_scalar_, pow_tensor_tensor,
+                               pow_tensor_tensor_)
 from flag_gems.ops.prelu import prelu
 from flag_gems.ops.prod import prod, prod_dim
 from flag_gems.ops.quantile import quantile
@@ -218,24 +172,27 @@ from flag_gems.ops.randn import randn
 from flag_gems.ops.randn_like import randn_like
 from flag_gems.ops.randperm import randperm
 from flag_gems.ops.reciprocal import reciprocal, reciprocal_
-from flag_gems.ops.reflection_pad1d import reflection_pad1d, reflection_pad1d_out
-from flag_gems.ops.reflection_pad2d import reflection_pad2d, reflection_pad2d_out
+from flag_gems.ops.reflection_pad1d import (reflection_pad1d,
+                                            reflection_pad1d_out)
+from flag_gems.ops.reflection_pad2d import (reflection_pad2d,
+                                            reflection_pad2d_out)
 from flag_gems.ops.relu import relu, relu_
 from flag_gems.ops.relu6 import relu6
 from flag_gems.ops.repeat import repeat
-from flag_gems.ops.repeat_interleave import (
-    repeat_interleave_self_int,
-    repeat_interleave_self_tensor,
-    repeat_interleave_tensor,
-)
-from flag_gems.ops.replication_pad1d import replication_pad1d, replication_pad1d_out
+from flag_gems.ops.repeat_interleave import (repeat_interleave_self_int,
+                                             repeat_interleave_self_tensor,
+                                             repeat_interleave_tensor)
+from flag_gems.ops.replication_pad1d import (replication_pad1d,
+                                             replication_pad1d_out)
 from flag_gems.ops.replication_pad3d import replication_pad3d
 from flag_gems.ops.resolve_conj import resolve_conj
 from flag_gems.ops.resolve_neg import resolve_neg
-from flag_gems.ops.rms_norm import rms_norm, rms_norm_backward, rms_norm_forward
+from flag_gems.ops.rms_norm import (rms_norm, rms_norm_backward,
+                                    rms_norm_forward)
 from flag_gems.ops.rrelu_with_noise_backward import rrelu_with_noise_backward
 from flag_gems.ops.rsqrt import rsqrt, rsqrt_
-from flag_gems.ops.scaled_softmax import scaled_softmax_backward, scaled_softmax_forward
+from flag_gems.ops.scaled_softmax import (scaled_softmax_backward,
+                                          scaled_softmax_forward)
 from flag_gems.ops.scatter import scatter, scatter_
 from flag_gems.ops.scatter_add_ import scatter_add_
 from flag_gems.ops.select_scatter import select_scatter
@@ -248,7 +205,8 @@ from flag_gems.ops.sin import sin, sin_
 from flag_gems.ops.sinh_ import sinh_
 from flag_gems.ops.slice_backward import slice_backward
 from flag_gems.ops.slice_scatter import slice_scatter
-from flag_gems.ops.soft_margin_loss import soft_margin_loss, soft_margin_loss_out
+from flag_gems.ops.soft_margin_loss import (soft_margin_loss,
+                                            soft_margin_loss_out)
 from flag_gems.ops.softmax import softmax, softmax_backward
 from flag_gems.ops.softplus import softplus
 from flag_gems.ops.softshrink import softshrink, softshrink_out
@@ -284,16 +242,10 @@ from flag_gems.ops.vdot import vdot
 from flag_gems.ops.vector_norm import vector_norm
 from flag_gems.ops.vstack import vstack
 from flag_gems.ops.w8a8_block_fp8_matmul import w8a8_block_fp8_matmul
-from flag_gems.ops.weightnorm import (
-    weight_norm_interface,
-    weight_norm_interface_backward,
-)
-from flag_gems.ops.where import (
-    where_scalar_other,
-    where_scalar_self,
-    where_self,
-    where_self_out,
-)
+from flag_gems.ops.weightnorm import (weight_norm_interface,
+                                      weight_norm_interface_backward)
+from flag_gems.ops.where import (where_scalar_other, where_scalar_self,
+                                 where_self, where_self_out)
 from flag_gems.ops.zero import zero, zero_out
 from flag_gems.ops.zeros import zero_, zeros
 from flag_gems.ops.zeros_like import zeros_like

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -178,6 +178,7 @@ from flag_gems.ops.nan_to_num import nan_to_num
 from flag_gems.ops.ne import ne, ne_scalar
 from flag_gems.ops.neg import neg, neg_
 from flag_gems.ops.nll_loss_nd import nll_loss_nd_backward, nll_loss_nd_forward
+from flag_gems.ops.new_full import new_full
 from flag_gems.ops.nllloss import (
     nll_loss2d_backward,
     nll_loss2d_forward,
@@ -522,6 +523,7 @@ __all__ = [
     "ne_scalar",
     "neg",
     "neg_",
+    "new_full",
     "nll_loss_backward",
     "nll_loss_forward",
     "nll_loss2d_backward",

--- a/src/flag_gems/ops/new_full.py
+++ b/src/flag_gems/ops/new_full.py
@@ -1,0 +1,30 @@
+import logging
+
+import torch
+
+from flag_gems.ops.full import check_dtype, full_func, full_func_scalar
+
+logger = logging.getLogger(__name__)
+
+
+def new_full(
+    x,
+    size,
+    fill_value,
+    *,
+    dtype=None,
+    layout=None,
+    device=None,
+    pin_memory=None,
+):
+    logger.debug("GEMS NEW_FULL")
+    if device is None:
+        device = x.device
+    if dtype is None:
+        dtype = x.dtype
+    fill_value = check_dtype(fill_value, dtype, device)
+    out = torch.empty(size, device=device, dtype=dtype)
+    if isinstance(fill_value, torch.Tensor):
+        return full_func(out, fill_value, out0=out)
+    else:
+        return full_func_scalar(out, fill_value, out0=out)

--- a/tests/test_tensor_constructor_ops.py
+++ b/tests/test_tensor_constructor_ops.py
@@ -193,6 +193,38 @@ def test_accuracy_full_like(shape, dtype, xdtype, fill_value):
     gems_assert_equal(res_out, ref_out, equal_nan=True)
 
 
+@pytest.mark.new_full
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", BOOL_TYPES + ALL_INT_DTYPES + ALL_FLOAT_DTYPES)
+@pytest.mark.parametrize("xdtype", BOOL_TYPES + ALL_INT_DTYPES + ALL_FLOAT_DTYPES)
+@pytest.mark.parametrize(
+    "fill_value", [3.1415926, 2, False, float("inf"), float("nan")]
+)
+def test_accuracy_new_full(shape, dtype, xdtype, fill_value):
+    if isinstance(fill_value, float) and (
+        math.isinf(fill_value) or math.isnan(fill_value)
+    ):
+        if dtype not in ALL_FLOAT_DTYPES:
+            pytest.skip("Skipping inf/nan test for non-float output dtypes")
+        if xdtype not in ALL_FLOAT_DTYPES:
+            pytest.skip("Skipping inf/nan test for non-float input dtypes")
+    # Create input tensor with xdtype (used to infer default dtype/device)
+    inp = torch.empty(size=(4, 4), dtype=xdtype, device=device)
+    ref_inp = to_reference(inp)
+
+    # without dtype - should inherit dtype from input tensor
+    ref_out = ref_inp.new_full(shape, fill_value)
+    with flag_gems.use_gems():
+        res_out = inp.new_full(shape, fill_value)
+    gems_assert_equal(res_out, ref_out, equal_nan=True)
+
+    # with dtype - should use specified dtype
+    ref_out = ref_inp.new_full(shape, fill_value, dtype=dtype)
+    with flag_gems.use_gems():
+        res_out = inp.new_full(shape, fill_value, dtype=dtype)
+    gems_assert_equal(res_out, ref_out, equal_nan=True)
+
+
 # @pytest.mark.skipif(flag_gems.vendor_name == "hygon", reason="RESULT TODOFIX")
 @pytest.mark.randperm
 @pytest.mark.parametrize("n", [123, 12345, 123456])

--- a/tests/test_tensor_constructor_ops.py
+++ b/tests/test_tensor_constructor_ops.py
@@ -6,17 +6,10 @@ from packaging import version
 
 import flag_gems
 
-from .accuracy_utils import (
-    ALL_FLOAT_DTYPES,
-    ALL_INT_DTYPES,
-    BOOL_TYPES,
-    DISTRIBUTION_SHAPES,
-    FLOAT_DTYPES,
-    POINTWISE_SHAPES,
-    gems_assert_close,
-    gems_assert_equal,
-    to_reference,
-)
+from .accuracy_utils import (ALL_FLOAT_DTYPES, ALL_INT_DTYPES, BOOL_TYPES,
+                             DISTRIBUTION_SHAPES, FLOAT_DTYPES,
+                             POINTWISE_SHAPES, gems_assert_close,
+                             gems_assert_equal, to_reference)
 from .conftest import TO_CPU
 
 device = flag_gems.device


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `new_full` operator implementation with Triton kernel.

- Implementation mode: `manual_kernel`
- Accuracy test: 1344/1920 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 1.3887 | 1.4129 | 0.983 |
| [64, 64] | 0.0066 | 0.0066 | 1.000 |
| [4096, 4096] | 0.0288 | 0.0306 | 0.940 |
| [64, 512, 512] | 0.0279 | 0.0306 | 0.913 |
| [1024, 1024, 1024] | 1.3874 | 1.4124 | 0.982 |
| [268435456] | 0.3524 | 0.3546 | 0.994 |
| [10000, 1] | 0.0062 | 0.0062 | 1.000 |
| [10000, 256] | 0.0094 | 0.0106 | 0.891 |
| [10000, 65536] | 0.8493 | 0.8590 | 0.989 |
| [100, 1, 100] | 0.0062 | 0.0066 | 0.947 |
| [100, 256, 100] | 0.0095 | 0.0101 | 0.937 |
| [100, 65536, 100] | 0.8503 | 0.8594 | 0.989 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 1.3874 | 1.4129 | 0.982 |
| [64, 64] | 0.0062 | 0.0066 | 0.942 |
| [4096, 4096] | 0.0279 | 0.0305 | 0.916 |
| [64, 512, 512] | 0.0279 | 0.0306 | 0.914 |
| [1024, 1024, 1024] | 1.3874 | 1.4129 | 0.982 |
| [268435456] | 0.3525 | 0.3545 | 0.994 |
| [10000, 1] | 0.0062 | 0.0062 | 1.000 |
| [10000, 256] | 0.0095 | 0.0109 | 0.865 |
| [10000, 65536] | 0.8493 | 0.8593 | 0.988 |
| [100, 1, 100] | 0.0067 | 0.0062 | 1.077 |
| [100, 256, 100] | 0.0103 | 0.0101 | 1.019 |
| [100, 65536, 100] | 0.8492 | 0.8597 | 0.988 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 2.7725 | 2.8399 | 0.976 |
| [64, 64] | 0.0062 | 0.0062 | 1.000 |
| [4096, 4096] | 0.0502 | 0.0501 | 1.001 |
| [64, 512, 512] | 0.0502 | 0.0501 | 1.003 |
| [1024, 1024, 1024] | 2.7722 | 2.8390 | 0.976 |
| [268435456] | 0.6977 | 0.7008 | 0.996 |
| [10000, 1] | 0.0067 | 0.0074 | 0.901 |
| [10000, 256] | 0.0127 | 0.0133 | 0.959 |
| [10000, 65536] | 1.6956 | 1.7230 | 0.984 |
| [100, 1, 100] | 0.0066 | 0.0062 | 1.056 |
| [100, 256, 100] | 0.0134 | 0.0134 | 1.002 |
| [100, 65536, 100] | 1.6955 | 1.7233 | 0.984 |

**Overall: median speedup = 0.984x, mean speedup = 0.974x** (36 data points)

---
_Generated by auto_gen tool with Claude Code_
