### PR TITLE
Fix coverage empty

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -65,7 +65,7 @@ jobs:
       - uses: actions/upload-artifact@v4
         with:
           name: op-ut-coverage
-          path: coverage
+          path: coverage/
 
   examples:
     needs: prepare

--- a/tools/test-op.sh
+++ b/tools/test-op.sh
@@ -79,11 +79,12 @@ fi
 
 # Process coverage data only when full-range testing
 # Coverage data HTML dumped to `htmlcov/` by default
-if [[ "$CHANGED_FILES" == "__ALL__" ]]; then
+# if [[ "$CHANGED_FILES" == "__ALL__" ]]; then
   coverage combine
   coverage html
   rm -fr coverage
   mkdir coverage
   mv htmlcov coverage/
   echo "${PR_ID}-${SUFFIX::7}" > coverage/COVERAGE_ID
-fi
+  ls coverage
+# fi


### PR DESCRIPTION
Why the hack the 'coverage' directory is empty?