### PR TITLE
【KernelGen】Add upsample_bilinear2d operator

### DIFF
--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -473,6 +473,33 @@ def test_perf_upsample_bicubic2d_aa():
     bench.run()
 
 
+@pytest.mark.upsample_bilinear2d
+def test_perf_upsample_bilinear2d():
+    def upsample_bilinear2d_input_fn(shape, dtype, device):
+        batch, channel, height, weight = shape
+        input = torch.randn(size=shape, device=device, dtype=dtype)
+        scale_factors = (2, 2)
+        output_size = (
+            int(height * scale_factors[0]),
+            int(weight * scale_factors[1]),
+        )
+        yield {
+            "input": input,
+            "output_size": output_size,
+            "align_corners": False,
+            "scales_h": None,
+            "scales_w": None,
+        },
+
+    bench = UpsampleBenchmark(
+        input_fn=upsample_bilinear2d_input_fn,
+        op_name="upsample_bilinear2d",
+        torch_op=torch._C._nn.upsample_bilinear2d,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.run()
+
+
 @pytest.mark.upsample_nearest1d
 def test_perf_upsample_nearest1d():
     def upsample_nearest1d_input_fn(shape, dtype, device):

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -345,6 +345,7 @@ _FULL_CONFIG = (
     ("true_divide_.Scalar", true_divide_),
     ("true_divide_.Tensor", true_divide_),
     ("uniform_", uniform_),
+    ("upsample_bilinear2d", upsample_bilinear2d),
     ("upsample_nearest1d", upsample_nearest1d),
     ("upsample_nearest2d", upsample_nearest2d),
     ("var_mean.correction", var_mean),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -220,6 +220,7 @@ from flag_gems.ops.triu import triu, triu_
 from flag_gems.ops.uniform import uniform_
 from flag_gems.ops.unique import _unique2
 from flag_gems.ops.upsample_bicubic2d_aa import _upsample_bicubic2d_aa
+from flag_gems.ops.upsample_bilinear2d import upsample_bilinear2d
 from flag_gems.ops.upsample_nearest1d import upsample_nearest1d
 from flag_gems.ops.upsample_nearest2d import upsample_nearest2d
 from flag_gems.ops.var_mean import var_mean
@@ -528,6 +529,7 @@ __all__ = [
     "true_divide_",
     "true_divide_out",
     "uniform_",
+    "upsample_bilinear2d",
     "upsample_nearest1d",
     "upsample_nearest2d",
     "var_mean",

--- a/src/flag_gems/ops/upsample_bilinear2d.py
+++ b/src/flag_gems/ops/upsample_bilinear2d.py
@@ -1,0 +1,172 @@
+import logging
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.runtime import device, torch_device_fn
+from flag_gems.utils import triton_lang_extension as tle
+
+device = device.name
+logger = logging.getLogger(__name__)
+
+
+@triton.autotune(
+    configs=runtime.get_tuned_config("upsample_bilinear2d"),
+    key=["N", "C", "OH", "OW"],
+)
+@triton.jit
+def upsample_bilinear2d_kernel(
+    ptr_o,
+    ptr_i,
+    N,
+    C,
+    OH,
+    OW,
+    IH,
+    IW,
+    reciprocal_scale_h,
+    reciprocal_scale_w,
+    ALIGN_CORNERS: tl.constexpr,
+    BLOCK_X: tl.constexpr,
+    BLOCK_Y: tl.constexpr,
+):
+    pid_x = tle.program_id(axis=0)
+    pid_y = tle.program_id(axis=1)
+    ow = (pid_x * BLOCK_X + tl.arange(0, BLOCK_X)) % OW
+    oh = (pid_y * BLOCK_Y + tl.arange(0, BLOCK_Y)) % OH
+
+    # Compute the source coordinates
+    if ALIGN_CORNERS:
+        # When align_corners is True, map corners to corners
+        # real_h = oh * (IH - 1) / (OH - 1) when OH > 1
+        real_h = tl.where(
+            OH > 1,
+            oh.to(tl.float32) * (IH - 1) / (OH - 1),
+            tl.zeros_like(oh).to(tl.float32),
+        )
+        real_w = tl.where(
+            OW > 1,
+            ow.to(tl.float32) * (IW - 1) / (OW - 1),
+            tl.zeros_like(ow).to(tl.float32),
+        )
+    else:
+        # When align_corners is False, use area-based scaling
+        # real_h = (oh + 0.5) * scale_h - 0.5
+        real_h = (oh.to(tl.float32) + 0.5) * reciprocal_scale_h - 0.5
+        real_w = (ow.to(tl.float32) + 0.5) * reciprocal_scale_w - 0.5
+
+    # Clamp to valid range
+    real_h = tl.maximum(real_h, 0.0)
+    real_w = tl.maximum(real_w, 0.0)
+
+    # Get integer parts (top-left corner of the 2x2 region)
+    h0 = real_h.to(tl.int32)
+    w0 = real_w.to(tl.int32)
+
+    # Clamp to ensure we don't go out of bounds
+    h0 = tl.minimum(h0, IH - 1)
+    w0 = tl.minimum(w0, IW - 1)
+    h1 = tl.minimum(h0 + 1, IH - 1)
+    w1 = tl.minimum(w0 + 1, IW - 1)
+
+    # Compute interpolation weights
+    h_weight = real_h - h0.to(tl.float32)
+    w_weight = real_w - w0.to(tl.float32)
+
+    # Clamp weights to [0, 1]
+    h_weight = tl.maximum(tl.minimum(h_weight, 1.0), 0.0)
+    w_weight = tl.maximum(tl.minimum(w_weight, 1.0), 0.0)
+
+    # Compute bilinear weights
+    w00 = (1.0 - h_weight[:, None]) * (1.0 - w_weight[None, :])
+    w01 = (1.0 - h_weight[:, None]) * w_weight[None, :]
+    w10 = h_weight[:, None] * (1.0 - w_weight[None, :])
+    w11 = h_weight[:, None] * w_weight[None, :]
+
+    # Process all N*C slices
+    for n in range(0, N, 1):
+        for c in range(0, C, 1):
+            # Compute base offset for input
+            base_offset = (n * C + c) * IH
+
+            # Load the 4 neighbors
+            offset_00 = (base_offset + h0[:, None]) * IW + w0[None, :]
+            offset_01 = (base_offset + h0[:, None]) * IW + w1[None, :]
+            offset_10 = (base_offset + h1[:, None]) * IW + w0[None, :]
+            offset_11 = (base_offset + h1[:, None]) * IW + w1[None, :]
+
+            data_00 = tl.load(ptr_i + offset_00)
+            data_01 = tl.load(ptr_i + offset_01)
+            data_10 = tl.load(ptr_i + offset_10)
+            data_11 = tl.load(ptr_i + offset_11)
+
+            # Compute bilinear interpolation
+            result = (
+                data_00.to(tl.float32) * w00
+                + data_01.to(tl.float32) * w01
+                + data_10.to(tl.float32) * w10
+                + data_11.to(tl.float32) * w11
+            )
+
+            # Store result
+            offset_o = ((n * C + c) * OH + oh[:, None]) * OW + ow[None, :]
+            tl.store(ptr_o + offset_o, result)
+
+
+def bilinear_reciprocal_scale(src_size, dst_size, align_corners, scale):
+    if align_corners:
+        if dst_size > 1:
+            return (src_size - 1) / (dst_size - 1)
+        else:
+            return 0.0
+    else:
+        if scale is not None and scale > 0:
+            return 1.0 / scale
+        else:
+            return src_size / dst_size
+
+
+def upsample_bilinear2d(
+    input: torch.Tensor,
+    output_size: Tuple[int],
+    align_corners: bool = False,
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> torch.Tensor:
+    logger.debug("GEMS UPSAMPLE BILINEAR2D")
+    assert input.device.type == device
+    assert input.ndim == 4, "The ndim of input must be 4"
+    assert len(output_size) == 2, "The len of output_size must be 2"
+
+    OH, OW = output_size
+    N, C, IH, IW = input.shape
+
+    reciprocal_scale_h = bilinear_reciprocal_scale(IH, OH, align_corners, scales_h)
+    reciprocal_scale_w = bilinear_reciprocal_scale(IW, OW, align_corners, scales_w)
+
+    # Allocate output
+    output = torch.empty((N, C, OH, OW), device=input.device, dtype=input.dtype)
+
+    grid = lambda META: (
+        triton.cdiv(OW, META["BLOCK_X"]),
+        triton.cdiv(OH, META["BLOCK_Y"]),
+    )
+
+    with torch_device_fn.device(input.device):
+        upsample_bilinear2d_kernel[grid](
+            output,
+            input,
+            N,
+            C,
+            OH,
+            OW,
+            IH,
+            IW,
+            reciprocal_scale_h,
+            reciprocal_scale_w,
+            align_corners,
+        )
+    return output

--- a/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
@@ -676,6 +676,17 @@ upsample_bicubic2d_aa:
     block_y: [2, 1]
     warps: [4, 8]
 
+upsample_bilinear2d:
+  - gen: true
+    param_map:
+      META:
+        BLOCK_X: block_x
+        BLOCK_Y: block_y
+      num_warps: warps
+    block_x: [512, 256, 128, 64]
+    block_y: [2, 1]
+    warps: [4, 8]
+
 mv:
   - gen: true
     param_map:

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -819,6 +819,28 @@ def test_upsample_bicubic2d_aa(dtype, shape, scale, align_corners):
     gems_assert_close(res_out, ref_out, dtype, reduce_dim=reduce_dim)
 
 
+@pytest.mark.upsample_bilinear2d
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("scale", [(2, 2), (2.1, 3.7), (1.3, 5.1), (0.3, 0.7)])
+@pytest.mark.parametrize("shape", UPSAMPLE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_upsample_bilinear2d(dtype, shape, scale, align_corners):
+    input = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_i = to_reference(input, True)
+    output_size = tuple([int(input.shape[i + 2] * scale[i]) for i in range(2)])
+    ref_out = torch._C._nn.upsample_bilinear2d(
+        ref_i, output_size=output_size, align_corners=align_corners
+    )
+    with flag_gems.use_gems():
+        res_out = torch._C._nn.upsample_bilinear2d(
+            input, output_size=output_size, align_corners=align_corners
+        )
+    if ref_out.dtype != res_out.dtype:
+        ref_out = ref_out.to(res_out.dtype)
+    # Bilinear interpolation uses 4 neighbors with weighted average
+    gems_assert_close(res_out, ref_out, dtype, reduce_dim=8)
+
+
 @pytest.mark.upsample_nearest1d
 @pytest.mark.parametrize("scale", [2, 2.5, 0.3, 0.7])
 @pytest.mark.parametrize("shape", UPSAMPLE_SHAPES_1D)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `upsample_bilinear2d` operator implementation with Triton kernel.

- Implementation mode: `manual_kernel`
- Accuracy test: 120/120 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1, 3, 512, 512] | 0.0440 | 0.0224 | 1.966 |
| [8, 16, 128, 128] | 0.0819 | 0.0811 | 1.010 |
| [2, 3, 1024, 1024] | 0.2287 | 0.1020 | 2.241 |
| [16, 16, 512, 512] | 1.5958 | 0.9014 | 1.770 |
| [16, 16, 1024, 1024] | 6.0912 | 3.3108 | 1.840 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1, 3, 512, 512] | 0.0523 | 0.0226 | 2.313 |
| [8, 16, 128, 128] | 0.0818 | 0.0818 | 1.000 |
| [2, 3, 1024, 1024] | 0.2254 | 0.1006 | 2.241 |
| [16, 16, 512, 512] | 1.6027 | 0.8977 | 1.785 |
| [16, 16, 1024, 1024] | 6.1205 | 3.2779 | 1.867 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| [1, 3, 512, 512] | 0.0440 | 0.0230 | 1.914 |
| [8, 16, 128, 128] | 0.0905 | 0.0896 | 1.010 |
| [2, 3, 1024, 1024] | 0.2399 | 0.1141 | 2.103 |
| [16, 16, 512, 512] | 1.7908 | 1.1373 | 1.575 |
| [16, 16, 1024, 1024] | 6.8680 | 4.5116 | 1.522 |

**Overall: median speedup = 1.840x, mean speedup = 1.744x** (15 data points)

---
_Generated by auto_gen tool with Claude Code_
