### PR TITLE
fix(moe-align): import TLE GPU language module for DSA compatibility

### DIFF
--- a/src/flag_gems/fused/moe_align_block_size.py
+++ b/src/flag_gems/fused/moe_align_block_size.py
@@ -10,10 +10,12 @@ from flag_gems.utils import libentry, libtuner
 
 try:
     import triton.experimental.tle.language as tle
+    import triton.experimental.tle.language.gpu as tleg
 
     HAS_TLE = True
 except ImportError:
     tle = None
+    tleg = None
     HAS_TLE = False
 
 


### PR DESCRIPTION
## Summary
- add `import triton.experimental.tle.language.gpu as tleg` in `src/flag_gems/fused/moe_align_block_size.py`
- keep TLE import handling safe by setting `tleg = None` in the `ImportError` fallback path

## Why
Some DSA environments do not expose `tle.gpu` / `tle.distributed_barrier` through implicit module loading, which can make `moe_align_block_size` fail at import time in FlagTree.

Explicitly importing the TLE GPU submodule ensures those symbols are registered before use and avoids import-time failures on those platforms.

## Validation
- `python -m compileall -q src/flag_gems/fused/moe_align_block_size.py`
