### PR TITLE
Make generated Triton kernels self-contained for C++ standalone compilation

### DIFF
--- a/src/flag_gems/utils/pointwise_dynamic.py
+++ b/src/flag_gems/utils/pointwise_dynamic.py
@@ -240,9 +240,8 @@ class KernelGenerator:
         self.fn_module = scalar_fn.__module__
 
     def gen_import_function(self, code: IndentedBuffer):
-        code.writeline(f'"""Quoted source of {self.fn_name}:')
+        code.writeline("@triton.jit")
         code.writemultiline(self.fn.src)
-        code.writeline('"""')
         code.newline()
 
     def gen_decorators(self, code):
@@ -1043,6 +1042,7 @@ class ModuleGenerator:
         config: CodeGenConfig,
     ):
         self.config = config
+        self.scalar_fn = scalar_fn
         self.wrapper_gen = WrapperGenerator(
             function_schema, jit_fn_name, ndim, wrapper_name, config
         )
@@ -1051,7 +1051,87 @@ class ModuleGenerator:
         )
 
     @staticmethod
-    def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
+    def _collect_jit_deps(scalar_fn):
+        """Collect extra imports and local @triton.jit helper sources.
+
+        Parses the source module where scalar_fn is defined using AST.
+        Returns a tuple of:
+          - extra_imports: dict of module_path -> set of names
+          - local_sources: list of source strings for local @triton.jit
+            functions (those NOT decorated with @pointwise_dynamic)
+        """
+        import ast
+        import inspect
+
+        py_fn = getattr(scalar_fn, "fn", scalar_fn)
+        module_name = getattr(py_fn, "__module__", None)
+        if not module_name:
+            return {}, []
+        try:
+            mod = importlib.import_module(module_name)
+            source_file = inspect.getfile(mod)
+        except (ImportError, TypeError, OSError):
+            return {}, []
+        try:
+            with open(source_file) as f:
+                module_source = f.read()
+            source_lines = module_source.splitlines(keepends=True)
+            tree = ast.parse(module_source)
+        except (OSError, SyntaxError):
+            return {}, []
+
+        # Collect non-standard import-from lines
+        ALREADY_IMPORTED = {
+            "math",
+            "typing",
+            "torch",
+            "triton",
+            "triton.language",
+            "flag_gems.utils.shape_utils",
+            "flag_gems.utils.tensor_wrapper",
+            "flag_gems.utils.libentry",
+            "flag_gems.utils",
+            "flag_gems.runtime",
+            "flag_gems.utils.pointwise_dynamic",
+        }
+        extra_imports = {}
+        for node in ast.iter_child_nodes(tree):
+            if isinstance(node, ast.ImportFrom) and node.module:
+                if node.module in ALREADY_IMPORTED:
+                    continue
+                names = {alias.name for alias in node.names}
+                extra_imports.setdefault(node.module, set()).update(names)
+
+        # Collect local @triton.jit functions (without @pointwise_dynamic)
+        def _has_decorator(func_node, name):
+            for dec in func_node.decorator_list:
+                src = "".join(source_lines[dec.lineno - 1 : dec.end_lineno])
+                if name in src:
+                    return True
+            return False
+
+        def _extract_source(func_node):
+            start = func_node.lineno - 1
+            if func_node.decorator_list:
+                start = func_node.decorator_list[0].lineno - 1
+            end = func_node.end_lineno
+            return "".join(source_lines[start:end])
+
+        local_sources = []
+        for node in ast.iter_child_nodes(tree):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            if not _has_decorator(node, "triton.jit") and not _has_decorator(
+                node, "jit"
+            ):
+                continue
+            if _has_decorator(node, "pointwise_dynamic"):
+                continue
+            local_sources.append(_extract_source(node))
+
+        return extra_imports, local_sources
+
+    def generate_imports(self, code: IndentedBuffer) -> IndentedBuffer:
         code.writeline("import math")
         code.writeline("from typing import Union")
         code.writeline("import torch")
@@ -1067,12 +1147,25 @@ class ModuleGenerator:
         code.writeline("from flag_gems.utils.libentry import libentry")
         code.writeline("from flag_gems.utils import triton_lang_extension as tle")
         code.writeline("from flag_gems.runtime import torch_device_fn")
+
+        # Generate extra imports and local JIT deps of the scalar function
+        jit_dep_imports, local_jit_sources = self._collect_jit_deps(self.scalar_fn)
+        for module_path, names in sorted(jit_dep_imports.items()):
+            sorted_names = ", ".join(sorted(names))
+            code.writeline(f"from {module_path} import {sorted_names}")
+
         code.newline()
         code.newline()
+
+        # Emit local @triton.jit helper functions
+        for source in local_jit_sources:
+            for line in source.splitlines():
+                code.writeline(line)
+            code.newline()
+
         return code
 
     def codegen(self, code: IndentedBuffer):
-        # the only runtime determined factor is the rank of the task space
         code = self.generate_imports(code)
         if self.config.prefer_1d_tile:
             code = self.wrapper_gen.codegen_1d_tile(code)

--- a/src/flag_gems/utils/pointwise_dynamic_backup.py
+++ b/src/flag_gems/utils/pointwise_dynamic_backup.py
@@ -240,8 +240,9 @@ class KernelGenerator:
         self.fn_module = scalar_fn.__module__
 
     def gen_import_function(self, code: IndentedBuffer):
-        code.writeline("@triton.jit")
+        code.writeline(f'"""Quoted source of {self.fn_name}:')
         code.writemultiline(self.fn.src)
+        code.writeline('"""')
         code.newline()
 
     def gen_decorators(self, code):
@@ -1042,7 +1043,6 @@ class ModuleGenerator:
         config: CodeGenConfig,
     ):
         self.config = config
-        self.scalar_fn = scalar_fn
         self.wrapper_gen = WrapperGenerator(
             function_schema, jit_fn_name, ndim, wrapper_name, config
         )
@@ -1051,87 +1051,7 @@ class ModuleGenerator:
         )
 
     @staticmethod
-    def _collect_jit_deps(scalar_fn):
-        """Collect extra imports and local @triton.jit helper sources.
-
-        Parses the source module where scalar_fn is defined using AST.
-        Returns a tuple of:
-          - extra_imports: dict of module_path -> set of names
-          - local_sources: list of source strings for local @triton.jit
-            functions (those NOT decorated with @pointwise_dynamic)
-        """
-        import ast
-        import inspect
-
-        py_fn = getattr(scalar_fn, "fn", scalar_fn)
-        module_name = getattr(py_fn, "__module__", None)
-        if not module_name:
-            return {}, []
-        try:
-            mod = importlib.import_module(module_name)
-            source_file = inspect.getfile(mod)
-        except (ImportError, TypeError, OSError):
-            return {}, []
-        try:
-            with open(source_file) as f:
-                module_source = f.read()
-            source_lines = module_source.splitlines(keepends=True)
-            tree = ast.parse(module_source)
-        except (OSError, SyntaxError):
-            return {}, []
-
-        # Collect non-standard import-from lines
-        ALREADY_IMPORTED = {
-            "math",
-            "typing",
-            "torch",
-            "triton",
-            "triton.language",
-            "flag_gems.utils.shape_utils",
-            "flag_gems.utils.tensor_wrapper",
-            "flag_gems.utils.libentry",
-            "flag_gems.utils",
-            "flag_gems.runtime",
-            "flag_gems.utils.pointwise_dynamic",
-        }
-        extra_imports = {}
-        for node in ast.iter_child_nodes(tree):
-            if isinstance(node, ast.ImportFrom) and node.module:
-                if node.module in ALREADY_IMPORTED:
-                    continue
-                names = {alias.name for alias in node.names}
-                extra_imports.setdefault(node.module, set()).update(names)
-
-        # Collect local @triton.jit functions (without @pointwise_dynamic)
-        def _has_decorator(func_node, name):
-            for dec in func_node.decorator_list:
-                src = "".join(source_lines[dec.lineno - 1 : dec.end_lineno])
-                if name in src:
-                    return True
-            return False
-
-        def _extract_source(func_node):
-            start = func_node.lineno - 1
-            if func_node.decorator_list:
-                start = func_node.decorator_list[0].lineno - 1
-            end = func_node.end_lineno
-            return "".join(source_lines[start:end])
-
-        local_sources = []
-        for node in ast.iter_child_nodes(tree):
-            if not isinstance(node, ast.FunctionDef):
-                continue
-            if not _has_decorator(node, "triton.jit") and not _has_decorator(
-                node, "jit"
-            ):
-                continue
-            if _has_decorator(node, "pointwise_dynamic"):
-                continue
-            local_sources.append(_extract_source(node))
-
-        return extra_imports, local_sources
-
-    def generate_imports(self, code: IndentedBuffer) -> IndentedBuffer:
+    def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
         code.writeline("import math")
         code.writeline("from typing import Union")
         code.writeline("import torch")
@@ -1147,25 +1067,12 @@ class ModuleGenerator:
         code.writeline("from flag_gems.utils.libentry import libentry")
         code.writeline("from flag_gems.utils import triton_lang_extension as tle")
         code.writeline("from flag_gems.runtime import torch_device_fn")
-
-        # Generate extra imports and local JIT deps of the scalar function
-        jit_dep_imports, local_jit_sources = self._collect_jit_deps(self.scalar_fn)
-        for module_path, names in sorted(jit_dep_imports.items()):
-            sorted_names = ", ".join(sorted(names))
-            code.writeline(f"from {module_path} import {sorted_names}")
-
         code.newline()
         code.newline()
-
-        # Emit local @triton.jit helper functions
-        for source in local_jit_sources:
-            for line in source.splitlines():
-                code.writeline(line)
-            code.newline()
-
         return code
 
     def codegen(self, code: IndentedBuffer):
+        # the only runtime determined factor is the rank of the task space
         code = self.generate_imports(code)
         if self.config.prefer_1d_tile:
             code = self.wrapper_gen.codegen_1d_tile(code)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Other

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Refactor

### Background

Take `trunc_div_func(A, B)` as an example. It is implemented in `src/flag_gems/ops/div.py`:

```python
@pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
@triton.jit
def trunc_div_func(x, y):
    return trunc(div_rz(x, y))
```
The generated kernel file calls `trunc_div_func(A, B)`, but the function is neither defined nor imported in that file.
This behavior is intentional.

### Why this works in Python (runtime injection):
During `PointwiseDynamicFunction.instantiate()(line ~1337)`, the generated module is first loaded and then patched at runtime:
```python
# PointwiseDynamicFunction.instantiate(), line ~1337
# NOTE: [why not import the scalar function]
# we do not re-import the scalar function, although the generated kernel **calls** it
# Since a function's __name__ may be changed, from the module where it is defined import its
# __name__ is not same; Also the same may be rebind to something else, importing via name
# cannot guarantee that scalar function is imported.
# So we copy the scalar function and its __globals__ to the generated module to do this
# https://stackoverflow.com/questions/11170949/how-to-make-a-copy-of-a-python-module-at-runtime
spec.loader.exec_module(m)      # load the file
m.__dict__.update(self._scalar_fn.__globals__)  # globals injection, this copies all globals from div.py into the module
m.__dict__[self._scalar_fn.__name__] = self._scalar_fn   # inject add_func into module
```
This mechanism injects the scalar function together with all required global symbols from `div.py` into the module namespace before kernel compilation. These include:
     - `trunc  (a @triton.jit function)`
     - `div_rz (a @triton.jit function)`
     - `fmod`, `div_rn`, etc.
As a result, the generated file does not need to explicitly define or import `trunc_div_func`; the symbol is resolved via runtime patching.

### Why this fails in C++ (standalone compilation):
In the C++ workflow:
```
  TritonJITFunction::get_instance(file_path, kernel_name)
    → standalone_compile.py loads the .py file
        → triton.compile() parses the kernel function
            → sees trunc_div_func() call → NameError: not defined
```
The standalone Triton compiler loads the Python file in isolation. No runtime symbol injection is performed, so the scalar function is  unresolved at compile time.
### Solution

1. **Emit scalar function as real `@triton.jit` definition**
  -  Before (quoted comment — not callable):
 ````
  ```
  Quoted source of trunc_div_func:
  def trunc_div_func(x, y):
      return trunc(div_rz(x, y))
  ```
 ```` 
  - After (actual JIT definition — callable at Triton compile time):
 ```python
   @triton.jit
  def trunc_div_func(x, y):
      return trunc(div_rz(x, y))
```

**2. Emit required imports from the source module （Uses AST to parse the source code）**
  - Example:` div.py `has `from flag_gems.utils.triton_lang_extension import div_rn, div_rz, fmod, trunc`. This line is copied into the generated kernel file.
 
**3. Inline locally defined `@triton.jit` helper functions** 
  - These are helper functions like `_int_floordiv` , `_float_floordiv`, `_remainder `that are defined locally in the ops module. Their full source (including `@triton.jit` decorator) is inlined into the generated kernel file, before the wrapper and kernel functions.
 
**4. Generated File layout (after modification)**
```python
# --- Standard imports (always emitted) ---
  import math
  from typing import Union
  import torch
  import triton
  from triton import language as tl
  from flag_gems.utils.shape_utils import (...)
  from flag_gems.utils.tensor_wrapper import StridedBuffer
  from flag_gems.utils.libentry import libentry
  from flag_gems.utils import triton_lang_extension as tle
  from flag_gems.runtime import torch_device_fn

  # --- Extra imports (from _collect_jit_deps) ---
  from flag_gems.utils.triton_lang_extension import div_rn, div_rz, fmod, trunc

  # --- Inlined local helpers (from _collect_jit_deps) ---
  @triton.jit
  def _int_floordiv(x, y):
      r = x % y
      ...

  @triton.jit
  def _float_floordiv(x, y):
      remainder = fmod(x, y)
      ...

  # --- Wrapper function (from WrapperGenerator) ---
  def floor_div_func_wrapper_rank_2(...):
      ...

  # --- Scalar function (from KernelGenerator.gen_import_function) ---
  @triton.jit
  def floor_div_func(x, y):
      if x.type.scalar.is_int() & x.type.scalar.is_int():
          return _int_floordiv(x, y)
      else:
          return _float_floordiv(x, y)

  # --- Kernel function (from KernelGenerator) ---
  @libentry()
  @triton.jit
  def floor_div_func_kernel_rank_2(...):
      ...
      out0 = floor_div_func(in0, in1)
      ...
```

### Alternative approach considered (and rejected)
An attempted workaround was to emit:
```python
from flag_gems.ops.div import *
```
 It didn't work for two reasons:
  1. Helper functions like `_init_floordiv` start with `_` excluded by` import *`
  2. Would also import `@pointwise_dynamic` decorated objects, risking effects and circular imports

### Note:
 **A backup of the previous implementation is available at `pointwise_dynamic_backup.py`.
 If needed, you can restore this file and clear the build/cache directories to recover the previous working state.**
