### PR TITLE
[FIX] exclude zero_ op impact on benchmark

### DIFF
--- a/benchmark/performance_utils.py
+++ b/benchmark/performance_utils.py
@@ -410,6 +410,7 @@ class Benchmark:
                                         self.torch_op, *args, **kwargs
                                     )
                             else:
+                                # exclude flaggems' zero_ to avoid the overhead of zero_ in do_bench's clear_cache
                                 with flag_gems.use_gems(exclude=["zero_"]):
                                     metric.latency = self.get_latency(
                                         self.torch_op, *args, **kwargs


### PR DESCRIPTION
PR Category
Benchmark

Type of Change
Bug Fix

Description
FlagGems 在2月3号支持了 zero_算子 （https://github.com/flagos-ai/FlagGems/pull/1539%EF%BC%89

这笔patch我们发现会影响性能测试的准确度。
性能测试时有这样的call flow：benchmark/performance_utils.py的 run -> with flag_gems.use_gems(): get_latency -> do_bench -> cache.zero_

也就是triton官方的do_bench都会包在 use_gems里，而官方do_bench内会做一次 zero_，也就被FlagGems zero_算子替代了，这样厂商在做测试时实际对比的是 (triton的zero_+triton的A_kernel) vs. (topsAten手写的zero_和topsAten手写的A算子)
更合理的对比方式（减少zero_ triton算子跟手写算子的差异影响），应该是 (topsAten手写的zero_+triton的A_kernel) vs. (topsAten手写的zero_和topsAten手写的A算子)

我们建议的方式是在benchmark/performance_utils.py:407 ，判断当 self.op_name, 不是 zero_ 时，with flag_gems.use_gems() 加上 exclude="zero_"
