### PR TITLE
Update image-builder trigger to PR merged

### DIFF
--- a/.github/workflows/image-builder.yaml
+++ b/.github/workflows/image-builder.yaml
@@ -3,20 +3,8 @@ name: image-builder
 on:
   schedule:
     - cron: '0 3 * * *'
-  push:
-    branches:
-      - master
-    paths-ignore:
-      # we don't need smoke test for document change
-      # we don't need smoke test for specific operator
-      # so far test folder don't have unit test? just operator test
-      - docs/**
-      - src/flag_gems/ops/**
-      - src/flag_gems/experimental_ops/**
-      - src/flag_gems/fused/**
-      - experimental_tests/**
-      - tests/**
   pull_request:
+    types: [closed]
     branches:
       - master
     paths-ignore:
@@ -36,18 +24,19 @@ on:
 
 jobs:
   build-matrix:
+    if: github.event.pull_request.merged == true
     strategy:
       fail-fast: false
       matrix:
         include:
           # due to disk space issue, we have to use self host instance for this job
           - job_name: build-gems-nvidia-image
-            push: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' && inputs.push_images }}
+            push: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.push_images }}
             containerfile: 'containerfile'
             image_name: 'flaggems-nvidia'
             tag: 'latest'
             runson: 'h20'
-            no-cache: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' && inputs.push_images }}
+            no-cache: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.push_images }}
             build-args: |
               BASE_IMAGE=harbor.baai.ac.cn/flagbase/flagbase-nvidia
               BASE_IMAGE_VERSION=latest
@@ -55,12 +44,12 @@ jobs:
 
           # due to disk space issue, we have to use self host instance for this job
           - job_name: build-gems-nvidia-image-py312torch2.8
-            push: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' && inputs.push_images }}
+            push: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.push_images }}
             containerfile: 'containerfile'
             image_name: 'flaggems-nvidia'
             tag: 'py312torch2.8'
             runson: 'h20'
-            no-cache: ${{ github.event_name == 'schedule' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' && inputs.push_images }}
+            no-cache: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.push_images }}
             build-args: |
               BASE_IMAGE=harbor.baai.ac.cn/flagbase/flagbase-nvidia
               BASE_IMAGE_VERSION=py312torch2.8


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Refactor

### Description

Make the container build workflow only triggered when a PR is merged.
Before a PR is merged, there could be many many iterations,
we don't want to trigger the time-consuming image build workflow in these cases.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
