### PR TITLE
[Fix] conv1d passes dilation as proper 2D tuple to conv2d

### DIFF
--- a/src/flag_gems/ops/conv1d.py
+++ b/src/flag_gems/ops/conv1d.py
@@ -13,6 +13,11 @@ def conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
     else:
         stride_width = stride
 
+    if isinstance(dilation, (list, tuple)):
+        dilation_width = dilation[0]
+    else:
+        dilation_width = dilation
+
     if isinstance(padding, str):
         if padding == "same":
             assert (
@@ -22,10 +27,13 @@ def conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
             il = input.shape[-1]
             kernel_size = weight.shape[-1]
             padding_width = math.ceil(
-                (stride * (il - 1) + 1 + dilation * (kernel_size - 1) - il) / 2
+                (stride_width * (il - 1) + 1 + dilation_width * (kernel_size - 1) - il)
+                / 2
             )
             ol = int(
-                (il + 2 * padding_width - dilation * (kernel_size - 1) - 1) / stride + 1
+                (il + 2 * padding_width - dilation_width * (kernel_size - 1) - 1)
+                / stride_width
+                + 1
             )
             return conv2d(
                 input.unsqueeze(-1),
@@ -33,7 +41,7 @@ def conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
                 bias,
                 (stride_width, 1),
                 (padding_width, 0),
-                dilation,
+                (dilation_width, 1),
                 groups,
             ).squeeze(-1)[..., (ol - il) :]
         elif padding == "valid":
@@ -52,6 +60,6 @@ def conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
         bias,
         (stride_width, 1),
         (padding_width, 0),
-        dilation,
+        (dilation_width, 1),
         groups,
     ).squeeze(-1)

--- a/tests/test_convolution_ops.py
+++ b/tests/test_convolution_ops.py
@@ -71,6 +71,45 @@ def test_accuracy_conv1d_padding(shape, kernel, stride, padding, dtype):
         del os.environ["MUSA_ENABLE_SQMMA"]
 
 
+SHAPE_CONV1D_DILATION = [
+    ((32, 2, 16), (17, 2, 3)),
+    ((32, 15, 32), (17, 15, 3)),
+    ((64, 64, 64), (128, 64, 3)),
+]
+
+
+@pytest.mark.conv1d
+@pytest.mark.parametrize("shape, kernel", SHAPE_CONV1D_DILATION)
+@pytest.mark.parametrize("stride", [1])
+@pytest.mark.parametrize("padding", [0, 2])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float16])
+@pytest.mark.parametrize("dilation", [1, 2, (1,), (2,)])
+def test_accuracy_conv1d_dilation(shape, kernel, stride, padding, dtype, dilation):
+    """Test conv1d with various dilation values, including tuple form.
+
+    This specifically tests the fix where conv1d must properly convert dilation
+    to a 2D tuple before delegating to conv2d. Previously, passing dilation as
+    a single-element tuple (e.g., (1,)) would cause a ValueError in conv2d.
+    """
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    ref_inp = to_reference(inp, True)
+    weight = torch.randn(kernel, dtype=dtype, device=flag_gems.device)
+    ref_weight = to_reference(weight, True)
+    ref_out = torch.nn.functional.conv1d(
+        ref_inp,
+        ref_weight,
+        bias=None,
+        stride=stride,
+        padding=padding,
+        dilation=dilation,
+    )
+
+    res_out = flag_gems.conv1d(
+        inp, weight, bias=None, stride=stride, padding=padding, dilation=dilation
+    )
+    gems_assert_close(res_out, ref_out, dtype)
+
+
 SHAPE_CONV2D = [
     ((1, 2, 5, 5), (1, 2, 3, 3), 1),
     ((2, 3, 9, 9), (1, 3, 3, 3), 1),


### PR DESCRIPTION
## Summary
- Fix conv1d to correctly convert dilation parameter to a 2D tuple before calling conv2d, matching the existing handling of stride and padding.
- Without this fix, when dilation is a single-element tuple (e.g., (1,)), conv2d.forward raises ValueError: not enough values to unpack (expected 2, got 1).

## Root Cause
conv1d converts stride to (stride_width, 1) and padding to (padding_width, 0) before delegating to conv2d, but passes dilation as-is. When PyTorch passes dilation as a single-element tuple (1,), conv2d.forward's unpacking `dilation_height, dilation_width = dilation` fails because it expects exactly 2 values.

## Changes
- Extract dilation_width from the 1D dilation parameter (same pattern as stride_width)
- Pass (dilation_width, 1) to both conv2d() call sites
- Fix "same" padding branch to use scalar dilation_width and stride_width in padding/output-length calculations

## Test plan
- [x] Tested with NeMo parakeet-tdt-0.6b-v3 model which uses conv1d with default dilation
- [x] Both test_reference_device and test_target_device pass successfully
- [x] Speedup results: e2e=1.01539, gpu=1.01543