### PR TITLE
[FlagGems Operator Development Competition] Add leaky_relu operator

### DIFF
--- a/benchmark/test_leaky_relu_perf.py
+++ b/benchmark/test_leaky_relu_perf.py
@@ -1,0 +1,28 @@
+import torch
+
+from .performance_utils import GenericBenchmark, generate_tensor_input
+
+
+class LeakyReluBenchmark(GenericBenchmark):
+    input_generator = generate_tensor_input
+
+    def set_more_shapes(self):
+        return [
+            (1024,),
+            (1024 * 1024,),
+            (4096, 4096),
+            (128, 512, 512),
+        ]
+
+    def set_more_metrics(self):
+        return []
+
+
+bench_leaky_relu = LeakyReluBenchmark(
+    op_name="leaky_relu",
+    torch_op=torch.nn.functional.leaky_relu,
+    dtypes=[torch.float16, torch.float32, torch.bfloat16],
+)
+
+if __name__ == "__main__":
+    bench_leaky_relu.run(print_data=True)

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -199,6 +199,8 @@ _FULL_CONFIG = (
     ("kron", kron),
     ("le.Scalar", le_scalar),
     ("le.Tensor", le),
+    ("leaky_relu", leaky_relu),
+    ("leaky_relu_", leaky_relu_),
     ("lerp.Scalar", lerp_scalar),
     ("lerp.Tensor", lerp_tensor),
     ("lerp_.Scalar", lerp_scalar_),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -114,6 +114,7 @@ from flag_gems.ops.isnan import isnan
 from flag_gems.ops.kron import kron
 from flag_gems.ops.layernorm import layer_norm, layer_norm_backward
 from flag_gems.ops.le import le, le_scalar
+from flag_gems.ops.leaky_relu import leaky_relu, leaky_relu_
 from flag_gems.ops.lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tensor_
 from flag_gems.ops.linspace import linspace
 from flag_gems.ops.log import log
@@ -385,6 +386,8 @@ __all__ = [
     "layer_norm_backward",
     "le",
     "le_scalar",
+    "leaky_relu",
+    "leaky_relu_",
     "lerp_scalar",
     "lerp_scalar_",
     "lerp_tensor",

--- a/src/flag_gems/ops/leaky_relu.py
+++ b/src/flag_gems/ops/leaky_relu.py
@@ -1,0 +1,25 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, "DEFAULT")])
+@triton.jit
+def leaky_relu_kernel(x, negative_slope):
+    return tl.where(x >= 0, x, x * negative_slope)
+
+
+def leaky_relu(A, negative_slope=0.01):
+    logger.debug("GEMS LEAKY_RELU")
+    return leaky_relu_kernel(A, negative_slope)
+
+
+def leaky_relu_(A, negative_slope=0.01):
+    logger.debug("GEMS LEAKY_RELU_")
+    leaky_relu_kernel(A, negative_slope, out0=A)
+    return A

--- a/tests/test_leaky_relu_ops.py
+++ b/tests/test_leaky_relu_ops.py
@@ -1,0 +1,30 @@
+import pytest
+import torch
+
+import flag_gems
+
+from .accuracy_utils import gems_assert_close, to_reference
+
+
+@pytest.mark.parametrize(
+    "shape", [(1,), (1024,), (1024, 1024), (4, 1024, 1024), (2, 4, 256, 256)]
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("negative_slope", [0.01, 0.1, 0.2])
+def test_accuracy_leaky_relu(shape, dtype, negative_slope):
+    x = torch.randn(shape, dtype=dtype, device="cuda")
+    ref_inp = to_reference(x)
+    ref_out = torch.nn.functional.leaky_relu(ref_inp, negative_slope=negative_slope)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.leaky_relu(x, negative_slope=negative_slope)
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.parametrize("shape", [(1024,), (1024, 1024), (4, 1024, 1024)])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.bfloat16])
+def test_accuracy_leaky_relu_(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device="cuda")
+    ref = torch.nn.functional.leaky_relu(x.float()).to(dtype)
+    with flag_gems.use_gems():
+        torch.nn.functional.leaky_relu_(x)
+    gems_assert_close(x, ref, dtype)


### PR DESCRIPTION
## Summary
- Implements `torch.nn.functional.leaky_relu` and `leaky_relu_` using `@pointwise_dynamic` + Triton JIT
- Formula: `y = x if x >= 0 else x * negative_slope` (branchless via tl.where)
- Supports float16, float32, bfloat16; `negative_slope` passed as scalar

## Test plan
- `tests/test_leaky_relu_ops.py`: accuracy tests for out-of-place and in-place, multiple negative_slope values
- `benchmark/test_leaky_relu_perf.py`: performance benchmark

## GPU Tested
- A100-SXM4-80GB (Lightning AI Studio)
- Accuracy: ALL PASS across all shapes and dtypes