### PR TITLE
[FlagGems Operator Development Competition] Add smooth_l1_loss operator

### DIFF
--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -8,7 +8,8 @@ from flag_gems import runtime
 from flag_gems.config import aten_patch_list, resolve_user_setting
 from flag_gems.experimental_ops import *  # noqa: F403
 from flag_gems.fused import *  # noqa: F403
-from flag_gems.logging_utils import setup_flaggems_logging, teardown_flaggems_logging
+from flag_gems.logging_utils import (setup_flaggems_logging,
+                                     teardown_flaggems_logging)
 from flag_gems.modules import *  # noqa: F403
 from flag_gems.ops import *  # noqa: F403
 from flag_gems.patches import *  # noqa: F403

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -8,8 +8,7 @@ from flag_gems import runtime
 from flag_gems.config import aten_patch_list, resolve_user_setting
 from flag_gems.experimental_ops import *  # noqa: F403
 from flag_gems.fused import *  # noqa: F403
-from flag_gems.logging_utils import (setup_flaggems_logging,
-                                     teardown_flaggems_logging)
+from flag_gems.logging_utils import setup_flaggems_logging, teardown_flaggems_logging
 from flag_gems.modules import *  # noqa: F403
 from flag_gems.ops import *  # noqa: F403
 from flag_gems.patches import *  # noqa: F403

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -363,6 +363,7 @@ _FULL_CONFIG = (
     ("zeros", zeros),
     ("zero_", zero_),
     ("zeros_like", zeros_like),
+    ("smooth_l1_loss", smooth_l1_loss),
 )
 
 # Cache mapping from function name -> list of _FULL_CONFIG entries for quick lookup

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -14,46 +14,30 @@ from flag_gems.ops.arange import arange, arange_start
 from flag_gems.ops.argmax import argmax
 from flag_gems.ops.argmin import argmin
 from flag_gems.ops.atan import atan, atan_
-from flag_gems.ops.attention import (
-    ScaleDotProductAttention,
-    flash_attention_forward,
-    flash_attn_varlen_func,
-    scaled_dot_product_attention,
-    scaled_dot_product_attention_backward,
-    scaled_dot_product_attention_forward,
-)
+from flag_gems.ops.attention import (ScaleDotProductAttention,
+                                     flash_attention_forward,
+                                     flash_attn_varlen_func,
+                                     scaled_dot_product_attention,
+                                     scaled_dot_product_attention_backward,
+                                     scaled_dot_product_attention_forward)
 from flag_gems.ops.avg_pool2d import avg_pool2d, avg_pool2d_backward
 from flag_gems.ops.baddbmm import baddbmm
 from flag_gems.ops.batch_norm import batch_norm, batch_norm_backward
-from flag_gems.ops.bitwise_and import (
-    bitwise_and_scalar,
-    bitwise_and_scalar_,
-    bitwise_and_scalar_tensor,
-    bitwise_and_tensor,
-    bitwise_and_tensor_,
-)
+from flag_gems.ops.bitwise_and import (bitwise_and_scalar, bitwise_and_scalar_,
+                                       bitwise_and_scalar_tensor,
+                                       bitwise_and_tensor, bitwise_and_tensor_)
 from flag_gems.ops.bitwise_left_shift import bitwise_left_shift
 from flag_gems.ops.bitwise_not import bitwise_not, bitwise_not_
-from flag_gems.ops.bitwise_or import (
-    bitwise_or_scalar,
-    bitwise_or_scalar_,
-    bitwise_or_scalar_tensor,
-    bitwise_or_tensor,
-    bitwise_or_tensor_,
-)
+from flag_gems.ops.bitwise_or import (bitwise_or_scalar, bitwise_or_scalar_,
+                                      bitwise_or_scalar_tensor,
+                                      bitwise_or_tensor, bitwise_or_tensor_)
 from flag_gems.ops.bitwise_right_shift import bitwise_right_shift
 from flag_gems.ops.bmm import bmm, bmm_out
 from flag_gems.ops.cat import cat
 from flag_gems.ops.ceil import ceil, ceil_, ceil_out
 from flag_gems.ops.celu import celu, celu_
-from flag_gems.ops.clamp import (
-    clamp,
-    clamp_,
-    clamp_min,
-    clamp_min_,
-    clamp_tensor,
-    clamp_tensor_,
-)
+from flag_gems.ops.clamp import (clamp, clamp_, clamp_min, clamp_min_,
+                                 clamp_tensor, clamp_tensor_)
 from flag_gems.ops.contiguous import contiguous
 from flag_gems.ops.conv1d import conv1d
 from flag_gems.ops.conv2d import conv2d
@@ -68,17 +52,9 @@ from flag_gems.ops.cumsum import cumsum, cumsum_out, normed_cumsum
 from flag_gems.ops.diag import diag
 from flag_gems.ops.diag_embed import diag_embed
 from flag_gems.ops.diagonal import diagonal_backward
-from flag_gems.ops.div import (
-    div_mode,
-    div_mode_,
-    floor_divide,
-    floor_divide_,
-    remainder,
-    remainder_,
-    true_divide,
-    true_divide_,
-    true_divide_out,
-)
+from flag_gems.ops.div import (div_mode, div_mode_, floor_divide,
+                               floor_divide_, remainder, remainder_,
+                               true_divide, true_divide_, true_divide_out)
 from flag_gems.ops.dot import dot
 from flag_gems.ops.dropout import dropout, dropout_backward
 from flag_gems.ops.elu import elu, elu_, elu_backward
@@ -90,14 +66,8 @@ from flag_gems.ops.exp2 import exp2, exp2_
 from flag_gems.ops.exponential_ import exponential_
 from flag_gems.ops.eye import eye
 from flag_gems.ops.eye_m import eye_m
-from flag_gems.ops.fill import (
-    fill_scalar,
-    fill_scalar_,
-    fill_scalar_out,
-    fill_tensor,
-    fill_tensor_,
-    fill_tensor_out,
-)
+from flag_gems.ops.fill import (fill_scalar, fill_scalar_, fill_scalar_out,
+                                fill_tensor, fill_tensor_, fill_tensor_out)
 from flag_gems.ops.flip import flip
 from flag_gems.ops.full import full
 from flag_gems.ops.full_like import full_like
@@ -121,7 +91,8 @@ from flag_gems.ops.isnan import isnan
 from flag_gems.ops.kron import kron
 from flag_gems.ops.layernorm import layer_norm, layer_norm_backward
 from flag_gems.ops.le import le, le_scalar
-from flag_gems.ops.lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tensor_
+from flag_gems.ops.lerp import (lerp_scalar, lerp_scalar_, lerp_tensor,
+                                lerp_tensor_)
 from flag_gems.ops.linspace import linspace
 from flag_gems.ops.log import log
 from flag_gems.ops.log_sigmoid import log_sigmoid
@@ -136,10 +107,8 @@ from flag_gems.ops.masked_fill import masked_fill, masked_fill_
 from flag_gems.ops.masked_scatter import masked_scatter, masked_scatter_
 from flag_gems.ops.masked_select import masked_select
 from flag_gems.ops.max import max, max_dim
-from flag_gems.ops.max_pool2d_with_indices import (
-    max_pool2d_backward,
-    max_pool2d_with_indices,
-)
+from flag_gems.ops.max_pool2d_with_indices import (max_pool2d_backward,
+                                                   max_pool2d_with_indices)
 from flag_gems.ops.maximum import maximum
 from flag_gems.ops.mean import mean, mean_dim
 from flag_gems.ops.min import min, min_dim
@@ -152,35 +121,21 @@ from flag_gems.ops.mv import mv
 from flag_gems.ops.nan_to_num import nan_to_num
 from flag_gems.ops.ne import ne, ne_scalar
 from flag_gems.ops.neg import neg, neg_
-from flag_gems.ops.nllloss import (
-    nll_loss2d_backward,
-    nll_loss2d_forward,
-    nll_loss_backward,
-    nll_loss_forward,
-)
+from flag_gems.ops.nllloss import (nll_loss2d_backward, nll_loss2d_forward,
+                                   nll_loss_backward, nll_loss_forward)
 from flag_gems.ops.nonzero import nonzero
-from flag_gems.ops.normal import (
-    normal_,
-    normal_float_tensor,
-    normal_tensor_float,
-    normal_tensor_tensor,
-)
+from flag_gems.ops.normal import (normal_, normal_float_tensor,
+                                  normal_tensor_float, normal_tensor_tensor)
 from flag_gems.ops.one_hot import one_hot
 from flag_gems.ops.ones import ones
 from flag_gems.ops.ones_like import ones_like
 from flag_gems.ops.pad import constant_pad_nd, pad
-from flag_gems.ops.per_token_group_quant_fp8 import (
-    SUPPORTED_FP8_DTYPE,
-    per_token_group_quant_fp8,
-)
+from flag_gems.ops.per_token_group_quant_fp8 import (SUPPORTED_FP8_DTYPE,
+                                                     per_token_group_quant_fp8)
 from flag_gems.ops.polar import polar
-from flag_gems.ops.pow import (
-    pow_scalar,
-    pow_tensor_scalar,
-    pow_tensor_scalar_,
-    pow_tensor_tensor,
-    pow_tensor_tensor_,
-)
+from flag_gems.ops.pow import (pow_scalar, pow_tensor_scalar,
+                               pow_tensor_scalar_, pow_tensor_tensor,
+                               pow_tensor_tensor_)
 from flag_gems.ops.prod import prod, prod_dim
 from flag_gems.ops.quantile import quantile
 from flag_gems.ops.rand import rand
@@ -191,17 +146,17 @@ from flag_gems.ops.randperm import randperm
 from flag_gems.ops.reciprocal import reciprocal, reciprocal_
 from flag_gems.ops.relu import relu, relu_
 from flag_gems.ops.repeat import repeat
-from flag_gems.ops.repeat_interleave import (
-    repeat_interleave_self_int,
-    repeat_interleave_self_tensor,
-    repeat_interleave_tensor,
-)
+from flag_gems.ops.repeat_interleave import (repeat_interleave_self_int,
+                                             repeat_interleave_self_tensor,
+                                             repeat_interleave_tensor)
 from flag_gems.ops.replication_pad3d import replication_pad3d
 from flag_gems.ops.resolve_conj import resolve_conj
 from flag_gems.ops.resolve_neg import resolve_neg
-from flag_gems.ops.rms_norm import rms_norm, rms_norm_backward, rms_norm_forward
+from flag_gems.ops.rms_norm import (rms_norm, rms_norm_backward,
+                                    rms_norm_forward)
 from flag_gems.ops.rsqrt import rsqrt, rsqrt_
-from flag_gems.ops.scaled_softmax import scaled_softmax_backward, scaled_softmax_forward
+from flag_gems.ops.scaled_softmax import (scaled_softmax_backward,
+                                          scaled_softmax_forward)
 from flag_gems.ops.scatter import scatter, scatter_
 from flag_gems.ops.scatter_add_ import scatter_add_
 from flag_gems.ops.select_scatter import select_scatter
@@ -209,6 +164,7 @@ from flag_gems.ops.sigmoid import sigmoid, sigmoid_, sigmoid_backward
 from flag_gems.ops.silu import silu, silu_, silu_backward
 from flag_gems.ops.sin import sin, sin_
 from flag_gems.ops.slice_scatter import slice_scatter
+from flag_gems.ops.smooth_l1_loss import smooth_l1_loss
 from flag_gems.ops.softmax import softmax, softmax_backward
 from flag_gems.ops.softplus import softplus
 from flag_gems.ops.sort import sort, sort_stable
@@ -237,20 +193,12 @@ from flag_gems.ops.var_mean import var_mean
 from flag_gems.ops.vdot import vdot
 from flag_gems.ops.vector_norm import vector_norm
 from flag_gems.ops.vstack import vstack
-from flag_gems.ops.weightnorm import (
-    weight_norm_interface,
-    weight_norm_interface_backward,
-)
-from flag_gems.ops.where import (
-    where_scalar_other,
-    where_scalar_self,
-    where_self,
-    where_self_out,
-)
+from flag_gems.ops.weightnorm import (weight_norm_interface,
+                                      weight_norm_interface_backward)
+from flag_gems.ops.where import (where_scalar_other, where_scalar_self,
+                                 where_self, where_self_out)
 from flag_gems.ops.zeros import zero_, zeros
 from flag_gems.ops.zeros_like import zeros_like
-
-from flag_gems.ops.smooth_l1_loss import smooth_l1_loss
 
 __all__ = [
     "smooth_l1_loss",

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -14,30 +14,46 @@ from flag_gems.ops.arange import arange, arange_start
 from flag_gems.ops.argmax import argmax
 from flag_gems.ops.argmin import argmin
 from flag_gems.ops.atan import atan, atan_
-from flag_gems.ops.attention import (ScaleDotProductAttention,
-                                     flash_attention_forward,
-                                     flash_attn_varlen_func,
-                                     scaled_dot_product_attention,
-                                     scaled_dot_product_attention_backward,
-                                     scaled_dot_product_attention_forward)
+from flag_gems.ops.attention import (
+    ScaleDotProductAttention,
+    flash_attention_forward,
+    flash_attn_varlen_func,
+    scaled_dot_product_attention,
+    scaled_dot_product_attention_backward,
+    scaled_dot_product_attention_forward,
+)
 from flag_gems.ops.avg_pool2d import avg_pool2d, avg_pool2d_backward
 from flag_gems.ops.baddbmm import baddbmm
 from flag_gems.ops.batch_norm import batch_norm, batch_norm_backward
-from flag_gems.ops.bitwise_and import (bitwise_and_scalar, bitwise_and_scalar_,
-                                       bitwise_and_scalar_tensor,
-                                       bitwise_and_tensor, bitwise_and_tensor_)
+from flag_gems.ops.bitwise_and import (
+    bitwise_and_scalar,
+    bitwise_and_scalar_,
+    bitwise_and_scalar_tensor,
+    bitwise_and_tensor,
+    bitwise_and_tensor_,
+)
 from flag_gems.ops.bitwise_left_shift import bitwise_left_shift
 from flag_gems.ops.bitwise_not import bitwise_not, bitwise_not_
-from flag_gems.ops.bitwise_or import (bitwise_or_scalar, bitwise_or_scalar_,
-                                      bitwise_or_scalar_tensor,
-                                      bitwise_or_tensor, bitwise_or_tensor_)
+from flag_gems.ops.bitwise_or import (
+    bitwise_or_scalar,
+    bitwise_or_scalar_,
+    bitwise_or_scalar_tensor,
+    bitwise_or_tensor,
+    bitwise_or_tensor_,
+)
 from flag_gems.ops.bitwise_right_shift import bitwise_right_shift
 from flag_gems.ops.bmm import bmm, bmm_out
 from flag_gems.ops.cat import cat
 from flag_gems.ops.ceil import ceil, ceil_, ceil_out
 from flag_gems.ops.celu import celu, celu_
-from flag_gems.ops.clamp import (clamp, clamp_, clamp_min, clamp_min_,
-                                 clamp_tensor, clamp_tensor_)
+from flag_gems.ops.clamp import (
+    clamp,
+    clamp_,
+    clamp_min,
+    clamp_min_,
+    clamp_tensor,
+    clamp_tensor_,
+)
 from flag_gems.ops.contiguous import contiguous
 from flag_gems.ops.conv1d import conv1d
 from flag_gems.ops.conv2d import conv2d
@@ -52,9 +68,17 @@ from flag_gems.ops.cumsum import cumsum, cumsum_out, normed_cumsum
 from flag_gems.ops.diag import diag
 from flag_gems.ops.diag_embed import diag_embed
 from flag_gems.ops.diagonal import diagonal_backward
-from flag_gems.ops.div import (div_mode, div_mode_, floor_divide,
-                               floor_divide_, remainder, remainder_,
-                               true_divide, true_divide_, true_divide_out)
+from flag_gems.ops.div import (
+    div_mode,
+    div_mode_,
+    floor_divide,
+    floor_divide_,
+    remainder,
+    remainder_,
+    true_divide,
+    true_divide_,
+    true_divide_out,
+)
 from flag_gems.ops.dot import dot
 from flag_gems.ops.dropout import dropout, dropout_backward
 from flag_gems.ops.elu import elu, elu_, elu_backward
@@ -66,8 +90,14 @@ from flag_gems.ops.exp2 import exp2, exp2_
 from flag_gems.ops.exponential_ import exponential_
 from flag_gems.ops.eye import eye
 from flag_gems.ops.eye_m import eye_m
-from flag_gems.ops.fill import (fill_scalar, fill_scalar_, fill_scalar_out,
-                                fill_tensor, fill_tensor_, fill_tensor_out)
+from flag_gems.ops.fill import (
+    fill_scalar,
+    fill_scalar_,
+    fill_scalar_out,
+    fill_tensor,
+    fill_tensor_,
+    fill_tensor_out,
+)
 from flag_gems.ops.flip import flip
 from flag_gems.ops.full import full
 from flag_gems.ops.full_like import full_like
@@ -91,8 +121,7 @@ from flag_gems.ops.isnan import isnan
 from flag_gems.ops.kron import kron
 from flag_gems.ops.layernorm import layer_norm, layer_norm_backward
 from flag_gems.ops.le import le, le_scalar
-from flag_gems.ops.lerp import (lerp_scalar, lerp_scalar_, lerp_tensor,
-                                lerp_tensor_)
+from flag_gems.ops.lerp import lerp_scalar, lerp_scalar_, lerp_tensor, lerp_tensor_
 from flag_gems.ops.linspace import linspace
 from flag_gems.ops.log import log
 from flag_gems.ops.log_sigmoid import log_sigmoid
@@ -107,8 +136,10 @@ from flag_gems.ops.masked_fill import masked_fill, masked_fill_
 from flag_gems.ops.masked_scatter import masked_scatter, masked_scatter_
 from flag_gems.ops.masked_select import masked_select
 from flag_gems.ops.max import max, max_dim
-from flag_gems.ops.max_pool2d_with_indices import (max_pool2d_backward,
-                                                   max_pool2d_with_indices)
+from flag_gems.ops.max_pool2d_with_indices import (
+    max_pool2d_backward,
+    max_pool2d_with_indices,
+)
 from flag_gems.ops.maximum import maximum
 from flag_gems.ops.mean import mean, mean_dim
 from flag_gems.ops.min import min, min_dim
@@ -121,21 +152,35 @@ from flag_gems.ops.mv import mv
 from flag_gems.ops.nan_to_num import nan_to_num
 from flag_gems.ops.ne import ne, ne_scalar
 from flag_gems.ops.neg import neg, neg_
-from flag_gems.ops.nllloss import (nll_loss2d_backward, nll_loss2d_forward,
-                                   nll_loss_backward, nll_loss_forward)
+from flag_gems.ops.nllloss import (
+    nll_loss2d_backward,
+    nll_loss2d_forward,
+    nll_loss_backward,
+    nll_loss_forward,
+)
 from flag_gems.ops.nonzero import nonzero
-from flag_gems.ops.normal import (normal_, normal_float_tensor,
-                                  normal_tensor_float, normal_tensor_tensor)
+from flag_gems.ops.normal import (
+    normal_,
+    normal_float_tensor,
+    normal_tensor_float,
+    normal_tensor_tensor,
+)
 from flag_gems.ops.one_hot import one_hot
 from flag_gems.ops.ones import ones
 from flag_gems.ops.ones_like import ones_like
 from flag_gems.ops.pad import constant_pad_nd, pad
-from flag_gems.ops.per_token_group_quant_fp8 import (SUPPORTED_FP8_DTYPE,
-                                                     per_token_group_quant_fp8)
+from flag_gems.ops.per_token_group_quant_fp8 import (
+    SUPPORTED_FP8_DTYPE,
+    per_token_group_quant_fp8,
+)
 from flag_gems.ops.polar import polar
-from flag_gems.ops.pow import (pow_scalar, pow_tensor_scalar,
-                               pow_tensor_scalar_, pow_tensor_tensor,
-                               pow_tensor_tensor_)
+from flag_gems.ops.pow import (
+    pow_scalar,
+    pow_tensor_scalar,
+    pow_tensor_scalar_,
+    pow_tensor_tensor,
+    pow_tensor_tensor_,
+)
 from flag_gems.ops.prod import prod, prod_dim
 from flag_gems.ops.quantile import quantile
 from flag_gems.ops.rand import rand
@@ -146,17 +191,17 @@ from flag_gems.ops.randperm import randperm
 from flag_gems.ops.reciprocal import reciprocal, reciprocal_
 from flag_gems.ops.relu import relu, relu_
 from flag_gems.ops.repeat import repeat
-from flag_gems.ops.repeat_interleave import (repeat_interleave_self_int,
-                                             repeat_interleave_self_tensor,
-                                             repeat_interleave_tensor)
+from flag_gems.ops.repeat_interleave import (
+    repeat_interleave_self_int,
+    repeat_interleave_self_tensor,
+    repeat_interleave_tensor,
+)
 from flag_gems.ops.replication_pad3d import replication_pad3d
 from flag_gems.ops.resolve_conj import resolve_conj
 from flag_gems.ops.resolve_neg import resolve_neg
-from flag_gems.ops.rms_norm import (rms_norm, rms_norm_backward,
-                                    rms_norm_forward)
+from flag_gems.ops.rms_norm import rms_norm, rms_norm_backward, rms_norm_forward
 from flag_gems.ops.rsqrt import rsqrt, rsqrt_
-from flag_gems.ops.scaled_softmax import (scaled_softmax_backward,
-                                          scaled_softmax_forward)
+from flag_gems.ops.scaled_softmax import scaled_softmax_backward, scaled_softmax_forward
 from flag_gems.ops.scatter import scatter, scatter_
 from flag_gems.ops.scatter_add_ import scatter_add_
 from flag_gems.ops.select_scatter import select_scatter
@@ -193,10 +238,16 @@ from flag_gems.ops.var_mean import var_mean
 from flag_gems.ops.vdot import vdot
 from flag_gems.ops.vector_norm import vector_norm
 from flag_gems.ops.vstack import vstack
-from flag_gems.ops.weightnorm import (weight_norm_interface,
-                                      weight_norm_interface_backward)
-from flag_gems.ops.where import (where_scalar_other, where_scalar_self,
-                                 where_self, where_self_out)
+from flag_gems.ops.weightnorm import (
+    weight_norm_interface,
+    weight_norm_interface_backward,
+)
+from flag_gems.ops.where import (
+    where_scalar_other,
+    where_scalar_self,
+    where_self,
+    where_self_out,
+)
 from flag_gems.ops.zeros import zero_, zeros
 from flag_gems.ops.zeros_like import zeros_like
 

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -250,7 +250,10 @@ from flag_gems.ops.where import (
 from flag_gems.ops.zeros import zero_, zeros
 from flag_gems.ops.zeros_like import zeros_like
 
+from flag_gems.ops.smooth_l1_loss import smooth_l1_loss
+
 __all__ = [
+    "smooth_l1_loss",
     "_conv_depthwise2d",
     "_unique2",
     "_upsample_bicubic2d_aa",

--- a/src/flag_gems/ops/smooth_l1_loss.py
+++ b/src/flag_gems/ops/smooth_l1_loss.py
@@ -1,0 +1,107 @@
+import logging
+import math
+from enum import Enum
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, pointwise_dynamic
+from flag_gems.utils import triton_lang_extension as tle
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(is_tensor=[True, True, False], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def smooth_l1_none_func(x, y, beta):
+    diff = x - y
+    ad = tl.abs(diff)
+    ad_fp32 = ad.to(tl.float32)
+    beta_fp32 = beta.to(tl.float32)
+    # Smooth L1: 0.5 * x^2 / beta if |x| < beta, else |x| - 0.5 * beta
+    loss_quad = 0.5 * ad_fp32 * ad_fp32 / beta_fp32
+    loss_linear = ad_fp32 - 0.5 * beta_fp32
+    # beta <= 0 falls back to L1
+    result = tl.where(beta_fp32 > 0, tl.where(ad_fp32 < beta_fp32, loss_quad, loss_linear), ad_fp32)
+    return result
+
+
+@libentry()
+@triton.jit
+def smooth_l1_reduce_kernel(
+    inp,
+    target,
+    mid,
+    M,
+    beta,
+    BLOCK_SIZE: tl.constexpr,
+    IS_MEAN: tl.constexpr,
+):
+    pid = tle.program_id(0)
+    offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offset < M
+
+    inp_val = tl.load(inp + offset, mask=mask, other=0).to(tl.float32)
+    target_val = tl.load(target + offset, mask=mask, other=0).to(tl.float32)
+
+    diff = inp_val - target_val
+    ad = tl.abs(diff)
+
+    # Smooth L1 piecewise
+    loss_quad = 0.5 * ad * ad / beta
+    loss_linear = ad - 0.5 * beta
+    loss = tl.where(beta > 0, tl.where(ad < beta, loss_quad, loss_linear), ad)
+
+    if IS_MEAN:
+        sum_val = tl.sum(loss) / M
+    else:
+        sum_val = tl.sum(loss)
+
+    tl.store(mid + pid, sum_val)
+
+
+@libentry()
+@triton.jit
+def reduce_mid_kernel(mid, out, mid_size, BLOCK_MID: tl.constexpr):
+    offset = tl.arange(0, BLOCK_MID)
+    mask = offset < mid_size
+    mid_val = tl.load(mid + offset, mask=mask, other=0).to(tl.float32)
+    sum_val = tl.sum(mid_val)
+    tl.store(out, sum_val)
+
+
+class Reduction(Enum):
+    NONE = 0
+    MEAN = 1
+    SUM = 2
+
+
+def smooth_l1_loss(inp, target, reduction=Reduction.MEAN.value, beta=1.0):
+    logger.debug("GEMS SMOOTH_L1_LOSS")
+
+    if reduction == Reduction.NONE.value:
+        return smooth_l1_none_func(inp, target, beta)
+
+    inp = inp.contiguous()
+    target = target.contiguous()
+    M = inp.numel()
+    dtype = inp.dtype
+
+    block_size = triton.next_power_of_2(math.ceil(math.sqrt(M)))
+    mid_size = triton.cdiv(M, block_size)
+    block_mid = triton.next_power_of_2(mid_size)
+
+    mid = torch.empty((mid_size,), dtype=torch.float32, device=inp.device)
+    out = torch.empty([], dtype=dtype, device=inp.device)
+
+    is_mean = reduction == Reduction.MEAN.value
+
+    with torch_device_fn.device(inp.device):
+        smooth_l1_reduce_kernel[(mid_size, 1, 1)](
+            inp, target, mid, M, float(beta), block_size, is_mean
+        )
+        reduce_mid_kernel[(1, 1, 1)](mid, out, mid_size, block_mid)
+
+    return out


### PR DESCRIPTION
## Summary
- Add `smooth_l1_loss` operator implementation using Triton
- Difficulty: **Medium**
- Registered in `_FULL_CONFIG` for use with `flag_gems.use_gems()`

## Test plan
- [x] Tested accuracy against PyTorch CPU reference on Kaggle T4 GPU
- [x] Supports float32 and float16 dtypes
- [x] Passes `torch.allclose` with competition tolerance thresholds
- [ ] FlagGems CI pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)