### PR TITLE
【KernelGen】Add softplus_backward operator

### DIFF
--- a/benchmark/test_binary_pointwise_perf.py
+++ b/benchmark/test_binary_pointwise_perf.py
@@ -109,3 +109,23 @@ def test_general_inplace_binary_pointwise_perf(op_name, torch_op, dtypes):
         op_name=op_name, torch_op=torch_op, dtypes=dtypes, is_inplace=True
     )
     bench.run()
+
+
+class SoftplusBackwardBenchmark(BinaryPointwiseBenchmark):
+    def get_input_iter(self, cur_dtype) -> Generator:
+        for shape in self.shapes:
+            inp = generate_tensor_input(shape, cur_dtype, self.device)
+            grad_out = torch.randn_like(inp)
+            beta = 1.0
+            threshold = 20.0
+            yield grad_out, inp, beta, threshold
+
+
+@pytest.mark.softplus_backward
+def test_softplus_backward_perf():
+    bench = SoftplusBackwardBenchmark(
+        op_name="softplus_backward",
+        torch_op=torch.ops.aten.softplus_backward,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -316,6 +316,7 @@ _FULL_CONFIG = (
     ("sin_", sin_),
     ("slice_scatter", slice_scatter),
     ("softplus", softplus),
+    ("softplus_backward", softplus_backward),
     ("sort", sort),
     ("sort.stable", sort_stable),
     ("sqrt", sqrt),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -203,6 +203,7 @@ from flag_gems.ops.sin import sin, sin_
 from flag_gems.ops.slice_scatter import slice_scatter
 from flag_gems.ops.softmax import softmax, softmax_backward
 from flag_gems.ops.softplus import softplus
+from flag_gems.ops.softplus_backward import softplus_backward
 from flag_gems.ops.sort import sort, sort_stable
 from flag_gems.ops.sqrt import sqrt, sqrt_
 from flag_gems.ops.stack import stack
@@ -497,6 +498,7 @@ __all__ = [
     "softmax",
     "softmax_backward",
     "softplus",
+    "softplus_backward",
     "sort",
     "sort_stable",
     "sqrt",

--- a/src/flag_gems/ops/softplus_backward.py
+++ b/src/flag_gems/ops/softplus_backward.py
@@ -1,0 +1,25 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(is_tensor=[True, True, False, False], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def softplus_backward_kernel(grad_output, self, beta, threshold):
+    grad_output_fp = grad_output.to(tl.float32)
+    self_fp = self.to(tl.float32)
+    z = self_fp * beta
+    # sigmoid(z) = 1 / (1 + exp(-z))
+    sigmoid_z = 1.0 / (1.0 + tl.exp(-z))
+    grad_input = tl.where(z > threshold, grad_output_fp, grad_output_fp * sigmoid_z)
+    return grad_input.to(grad_output.dtype)
+
+
+def softplus_backward(grad_output, self, beta, threshold):
+    logger.debug("GEMS SOFTPLUS_BACKWARD")
+    return softplus_backward_kernel(grad_output, self, beta, threshold)

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -2166,3 +2166,22 @@ def test_accuracy_addcdiv(shape, dtype):
         res_out = torch.addcdiv(res_inp, t1, t2, value=v)
 
     gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.softplus_backward
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_softplus_backward(shape, dtype):
+    res_inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    res_grad = torch.randn_like(res_inp)
+    beta = 1.0
+    threshold = 20.0
+
+    ref_inp = to_reference(res_inp, True)
+    ref_grad = to_reference(res_grad, True)
+
+    ref_in_grad = torch.ops.aten.softplus_backward(ref_grad, ref_inp, beta, threshold)
+    with flag_gems.use_gems():
+        res_in_grad = torch.ops.aten.softplus_backward(res_grad, res_inp, beta, threshold)
+
+    gems_assert_close(res_in_grad, ref_in_grad, dtype)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `softplus_backward` operator implementation with Triton kernel.

- Implementation mode: `N/A`
- Accuracy test: 18/18 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1073741824]) | 4.6855 | 4.6783 | 1.002 |
| torch.Size([64, 64]) | 0.0075 | 0.0072 | 1.040 |
| torch.Size([4096, 4096]) | 0.0880 | 0.0870 | 1.011 |
| torch.Size([64, 512, 512]) | 0.0884 | 0.0881 | 1.004 |
| torch.Size([1024, 1024, 1024]) | 4.6824 | 4.6647 | 1.004 |
| torch.Size([1024, 1]) | 0.0085 | 0.0070 | 1.215 |
| torch.Size([1024, 16]) | 0.0081 | 0.0076 | 1.068 |
| torch.Size([1024, 256]) | 0.0098 | 0.0094 | 1.048 |
| torch.Size([1024, 4096]) | 0.0294 | 0.0287 | 1.025 |
| torch.Size([1024, 65536]) | 0.3071 | 0.3044 | 1.009 |
| torch.Size([64, 64, 1]) | 0.0075 | 0.0083 | 0.904 |
| torch.Size([64, 64, 16]) | 0.0084 | 0.0081 | 1.032 |
| torch.Size([64, 64, 256]) | 0.0146 | 0.0131 | 1.112 |
| torch.Size([64, 64, 4096]) | 0.0888 | 0.0877 | 1.013 |
| torch.Size([64, 64, 65536]) | 1.1829 | 1.1850 | 0.998 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1073741824]) | 4.6839 | 4.6809 | 1.001 |
| torch.Size([64, 64]) | 0.0075 | 0.0084 | 0.900 |
| torch.Size([4096, 4096]) | 0.0887 | 0.0874 | 1.015 |
| torch.Size([64, 512, 512]) | 0.0883 | 0.0877 | 1.007 |
| torch.Size([1024, 1024, 1024]) | 4.7005 | 4.6674 | 1.007 |
| torch.Size([1024, 1]) | 0.0078 | 0.0070 | 1.124 |
| torch.Size([1024, 16]) | 0.0081 | 0.0078 | 1.037 |
| torch.Size([1024, 256]) | 0.0098 | 0.0088 | 1.105 |
| torch.Size([1024, 4096]) | 0.0293 | 0.0286 | 1.026 |
| torch.Size([1024, 65536]) | 0.3078 | 0.3039 | 1.013 |
| torch.Size([64, 64, 1]) | 0.0080 | 0.0072 | 1.111 |
| torch.Size([64, 64, 16]) | 0.0091 | 0.0076 | 1.199 |
| torch.Size([64, 64, 256]) | 0.0145 | 0.0138 | 1.053 |
| torch.Size([64, 64, 4096]) | 0.0886 | 0.0874 | 1.014 |
| torch.Size([64, 64, 65536]) | 1.1824 | 1.1854 | 0.998 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1073741824]) | 9.4455 | 9.3273 | 1.013 |
| torch.Size([64, 64]) | 0.0075 | 0.0072 | 1.040 |
| torch.Size([4096, 4096]) | 0.1595 | 0.1580 | 1.010 |
| torch.Size([64, 512, 512]) | 0.1586 | 0.1587 | 0.999 |
| torch.Size([1024, 1024, 1024]) | 9.4386 | 9.3329 | 1.011 |
| torch.Size([1024, 1]) | 0.0075 | 0.0075 | 0.996 |
| torch.Size([1024, 16]) | 0.0082 | 0.0079 | 1.041 |
| torch.Size([1024, 256]) | 0.0111 | 0.0102 | 1.091 |
| torch.Size([1024, 4096]) | 0.0482 | 0.0483 | 0.997 |
| torch.Size([1024, 65536]) | 0.6032 | 0.5977 | 1.009 |
| torch.Size([64, 64, 1]) | 0.0088 | 0.0076 | 1.151 |
| torch.Size([64, 64, 16]) | 0.0086 | 0.0091 | 0.947 |
| torch.Size([64, 64, 256]) | 0.0174 | 0.0179 | 0.975 |
| torch.Size([64, 64, 4096]) | 0.1595 | 0.1588 | 1.004 |
| torch.Size([64, 64, 65536]) | 2.3755 | 2.3480 | 1.012 |

**Overall: median speedup = 1.013x, mean speedup = 1.031x** (45 data points)

---
_Generated by auto_gen tool with Claude Code_
