### PR TITLE
fix: codestyle fixes for _safe_softmax.py and test_special_ops.py

### DIFF
--- a/src/flag_gems/ops/_safe_softmax.py
+++ b/src/flag_gems/ops/_safe_softmax.py
@@ -9,7 +9,9 @@ logger = logging.getLogger(__name__)
 
 
 @triton.jit
-def _safe_softmax_kernel(input_ptr, output_ptr, n_rows, n_cols, BLOCK_SIZE: tl.constexpr):
+def _safe_softmax_kernel(
+    input_ptr, output_ptr, n_rows, n_cols, BLOCK_SIZE: tl.constexpr
+):
     row_id = tl.program_id(0)
     cols = tl.arange(0, BLOCK_SIZE)
     mask = cols < n_cols

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -2345,6 +2345,7 @@ def test_accuracy_t_copy_out(shape, dtype):
         act_out = torch.ops.aten.t_copy(x, out=act_out_buf)
     gems_assert_close(act_out, ref_out, dtype)
 
+
 @pytest.mark.safe_softmax
 @pytest.mark.parametrize("shape", [(2, 3), (128, 256), (512, 512)])
 @pytest.mark.parametrize("in_dtype", FLOAT_DTYPES)


### PR DESCRIPTION
Fix black formatting issues in master:
- `src/flag_gems/ops/_safe_softmax.py`: line too long in kernel function signature
- `tests/test_special_ops.py`: missing blank line before function definition

These were introduced by recent merges and cause pre-commit CI failures on all open PRs.