### PR TITLE
[FlagGems Operator Development Competition] Add cosh operator

### DIFF
--- a/benchmark/test_cosh_perf.py
+++ b/benchmark/test_cosh_perf.py
@@ -1,0 +1,28 @@
+import torch
+
+from .performance_utils import GenericBenchmark, generate_tensor_input
+
+
+class CoshBenchmark(GenericBenchmark):
+    input_generator = generate_tensor_input
+
+    def set_more_shapes(self):
+        return [
+            (1024,),
+            (1024 * 1024,),
+            (4096, 4096),
+            (128, 512, 512),
+        ]
+
+    def set_more_metrics(self):
+        return []
+
+
+bench_cosh = CoshBenchmark(
+    op_name="cosh",
+    torch_op=torch.cosh,
+    dtypes=[torch.float16, torch.float32, torch.bfloat16],
+)
+
+if __name__ == "__main__":
+    bench_cosh.run(print_data=True)

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -206,6 +206,8 @@ _FULL_CONFIG = (
     ("linalg_vector_norm", vector_norm),
     ("linspace", linspace),
     ("log", log),
+    ("cosh", cosh),
+    ("cosh_", cosh_),
     ("log_sigmoid", log_sigmoid),
     ("logical_and", logical_and),
     ("logical_and_", logical_and_),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -61,6 +61,7 @@ from flag_gems.ops.conv3d import conv3d
 from flag_gems.ops.conv_depthwise2d import _conv_depthwise2d
 from flag_gems.ops.copy import copy, copy_
 from flag_gems.ops.cos import cos, cos_
+from flag_gems.ops.cosh import cosh, cosh_
 from flag_gems.ops.count_nonzero import count_nonzero
 from flag_gems.ops.cummax import cummax
 from flag_gems.ops.cummin import cummin
@@ -390,6 +391,8 @@ __all__ = [
     "lerp_tensor",
     "lerp_tensor_",
     "linspace",
+    "cosh",
+    "cosh_",
     "log",
     "log_sigmoid",
     "log_softmax",

--- a/src/flag_gems/ops/cosh.py
+++ b/src/flag_gems/ops/cosh.py
@@ -1,0 +1,26 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
+
+_cosh = tl_extra_shim.cosh
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
+@triton.jit
+def cosh_kernel(x):
+    return _cosh(x.to(tl.float32))
+
+
+def cosh(A):
+    logger.debug("GEMS COSH")
+    return cosh_kernel(A)
+
+
+def cosh_(A):
+    logger.debug("GEMS COSH_")
+    cosh_kernel(A, out0=A)
+    return A

--- a/tests/test_cosh_ops.py
+++ b/tests/test_cosh_ops.py
@@ -1,0 +1,30 @@
+import pytest
+import torch
+
+import flag_gems
+
+from .accuracy_utils import gems_assert_close, to_reference
+
+
+@pytest.mark.parametrize(
+    "shape", [(1,), (1024,), (1024, 1024), (4, 1024, 1024), (2, 4, 256, 256)]
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.bfloat16])
+def test_accuracy_cosh(shape, dtype):
+    # keep values small to avoid fp16 overflow (cosh grows fast)
+    x = torch.randn(shape, dtype=dtype, device="cuda") * 5
+    ref_inp = to_reference(x)
+    ref_out = torch.cosh(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.cosh(x)
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.parametrize("shape", [(1024,), (1024, 1024), (4, 1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.bfloat16])
+def test_accuracy_cosh_(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device="cuda") * 5
+    ref = torch.cosh(x.float()).to(dtype)
+    with flag_gems.use_gems():
+        torch.cosh_(x)
+    gems_assert_close(x, ref, dtype)


### PR DESCRIPTION
## Summary
- Implements `torch.cosh` and `torch.cosh_` using `@pointwise_dynamic` + Triton JIT
- Formula: `cosh(x) = (exp(x) + exp(-x)) * 0.5`, computed in float32
- Supports float16, float32, bfloat16

## Test plan
- `tests/test_cosh_ops.py`: accuracy tests for both out-of-place and in-place variants
- `benchmark/test_cosh_perf.py`: performance benchmark

## GPU Tested
- A100-SXM4-80GB (Lightning AI Studio)
- Accuracy: ALL PASS across all shapes and dtypes