### PR TITLE
Tweak coverage data publish url

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -63,7 +63,7 @@ jobs:
           DATE=${COV_ID:0:8}
           rm -fr docs/coverage/${DATE}*
           mkdir -p docs/coverage/${COV_ID}
-          mv ${{ runner.temp }}/artifacts/htmlcov docs/coverage/${COV_ID}
+          mv ${{ runner.temp }}/artifacts/htmlcov/* docs/coverage/${COV_ID}/
 
       - id: commit-change
         run: |

--- a/tools/test-op.sh
+++ b/tools/test-op.sh
@@ -16,11 +16,6 @@ else
   SUFFIX="-${GITHUB_SHA::7}"
 fi
 
-# Temporary hack
-CHANGED_FILES=(
-  "tests/test_tensor_wrapper.py"
-)
-
 # Test cases that needs to run quick cpu tests
 QUICK_CPU_TESTS=(
   "tests/test_attention_ops.py"


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Improvement

### Description

Tweak the publish URL so that we don't need to remember the htmlcov part.
This PR also restores the temporary hack on test-op.sh.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
