### PR TITLE
Merge coverage data before upload

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -64,7 +64,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: ut-coverage
+          name: op-ut-coverage
           path: coverage
 
   examples:

--- a/tools/test-op.sh
+++ b/tools/test-op.sh
@@ -18,7 +18,7 @@ fi
 
 # Temporary hack
 CHANGED_FILES=(
-  "tests/test_libentry.py"
+  "tests/test_tensor_wrapper.py"
 )
 
 # Test cases that needs to run quick cpu tests
@@ -80,6 +80,7 @@ fi
 # Process coverage data only when full-range testing
 # Coverage data HTML dumped to `htmlcov/` by default
 if [[ "$CHANGED_FILES" == "__ALL__" ]]; then
+  coverage combine
   coverage html
   rm -fr coverage
   mkdir coverage


### PR DESCRIPTION
The coverage data generated has to be merged before further processing.
This was a new knowledge happy to learn.