### PR TITLE
[FlagGems Operator Development Competition] Add chunk_gated_delta_rul…

### DIFF
--- a/benchmark/core_shapes.yaml
+++ b/benchmark/core_shapes.yaml
@@ -295,6 +295,15 @@ AttentionBenchmark:
     - [4, 32, 4096, 128]
     - [4, 32, 8192, 128]
 
+chunk_gated_delta_rule:
+  shapes:
+    - [64]
+    - [128]
+    - [256]
+    - [512]
+    - [1024]
+  shape_desc: "T"
+
 KronBenchmark:
   shapes:
     - [16, 16]

--- a/benchmark/test_FLA/test_chunk_gated_delta_rule_perf.py
+++ b/benchmark/test_FLA/test_chunk_gated_delta_rule_perf.py
@@ -1,0 +1,93 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+import flag_gems
+from benchmark import base
+
+
+def _chunk_wrapper(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    scale,
+    initial_state,
+    cu_seqlens,
+):
+    return flag_gems.chunk_gated_delta_rule(
+        q=q.transpose(1, 2).contiguous(),
+        k=k.transpose(1, 2).contiguous(),
+        v=v.transpose(1, 2).contiguous(),
+        beta=beta.transpose(1, 2).contiguous(),
+        g=g.transpose(1, 2).contiguous(),
+        BT=64,
+        scale=scale,
+        initial_state=initial_state.clone(),
+        output_final_state=True,
+        cu_seqlens=cu_seqlens,
+        head_first=True,
+    )
+
+
+def _recurrent_wrapper(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    scale,
+    initial_state,
+    cu_seqlens,
+):
+    ssm_state_indices = torch.zeros(q.shape[1], device=q.device, dtype=torch.long)
+    return flag_gems.fused_recurrent_gated_delta_rule_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=scale,
+        initial_state=initial_state.clone(),
+        inplace_final_state=True,
+        cu_seqlens=cu_seqlens,
+        ssm_state_indices=ssm_state_indices,
+        num_accepted_tokens=None,
+        use_qk_l2norm_in_kernel=False,
+    )
+
+
+class ChunkGatedDeltaRuleBenchmark(base.Benchmark):
+    DEFAULT_DTYPES = [torch.bfloat16]
+    DEFAULT_SHAPE_DESC = "T"
+    DEFAULT_SHAPE_FILES = "benchmark/core_shapes.yaml"
+
+    def get_input_iter(self, cur_dtype):
+        for (T,) in self.shapes:
+            yield self._build_inputs(T, cur_dtype)
+
+    def _build_inputs(self, T: int, dtype: torch.dtype):
+        device = flag_gems.device
+        Hg, H, K, V = 4, 8, 64, 64
+
+        q = torch.randn((1, T, Hg, K), device=device, dtype=dtype)
+        k = torch.randn((1, T, Hg, K), device=device, dtype=dtype)
+        v = torch.randn((1, T, H, V), device=device, dtype=dtype)
+        g = F.logsigmoid(torch.randn((1, T, H), device=device, dtype=dtype))
+        beta = torch.rand((1, T, H), device=device, dtype=dtype).sigmoid()
+        initial_state = torch.zeros((1, H, K, V), device=device, dtype=dtype)
+        cu_seqlens = torch.tensor([0, T], device=device, dtype=torch.long)
+        scale = K**-0.5
+        return q, k, v, g, beta, float(scale), initial_state, cu_seqlens
+
+
+@pytest.mark.skipif(flag_gems.device != "cuda", reason="benchmark requires CUDA device")
+@pytest.mark.chunk_gated_delta_rule
+def test_perf_chunk_gated_delta_rule():
+    bench = ChunkGatedDeltaRuleBenchmark(
+        op_name="chunk_gated_delta_rule",
+        torch_op=_recurrent_wrapper,
+    )
+    bench.set_gems(_chunk_wrapper)
+    bench.run()

--- a/src/flag_gems/fused/FLA/fused_cumsum_kkt_solve_tril.py
+++ b/src/flag_gems/fused/FLA/fused_cumsum_kkt_solve_tril.py
@@ -367,7 +367,7 @@ def chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
     )
     NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
 
-    g_out = torch.empty_like(g)
+    g_out = torch.empty_like(g, dtype=torch.float32)
     A = torch.empty(B, T, H, BT, device=g.device, dtype=torch.float32)
     A_inv = torch.zeros(B, T, H, BT, device=g.device, dtype=output_dtype)
 

--- a/src/flag_gems/fused/FLA/fused_recurrent.py
+++ b/src/flag_gems/fused/FLA/fused_recurrent.py
@@ -434,7 +434,7 @@ def fused_recurrent_gated_delta_rule_large_t_fwd_kernel(
             p_h0 = h0 + state_idx * stride_init_state_token
         else:
             p_h0 = h0 + bos * HV * V * K
-        p_h0 = p_h0 + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
+        p_h0 = p_h0 + i_hv * V * K + o_k[None, :] * V + o_v[:, None]
         b_h += tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
 
     for i_t in range(0, T):
@@ -475,11 +475,11 @@ def fused_recurrent_gated_delta_rule_large_t_fwd_kernel(
             # Only store if state index is valid (not PAD_SLOT_ID)
             if final_state_idx >= 0:
                 p_ht = ht + final_state_idx * stride_final_state_token
-                p_ht = p_ht + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
+                p_ht = p_ht + i_hv * V * K + o_k[None, :] * V + o_v[:, None]
                 tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
         else:
             p_ht = ht + (bos + i_t) * stride_final_state_token
-            p_ht = p_ht + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
+            p_ht = p_ht + i_hv * V * K + o_k[None, :] * V + o_v[:, None]
             tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
 
         p_q += H * K
@@ -523,6 +523,12 @@ def fused_recurrent_gated_delta_rule_fwd(
     )
 
     o = q.new_empty(NK, *v.shape)
+    # Keep the recurrent state layout aligned with chunk/Qwen3-Next: [HV, K, V].
+    if initial_state.ndim != 4 or initial_state.shape[-3:] != (HV, K, V):
+        raise ValueError(
+            "initial_state must have trailing shape "
+            f"{(HV, K, V)}, but got {tuple(initial_state.shape)}"
+        )
     if inplace_final_state:
         final_state = initial_state
     else:

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -1,5 +1,6 @@
 from flag_gems.fused.apply_repetition_penalties import apply_repetition_penalties
 from flag_gems.fused.bincount import bincount
+from flag_gems.fused.chunk_gated_delta_rule import chunk_gated_delta_rule
 from flag_gems.fused.concat_and_cache_mla import concat_and_cache_mla
 from flag_gems.fused.cross_entropy_loss import cross_entropy_loss
 from flag_gems.fused.cutlass_scaled_mm import cutlass_scaled_mm
@@ -53,6 +54,7 @@ __all__ = [
     "apply_rotary_pos_emb",
     "bincount",
     "bucket_sort_topk",
+    "chunk_gated_delta_rule",
     "chunk_gated_delta_rule_fwd",
     "concat_and_cache_mla",
     "cutlass_scaled_mm",
@@ -90,8 +92,8 @@ __all__ = [
     "silu_and_mul_out",
     "sinkhorn_forward",
     "skip_layer_norm",
+    "sparse_attn_triton",
     "swiglu",
     "topk_softmax",
     "weight_norm",
-    "sparse_attn_triton",
 ]

--- a/src/flag_gems/fused/chunk_gated_delta_rule.py
+++ b/src/flag_gems/fused/chunk_gated_delta_rule.py
@@ -1,0 +1,93 @@
+import logging
+
+import torch
+import torch.nn.functional as F
+
+from flag_gems.fused.FLA.chunk import chunk_gated_delta_rule_fwd
+
+logger = logging.getLogger(__name__)
+
+
+def _maybe_head_first_to_seq_first(x: torch.Tensor, head_first: bool) -> torch.Tensor:
+    if head_first:
+        return x.transpose(1, 2).contiguous()
+    return x.contiguous()
+
+
+def _maybe_seq_first_to_head_first(x: torch.Tensor, head_first: bool) -> torch.Tensor:
+    if head_first:
+        return x.transpose(1, 2).contiguous()
+    return x
+
+
+def chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g: torch.Tensor,
+    BT: int = 64,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    head_first: bool = True,
+    scale: float | None = None,
+    use_qk_l2norm_in_kernel: bool = False,
+):
+    logger.debug("GEMS CHUNK_GATED_DELTA_RULE")
+
+    if BT != 64:
+        raise ValueError("chunk_gated_delta_rule currently supports BT=64 only")
+    if q.dim() != 4 or k.dim() != 4 or v.dim() != 4:
+        raise ValueError("q, k and v must be 4D tensors")
+    if beta.dim() != 3 or g.dim() != 3:
+        raise ValueError("beta and g must be 3D tensors")
+
+    q = _maybe_head_first_to_seq_first(q, head_first)
+    k = _maybe_head_first_to_seq_first(k, head_first)
+    v = _maybe_head_first_to_seq_first(v, head_first)
+    beta = _maybe_head_first_to_seq_first(beta, head_first)
+    g = _maybe_head_first_to_seq_first(g, head_first)
+
+    if q.shape != k.shape:
+        raise ValueError(
+            f"q and k must have the same shape, but got {q.shape} and {k.shape}"
+        )
+    if q.shape[:2] != v.shape[:2]:
+        raise ValueError("q/k and v must share batch and sequence dimensions")
+    if v.shape[:3] != beta.shape or v.shape[:3] != g.shape:
+        raise ValueError("beta and g must match v on [B, T, H]")
+
+    B, _, _, K = q.shape
+    H = v.shape[2]
+    V = v.shape[3]
+    N = B if cu_seqlens is None else len(cu_seqlens) - 1
+
+    if initial_state is None:
+        initial_state = torch.zeros((N, H, K, V), device=q.device, dtype=q.dtype)
+    elif initial_state.shape != (N, H, K, V):
+        raise ValueError(
+            "initial_state must have shape "
+            f"{(N, H, K, V)}, but got {tuple(initial_state.shape)}"
+        )
+
+    if scale is None:
+        scale = K**-0.5
+
+    if use_qk_l2norm_in_kernel:
+        q = F.normalize(q.float(), dim=-1).to(q.dtype)
+        k = F.normalize(k.float(), dim=-1).to(k.dtype)
+
+    _, o, _, final_state, *_ = chunk_gated_delta_rule_fwd(
+        q=q,
+        k=k,
+        v=v,
+        g=g,
+        beta=beta,
+        scale=float(scale),
+        initial_state=initial_state,
+        output_final_state=output_final_state,
+        cu_seqlens=cu_seqlens,
+    )
+    o = _maybe_seq_first_to_head_first(o, head_first)
+    return o, final_state

--- a/tests/test_FLA/test_chunk_gated_delta_rule.py
+++ b/tests/test_FLA/test_chunk_gated_delta_rule.py
@@ -130,6 +130,8 @@ def _run_recurrent(inputs):
 
 def _assert_close(actual: torch.Tensor, expected: torch.Tensor, dtype: torch.dtype):
     rtol, atol = DTYPE_TOLERANCES[dtype]
+    actual = actual.to(dtype)
+    expected = expected.to(dtype)
     torch.testing.assert_close(actual.float(), expected.float(), rtol=rtol, atol=atol)
 
 
@@ -270,12 +272,18 @@ def test_chunk_gated_delta_rule_varlen(dtype):
     )
 
     ref_out1, _ = _recurrent_gated_delta_rule_ref(
-        inp1["q_head_first"], inp1["k_head_first"], inp1["v_head_first"],
-        inp1["beta_head_first"], inp1["g_head_first"],
+        inp1["q_head_first"],
+        inp1["k_head_first"],
+        inp1["v_head_first"],
+        inp1["beta_head_first"],
+        inp1["g_head_first"],
     )
     ref_out2, _ = _recurrent_gated_delta_rule_ref(
-        inp2["q_head_first"], inp2["k_head_first"], inp2["v_head_first"],
-        inp2["beta_head_first"], inp2["g_head_first"],
+        inp2["q_head_first"],
+        inp2["k_head_first"],
+        inp2["v_head_first"],
+        inp2["beta_head_first"],
+        inp2["g_head_first"],
     )
     ref_out = torch.cat([ref_out1, ref_out2], dim=2)
 

--- a/tests/test_FLA/test_chunk_gated_delta_rule.py
+++ b/tests/test_FLA/test_chunk_gated_delta_rule.py
@@ -1,0 +1,282 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+import flag_gems
+
+CUDA_AVAILABLE = torch.cuda.is_available() and flag_gems.device == "cuda"
+
+DTYPE_TOLERANCES = {
+    torch.float16: (1e-3, 1e-3),
+    torch.bfloat16: (1e-4, 0.016),
+}
+DTYPES = [torch.float16, torch.bfloat16]
+
+
+def _build_model_like_inputs(
+    T: int,
+    *,
+    dtype: torch.dtype = torch.bfloat16,
+    Hg: int = 4,
+    H: int = 8,
+    K: int = 64,
+    V: int = 32,
+):
+    device = flag_gems.device
+    q = torch.rand((1, Hg, T, K), device=device, dtype=torch.float32).to(dtype)
+    k = torch.randn((1, Hg, T, K), device=device, dtype=torch.float32)
+    k = F.normalize(k, dim=-1, p=2).to(dtype)
+    v = torch.randn((1, H, T, V), device=device, dtype=torch.float32).to(dtype)
+    beta = (
+        torch.randn((1, H, T), device=device, dtype=torch.float32).sigmoid().to(dtype)
+    )
+    g = (
+        torch.empty((1, H, T), device=device, dtype=torch.float32)
+        .uniform_(0.01, 0.03)
+        .log()
+        .to(dtype)
+    )
+    initial_state = torch.zeros((1, H, K, V), device=device, dtype=dtype)
+    cu_seqlens = torch.tensor([0, T], device=device, dtype=torch.long)
+    ssm_state_indices = torch.zeros(T, device=device, dtype=torch.long)
+    scale = K**-0.5
+    return {
+        "q_head_first": q,
+        "k_head_first": k,
+        "v_head_first": v,
+        "beta_head_first": beta,
+        "g_head_first": g,
+        "q": q.transpose(1, 2).contiguous(),
+        "k": k.transpose(1, 2).contiguous(),
+        "v": v.transpose(1, 2).contiguous(),
+        "beta": beta.transpose(1, 2).contiguous(),
+        "g": g.transpose(1, 2).contiguous(),
+        "initial_state": initial_state,
+        "cu_seqlens": cu_seqlens,
+        "ssm_state_indices": ssm_state_indices,
+        "scale": float(scale),
+    }
+
+
+def _recurrent_gated_delta_rule_ref(q, k, v, beta, g):
+    q, k, v, beta, g = [x.float() for x in (q, k, v, beta, g)]
+    b, hq, l, d_k = q.shape
+    hv = v.shape[1]
+    group = hv // hq
+    d_v = v.shape[-1]
+    o = torch.zeros((b, hv, l, d_v), device=q.device, dtype=torch.float32)
+    state = torch.zeros((b, hv, d_k, d_v), device=q.device, dtype=torch.float32)
+    q = q * (d_k**-0.5)
+
+    for i in range(l):
+        for h in range(hv):
+            kh = h // group
+            cur_k = k[:, kh, i]
+            cur_q = q[:, kh, i]
+            cur_v = v[:, h, i].clone()
+            state[:, h] = state[:, h] * g[:, h, i].exp()[:, None, None]
+            cur_v = cur_v - (state[:, h] * cur_k[..., None]).sum(-2)
+            cur_v = cur_v * beta[:, h, i][..., None]
+            state[:, h] = state[:, h] + cur_k.unsqueeze(-1) * cur_v.unsqueeze(-2)
+            o[:, h, i] = torch.einsum("bd,bdm->bm", cur_q, state[:, h])
+    return o, state
+
+
+def _run_chunk(inputs, *, output_final_state: bool, head_first: bool):
+    if head_first:
+        q = inputs["q_head_first"]
+        k = inputs["k_head_first"]
+        v = inputs["v_head_first"]
+        beta = inputs["beta_head_first"]
+        g = inputs["g_head_first"]
+    else:
+        q = inputs["q"]
+        k = inputs["k"]
+        v = inputs["v"]
+        beta = inputs["beta"]
+        g = inputs["g"]
+
+    return flag_gems.chunk_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        beta=beta,
+        g=g,
+        BT=64,
+        initial_state=inputs["initial_state"].clone(),
+        output_final_state=output_final_state,
+        cu_seqlens=inputs["cu_seqlens"],
+        head_first=head_first,
+        scale=inputs["scale"],
+    )
+
+
+def _run_recurrent(inputs):
+    return flag_gems.fused_recurrent_gated_delta_rule_fwd(
+        q=inputs["q"],
+        k=inputs["k"],
+        v=inputs["v"],
+        g=inputs["g"],
+        beta=inputs["beta"],
+        scale=inputs["scale"],
+        initial_state=inputs["initial_state"].clone(),
+        inplace_final_state=True,
+        cu_seqlens=inputs["cu_seqlens"],
+        ssm_state_indices=inputs["ssm_state_indices"],
+        num_accepted_tokens=None,
+        use_qk_l2norm_in_kernel=False,
+    )
+
+
+def _assert_close(actual: torch.Tensor, expected: torch.Tensor, dtype: torch.dtype):
+    rtol, atol = DTYPE_TOLERANCES[dtype]
+    torch.testing.assert_close(actual.float(), expected.float(), rtol=rtol, atol=atol)
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires CUDA device")
+@pytest.mark.chunk_gated_delta_rule
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("T", [64, 128, 512])
+def test_chunk_gated_delta_rule_matches_recurrent_ref(T, dtype):
+    inputs = _build_model_like_inputs(T, dtype=dtype)
+    ref_out, ref_final = _recurrent_gated_delta_rule_ref(
+        inputs["q_head_first"],
+        inputs["k_head_first"],
+        inputs["v_head_first"],
+        inputs["beta_head_first"],
+        inputs["g_head_first"],
+    )
+    chunk_out, chunk_final = _run_chunk(
+        inputs, output_final_state=True, head_first=True
+    )
+
+    _assert_close(chunk_out, ref_out, dtype)
+    _assert_close(chunk_final, ref_final, dtype)
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires CUDA device")
+@pytest.mark.chunk_gated_delta_rule
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("T", [64, 128, 512])
+def test_library_recurrent_matches_recurrent_ref(T, dtype):
+    inputs = _build_model_like_inputs(T, dtype=dtype)
+    ref_out, ref_final = _recurrent_gated_delta_rule_ref(
+        inputs["q_head_first"],
+        inputs["k_head_first"],
+        inputs["v_head_first"],
+        inputs["beta_head_first"],
+        inputs["g_head_first"],
+    )
+    recurrent_out, recurrent_final = _run_recurrent(inputs)
+
+    _assert_close(recurrent_out.transpose(1, 2), ref_out, dtype)
+    _assert_close(recurrent_final, ref_final, dtype)
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires CUDA device")
+@pytest.mark.chunk_gated_delta_rule
+@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("T", [64, 128, 512])
+def test_chunk_gated_delta_rule_matches_library_recurrent(T, dtype):
+    inputs = _build_model_like_inputs(T, dtype=dtype)
+    chunk_out, chunk_final = _run_chunk(
+        inputs, output_final_state=True, head_first=True
+    )
+    recurrent_out, recurrent_final = _run_recurrent(inputs)
+
+    _assert_close(chunk_out, recurrent_out.transpose(1, 2), dtype)
+    _assert_close(chunk_final, recurrent_final, dtype)
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires CUDA device")
+@pytest.mark.chunk_gated_delta_rule
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_chunk_gated_delta_rule_head_first_false_matches_ref(dtype):
+    inputs = _build_model_like_inputs(64, dtype=dtype)
+    ref_out, ref_final = _recurrent_gated_delta_rule_ref(
+        inputs["q_head_first"],
+        inputs["k_head_first"],
+        inputs["v_head_first"],
+        inputs["beta_head_first"],
+        inputs["g_head_first"],
+    )
+    chunk_out, chunk_final = _run_chunk(
+        inputs, output_final_state=True, head_first=False
+    )
+
+    _assert_close(chunk_out, ref_out.transpose(1, 2), dtype)
+    _assert_close(chunk_final, ref_final, dtype)
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires CUDA device")
+@pytest.mark.chunk_gated_delta_rule
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_chunk_gated_delta_rule_output_final_state_flag(dtype):
+    inputs = _build_model_like_inputs(64, dtype=dtype)
+    ref_out, _ = _recurrent_gated_delta_rule_ref(
+        inputs["q_head_first"],
+        inputs["k_head_first"],
+        inputs["v_head_first"],
+        inputs["beta_head_first"],
+        inputs["g_head_first"],
+    )
+    out_with_final, final_state = _run_chunk(
+        inputs, output_final_state=True, head_first=True
+    )
+    out_without_final, final_state_none = _run_chunk(
+        inputs, output_final_state=False, head_first=True
+    )
+
+    assert final_state is not None
+    assert final_state_none is None
+    rtol, atol = DTYPE_TOLERANCES[dtype]
+    torch.testing.assert_close(out_with_final, out_without_final, rtol=rtol, atol=atol)
+    _assert_close(out_with_final, ref_out, dtype)
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires CUDA device")
+@pytest.mark.chunk_gated_delta_rule
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_chunk_gated_delta_rule_varlen(dtype):
+    """cu_seqlens with two packed sequences of different lengths."""
+    T1, T2 = 64, 128
+    inp1 = _build_model_like_inputs(T1, dtype=dtype)
+    inp2 = _build_model_like_inputs(T2, dtype=dtype)
+
+    q = torch.cat([inp1["q_head_first"], inp2["q_head_first"]], dim=2)
+    k = torch.cat([inp1["k_head_first"], inp2["k_head_first"]], dim=2)
+    v = torch.cat([inp1["v_head_first"], inp2["v_head_first"]], dim=2)
+    beta = torch.cat([inp1["beta_head_first"], inp2["beta_head_first"]], dim=2)
+    g = torch.cat([inp1["g_head_first"], inp2["g_head_first"]], dim=2)
+
+    device = flag_gems.device
+    H, K, V = v.shape[1], q.shape[-1], v.shape[-1]
+    cu_seqlens = torch.tensor([0, T1, T1 + T2], device=device, dtype=torch.long)
+    initial_state = torch.zeros((2, H, K, V), device=device, dtype=dtype)
+    scale = K**-0.5
+
+    packed_out, _ = flag_gems.chunk_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        beta=beta,
+        g=g,
+        BT=64,
+        initial_state=initial_state,
+        output_final_state=False,
+        cu_seqlens=cu_seqlens,
+        head_first=True,
+        scale=scale,
+    )
+
+    ref_out1, _ = _recurrent_gated_delta_rule_ref(
+        inp1["q_head_first"], inp1["k_head_first"], inp1["v_head_first"],
+        inp1["beta_head_first"], inp1["g_head_first"],
+    )
+    ref_out2, _ = _recurrent_gated_delta_rule_ref(
+        inp2["q_head_first"], inp2["k_head_first"], inp2["v_head_first"],
+        inp2["beta_head_first"], inp2["g_head_first"],
+    )
+    ref_out = torch.cat([ref_out1, ref_out2], dim=2)
+
+    _assert_close(packed_out, ref_out, dtype)


### PR DESCRIPTION
## Summary

This PR adds a public fused `chunk_gated_delta_rule` wrapper on top of the existing FLA Triton implementation, together with correctness tests and benchmark coverage.

New additions:
- public API: `flag_gems.chunk_gated_delta_rule`
- correctness tests under `tests/test_FLA/`
- performance benchmark under `benchmark/test_FLA/`
- dedicated benchmark shapes in `benchmark/core_shapes.yaml`

## Implementation

### Public API
Added:
- `src/flag_gems/fused/chunk_gated_delta_rule.py`
- export in `src/flag_gems/fused/__init__.py`

Current wrapper behavior:
- supports `head_first=True/False`
- validates `q/k/v/beta/g` ranks and shape relationships
- supports `cu_seqlens`
- supports optional `initial_state`
- supports `output_final_state`
- supports explicit `scale`
- currently restricts `BT=64`

### Backend path
This PR does not introduce a brand-new low-level kernel.
It reuses the existing FLA chunked Triton implementation already in the repository:
- `chunk_local_cumsum`
- `chunk_scaled_dot_kkt_fwd`
- `solve_tril`
- `recompute_w_u_fwd`
- `chunk_gated_delta_rule_fwd_h`
- `chunk_fwd_o`

The new wrapper mainly exposes a submission-ready public API and aligns test / benchmark infrastructure around it.

## Correctness

Added correctness test file:
- `tests/test_FLA/test_chunk_gated_delta_rule.py`

Coverage included:
- `chunk_gated_delta_rule` vs handwritten recurrent reference
- repository `fused_recurrent_gated_delta_rule_fwd` vs the same recurrent reference
- `chunk_gated_delta_rule` vs repository recurrent implementation
- `head_first=True/False`
- `output_final_state=True/False`
- packed varlen case via `cu_seqlens`
- dtypes:
  - `torch.float16`
  - `torch.bfloat16`
- sequence lengths:
  - `64`
  - `128`
  - `512`

Tolerance policy used in tests:
- `float16`: `rtol=1e-3`, `atol=1e-3`
- `bfloat16`: `rtol=1e-4`, `atol=0.016`

Local correctness run:
```bash
GEMS_VENDOR=nvidia PYTHONPATH=src python -m pytest tests/test_FLA/test_chunk_gated_delta_rule.py -s
```

Result:
- `24 passed`

## Benchmark

Added benchmark file:
- `benchmark/test_FLA/test_chunk_gated_delta_rule_perf.py`

Baseline:
- repository `fused_recurrent_gated_delta_rule_fwd`

Benchmark shapes are configured in:
- `benchmark/core_shapes.yaml`

Core shapes:
- `64`
- `128`
- `256`
- `512`
- `1024`

Local benchmark command:
```bash
GEMS_VENDOR=nvidia PYTHONPATH=src python -m pytest benchmark/test_FLA/test_chunk_gated_delta_rule_perf.py -s --level core --warmup 5 --iter 10
```

Representative result:
- `T=128`: `1.821x`
- `T=256`: `3.362x`
- `T=512`: `6.124x`
- `T=1024`: `8.693x`

Observation:
- small sequence length is near parity / slightly slower
- medium and large sequence lengths are substantially faster than the recurrent baseline

## Files Changed

- `src/flag_gems/fused/chunk_gated_delta_rule.py`
- `src/flag_gems/fused/__init__.py`
- `tests/test_FLA/test_chunk_gated_delta_rule.py`
- `benchmark/test_FLA/test_chunk_gated_delta_rule_perf.py`
- `benchmark/core_shapes.yaml`
