### PR TITLE
Move alpha op test back to hopper

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -159,7 +159,7 @@ jobs:
     uses: ./.github/workflows/backend-test.yaml
     with:
       vendor: nvidia
-      runner_label: jiuding
+      runner_label: hopper
       gpu_check_script: tools/gpu_check.sh
       test_script: tools/test-op-experimental.sh
       changed_files: ${{ needs.preprocess.outputs.changed_files }}


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

BugFix

### Description

The testing of alpha operators has to be done on 'hopper'.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
