### PR TITLE
[FlagGems Operator Development Competition] Add acosh operator

### DIFF
--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -71,6 +71,7 @@ forward_operations = [
     ("tanh", torch.tanh, FLOAT_DTYPES),
     ("atan", torch.atan, FLOAT_DTYPES),
     ("acos", torch.acos, FLOAT_DTYPES),
+    ("acosh", torch.acosh, FLOAT_DTYPES),
     # Bitwise operations
     ("bitwise_not", torch.bitwise_not, INT_DTYPES),
     # Numerical Checks
@@ -126,6 +127,7 @@ forward_inplace_operations = [
     ("tan_", torch.tan_, FLOAT_DTYPES),
     ("tanh_", torch.tanh_, FLOAT_DTYPES),
     ("atan_", torch.atan_, FLOAT_DTYPES),
+    ("acosh_", torch.acosh_, FLOAT_DTYPES),
     # Bitwise operations
     ("bitwise_not_", lambda a: a.bitwise_not_(), INT_DTYPES),
 ]

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -1,5 +1,6 @@
 from flag_gems.ops.abs import abs, abs_
 from flag_gems.ops.acos import acos
+from flag_gems.ops.acosh import acosh, acosh_
 from flag_gems.ops.add import add, add_
 from flag_gems.ops.addcdiv import addcdiv
 from flag_gems.ops.addcmul import addcmul
@@ -246,6 +247,8 @@ __all__ = [
     "abs",
     "abs_",
     "acos",
+    "acosh",
+    "acosh_",
     "add",
     "add_",
     "addcdiv",

--- a/src/flag_gems/ops/acosh.py
+++ b/src/flag_gems/ops/acosh.py
@@ -1,0 +1,26 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
+
+_acosh = tl_extra_shim.acosh
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
+@triton.jit
+def acosh_kernel(x):
+    return _acosh(x.to(tl.float32))
+
+
+def acosh(A):
+    logger.debug("GEMS ACOSH")
+    return acosh_kernel(A)
+
+
+def acosh_(A):
+    logger.debug("GEMS ACOSH_")
+    acosh_kernel(A, out0=A)
+    return A

--- a/tests/test_unary_pointwise_ops.py
+++ b/tests/test_unary_pointwise_ops.py
@@ -1769,3 +1769,32 @@ def test_accuracy_ceil_out(shape, dtype):
         torch.ceil(inp, out=out)
 
     gems_assert_equal(out, ref_out)
+
+
+@pytest.mark.acosh
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_acosh(shape, dtype):
+    inp = torch.rand(shape, dtype=dtype, device=flag_gems.device) + 1.0
+    ref_inp = to_reference(inp)
+
+    ref_out = torch.acosh(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.acosh(inp)
+
+    gems_assert_close(res_out, ref_out, dtype, equal_nan=True)
+
+
+@pytest.mark.inplace
+@pytest.mark.acosh_
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_acosh_(shape, dtype):
+    inp = torch.rand(shape, dtype=dtype, device=flag_gems.device) + 1.0
+    ref_inp = to_reference(inp.clone())
+
+    ref_out = torch.acosh_(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.acosh_(inp)
+
+    gems_assert_close(res_out, ref_out, dtype, equal_nan=True)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Implements `torch.acosh` and `torch.acosh_` (in-place) operators using Triton.

Uses `tl_extra_shim.acosh` (Triton libdevice hardware-accelerated instruction), following the same pattern as the existing `tanh` operator. This is superior to a manual formula approach (`tl.log(x + tl.sqrt(x*x - 1))`) which requires multiple Triton ops, redundant casts, and is less numerically precise near the domain boundary (x ≈ 1).

Interfaces implemented:
- `acosh(A)` — out-of-place
- `acosh_(A)` — in-place

Domain: input values ≥ 1. Tests use `torch.rand(...) + 1.0` to ensure valid inputs, with `equal_nan=True` for boundary correctness.

Supported dtypes: all `FLOAT_DTYPES` (fp16, bf16, fp32)

### Issue
Associated with FlagGems Operator Development Competition

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
Benchmarks added to `benchmark/test_unary_pointwise_perf.py` under `forward_operations` and `forward_inplace_operations`. Uses libdevice hardware instruction via `tl_extra_shim` — cross-platform (NVIDIA/AMD/Ascend).