### PR TITLE
[FlagGems Operator Development Competition] Add pixel_shuffle

### DIFF
--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -1020,3 +1020,46 @@ def test_perf_unfold_backward():
     )
     bench.set_gems(flag_gems.unfold_backward)
     bench.run()
+
+
+class PixelShuffleBenchmark(Benchmark):
+    # pixel_shuffle needs (N, C, H, W) with C divisible by r^2
+    DEFAULT_SHAPES = [
+        (1, 16, 64, 64),
+        (1, 16, 128, 128),
+        (1, 16, 256, 256),
+        (4, 64, 64, 64),
+        (4, 64, 128, 128),
+        (1, 36, 64, 64),
+        (1, 36, 128, 128),
+        (2, 36, 256, 256),
+    ]
+
+    def __init__(self, upscale_factor, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.upscale_factor = upscale_factor
+        self.shapes = self.DEFAULT_SHAPES
+
+    def set_shapes(self, shape_file_path=None):
+        # Override to use fixed pixel_shuffle shapes only
+        self.shapes = self.DEFAULT_SHAPES
+
+    def get_input_iter(self, cur_dtype):
+        for shape in self.shapes:
+            N, C, H, W = shape
+            r2 = self.upscale_factor * self.upscale_factor
+            C_in = C * r2
+            inp = torch.randn(N, C_in, H, W, dtype=cur_dtype, device=self.device)
+            yield {"input": inp, "upscale_factor": self.upscale_factor},
+
+
+@pytest.mark.pixel_shuffle
+@pytest.mark.parametrize("upscale_factor", [2, 3, 4], ids=["r2", "r3", "r4"])
+def test_perf_pixel_shuffle(upscale_factor):
+    bench = PixelShuffleBenchmark(
+        upscale_factor=upscale_factor,
+        op_name=f"pixel_shuffle_r{upscale_factor}",
+        torch_op=torch.pixel_shuffle,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -268,6 +268,7 @@ _FULL_CONFIG = (
     ("ones_like", ones_like),
     ("one_hot", one_hot),
     ("pad", pad),
+    ("pixel_shuffle", pixel_shuffle),
     ("polar", polar),
     ("pow.Scalar", pow_scalar),
     ("pow.Tensor_Scalar", pow_tensor_scalar),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -173,6 +173,7 @@ from flag_gems.ops.per_token_group_quant_fp8 import (
     SUPPORTED_FP8_DTYPE,
     per_token_group_quant_fp8,
 )
+from flag_gems.ops.pixel_shuffle import pixel_shuffle
 from flag_gems.ops.polar import polar
 from flag_gems.ops.pow import (
     pow_scalar,
@@ -457,6 +458,7 @@ __all__ = [
     "ones_like",
     "one_hot",
     "pad",
+    "pixel_shuffle",
     "per_token_group_quant_fp8",
     "polar",
     "pow_scalar",

--- a/src/flag_gems/ops/pixel_shuffle.py
+++ b/src/flag_gems/ops/pixel_shuffle.py
@@ -1,0 +1,132 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+
+logger = logging.getLogger(__name__)
+
+AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCK_SIZE": 256}, num_warps=2, num_stages=3),
+    triton.Config({"BLOCK_SIZE": 512}, num_warps=4, num_stages=3),
+    triton.Config({"BLOCK_SIZE": 1024}, num_warps=4, num_stages=3),
+    triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=3),
+    triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=4),
+    triton.Config({"BLOCK_SIZE": 1024}, num_warps=8, num_stages=4),
+    triton.Config({"BLOCK_SIZE": 2048}, num_warps=4, num_stages=4),
+]
+
+
+@libentry()
+@triton.autotune(configs=AUTOTUNE_CONFIGS, key=["hw_elements"])
+@triton.jit
+def pixel_shuffle_kernel(
+    in_ptr,
+    out_ptr,
+    # input strides
+    s_in_batch,
+    s_in_c,
+    s_in_h,
+    s_in_w,
+    # output batch stride (output is contiguous)
+    s_out_batch,
+    # dims
+    H_out,
+    W_out,
+    hw_elements,
+    R: tl.constexpr,
+    R2: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tle.program_id(0)
+    batch_id = tle.program_id(1)
+
+    block_start = pid * BLOCK_SIZE
+    offs = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offs < hw_elements
+
+    # Decompose flat index into (co, ho, wo) within one batch element
+    wo = offs % W_out
+    tmp = offs // W_out
+    ho = tmp % H_out
+    co = tmp // H_out
+
+    # Map output (co, ho, wo) -> input (cin, h, w)
+    # R is constexpr so these divmod ops compile to fast shifts/multiplies
+    rh = ho % R
+    h = ho // R
+    rw = wo % R
+    w = wo // R
+    cin = co * R2 + rh * R + rw
+
+    in_idx = batch_id * s_in_batch + cin * s_in_c + h * s_in_h + w * s_in_w
+    # Output is contiguous: use linear index directly
+    out_idx = batch_id * s_out_batch + offs
+
+    val = tl.load(in_ptr + in_idx, mask=mask, other=0)
+    tl.store(out_ptr + out_idx, val, mask=mask)
+
+
+def pixel_shuffle(self: torch.Tensor, upscale_factor: int) -> torch.Tensor:
+    logger.debug("GEMS PIXEL_SHUFFLE")
+    assert self.ndim >= 3, (
+        f"pixel_shuffle expects input to have at least 3 dimensions, "
+        f"but got input with {self.ndim} dimension(s)"
+    )
+    r = upscale_factor
+    r2 = r * r
+    C_in = self.shape[-3]
+    H = self.shape[-2]
+    W = self.shape[-1]
+    assert C_in % r2 == 0, (
+        f"pixel_shuffle expects input channel to be divisible by "
+        f"upscale_factor^2={r2}, but got {C_in} channels"
+    )
+
+    C_out = C_in // r2
+    H_out = H * r
+    W_out = W * r
+
+    # Handle arbitrary leading batch dimensions
+    batch_shape = self.shape[:-3]
+    batch = 1
+    for s in batch_shape:
+        batch *= s
+
+    out_shape = batch_shape + (C_out, H_out, W_out)
+    output = torch.empty(out_shape, dtype=self.dtype, device=self.device)
+
+    if self.numel() == 0:
+        return output
+
+    # Flatten batch dims for kernel
+    inp_view = self.reshape(batch, C_in, H, W)
+    out_view = output.reshape(batch, C_out, H_out, W_out)
+
+    s_in_batch, s_in_c, s_in_h, s_in_w = inp_view.stride()
+    s_out_batch = out_view.stride()[0]
+
+    hw_elements = C_out * H_out * W_out
+    grid = lambda meta: (triton.cdiv(hw_elements, meta["BLOCK_SIZE"]), batch)
+
+    with torch_device_fn.device(self.device):
+        pixel_shuffle_kernel[grid](
+            inp_view,
+            out_view,
+            s_in_batch,
+            s_in_c,
+            s_in_h,
+            s_in_w,
+            s_out_batch,
+            H_out,
+            W_out,
+            hw_elements,
+            R=r,
+            R2=r2,
+        )
+
+    return output

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -2049,3 +2049,140 @@ def test_unfold_backward(input_sizes, dim, size, step, dtype):
     with flag_gems.use_gems():
         res_out = flag_gems.unfold_backward(grad_in, input_sizes, dim, size, step)
     gems_assert_close(res_out, ref_out, dtype, reduce_dim=size)
+
+
+# ========== pixel_shuffle tests ==========
+
+PIXEL_SHUFFLE_SHAPES_R2 = [
+    (1, 4, 2, 3),
+    (2, 8, 4, 4),
+    (4, 64, 32, 32),
+    (2, 128, 64, 64),
+    (1, 4, 1, 1),
+    (1, 4, 7, 13),
+    (1, 4, 127, 131),
+    (3, 16, 33, 57),
+]
+
+PIXEL_SHUFFLE_SHAPES_R3 = [
+    (1, 9, 4, 4),
+    (2, 18, 8, 8),
+    (1, 9, 1, 1),
+    (1, 9, 7, 13),
+    (2, 27, 17, 31),
+]
+
+PIXEL_SHUFFLE_SHAPES_R4 = [
+    (1, 16, 4, 4),
+    (1, 64, 16, 16),
+    (2, 32, 8, 8),
+]
+
+
+@pytest.mark.pixel_shuffle
+@pytest.mark.parametrize("shape", PIXEL_SHUFFLE_SHAPES_R2)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_pixel_shuffle_r2(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=device)
+    ref_inp = to_reference(inp)
+    ref_out = torch.pixel_shuffle(ref_inp, 2)
+    with flag_gems.use_gems():
+        res_out = torch.pixel_shuffle(inp, 2)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.pixel_shuffle
+@pytest.mark.parametrize("shape", PIXEL_SHUFFLE_SHAPES_R3)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_pixel_shuffle_r3(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=device)
+    ref_inp = to_reference(inp)
+    ref_out = torch.pixel_shuffle(ref_inp, 3)
+    with flag_gems.use_gems():
+        res_out = torch.pixel_shuffle(inp, 3)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.pixel_shuffle
+@pytest.mark.parametrize("shape", PIXEL_SHUFFLE_SHAPES_R4)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_pixel_shuffle_r4(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=device)
+    ref_inp = to_reference(inp)
+    ref_out = torch.pixel_shuffle(ref_inp, 4)
+    with flag_gems.use_gems():
+        res_out = torch.pixel_shuffle(inp, 4)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.pixel_shuffle
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_pixel_shuffle_3d(dtype):
+    # 3D input: (C, H, W)
+    inp = torch.randn(18, 4, 4, dtype=dtype, device=device)
+    ref_inp = to_reference(inp)
+    ref_out = torch.pixel_shuffle(ref_inp, 3)
+    with flag_gems.use_gems():
+        res_out = torch.pixel_shuffle(inp, 3)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.pixel_shuffle
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_pixel_shuffle_5d(dtype):
+    # 5D input: (B1, B2, C, H, W)
+    inp = torch.randn(2, 3, 18, 4, 4, dtype=dtype, device=device)
+    ref_inp = to_reference(inp)
+    ref_out = torch.pixel_shuffle(ref_inp, 3)
+    with flag_gems.use_gems():
+        res_out = torch.pixel_shuffle(inp, 3)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.pixel_shuffle
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_pixel_shuffle_non_contiguous(dtype):
+    # Non-contiguous via transpose
+    inp = torch.randn(2, 4, 4, 4, dtype=dtype, device=device).permute(0, 1, 3, 2)
+    assert not inp.is_contiguous()
+    ref_inp = to_reference(inp)
+    ref_out = torch.pixel_shuffle(ref_inp, 2)
+    with flag_gems.use_gems():
+        res_out = torch.pixel_shuffle(inp, 2)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.pixel_shuffle
+@pytest.mark.parametrize("dtype", INT_DTYPES + BOOL_TYPES)
+def test_accuracy_pixel_shuffle_int_bool(dtype):
+    if dtype == torch.bool:
+        inp = torch.randint(0, 2, (1, 4, 4, 4), dtype=dtype, device=device)
+    else:
+        inp = torch.randint(-100, 100, (1, 4, 4, 4), dtype=dtype, device=device)
+    ref_inp = to_reference(inp)
+    ref_out = torch.pixel_shuffle(ref_inp, 2)
+    with flag_gems.use_gems():
+        res_out = torch.pixel_shuffle(inp, 2)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.pixel_shuffle
+def test_accuracy_pixel_shuffle_upscale_factor_1():
+    # upscale_factor=1 is identity (no rearrangement)
+    inp = torch.randn(2, 3, 8, 8, dtype=torch.float32, device=device)
+    ref_inp = to_reference(inp)
+    ref_out = torch.pixel_shuffle(ref_inp, 1)
+    with flag_gems.use_gems():
+        res_out = torch.pixel_shuffle(inp, 1)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.pixel_shuffle
+def test_accuracy_pixel_shuffle_large(dtype=torch.float32):
+    # Large tensor
+    inp = torch.randn(4, 64, 128, 128, dtype=dtype, device=device)
+    ref_inp = to_reference(inp)
+    ref_out = torch.pixel_shuffle(ref_inp, 4)
+    with flag_gems.use_gems():
+        res_out = torch.pixel_shuffle(inp, 4)
+    gems_assert_equal(res_out, ref_out)


### PR DESCRIPTION
## [FlagGems Operator Development Competition] Add pixel_shuffle

## Summary
- Implement `torch.pixel_shuffle` using Triton kernel with output-centric element mapping
- Support arbitrary batch dimensions (3D, 4D, 5D+ inputs)
- Non-contiguous input support via explicit stride parameters
- Optimized with `@triton.autotune` (7 configs), `R` as `tl.constexpr`, and contiguous output linear indexing
- Precision: bit-exact (`gems_assert_equal`) — pure layout operation, no numerical computation

## Test Coverage

### Test Functions (10 total)
| Test Function | upscale_factor | Input Type |
|---------------|----------------|------------|
| `test_accuracy_pixel_shuffle_r2` | 2 | contiguous 4D, 8 shapes × 3 dtypes |
| `test_accuracy_pixel_shuffle_r3` | 3 | contiguous 4D, 5 shapes × 3 dtypes |
| `test_accuracy_pixel_shuffle_r4` | 4 | contiguous 4D, 3 shapes × 3 dtypes |
| `test_accuracy_pixel_shuffle_3d` | 3 | contiguous 3D, 3 dtypes |
| `test_accuracy_pixel_shuffle_5d` | 3 | contiguous 5D, 3 dtypes |
| `test_accuracy_pixel_shuffle_non_contiguous` | 2 | non-contiguous (permuted) 4D, 3 dtypes |
| `test_accuracy_pixel_shuffle_int_bool` | 2 | int16, int32, bool |
| `test_accuracy_pixel_shuffle_upscale_factor_1` | 1 | identity case |
| `test_accuracy_pixel_shuffle_large` | 4 | large tensor (4, 64, 128, 128) |

### Parameter Coverage

| Dimension | Values | Count |
|-----------|--------|-------|
| **Shape (r=2)** | (1,4,2,3), (2,8,4,4), (4,64,32,32), (2,128,64,64), (1,4,1,1), (1,4,7,13), (1,4,127,131), (3,16,33,57) | 8 shapes |
| **Shape (r=3)** | (1,9,4,4), (2,18,8,8), (1,9,1,1), (1,9,7,13), (2,27,17,31) | 5 shapes |
| **Shape (r=4)** | (1,16,4,4), (1,64,16,16), (2,32,8,8) | 3 shapes |
| **dtype (float)** | float16, float32, bfloat16 | 3 dtypes |
| **dtype (int/bool)** | int16, int32, bool | 3 dtypes |
| **upscale_factor** | 1, 2, 3, 4 | 4 values |
| **ndim** | 3D, 4D, 5D | 3 variants |
| **Contiguity** | contiguous, non-contiguous (permuted) | 2 modes |

**Shape details:**
- Small: (1,4,1,1), (1,9,1,1), (1,4,2,3)
- Medium: (2,8,4,4), (1,9,4,4), (1,16,4,4), (2,32,8,8)
- Large: (4,64,32,32), (2,128,64,64), (1,64,16,16), (4,64,128,128)
- Prime dims: (1,4,7,13), (1,4,127,131), (1,9,7,13), (2,27,17,31), (3,16,33,57) — exposes mask boundary bugs
- 3D: (18,4,4) — no batch dim
- 5D: (2,3,18,4,4) — multiple batch dims

**Assertion method:** `gems_assert_equal` (bit-exact match) — pixel_shuffle is a pure data rearrangement with no arithmetic.

**Total test cases:** (8×3) + (5×3) + (3×3) + 3 + 3 + 3 + 3 + 1 + 1 = **62 test cases**

## Performance (NVIDIA H100 80GB HBM3, CUDA 12.8)

### `pixel_shuffle` (r=2) Benchmark

| Shape | dtype | PyTorch (ms) | FlagGems (ms) | Speedup |
|-------|-------|-------------|--------------|---------|
| [1, 64, 64, 64] | float16 | 0.0083 | 0.0066 | **1.26x** |
| [1, 64, 128, 128] | float16 | 0.0095 | 0.0082 | **1.16x** |
| [1, 64, 256, 256] | float16 | 0.0199 | 0.0141 | **1.41x** |
| [4, 256, 64, 64] | float16 | 0.0201 | 0.0153 | **1.31x** |
| [4, 256, 128, 128] | float16 | 0.0582 | 0.0371 | **1.57x** |
| [1, 144, 64, 64] | float16 | 0.0090 | 0.0076 | **1.19x** |
| [1, 144, 128, 128] | float16 | 0.0145 | 0.0106 | **1.36x** |
| [2, 144, 256, 256] | float16 | 0.0652 | 0.0408 | **1.60x** |
| [1, 64, 64, 64] | float32 | 0.0076 | 0.0070 | **1.08x** |
| [1, 64, 128, 128] | float32 | 0.0105 | 0.0095 | **1.10x** |
| [1, 64, 256, 256] | float32 | 0.0223 | 0.0184 | **1.21x** |
| [4, 256, 64, 64] | float32 | 0.0222 | 0.0183 | **1.22x** |
| [4, 256, 128, 128] | float32 | 0.0678 | 0.0516 | **1.31x** |
| [1, 144, 64, 64] | float32 | 0.0088 | 0.0082 | **1.08x** |
| [1, 144, 128, 128] | float32 | 0.0153 | 0.0131 | **1.17x** |
| [2, 144, 256, 256] | float32 | 0.0754 | 0.0565 | **1.33x** |
| [1, 64, 64, 64] | bfloat16 | 0.0083 | 0.0066 | **1.25x** |
| [1, 64, 128, 128] | bfloat16 | 0.0097 | 0.0085 | **1.15x** |
| [1, 64, 256, 256] | bfloat16 | 0.0199 | 0.0142 | **1.41x** |
| [4, 256, 64, 64] | bfloat16 | 0.0201 | 0.0152 | **1.32x** |
| [4, 256, 128, 128] | bfloat16 | 0.0580 | 0.0371 | **1.57x** |
| [1, 144, 64, 64] | bfloat16 | 0.0089 | 0.0076 | **1.18x** |
| [1, 144, 128, 128] | bfloat16 | 0.0145 | 0.0106 | **1.37x** |
| [2, 144, 256, 256] | bfloat16 | 0.0650 | 0.0407 | **1.60x** |

### `pixel_shuffle` (r=3) Benchmark

| Shape | dtype | PyTorch (ms) | FlagGems (ms) | Speedup |
|-------|-------|-------------|--------------|---------|
| [1, 144, 64, 64] | float16 | 0.0088 | 0.0075 | **1.17x** |
| [1, 144, 128, 128] | float16 | 0.0140 | 0.0112 | **1.25x** |
| [1, 144, 256, 256] | float16 | 0.0344 | 0.0253 | **1.36x** |
| [4, 576, 64, 64] | float16 | 0.0343 | 0.0254 | **1.35x** |
| [4, 576, 128, 128] | float16 | 0.1144 | 0.0815 | **1.40x** |
| [1, 324, 64, 64] | float16 | 0.0110 | 0.0088 | **1.24x** |
| [1, 324, 128, 128] | float16 | 0.0224 | 0.0169 | **1.32x** |
| [2, 324, 256, 256] | float16 | 0.1281 | 0.0915 | **1.40x** |
| [1, 144, 64, 64] | float32 | 0.0088 | 0.0080 | **1.10x** |
| [1, 144, 128, 128] | float32 | 0.0156 | 0.0134 | **1.17x** |
| [1, 144, 256, 256] | float32 | 0.0420 | 0.0325 | **1.29x** |
| [4, 576, 64, 64] | float32 | 0.0418 | 0.0327 | **1.28x** |
| [4, 576, 128, 128] | float32 | 0.1439 | 0.1080 | **1.33x** |
| [1, 324, 64, 64] | float32 | 0.0116 | 0.0104 | **1.12x** |
| [1, 324, 128, 128] | float32 | 0.0269 | 0.0213 | **1.26x** |
| [2, 324, 256, 256] | float32 | 0.1617 | 0.1195 | **1.35x** |
| [1, 144, 64, 64] | bfloat16 | 0.0088 | 0.0076 | **1.16x** |
| [1, 144, 128, 128] | bfloat16 | 0.0140 | 0.0112 | **1.25x** |
| [1, 144, 256, 256] | bfloat16 | 0.0345 | 0.0255 | **1.35x** |
| [4, 576, 64, 64] | bfloat16 | 0.0344 | 0.0255 | **1.35x** |
| [4, 576, 128, 128] | bfloat16 | 0.1150 | 0.0820 | **1.40x** |
| [1, 324, 64, 64] | bfloat16 | 0.0112 | 0.0089 | **1.26x** |
| [1, 324, 128, 128] | bfloat16 | 0.0224 | 0.0171 | **1.31x** |
| [2, 324, 256, 256] | bfloat16 | 0.1286 | 0.0915 | **1.41x** |

### `pixel_shuffle` (r=4) Benchmark

| Shape | dtype | PyTorch (ms) | FlagGems (ms) | Speedup |
|-------|-------|-------------|--------------|---------|
| [1, 256, 64, 64] | float16 | 0.0097 | 0.0086 | **1.12x** |
| [1, 256, 128, 128] | float16 | 0.0203 | 0.0148 | **1.37x** |
| [1, 256, 256, 256] | float16 | 0.0617 | 0.0400 | **1.54x** |
| [4, 1024, 64, 64] | float16 | 0.0611 | 0.0400 | **1.53x** |
| [4, 1024, 128, 128] | float16 | 0.2167 | 0.1408 | **1.54x** |
| [1, 576, 64, 64] | float16 | 0.0152 | 0.0112 | **1.35x** |
| [1, 576, 128, 128] | float16 | 0.0376 | 0.0253 | **1.48x** |
| [2, 576, 256, 256] | float16 | 0.2459 | 0.1576 | **1.56x** |
| [1, 256, 64, 64] | float32 | 0.0106 | 0.0096 | **1.10x** |
| [1, 256, 128, 128] | float32 | 0.0229 | 0.0182 | **1.26x** |
| [1, 256, 256, 256] | float32 | 0.0704 | 0.0517 | **1.36x** |
| [4, 1024, 64, 64] | float32 | 0.0695 | 0.0517 | **1.34x** |
| [4, 1024, 128, 128] | float32 | 0.2554 | 0.1831 | **1.40x** |
| [1, 576, 64, 64] | float32 | 0.0155 | 0.0131 | **1.19x** |
| [1, 576, 128, 128] | float32 | 0.0427 | 0.0317 | **1.35x** |
| [2, 576, 256, 256] | float32 | 0.2880 | 0.2054 | **1.40x** |
| [1, 256, 64, 64] | bfloat16 | 0.0097 | 0.0085 | **1.13x** |
| [1, 256, 128, 128] | bfloat16 | 0.0203 | 0.0149 | **1.36x** |
| [1, 256, 256, 256] | bfloat16 | 0.0616 | 0.0401 | **1.53x** |
| [4, 1024, 64, 64] | bfloat16 | 0.0611 | 0.0402 | **1.52x** |
| [4, 1024, 128, 128] | bfloat16 | 0.2169 | 0.1407 | **1.54x** |
| [1, 576, 64, 64] | bfloat16 | 0.0151 | 0.0114 | **1.33x** |
| [1, 576, 128, 128] | bfloat16 | 0.0374 | 0.0255 | **1.47x** |
| [2, 576, 256, 256] | bfloat16 | 0.2458 | 0.1578 | **1.56x** |

### Performance Summary

| Variant | Min Speedup | Max Speedup | Median Speedup | Shapes < 0.9x |
|---------|-------------|-------------|----------------|----------------|
| `pixel_shuffle` (r=2) | 1.08x | 1.60x | 1.27x | 0/24 |
| `pixel_shuffle` (r=3) | 1.10x | 1.41x | 1.31x | 0/24 |
| `pixel_shuffle` (r=4) | 1.10x | 1.56x | 1.39x | 0/24 |

**All 72 benchmark configurations exceed PyTorch native performance (min speedup 1.08x).** No sub-0.9x cases.
