### PR TITLE
【KernelGen】Add signbit operator

### DIFF
--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -94,6 +94,7 @@ forward_operations = [
     ("isinf", torch.isinf, FLOAT_DTYPES),
     ("isnan", torch.isnan, FLOAT_DTYPES),
     ("isfinite", torch.isfinite, FLOAT_DTYPES),
+    ("signbit", torch.signbit, FLOAT_DTYPES),
 ]
 
 

--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -4,14 +4,10 @@ import pytest
 import torch
 
 import flag_gems
-from benchmark.attri_util import (
-    BOOL_DTYPES,
-    COMPLEX_DTYPES,
-    DEFAULT_METRICS,
-    FLOAT_DTYPES,
-    INT_DTYPES,
-)
-from benchmark.performance_utils import Benchmark, SkipVersion, generate_tensor_input
+from benchmark.attri_util import (BOOL_DTYPES, COMPLEX_DTYPES, DEFAULT_METRICS,
+                                  FLOAT_DTYPES, INT_DTYPES)
+from benchmark.performance_utils import (Benchmark, SkipVersion,
+                                         generate_tensor_input)
 
 vendor_name = flag_gems.vendor_name
 fp64_is_supported = flag_gems.runtime.device.support_fp64

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -360,6 +360,7 @@ _FULL_CONFIG = (
     ("sigmoid", sigmoid),
     ("sigmoid_", sigmoid_),
     ("sigmoid_backward", sigmoid_backward),
+    ("signbit", signbit),
     ("silu", silu),
     ("silu_", silu_),
     ("silu_backward", silu_backward),

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -8,7 +8,8 @@ from flag_gems import runtime
 from flag_gems.config import aten_patch_list, resolve_user_setting
 from flag_gems.experimental_ops import *  # noqa: F403
 from flag_gems.fused import *  # noqa: F403
-from flag_gems.logging_utils import setup_flaggems_logging, teardown_flaggems_logging
+from flag_gems.logging_utils import (setup_flaggems_logging,
+                                     teardown_flaggems_logging)
 from flag_gems.modules import *  # noqa: F403
 from flag_gems.ops import *  # noqa: F403
 from flag_gems.patches import *  # noqa: F403

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -1,6 +1,5 @@
-from flag_gems.ops._functional_sym_constrain_range_for_size import (
-    _functional_sym_constrain_range_for_size,
-)
+from flag_gems.ops._functional_sym_constrain_range_for_size import \
+    _functional_sym_constrain_range_for_size
 from flag_gems.ops._safe_softmax import _safe_softmax
 from flag_gems.ops._upsample_nearest_exact1d import _upsample_nearest_exact1d
 from flag_gems.ops.abs import abs, abs_
@@ -25,46 +24,30 @@ from flag_gems.ops.argmax import argmax
 from flag_gems.ops.argmin import argmin
 from flag_gems.ops.asinh_ import asinh_
 from flag_gems.ops.atan import atan, atan_
-from flag_gems.ops.attention import (
-    ScaleDotProductAttention,
-    flash_attention_forward,
-    flash_attn_varlen_func,
-    scaled_dot_product_attention,
-    scaled_dot_product_attention_backward,
-    scaled_dot_product_attention_forward,
-)
+from flag_gems.ops.attention import (ScaleDotProductAttention,
+                                     flash_attention_forward,
+                                     flash_attn_varlen_func,
+                                     scaled_dot_product_attention,
+                                     scaled_dot_product_attention_backward,
+                                     scaled_dot_product_attention_forward)
 from flag_gems.ops.avg_pool2d import avg_pool2d, avg_pool2d_backward
 from flag_gems.ops.baddbmm import baddbmm
 from flag_gems.ops.batch_norm import batch_norm, batch_norm_backward
-from flag_gems.ops.bitwise_and import (
-    bitwise_and_scalar,
-    bitwise_and_scalar_,
-    bitwise_and_scalar_tensor,
-    bitwise_and_tensor,
-    bitwise_and_tensor_,
-)
+from flag_gems.ops.bitwise_and import (bitwise_and_scalar, bitwise_and_scalar_,
+                                       bitwise_and_scalar_tensor,
+                                       bitwise_and_tensor, bitwise_and_tensor_)
 from flag_gems.ops.bitwise_left_shift import bitwise_left_shift
 from flag_gems.ops.bitwise_not import bitwise_not, bitwise_not_
-from flag_gems.ops.bitwise_or import (
-    bitwise_or_scalar,
-    bitwise_or_scalar_,
-    bitwise_or_scalar_tensor,
-    bitwise_or_tensor,
-    bitwise_or_tensor_,
-)
+from flag_gems.ops.bitwise_or import (bitwise_or_scalar, bitwise_or_scalar_,
+                                      bitwise_or_scalar_tensor,
+                                      bitwise_or_tensor, bitwise_or_tensor_)
 from flag_gems.ops.bitwise_right_shift import bitwise_right_shift
 from flag_gems.ops.bmm import bmm, bmm_out
 from flag_gems.ops.cat import cat
 from flag_gems.ops.ceil import ceil, ceil_, ceil_out
 from flag_gems.ops.celu import celu, celu_
-from flag_gems.ops.clamp import (
-    clamp,
-    clamp_,
-    clamp_min,
-    clamp_min_,
-    clamp_tensor,
-    clamp_tensor_,
-)
+from flag_gems.ops.clamp import (clamp, clamp_, clamp_min, clamp_min_,
+                                 clamp_tensor, clamp_tensor_)
 from flag_gems.ops.contiguous import contiguous
 from flag_gems.ops.conv1d import conv1d
 from flag_gems.ops.conv2d import conv2d
@@ -80,17 +63,9 @@ from flag_gems.ops.diag import diag
 from flag_gems.ops.diag_embed import diag_embed
 from flag_gems.ops.diagonal import diagonal_backward
 from flag_gems.ops.digamma_ import digamma_
-from flag_gems.ops.div import (
-    div_mode,
-    div_mode_,
-    floor_divide,
-    floor_divide_,
-    remainder,
-    remainder_,
-    true_divide,
-    true_divide_,
-    true_divide_out,
-)
+from flag_gems.ops.div import (div_mode, div_mode_, floor_divide,
+                               floor_divide_, remainder, remainder_,
+                               true_divide, true_divide_, true_divide_out)
 from flag_gems.ops.dot import dot
 from flag_gems.ops.dropout import dropout, dropout_backward
 from flag_gems.ops.elu import elu, elu_, elu_backward
@@ -103,14 +78,8 @@ from flag_gems.ops.exp2 import exp2, exp2_
 from flag_gems.ops.exponential_ import exponential_
 from flag_gems.ops.eye import eye
 from flag_gems.ops.eye_m import eye_m
-from flag_gems.ops.fill import (
-    fill_scalar,
-    fill_scalar_,
-    fill_scalar_out,
-    fill_tensor,
-    fill_tensor_,
-    fill_tensor_out,
-)
+from flag_gems.ops.fill import (fill_scalar, fill_scalar_, fill_scalar_out,
+                                fill_tensor, fill_tensor_, fill_tensor_out)
 from flag_gems.ops.flip import flip
 from flag_gems.ops.floor_ import floor_
 from flag_gems.ops.fmin import fmin, fmin_out
@@ -141,7 +110,8 @@ from flag_gems.ops.isnan import isnan
 from flag_gems.ops.kron import kron
 from flag_gems.ops.layernorm import layer_norm, layer_norm_backward
 from flag_gems.ops.le import le, le_scalar
-from flag_gems.ops.lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tensor_
+from flag_gems.ops.lerp import (lerp_scalar, lerp_scalar_, lerp_tensor,
+                                lerp_tensor_)
 from flag_gems.ops.lift_fresh_copy import lift_fresh_copy, lift_fresh_copy_out
 from flag_gems.ops.linspace import linspace
 from flag_gems.ops.log import log
@@ -161,10 +131,8 @@ from flag_gems.ops.masked_fill import masked_fill, masked_fill_
 from flag_gems.ops.masked_scatter import masked_scatter, masked_scatter_
 from flag_gems.ops.masked_select import masked_select
 from flag_gems.ops.max import max, max_dim
-from flag_gems.ops.max_pool2d_with_indices import (
-    max_pool2d_backward,
-    max_pool2d_with_indices,
-)
+from flag_gems.ops.max_pool2d_with_indices import (max_pool2d_backward,
+                                                   max_pool2d_with_indices)
 from flag_gems.ops.maximum import maximum
 from flag_gems.ops.mean import mean, mean_dim
 from flag_gems.ops.min import min, min_dim
@@ -178,36 +146,22 @@ from flag_gems.ops.nan_to_num import nan_to_num
 from flag_gems.ops.ne import ne, ne_scalar
 from flag_gems.ops.neg import neg, neg_
 from flag_gems.ops.nll_loss_nd import nll_loss_nd_backward, nll_loss_nd_forward
-from flag_gems.ops.nllloss import (
-    nll_loss2d_backward,
-    nll_loss2d_forward,
-    nll_loss_backward,
-    nll_loss_forward,
-)
+from flag_gems.ops.nllloss import (nll_loss2d_backward, nll_loss2d_forward,
+                                   nll_loss_backward, nll_loss_forward)
 from flag_gems.ops.nonzero import nonzero
-from flag_gems.ops.normal import (
-    normal_,
-    normal_float_tensor,
-    normal_tensor_float,
-    normal_tensor_tensor,
-)
+from flag_gems.ops.normal import (normal_, normal_float_tensor,
+                                  normal_tensor_float, normal_tensor_tensor)
 from flag_gems.ops.one_hot import one_hot
 from flag_gems.ops.ones import ones
 from flag_gems.ops.ones_like import ones_like
 from flag_gems.ops.pad import constant_pad_nd, pad
-from flag_gems.ops.per_token_group_quant_fp8 import (
-    SUPPORTED_FP8_DTYPE,
-    per_token_group_quant_fp8,
-)
+from flag_gems.ops.per_token_group_quant_fp8 import (SUPPORTED_FP8_DTYPE,
+                                                     per_token_group_quant_fp8)
 from flag_gems.ops.pixel_unshuffle import pixel_unshuffle, pixel_unshuffle_out
 from flag_gems.ops.polar import polar
-from flag_gems.ops.pow import (
-    pow_scalar,
-    pow_tensor_scalar,
-    pow_tensor_scalar_,
-    pow_tensor_tensor,
-    pow_tensor_tensor_,
-)
+from flag_gems.ops.pow import (pow_scalar, pow_tensor_scalar,
+                               pow_tensor_scalar_, pow_tensor_tensor,
+                               pow_tensor_tensor_)
 from flag_gems.ops.prelu import prelu
 from flag_gems.ops.prod import prod, prod_dim
 from flag_gems.ops.quantile import quantile
@@ -217,24 +171,27 @@ from flag_gems.ops.randn import randn
 from flag_gems.ops.randn_like import randn_like
 from flag_gems.ops.randperm import randperm
 from flag_gems.ops.reciprocal import reciprocal, reciprocal_
-from flag_gems.ops.reflection_pad1d import reflection_pad1d, reflection_pad1d_out
-from flag_gems.ops.reflection_pad2d import reflection_pad2d, reflection_pad2d_out
+from flag_gems.ops.reflection_pad1d import (reflection_pad1d,
+                                            reflection_pad1d_out)
+from flag_gems.ops.reflection_pad2d import (reflection_pad2d,
+                                            reflection_pad2d_out)
 from flag_gems.ops.relu import relu, relu_
 from flag_gems.ops.relu6 import relu6
 from flag_gems.ops.repeat import repeat
-from flag_gems.ops.repeat_interleave import (
-    repeat_interleave_self_int,
-    repeat_interleave_self_tensor,
-    repeat_interleave_tensor,
-)
-from flag_gems.ops.replication_pad1d import replication_pad1d, replication_pad1d_out
+from flag_gems.ops.repeat_interleave import (repeat_interleave_self_int,
+                                             repeat_interleave_self_tensor,
+                                             repeat_interleave_tensor)
+from flag_gems.ops.replication_pad1d import (replication_pad1d,
+                                             replication_pad1d_out)
 from flag_gems.ops.replication_pad3d import replication_pad3d
 from flag_gems.ops.resolve_conj import resolve_conj
 from flag_gems.ops.resolve_neg import resolve_neg
-from flag_gems.ops.rms_norm import rms_norm, rms_norm_backward, rms_norm_forward
+from flag_gems.ops.rms_norm import (rms_norm, rms_norm_backward,
+                                    rms_norm_forward)
 from flag_gems.ops.rrelu_with_noise_backward import rrelu_with_noise_backward
 from flag_gems.ops.rsqrt import rsqrt, rsqrt_
-from flag_gems.ops.scaled_softmax import scaled_softmax_backward, scaled_softmax_forward
+from flag_gems.ops.scaled_softmax import (scaled_softmax_backward,
+                                          scaled_softmax_forward)
 from flag_gems.ops.scatter import scatter, scatter_
 from flag_gems.ops.scatter_add_ import scatter_add_
 from flag_gems.ops.select_scatter import select_scatter
@@ -248,7 +205,8 @@ from flag_gems.ops.sin import sin, sin_
 from flag_gems.ops.sinh_ import sinh_
 from flag_gems.ops.slice_backward import slice_backward
 from flag_gems.ops.slice_scatter import slice_scatter
-from flag_gems.ops.soft_margin_loss import soft_margin_loss, soft_margin_loss_out
+from flag_gems.ops.soft_margin_loss import (soft_margin_loss,
+                                            soft_margin_loss_out)
 from flag_gems.ops.softmax import softmax, softmax_backward
 from flag_gems.ops.softplus import softplus
 from flag_gems.ops.softshrink import softshrink, softshrink_out
@@ -284,16 +242,10 @@ from flag_gems.ops.vdot import vdot
 from flag_gems.ops.vector_norm import vector_norm
 from flag_gems.ops.vstack import vstack
 from flag_gems.ops.w8a8_block_fp8_matmul import w8a8_block_fp8_matmul
-from flag_gems.ops.weightnorm import (
-    weight_norm_interface,
-    weight_norm_interface_backward,
-)
-from flag_gems.ops.where import (
-    where_scalar_other,
-    where_scalar_self,
-    where_self,
-    where_self_out,
-)
+from flag_gems.ops.weightnorm import (weight_norm_interface,
+                                      weight_norm_interface_backward)
+from flag_gems.ops.where import (where_scalar_other, where_scalar_self,
+                                 where_self, where_self_out)
 from flag_gems.ops.zero import zero, zero_out
 from flag_gems.ops.zeros import zero_, zeros
 from flag_gems.ops.zeros_like import zeros_like

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -242,6 +242,7 @@ from flag_gems.ops.selu import selu
 from flag_gems.ops.selu_ import selu_
 from flag_gems.ops.sgn_ import sgn_
 from flag_gems.ops.sigmoid import sigmoid, sigmoid_, sigmoid_backward
+from flag_gems.ops.signbit import signbit
 from flag_gems.ops.silu import silu, silu_, silu_backward
 from flag_gems.ops.sin import sin, sin_
 from flag_gems.ops.sinh_ import sinh_
@@ -597,6 +598,7 @@ __all__ = [
     "sigmoid",
     "sigmoid_",
     "sigmoid_backward",
+    "signbit",
     "silu",
     "silu_",
     "silu_backward",

--- a/src/flag_gems/ops/signbit.py
+++ b/src/flag_gems/ops/signbit.py
@@ -1,0 +1,21 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
+
+_signbit = tl_extra_shim.signbit
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=[(0, "ALWAYS_BOOL")])
+@triton.jit
+def signbit_func(x):
+    return _signbit(x.to(tl.float32))
+
+
+def signbit(A):
+    logger.debug("GEMS SIGNBIT")
+    return signbit_func(A)

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -974,6 +974,21 @@ def test_accuracy_log_sigmoid(shape, dtype):
     gems_assert_close(res_out, ref_out, dtype)
 
 
+@pytest.mark.signbit
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_signbit(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    # Include some negative zeros and special values to test sign bit detection
+    ref_inp = to_reference(inp)
+
+    ref_out = torch.signbit(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.signbit(inp)
+
+    gems_assert_equal(res_out, ref_out)
+
+
 @pytest.mark.silu
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -11,22 +11,11 @@ try:
 except ImportError:
     TE_AVAILABLE = False
 
-from .accuracy_utils import (
-    ALL_FLOAT_DTYPES,
-    ALL_INT_DTYPES,
-    BOOL_TYPES,
-    COMPLEX_DTYPES,
-    FLOAT_DTYPES,
-    INT_DTYPES,
-    POINTWISE_SHAPES,
-    SWIGLU_SPECIAL_SHAPES,
-    SkipVersion,
-    gems_assert_close,
-    gems_assert_equal,
-    to_reference,
-    unsqueeze_tensor,
-    unsqueeze_tuple,
-)
+from .accuracy_utils import (ALL_FLOAT_DTYPES, ALL_INT_DTYPES, BOOL_TYPES,
+                             COMPLEX_DTYPES, FLOAT_DTYPES, INT_DTYPES,
+                             POINTWISE_SHAPES, SWIGLU_SPECIAL_SHAPES,
+                             SkipVersion, gems_assert_close, gems_assert_equal,
+                             to_reference, unsqueeze_tensor, unsqueeze_tuple)
 
 
 @pytest.mark.abs


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `signbit` operator implementation with Triton kernel.

- Implementation mode: `pointwise_dynamic`
- Accuracy test: 18/18 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 2.3886 | 2.4402 | 0.979 |
| [64, 64] | 0.0081 | 0.0075 | 1.081 |
| [4096, 4096] | 0.0482 | 0.0507 | 0.950 |
| [64, 512, 512] | 0.0479 | 0.0506 | 0.947 |
| [1024, 1024, 1024] | 2.3878 | 2.4405 | 0.978 |
| [1024, 1] | 0.0074 | 0.0069 | 1.074 |
| [1024, 16] | 0.0071 | 0.0081 | 0.881 |
| [1024, 256] | 0.0084 | 0.0084 | 0.989 |
| [1024, 4096] | 0.0176 | 0.0176 | 1.002 |
| [1024, 65536] | 0.1596 | 0.1629 | 0.980 |
| [64, 64, 1] | 0.0073 | 0.0075 | 0.979 |
| [64, 64, 16] | 0.0084 | 0.0078 | 1.074 |
| [64, 64, 256] | 0.0100 | 0.0107 | 0.940 |
| [64, 64, 4096] | 0.0486 | 0.0506 | 0.960 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 2.3901 | 2.4437 | 0.978 |
| [64, 64] | 0.0075 | 0.0080 | 0.936 |
| [4096, 4096] | 0.0487 | 0.0508 | 0.959 |
| [64, 512, 512] | 0.0479 | 0.0507 | 0.945 |
| [1024, 1024, 1024] | 2.3904 | 2.4424 | 0.979 |
| [1024, 1] | 0.0069 | 0.0072 | 0.964 |
| [1024, 16] | 0.0072 | 0.0072 | 1.000 |
| [1024, 256] | 0.0079 | 0.0079 | 1.004 |
| [1024, 4096] | 0.0185 | 0.0176 | 1.051 |
| [1024, 65536] | 0.1603 | 0.1621 | 0.989 |
| [64, 64, 1] | 0.0069 | 0.0072 | 0.960 |
| [64, 64, 16] | 0.0076 | 0.0074 | 1.030 |
| [64, 64, 256] | 0.0105 | 0.0100 | 1.051 |
| [64, 64, 4096] | 0.0485 | 0.0507 | 0.958 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1073741824] | 3.8492 | 3.8988 | 0.987 |
| [64, 64] | 0.0069 | 0.0070 | 0.986 |
| [4096, 4096] | 0.0796 | 0.0793 | 1.004 |
| [64, 512, 512] | 0.0803 | 0.0799 | 1.004 |
| [1024, 1024, 1024] | 3.8498 | 3.8982 | 0.988 |
| [1024, 1] | 0.0072 | 0.0069 | 1.051 |
| [1024, 16] | 0.0075 | 0.0071 | 1.049 |
| [1024, 256] | 0.0091 | 0.0092 | 0.979 |
| [1024, 4096] | 0.0256 | 0.0263 | 0.971 |
| [1024, 65536] | 0.2599 | 0.2584 | 1.006 |
| [64, 64, 1] | 0.0080 | 0.0070 | 1.132 |
| [64, 64, 16] | 0.0074 | 0.0074 | 1.000 |
| [64, 64, 256] | 0.0122 | 0.0126 | 0.970 |
| [64, 64, 4096] | 0.0802 | 0.0793 | 1.011 |

**Overall: median speedup = 0.986x, mean speedup = 0.994x** (42 data points)

---
_Generated by auto_gen tool with Claude Code_
