### PR TITLE
Remove proxy env

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -31,9 +31,9 @@ on:
 # mitigate the network connection problems. However, this may not work
 # if the PR is triggered from a forked repository because in that case
 # GitHub doesn't allow the workflow to access any secrets.
-env:
-  http_proxy: ${{ secrets.HTTP_PROXY }}
-  https_proxy: ${{ secrets.HTTPS_PROXY }}
+# env:
+#  http_proxy: ${{ secrets.HTTP_PROXY }}
+#  https_proxy: ${{ secrets.HTTPS_PROXY }}
 
 jobs:
   test:


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

On the self-hosted runners, we set proxy settings in the `action-runners` service so that the runner can access github.com. These settings do not have to be customized in the backend test workflow.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
