### PR TITLE
ci: use GCC 11 for cpp-ops to enable C++20 support

### DIFF
--- a/.github/workflows/cpp-op-test.yaml
+++ b/.github/workflows/cpp-op-test.yaml
@@ -9,8 +9,13 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - shell: bash
+        env:
+          SKBUILD_CMAKE_ARGS: >
+            -DFLAGGEMS_BUILD_C_EXTENSIONS=ON
+            -DCMAKE_C_COMPILER=/usr/bin/gcc-11
+            -DCMAKE_CXX_COMPILER=/usr/bin/g++-11
         run: |
-          SKBUILD_CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON" pip install --no-build-isolation -v -e .
+          pip install --no-build-isolation -v -e .
       - shell: bash
         run: |
           cd build/cpython-311/ctests


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Other

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Other


### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Use GCC 11 in CI for C++ extension builds.

#### Reason
GCC 9 does not support `<concepts>` (C++20), causing build failures.

#### Change
Force CMake to use g++-11 via SKBUILD_CMAKE_ARGS.


### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
