### PR TITLE
fix(moe-align): guard TLE imports with triton>=3.6.0

### DIFF
--- a/src/flag_gems/fused/moe_align_block_size.py
+++ b/src/flag_gems/fused/moe_align_block_size.py
@@ -8,12 +8,35 @@ import triton.language as tl
 
 from flag_gems.utils import libentry, libtuner
 
-try:
-    import triton.experimental.tle.language as tle
-    import triton.experimental.tle.language.gpu as tleg
 
-    HAS_TLE = True
-except ImportError:
+def _triton_version_at_least(major: int, minor: int, patch: int = 0) -> bool:
+    version = str(getattr(triton, "__version__", "0.0.0")).split("+", 1)[0]
+    parts = version.split(".")
+    parsed = []
+    for part in parts[:3]:
+        digits = []
+        for ch in part:
+            if ch.isdigit():
+                digits.append(ch)
+            else:
+                break
+        parsed.append(int("".join(digits)) if digits else 0)
+    while len(parsed) < 3:
+        parsed.append(0)
+    return tuple(parsed) >= (major, minor, patch)
+
+
+if _triton_version_at_least(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle
+        import triton.experimental.tle.language.gpu as tleg
+
+        HAS_TLE = True
+    except ImportError:
+        tle = None
+        tleg = None
+        HAS_TLE = False
+else:
     tle = None
     tleg = None
     HAS_TLE = False


### PR DESCRIPTION
## Summary
- keep explicit TLE GPU submodule import in `src/flag_gems/fused/moe_align_block_size.py`
- add a Triton version gate so TLE imports are attempted only when `triton >= 3.6.0`
- fall back to non-TLE path (`HAS_TLE = False`) on Triton 3.5.x and other lower versions

## Why
FlagTree 3.5 environments can fail when importing TLE-related symbols used by `moe_align_block_size`.

By gating TLE initialization on `triton >= 3.6.0`, we avoid import-time incompatibility on 3.5 while preserving the TLE fast path for supported Triton versions.

## Implementation details
- introduced `_triton_version_at_least(major, minor, patch)` for robust version parsing (handles suffixes like `+` build tags)
- wrapped `triton.experimental.tle.language` imports inside the version check
- retained safe fallback values: `tle = None`, `tleg = None`, `HAS_TLE = False`

## Validation
- `python -m compileall -q src/flag_gems/fused/moe_align_block_size.py`

## Notes
- this PR supersedes the previous import-only fix by adding explicit Triton version compatibility handling.
