### PR TITLE
Move backend detection and setup under FLAGGEMS_BUILD_C_EXTENSIONS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 # --------------------------- project options ---------------------------
 option(FLAGGEMS_USE_EXTERNAL_TRITON_JIT "whether to use external triton jit library" OFF)
 option(FLAGGEMS_USE_EXTERNAL_PYBIND11 "whether to use external pybind11 library" ON)
-option(FLAGGEMS_BUILD_C_EXTENSIONS "whether to build c extension" ON)
+option(FLAGGEMS_BUILD_C_EXTENSIONS "whether to build c extension" OFF)
 option(FLAGGEMS_BUILD_CTESTS "Whether to build CPP unit tests" ${FLAGGEMS_BUILD_C_EXTENSIONS})
 option(FLAGGEMS_INSTALL "Whether to install the package" ${PROJECT_IS_TOP_LEVEL})
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -60,7 +60,7 @@ add_library(FlagGems::operators ALIAS operators)
 # ==============================================================================
 # Pointwise dynamic C++ support (experimental feature, disabled by default)
 # ==============================================================================
-option(FLAGGEMS_BUILD_POINTWISE_DYNAMIC_CPP "Build pointwise_dynamic C++ support" ON)
+option(FLAGGEMS_BUILD_POINTWISE_DYNAMIC_CPP "Build pointwise_dynamic C++ support" OFF)
 if(FLAGGEMS_BUILD_POINTWISE_DYNAMIC_CPP)
   add_subdirectory(pointwise_dynamic_cpp)
   target_sources(operators PRIVATE add.cpp div.cpp fill.cpp)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Other

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Other

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Move backend detection and setup under FLAGGEMS_BUILD_C_EXTENSIONS to avoid unnecessary CMake configuration when building the Python-only version of FlagGems

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
