### PR TITLE
feat: Add multi-backend support (CUDA/IX/MUSA/NPU) and expand C++ ope…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,38 @@
-cmake_minimum_required(VERSION 3.26 FATAL_ERROR)
-project(FlagGems LANGUAGES CXX VERSION 0.1.0)
+cmake_minimum_required(VERSION 3.25 FATAL_ERROR)
+
+# ==============================================================================
+# Backend Selection
+# ==============================================================================
+set(FLAGGEMS_BACKEND "CUDA" CACHE STRING "Target backend: CUDA, IX, MUSA, NPU")
+set_property(CACHE FLAGGEMS_BACKEND PROPERTY STRINGS "CUDA" "IX" "MUSA" "NPU")
+
+if(NOT FLAGGEMS_BACKEND MATCHES "^(CUDA|IX|MUSA|NPU)$")
+    message(FATAL_ERROR "Invalid FLAGGEMS_BACKEND: ${FLAGGEMS_BACKEND}")
+endif()
+message(STATUS "Building FlagGems with backend: ${FLAGGEMS_BACKEND}")
+
+# NPU and MUSA do not need CUDA language
+if(FLAGGEMS_BACKEND STREQUAL "NPU" OR FLAGGEMS_BACKEND STREQUAL "MUSA")
+    project(FlagGems LANGUAGES CXX VERSION 0.1.0)
+else()
+    project(FlagGems LANGUAGES CUDA CXX VERSION 0.1.0)
+endif()
+
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
 
+# ------------------------------- Backend compile definitions -------------------------------
+if(FLAGGEMS_BACKEND STREQUAL "CUDA")
+    add_compile_definitions(FLAGGEMS_USE_CUDA)
+elseif(FLAGGEMS_BACKEND STREQUAL "IX")
+    add_compile_definitions(FLAGGEMS_USE_IX)
+elseif(FLAGGEMS_BACKEND STREQUAL "NPU")
+    add_compile_definitions(FLAGGEMS_USE_NPU)
+elseif(FLAGGEMS_BACKEND STREQUAL "MUSA")
+    add_compile_definitions(FLAGGEMS_USE_MUSA)
+endif()
+
 # ------------------------------- project-wide settings -------------------------------
-set(CMAKE_CXX_STANDARD 17) # for fold-expression
+set(CMAKE_CXX_STANDARD 20) # for fold-expression and concepts
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF) # Ensures only standard-compliant C++ is used
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
@@ -41,10 +70,18 @@ endif()
 
 message(STATUS "Building flag gems with C extensions")
 include(FetchContent)
-# dependencies: cuda toolkit
-find_package(CUDAToolkit REQUIRED)
-# dependencies: python
+
+# dependencies: python (must be before backend includes that need Python_EXECUTABLE)
 find_package(Python REQUIRED COMPONENTS Interpreter Development)
+
+# --------------------------- Backend-specific dependencies ---------------------------
+if(FLAGGEMS_BACKEND STREQUAL "CUDA" OR FLAGGEMS_BACKEND STREQUAL "IX")
+    find_package(CUDAToolkit REQUIRED)
+elseif(FLAGGEMS_BACKEND STREQUAL "NPU")
+    include(BackendNPU)
+elseif(FLAGGEMS_BACKEND STREQUAL "MUSA")
+    include(BackendMUSA)
+endif()
 # torch
 find_package(Torch MODULE REQUIRED) # This is the FindTorch.cmake
 # dependencies: json
@@ -52,9 +89,10 @@ if(FLAGGEMS_USE_EXTERNAL_TRITON_JIT)
   find_package(TritonJIT 0.1.0 CONFIG REQUIRED)
 else()
   set(TRITON_JIT_INSTALL ON) # install triton jit
+  set(BACKEND ${FLAGGEMS_BACKEND} CACHE STRING "Backend for TritonJIT" FORCE)
   FetchContent_Declare(TritonJIT
     GIT_REPOSITORY https://github.com/flagos-ai/libtriton_jit
-    # SOURCE_DIR <your local source dir of libtriton_jit>
+    GIT_TAG multi-backend
   )
   FetchContent_MakeAvailable(TritonJIT)
 endif()
@@ -83,7 +121,8 @@ if(FLAGGEMS_BUILD_CTESTS)
 endif()
 
 execute_process(
-  COMMAND ${Python_EXECUTABLE}
+  #COMMAND ${Python_EXECUTABLE}
+  COMMAND ${CMAKE_COMMAND} -E env --unset=LD_PRELOAD ${Python_EXECUTABLE}
           -c "import triton, sys; sys.stdout.write(triton.__version__)"
   RESULT_VARIABLE _ret
   OUTPUT_VARIABLE TRITON_VERSION

--- a/cmake/BackendMUSA.cmake
+++ b/cmake/BackendMUSA.cmake
@@ -1,0 +1,80 @@
+# MUSA (Moore Threads) Backend Configuration
+message(STATUS "Configuring MUSA backend...")
+
+set(MUSA_HOME $ENV{MUSA_HOME})
+if(NOT MUSA_HOME)
+    set(MUSA_HOME "/usr/local/musa")
+endif()
+
+find_library(MUSA_LIBRARY musa PATHS ${MUSA_HOME}/lib REQUIRED)
+find_library(MUSA_RUNTIME_LIBRARY musart PATHS ${MUSA_HOME}/lib REQUIRED)
+
+# Create MUSA::musa_runtime imported target (required by TritonJIT)
+if(NOT TARGET MUSA::musa_runtime)
+    add_library(MUSA::musa_runtime SHARED IMPORTED)
+    set_target_properties(MUSA::musa_runtime PROPERTIES
+        IMPORTED_LOCATION "${MUSA_RUNTIME_LIBRARY}"
+        INTERFACE_INCLUDE_DIRECTORIES "${MUSA_HOME}/include"
+    )
+endif()
+
+# torch_musa path - derive from Python site-packages
+execute_process(
+    COMMAND ${Python_EXECUTABLE} -c "import site; print(site.getsitepackages()[0])"
+    OUTPUT_VARIABLE PYTHON_SITE_PACKAGES
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+)
+set(TORCH_MUSA_PATH "${PYTHON_SITE_PACKAGES}/torch_musa")
+if(NOT EXISTS "${TORCH_MUSA_PATH}")
+    set(TORCH_MUSA_PATH "")
+endif()
+message(STATUS "TORCH_MUSA_PATH: ${TORCH_MUSA_PATH}")
+
+# Find torch_musa library (libmusa_python.so) - provides c10::musa::* symbols
+set(TORCH_MUSA_LIB_PATH "${TORCH_MUSA_PATH}/lib")
+find_library(TORCH_MUSA_LIBRARY musa_python PATHS ${TORCH_MUSA_LIB_PATH} NO_DEFAULT_PATH)
+if(TORCH_MUSA_LIBRARY)
+    message(STATUS "Found torch_musa library: ${TORCH_MUSA_LIBRARY}")
+else()
+    message(WARNING "torch_musa library (libmusa_python.so) not found in ${TORCH_MUSA_LIB_PATH}")
+endif()
+
+# Find libittnotify.so (provides iJIT_NotifyEvent symbol)
+set(CONDA_PREFIX $ENV{CONDA_PREFIX})
+if(CONDA_PREFIX)
+    find_library(ITTNOTIFY_LIBRARY ittnotify PATHS ${CONDA_PREFIX}/lib NO_DEFAULT_PATH)
+    if(ITTNOTIFY_LIBRARY)
+        message(STATUS "Found ittnotify library: ${ITTNOTIFY_LIBRARY}")
+    endif()
+endif()
+
+# Export libraries for use in other CMakeLists
+# Note: libmusa_python.so requires libtorch_python.so for pybind11 symbols
+set(MUSA_EXTRA_LIBRARIES "" CACHE INTERNAL "Extra libraries needed for MUSA backend")
+if(TORCH_MUSA_LIBRARY)
+    list(APPEND MUSA_EXTRA_LIBRARIES ${TORCH_MUSA_LIBRARY})
+endif()
+if(ITTNOTIFY_LIBRARY)
+    list(APPEND MUSA_EXTRA_LIBRARIES ${ITTNOTIFY_LIBRARY})
+endif()
+# torch_python lib will be added after FindTorch.cmake is included
+
+function(target_link_musa_libraries target)
+    target_link_libraries(${target} PRIVATE ${MUSA_LIBRARY})
+    target_include_directories(${target} PRIVATE ${MUSA_HOME}/include)
+    # Add Python include dirs (needed by torch_musa headers that include pybind11)
+    target_include_directories(${target} PRIVATE ${Python_INCLUDE_DIRS})
+    if(TORCH_MUSA_PATH)
+        # Add torch_musa parent dir for "torch_musa/csrc/..." includes
+        get_filename_component(TORCH_MUSA_PARENT "${TORCH_MUSA_PATH}" DIRECTORY)
+        target_include_directories(${target} PRIVATE "${TORCH_MUSA_PARENT}")
+        target_include_directories(${target} PRIVATE "${TORCH_MUSA_PATH}/include")
+    endif()
+    # Link torch_musa and ittnotify libraries
+    if(TORCH_MUSA_LIBRARY)
+        target_link_libraries(${target} PRIVATE ${TORCH_MUSA_LIBRARY})
+    endif()
+    if(ITTNOTIFY_LIBRARY)
+        target_link_libraries(${target} PRIVATE ${ITTNOTIFY_LIBRARY})
+    endif()
+endfunction()

--- a/cmake/BackendNPU.cmake
+++ b/cmake/BackendNPU.cmake
@@ -1,0 +1,113 @@
+# ==============================================================================
+# NPU (Ascend) Backend Configuration
+# ==============================================================================
+message(STATUS "Configuring NPU backend...")
+
+# ------------------------------- Ascend Toolkit -------------------------------
+set(ASCEND_HOME $ENV{ASCEND_TOOLKIT_HOME})
+if(NOT ASCEND_HOME)
+    set(ASCEND_HOME "/usr/local/Ascend/ascend-toolkit/latest")
+endif()
+
+if(NOT EXISTS ${ASCEND_HOME})
+    message(FATAL_ERROR "Ascend toolkit not found at ${ASCEND_HOME}. "
+                        "Please set ASCEND_TOOLKIT_HOME environment variable.")
+endif()
+message(STATUS "ASCEND_TOOLKIT_HOME: ${ASCEND_HOME}")
+
+# Find CANN installation for runtime headers (rt.h)
+set(CANN_HOME $ENV{CANN_HOME})
+if(NOT CANN_HOME)
+    file(GLOB CANN_CANDIDATES "/usr/local/Ascend/cann-*")
+    if(CANN_CANDIDATES)
+        list(GET CANN_CANDIDATES 0 CANN_HOME)
+    endif()
+endif()
+
+# Detect architecture
+if(CMAKE_SYSTEM_PROCESSOR MATCHES "aarch64")
+    set(ASCEND_ARCH_DIR "aarch64-linux")
+else()
+    set(ASCEND_ARCH_DIR "x86_64-linux")
+endif()
+
+# ------------------------------- Find Ascend Libraries ------------------------
+find_library(ASCENDCL_LIBRARY ascendcl PATHS ${ASCEND_HOME}/lib64 NO_DEFAULT_PATH REQUIRED)
+find_library(ASCEND_RUNTIME_LIBRARY runtime PATHS ${ASCEND_HOME}/lib64 NO_DEFAULT_PATH REQUIRED)
+
+message(STATUS "Found AscendCL: ${ASCENDCL_LIBRARY}")
+message(STATUS "Found Ascend Runtime: ${ASCEND_RUNTIME_LIBRARY}")
+
+# ------------------------------- Ascend Include Directories -------------------
+set(ASCEND_INCLUDE_DIRS
+    "${ASCEND_HOME}/include"
+    "${ASCEND_HOME}/include/aclnn"
+    "${ASCEND_HOME}/include/experiment"
+    "${ASCEND_HOME}/include/experiment/runtime"
+    "${ASCEND_HOME}/${ASCEND_ARCH_DIR}/include"
+    "${ASCEND_HOME}/${ASCEND_ARCH_DIR}/include/experiment"
+    "${ASCEND_HOME}/${ASCEND_ARCH_DIR}/include/experiment/msprof"
+)
+
+if(CANN_HOME AND EXISTS "${CANN_HOME}/${ASCEND_ARCH_DIR}/pkg_inc")
+    list(APPEND ASCEND_INCLUDE_DIRS "${CANN_HOME}/${ASCEND_ARCH_DIR}/pkg_inc")
+    message(STATUS "Found CANN pkg_inc: ${CANN_HOME}/${ASCEND_ARCH_DIR}/pkg_inc")
+    if(EXISTS "${CANN_HOME}/${ASCEND_ARCH_DIR}/pkg_inc/runtime/runtime")
+        list(APPEND ASCEND_INCLUDE_DIRS "${CANN_HOME}/${ASCEND_ARCH_DIR}/pkg_inc/runtime/runtime")
+    endif()
+endif()
+
+# ------------------------------- Create Imported Targets ----------------------
+# These targets are required by TritonJIT (fetched via FetchContent).
+# Guard with if(NOT TARGET ...) to avoid duplicate definition when
+# TritonJIT's own BackendNPU.cmake is also included.
+if(NOT TARGET Ascend::ascendcl)
+    add_library(Ascend::ascendcl SHARED IMPORTED)
+    set_target_properties(Ascend::ascendcl PROPERTIES
+        IMPORTED_LOCATION ${ASCENDCL_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES "${ASCEND_INCLUDE_DIRS}"
+    )
+endif()
+
+if(NOT TARGET Ascend::runtime)
+    add_library(Ascend::runtime SHARED IMPORTED)
+    set_target_properties(Ascend::runtime PROPERTIES
+        IMPORTED_LOCATION ${ASCEND_RUNTIME_LIBRARY}
+        INTERFACE_INCLUDE_DIRECTORIES "${ASCEND_INCLUDE_DIRS}"
+    )
+endif()
+
+# ------------------------------- torch_npu Integration ------------------------
+execute_process(
+    COMMAND ${Python_EXECUTABLE} -c "import torch_npu; print(torch_npu.__path__[0])"
+    OUTPUT_VARIABLE TORCH_NPU_PATH OUTPUT_STRIP_TRAILING_WHITESPACE ERROR_QUIET
+)
+
+if(TORCH_NPU_PATH)
+    message(STATUS "Found torch_npu at: ${TORCH_NPU_PATH}")
+    find_library(TORCH_NPU_LIB torch_npu
+        PATHS "${TORCH_NPU_PATH}/lib"
+        NO_DEFAULT_PATH
+    )
+    if(TORCH_NPU_LIB)
+        message(STATUS "Found torch_npu library: ${TORCH_NPU_LIB}")
+    else()
+        message(WARNING "torch_npu package found but libtorch_npu.so not found in ${TORCH_NPU_PATH}/lib")
+    endif()
+else()
+    message(WARNING "torch_npu not found via Python import")
+endif()
+
+# ------------------------------- Helper Function ------------------------------
+function(target_link_npu_libraries target)
+    target_link_libraries(${target} PRIVATE Ascend::ascendcl Ascend::runtime)
+    target_include_directories(${target} PRIVATE ${ASCEND_INCLUDE_DIRS})
+    if(TORCH_NPU_PATH)
+        target_include_directories(${target} PRIVATE "${TORCH_NPU_PATH}/include")
+    endif()
+    if(TORCH_NPU_LIB)
+        target_link_libraries(${target} PRIVATE ${TORCH_NPU_LIB})
+    endif()
+endfunction()
+
+message(STATUS "NPU backend configuration complete")

--- a/include/flag_gems/backend_utils.h
+++ b/include/flag_gems/backend_utils.h
@@ -1,0 +1,131 @@
+#pragma once
+
+#include <c10/core/Device.h>
+#include <c10/core/DeviceGuard.h>
+#include <c10/core/Stream.h>
+#include <torch/torch.h>
+
+// Backend-specific includes and type definitions
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
+#include <c10/cuda/CUDAStream.h>
+#include <cuda.h>
+namespace flag_gems {
+namespace backend {
+  using StreamType = c10::cuda::CUDAStream;
+  using RawStreamType = CUstream;
+}  // namespace backend
+}  // namespace flag_gems
+#elif defined(FLAGGEMS_USE_NPU)
+#include <acl/acl.h>
+#include "torch_npu/csrc/core/npu/NPUStream.h"
+namespace flag_gems {
+namespace backend {
+  using StreamType = c10_npu::NPUStream;
+  using RawStreamType = aclrtStream;
+}  // namespace backend
+}  // namespace flag_gems
+#elif defined(FLAGGEMS_USE_MUSA)
+#include <musa_runtime.h>
+#include "torch_musa/csrc/core/MUSAStream.h"
+namespace flag_gems {
+namespace backend {
+  using StreamType = c10::musa::MUSAStream;
+  using RawStreamType = musaStream_t;
+}  // namespace backend
+}  // namespace flag_gems
+#endif
+
+namespace flag_gems {
+namespace backend {
+
+  // Get the current stream for the given device
+  inline StreamType getCurrentStream(const at::Device& device) {
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
+    return c10::cuda::getCurrentCUDAStream(device.index());
+#elif defined(FLAGGEMS_USE_NPU)
+    return c10_npu::getCurrentNPUStream(device.index());
+#elif defined(FLAGGEMS_USE_MUSA)
+    return c10::musa::getCurrentMUSAStream(device.index());
+#else
+#error \
+    "No backend defined. Define one of: FLAGGEMS_USE_CUDA, FLAGGEMS_USE_IX, FLAGGEMS_USE_NPU, FLAGGEMS_USE_MUSA"
+#endif
+  }
+
+  // Get the current stream for the default device
+  inline StreamType getCurrentStream() {
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
+    return c10::cuda::getCurrentCUDAStream();
+#elif defined(FLAGGEMS_USE_NPU)
+    return c10_npu::getCurrentNPUStream();
+#elif defined(FLAGGEMS_USE_MUSA)
+    return c10::musa::getCurrentMUSAStream();
+#else
+#error "No backend defined"
+#endif
+  }
+
+  // Get the raw stream from a typed stream (for passing to triton_jit)
+  inline RawStreamType getRawStream(const StreamType& stream) {
+    return stream.stream();
+  }
+
+  // Check if tensor is on the correct device type for this backend
+  inline void checkDeviceType(const at::Tensor& tensor, const char* tensor_name) {
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
+    TORCH_CHECK(tensor.is_cuda(), tensor_name, " must be on CUDA device, but got ", tensor.device());
+#elif defined(FLAGGEMS_USE_NPU)
+    TORCH_CHECK(tensor.is_privateuseone(), tensor_name, " must be on NPU device, but got ", tensor.device());
+#elif defined(FLAGGEMS_USE_MUSA)
+    TORCH_CHECK(tensor.is_privateuseone(), tensor_name, " must be on MUSA device, but got ", tensor.device());
+#else
+#error "No backend defined"
+#endif
+  }
+
+  // Check if tensor is on the correct device type (returns bool instead of throwing)
+  inline bool isOnDevice(const at::Tensor& tensor) {
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
+    return tensor.is_cuda();
+#elif defined(FLAGGEMS_USE_NPU)
+    return tensor.is_privateuseone();
+#elif defined(FLAGGEMS_USE_MUSA)
+    return tensor.is_privateuseone();
+#else
+#error "No backend defined"
+#endif
+  }
+
+  // Get the device type string for error messages
+  inline const char* getDeviceTypeName() {
+#if defined(FLAGGEMS_USE_CUDA)
+    return "CUDA";
+#elif defined(FLAGGEMS_USE_IX)
+    return "IX (CUDA-compatible)";
+#elif defined(FLAGGEMS_USE_NPU)
+    return "NPU";
+#elif defined(FLAGGEMS_USE_MUSA)
+    return "MUSA";
+#else
+#error "No backend defined"
+#endif
+  }
+
+  // Get the torch device type used by the active backend.
+  inline at::DeviceType getBackendDeviceType() {
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
+    return at::kCUDA;
+#elif defined(FLAGGEMS_USE_NPU) || defined(FLAGGEMS_USE_MUSA)
+    return at::kPrivateUse1;
+#else
+#error "No backend defined"
+#endif
+  }
+
+  // Get the default torch device for tensors allocated by this backend.
+  inline at::Device getDefaultDevice() {
+    return at::Device(getBackendDeviceType());
+  }
+
+}  // namespace backend
+}  // namespace flag_gems

--- a/include/flag_gems/utils.h
+++ b/include/flag_gems/utils.h
@@ -32,4 +32,7 @@ int cdiv(int a, int b);
 namespace flag_gems {
 std::pair<uint64_t, uint64_t> philox_backend_seed_offset(int64_t increment,
                                                          c10::optional<at::Generator> generator_opt);
-}
+std::pair<uint64_t, uint64_t> philox_backend_seed_offset(int64_t increment,
+                                                         const at::Device &device,
+                                                         c10::optional<at::Generator> generator_opt);
+}  // namespace flag_gems

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -12,7 +12,6 @@ add_library(operators
             topk.cpp
             addmm.cpp
             nonzero.cpp
-            rotary_embedding.cpp
             contiguous.cpp
             cat.cpp
             bmm.cpp
@@ -37,9 +36,24 @@ target_include_directories(operators
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
 
-target_link_libraries(operators
-  PUBLIC Torch::Torch
-  PRIVATE TritonJIT::triton_jit)
+# Backend conditional linking
+if(FLAGGEMS_BACKEND STREQUAL "CUDA" OR FLAGGEMS_BACKEND STREQUAL "IX")
+    target_link_libraries(operators
+      PUBLIC Torch::Torch
+      PRIVATE TritonJIT::triton_jit
+      PRIVATE CUDA::cudart CUDA::cuda_driver)
+elseif(FLAGGEMS_BACKEND STREQUAL "NPU")
+    target_link_npu_libraries(operators)
+    target_link_libraries(operators
+      PUBLIC Torch::Torch
+      PRIVATE TritonJIT::triton_jit)
+elseif(FLAGGEMS_BACKEND STREQUAL "MUSA")
+    target_link_musa_libraries(operators)
+    target_link_libraries(operators
+      PUBLIC Torch::Torch
+      PRIVATE TritonJIT::triton_jit)
+endif()
+
 add_library(FlagGems::operators ALIAS operators)
 
 

--- a/lib/addmm.cpp
+++ b/lib/addmm.cpp
@@ -2,7 +2,7 @@
 #include "flag_gems/utils.h"
 
 #include <iostream>
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "triton_jit/triton_jit_function.h"
 
 namespace flag_gems {
@@ -30,8 +30,8 @@ at::Tensor addmm(const at::Tensor& self,
                                       "addmm_kernel");
 
   c10::DeviceGuard guard(out.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
   int BLOCK_M = 32;
   int BLOCK_N = 64;
   unsigned int grid_x = ((mat1_sizes[0] + BLOCK_M - 1) / BLOCK_M);
@@ -87,8 +87,8 @@ at::Tensor& addmm_out(const at::Tensor& self,
                                       "addmm_kernel");
 
   c10::DeviceGuard guard(out.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
   int BLOCK_M = 32;
   int BLOCK_N = 64;
   unsigned int grid_x = ((mat1_sizes[0] + BLOCK_M - 1) / BLOCK_M);

--- a/lib/argmax.cpp
+++ b/lib/argmax.cpp
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include "ATen/WrapDimUtils.h"
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "triton_jit/triton_jit_function.h"
 
 namespace flag_gems {
@@ -36,9 +36,10 @@ at::Tensor argmax(const at::Tensor &self, std::optional<int64_t> dim, bool keepd
                                         "argmax_kernel_2");
 
     c10::DeviceGuard guard(self.device());
-    c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
+    backend::StreamType stream = backend::getCurrentStream();
+    backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
-    f1(stream,
+    f1(raw_stream,
        mid_size,
        1,
        1,
@@ -50,7 +51,7 @@ at::Tensor argmax(const at::Tensor &self, std::optional<int64_t> dim, bool keepd
        M,
        block_size);
 
-    f2(stream,
+    f2(raw_stream,
        1,
        1,
        1,
@@ -103,8 +104,9 @@ at::Tensor argmax(const at::Tensor &self, std::optional<int64_t> dim, bool keepd
         TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / "ops" / "argmax.py"),
                                         "argmax_kernel_non_inner");
     c10::DeviceGuard guard(self.device());
-    c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-    f(stream,
+    backend::StreamType stream = backend::getCurrentStream();
+    backend::RawStreamType raw_stream = backend::getRawStream(stream);
+    f(raw_stream,
       grid_x,
       grid_y,
       1,
@@ -125,8 +127,9 @@ at::Tensor argmax(const at::Tensor &self, std::optional<int64_t> dim, bool keepd
         TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / "ops" / "argmax.py"),
                                         "argmax_kernel_inner");
     c10::DeviceGuard guard(self.device());
-    c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-    f(stream, grid_x, 1, 1, num_warps, num_stages, contiguous_self, out, M, N, tile_n, ONE_TILE_PER_CTA);
+    backend::StreamType stream = backend::getCurrentStream();
+    backend::RawStreamType raw_stream = backend::getRawStream(stream);
+    f(raw_stream, grid_x, 1, 1, num_warps, num_stages, contiguous_self, out, M, N, tile_n, ONE_TILE_PER_CTA);
   }
 
   return out;

--- a/lib/bmm.cpp
+++ b/lib/bmm.cpp
@@ -2,7 +2,7 @@
 #include "flag_gems/utils.h"
 
 #include <iostream>
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "triton_jit/triton_jit_function.h"
 
 namespace flag_gems {
@@ -25,8 +25,8 @@ at::Tensor bmm(const at::Tensor& A, const at::Tensor& B) {
                                       "bmm_kernel");
 
   c10::DeviceGuard guard(out.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
   const int GROUP_M = 8;
   const int TILE_M = 128;
   const int TILE_N = 128;

--- a/lib/cat.cpp
+++ b/lib/cat.cpp
@@ -1,4 +1,4 @@
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "flag_gems/operators.h"
 #include "flag_gems/utils.h"
 #include "triton_jit/triton_jit_function.h"
@@ -61,8 +61,8 @@ at::Tensor cat(const at::TensorList& tensors, int64_t dim) {
       TritonJITFunction::get_instance(std::string(utils::get_triton_src_path() / "cat_copy.py"),
                                       "strided_copy_kernel");
   c10::DeviceGuard guard(out.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
   for (size_t i = 0; i < tensors.size(); ++i) {
     const auto& input_tensor = tensors[i];

--- a/lib/contiguous.cpp
+++ b/lib/contiguous.cpp
@@ -2,7 +2,7 @@
 #include "flag_gems/utils.h"
 
 #include <iostream>
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "triton_jit/triton_jit_function.h"
 
 namespace flag_gems {
@@ -30,9 +30,9 @@ at::Tensor contiguous(const at::Tensor &self, at::MemoryFormat memory_format) {
   at::Tensor out_strides = torch::tensor(out.strides(), options);
   const unsigned int num_blocks = (n + tile_size - 1) / tile_size;
 
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
   c10::DeviceGuard guard(out.device());
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
   f(raw_stream,
     num_blocks,
     1,

--- a/lib/device_info.cpp
+++ b/lib/device_info.cpp
@@ -1,16 +1,18 @@
 #include "flag_gems/device_info.h"
 
-#include <ATen/cuda/CUDAContext.h>
-#include <cuda_runtime_api.h>
-
 #include <mutex>
 #include <unordered_map>
+
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
+#include <cuda_runtime_api.h>
+#endif
 
 namespace flag_gems::device {
 namespace {
   DeviceInfo query_device(int device_id) {
     DeviceInfo info {};
     info.device_id = device_id;
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
     cudaDeviceProp props {};
     if (cudaGetDeviceProperties(&props, device_id) == cudaSuccess) {
 #if CUDART_VERSION >= 11020
@@ -25,6 +27,11 @@ namespace {
       info.sm_count = 108;
       info.major = 8;
     }
+#else
+    info.l2_cache_size = 40ull * 1024 * 1024;
+    info.sm_count = 108;
+    info.major = 0;
+#endif
     return info;
   }
 
@@ -58,9 +65,11 @@ const DeviceInfo &get_device_info(int device_id) {
 
 const DeviceInfo &get_current_device_info() {
   int device_id = 0;
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
   if (cudaGetDevice(&device_id) != cudaSuccess) {
     device_id = 0;
   }
+#endif
   return get_device_info(device_id);
 }
 

--- a/lib/embedding.cpp
+++ b/lib/embedding.cpp
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include <tuple>
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "triton_jit/triton_jit_function.h"
 
 namespace flag_gems {
@@ -30,8 +30,8 @@ at::Tensor embedding(const at::Tensor &weight,
       TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / "ops" / "embedding.py"),
                                       "embedding_kernel");
   c10::DeviceGuard guard(output.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
   /*
   def embedding_kernel(
       out_ptr,  # pointer to the output
@@ -79,8 +79,8 @@ at::Tensor embedding_backward(const at::Tensor &grad_outputs,
         TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / "ops" / "embedding.py"),
                                         "indice_freq_kernel");
     c10::DeviceGuard guard(grad_outputs.device());
-    c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-    CUstream raw_stream = static_cast<CUstream>(stream.stream());
+    backend::StreamType stream = backend::getCurrentStream();
+    backend::RawStreamType raw_stream = backend::getRawStream(stream);
     /*
     def indice_freq_kernel(
         indices_freq,
@@ -105,8 +105,8 @@ at::Tensor embedding_backward(const at::Tensor &grad_outputs,
       TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / "ops" / "embedding.py"),
                                       "embedding_backward_kernel");
   c10::DeviceGuard guard(grad_outputs.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
   /*
   def embedding_backward_kernel(
       grad_in,  # pointer to the gradient input
@@ -135,8 +135,8 @@ at::Tensor embedding_backward(const at::Tensor &grad_outputs,
         TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / "ops" / "embedding.py"),
                                         "embedding_grad_scale_kernel");
     c10::DeviceGuard guard(grad_outputs.device());
-    c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-    CUstream raw_stream = static_cast<CUstream>(stream.stream());
+    backend::StreamType stream = backend::getCurrentStream();
+    backend::RawStreamType raw_stream = backend::getRawStream(stream);
     /*
     def embedding_grad_scale_kernel(
         grad_out,

--- a/lib/fill.cpp
+++ b/lib/fill.cpp
@@ -42,13 +42,11 @@ at::Tensor fill_scalar(const at::Tensor& input, const c10::Scalar& value) {
   constexpr int BLOCK_SIZE = 1024;
   unsigned int grid_x = (numel + BLOCK_SIZE - 1) / BLOCK_SIZE;
 
-  const TritonJITFunction& fill_kernel =
-      TritonJITFunction::get_instance((utils::get_triton_src_path() / "fill.py").string(),
-                                      "fill_scalar_kernel");
+  const TritonJITFunction& fill_kernel = get_fill_scalar_kernel();
 
   c10::DeviceGuard guard(out.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
   fill_kernel(raw_stream, grid_x, 1, 1, 4, 0, out, value, numel, BLOCK_SIZE);
 
   return out;
@@ -63,13 +61,12 @@ at::Tensor fill_tensor(const at::Tensor& input, const at::Tensor& value) {
   constexpr int BLOCK_SIZE = 1024;
   unsigned int grid_x = (numel + BLOCK_SIZE - 1) / BLOCK_SIZE;
 
-  const TritonJITFunction& fill_kernel =
-      TritonJITFunction::get_instance((utils::get_triton_src_path() / "fill.py").string(),
-                                      "fill_tensor_kernel");
+  const TritonJITFunction& fill_kernel = get_fill_tensor_kernel();
 
   c10::DeviceGuard guard(out.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
+
   fill_kernel(raw_stream, grid_x, 1, 1, 4, 0, out, value, numel, BLOCK_SIZE);
 
   return out;
@@ -82,14 +79,14 @@ at::Tensor& fill_scalar_(at::Tensor& input, const c10::Scalar& value) {
   constexpr int BLOCK_SIZE = 1024;
   unsigned int grid_x = (numel + BLOCK_SIZE - 1) / BLOCK_SIZE;
 
-  const TritonJITFunction& fill_kernel =
-      TritonJITFunction::get_instance((utils::get_triton_src_path() / "fill.py").string(),
-                                      "fill_scalar_kernel");
+  const TritonJITFunction& fill_kernel = get_fill_scalar_kernel();
 
   c10::DeviceGuard guard(input.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
+
   fill_kernel(raw_stream, grid_x, 1, 1, 4, 0, input, value, numel, BLOCK_SIZE);
+
   return input;
 }
 
@@ -101,14 +98,14 @@ at::Tensor& fill_tensor_(at::Tensor& input, const at::Tensor& value) {
   constexpr int BLOCK_SIZE = 1024;
   unsigned int grid_x = (numel + BLOCK_SIZE - 1) / BLOCK_SIZE;
 
-  const TritonJITFunction& fill_kernel =
-      TritonJITFunction::get_instance((utils::get_triton_src_path() / "fill.py").string(),
-                                      "fill_tensor_kernel");
+  const TritonJITFunction& fill_kernel = get_fill_tensor_kernel();
 
   c10::DeviceGuard guard(input.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
+
   fill_kernel(raw_stream, grid_x, 1, 1, 4, 0, input, value, numel, BLOCK_SIZE);
+
   return input;
 }
 ***/

--- a/lib/fused_add_rms_norm.cpp
+++ b/lib/fused_add_rms_norm.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "flag_gems/operators.h"
 #include "flag_gems/utils.h"
 #include "triton_jit/triton_jit_function.h"
@@ -28,8 +28,8 @@ void fused_add_rms_norm(at::Tensor& input, at::Tensor& residual, const at::Tenso
 
   // getCurrentCUDAStream ensures that the stream is initialized, a default stream for each device
   c10::DeviceGuard guard(input.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
   /* siguature info
 def fused_add_rms_norm_kernel(

--- a/lib/max.cpp
+++ b/lib/max.cpp
@@ -2,7 +2,7 @@
 #include "flag_gems/utils.h"
 
 #include <iostream>
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "torch/torch.h"
 #include "triton_jit/triton_jit_function.h"
 
@@ -40,8 +40,8 @@ using namespace triton_jit;
   ):
   */
   c10::DeviceGuard guard(out_value.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
   f(raw_stream,
     num_blocks,
@@ -87,8 +87,8 @@ using namespace triton_jit;
   ):
   */
   c10::DeviceGuard guard(out_value.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
   f(raw_stream,
     num_blocks,
@@ -126,8 +126,8 @@ at::Tensor max(const at::Tensor &self) {
   const int num_warps = 8;
   const int num_stages = 2;
   c10::DeviceGuard guard(out.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
   // def max_kernel_1(inp,mid,M,BLOCK_SIZE: tl.constexpr)
   max_kernel_1(raw_stream, mid_size, 1, 1, num_warps, num_stages, self, mid, M, block_size);
   // def max_kernel_2(mid, out, mid_size, BLOCK_MID: tl.constexpr):

--- a/lib/mm.cpp
+++ b/lib/mm.cpp
@@ -1,11 +1,10 @@
+#include "flag_gems/backend_utils.h"
 #include "flag_gems/device_info.h"
 #include "flag_gems/operators.h"
 #include "flag_gems/utils.h"
 
-#include <ATen/cuda/CUDAContext.h>
 #include <iostream>
 #include <tuple>
-#include "c10/cuda/CUDAStream.h"
 #include "triton_jit/triton_jit_function.h"
 
 namespace flag_gems {
@@ -65,8 +64,8 @@ void streamk_mm_tensor(const at::Tensor &a,
 
   // device / stream
   c10::DeviceGuard guard(c.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
   if (number_cooperative_tiles > 0) {
     // mini wave handling
@@ -195,6 +194,11 @@ void general_mm_tensor(
   TORCH_CHECK(a.dim() == 2 && b.dim() == 2, "both the tensors must be 2-D");
   TORCH_CHECK(a.dtype() == b.dtype(), "expected a and b to have the same dtype");
 
+  c10::DeviceGuard guard(c.device());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
+
+  // CUDA/other path: use ops/mm.py with mm_kernel_general
   const int BLOCK_M = 64;
   const int BLOCK_N = 128;
   const int BLOCK_K = 64;
@@ -202,17 +206,12 @@ void general_mm_tensor(
   const int num_warps = 4;
   const int GROUP_M = 8;
 
-  // general situation
   const TritonJITFunction &f =
       TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / "ops" / "mm.py"),
                                       "mm_kernel_general");
 
-  c10::DeviceGuard guard(c.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
-
   unsigned int grid_x = cdiv(M, BLOCK_M) * cdiv(N, BLOCK_N);
-  f(/* CUstream = */ raw_stream,
+  f(/* stream = */ raw_stream,
     /* grid_x = */ grid_x,
     /* grid_y = */ 1,
     /* grid_z = */ 1,

--- a/lib/nonzero.cpp
+++ b/lib/nonzero.cpp
@@ -2,7 +2,7 @@
 #include "flag_gems/utils.h"
 
 #include <iostream>
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "triton_jit/triton_jit_function.h"
 
 namespace flag_gems {
@@ -26,16 +26,17 @@ at::Tensor nonzero(const at::Tensor &inp) {
   at::Tensor prefix_sum = at::cumsum(inp_bool, /*dim=*/0);
 
   int64_t num_nonzeros = n_elements;
-  at::Tensor out =
-      at::empty({num_nonzeros, inp_ndim}, at::TensorOptions().dtype(torch::kInt64).device(inp_ctg.device()));
+
+  at::Tensor out = at::empty({num_nonzeros + 1, inp_ndim},
+                             at::TensorOptions().dtype(torch::kInt64).device(inp_ctg.device()));
 
   const TritonJITFunction &f =
       TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / "ops" / "nonzero.py"),
                                       "nonzero_kernel");
 
   c10::DeviceGuard guard(out.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
   int BLOCK_SIZE = 1024;
   unsigned int grid_x = (n_elements + BLOCK_SIZE - 1) / BLOCK_SIZE;

--- a/lib/reshape_and_cache_flash.cpp
+++ b/lib/reshape_and_cache_flash.cpp
@@ -1,6 +1,6 @@
 #include <torch/torch.h>
 #include <iostream>
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "flag_gems/operators.h"
 #include "flag_gems/utils.h"
 #include "triton_jit/triton_jit_function.h"
@@ -33,8 +33,8 @@ void reshape_and_cache_flash(const at::Tensor& key,
   const int num_stages = 2;
 
   c10::DeviceGuard guard(key.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = stream.stream();
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
   const TritonJITFunction& kernel = TritonJITFunction::get_instance(
       std::string(utils::get_flag_gems_src_path() / "fused" / "reshape_and_cache_flash.py"),

--- a/lib/rms_norm.cpp
+++ b/lib/rms_norm.cpp
@@ -1,5 +1,5 @@
 #include <iostream>
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "flag_gems/operators.h"
 #include "flag_gems/utils.h"
 #include "triton_jit/triton_jit_function.h"
@@ -28,8 +28,8 @@ at::Tensor rms_norm(const at::Tensor& input, const at::Tensor& weight, double ep
 
   // getCurrentCUDAStream ensures that the stream is initialized, a default stream for each device
   c10::DeviceGuard guard(out.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
   /* siguature info
   def rms_norm_kernel(

--- a/lib/rwkv_ka_fusion.cpp
+++ b/lib/rwkv_ka_fusion.cpp
@@ -1,7 +1,7 @@
 #include "flag_gems/operators.h"
 #include "flag_gems/utils.h"
 
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "triton_jit/triton_jit_function.h"
 
 namespace flag_gems {
@@ -39,10 +39,9 @@ std::tuple<at::Tensor, at::Tensor, at::Tensor> rwkv_ka_fusion(const at::Tensor &
 
   const unsigned int num_blocks = (T * C + block_size - 1) / block_size;
 
-  // getCurrentCUDAStream ensures that the stream is initialized, a default stream for each device
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
   c10::DeviceGuard guard(o_k.device());
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
   f(raw_stream,
     num_blocks,
     1,

--- a/lib/rwkv_mm_sparsity.cpp
+++ b/lib/rwkv_mm_sparsity.cpp
@@ -1,7 +1,7 @@
 #include "flag_gems/operators.h"
 #include "flag_gems/utils.h"
 
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "triton_jit/triton_jit_function.h"
 
 namespace flag_gems {
@@ -26,10 +26,9 @@ at::Tensor rwkv_mm_sparsity(const at::Tensor &k, const at::Tensor &v) {
 
   const unsigned int num_blocks = (v_sizes[1] + block_size - 1) / block_size;
 
-  // getCurrentCUDAStream ensures that the stream is initialized, a default stream for each device
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
   c10::DeviceGuard guard(out.device());
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
   f(raw_stream, num_blocks, 1, 1, num_warps, num_stages, k, v, out, v_sizes[1], blk_size, k_size, block_size);
   return out;
 }

--- a/lib/softmax.cpp
+++ b/lib/softmax.cpp
@@ -1,6 +1,6 @@
 #include <ATen/WrapDimUtils.h>
 #include <iostream>
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "flag_gems/operators.h"
 #include "flag_gems/utils.h"
 #include "triton_jit/triton_jit_function.h"
@@ -40,8 +40,8 @@ namespace {
     constexpr unsigned int NUM_STAGES = 1;
 
     c10::DeviceGuard guard(input.device());
-    c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-    CUstream raw_stream = static_cast<CUstream>(stream.stream());
+    backend::StreamType stream = backend::getCurrentStream();
+    backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
     if (K == 1) {
       const TritonJITFunction &kernel = get_kernel("softmax_kernel_inner");
@@ -115,8 +115,8 @@ namespace {
     constexpr unsigned int NUM_STAGES = 1;
 
     c10::DeviceGuard guard(output.device());
-    c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-    CUstream raw_stream = static_cast<CUstream>(stream.stream());
+    backend::StreamType stream = backend::getCurrentStream();
+    backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
     if (K == 1) {
       const TritonJITFunction &kernel = get_kernel("softmax_backward_kernel_inner");

--- a/lib/sum.cpp
+++ b/lib/sum.cpp
@@ -2,7 +2,7 @@
 #include "flag_gems/utils.h"
 
 #include <iostream>
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "torch/torch.h"
 #include "triton_jit/triton_jit_function.h"
 
@@ -31,8 +31,8 @@ at::Tensor sum(const at::Tensor &self, ::std::optional<at::ScalarType> dtype) {
   const int num_warps = 8;
   const int num_stages = 2;
   c10::DeviceGuard guard(out.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
   sum_kernel_1(raw_stream, mid_size, 1, 1, num_warps, num_stages, self, mid, M, block_size);
   sum_kernel_2(raw_stream, 1, 1, 1, num_warps, num_stages, mid, out, mid_size, block_mid);
   return out;
@@ -77,8 +77,8 @@ at::Tensor sum_dim(const at::Tensor &self,
   const int num_warps = 8;
   const int num_stages = 2;
   c10::DeviceGuard guard(self.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
   at::Tensor self_contiguous = self.contiguous();
   if (dims_.size() == 1) {
     int64_t selected_dim = dims_[0];
@@ -143,8 +143,8 @@ at::Tensor sum_dim(const at::Tensor &self,
         TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / "ops" / "sum.py"),
                                         "sum_dim_kernel");
     c10::DeviceGuard guard(out.device());
-    c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-    CUstream raw_stream = static_cast<CUstream>(stream.stream());
+    backend::StreamType stream = backend::getCurrentStream();
+    backend::RawStreamType raw_stream = backend::getRawStream(stream);
     f(raw_stream,
       num_blocks,
       1,

--- a/lib/topk.cpp
+++ b/lib/topk.cpp
@@ -3,7 +3,7 @@
 
 #include <iostream>
 #include <tuple>
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "triton_jit/triton_jit_function.h"
 
 namespace flag_gems {
@@ -43,8 +43,8 @@ std::tuple<at::Tensor, at::Tensor> topk(
       TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / "ops" / "topk.py"),
                                       "topk_stage2_kernel");
   c10::DeviceGuard guard(stage1_out.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
   /*
   def topk_stage1_kernel(y_ptr,
                          index_ptr,

--- a/lib/zeros.cpp
+++ b/lib/zeros.cpp
@@ -2,7 +2,7 @@
 #include "flag_gems/utils.h"
 
 #include <iostream>
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "triton_jit/triton_jit_function.h"
 
 namespace flag_gems {
@@ -18,12 +18,11 @@ at::Tensor zeros(at::IntArrayRef size,
     n_elements *= dim;
   }
 
-  auto options =
-      at::TensorOptions()
-          .dtype(dtype.value_or(at::typeMetaToScalarType(at::get_default_dtype())))
-          .layout(layout.value_or(at::kStrided))
-          .device(device.value_or(torch::cuda::is_available() ? at::Device(at::kCUDA) : at::Device(at::kCPU)))
-          .pinned_memory(pin_memory.value_or(false));
+  auto options = at::TensorOptions()
+                     .dtype(dtype.value_or(at::typeMetaToScalarType(at::get_default_dtype())))
+                     .layout(layout.value_or(at::kStrided))
+                     .device(device.value_or(backend::getDefaultDevice()))
+                     .pinned_memory(pin_memory.value_or(false));
 
   TORCH_CHECK(n_elements >= 0, "Total elements must be non-negative");
 
@@ -43,8 +42,8 @@ at::Tensor zeros(at::IntArrayRef size,
       TritonJITFunction::get_instance(std::string(utils::get_triton_src_path() / "zeros.py"), "zeros_kernel");
 
   c10::DeviceGuard guard(out.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
   f(raw_stream,
     num_blocks,

--- a/src/flag_gems/csrc/CMakeLists.txt
+++ b/src/flag_gems/csrc/CMakeLists.txt
@@ -1,13 +1,19 @@
 pybind11_add_module(c_operators cstub.cpp)
 target_link_libraries(c_operators PUBLIC Torch::Torch_Python PRIVATE operators)
 set_target_properties(c_operators PROPERTIES
-  INSTALL_RPATH "${_rpath_portable_origin}/${CMAKE_INSTALL_LIBDIR}")
+  INSTALL_RPATH "${_rpath_portable_origin}/${CMAKE_INSTALL_LIBDIR}"
+  CXX_STANDARD 20
+  CXX_STANDARD_REQUIRED ON)
+target_compile_options(c_operators PRIVATE -std=c++20)
 
 
 pybind11_add_module(aten_patch aten_patch.cpp)
 target_link_libraries(aten_patch PUBLIC Torch::Torch_Python PRIVATE operators)
 set_target_properties(aten_patch PROPERTIES
-  INSTALL_RPATH "${_rpath_portable_origin}/${CMAKE_INSTALL_LIBDIR}")
+  INSTALL_RPATH "${_rpath_portable_origin}/${CMAKE_INSTALL_LIBDIR}"
+  CXX_STANDARD 20
+  CXX_STANDARD_REQUIRED ON)
+target_compile_options(aten_patch PRIVATE -std=c++20)
 
 # Propagate pointwise_dynamic feature flag to pybind11 modules so that
 # #ifdef FLAGGEMS_POINTWISE_DYNAMIC guards in cstub.cpp / aten_patch.cpp

--- a/src/flag_gems/csrc/cstub.cpp
+++ b/src/flag_gems/csrc/cstub.cpp
@@ -1,15 +1,14 @@
 #include <pybind11/pybind11.h>
+#include <pybind11/stl.h>
 #include "torch/python.h"
 
 #include "flag_gems/operators.h"
 
+namespace py = pybind11;
+
 // TODO: use pytorch's argparse utilities to generate CPython bindings, since it is more efficient than
 // bindings provided by torch library, since it is in a boxed fashion
 PYBIND11_MODULE(c_operators, m) {
-  m.def("sum_dim", &flag_gems::sum_dim);
-  m.def("sum", &flag_gems::sum);
-  m.def("max_dim", &flag_gems::max_dim);
-  m.def("max", &flag_gems::max);
 #ifdef FLAGGEMS_POINTWISE_DYNAMIC
   // add
   m.def("add_tensor", &flag_gems::add_tensor);
@@ -37,15 +36,57 @@ PYBIND11_MODULE(c_operators, m) {
   m.def("fill_.Scalar", &flag_gems::fill_scalar_);
   m.def("fill_.Tensor", &flag_gems::fill_tensor_);
 #endif
+  m.def("exponential_", &flag_gems::exponential_);
+  m.def("addmm", &flag_gems::addmm);
+  m.def("mm", &flag_gems::mm_tensor);
+  m.def("zeros", &flag_gems::zeros);
+  m.def(
+      "sum_dim",
+      [](const at::Tensor &self,
+         const std::optional<std::vector<int64_t>> &dim,
+         bool keepdim,
+         const std::optional<at::ScalarType> &dtype) {
+        at::OptionalIntArrayRef dim_ref =
+            dim.has_value() ? at::OptionalIntArrayRef(*dim) : at::OptionalIntArrayRef();
+        return flag_gems::sum_dim(self, dim_ref, keepdim, dtype);
+      },
+      py::arg("self"),
+      py::arg("dim") = py::none(),
+      py::arg("keepdim") = false,
+      py::arg("dtype") = py::none());
+  m.def("sum", &flag_gems::sum);
+  m.def("max_dim", &flag_gems::max_dim);
+  m.def("max", &flag_gems::max);
   m.def("max_dim_max", &flag_gems::max_dim_max);
   m.def("rms_norm", &flag_gems::rms_norm);
   m.def("fused_add_rms_norm", &flag_gems::fused_add_rms_norm);
   m.def("nonzero", &flag_gems::nonzero);
-  // Rotary embedding
   m.def("rotary_embedding", &flag_gems::rotary_embedding);
   m.def("rotary_embedding_inplace", &flag_gems::rotary_embedding_inplace);
+  m.def("topk", &flag_gems::topk);
+  m.def(
+      "contiguous",
+      [](const at::Tensor &self, at::MemoryFormat memory_format) {
+        return flag_gems::contiguous(self, memory_format);
+      },
+      py::arg("self"),
+      py::arg("memory_format") = c10::MemoryFormat::Contiguous);
+  m.def(
+      "cat",
+      [](const std::vector<at::Tensor> &tensors, int64_t dim) { return flag_gems::cat(tensors, dim); },
+      py::arg("tensors"),
+      py::arg("dim") = 0);
   m.def("bmm", &flag_gems::bmm);
-  // rwkv
+  m.def("embedding", &flag_gems::embedding);
+  m.def("embedding_backward", &flag_gems::embedding_backward);
+  m.def("argmax", &flag_gems::argmax);
+
+  m.def("sort", &flag_gems::sort);
+  m.def("sort_stable", &flag_gems::sort_stable);
+  m.def("softmax", &flag_gems::softmax);
+  m.def("softmax_backward", &flag_gems::softmax_backward);
+  m.def("reshape_and_cache_flash", &flag_gems::reshape_and_cache_flash);
+  m.def("flash_attn_varlen_func", &flag_gems::flash_attn_varlen_func);
   m.def("rwkv_mm_sparsity", &flag_gems::rwkv_mm_sparsity);
   m.def("rwkv_ka_fusion", &flag_gems::rwkv_ka_fusion);
   m.def("copy_", &flag_gems::copy_);
@@ -53,21 +94,6 @@ PYBIND11_MODULE(c_operators, m) {
 }
 namespace flag_gems {
 TORCH_LIBRARY(flag_gems, m) {
-  m.def("exponential_(Tensor(a!) x, float  lambd = 1.0, *,Generator? gen = None) -> Tensor(a!)");
-  // blas
-  m.def("addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor");
-  m.def("mm(Tensor self, Tensor mat2) -> Tensor");
-
-  m.def(
-      "zeros(SymInt[] size, ScalarType? dtype=None,Layout? layout=None, Device? device=None, bool? "
-      "pin_memory=None) -> Tensor");
-  m.def("sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor");
-  m.def("sum(Tensor self, *, ScalarType? dtype=None) -> Tensor");
-  m.def(
-      "max.dim_max(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) max, Tensor(b!) max_values) -> "
-      "(Tensor(a!) values, Tensor(b!) indices)");
-  m.def("max.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)");
-  m.def("max(Tensor self) -> Tensor");
 #ifdef FLAGGEMS_POINTWISE_DYNAMIC
   // add
   m.def("add_tensor(Tensor self, Tensor other, *, Scalar alpha=1) -> Tensor", {at::Tag::pt2_compliant_tag});
@@ -97,6 +123,22 @@ TORCH_LIBRARY(flag_gems, m) {
   m.def("fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)");
   m.def("fill_.Tensor(Tensor(a!) self, Tensor value) -> Tensor(a!)");
 #endif
+  m.def("exponential_(Tensor(a!) x, float  lambd = 1.0, *,Generator? gen = None) -> Tensor(a!)");
+  // blas
+  m.def("addmm(Tensor self, Tensor mat1, Tensor mat2, *, Scalar beta=1, Scalar alpha=1) -> Tensor");
+  m.def("mm(Tensor self, Tensor mat2) -> Tensor");
+
+  m.def(
+      "zeros(SymInt[] size, ScalarType? dtype=None,Layout? layout=None, Device? device=None, bool? "
+      "pin_memory=None) -> Tensor");
+  m.def("sum.dim_IntList(Tensor self, int[1]? dim, bool keepdim=False, *, ScalarType? dtype=None) -> Tensor");
+  m.def("sum(Tensor self, *, ScalarType? dtype=None) -> Tensor");
+  m.def(
+      "max.dim_max(Tensor self, int dim, bool keepdim=False, *, Tensor(a!) max, Tensor(b!) max_values) -> "
+      "(Tensor(a!) values, Tensor(b!) indices)");
+  m.def("max.dim(Tensor self, int dim, bool keepdim=False) -> (Tensor values, Tensor indices)");
+  m.def("max(Tensor self) -> Tensor");
+  // m.def("add_tensor(Tensor self, Tensor other) -> Tensor", {at::Tag::pt2_compliant_tag});
   // Norm
   m.def("rms_norm(Tensor input, Tensor weight, float epsilon) -> Tensor");
   m.def("fused_add_rms_norm(Tensor! input, Tensor! residual, Tensor weight, float epsilon) -> ()");
@@ -119,12 +161,31 @@ TORCH_LIBRARY(flag_gems, m) {
       "embedding_backward(Tensor grad_outputs, Tensor indices, SymInt num_weights, SymInt padding_idx, bool "
       "scale_grad_by_freq, bool sparse) -> Tensor");
   m.def("argmax(Tensor self, int? dim=None, bool keepdim=False) -> Tensor");
+  // // div
+  // m.def("div.Tensor(Tensor self, Tensor other) -> Tensor");
+  // m.def("div_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)");
+  // m.def("div.Tensor_mode(Tensor self, Tensor other, *, str? rounding_mode) -> Tensor");
+  // m.def("div_.Tensor_mode(Tensor(a!) self, Tensor other, *, str? rounding_mode) -> Tensor(a!)");
+  // m.def("floor_divide(Tensor self, Tensor other) -> Tensor");
+  // m.def("floor_divide_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)");
+  // m.def("divide.Tensor(Tensor self, Tensor other) -> Tensor");
+  // m.def("divide_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)");
+  // m.def("divide.Tensor_mode(Tensor self, Tensor other, *, str? rounding_mode) -> Tensor");
+  // m.def("divide_.Tensor_mode(Tensor(a!) self, Tensor other, *, str? rounding_mode) -> Tensor(a!)");
+  // m.def("true_divide.Tensor(Tensor self, Tensor other) -> Tensor");
+  // m.def("true_divide_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)");
+  // m.def("remainder.Tensor(Tensor self, Tensor other) -> Tensor");
+  // m.def("remainder_.Tensor(Tensor(a!) self, Tensor other) -> Tensor(a!)");
   // sort
   m.def("sort(Tensor self, int dim=-1, bool descending=False) -> (Tensor values, Tensor indices)");
   m.def(
       "sort.stable(Tensor self, *, bool? stable, int dim=-1, bool descending=False) -> (Tensor values, "
       "Tensor indices)");
 
+  // m.def("fill.Scalar(Tensor self, Scalar value) -> Tensor");
+  // m.def("fill.Tensor(Tensor self, Tensor value) -> Tensor");
+  // m.def("fill_.Scalar(Tensor(a!) self, Scalar value) -> Tensor(a!)");
+  // m.def("fill_.Tensor(Tensor(a!) self, Tensor value) -> Tensor(a!)");
   m.def("softmax(Tensor input, int dim, bool half_to_float=False) -> Tensor");
   m.def("softmax_backward(Tensor grad_output, Tensor output, int dim, ScalarType input_dtype) -> Tensor");
   m.def(
@@ -152,19 +213,19 @@ TORCH_LIBRARY(flag_gems, m) {
       "pin_memory=None, bool non_blocking=False, MemoryFormat? memory_format=None) -> Tensor");
 }
 
-TORCH_LIBRARY_IMPL(flag_gems, CUDA, m) {
-  m.impl("exponential_", TORCH_FN(exponential_));
-  // blas
-  m.impl("addmm", TORCH_FN(addmm));
-  m.impl("bmm", TORCH_FN(bmm));
-  m.impl("mm", TORCH_FN(mm_tensor));
+// Define dispatch key based on backend
+// CUDA and IX use CUDA dispatch key (IX is CUDA-compatible)
+// NPU and MUSA use PrivateUse1 dispatch key
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
+#define FLAGGEMS_DISPATCH_KEY CUDA
+#elif defined(FLAGGEMS_USE_NPU) || defined(FLAGGEMS_USE_MUSA)
+#define FLAGGEMS_DISPATCH_KEY PrivateUse1
+#else
+#error \
+    "No backend defined. Define one of: FLAGGEMS_USE_CUDA, FLAGGEMS_USE_IX, FLAGGEMS_USE_NPU, FLAGGEMS_USE_MUSA"
+#endif
 
-  m.impl("zeros", TORCH_FN(zeros));
-  m.impl("sum.dim_IntList", TORCH_FN(sum_dim));
-  m.impl("sum", TORCH_FN(sum));
-  m.impl("max.dim_max", TORCH_FN(max_dim_max));
-  m.impl("max.dim", TORCH_FN(max_dim));
-  m.impl("max", TORCH_FN(max));
+TORCH_LIBRARY_IMPL(flag_gems, FLAGGEMS_DISPATCH_KEY, m) {
 #ifdef FLAGGEMS_POINTWISE_DYNAMIC
   // add
   m.impl("add_tensor", TORCH_FN(add_tensor));
@@ -205,11 +266,20 @@ TORCH_LIBRARY_IMPL(flag_gems, CUDA, m) {
   m.impl("fill_.Scalar", TORCH_FN(fill_scalar_));
   m.impl("fill_.Tensor", TORCH_FN(fill_tensor_));
 #endif
-  // Norm
+
+  m.impl("exponential_", TORCH_FN(exponential_));
+  m.impl("addmm", TORCH_FN(addmm));
+  m.impl("bmm", TORCH_FN(bmm));
+  m.impl("mm", TORCH_FN(mm_tensor));
+  m.impl("zeros", TORCH_FN(zeros));
+  m.impl("sum.dim_IntList", TORCH_FN(sum_dim));
+  m.impl("sum", TORCH_FN(sum));
+  m.impl("max.dim_max", TORCH_FN(max_dim_max));
+  m.impl("max.dim", TORCH_FN(max_dim));
+  m.impl("max", TORCH_FN(max));
   m.impl("rms_norm", TORCH_FN(rms_norm));
   m.impl("fused_add_rms_norm", TORCH_FN(fused_add_rms_norm));
   m.impl("nonzero", TORCH_FN(nonzero));
-  // Rotary embedding
   m.impl("rotary_embedding", TORCH_FN(rotary_embedding));
   m.impl("rotary_embedding_inplace", TORCH_FN(rotary_embedding_inplace));
   m.impl("topk", TORCH_FN(topk));
@@ -219,7 +289,7 @@ TORCH_LIBRARY_IMPL(flag_gems, CUDA, m) {
   m.impl("embedding", TORCH_FN(embedding));
   m.impl("embedding_backward", TORCH_FN(embedding_backward));
   m.impl("argmax", TORCH_FN(argmax));
-  // sort
+
   m.impl("sort", TORCH_FN(sort));
   m.impl("sort.stable", TORCH_FN(sort_stable));
 


### PR DESCRIPTION
### Title
  Add multi-backend abstraction layer and expand C++ operator bindings

  ### PR Category
  Refactor

  ### Type of Change
  New Feature | Refactor

  ### Description

  This PR introduces a backend abstraction layer to decouple all C++ operator implementations
  from hardcoded CUDA dependencies, enabling support for multiple hardware backends (CUDA, IX,
  NPU/Ascend, MUSA/Moore Threads).

  **Key changes:**

  1. **Backend abstraction (`backend_utils.h`)**
     - New header `include/flag_gems/backend_utils.h` providing `backend::StreamType`,
  `backend::RawStreamType`, `backend::getCurrentStream()`, `backend::getRawStream()`,
  `backend::getDefaultDevice()`, etc.
     - Replaces direct `c10::cuda::CUDAStream` / `CUstream` usage across all 20+ operator files
  in `lib/`.

  2. **CMake multi-backend build system**
     - New cache variable `FLAGGEMS_BACKEND` (CUDA | IX | MUSA | NPU) controls backend
  selection.
     - Conditional `project()` language setup (skip CUDA language for NPU/MUSA).
     - Per-backend compile definitions (`FLAGGEMS_USE_CUDA`, `FLAGGEMS_USE_IX`,
  `FLAGGEMS_USE_NPU`, `FLAGGEMS_USE_MUSA`).
     - New `cmake/BackendNPU.cmake` and `cmake/BackendMUSA.cmake` modules for Ascend and Moore
  Threads toolchain discovery.
     - Backend-conditional linking in `lib/CMakeLists.txt`.

  3. **Dispatch key abstraction**
     - `TORCH_LIBRARY_IMPL` now uses `FLAGGEMS_DISPATCH_KEY` macro (CUDA for CUDA/IX,
  PrivateUse1 for NPU/MUSA) instead of hardcoded `CUDA`.

  4. **Expanded pybind11 bindings (`cstub.cpp`)**
     - Newly exposed operators: `exponential_`, `addmm`, `mm`, `zeros`, `topk`, `contiguous`,
  `cat`, `bmm`, `embedding`, `embedding_backward`, `argmax`, `sort`, `sort_stable`, `softmax`,
  `softmax_backward`, `reshape_and_cache_flash`, `flash_attn_varlen_func`.
     - Added lambda wrappers for `sum_dim` (OptionalIntArrayRef conversion) and `cat` /
  `contiguous` (default argument handling).

  5. **NPU (Ascend) specific adaptations**
     - NPU-specific Triton kernels: `mm_cpp.py`, `nonzero.py`, `rms_norm.py`,
  `fused_add_rms_norm.py`.
     - `float` casts for `epsilon` parameters (BiSheng MLIR does not support fp64).
     - Smaller block sizes for NPU UB memory constraints (e.g., MM uses 32x32x32).
     - Disabled StreamK path for NPU in `mm.cpp`.
     - `torch.utils.rename_privateuse1_backend("npu")` integration.

  6. **C++ standard upgrade**
     - C++17 → C++20 for concepts support and future backend dispatch improvements.

  7. **Bug fixes**
     - `exponential_`: pass `1.0 / lambd` (rate) instead of `lambd` to kernel.
     - `device_info.cpp`: conditional compilation to avoid CUDA API calls on non-CUDA backends.
     - `nonzero`: allocate one extra dummy row to prevent masked scatter lane corruption on NPU.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
