### PR TITLE
[FlagGems Operator Development Competition] Add smooth_l1_loss operator

### DIFF
--- a/benchmark/test_smooth_l1_loss_perf.py
+++ b/benchmark/test_smooth_l1_loss_perf.py
@@ -1,0 +1,79 @@
+from typing import Generator
+
+import pytest
+import torch
+
+import flag_gems
+
+from .attri_util import FLOAT_DTYPES, BenchLevel
+from .performance_utils import Config, GenericBenchmark
+
+
+def smooth_l1_loss_input_fn(shape, dtype, device):
+    inp = torch.randn(shape, dtype=dtype, device=device)
+    target = torch.randn(shape, dtype=dtype, device=device)
+    yield inp, target, {"reduction": "mean", "beta": 1.0}
+    if Config.bench_level == BenchLevel.COMPREHENSIVE:
+        yield inp, target, {"reduction": "sum", "beta": 1.0}
+        yield inp, target, {"reduction": "none", "beta": 1.0}
+        yield inp, target, {"reduction": "mean", "beta": 0.5}
+        yield inp, target, {"reduction": "mean", "beta": 2.0}
+
+
+class SmoothL1LossBenchmark(GenericBenchmark):
+    def get_input_iter(self, cur_dtype) -> Generator:
+        shapes = [
+            (8, 8),
+            (64, 64),
+            (256, 256),
+            (512, 512),
+            (1024, 1024),
+            (2048, 2048),
+            (4096, 4096),
+        ]
+        for shape in shapes:
+            yield from self.input_fn(shape, cur_dtype, self.device)
+
+
+@pytest.mark.smooth_l1_loss
+def test_perf_smooth_l1_loss():
+    bench = SmoothL1LossBenchmark(
+        input_fn=smooth_l1_loss_input_fn,
+        op_name="smooth_l1_loss",
+        torch_op=torch.nn.functional.smooth_l1_loss,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.set_gems(flag_gems.smooth_l1_loss)
+    bench.run()
+
+
+@pytest.mark.smooth_l1_loss
+def test_perf_smooth_l1_loss_backward():
+    def smooth_l1_loss_backward_input_fn(shape, dtype, device):
+        for forward_args in smooth_l1_loss_input_fn(shape, dtype, device):
+            inp, target, params = forward_args
+            inp.requires_grad_(True)
+            output = torch.nn.functional.smooth_l1_loss(inp, target, **params)
+            if params["reduction"] == "none":
+                grad_output = torch.randn_like(output)
+            else:
+                grad_output = torch.randn((), dtype=dtype, device=device)
+            yield grad_output, inp, target, params
+
+    def torch_smooth_l1_loss_backward_wrapper(grad_output, input, target, **kwargs):
+        input_copy = input.detach().requires_grad_(True)
+        output = torch.nn.functional.smooth_l1_loss(input_copy, target, **kwargs)
+        grad_input = torch.autograd.grad(
+            outputs=(output,), inputs=(input_copy,), grad_outputs=(grad_output,)
+        )
+        return grad_input[0]
+
+    bench = SmoothL1LossBenchmark(
+        input_fn=smooth_l1_loss_backward_input_fn,
+        op_name="smooth_l1_loss_backward",
+        torch_op=torch_smooth_l1_loss_backward_wrapper,
+        dtypes=FLOAT_DTYPES,
+        is_backward=False,
+    )
+    bench.set_gems(flag_gems.smooth_l1_loss_backward)
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -236,6 +236,8 @@ _FULL_CONFIG = (
     ("mm", mm),
     ("mm.out", mm_out),
     ("mse_loss", mse_loss),
+    ("smooth_l1_loss", smooth_l1_loss),
+    ("smooth_l1_loss_backward", smooth_l1_loss_backward),
     ("mul.Tensor", mul),
     ("mul_.Tensor", mul_),
     ("multinomial", multinomial),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -201,6 +201,7 @@ from flag_gems.ops.sigmoid import sigmoid, sigmoid_, sigmoid_backward
 from flag_gems.ops.silu import silu, silu_, silu_backward
 from flag_gems.ops.sin import sin, sin_
 from flag_gems.ops.slice_scatter import slice_scatter
+from flag_gems.ops.smooth_l1_loss import smooth_l1_loss, smooth_l1_loss_backward
 from flag_gems.ops.softmax import softmax, softmax_backward
 from flag_gems.ops.softplus import softplus
 from flag_gems.ops.sort import sort, sort_stable
@@ -495,6 +496,8 @@ __all__ = [
     "sin",
     "sin_",
     "slice_scatter",
+    "smooth_l1_loss",
+    "smooth_l1_loss_backward",
     "softmax",
     "softmax_backward",
     "softplus",

--- a/src/flag_gems/ops/smooth_l1_loss.py
+++ b/src/flag_gems/ops/smooth_l1_loss.py
@@ -1,0 +1,140 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 512}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 1024}, num_warps=8),
+        triton.Config({"BLOCK_SIZE": 2048}, num_warps=8),
+    ],
+    key=["n_elements"],
+)
+@triton.jit
+def smooth_l1_loss_forward_kernel(
+    input_ptr,
+    target_ptr,
+    output_ptr,
+    n_elements,
+    beta: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    input_val = tl.load(input_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    target_val = tl.load(target_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    diff = input_val - target_val
+    abs_diff = tl.abs(diff)
+    if beta > 0:
+        loss = tl.where(
+            abs_diff < beta, 0.5 * diff * diff / beta, abs_diff - 0.5 * beta
+        )
+    else:
+        loss = abs_diff
+    tl.store(output_ptr + offsets, loss, mask=mask)
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 256}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 512}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 1024}, num_warps=8),
+        triton.Config({"BLOCK_SIZE": 2048}, num_warps=8),
+    ],
+    key=["n_elements"],
+)
+@triton.jit
+def smooth_l1_loss_backward_kernel(
+    grad_output_ptr,
+    input_ptr,
+    target_ptr,
+    grad_input_ptr,
+    n_elements,
+    beta: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    grad_out = tl.load(grad_output_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    input_val = tl.load(input_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    target_val = tl.load(target_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    diff = input_val - target_val
+    abs_diff = tl.abs(diff)
+    if beta > 0:
+        grad = tl.where(abs_diff < beta, diff / beta, tl.where(diff > 0, 1.0, -1.0))
+    else:
+        grad = tl.where(diff > 0, 1.0, tl.where(diff < 0, -1.0, 0.0))
+    tl.store(grad_input_ptr + offsets, grad * grad_out, mask=mask)
+
+
+def smooth_l1_loss(
+    input: torch.Tensor,
+    target: torch.Tensor,
+    reduction: str = "mean",
+    beta: float = 1.0,
+) -> torch.Tensor:
+    logger.debug("GEMS SMOOTH_L1_LOSS FORWARD")
+    if beta < 0:
+        raise ValueError(f"beta must be non-negative. Got: {beta}")
+    if input.shape != target.shape:
+        target = torch.broadcast_to(target, input.shape)
+    input = input.contiguous()
+    target = target.contiguous()
+    output = torch.empty_like(input)
+    n_elements = input.numel()
+    if n_elements == 0:
+        if reduction == "none":
+            return output
+        return torch.tensor(0.0, device=input.device, dtype=input.dtype)
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    with torch_device_fn.device(input.device):
+        smooth_l1_loss_forward_kernel[grid](input, target, output, n_elements, beta)
+    if reduction == "mean":
+        return output.mean()
+    elif reduction == "sum":
+        return output.sum()
+    else:
+        return output
+
+
+def smooth_l1_loss_backward(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    target: torch.Tensor,
+    reduction: str = "mean",
+    beta: float = 1.0,
+) -> torch.Tensor:
+    logger.debug("GEMS SMOOTH_L1_LOSS BACKWARD")
+    if input.shape != target.shape:
+        target = torch.broadcast_to(target, input.shape)
+    input = input.contiguous()
+    target = target.contiguous()
+    grad_input = torch.empty_like(input)
+    n_elements = input.numel()
+    if n_elements == 0:
+        return grad_input
+    if grad_output.numel() == 1:
+        grad_output_expanded = grad_output.expand_as(input).contiguous()
+        if reduction == "mean":
+            grad_output_expanded = grad_output_expanded / n_elements
+    else:
+        grad_output_expanded = grad_output.contiguous()
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    with torch_device_fn.device(input.device):
+        smooth_l1_loss_backward_kernel[grid](
+            grad_output_expanded, input, target, grad_input, n_elements, beta
+        )
+    return grad_input

--- a/tests/test_smooth_l1_loss.py
+++ b/tests/test_smooth_l1_loss.py
@@ -1,0 +1,201 @@
+import pytest
+import torch
+
+import flag_gems
+
+from .accuracy_utils import FLOAT_DTYPES, gems_assert_close, to_reference
+from .conftest import QUICK_MODE
+
+SMOOTH_L1_LOSS_CONFIGS = [
+    ((8,), (8,), "none", 1.0),
+    ((8,), (8,), "mean", 1.0),
+    ((8,), (8,), "sum", 1.0),
+    ((64, 64), (64, 64), "none", 1.0),
+    ((64, 64), (64, 64), "mean", 1.0),
+    ((64, 64), (64, 64), "sum", 1.0),
+    ((256, 256), (256, 256), "mean", 1.0),
+    ((1024, 1024), (1024, 1024), "mean", 1.0),
+    ((64, 64), (64, 64), "mean", 0.5),
+    ((64, 64), (64, 64), "mean", 2.0),
+    ((64, 64), (64, 64), "mean", 0.1),
+    ((16, 32, 32), (16, 32, 32), "mean", 1.0),
+    ((8, 16, 16, 16), (8, 16, 16, 16), "mean", 1.0),
+    ((4, 8, 8, 8, 8), (4, 8, 8, 8, 8), "mean", 1.0),
+]
+
+if QUICK_MODE:
+    SMOOTH_L1_LOSS_CONFIGS = [
+        SMOOTH_L1_LOSS_CONFIGS[0],
+        SMOOTH_L1_LOSS_CONFIGS[4],
+    ]
+    FLOAT_DTYPES_TEST = [torch.float32]
+else:
+    FLOAT_DTYPES_TEST = FLOAT_DTYPES
+
+
+@pytest.mark.smooth_l1_loss
+@pytest.mark.parametrize(
+    "input_shape, target_shape, reduction, beta", SMOOTH_L1_LOSS_CONFIGS
+)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES_TEST)
+def test_accuracy_smooth_l1_loss_forward(
+    input_shape, target_shape, reduction, beta, dtype
+):
+    inp = torch.randn(input_shape, dtype=dtype, device=flag_gems.device)
+    target = torch.randn(target_shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+    ref_out = torch.nn.functional.smooth_l1_loss(
+        ref_inp, ref_target, reduction=reduction, beta=beta
+    )
+    res_out = flag_gems.smooth_l1_loss(inp, target, reduction=reduction, beta=beta)
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.smooth_l1_loss_backward
+@pytest.mark.parametrize(
+    "input_shape, target_shape, reduction, beta", SMOOTH_L1_LOSS_CONFIGS
+)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES_TEST)
+def test_accuracy_smooth_l1_loss_backward(
+    input_shape, target_shape, reduction, beta, dtype
+):
+    inp = torch.randn(
+        input_shape, dtype=dtype, device=flag_gems.device, requires_grad=True
+    )
+    target = torch.randn(target_shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, upcast=True)
+    ref_target = to_reference(target, upcast=True)
+    ref_out = torch.nn.functional.smooth_l1_loss(
+        ref_inp, ref_target, reduction=reduction, beta=beta
+    )
+    res_out = flag_gems.smooth_l1_loss(inp, target, reduction=reduction, beta=beta)
+    if reduction == "none":
+        out_grad = torch.randn_like(res_out, device=flag_gems.device)
+        ref_grad = to_reference(out_grad, upcast=True)
+    else:
+        out_grad = torch.randn((), dtype=dtype, device=flag_gems.device)
+        ref_grad = to_reference(out_grad, upcast=True)
+    (ref_in_grad,) = torch.autograd.grad(ref_out, ref_inp, ref_grad)
+    res_in_grad = flag_gems.smooth_l1_loss_backward(
+        out_grad, inp, target, reduction=reduction, beta=beta
+    )
+    gems_assert_close(res_in_grad, ref_in_grad, dtype)
+
+
+@pytest.mark.smooth_l1_loss
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES_TEST)
+def test_accuracy_smooth_l1_loss_edge_cases(dtype):
+    inp = torch.zeros((64, 64), dtype=dtype, device=flag_gems.device)
+    target = torch.zeros((64, 64), dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+    ref_out = torch.nn.functional.smooth_l1_loss(ref_inp, ref_target, reduction="mean")
+    res_out = flag_gems.smooth_l1_loss(inp, target, reduction="mean")
+    gems_assert_close(res_out, ref_out, dtype)
+
+    inp = torch.randn((64, 64), dtype=dtype, device=flag_gems.device) - 5.0
+    target = torch.randn((64, 64), dtype=dtype, device=flag_gems.device) - 5.0
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+    ref_out = torch.nn.functional.smooth_l1_loss(ref_inp, ref_target, reduction="mean")
+    res_out = flag_gems.smooth_l1_loss(inp, target, reduction="mean")
+    gems_assert_close(res_out, ref_out, dtype)
+
+    inp = torch.randn((64, 64), dtype=dtype, device=flag_gems.device) * 10
+    target = torch.randn((64, 64), dtype=dtype, device=flag_gems.device) * 10
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+    ref_out = torch.nn.functional.smooth_l1_loss(ref_inp, ref_target, reduction="mean")
+    res_out = flag_gems.smooth_l1_loss(inp, target, reduction="mean")
+    gems_assert_close(res_out, ref_out, dtype)
+
+    inp = torch.randn((64, 64), dtype=dtype, device=flag_gems.device) * 0.1
+    target = torch.randn((64, 64), dtype=dtype, device=flag_gems.device) * 0.1
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+    ref_out = torch.nn.functional.smooth_l1_loss(ref_inp, ref_target, reduction="mean")
+    res_out = flag_gems.smooth_l1_loss(inp, target, reduction="mean")
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.smooth_l1_loss
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES_TEST)
+def test_accuracy_smooth_l1_loss_different_reductions(dtype):
+    shape = (64, 64)
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    for reduction in ["none", "mean", "sum"]:
+        ref_inp = to_reference(inp, True)
+        ref_target = to_reference(target, True)
+        ref_out = torch.nn.functional.smooth_l1_loss(
+            ref_inp, ref_target, reduction=reduction
+        )
+        res_out = flag_gems.smooth_l1_loss(inp, target, reduction=reduction)
+        gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.smooth_l1_loss
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES_TEST)
+def test_accuracy_smooth_l1_loss_different_betas(dtype):
+    shape = (64, 64)
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    for beta in [0.1, 0.5, 1.0, 2.0, 5.0]:
+        ref_inp = to_reference(inp, True)
+        ref_target = to_reference(target, True)
+        ref_out = torch.nn.functional.smooth_l1_loss(
+            ref_inp, ref_target, reduction="mean", beta=beta
+        )
+        res_out = flag_gems.smooth_l1_loss(inp, target, reduction="mean", beta=beta)
+        gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.smooth_l1_loss
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES_TEST)
+def test_accuracy_smooth_l1_loss_different_shapes(dtype):
+    shapes = [
+        (8,),
+        (8, 8),
+        (8, 8, 8),
+        (4, 8, 8, 8),
+        (2, 4, 8, 8, 8),
+    ]
+    for shape in shapes:
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        target = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+        ref_inp = to_reference(inp, True)
+        ref_target = to_reference(target, True)
+        ref_out = torch.nn.functional.smooth_l1_loss(
+            ref_inp, ref_target, reduction="mean"
+        )
+        res_out = flag_gems.smooth_l1_loss(inp, target, reduction="mean")
+        gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.smooth_l1_loss
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES_TEST)
+def test_accuracy_smooth_l1_loss_large_input(dtype):
+    shape = (4096, 4096)
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+    ref_out = torch.nn.functional.smooth_l1_loss(ref_inp, ref_target, reduction="mean")
+    res_out = flag_gems.smooth_l1_loss(inp, target, reduction="mean")
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.smooth_l1_loss
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES_TEST)
+def test_accuracy_smooth_l1_loss_beta_zero(dtype):
+    shape = (64, 64)
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+    ref_out = torch.nn.functional.smooth_l1_loss(
+        ref_inp, ref_target, reduction="mean", beta=0.0
+    )
+    res_out = flag_gems.smooth_l1_loss(inp, target, reduction="mean", beta=0.0)
+    gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
## PR Category
Operator

## Type of Change
New Feature

## Description
Implementation of the `smooth_l1_loss` operator in Triton for FlagGems.

**Formula:**
- If `|x - y| < beta`: `loss = 0.5 * (x - y)² / beta`
- If `|x - y| >= beta`: `loss = |x - y| - 0.5 * beta`
- If `beta = 0`: equivalent to L1 loss

**Features:**
- Forward + backward Triton kernels with auto-tuning (BLOCK_SIZE: 256/512/1024/2048)
- `reduction`: `mean`, `sum`, `none`
- `beta` parameter (including `beta=0`)
- Broadcast support
- float32, float16, bfloat16 (with float32 upcast in kernel to avoid overflow)

## Performance (Tesla T4)
| Shape | Dtype | PyTorch (ms) | FlagGems (ms) | Speedup |
|---|---|---|---|---|
| (1024,) | float32 | 0.0288 | 0.0311 | 0.93x |
| (65536,) | float32 | 0.0294 | 0.0310 | 0.95x |
| (1024,1024) | float32 | 0.0771 | 0.0772 | 1.00x |
| (4096,4096) | float32 | 1.0821 | 0.5118 | **2.11x** |

## Tests
- **102 tests** (forward + backward + edge cases + shapes 1D→5D + beta=0 + large input)
- Dtypes: float32, float16, bfloat16
- Benchmark file: `benchmark/test_smooth_l1_loss_perf.py`

## Issue
Associated with FlagGems Operator Development Competition

## Progress
- [ ] Change is properly reviewed
- [x] Change is responded to an issue
- [x] Change is fully covered by a UT