### PR TITLE
【KernelGen】Add scatter_reduce_ operator

### DIFF
--- a/benchmark/test_scatter_reduce_two.py
+++ b/benchmark/test_scatter_reduce_two.py
@@ -1,0 +1,64 @@
+import pytest
+import torch
+
+from . import base, consts
+
+
+def _input_fn_factory(reduce):
+    def inner(shape, dtype, device):
+        inp = torch.randn(shape, dtype=dtype, device=device)
+        dim = -1
+        size_dim = shape[dim]
+        index = torch.randint(0, size_dim, shape, dtype=torch.long, device=device)
+        src = torch.randn(shape, dtype=dtype, device=device)
+        yield inp, dim, index, src, {"reduce": reduce}
+
+    return inner
+
+
+@pytest.mark.scatter_reduce_two_
+def test_scatter_reduce_two_inplace_sum():
+    bench = base.GenericBenchmark2DOnly(
+        op_name="scatter_reduce_.sum",
+        torch_op=torch.Tensor.scatter_reduce_,
+        input_fn=_input_fn_factory("sum"),
+        dtypes=consts.FLOAT_DTYPES,
+        inplace=True,
+    )
+    bench.run()
+
+
+@pytest.mark.scatter_reduce_two_
+def test_scatter_reduce_two_inplace_amax():
+    bench = base.GenericBenchmark2DOnly(
+        op_name="scatter_reduce_.amax",
+        torch_op=torch.Tensor.scatter_reduce_,
+        input_fn=_input_fn_factory("amax"),
+        dtypes=consts.FLOAT_DTYPES,
+        inplace=True,
+    )
+    bench.run()
+
+
+@pytest.mark.scatter_reduce_two_
+def test_scatter_reduce_two_inplace_amin():
+    bench = base.GenericBenchmark2DOnly(
+        op_name="scatter_reduce_.amin",
+        torch_op=torch.Tensor.scatter_reduce_,
+        input_fn=_input_fn_factory("amin"),
+        dtypes=consts.FLOAT_DTYPES,
+        inplace=True,
+    )
+    bench.run()
+
+
+@pytest.mark.scatter_reduce_two_
+def test_scatter_reduce_two_inplace_mean():
+    bench = base.GenericBenchmark2DOnly(
+        op_name="scatter_reduce_.mean",
+        torch_op=torch.Tensor.scatter_reduce_,
+        input_fn=_input_fn_factory("mean"),
+        dtypes=consts.FLOAT_DTYPES,
+        inplace=True,
+    )
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -417,6 +417,7 @@ _FULL_CONFIG = (
     ("scatter_.reduce", scatter_),
     ("scatter_.src", scatter_),
     ("scatter_add_", scatter_add_),
+    ("scatter_reduce_.two", scatter_reduce_),
     ("select_backward", select_backward),
     ("select_scatter", select_scatter),
     ("selu", selu),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -280,6 +280,7 @@ from flag_gems.ops.rsqrt import rsqrt, rsqrt_
 from flag_gems.ops.scaled_softmax import scaled_softmax_backward, scaled_softmax_forward
 from flag_gems.ops.scatter import scatter, scatter_
 from flag_gems.ops.scatter_add_ import scatter_add_
+from flag_gems.ops.scatter_reduce_ import scatter_reduce_
 from flag_gems.ops.select_backward import select_backward
 from flag_gems.ops.select_scatter import select_scatter
 from flag_gems.ops.selu import selu
@@ -704,6 +705,7 @@ __all__ = [
     "scatter",
     "scatter_",
     "scatter_add_",
+    "scatter_reduce_",
     "select_backward",
     "select_scatter",
     "selu",

--- a/src/flag_gems/ops/scatter_reduce_.py
+++ b/src/flag_gems/ops/scatter_reduce_.py
@@ -1,0 +1,610 @@
+import importlib
+import logging
+import os
+from typing import Any, Callable, List, Mapping, Tuple
+
+import torch
+
+from flag_gems.utils.code_cache import code_cache_dir
+from flag_gems.utils.code_utils import IndentedBuffer, write_atomic
+from flag_gems.utils.shape_utils import (
+    MemOverlap,
+    has_internal_overlapping,
+    restride_dim,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
+    code.writeline("import torch")
+    code.writeline("import triton")
+    code.writeline("import triton.language as tl")
+    code.newline()
+    code.writeline("from flag_gems.utils import libentry")
+    code.writeline("from flag_gems import runtime")
+    code.writeline("import flag_gems")
+    code.newline()
+    code.newline()
+    return code
+
+
+def generate_scatter_reduce_kernel(
+    rank: int,
+    kernel_name: str,
+    code: IndentedBuffer,
+) -> IndentedBuffer:
+    code.newline()
+
+    # the autotune function
+    code.writeline("def heur_block(args):")
+    with code.indent():
+        code.writeline("if(flag_gems.vendor_name in ['metax', 'iluvatar']):")
+        with code.indent():
+            code.writeline("return 256")
+        code.writeline("return 128")
+    code.newline()
+    code.newline()
+
+    code.writeline("def loop_count(args):")
+    with code.indent():
+        code.writeline("return 4")
+    code.newline()
+    code.newline()
+
+    # the decorators
+    code.writeline("@libentry()")
+    code.writeline("@triton.heuristics(")
+    with code.indent():
+        code.writeline("{")
+        with code.indent():
+            code.writeline('"BLOCK": heur_block,')
+            code.writeline('"LOOP": loop_count,')
+        code.writeline("}")
+    code.writeline(")")
+    inp_stride_vars = ",".join(f"'inp_stride_{i}'" for i in range(rank))
+    index_stride_vars = ",".join(f"'index_stride_{i}'" for i in range(rank))
+    src_stride_vars = ",".join(f"'src_stride_{i}'" for i in range(rank))
+    shape_vars = ",".join(f"'shape_{i}'" for i in range(rank))
+    code.writeline(
+        f"@triton.jit(do_not_specialize=['N','stride_dim','inp_size_dim',"
+        f"{inp_stride_vars},{index_stride_vars},{src_stride_vars},{shape_vars}])"
+    )
+
+    # signature
+    code.writeline(f"def {kernel_name}(")
+    with code.indent():
+        if rank > 0:
+            code.writeline("src_strided,")
+            code.writeline("index,")
+            code.writeline("inp,")
+            code.writeline("out,")
+
+            stride_args = ", ".join(f"inp_stride_{i}: int" for i in range(rank))
+            code.writeline(f"{stride_args}, # stride for inp")
+
+            stride_args = ", ".join(f"index_stride_{i}: int" for i in range(rank))
+            code.writeline(f"{stride_args}, # stride for index")
+
+            stride_args = ", ".join(f"src_stride_{i}: int" for i in range(rank))
+            code.writeline(f"{stride_args}, # stride for src")
+
+            shape_args = ", ".join(f"shape_{i}: int" for i in range(rank))
+            code.writeline(f"{shape_args}, # shape")
+            code.writeline("inp_size_dim,")
+            code.writeline("stride_dim,")
+            code.writeline("N,")
+            # reduce options
+            code.writeline("IS_SUM: tl.constexpr,")
+            code.writeline("IS_PROD: tl.constexpr,")
+            code.writeline("IS_AMAX: tl.constexpr,")
+            code.writeline("IS_AMIN: tl.constexpr,")
+            code.writeline("IS_MEAN: tl.constexpr,")
+            code.writeline("IS_FLOAT32: tl.constexpr,")
+            code.writeline("BLOCK: tl.constexpr,")
+            code.writeline("LOOP: tl.constexpr,")
+            code.writeline("INT32_OFFSET: tl.constexpr")
+
+    code.writeline("):")
+
+    # Kernel Code
+    with code.indent():
+        code.writeline("pid = tl.program_id(0)")
+        code.writeline("if not INT32_OFFSET:")
+        with code.indent():
+            code.writeline("pid = pid.to(tl.int64)")
+        code.writeline("offsets = pid * LOOP * BLOCK + tl.arange(0, BLOCK)")
+
+        #   1. Calculate inp_offsets and idx_offsets
+        code.writeline("for loop_iter in tl.static_range(LOOP):")
+        with code.indent():
+            code.writeline("mask = offsets < N")
+            code.writeline("cur_idx = offsets")
+            code.writeline("if INT32_OFFSET:")
+            with code.indent():
+                code.writeline("inp_offsets = tl.zeros((BLOCK, ), dtype=tl.int32)")
+                code.writeline("idx_offsets = tl.zeros((BLOCK, ), dtype=tl.int32)")
+                code.writeline("src_offsets = tl.zeros((BLOCK, ), dtype=tl.int32)")
+            code.writeline("else:")
+            with code.indent():
+                code.writeline("inp_offsets = tl.zeros((BLOCK, ), dtype=tl.int64)")
+                code.writeline("idx_offsets = tl.zeros((BLOCK, ), dtype=tl.int64)")
+                code.writeline("src_offsets = tl.zeros((BLOCK, ), dtype=tl.int64)")
+            for i in range(rank)[::-1]:
+                code.writeline("if INT32_OFFSET:")
+                with code.indent():
+                    code.writeline(f"shape_{i} = shape_{i}.to(tl.int32)")
+                    code.writeline(f"inp_stride_{i} = inp_stride_{i}.to(tl.int32)")
+                    code.writeline(f"index_stride_{i} = index_stride_{i}.to(tl.int32)")
+                    code.writeline(f"src_stride_{i} = src_stride_{i}.to(tl.int32)")
+                code.writeline(f"mod = cur_idx % shape_{i}")
+                code.writeline(f"inp_offsets += mod * inp_stride_{i}")
+                code.writeline(f"idx_offsets += mod * index_stride_{i}")
+                code.writeline(f"src_offsets += mod * src_stride_{i}")
+                if i != 0:
+                    code.writeline(f"cur_idx = cur_idx // shape_{i}")
+
+            #   2. Use offsets to scatter
+            code.writeline(
+                "cur_src = tl.load(src_strided + src_offsets, mask=mask, other=0)"
+            )
+            code.writeline(
+                "cur_index = tl.load(index + idx_offsets, mask=mask, other=0)"
+            )
+            code.writeline("if INT32_OFFSET:")
+            with code.indent():
+                code.writeline("cur_index = cur_index.to(tl.int32)")
+                code.writeline("stride_dim = stride_dim.to(tl.int32)")
+
+            code.writeline("dim_offsets = cur_index * stride_dim")
+            code.writeline("inp_offsets += dim_offsets")
+            code.newline()
+
+            # Sum reduction using atomic_add (float32) or CAS loop (bf16/fp16)
+            code.writeline("if IS_SUM or IS_MEAN:")
+            with code.indent():
+                code.writeline("if IS_FLOAT32:")
+                with code.indent():
+                    code.writeline(
+                        "tl.atomic_add(out + inp_offsets, cur_src, mask=mask)"
+                    )
+                code.writeline("else:")
+                with code.indent():
+                    code.writeline("stop = tl.where(mask, 0, 1).to(tl.int1)")
+                    code.writeline("block_stop = False")
+                    code.writeline("while not block_stop:")
+                    with code.indent():
+                        code.writeline(
+                            "cur_inp = tl.load(out + inp_offsets, mask=mask, other=0)"
+                        )
+                        code.writeline(
+                            "res = tl.where(stop, cur_inp, cur_inp + cur_src)"
+                        )
+                        code.writeline(
+                            "cas_res = tl.atomic_cas(out + inp_offsets, cur_inp, res)"
+                        )
+                        code.writeline("stop |= cur_inp == cas_res")
+                        code.writeline(
+                            "block_stop = tl.sum(stop.to(tl.int32)) == BLOCK"
+                        )
+
+            # Product reduction using CAS loop
+            code.writeline("elif IS_PROD:")
+            with code.indent():
+                code.writeline("stop = tl.where(mask, 0, 1).to(tl.int1)")
+                code.writeline("block_stop = False")
+                code.writeline("while not block_stop:")
+                with code.indent():
+                    code.writeline(
+                        "cur_inp = tl.load(out + inp_offsets, mask=mask, other=0)"
+                    )
+                    code.writeline("res = tl.where(stop, cur_inp, cur_inp * cur_src)")
+                    code.writeline(
+                        "cas_res = tl.atomic_cas(out + inp_offsets, cur_inp, res)"
+                    )
+                    code.writeline("stop |= cur_inp == cas_res")
+                    code.writeline("block_stop = tl.sum(stop.to(tl.int32)) == BLOCK")
+
+            # Max reduction using CAS loop (atomic_max doesn't support float)
+            code.writeline("elif IS_AMAX:")
+            with code.indent():
+                code.writeline("stop = tl.where(mask, 0, 1).to(tl.int1)")
+                code.writeline("block_stop = False")
+                code.writeline("while not block_stop:")
+                with code.indent():
+                    code.writeline(
+                        "cur_inp = tl.load(out + inp_offsets, mask=mask, other=0)"
+                    )
+                    code.writeline(
+                        "new_val = tl.where(cur_src > cur_inp, cur_src, cur_inp)"
+                    )
+                    code.writeline("res = tl.where(stop, cur_inp, new_val)")
+                    code.writeline(
+                        "cas_res = tl.atomic_cas(out + inp_offsets, cur_inp, res)"
+                    )
+                    code.writeline("stop |= cur_inp == cas_res")
+                    code.writeline("block_stop = tl.sum(stop.to(tl.int32)) == BLOCK")
+
+            # Min reduction using CAS loop (atomic_min doesn't support float)
+            code.writeline("elif IS_AMIN:")
+            with code.indent():
+                code.writeline("stop = tl.where(mask, 0, 1).to(tl.int1)")
+                code.writeline("block_stop = False")
+                code.writeline("while not block_stop:")
+                with code.indent():
+                    code.writeline(
+                        "cur_inp = tl.load(out + inp_offsets, mask=mask, other=0)"
+                    )
+                    code.writeline(
+                        "new_val = tl.where(cur_src < cur_inp, cur_src, cur_inp)"
+                    )
+                    code.writeline("res = tl.where(stop, cur_inp, new_val)")
+                    code.writeline(
+                        "cas_res = tl.atomic_cas(out + inp_offsets, cur_inp, res)"
+                    )
+                    code.writeline("stop |= cur_inp == cas_res")
+                    code.writeline("block_stop = tl.sum(stop.to(tl.int32)) == BLOCK")
+
+            code.writeline("offsets += BLOCK")
+
+    code.newline()
+    code.newline()
+    return code
+
+
+def generate_count_kernel(
+    rank: int,
+    kernel_name: str,
+    code: IndentedBuffer,
+) -> IndentedBuffer:
+    """Generate kernel to count elements for mean reduction."""
+    code.newline()
+
+    # the decorators
+    code.writeline("@libentry()")
+    code.writeline("@triton.heuristics(")
+    with code.indent():
+        code.writeline("{")
+        with code.indent():
+            code.writeline('"BLOCK": heur_block,')
+            code.writeline('"LOOP": loop_count,')
+        code.writeline("}")
+    code.writeline(")")
+    inp_stride_vars = ",".join(f"'inp_stride_{i}'" for i in range(rank))
+    index_stride_vars = ",".join(f"'index_stride_{i}'" for i in range(rank))
+    shape_vars = ",".join(f"'shape_{i}'" for i in range(rank))
+    code.writeline(
+        f"@triton.jit(do_not_specialize=['N','stride_dim','inp_size_dim',"
+        f"{inp_stride_vars},{index_stride_vars},{shape_vars}])"
+    )
+
+    # signature
+    code.writeline(f"def {kernel_name}(")
+    with code.indent():
+        if rank > 0:
+            code.writeline("index,")
+            code.writeline("count,")
+
+            stride_args = ", ".join(f"inp_stride_{i}: int" for i in range(rank))
+            code.writeline(f"{stride_args}, # stride for inp")
+
+            stride_args = ", ".join(f"index_stride_{i}: int" for i in range(rank))
+            code.writeline(f"{stride_args}, # stride for index")
+
+            shape_args = ", ".join(f"shape_{i}: int" for i in range(rank))
+            code.writeline(f"{shape_args}, # shape")
+            code.writeline("inp_size_dim,")
+            code.writeline("stride_dim,")
+            code.writeline("N,")
+            code.writeline("BLOCK: tl.constexpr,")
+            code.writeline("LOOP: tl.constexpr,")
+            code.writeline("INT32_OFFSET: tl.constexpr")
+
+    code.writeline("):")
+
+    # Kernel Code
+    with code.indent():
+        code.writeline("pid = tl.program_id(0)")
+        code.writeline("if not INT32_OFFSET:")
+        with code.indent():
+            code.writeline("pid = pid.to(tl.int64)")
+        code.writeline("offsets = pid * LOOP * BLOCK + tl.arange(0, BLOCK)")
+
+        code.writeline("for loop_iter in tl.static_range(LOOP):")
+        with code.indent():
+            code.writeline("mask = offsets < N")
+            code.writeline("cur_idx = offsets")
+            code.writeline("if INT32_OFFSET:")
+            with code.indent():
+                code.writeline("inp_offsets = tl.zeros((BLOCK, ), dtype=tl.int32)")
+                code.writeline("idx_offsets = tl.zeros((BLOCK, ), dtype=tl.int32)")
+            code.writeline("else:")
+            with code.indent():
+                code.writeline("inp_offsets = tl.zeros((BLOCK, ), dtype=tl.int64)")
+                code.writeline("idx_offsets = tl.zeros((BLOCK, ), dtype=tl.int64)")
+            for i in range(rank)[::-1]:
+                code.writeline("if INT32_OFFSET:")
+                with code.indent():
+                    code.writeline(f"shape_{i} = shape_{i}.to(tl.int32)")
+                    code.writeline(f"inp_stride_{i} = inp_stride_{i}.to(tl.int32)")
+                    code.writeline(f"index_stride_{i} = index_stride_{i}.to(tl.int32)")
+                code.writeline(f"mod = cur_idx % shape_{i}")
+                code.writeline(f"inp_offsets += mod * inp_stride_{i}")
+                code.writeline(f"idx_offsets += mod * index_stride_{i}")
+                if i != 0:
+                    code.writeline(f"cur_idx = cur_idx // shape_{i}")
+
+            code.writeline(
+                "cur_index = tl.load(index + idx_offsets, mask=mask, other=0)"
+            )
+            code.writeline("if INT32_OFFSET:")
+            with code.indent():
+                code.writeline("cur_index = cur_index.to(tl.int32)")
+                code.writeline("stride_dim = stride_dim.to(tl.int32)")
+
+            code.writeline("dim_offsets = cur_index * stride_dim")
+            code.writeline("inp_offsets += dim_offsets")
+            code.newline()
+
+            # Add 1 for each element
+            code.writeline("one = tl.full((BLOCK,), 1, dtype=tl.int32)")
+            code.writeline("tl.atomic_add(count + inp_offsets, one, mask=mask)")
+            code.writeline("offsets += BLOCK")
+
+    code.newline()
+    code.newline()
+    return code
+
+
+def parameter_for_wrapper() -> str:
+    parameters: List[str] = []
+
+    parameters.append("src_strided")
+    parameters.append("index")
+    parameters.append("inp")
+    parameters.append("out")
+    parameters.append("dim_size")
+    parameters.append("dim_stride")
+    parameters.append("N")
+    parameters.append("reduce: tl.constexpr=None")
+    parameters.append("include_self: tl.constexpr=True")
+    parameters.append("int32_offset: tl.constexpr=None")
+
+    return ", ".join(parameters)
+
+
+def generate_destination_passing_wrapper(
+    rank: int,
+    wrapper_name: str,
+    kernel_name: str,
+    count_kernel_name: str,
+    code: IndentedBuffer,
+) -> IndentedBuffer:
+    parameters: str = parameter_for_wrapper()
+    wrapper_signature: str = f"def {wrapper_name}({parameters}):"
+    code.writeline(wrapper_signature)
+
+    with code.indent():
+        code.writeline("inp_strides = list(inp.stride())")
+        code.writeline("index_strides = index.stride()")
+        code.writeline("src_strides = src_strided.stride()")
+        code.writeline("index_shapes = list(index.shape)")
+        code.writeline("inp_size_dim = dim_size")
+        code.writeline("stride_dim = dim_stride")
+
+        code.writeline('IS_SUM = reduce == "sum"')
+        code.writeline('IS_PROD = reduce == "prod"')
+        code.writeline('IS_AMAX = reduce == "amax"')
+        code.writeline('IS_AMIN = reduce == "amin"')
+        code.writeline('IS_MEAN = reduce == "mean"')
+        code.writeline("IS_FLOAT32 = out.dtype == torch.float32")
+        code.writeline("int32_offset = int32_offset or True")
+
+        # kernel launch
+        code.writeline("grid = lambda meta: (")
+        with code.indent():
+            code.writeline('triton.cdiv(N, meta["BLOCK"] * meta["LOOP"]), ')
+        code.writeline(")")
+
+        kernel_launch: str = f"{kernel_name}[grid]("
+        code.writeline(kernel_launch)
+
+        with code.indent():
+            code.writeline("src_strided, index, inp, out, ")
+            if rank > 0:
+                s = ", ".join(f"inp_strides[{i}]" for i in range(rank))
+                code.writeline(f"{s},")
+
+                s = ", ".join(f"index_strides[{i}]" for i in range(rank))
+                code.writeline(f"{s},")
+
+                s = ", ".join(f"src_strides[{i}]" for i in range(rank))
+                code.writeline(f"{s},")
+
+                s = ", ".join(f"index_shapes[{i}]" for i in range(rank))
+                code.writeline(f"{s},")
+
+                code.writeline("inp_size_dim,")
+                code.writeline("stride_dim,")
+                code.writeline("N,")
+                # reduce options
+                code.writeline("IS_SUM,")
+                code.writeline("IS_PROD,")
+                code.writeline("IS_AMAX,")
+                code.writeline("IS_AMIN,")
+                code.writeline("IS_MEAN,")
+                code.writeline("IS_FLOAT32,")
+                code.writeline("INT32_OFFSET=int32_offset,")
+        code.writeline(")")
+
+        # Handle mean: need to divide by count
+        code.writeline("if IS_MEAN:")
+        with code.indent():
+            code.writeline("count = torch.zeros_like(out, dtype=torch.int32)")
+            # if include_self, initialize count to 1
+            code.writeline("if include_self:")
+            with code.indent():
+                code.writeline("count.fill_(1)")
+            count_launch: str = f"{count_kernel_name}[grid]("
+            code.writeline(count_launch)
+            with code.indent():
+                code.writeline("index, count, ")
+                if rank > 0:
+                    s = ", ".join(f"inp_strides[{i}]" for i in range(rank))
+                    code.writeline(f"{s},")
+
+                    s = ", ".join(f"index_strides[{i}]" for i in range(rank))
+                    code.writeline(f"{s},")
+
+                    s = ", ".join(f"index_shapes[{i}]" for i in range(rank))
+                    code.writeline(f"{s},")
+
+                    code.writeline("inp_size_dim,")
+                    code.writeline("stride_dim,")
+                    code.writeline("N,")
+                    code.writeline("INT32_OFFSET=int32_offset,")
+            code.writeline(")")
+            code.writeline("count = count.clamp(min=1)")
+            code.writeline("out.div_(count)")
+
+        code.writeline("return out")
+
+    return code
+
+
+def generate_code(
+    inputs: Tuple[Any],
+    wrapper_name: str,
+    kernel_name: str,
+    count_kernel_name: str,
+    code: IndentedBuffer,
+) -> IndentedBuffer:
+    shape = inputs[1].shape
+    rank = len(shape)
+
+    code = generate_imports(code)
+    code = generate_scatter_reduce_kernel(rank, kernel_name, code)
+    code = generate_count_kernel(rank, count_kernel_name, code)
+    code = generate_destination_passing_wrapper(
+        rank, wrapper_name, kernel_name, count_kernel_name, code
+    )
+    return code
+
+
+class ScatterReduceFunction:
+    def __init__(self):
+        self.pid = os.getpid()
+        self.overloads: Mapping[str, Callable] = {}
+
+    def __call__(self, *args, **kwargs):
+        key = f"{self.arg_key(*args)}"
+        if key in self.overloads:
+            overload = self.overloads[key]
+        else:
+            code = IndentedBuffer()
+            code = generate_code(
+                args,
+                "_scatter_reduce_wrapper",
+                "_scatter_reduce_jit_function",
+                "_scatter_reduce_count_jit_function",
+                code,
+            )
+
+            file_name = f"scatter_reduce_rank_{key}.py"
+            file_path = code_cache_dir() / file_name
+            write_atomic(file_path, code.getvalue())
+
+            # load
+            spec = importlib.util.spec_from_file_location(
+                f"_gen_scatter_reduce_module_rank_{key}",
+                file_path,
+            )
+
+            m = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(m)
+            overload = getattr(m, "_scatter_reduce_wrapper")
+            self.overloads[key] = overload
+
+        return overload(*args, **kwargs)
+
+    def arg_key(self, *args):
+        tensors = [item for item in args if torch.is_tensor(item)]
+        max_rank = max(item.ndim for item in tensors)
+        return max_rank
+
+
+_scatter_reduce_func = ScatterReduceFunction()
+
+
+def _get_init_value(reduce: str, dtype: torch.dtype, include_self: bool):
+    """Get the initial value for reduction when include_self=False."""
+    if include_self:
+        return None  # No initialization needed, use original values
+
+    if reduce == "sum":
+        return 0
+    elif reduce == "prod":
+        return 1
+    elif reduce == "amax":
+        if dtype.is_floating_point:
+            return float("-inf")
+        else:
+            return torch.iinfo(dtype).min
+    elif reduce == "amin":
+        if dtype.is_floating_point:
+            return float("inf")
+        else:
+            return torch.iinfo(dtype).max
+    elif reduce == "mean":
+        return 0
+    else:
+        raise ValueError(f"Unknown reduce operation: {reduce}")
+
+
+def scatter_reduce_(inp, dim, index, src, reduce, *, include_self=True):
+    logger.debug("GEMS SCATTER_REDUCE_")
+    out = inp
+
+    # Validate reduce operation
+    assert reduce in (
+        "sum",
+        "prod",
+        "mean",
+        "amax",
+        "amin",
+    ), f"Unsupported reduce operation: {reduce}"
+
+    # Check for internal overlapping
+    assert (
+        has_internal_overlapping(out) != MemOverlap.Yes
+    ), "Unsupported operation: trying to inplace write to an internally overlapping tensor."
+
+    # Handle include_self=False: initialize with identity values
+    if not include_self:
+        init_value = _get_init_value(reduce, inp.dtype, include_self)
+        if init_value is not None:
+            out.fill_(init_value)
+
+    src_restrided = src.as_strided(index.shape, src.stride())
+    inp_restrided = restride_dim(inp, dim, index.shape)
+    dim_size = inp.size(dim)
+    dim_stride = inp.stride(dim)
+    N = index.numel()
+
+    int32_size_dim = lambda x: x.stride(dim) * x.size(dim) < 2**32
+    use_int32_offset = all(map(int32_size_dim, (inp, index, src)))
+
+    _scatter_reduce_func(
+        src_restrided,
+        index,
+        inp_restrided,
+        out,
+        dim_size,
+        dim_stride,
+        N,
+        reduce,
+        include_self,
+        int32_offset=use_int32_offset,
+    )
+
+    return inp

--- a/tests/test_scatter_reduce_two.py
+++ b/tests/test_scatter_reduce_two.py
@@ -1,0 +1,50 @@
+import random
+
+import pytest
+import torch
+
+import flag_gems
+
+from .accuracy_utils import gems_assert_close, to_reference
+from .conftest import QUICK_MODE
+
+
+@pytest.mark.scatter_reduce_two_
+@pytest.mark.parametrize(
+    "src_shape", [(32, 8, 4)] if QUICK_MODE else [(128, 16, 4), (256, 32, 8)]
+)
+@pytest.mark.parametrize(
+    "inp_shape", [(64, 16, 8)] if QUICK_MODE else [(512, 128, 32), (1024, 64, 16)]
+)
+@pytest.mark.parametrize("dim", [0, 1, 2])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+@pytest.mark.parametrize("reduce", ["sum", "prod", "amax", "amin", "mean"])
+def test_scatter_reduce_two_(src_shape, inp_shape, dim, dtype, reduce):
+    inp = torch.randn(inp_shape, dtype=dtype, device=flag_gems.device)
+    src = torch.randn(src_shape, dtype=dtype, device=flag_gems.device)
+    size_dim = min(src_shape[dim], inp_shape[dim])
+
+    index_shape = [
+        random.randint(1, min(src_shape[0], inp_shape[0])),
+        random.randint(1, min(src_shape[1], inp_shape[1])),
+        random.randint(1, min(src_shape[2], inp_shape[2])),
+    ]
+    index = torch.empty(tuple(index_shape), dtype=torch.long, device=flag_gems.device)
+
+    m, n, o = index_shape
+    index_size_dim = index_shape[dim]
+    for i in range(1 if dim == 0 else m):
+        for j in range(1 if dim == 1 else n):
+            for k in range(1 if dim == 2 else o):
+                ii = [i, j, k]
+                ii[dim] = slice(0, index.size(dim) + 1)
+                index[tuple(ii)] = torch.randperm(size_dim)[0:index_size_dim]
+
+    ref_inp = to_reference(inp.clone(), upcast=True)
+    ref_index = to_reference(index)
+    ref_src = to_reference(src, upcast=True)
+    ref_out = ref_inp.scatter_reduce_(dim, ref_index, ref_src, reduce=reduce)
+    with flag_gems.use_gems():
+        res_out = inp.scatter_reduce_(dim, index, src, reduce=reduce)
+
+    gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `scatter_reduce_` operator implementation with Triton kernel.

- Implementation mode: `manual_kernel`
- Accuracy test: 120/120 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1024, 1024] | 0.0413 | 0.0633 | 0.653 |
| [4096, 4096] | 0.4259 | 1.1239 | 0.379 |
| [1024, 1024] | 0.0686 | 0.0896 | 0.765 |
| [1024, 1024] | 0.0565 | 0.0556 | 1.017 |
| [4096, 4096] | 0.9758 | 0.8354 | 1.168 |
| [1024, 1024] | 0.0567 | 0.0550 | 1.030 |
| [4096, 4096] | 0.9740 | 0.8335 | 1.169 |
| [1024, 1024] | 0.0932 | 0.2843 | 0.328 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1024, 1024] | 0.0377 | 0.0364 | 1.037 |
| [4096, 4096] | 0.3931 | 0.3965 | 0.991 |
| [1024, 1024] | 0.0671 | 0.0874 | 0.768 |
| [1024, 1024] | 0.0595 | 0.0557 | 1.068 |
| [4096, 4096] | 0.8990 | 0.8166 | 1.101 |
| [1024, 1024] | 0.0602 | 0.0564 | 1.066 |
| [4096, 4096] | 0.8990 | 0.8167 | 1.101 |
| [4096, 4096] | 1.1928 | 1.0919 | 1.092 |

**Overall: median speedup = 1.034x, mean speedup = 0.921x** (16 data points)

---
_Generated by auto_gen tool with Claude Code_
