### PR TITLE
【KernelGen】Add value_selecting_reduction_backward operator

### DIFF
--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -557,3 +557,49 @@ def test_perf_scaled_softmax_backward():
     )
     bench.set_gems(flag_gems.scaled_softmax_backward)
     bench.run()
+
+
+class ValueSelectingReductionBackwardBenchmark(GenericBenchmark):
+    """
+    Benchmark for value_selecting_reduction_backward operation.
+    """
+
+    def get_input_iter(self, cur_dtype) -> Generator:
+        # Shape configurations: (output_shape, input_sizes, dim, keepdim)
+        shapes_2d = [
+            ((1024,), (1024, 1024), 1, False),
+            ((4096,), (4096, 4096), 1, False),
+            ((8192,), (8192, 8192), 1, False),
+        ]
+        shapes_3d = [
+            ((32, 64), (32, 64, 128), 2, False),
+            ((64, 128), (64, 128, 256), 2, False),
+            ((128, 256), (128, 256, 512), 2, False),
+        ]
+
+        for grad_shape, sizes, dim, keepdim in shapes_2d + shapes_3d:
+            yield from self.input_fn(
+                grad_shape, cur_dtype, self.device, sizes=sizes, dim=dim, keepdim=keepdim
+            )
+
+
+def value_selecting_reduction_backward_input_fn(
+    shape, dtype, device, sizes=None, dim=1, keepdim=False
+):
+    """Generate inputs for value_selecting_reduction_backward."""
+    grad = generate_tensor_input(shape, dtype, device)
+    max_index = sizes[dim]
+    indices = torch.randint(0, max_index, shape, device=device)
+    yield grad, dim, indices, list(sizes), keepdim
+
+
+@pytest.mark.value_selecting_reduction_backward
+def test_perf_value_selecting_reduction_backward():
+    bench = ValueSelectingReductionBackwardBenchmark(
+        input_fn=value_selecting_reduction_backward_input_fn,
+        op_name="value_selecting_reduction_backward",
+        torch_op=torch.ops.aten.value_selecting_reduction_backward,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.set_gems(flag_gems.value_selecting_reduction_backward)
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -347,6 +347,7 @@ _FULL_CONFIG = (
     ("uniform_", uniform_),
     ("upsample_nearest1d", upsample_nearest1d),
     ("upsample_nearest2d", upsample_nearest2d),
+    ("value_selecting_reduction_backward", value_selecting_reduction_backward),
     ("var_mean.correction", var_mean),
     ("vdot", vdot),
     ("vstack", vstack),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -222,6 +222,9 @@ from flag_gems.ops.unique import _unique2
 from flag_gems.ops.upsample_bicubic2d_aa import _upsample_bicubic2d_aa
 from flag_gems.ops.upsample_nearest1d import upsample_nearest1d
 from flag_gems.ops.upsample_nearest2d import upsample_nearest2d
+from flag_gems.ops.value_selecting_reduction_backward import (
+    value_selecting_reduction_backward,
+)
 from flag_gems.ops.var_mean import var_mean
 from flag_gems.ops.vdot import vdot
 from flag_gems.ops.vector_norm import vector_norm
@@ -530,6 +533,7 @@ __all__ = [
     "uniform_",
     "upsample_nearest1d",
     "upsample_nearest2d",
+    "value_selecting_reduction_backward",
     "var_mean",
     "vdot",
     "vector_norm",

--- a/src/flag_gems/ops/value_selecting_reduction_backward.py
+++ b/src/flag_gems/ops/value_selecting_reduction_backward.py
@@ -1,0 +1,55 @@
+import logging
+from typing import List
+
+import torch
+
+from flag_gems.ops.scatter import scatter_
+
+logger = logging.getLogger(__name__)
+
+
+def value_selecting_reduction_backward(
+    grad: torch.Tensor,
+    dim: int,
+    indices: torch.Tensor,
+    sizes: List[int],
+    keepdim: bool,
+) -> torch.Tensor:
+    """
+    Backward pass for value-selecting reduction operations (max.dim, min.dim, etc.).
+
+    This operation scatters the gradient values back to the positions indicated
+    by the indices from the forward pass.
+
+    Args:
+        grad: Gradient with respect to the reduced values
+        dim: The dimension that was reduced in the forward pass
+        indices: Indices of the selected values (e.g., argmax/argmin results)
+        sizes: Original input tensor shape
+        keepdim: Whether keepdim was used in the forward pass
+
+    Returns:
+        Gradient with respect to the original input tensor
+    """
+    logger.debug("GEMS VALUE_SELECTING_REDUCTION_BACKWARD")
+
+    # Normalize dim to positive
+    ndim = len(sizes)
+    if dim < 0:
+        dim = dim + ndim
+
+    # Create output tensor filled with zeros
+    result = grad.new_zeros(sizes)
+
+    # If keepdim was False, we need to unsqueeze grad and indices to match
+    # the expected shape for scatter operation
+    if not keepdim:
+        grad = grad.unsqueeze(dim)
+        indices = indices.unsqueeze(dim)
+
+    # Scatter the gradients to the positions indicated by indices
+    # For value-selecting reductions (max/min), each index appears at most once
+    # per reduction group, so we don't need reduce="add"
+    scatter_(result, dim, indices, grad)
+
+    return result

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -2201,3 +2201,118 @@ def test_accuracy_masked_scatter_(shape, dtype, threshold):
         inp.masked_scatter_(mask, src)
 
     gems_assert_equal(inp, ref_inp)
+
+
+# Test shapes for value_selecting_reduction_backward
+VALUE_SELECTING_SHAPES = (
+    [((3,), (3, 4))]
+    if QUICK_MODE
+    else [
+        ((3,), (3, 4)),
+        ((4,), (4, 8)),
+        ((2, 3), (2, 3, 5)),
+        ((8, 16), (8, 16, 32)),
+    ]
+)
+
+
+@pytest.mark.value_selecting_reduction_backward
+@pytest.mark.parametrize("grad_shape, sizes", VALUE_SELECTING_SHAPES)
+@pytest.mark.parametrize("dim", DIM_LIST)
+@pytest.mark.parametrize("keepdim", [True, False])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_value_selecting_reduction_backward(
+    grad_shape, sizes, dim, keepdim, dtype
+):
+    # Adjust dim to be valid for the sizes
+    ndim = len(sizes)
+    dim = dim % ndim
+
+    # Determine the actual grad shape based on keepdim
+    if keepdim:
+        grad_actual_shape = list(sizes)
+        grad_actual_shape[dim] = 1
+    else:
+        grad_actual_shape = list(sizes)
+        grad_actual_shape.pop(dim)
+
+    # Create gradient tensor
+    grad = torch.randn(grad_actual_shape, dtype=dtype, device=flag_gems.device)
+    ref_grad = to_reference(grad)
+
+    # Create indices tensor with valid indices for the dim
+    index_shape = grad_actual_shape
+    max_index = sizes[dim]
+    indices = torch.randint(0, max_index, index_shape, device=flag_gems.device)
+    ref_indices = to_reference(indices)
+
+    # Test reference implementation
+    ref_out = torch.ops.aten.value_selecting_reduction_backward(
+        ref_grad, dim, ref_indices, list(sizes), keepdim
+    )
+
+    # Test FlagGems implementation
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.value_selecting_reduction_backward(
+            grad, dim, indices, list(sizes), keepdim
+        )
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.value_selecting_reduction_backward
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_value_selecting_reduction_backward_max_dim(dtype):
+    """Test value_selecting_reduction_backward in a realistic max.dim backward scenario."""
+    # Create input tensor
+    inp = torch.randn((4, 8), dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp)
+
+    # Forward pass: max.dim
+    values, indices = inp.max(dim=1)
+    ref_values, ref_indices = ref_inp.max(dim=1)
+
+    # Create upstream gradient
+    grad_output = torch.randn_like(values)
+    ref_grad_output = to_reference(grad_output)
+
+    # Backward using value_selecting_reduction_backward
+    ref_out = torch.ops.aten.value_selecting_reduction_backward(
+        ref_grad_output, 1, ref_indices, list(ref_inp.shape), False
+    )
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.value_selecting_reduction_backward(
+            grad_output, 1, indices, list(inp.shape), False
+        )
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.value_selecting_reduction_backward
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_value_selecting_reduction_backward_min_dim(dtype):
+    """Test value_selecting_reduction_backward in a realistic min.dim backward scenario."""
+    # Create input tensor
+    inp = torch.randn((4, 8), dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp)
+
+    # Forward pass: min.dim
+    values, indices = inp.min(dim=1)
+    ref_values, ref_indices = ref_inp.min(dim=1)
+
+    # Create upstream gradient
+    grad_output = torch.randn_like(values)
+    ref_grad_output = to_reference(grad_output)
+
+    # Backward using value_selecting_reduction_backward
+    ref_out = torch.ops.aten.value_selecting_reduction_backward(
+        ref_grad_output, 1, ref_indices, list(ref_inp.shape), False
+    )
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.value_selecting_reduction_backward(
+            grad_output, 1, indices, list(inp.shape), False
+        )
+
+    gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `value_selecting_reduction_backward` operator implementation with Triton kernel.

- Implementation mode: `N/A`
- Accuracy test: 48/48 passed

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**torch.bfloat16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1024]) | 0.0159 | 0.0135 | 1.175 |
| torch.Size([4096]) | 0.0371 | 0.0347 | 1.069 |
| torch.Size([8192]) | 0.1018 | 0.0991 | 1.027 |
| torch.Size([32, 64]) | 0.0145 | 0.0122 | 1.192 |
| torch.Size([64, 128]) | 0.0174 | 0.0151 | 1.157 |
| torch.Size([128, 256]) | 0.0379 | 0.0351 | 1.079 |

**torch.float16**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1024]) | 0.0189 | 0.0136 | 1.390 |
| torch.Size([4096]) | 0.0368 | 0.0343 | 1.074 |
| torch.Size([8192]) | 0.1025 | 0.0999 | 1.026 |
| torch.Size([32, 64]) | 0.0146 | 0.0122 | 1.194 |
| torch.Size([64, 128]) | 0.0174 | 0.0150 | 1.157 |
| torch.Size([128, 256]) | 0.0380 | 0.0352 | 1.080 |

**torch.float32**

| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|-------------------:|-------------------:|--------:|
| torch.Size([1024]) | 0.0167 | 0.0144 | 1.158 |
| torch.Size([4096]) | 0.0579 | 0.0556 | 1.041 |
| torch.Size([8192]) | 0.1882 | 0.1855 | 1.014 |
| torch.Size([32, 64]) | 0.0151 | 0.0131 | 1.157 |
| torch.Size([64, 128]) | 0.0203 | 0.0177 | 1.145 |
| torch.Size([128, 256]) | 0.0593 | 0.0565 | 1.049 |

**Overall: median speedup = 1.113x, mean speedup = 1.121x** (18 data points)

---
_Generated by auto_gen tool with Claude Code_
