### PR TITLE
【KernelGen】Add nll_loss_nd operator

### DIFF
--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -233,6 +233,44 @@ def test_nll_loss2d_benchmark():
     bench.run()
 
 
+def nll_loss_nd_input_fn(shape, cur_dtype, device):
+    """Input function for nll_loss_nd supporting N-dimensional inputs."""
+    inp = generate_tensor_input(shape, cur_dtype, device)
+    target_shape = list(shape)
+    del target_shape[1]  # Remove C dimension
+    target = torch.randint(0, shape[1], target_shape, device=device)
+    yield inp, target
+    if Config.bench_level == BenchLevel.COMPREHENSIVE:
+        weight = torch.randn(shape[1], dtype=cur_dtype, device=device)
+        yield inp, target, {"weight": weight, "ignore_index": 1, "reduction": "none"}
+
+
+class NLLLossNDBenchmark(GenericBenchmark):
+    """Benchmark for N-dimensional NLL Loss."""
+
+    def get_input_iter(self, cur_dtype) -> Generator:
+        # N-dimensional shapes: (N, C, d1, d2, ..., dk)
+        shapes_nd = [
+            (16, 32),  # 2D: (N, C)
+            (8, 16, 128),  # 3D: (N, C, L)
+            (4, 8, 32, 32),  # 4D: (N, C, H, W)
+            (2, 4, 8, 16, 16),  # 5D: (N, C, D, H, W)
+        ]
+        for shape in shapes_nd:
+            yield from self.input_fn(shape, cur_dtype, self.device)
+
+
+@pytest.mark.nll_loss_nd
+def test_nll_loss_nd_benchmark():
+    bench = NLLLossNDBenchmark(
+        input_fn=nll_loss_nd_input_fn,
+        op_name="nll_loss_nd",
+        torch_op=torch.nn.functional.nll_loss,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.run()
+
+
 # @pytest.mark.skipif(vendor_name == "hygon", reason="RESULT TODOFIX")
 @pytest.mark.count_nonzero
 def test_perf_count_nonzero():

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -255,6 +255,7 @@ _FULL_CONFIG = (
     ("neg_", neg_),
     ("nll_loss_backward", nll_loss_backward),
     ("nll_loss_forward", nll_loss_forward),
+    ("nll_loss_nd", nll_loss_nd),
     ("nll_loss2d_backward", nll_loss2d_backward),
     ("nll_loss2d_forward", nll_loss2d_forward),
     ("nonzero", nonzero),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -145,6 +145,7 @@ from flag_gems.ops.mv import mv
 from flag_gems.ops.nan_to_num import nan_to_num
 from flag_gems.ops.ne import ne, ne_scalar
 from flag_gems.ops.neg import neg, neg_
+from flag_gems.ops.nll_loss_nd import nll_loss_nd
 from flag_gems.ops.nllloss import (
     nll_loss2d_backward,
     nll_loss2d_forward,
@@ -432,6 +433,7 @@ __all__ = [
     "neg_",
     "nll_loss_backward",
     "nll_loss_forward",
+    "nll_loss_nd",
     "nll_loss2d_backward",
     "nll_loss2d_forward",
     "nonzero",

--- a/src/flag_gems/ops/nll_loss_nd.py
+++ b/src/flag_gems/ops/nll_loss_nd.py
@@ -1,0 +1,256 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.jit(do_not_specialize=["ignore_index"])
+def nll_loss_nd_kernel(
+    inp_ptr,
+    tgt_ptr,
+    wgt_ptr,
+    out_ptr,
+    total_weight_ptr,
+    ignore_index,
+    N,
+    C,
+    D,
+    reduction: tl.constexpr = 1,
+    BLOCK_ND: tl.constexpr = 128,
+):
+    """
+    N-dimensional NLL Loss forward kernel.
+
+    Input shape: (N, C, d1, d2, ..., dk) where D = d1 * d2 * ... * dk
+    Target shape: (N, d1, d2, ..., dk) where D = d1 * d2 * ... * dk
+
+    Memory layout:
+    - inp: inp[n, c, d] = inp_ptr[n * C * D + c * D + d]
+    - tgt: tgt[n, d] = tgt_ptr[n * D + d]
+    """
+    pid_nd = tl.program_id(0)
+    offset_nd = pid_nd * BLOCK_ND + tl.arange(0, BLOCK_ND)
+    offset_d = offset_nd % D
+    offset_n = offset_nd // D
+
+    mask_block = offset_nd < N * D
+
+    tgt_ptrs = tgt_ptr + offset_n * D + offset_d
+    tgt = tl.load(tgt_ptrs, mask=mask_block, other=0)
+    ignore_mask = not (tgt == ignore_index) and mask_block
+
+    if wgt_ptr is None:
+        wgt_tgt = ignore_mask.to(tl.float32)
+    else:
+        wgt_tgt = tl.load(wgt_ptr + tgt, mask=ignore_mask, other=0).to(tl.float32)
+
+    inp_tgt_ptrs = inp_ptr + offset_n * C * D + tgt * D + offset_d
+    inp_tgt = tl.load(inp_tgt_ptrs, mask=ignore_mask, other=0).to(tl.float32)
+    out = inp_tgt * wgt_tgt * -1
+
+    # none
+    if reduction == 0:
+        out_ptrs = out_ptr + offset_n * D + offset_d
+        tl.store(out_ptrs, out, mask=mask_block)
+    # mean
+    elif reduction == 1:
+        total_out = tl.sum(out)
+        total_wgt = tl.sum(wgt_tgt)
+        tl.atomic_add(out_ptr, total_out, sem="relaxed")  # output
+        tl.atomic_add(total_weight_ptr, total_wgt, sem="relaxed")  # weight
+        tl.atomic_add(total_weight_ptr + 1, 1, sem="release")  # counter
+        counter = tl.load(total_weight_ptr + 1)
+        if counter == tl.num_programs(0):
+            total_out = tl.load(out_ptr)
+            total_wgt = tl.load(total_weight_ptr)
+            tl.store(out_ptr, total_out / total_wgt)
+    # sum
+    else:
+        total_out = tl.sum(out)
+        tl.atomic_add(out_ptr, total_out, sem="relaxed")
+
+
+@libentry()
+@triton.jit(do_not_specialize=["ignore_index"])
+def nll_loss_nd_backward_kernel(
+    out_grad_ptr,
+    tgt_ptr,
+    wgt_ptr,
+    inp_grad_ptr,
+    ignore_index,
+    total_weight,
+    N,
+    C,
+    D,
+    reduction: tl.constexpr = 1,
+    BLOCK_ND: tl.constexpr = 128,
+):
+    """
+    N-dimensional NLL Loss backward kernel.
+    """
+    pid_nd = tl.program_id(0)
+    offset_nd = pid_nd * BLOCK_ND + tl.arange(0, BLOCK_ND)
+    offset_d = offset_nd % D
+    offset_n = offset_nd // D
+
+    mask_block = offset_nd < N * D
+
+    tgt_ptrs = tgt_ptr + offset_n * D + offset_d
+    tgt = tl.load(tgt_ptrs, mask=mask_block, other=0)
+    ignore_mask = not (tgt == ignore_index) and mask_block
+
+    if wgt_ptr is None:
+        wgt_tgt = ignore_mask.to(tl.float32)
+    else:
+        wgt_tgt = tl.load(wgt_ptr + tgt, mask=ignore_mask, other=0).to(tl.float32)
+
+    if reduction == 0:
+        out_grad_ptrs = out_grad_ptr + offset_n * D + offset_d
+        out_grad = tl.load(out_grad_ptrs, mask=mask_block, other=0).to(tl.float32)
+    else:
+        out_grad = tl.load(out_grad_ptr).to(tl.float32)
+
+    if reduction == 1:
+        total_w = tl.load(total_weight).to(tl.float32)
+    else:
+        total_w = 1
+
+    inp_grad = tl.where(ignore_mask, -1 * out_grad * wgt_tgt / total_w, 0)
+    inp_grad_ptrs = inp_grad_ptr + offset_n * C * D + tgt * D + offset_d
+    tl.store(inp_grad_ptrs, inp_grad, mask=mask_block)
+
+
+class NLLLossND(torch.autograd.Function):
+    """
+    Autograd Function for N-dimensional NLL Loss.
+    """
+
+    @staticmethod
+    def forward(ctx, self, target, weight, reduction, ignore_index):
+        logger.debug("GEMS NLL Loss ND")
+
+        # Handle input dimensions
+        # Input: (N, C) or (N, C, d1, d2, ..., dk)
+        # Target: (N,) or (N, d1, d2, ..., dk)
+        ndim = self.ndim
+        assert ndim >= 2, "Input must have at least 2 dimensions"
+
+        N = self.shape[0]
+        C = self.shape[1]
+
+        if ndim == 2:
+            # (N, C) -> D = 1
+            D = 1
+        else:
+            # (N, C, d1, d2, ..., dk) -> D = d1 * d2 * ... * dk
+            D = 1
+            for i in range(2, ndim):
+                D *= self.shape[i]
+
+        target_shape = list(target.shape)
+
+        # Validate target shape
+        expected_target_numel = N * D
+        assert (
+            target.numel() == expected_target_numel
+        ), f"Invalid target size: got {target.numel()}, expected {expected_target_numel}"
+
+        inp = self.contiguous()
+        target = target.contiguous()
+        weight = None if weight is None else weight.contiguous()
+
+        # Output shape
+        if reduction == 0:
+            out = torch.empty(target_shape, dtype=inp.dtype, device=inp.device)
+            total_weight = torch.empty([], dtype=inp.dtype, device=inp.device)
+        elif reduction == 1:
+            out = torch.zeros([], dtype=torch.float32, device=inp.device)
+            total_weight = torch.zeros([2], dtype=torch.float32, device=inp.device)
+        else:
+            out = torch.zeros([], dtype=torch.float32, device=inp.device)
+            total_weight = torch.empty([], dtype=inp.dtype, device=inp.device)
+
+        grid = lambda meta: (triton.cdiv(N * D, meta["BLOCK_ND"]),)
+        with torch_device_fn.device(inp.device):
+            nll_loss_nd_kernel[grid](
+                inp, target, weight, out, total_weight, ignore_index, N, C, D, reduction
+            )
+
+        # Process output based on reduction
+        if reduction == 0:
+            output = out
+        elif reduction == 1:
+            output = out.to(inp.dtype)
+            total_weight = total_weight[0:1].view([])  # Extract just the weight
+        else:
+            output = out.to(inp.dtype)
+
+        # Save for backward
+        ctx.save_for_backward(inp, target, weight, total_weight)
+        ctx.reduction = reduction
+        ctx.ignore_index = ignore_index
+        ctx.N = N
+        ctx.C = C
+        ctx.D = D
+
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        logger.debug("GEMS NLL Loss ND BWD")
+
+        inp, target, weight, total_weight = ctx.saved_tensors
+        reduction = ctx.reduction
+        ignore_index = ctx.ignore_index
+        N = ctx.N
+        C = ctx.C
+        D = ctx.D
+
+        grad_output = grad_output.contiguous()
+
+        grad_input = torch.zeros_like(inp).contiguous()
+
+        grid = lambda meta: (triton.cdiv(N * D, meta["BLOCK_ND"]),)
+        with torch_device_fn.device(inp.device):
+            nll_loss_nd_backward_kernel[grid](
+                grad_output,
+                target,
+                weight,
+                grad_input,
+                ignore_index,
+                total_weight,
+                N,
+                C,
+                D,
+                reduction,
+            )
+
+        return grad_input, None, None, None, None
+
+
+def nll_loss_nd(self, target, weight=None, reduction=1, ignore_index=-100):
+    """
+    N-dimensional NLL Loss.
+
+    Computes the negative log likelihood loss for N-dimensional inputs.
+
+    Args:
+        self: Input tensor of shape (N, C) or (N, C, d1, d2, ..., dk)
+              Expected to contain log-probabilities.
+        target: Target tensor of shape (N,) or (N, d1, d2, ..., dk)
+                Contains class indices in range [0, C-1].
+        weight: Optional weight tensor of shape (C,) for class weighting.
+        reduction: Reduction mode (0=none, 1=mean, 2=sum).
+        ignore_index: Target value to ignore in loss computation.
+
+    Returns:
+        Loss tensor.
+    """
+    return NLLLossND.apply(self, target, weight, reduction, ignore_index)

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -2201,3 +2201,62 @@ def test_accuracy_masked_scatter_(shape, dtype, threshold):
         inp.masked_scatter_(mask, src)
 
     gems_assert_equal(inp, ref_inp)
+
+
+# N-dimensional NLL Loss shapes: (N, C, d1, d2, ..., dk)
+# These shapes cover 2D, 3D, 4D, and 5D inputs
+NLLLOSS_ND_SHAPES = (
+    [(2, 4, 8)]  # 3D
+    if QUICK_MODE
+    else [
+        (3, 5),  # 2D: (N, C)
+        (2, 4, 8),  # 3D: (N, C, L)
+        (2, 4, 4, 8),  # 4D: (N, C, H, W)
+        (2, 3, 2, 4, 3),  # 5D: (N, C, D, H, W)
+    ]
+)
+
+
+@pytest.mark.nll_loss_nd
+@pytest.mark.parametrize("reduction", ["mean", "none", "sum"])
+@pytest.mark.parametrize("weight", [True, False])
+@pytest.mark.parametrize("shape", NLLLOSS_ND_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("ignore_index", [1, 200, -100])
+def test_accuracy_nll_loss_nd(shape, dtype, ignore_index, reduction, weight):
+    if flag_gems.vendor_name == "kunlunxin":
+        torch.manual_seed(0)
+        torch.cuda.manual_seed_all(0)
+        np.random.seed(0)
+        random.seed(0)
+
+    dim = 1
+    target_shape = list(shape)
+    del target_shape[dim]
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    target = torch.randint(0, shape[dim], target_shape, device=flag_gems.device)
+    if weight:
+        weight = torch.randn(shape[dim], dtype=dtype, device=flag_gems.device)
+    else:
+        weight = None
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target)
+    ref_weight = to_reference(weight, True)
+
+    ref_out = torch.nn.functional.nll_loss(
+        ref_inp, ref_target, ref_weight, reduction=reduction, ignore_index=ignore_index
+    )
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.nll_loss(
+            inp, target, weight, reduction=reduction, ignore_index=ignore_index
+        )
+    reduce_dim = 1 if reduction == "none" else target.numel()
+    gems_assert_close(res_out, ref_out, dtype, reduce_dim=reduce_dim, equal_nan=True)
+
+    out_grad = torch.randn_like(res_out)
+    ref_grad = to_reference(out_grad, True)
+    (ref_in_grad,) = torch.autograd.grad(ref_out, ref_inp, ref_grad)
+    with flag_gems.use_gems():
+        (res_in_grad,) = torch.autograd.grad(res_out, inp, out_grad)
+    gems_assert_close(res_in_grad, ref_in_grad, dtype, reduce_dim=shape[dim])


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `nll_loss_nd` operator implementation with Triton kernel.

- Implementation mode: `N/A`
- Accuracy test: 216/216 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([16, 32]) | 0.0088 | 0.1651 | 0.054 |
| torch.Size([8, 16, 128]) | 0.0218 | 0.1639 | 0.133 |
| torch.Size([4, 8, 32, 32]) | 0.0198 | 0.1652 | 0.120 |
| torch.Size([2, 4, 8, 16, 16]) | 0.0200 | 0.1697 | 0.118 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([16, 32]) | 0.0092 | 0.1596 | 0.058 |
| torch.Size([8, 16, 128]) | 0.0194 | 0.1628 | 0.119 |
| torch.Size([4, 8, 32, 32]) | 0.0187 | 0.1632 | 0.114 |
| torch.Size([2, 4, 8, 16, 16]) | 0.0197 | 0.1645 | 0.120 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([16, 32]) | 0.0081 | 0.0713 | 0.114 |
| torch.Size([8, 16, 128]) | 0.0162 | 0.0717 | 0.226 |
| torch.Size([4, 8, 32, 32]) | 0.0167 | 0.0739 | 0.226 |
| torch.Size([2, 4, 8, 16, 16]) | 0.0182 | 0.0717 | 0.254 |

**Overall: median speedup = 0.119x, mean speedup = 0.138x** (12 data points)

---
_Generated by auto_gen tool with Claude Code_
