### PR TITLE
[SiliconFlow] add select_backward

### DIFF
--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -1333,3 +1333,48 @@ def test_perf_t_copy():
         dtypes=FLOAT_DTYPES,
     )
     bench.run()
+
+
+class SelectBackwardBenchmark(Benchmark):
+    """
+    Benchmark for select_backward operator.
+    """
+
+    def set_more_shapes(self):
+        special_shapes_2d = [(1024, 2**i) for i in range(0, 20, 4)]
+        sp_shapes_3d = [(64, 64, 2**i) for i in range(0, 15, 4)]
+        return special_shapes_2d + sp_shapes_3d
+
+    def get_input_iter(self, cur_dtype):
+        for shape in self.shapes:
+            x = generate_tensor_input(shape, cur_dtype, self.device)
+            ndim = len(shape)
+
+            dim = 1 if ndim > 1 else 0
+            actual_dim = dim if dim >= 0 else dim + ndim
+
+            index = shape[actual_dim] // 2
+
+            y = torch.select(x, actual_dim, index)
+            grad = torch.randn_like(y)
+
+            yield grad, shape, actual_dim, index
+
+    def get_tflops(self, op, *args, **kwargs):
+        grad, shape, _, _ = args
+        return grad.numel()
+
+
+@pytest.mark.select_backward
+@pytest.mark.parametrize(
+    "dtype",
+    FLOAT_DTYPES,
+)
+def test_select_backward_perf(dtype):
+    bench = SelectBackwardBenchmark(
+        op_name="select_backward",
+        torch_op=torch.ops.aten.select_backward,
+        dtypes=[dtype],
+    )
+
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -353,6 +353,7 @@ _FULL_CONFIG = (
     ("scatter_.reduce", scatter_),
     ("scatter_.src", scatter_),
     ("scatter_add_", scatter_add_),
+    ("select_backward", select_backward),
     ("select_scatter", select_scatter),
     ("selu_", selu_),
     ("sgn_", sgn_),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -237,6 +237,7 @@ from flag_gems.ops.rsqrt import rsqrt, rsqrt_
 from flag_gems.ops.scaled_softmax import scaled_softmax_backward, scaled_softmax_forward
 from flag_gems.ops.scatter import scatter, scatter_
 from flag_gems.ops.scatter_add_ import scatter_add_
+from flag_gems.ops.select_backward import select_backward
 from flag_gems.ops.select_scatter import select_scatter
 from flag_gems.ops.selu import selu
 from flag_gems.ops.selu_ import selu_
@@ -590,6 +591,7 @@ __all__ = [
     "scatter",
     "scatter_",
     "scatter_add_",
+    "select_backward",
     "select_scatter",
     "selu",
     "selu_",

--- a/src/flag_gems/ops/select_backward.py
+++ b/src/flag_gems/ops/select_backward.py
@@ -1,0 +1,97 @@
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def _select_backward_kernel(
+    grad_ptr,
+    out_ptr,
+    outer_size,
+    inner_size,
+    dim_stride,
+    index,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    total = outer_size * inner_size
+
+    mask = offs < total
+
+    outer = offs // inner_size
+    inner = offs % inner_size
+
+    grad_vals = tl.load(grad_ptr + outer * inner_size + inner, mask=mask)
+
+    out_offset = outer * dim_stride + index * inner_size + inner
+
+    tl.store(out_ptr + out_offset, grad_vals, mask=mask)
+
+
+def _launch_select_backward(grad, input_sizes, dim, index, out=None):
+    if not grad.is_cuda:
+        raise ValueError("grad must be CUDA tensor")
+
+    dim = int(dim)
+    index = int(index)
+
+    sizes = list(input_sizes)
+    ndim = len(sizes)
+
+    if dim < 0:
+        dim += ndim
+
+    if dim < 0 or dim >= ndim:
+        raise ValueError("invalid dim")
+
+    dim_size = sizes[dim]
+
+    if index < 0 or index >= dim_size:
+        raise ValueError("index out of range")
+
+    outer_size = math.prod(sizes[:dim]) if dim > 0 else 1
+    inner_size = math.prod(sizes[dim + 1 :]) if dim < ndim - 1 else 1
+
+    grad_view = grad.contiguous().view(outer_size, inner_size)
+
+    if out is None:
+        out = torch.zeros(
+            sizes,
+            dtype=grad.dtype,
+            device=grad.device,
+        )
+    else:
+        if tuple(out.shape) != tuple(sizes):
+            raise ValueError("out shape mismatch")
+        if out.dtype != grad.dtype:
+            raise ValueError("dtype mismatch")
+        if out.device != grad.device:
+            raise ValueError("device mismatch")
+
+        out.zero_()
+
+    dim_stride = dim_size * inner_size
+
+    BLOCK = 1024
+    n_elements = outer_size * inner_size
+    grid = (triton.cdiv(n_elements, BLOCK),)
+
+    _select_backward_kernel[grid](
+        grad_view,
+        out,
+        outer_size,
+        inner_size,
+        dim_stride,
+        index,
+        BLOCK=BLOCK,
+    )
+
+    return out
+
+
+def select_backward(grad, input_sizes, dim, index, out=None):
+    return _launch_select_backward(grad, input_sizes, dim, index, out=out)

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -2464,3 +2464,137 @@ def test_accuracy__safe_softmax(shape, in_dtype, dim, dtype_arg_sel):
         act_out = torch.ops.aten._safe_softmax(x, dim, dtype=dtype_arg)
     expected_dtype = dtype_arg if dtype_arg is not None else in_dtype
     gems_assert_close(act_out, ref_out, expected_dtype)
+
+
+@pytest.mark.select_backward
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (10,),
+        (4, 8),
+        (4, 8, 16),
+        (2, 3, 4, 5),
+        (8, 16, 32),
+        (3, 7, 11),
+        (2, 1, 4),
+        (64, 512),
+        (32, 256, 256),
+    ],
+)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("dim", [0, 1, -1])
+def test_accuracy_select_backward(shape, dtype, dim):
+    ndim = len(shape)
+    actual_dim = dim + ndim if dim < 0 else dim
+
+    if actual_dim >= ndim:
+        pytest.skip(f"dim {dim} out of range for shape {shape}")
+
+    dim_size = shape[actual_dim]
+
+    indices_to_test = [0, dim_size // 2]
+    if dim_size > 1:
+        indices_to_test.append(dim_size - 1)
+
+    for index in indices_to_test:
+        grad_shape = list(shape)
+        grad_shape.pop(actual_dim)
+
+        res_grad = torch.randn(
+            grad_shape,
+            dtype=dtype,
+            device=flag_gems.device,
+        )
+        ref_grad = to_reference(res_grad)
+
+        ref_out = torch.ops.aten.select_backward(
+            ref_grad,
+            shape,
+            actual_dim,
+            index,
+        )
+
+        with flag_gems.use_gems():
+            res_out = torch.ops.aten.select_backward(
+                res_grad,
+                shape,
+                actual_dim,
+                index,
+            )
+
+        assert res_out.shape == tuple(shape)
+        assert res_out.dtype == res_grad.dtype
+
+        gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.select_backward
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_select_backward_non_contiguous(dtype):
+    base_shape = (8, 16, 32)
+
+    res_x = torch.randn(base_shape, dtype=dtype, device=flag_gems.device)
+    res_x = res_x.transpose(0, 1)  # non-contiguous
+
+    shape = res_x.shape
+    dim = 1
+    index = min(5, shape[dim] - 1)
+
+    grad_shape = list(shape)
+    grad_shape.pop(dim)
+
+    res_grad = torch.randn(
+        grad_shape,
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+    ref_grad = to_reference(res_grad)
+
+    ref_out = torch.ops.aten.select_backward(
+        ref_grad,
+        shape,
+        dim,
+        index,
+    )
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.select_backward(
+            res_grad,
+            shape,
+            dim,
+            index,
+        )
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.select_backward
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_select_backward_small_and_edge(dtype):
+    shape = (1, 1, 1)
+    dim = 0
+    index = 0
+
+    res_grad = torch.randn(
+        (1, 1),
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+    ref_grad = to_reference(res_grad)
+
+    ref_out = torch.ops.aten.select_backward(
+        ref_grad,
+        shape,
+        dim,
+        index,
+    )
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.select_backward(
+            res_grad,
+            shape,
+            dim,
+            index,
+        )
+
+    gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator , OP Test , Benchmark

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Implemented an select_backward operation using triton. Registered the new operation, added it to the benchmark suite, and included accuracy tests for various shapes and dtypes.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

```bash
(flag) xiexuan@oneflow-24:/data/xiexuan/git-repos/FlagGems$ python -m pytest -s benchmark/test_special_perf.py::test_select_backward_perf
==================================== test session starts ====================================
platform linux -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0
rootdir: /data/xiexuan/git-repos/FlagGems
configfile: pytest.ini
collected 3 items

benchmark/test_special_perf.py
Operator: select_backward  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.390592            1.389568               1.001          [torch.Size([]), [1073741824], 0, 536870912]
SUCCESS               0.009216            0.011264               0.818          [torch.Size([64]), [64, 64], 1, 32]
SUCCESS               0.033792            0.032768               1.031          [torch.Size([4096]), [4096, 4096], 1, 2048]
SUCCESS               0.033792            0.030720               1.100          [torch.Size([64, 512]), [64, 512, 512], 1, 256]
SUCCESS               1.397760            1.393664               1.003          [torch.Size([1024, 1024]), [1024, 1024, 1024], 1, 512]
SUCCESS               0.008192            0.009216               0.889          [torch.Size([1024]), [1024, 1], 1, 0]
SUCCESS               0.011264            0.010240               1.100          [torch.Size([1024]), [1024, 16], 1, 8]
SUCCESS               0.012288            0.011264               1.091          [torch.Size([1024]), [1024, 256], 1, 128]
SUCCESS               0.017408            0.015360               1.133          [torch.Size([1024]), [1024, 4096], 1, 2048]
SUCCESS               0.098304            0.097280               1.011          [torch.Size([1024]), [1024, 65536], 1, 32768]
SUCCESS               0.009216            0.009216               1.000          [torch.Size([64, 1]), [64, 64, 1], 1, 32]
SUCCESS               0.011264            0.009216               1.222          [torch.Size([64, 16]), [64, 64, 16], 1, 32]
SUCCESS               0.012288            0.010240               1.200          [torch.Size([64, 256]), [64, 64, 256], 1, 32]
SUCCESS               0.034816            0.031744               1.097          [torch.Size([64, 4096]), [64, 64, 4096], 1, 32]

.
Operator: select_backward  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.774016            2.770944               1.001          [torch.Size([]), [1073741824], 0, 536870912]
SUCCESS               0.009216            0.010240               0.900          [torch.Size([64]), [64, 64], 1, 32]
SUCCESS               0.054272            0.054272               1.000          [torch.Size([4096]), [4096, 4096], 1, 2048]
SUCCESS               0.054272            0.053248               1.019          [torch.Size([64, 512]), [64, 512, 512], 1, 256]
SUCCESS               2.787328            2.778112               1.003          [torch.Size([1024, 1024]), [1024, 1024, 1024], 1, 512]
SUCCESS               0.008192            0.009216               0.889          [torch.Size([1024]), [1024, 1], 1, 0]
SUCCESS               0.010240            0.010240               1.000          [torch.Size([1024]), [1024, 16], 1, 8]
SUCCESS               0.011264            0.010240               1.100          [torch.Size([1024]), [1024, 256], 1, 128]
SUCCESS               0.021504            0.021504               1.000          [torch.Size([1024]), [1024, 4096], 1, 2048]
SUCCESS               0.183296            0.183296               1.000          [torch.Size([1024]), [1024, 65536], 1, 32768]
SUCCESS               0.009216            0.010240               0.900          [torch.Size([64, 1]), [64, 64, 1], 1, 32]
SUCCESS               0.010240            0.009216               1.111          [torch.Size([64, 16]), [64, 64, 16], 1, 32]
SUCCESS               0.012288            0.011264               1.091          [torch.Size([64, 256]), [64, 64, 256], 1, 32]
SUCCESS               0.055296            0.054272               1.019          [torch.Size([64, 4096]), [64, 64, 4096], 1, 32]

.
Operator: select_backward  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.389568            1.389568               1.000          [torch.Size([]), [1073741824], 0, 536870912]
SUCCESS               0.009216            0.012288               0.750          [torch.Size([64]), [64, 64], 1, 32]
SUCCESS               0.033792            0.032768               1.031          [torch.Size([4096]), [4096, 4096], 1, 2048]
SUCCESS               0.033792            0.030720               1.100          [torch.Size([64, 512]), [64, 512, 512], 1, 256]
SUCCESS               1.397760            1.393664               1.003          [torch.Size([1024, 1024]), [1024, 1024, 1024], 1, 512]
SUCCESS               0.008192            0.010240               0.800          [torch.Size([1024]), [1024, 1], 1, 0]
SUCCESS               0.011264            0.009216               1.222          [torch.Size([1024]), [1024, 16], 1, 8]
SUCCESS               0.012288            0.011264               1.091          [torch.Size([1024]), [1024, 256], 1, 128]
SUCCESS               0.017408            0.015360               1.133          [torch.Size([1024]), [1024, 4096], 1, 2048]
SUCCESS               0.098304            0.097280               1.011          [torch.Size([1024]), [1024, 65536], 1, 32768]
SUCCESS               0.009216            0.011264               0.818          [torch.Size([64, 1]), [64, 64, 1], 1, 32]
SUCCESS               0.011264            0.009216               1.222          [torch.Size([64, 16]), [64, 64, 16], 1, 32]
SUCCESS               0.012288            0.010240               1.200          [torch.Size([64, 256]), [64, 64, 256], 1, 32]
SUCCESS               0.034816            0.031744               1.097          [torch.Size([64, 4096]), [64, 64, 4096], 1, 32]

.

===================================== warnings summary ======================================
../../miniconda3/envs/flag/lib/python3.12/site-packages/triton/runtime/autotuner.py:101: 28 warnings
  /data/xiexuan/miniconda3/envs/flag/lib/python3.12/site-packages/triton/runtime/autotuner.py:101: DeprecationWarning: warmup, rep, and use_cuda_graph parameters are deprecated. See https://github.com/triton-lang/triton/pull/4496 for details.
    warnings.warn(("warmup, rep, and use_cuda_graph parameters are deprecated. See "

benchmark/test_special_perf.py::test_select_backward_perf[dtype0]
  /data/xiexuan/miniconda3/envs/flag/lib/python3.12/site-packages/torch/library.py:357: UserWarning: Warning only once for all operators,  other operators may also be overridden.
    Overriding a previously registered kernel for the same operator and the same dispatch key
    operator: aten::_flash_attention_forward(Tensor query, Tensor key, Tensor value, Tensor? cum_seq_q, Tensor? cum_seq_k, SymInt max_q, SymInt max_k, float dropout_p, bool is_causal, bool return_debug_mask, *, float? scale=None, SymInt? window_size_left=None, SymInt? window_size_right=None, Tensor? seqused_k=None, Tensor? alibi_slopes=None) -> (Tensor output, Tensor softmax_logsumexp, Tensor rng_state, Tensor unused, Tensor debug_attn_mask)
      registered at /pytorch/build/aten/src/ATen/RegisterSchema.cpp:6
    dispatch key: CUDA
    previous kernel: registered at /pytorch/torch/csrc/autograd/generated/VariableType_0.cpp:18396
         new kernel: registered at /data/xiexuan/git-repos/FlagGems/src/flag_gems/__init__.py:540 (Triggered internally at /pytorch/aten/src/ATen/core/dispatch/OperatorEntry.cpp:208.)
    self.m.impl(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================== 3 passed, 29 warnings in 44.98s ==============================
(flag) xiexuan@oneflow-24:/data/xiexuan/git-repos/FlagGems$ python -m pytest tests/test_special_ops.py::test_accuracy_select_backward_non_contiguous tests/test_special_ops.py::test_accuracy_select_backward_small_and_edge tests/test_special_ops.py::test_accuracy_select_backward
==================================== test session starts ====================================
platform linux -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0
rootdir: /data/xiexuan/git-repos/FlagGems
configfile: pytest.ini
collected 87 items

tests/test_special_ops.py .................................s........s........s....... [ 67%]
............................                                                          [100%]

===================================== warnings summary ======================================
../../miniconda3/envs/flag/lib/python3.12/site-packages/triton/runtime/autotuner.py:101: 28 warnings
  /data/xiexuan/miniconda3/envs/flag/lib/python3.12/site-packages/triton/runtime/autotuner.py:101: DeprecationWarning: warmup, rep, and use_cuda_graph parameters are deprecated. See https://github.com/triton-lang/triton/pull/4496 for details.
    warnings.warn(("warmup, rep, and use_cuda_graph parameters are deprecated. See "

tests/test_special_ops.py::test_accuracy_select_backward_non_contiguous[dtype0]
  /data/xiexuan/miniconda3/envs/flag/lib/python3.12/site-packages/torch/library.py:357: UserWarning: Warning only once for all operators,  other operators may also be overridden.
    Overriding a previously registered kernel for the same operator and the same dispatch key
    operator: aten::_flash_attention_forward(Tensor query, Tensor key, Tensor value, Tensor? cum_seq_q, Tensor? cum_seq_k, SymInt max_q, SymInt max_k, float dropout_p, bool is_causal, bool return_debug_mask, *, float? scale=None, SymInt? window_size_left=None, SymInt? window_size_right=None, Tensor? seqused_k=None, Tensor? alibi_slopes=None) -> (Tensor output, Tensor softmax_logsumexp, Tensor rng_state, Tensor unused, Tensor debug_attn_mask)
      registered at /pytorch/build/aten/src/ATen/RegisterSchema.cpp:6
    dispatch key: CUDA
    previous kernel: registered at /pytorch/torch/csrc/autograd/generated/VariableType_0.cpp:18396
         new kernel: registered at /data/xiexuan/git-repos/FlagGems/src/flag_gems/__init__.py:540 (Triggered internally at /pytorch/aten/src/ATen/core/dispatch/OperatorEntry.cpp:208.)
    self.m.impl(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================== 84 passed, 3 skipped, 29 warnings in 3.41s =========================
```