### PR TITLE
[FlagGems Operator Development Competition] Add log10 operator

### DIFF
--- a/benchmark/test_log10_perf.py
+++ b/benchmark/test_log10_perf.py
@@ -1,0 +1,28 @@
+import torch
+
+from .performance_utils import GenericBenchmark, generate_tensor_input
+
+
+class Log10Benchmark(GenericBenchmark):
+    input_generator = generate_tensor_input
+
+    def set_more_shapes(self):
+        return [
+            (1024,),
+            (1024 * 1024,),
+            (4096, 4096),
+            (128, 512, 512),
+        ]
+
+    def set_more_metrics(self):
+        return []
+
+
+bench_log10 = Log10Benchmark(
+    op_name="log10",
+    torch_op=torch.log10,
+    dtypes=[torch.float16, torch.float32, torch.bfloat16],
+)
+
+if __name__ == "__main__":
+    bench_log10.run(print_data=True)

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -206,6 +206,8 @@ _FULL_CONFIG = (
     ("linalg_vector_norm", vector_norm),
     ("linspace", linspace),
     ("log", log),
+    ("log10", log10),
+    ("log10_", log10_),
     ("log_sigmoid", log_sigmoid),
     ("logical_and", logical_and),
     ("logical_and_", logical_and_),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -117,6 +117,7 @@ from flag_gems.ops.le import le, le_scalar
 from flag_gems.ops.lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tensor_
 from flag_gems.ops.linspace import linspace
 from flag_gems.ops.log import log
+from flag_gems.ops.log10 import log10, log10_
 from flag_gems.ops.log_sigmoid import log_sigmoid
 from flag_gems.ops.log_softmax import log_softmax, log_softmax_backward
 from flag_gems.ops.logical_and import logical_and, logical_and_
@@ -391,6 +392,8 @@ __all__ = [
     "lerp_tensor_",
     "linspace",
     "log",
+    "log10",
+    "log10_",
     "log_sigmoid",
     "log_softmax",
     "log_softmax_backward",

--- a/src/flag_gems/ops/log10.py
+++ b/src/flag_gems/ops/log10.py
@@ -7,14 +7,12 @@ from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 
-# log10(x) = log(x) * log10(e)  where log10(e) = 1/ln(10)
-_LOG10E = 0.4342944819032518
-
 
 @pointwise_dynamic(promotion_methods=[(0, "COMPLEX_TO_FLOAT")])
 @triton.jit
 def log10_kernel(x):
-    return tl.log(x.to(tl.float32)) * _LOG10E
+    # log10(x) = log(x) * log10(e), log10(e) = 0.4342944819032518
+    return tl.log(x.to(tl.float32)) * 0.4342944819032518
 
 
 def log10(A):

--- a/src/flag_gems/ops/log10.py
+++ b/src/flag_gems/ops/log10.py
@@ -1,0 +1,28 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+# log10(x) = log(x) * log10(e)  where log10(e) = 1/ln(10)
+_LOG10E = 0.4342944819032518
+
+
+@pointwise_dynamic(promotion_methods=[(0, "COMPLEX_TO_FLOAT")])
+@triton.jit
+def log10_kernel(x):
+    return tl.log(x.to(tl.float32)) * _LOG10E
+
+
+def log10(A):
+    logger.debug("GEMS LOG10")
+    return log10_kernel(A)
+
+
+def log10_(A):
+    logger.debug("GEMS LOG10_")
+    log10_kernel(A, out0=A)
+    return A

--- a/tests/test_log10_ops.py
+++ b/tests/test_log10_ops.py
@@ -1,0 +1,28 @@
+import pytest
+import torch
+
+import flag_gems
+
+from .accuracy_utils import gems_assert_close, to_reference
+
+
+@pytest.mark.parametrize("shape", [(1,), (1024,), (1024, 1024), (4, 1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.bfloat16])
+def test_accuracy_log10(shape, dtype):
+    # log10 requires positive input
+    x = torch.rand(shape, dtype=dtype, device="cuda") + 0.01
+    ref_inp = to_reference(x)
+    ref_out = torch.log10(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.log10(x)
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.parametrize("shape", [(1024,), (1024, 1024), (4, 1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.bfloat16])
+def test_accuracy_log10_(shape, dtype):
+    x = torch.rand(shape, dtype=dtype, device="cuda") + 0.01
+    ref = torch.log10(x.float()).to(dtype)
+    with flag_gems.use_gems():
+        torch.log10_(x)
+    gems_assert_close(x, ref, dtype)


### PR DESCRIPTION
## Summary
- Implements `torch.log10` and `torch.log10_` using `@pointwise_dynamic` + Triton JIT
- Formula: `log10(x) = log(x) * 0.4342944819032518` (log10(e), inlined as constexpr)
- Supports float16, float32, bfloat16

## Test plan
- `tests/test_log10_ops.py`: accuracy tests for both out-of-place and in-place variants
- `benchmark/test_log10_perf.py`: performance benchmark

## GPU Tested
- A100-SXM4-80GB (Lightning AI Studio)
- Accuracy: ALL PASS across all shapes and dtypes