### PR TITLE
[Fix: C++ runtime] Adapt C++ operators and ctests for MUSA backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,8 @@ tests/*.json
 *.ipa
 *.apk
 
+docs/
+scripts/
 # Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
 # should NOT be excluded as they contain compiler settings and other important
 # information for Eclipse / Flash Builder.

--- a/cmake/BackendMUSA.cmake
+++ b/cmake/BackendMUSA.cmake
@@ -61,14 +61,14 @@ endif()
 
 function(target_link_musa_libraries target)
     target_link_libraries(${target} PRIVATE ${MUSA_LIBRARY})
-    target_include_directories(${target} PRIVATE ${MUSA_HOME}/include)
+    target_include_directories(${target} PUBLIC ${MUSA_HOME}/include)
     # Add Python include dirs (needed by torch_musa headers that include pybind11)
-    target_include_directories(${target} PRIVATE ${Python_INCLUDE_DIRS})
+    target_include_directories(${target} PUBLIC ${Python_INCLUDE_DIRS})
     if(TORCH_MUSA_PATH)
         # Add torch_musa parent dir for "torch_musa/csrc/..." includes
         get_filename_component(TORCH_MUSA_PARENT "${TORCH_MUSA_PATH}" DIRECTORY)
-        target_include_directories(${target} PRIVATE "${TORCH_MUSA_PARENT}")
-        target_include_directories(${target} PRIVATE "${TORCH_MUSA_PATH}/include")
+        target_include_directories(${target} PUBLIC "${TORCH_MUSA_PARENT}")
+        target_include_directories(${target} PUBLIC "${TORCH_MUSA_PATH}/include")
     endif()
     # Link torch_musa and ittnotify libraries
     if(TORCH_MUSA_LIBRARY)

--- a/ctests/CMakeLists.txt
+++ b/ctests/CMakeLists.txt
@@ -1,3 +1,10 @@
+# MUSA backend: force-link libtorch_python.so (needed by libmusa_kernels.so
+# at runtime) and allow unresolved MPI/numa symbols from libtorch_cpu.so.
+if(FLAGGEMS_BACKEND STREQUAL "MUSA")
+    link_libraries("-Wl,--no-as-needed" ${torch_python_lib} "-Wl,--as-needed" ${Python_LIBRARIES})
+    add_link_options("-Wl,--allow-shlib-undefined")
+endif()
+
 if(FLAGGEMS_BUILD_POINTWISE_DYNAMIC_CPP)
   add_executable(test_triton_add test_triton_add.cpp)
   target_link_libraries(test_triton_add

--- a/ctests/test_triton_addmm.cpp
+++ b/ctests/test_triton_addmm.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 #include "flag_gems/accuracy_utils.h"
 #include "flag_gems/operators.h"
+#include "flag_gems/test_utils.h"
 #include "torch/torch.h"
 
 struct AddmmTestParam {
@@ -14,7 +15,7 @@ class AddmmTest : public ::testing::TestWithParam<AddmmTestParam> {};
 
 TEST_P(AddmmTest, addmm) {
   const AddmmTestParam param = GetParam();
-  const torch::Device device(torch::kCUDA, 0);
+  const torch::Device device = flag_gems::test::default_device();
   const at::TensorOptions opt = at::TensorOptions().device(device).dtype(param.dtype);
   const at::Tensor bias = at::randn({param.m, param.n}, opt);
   const at::Tensor mat1 = at::randn({param.m, param.k}, opt);
@@ -23,7 +24,6 @@ TEST_P(AddmmTest, addmm) {
   const at::Tensor ref_bias = flag_gems::accuracy_utils::to_reference(bias, /*upcast=*/false);
   const at::Tensor ref_mat1 = flag_gems::accuracy_utils::to_reference(mat1, /*upcast=*/false);
   const at::Tensor ref_mat2 = flag_gems::accuracy_utils::to_reference(mat2, /*upcast=*/false);
-
   at::Tensor out_torch = at::addmm(ref_bias, ref_mat1, ref_mat2);
   at::Tensor out_triton = flag_gems::addmm(bias, mat1, mat2);
 

--- a/ctests/test_triton_embedding.cpp
+++ b/ctests/test_triton_embedding.cpp
@@ -60,11 +60,18 @@ TEST_P(EmbeddingBackwardTest, FixedValueTest) {
   auto indices =
       torch::randint(0, EmbeddingSize, {Batch, M}, torch::TensorOptions().device(device).dtype(torch::kLong));
 
-  auto ref_grad = flag_gems::accuracy_utils::to_reference(grad);
   int64_t num_weights = EmbeddingSize;
   bool sparse = false;
+#if defined(FLAGGEMS_USE_MUSA)
+  // torch_musa does not support scale_grad_by_freq in native embedding_backward,
+  // so compute the reference on CPU instead.
+  auto torch_in_grad =
+      at::embedding_backward(grad.cpu(), indices.cpu(), num_weights, padding_idx, scale_grad_by_freq, sparse)
+          .to(device);
+#else
   auto torch_in_grad =
       at::embedding_backward(grad, indices, num_weights, padding_idx, scale_grad_by_freq, sparse);
+#endif
   auto triton_in_grad =
       flag_gems::embedding_backward(grad, indices, num_weights, padding_idx, scale_grad_by_freq, sparse);
   auto result = flag_gems::accuracy_utils::gems_assert_close(triton_in_grad, torch_in_grad);

--- a/ctests/test_triton_mm.cpp
+++ b/ctests/test_triton_mm.cpp
@@ -1,15 +1,16 @@
 #include <gtest/gtest.h>
 #include "flag_gems/accuracy_utils.h"
 #include "flag_gems/operators.h"
+#include "flag_gems/test_utils.h"
 #include "torch/torch.h"
 
 TEST(MmTest, mm) {
-  const torch::Device device(torch::kCUDA, 0);
+  const torch::Device device = flag_gems::test::default_device();
   torch::Tensor a = torch::randn({10, 10}, device);
   torch::Tensor b = torch::randn({10, 10}, device);
+
   torch::Tensor ref_a = flag_gems::accuracy_utils::to_reference(a, /*upcast=*/false);
   torch::Tensor ref_b = flag_gems::accuracy_utils::to_reference(b, /*upcast=*/false);
-
   torch::Tensor out_torch = at::mm(ref_a, ref_b);
   torch::Tensor out_triton = flag_gems::mm_tensor(a, b);
 

--- a/include/flag_gems/accuracy_utils.h
+++ b/include/flag_gems/accuracy_utils.h
@@ -14,7 +14,7 @@ struct CheckCloseResult {
 
 torch::Tensor to_reference(torch::Tensor inp, bool upcast = false);
 
-torch::Tensor to_cpu(torch::Tensor res, const torch::Tensor& ref);
+std::pair<torch::Tensor, torch::Tensor> to_cpu(torch::Tensor res, torch::Tensor ref);
 
 CheckCloseResult gems_assert_close(torch::Tensor res,
                                    torch::Tensor ref,

--- a/include/flag_gems/backend_utils.h
+++ b/include/flag_gems/backend_utils.h
@@ -122,6 +122,24 @@ namespace backend {
 #endif
   }
 
+  // Get the current device index for the active backend.
+  inline c10::DeviceIndex getCurrentDeviceIndex() {
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
+    return at::cuda::current_device();
+#elif defined(FLAGGEMS_USE_MUSA)
+    return c10::musa::current_device();
+#elif defined(FLAGGEMS_USE_NPU)
+    return 0;  // TODO: NPU current device query
+#else
+    return 0;
+#endif
+  }
+
+  // Get the current torch device for the active backend.
+  inline at::Device getCurrentDevice() {
+    return at::Device(getBackendDeviceType(), getCurrentDeviceIndex());
+  }
+
   // Get the default torch device for tensors allocated by this backend.
   inline at::Device getDefaultDevice(int index = 0) {
     return at::Device(getBackendDeviceType(), static_cast<c10::DeviceIndex>(index));

--- a/lib/accuracy_utils.cpp
+++ b/lib/accuracy_utils.cpp
@@ -1,4 +1,5 @@
 #include "flag_gems/accuracy_utils.h"
+#include "flag_gems/backend_utils.h"
 #if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
 #include <c10/cuda/CUDAGuard.h>
 #include <cuda_runtime_api.h>
@@ -8,7 +9,11 @@
 
 namespace flag_gems::accuracy_utils {
 
+#if defined(FLAGGEMS_USE_MUSA) || defined(FLAGGEMS_USE_NPU)
+bool TO_CPU = true;
+#else
 bool TO_CPU = false;
+#endif
 
 float resolution_for_dtype(c10::ScalarType dtype) {
   switch (dtype) {
@@ -67,19 +72,17 @@ torch::Tensor to_reference(torch::Tensor inp, bool upcast) {
   return ref_inp;
 }
 
-torch::Tensor to_cpu(torch::Tensor res, const torch::Tensor& ref) {
+std::pair<torch::Tensor, torch::Tensor> to_cpu(torch::Tensor res, torch::Tensor ref) {
   if (TO_CPU) {
-    TORCH_CHECK(ref.device().is_cpu(),
-                "to_cpu: reference tensor must be on CPU when TO_CPU is enabled, "
-                "but got device = ",
-                ref.device().str());
     res = res.to(torch::kCPU);
+    ref = ref.to(torch::kCPU);
   }
-  return res;
+  return {res, ref};
 }
 
 static std::pair<torch::Tensor, torch::Tensor> _maybe_move_to_cpu(torch::Tensor res, torch::Tensor ref) {
-  if (!(res.is_cuda() && ref.is_cuda())) {
+  bool both_on_device = backend::isOnDevice(res) && backend::isOnDevice(ref);
+  if (!both_on_device) {
     return {res, ref};
   }
 
@@ -120,7 +123,7 @@ CheckCloseResult gems_assert_close(torch::Tensor res,
                                    bool equal_nan,
                                    int64_t reduce_dim,
                                    float atol) {
-  res = to_cpu(res, ref);
+  std::tie(res, ref) = to_cpu(res, ref);
 
   if (dtype == c10::ScalarType::Undefined) {
     // dtype = c10::kFloat;
@@ -164,7 +167,7 @@ CheckCloseResult gems_assert_close(torch::Tensor res,
 }
 
 CheckCloseResult gems_assert_equal(torch::Tensor res, torch::Tensor ref, bool equal_nan) {
-  res = to_cpu(res, ref);
+  std::tie(res, ref) = to_cpu(res, ref);
 
   bool ok = torch::allclose(res, ref, 0.0, 0.0, equal_nan);
 
@@ -233,7 +236,7 @@ CheckCloseResult gems_assert_close_div_factor(torch::Tensor res,
                                               int64_t reduce_dim,
                                               float atol,
                                               bool inplace) {
-  res = to_cpu(res, ref);
+  std::tie(res, ref) = to_cpu(res, ref);
 
   if (dtype == c10::ScalarType::Undefined) {
     // dtype = c10::kFloat;

--- a/lib/copy.cpp
+++ b/lib/copy.cpp
@@ -37,7 +37,7 @@ std::vector<int64_t> broadcasted_stride(const std::vector<int64_t>& shape,
 }
 
 static bool _can_use_triton_copy(const at::Tensor& dst, const at::Tensor& src, bool non_blocking) {
-  if (!dst.is_cuda() || !src.is_cuda()) return false;
+  if (!backend::isOnDevice(dst) || !backend::isOnDevice(src)) return false;
   if (dst.device() != src.device()) return false;
   if (non_blocking) return false;
   return true;

--- a/lib/exponential_.cpp
+++ b/lib/exponential_.cpp
@@ -47,11 +47,19 @@ FloatType dtype_to_floattype(torch::Dtype dtype) {
   throw std::invalid_argument("Unsupported dtype");
 }
 std::string get_vendor_name_simulated() {
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
   return "nvidia";
+#elif defined(FLAGGEMS_USE_MUSA)
+  return "musa";
+#elif defined(FLAGGEMS_USE_NPU)
+  return "npu";
+#else
+  return "unknown";
+#endif
 }
 at::Device get_current_torch_device() {
-  if (torch::cuda::is_available()) {
-    return at::Device(at::kCUDA, at::cuda::current_device());
+  if (backend::isDeviceAvailable()) {
+    return backend::getCurrentDevice();
   } else {
     return at::Device(at::kCPU);
   }
@@ -99,7 +107,10 @@ at::Tensor &exponential_(at::Tensor &self, double lambd, c10::optional<at::Gener
                 dtype == torch::kFloat64,
             "Unsupported dtype");
   TORCH_CHECK(lambd > 0.0, "exponential_ requires lambd > 0.0, but got ", lambd);
-  TORCH_CHECK(self.is_cuda(), "exponential_ currently only supports CUDA tensors");
+  TORCH_CHECK(backend::isOnDevice(self),
+              "exponential_ currently only supports ",
+              backend::getDeviceTypeName(),
+              " tensors");
   bool is_double = (dtype == torch::kFloat64);
 
   const int UNROLL = is_double ? 2 : 4;

--- a/lib/flash_attn_varlen_func.cpp
+++ b/lib/flash_attn_varlen_func.cpp
@@ -440,6 +440,8 @@ mha_varlan_fwd_internal(const at::Tensor& q,
       params.window_size_left,
       params.window_size_right,
       params.seqlenq_ngroups_swapped,
+      // is_paged: page_table is always defined in this function
+      true,
       // alibi
       params.is_alibi,
       params.alibi_slopes,

--- a/lib/sort.cpp
+++ b/lib/sort.cpp
@@ -9,6 +9,12 @@
 namespace flag_gems {
 using namespace triton_jit;
 
+#if defined(FLAGGEMS_USE_MUSA)
+static const char* SORT_KERNEL_PATH = "runtime/backend/_mthreads/ops/sort.py";
+#else
+static const char* SORT_KERNEL_PATH = "ops/sort.py";
+#endif
+
 int64_t get_num_bits(const at::ScalarType& dtype) {
   if (dtype == torch::kBool) {
     return 1;
@@ -36,7 +42,7 @@ std::tuple<at::Tensor, at::Tensor> radix_sort(const at::Tensor& arr, int64_t k_b
   unsigned int grid_x_hist = m * grid_n_hist;
 
   const TritonJITFunction& hist_kernel =
-      TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / "ops" / "sort.py"),
+      TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / SORT_KERNEL_PATH),
                                       "compute_global_hist_kernel");
 
   c10::DeviceGuard guard(arr.device());
@@ -84,7 +90,7 @@ std::tuple<at::Tensor, at::Tensor> radix_sort(const at::Tensor& arr, int64_t k_b
       at::empty({m, num_bins, grid_n_sweep}, at::TensorOptions().device(arr.device()).dtype(torch::kInt32));
 
   const TritonJITFunction& sweep_kernel =
-      TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / "ops" / "sort.py"),
+      TritonJITFunction::get_instance(std::string(utils::get_flag_gems_src_path() / SORT_KERNEL_PATH),
                                       "sweep");
 
   for (int64_t i = 0; i < n_passes; ++i) {


### PR DESCRIPTION
### PR Category                                                                                                                                                                                                                                                      
  Operator
                                                                                                                                                                                                                                                                       
  ### Type of Change
  Bug Fix | Refactor

  ### Description                                                                                                                                                                                                                                                      
   
  Adapt C++ operator layer and ctests to support the MUSA (MThreads) backend, and fix a parameter mismatch bug in flash_attn_varlen.                                                                                                                                   
                  
  **Backend abstraction:**                                                                                                                                                                                                                                             
  - Replace hardcoded `is_cuda()` / `torch::kCUDA` calls with backend-agnostic helpers (`isOnDevice`, `getCurrentDevice`, `default_device()`, etc.)
  - Fix `to_cpu()` to move both result and reference tensors to CPU, enabling correct accuracy comparison on MUSA/NPU                                                                                                                                                  
  - Use compile-time macros to select MUSA-specific vendor name and sort kernel path                                                                                                                                                                                   
                                                                                                                                                                                                                                                                       
  **Build & link fixes (MUSA):**                                                                                                                                                                                                                                       
  - Change PRIVATE → PUBLIC include directories in `BackendMUSA.cmake` so ctests can find headers                                                                                                                                                                      
  - Add MUSA-specific linker flags (`--no-as-needed`, `--allow-shlib-undefined`) for ctest executables                                                                                                                                                                 
                                                                                                                                                                                                                                                                       
  **Bug fix:**
  - Add missing `is_paged` (constexpr) argument in `flash_attn_varlen_func.cpp` C++ kernel call, which caused all subsequent arguments to shift and a tensor to be passed to a `tl.constexpr` position                                                                 
                                                                                                                                                                                                                                                                       
  **Test workaround:**
  - Compute embedding_backward reference on CPU for MUSA, as `torch_musa` does not support `scale_grad_by_freq` in native `embedding_backward`                                                                                                                         
                                                                                                                                                                                                                                                                       
  ### Issue                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                       
  ### Progress                                                                                                                                                                                                                                                         
                  
  - [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
  - [ ] Change is responded to an issue.
  - [ ] Change is fully covered by a UT.

  ### Performance                                                                                                                                                                                                                                                      
  N/A — no performance-sensitive logic changed; focus is on correctness and backend compatibility.