### PR TITLE
Update hugo-site workflow to run on gh-pages branch

### DIFF
--- a/.github/workflows/hugo-site.yaml
+++ b/.github/workflows/hugo-site.yaml
@@ -2,7 +2,7 @@ name: Build and deploy
 on:
   push:
     branches:
-      - main
+      - gh-pages
   workflow_dispatch:
 permissions:
   contents: read
@@ -27,6 +27,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
         with:
+          ref: gh-pages
           submodules: recursive
           fetch-depth: 0
       - name: Setup Go


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Documentation Update

### Description

This PR updates the docs build to be triggered on gh-pages branch rather than master.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
