### PR TITLE
[FlagGems Operator Development Competition] Add sinh operator

### DIFF
--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -71,6 +71,7 @@ forward_operations = [
     ("tanh", torch.tanh, FLOAT_DTYPES),
     ("atan", torch.atan, FLOAT_DTYPES),
     ("acos", torch.acos, FLOAT_DTYPES),
+    ("sinh", torch.sinh, FLOAT_DTYPES),
     # Bitwise operations
     ("bitwise_not", torch.bitwise_not, INT_DTYPES),
     # Numerical Checks
@@ -126,6 +127,7 @@ forward_inplace_operations = [
     ("tan_", torch.tan_, FLOAT_DTYPES),
     ("tanh_", torch.tanh_, FLOAT_DTYPES),
     ("atan_", torch.atan_, FLOAT_DTYPES),
+    ("sinh_", torch.sinh_, FLOAT_DTYPES),
     # Bitwise operations
     ("bitwise_not_", lambda a: a.bitwise_not_(), INT_DTYPES),
 ]

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -200,6 +200,7 @@ from flag_gems.ops.select_scatter import select_scatter
 from flag_gems.ops.sigmoid import sigmoid, sigmoid_, sigmoid_backward
 from flag_gems.ops.silu import silu, silu_, silu_backward
 from flag_gems.ops.sin import sin, sin_
+from flag_gems.ops.sinh import sinh, sinh_
 from flag_gems.ops.slice_scatter import slice_scatter
 from flag_gems.ops.softmax import softmax, softmax_backward
 from flag_gems.ops.softplus import softplus
@@ -493,6 +494,8 @@ __all__ = [
     "silu_backward",
     "sin",
     "sin_",
+    "sinh",
+    "sinh_",
     "slice_scatter",
     "softmax",
     "softmax_backward",

--- a/src/flag_gems/ops/sinh.py
+++ b/src/flag_gems/ops/sinh.py
@@ -1,0 +1,26 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
+
+_sinh = tl_extra_shim.sinh
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
+@triton.jit
+def sinh_kernel(x):
+    return _sinh(x.to(tl.float32))
+
+
+def sinh(A):
+    logger.debug("GEMS SINH")
+    return sinh_kernel(A)
+
+
+def sinh_(A):
+    logger.debug("GEMS SINH_")
+    sinh_kernel(A, out0=A)
+    return A

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -1769,3 +1769,32 @@ def test_accuracy_ceil_out(shape, dtype):
         torch.ceil(inp, out=out)
 
     gems_assert_equal(out, ref_out)
+
+
+@pytest.mark.sinh
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_sinh(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+
+    ref_out = torch.sinh(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.sinh(inp)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.inplace
+@pytest.mark.sinh_
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_sinh_(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp.clone(), True)
+
+    ref_out = torch.sinh_(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.sinh_(inp)
+
+    gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Implements `torch.sinh` and `torch.sinh_` (in-place) operators using Triton.

Uses `tl_extra_shim.sinh` (Triton libdevice hardware-accelerated instruction), following the same pattern as the existing `tanh` operator (`src/flag_gems/ops/tanh.py`). This avoids the slower manual formula `(exp(x) - exp(-x)) / 2` and delegates to the native hardware instruction, giving better performance and accuracy across platforms.

Interfaces implemented:
- `sinh(A)` — out-of-place
- `sinh_(A)` — in-place

Supported dtypes: all `FLOAT_DTYPES` (fp16, bf16, fp32)

### Issue
Associated with FlagGems Operator Development Competition

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
Benchmarks added to `benchmark/test_unary_pointwise_perf.py` under `forward_operations` and `forward_inplace_operations`. Uses libdevice hardware instruction — expected to match or exceed `torch.sinh` baseline on NVIDIA GPUs.