### PR TITLE
【KernelGen】Add rsub operator

### DIFF
--- a/benchmark/test_rsub.py
+++ b/benchmark/test_rsub.py
@@ -1,0 +1,37 @@
+import pytest
+import torch
+
+from . import base, consts, utils
+
+
+def _tensor_input_fn(shape, dtype, device):
+    inp1 = utils.generate_tensor_input(shape, dtype, device)
+    inp2 = utils.generate_tensor_input(shape, dtype, device)
+    yield inp1, inp2
+
+
+def _scalar_input_fn(shape, dtype, device):
+    inp1 = utils.generate_tensor_input(shape, dtype, device)
+    yield inp1, 0.5
+
+
+@pytest.mark.rsub_tensor
+def test_rsub_tensor():
+    bench = base.GenericBenchmark(
+        input_fn=_tensor_input_fn,
+        op_name="rsub.Tensor",
+        torch_op=torch.rsub,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.rsub_scalar
+def test_rsub_scalar():
+    bench = base.GenericBenchmark(
+        input_fn=_scalar_input_fn,
+        op_name="rsub.Scalar",
+        torch_op=torch.rsub,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -410,6 +410,8 @@ _FULL_CONFIG = (
     ("rrelu_with_noise_backward", rrelu_with_noise_backward),
     ("rsqrt", rsqrt),
     ("rsqrt_", rsqrt_),
+    ("rsub.Scalar", rsub_scalar),
+    ("rsub.Tensor", rsub_tensor),
     ("scaled_softmax_backward", scaled_softmax_backward),
     ("scaled_softmax_forward", scaled_softmax_forward),
     ("scatter.reduce", scatter),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -277,6 +277,7 @@ from flag_gems.ops.roll import roll
 from flag_gems.ops.round import round, round_, round_out
 from flag_gems.ops.rrelu_with_noise_backward import rrelu_with_noise_backward
 from flag_gems.ops.rsqrt import rsqrt, rsqrt_
+from flag_gems.ops.rsub import rsub_scalar, rsub_tensor
 from flag_gems.ops.scaled_softmax import scaled_softmax_backward, scaled_softmax_forward
 from flag_gems.ops.scatter import scatter, scatter_
 from flag_gems.ops.scatter_add_ import scatter_add_
@@ -696,6 +697,8 @@ __all__ = [
     "rrelu_with_noise_backward",
     "rsqrt",
     "rsqrt_",
+    "rsub_scalar",
+    "rsub_tensor",
     "scaled_dot_product_attention",
     "scaled_dot_product_attention_backward",
     "scaled_dot_product_attention_forward",

--- a/src/flag_gems/ops/rsub.py
+++ b/src/flag_gems/ops/rsub.py
@@ -1,0 +1,31 @@
+import logging
+
+import triton
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(is_tensor=[True, True, False], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def rsub_func(x, y, alpha):
+    return y - x * alpha
+
+
+@pointwise_dynamic(
+    is_tensor=[True, False, False], promotion_methods=[(0, 1, "DEFAULT")]
+)
+@triton.jit
+def rsub_func_tensor_scalar(x, y, alpha):
+    return y - x * alpha
+
+
+def rsub_tensor(A, B, *, alpha=1):
+    logger.debug("GEMS RSUB_TENSOR")
+    return rsub_func(A, B, alpha)
+
+
+def rsub_scalar(A, B, alpha=1):
+    logger.debug("GEMS RSUB_SCALAR")
+    return rsub_func_tensor_scalar(A, B, alpha)

--- a/tests/test_rsub.py
+++ b/tests/test_rsub.py
@@ -1,0 +1,42 @@
+import pytest
+import torch
+
+import flag_gems
+
+from .accuracy_utils import (
+    FLOAT_DTYPES,
+    POINTWISE_SHAPES,
+    gems_assert_close,
+    to_reference,
+)
+
+
+@pytest.mark.rsub_tensor
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_rsub_tensor(shape, dtype):
+    inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    inp2 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.rsub(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.rsub(inp1, inp2)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.rsub_scalar
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_rsub_scalar(shape, dtype):
+    inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp1 = to_reference(inp1)
+    inp2 = 0.5
+
+    ref_out = torch.rsub(ref_inp1, inp2)
+    with flag_gems.use_gems():
+        res_out = torch.rsub(inp1, inp2)
+
+    gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `rsub` operator implementation with Triton kernel.

- Implementation mode: `pointwise_dynamic`
- Accuracy test: 360/360 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 4.7474 | 4.6703 | 1.017 |
| [64, 64] | 0.0068 | 0.0074 | 0.926 |
| [4096, 4096] | 0.0857 | 0.0857 | 1.001 |
| [64, 512, 512] | 0.0856 | 0.0857 | 0.999 |
| [1024, 1024, 1024] | 4.7481 | 4.6625 | 1.018 |
| [1024, 1] | 0.0071 | 0.0072 | 0.987 |
| [1024, 16] | 0.0074 | 0.0071 | 1.050 |
| [1024, 256] | 0.0086 | 0.0086 | 1.000 |
| [1024, 4096] | 0.0286 | 0.0288 | 0.992 |
| [1024, 65536] | 0.3061 | 0.3040 | 1.007 |
| [64, 64, 1] | 0.0078 | 0.0074 | 1.061 |
| [64, 64, 16] | 0.0073 | 0.0073 | 1.000 |
| [64, 64, 256] | 0.0134 | 0.0131 | 1.022 |
| [64, 64, 4096] | 0.0856 | 0.0856 | 1.000 |
| [64, 64, 65536] | 1.1927 | 1.1854 | 1.006 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 4.7495 | 4.6840 | 1.014 |
| [64, 64] | 0.0073 | 0.0074 | 0.987 |
| [4096, 4096] | 0.0857 | 0.0856 | 1.001 |
| [64, 512, 512] | 0.0863 | 0.0855 | 1.009 |
| [1024, 1024, 1024] | 4.7464 | 4.6970 | 1.011 |
| [1024, 1] | 0.0068 | 0.0072 | 0.951 |
| [1024, 16] | 0.0074 | 0.0071 | 1.050 |
| [1024, 256] | 0.0086 | 0.0093 | 0.925 |
| [1024, 4096] | 0.0278 | 0.0287 | 0.968 |
| [1024, 65536] | 0.3060 | 0.3032 | 1.009 |
| [64, 64, 1] | 0.0080 | 0.0076 | 1.050 |
| [64, 64, 16] | 0.0078 | 0.0077 | 1.017 |
| [64, 64, 256] | 0.0133 | 0.0133 | 1.000 |
| [64, 64, 4096] | 0.0856 | 0.0855 | 1.001 |
| [64, 64, 65536] | 1.1934 | 1.1858 | 1.006 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 9.4794 | 9.3395 | 1.015 |
| [64, 64] | 0.0068 | 0.0071 | 0.964 |
| [4096, 4096] | 0.1579 | 0.1578 | 1.001 |
| [64, 512, 512] | 0.1576 | 0.1575 | 1.001 |
| [1024, 1024, 1024] | 9.4795 | 9.3306 | 1.016 |
| [1024, 1] | 0.0068 | 0.0072 | 0.951 |
| [1024, 16] | 0.0071 | 0.0076 | 0.925 |
| [1024, 256] | 0.0101 | 0.0110 | 0.922 |
| [1024, 4096] | 0.0474 | 0.0480 | 0.987 |
| [1024, 65536] | 0.6022 | 0.5972 | 1.008 |
| [64, 64, 1] | 0.0074 | 0.0081 | 0.909 |
| [64, 64, 16] | 0.0079 | 0.0076 | 1.042 |
| [64, 64, 256] | 0.0165 | 0.0169 | 0.979 |
| [64, 64, 4096] | 0.1578 | 0.1584 | 0.996 |
| [64, 64, 65536] | 2.3780 | 2.3496 | 1.012 |

**Overall: median speedup = 1.001x, mean speedup = 0.996x** (45 data points)

---
_Generated by auto_gen tool with Claude Code_
