### PR TITLE
Tweak rmsnorm operator regarding kernel name

### DIFF
--- a/src/flag_gems/experimental_ops/rmsnorm.py
+++ b/src/flag_gems/experimental_ops/rmsnorm.py
@@ -10,7 +10,7 @@ import triton.language as tl
 
 
 @triton.jit
-def rmsnorm(
+def rmsnorm_kernel(
     input_ptr,  # *Pointer* to the input tensor flattened to 2D [M, N]
     weight_ptr,  # *Pointer* to the weight tensor [N]
     output_ptr,  # *Pointer* to the output tensor flattened to 2D [M, N]
@@ -46,10 +46,6 @@ def rmsnorm(
         y = x * inv_rms * w
         tl.store(output_ptr + row_start + offs, y, mask=mask)
         col_start += BLOCK_SIZE
-
-
-# Keep a handle to the Triton kernel before defining the Python wrapper with the same name
-rmsnorm_kernel = rmsnorm
 
 
 def rmsnorm(input_tensor: torch.Tensor, weight: torch.Tensor, eps: float = 1e-6):


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Refactor

### Description

Rename the kernel function to `rmsnorm_kernel` to follow naming convention.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
