### PR TITLE
Bump upload-artifact version to v7

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -62,7 +62,7 @@ jobs:
 
           bash tools/test-op.sh ${RUN_TAG}
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: op-ut-coverage
           path: coverage/

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -55,7 +55,7 @@ jobs:
           "
 
       - name: Upload wheel as artifact
-        uses: actions/upload-artifact@v5
+        uses: actions/upload-artifact@v7
         with:
           name: built-wheel-${{ github.ref_name }}
           path: ${{ runner.temp }}/wheelhouse/*.whl


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

The upload-artifact action has a latest release v7. We should use that for security and bug fixes reasons. For example, the v4 version was using NodeJS 20, where migration to NodeJS 24 is strongly recommended by GitHub.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
