### PR TITLE
[Fix]lib: use backend stream helpers across operators

### DIFF
--- a/lib/accuracy_utils.cpp
+++ b/lib/accuracy_utils.cpp
@@ -1,5 +1,8 @@
 #include "flag_gems/accuracy_utils.h"
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
 #include <c10/cuda/CUDAGuard.h>
+#include <cuda_runtime_api.h>
+#endif
 #include <torch/torch.h>
 #include <sstream>
 
@@ -82,22 +85,31 @@ static std::pair<torch::Tensor, torch::Tensor> _maybe_move_to_cpu(torch::Tensor 
 
   const int64_t required = res.numel() * static_cast<int64_t>(res.element_size());
 
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
   int64_t free_mem = -1;
 
   try {
     size_t free_mem_u = 0, total_mem_u = 0;
     c10::cuda::CUDAGuard device_guard(res.device());
-    cudaMemGetInfo(&free_mem_u, &total_mem_u);
-    free_mem = static_cast<int64_t>(free_mem_u);
+    if (cudaMemGetInfo(&free_mem_u, &total_mem_u) == cudaSuccess) {
+      free_mem = static_cast<int64_t>(free_mem_u);
+    }
   } catch (...) {
     free_mem = -1;
   }
+#endif
 
   constexpr int64_t HUGE_TENSOR_BYTES = int64_t(1) << 30;  // 1 GiB
 
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
   if ((free_mem >= 0 && required >= free_mem) || (required >= HUGE_TENSOR_BYTES)) {
     return {res.cpu(), ref.cpu()};
   }
+#else
+  if (required >= HUGE_TENSOR_BYTES) {
+    return {res.cpu(), ref.cpu()};
+  }
+#endif
 
   return {res, ref};
 }

--- a/lib/copy.cpp
+++ b/lib/copy.cpp
@@ -1,6 +1,6 @@
 #include <c10/core/DispatchKeySet.h>
 #include <vector>
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "flag_gems/utils.h"
 #include "torch/torch.h"
 #include "triton_jit/triton_jit_function.h"
@@ -111,8 +111,8 @@ at::Tensor to_copy(const at::Tensor& x,
   const unsigned int grid_x = (numel + BLOCK_SIZE - 1) / BLOCK_SIZE;
 
   c10::DeviceGuard guard(target_device);
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
   // at::Tensor x_linear = (x.scalar_type() != target_dtype) ? x.to(target_dtype) : x;
   at::Tensor x_linear = x;
@@ -184,8 +184,8 @@ at::Tensor& copy_(at::Tensor& dst, const at::Tensor& src, bool non_blocking = fa
   const unsigned int grid_x = (numel + BLOCK_SIZE - 1) / BLOCK_SIZE;
 
   c10::DeviceGuard guard(dst.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
   bool no_broadcast = src.sizes().equals(dst.sizes());
 

--- a/lib/exponential_.cpp
+++ b/lib/exponential_.cpp
@@ -1,12 +1,11 @@
 #include <ATen/ATen.h>
 #include <ATen/Generator.h>
 #include <ATen/core/Generator.h>
-#include <ATen/cuda/CUDAGeneratorImpl.h>
 #include <c10/util/Exception.h>
 #include <c10/util/Optional.h>
 #include <torch/torch.h>
 #include <iostream>
-#include "c10/cuda/CUDAStream.h"
+#include "flag_gems/backend_utils.h"
 #include "flag_gems/operators.h"
 #include "flag_gems/utils.h"
 #include "triton_jit/triton_jit_function.h"
@@ -130,8 +129,8 @@ at::Tensor &exponential_(at::Tensor &self, double lambd, c10::optional<at::Gener
   }
 
   c10::DeviceGuard guard(x_.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
   (*f)(raw_stream,
        grid_x,
        /* grid_y = */ 1,

--- a/lib/flash_attn_varlen_func.cpp
+++ b/lib/flash_attn_varlen_func.cpp
@@ -1,10 +1,9 @@
 #include <ATen/ATen.h>
-#include <cuda_runtime_api.h>
 #include <cmath>
 #include <limits>
 #include <tuple>
-#include "c10/cuda/CUDAStream.h"
 #include "c10/util/Optional.h"
+#include "flag_gems/backend_utils.h"
 #include "flag_gems/device_info.h"
 #include "flag_gems/operators.h"
 #include "flag_gems/utils.h"
@@ -378,8 +377,8 @@ mha_varlan_fwd_internal(const at::Tensor& q,
     const triton_jit::TritonJITFunction& f = triton_jit::TritonJITFunction::get_instance(
         (flag_gems::utils::get_flag_gems_src_path() / "ops" / "flash_kernel.py").string(),
         "flash_varlen_fwd_kernel");
-    c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-    CUstream raw_stream = stream.stream();
+    flag_gems::backend::StreamType stream = flag_gems::backend::getCurrentStream();
+    flag_gems::backend::RawStreamType raw_stream = flag_gems::backend::getRawStream(stream);
 
     f(raw_stream,
       grid_x,

--- a/lib/rotary_embedding.cpp
+++ b/lib/rotary_embedding.cpp
@@ -1,9 +1,9 @@
+#include "flag_gems/backend_utils.h"
 #include "flag_gems/operators.h"
 #include "flag_gems/utils.h"
 
 #include <iostream>
 #include <optional>
-#include "c10/cuda/CUDAStream.h"
 #include "triton_jit/triton_jit_function.h"
 
 namespace flag_gems {
@@ -127,10 +127,10 @@ void rotary_embedding_inplace(
       std::string(utils::get_flag_gems_src_path() / "fused" / "rotary_embedding.py"),
       "apply_rotary_pos_emb_inplace_kernel");
 
-  // getCurrentCUDAStream ensures that the stream is initialized, a default stream for each device
+  // Ensure the default stream for the active backend is initialized.
   c10::DeviceGuard guard(q.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
   /* signature info
 def apply_rotary_pos_emb_inplace_kernel(
@@ -230,10 +230,10 @@ std::tuple<at::Tensor, at::Tensor> rotary_embedding(const at::Tensor& q,
   const TritonJITFunction& f = TritonJITFunction::get_instance(
       std::string(utils::get_flag_gems_src_path() / "fused" / "rotary_embedding.py"),
       "apply_rotary_pos_emb_kernel");
-  // getCurrentCUDAStream ensures that the stream is initialized, a default stream for each device
+  // Ensure the default stream for the active backend is initialized.
   c10::DeviceGuard guard(q.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
   f(raw_stream,
     n_tokens,

--- a/lib/sort.cpp
+++ b/lib/sort.cpp
@@ -1,9 +1,9 @@
+#include "flag_gems/backend_utils.h"
 #include "flag_gems/operators.h"
 #include "flag_gems/utils.h"
 
 #include <iostream>
 #include "ATen/WrapDimUtils.h"
-#include "c10/cuda/CUDAStream.h"
 #include "triton_jit/triton_jit_function.h"
 
 namespace flag_gems {
@@ -40,8 +40,8 @@ std::tuple<at::Tensor, at::Tensor> radix_sort(const at::Tensor& arr, int64_t k_b
                                       "compute_global_hist_kernel");
 
   c10::DeviceGuard guard(arr.device());
-  c10::cuda::CUDAStream stream = c10::cuda::getCurrentCUDAStream();
-  CUstream raw_stream = static_cast<CUstream>(stream.stream());
+  backend::StreamType stream = backend::getCurrentStream();
+  backend::RawStreamType raw_stream = backend::getRawStream(stream);
 
   at::Tensor global_hist =
       at::zeros({m, n_passes, num_bins}, at::TensorOptions().device(arr.device()).dtype(torch::kInt32));


### PR DESCRIPTION
### PR Category
  Operator

  ### Type of Change
  Bug Fix

  ### Description
  This PR updates multiple operators to use unified backend stream helpers instead of directly relying on CUDA-specific stream APIs.

  The change mainly covers `copy`, `exponential_`, `flash_attn_varlen_func`, `rotary_embedding`, and `sort`, replacing direct CUDA stream retrieval with backend-agnostic helpers for better consistency and backend compatibility. 

  ### Issue

  N/A

  ### Progress

  - [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
  - [ ] Change is responded to an issue.
  - [ ] Change is fully covered by a UT.

  ### Performance
  No dedicated benchmark was added for this PR.

