### PR TITLE
[PerfXLab] Optimze radix_sort and unique

### DIFF
--- a/src/flag_gems/ops/sort.py
+++ b/src/flag_gems/ops/sort.py
@@ -193,7 +193,8 @@ def sweep(
     arr = tl.load(arr_ptr + pid_m * N + n_offsets, mask=mask)
     arr_u = convert_to_uint_preverse_order(arr, descending)
     key = (arr_u >> bit_offset) & bfe_mask  # (TILE_N, )
-
+    if associate_arr_ptr is not None:
+        associate_arr = tl.load(associate_arr_ptr + pid_m * N + n_offsets, mask=mask)
     # since triton can only use scalar as condition, loop by bin_index
     # status must be pre zero-initialized, or else we have to initialize it
     for bin_index in range(cta_r_start, cta_r_end):
@@ -237,9 +238,6 @@ def sweep(
         # scatter
         tl.store(out_ptr + pid_m * N + pos, arr, mask=matches)
         if associate_arr_ptr is not None:
-            associate_arr = tl.load(
-                associate_arr_ptr + pid_m * N + n_offsets, mask=mask
-            )
             tl.store(associate_out_ptr + pid_m * N + pos, associate_arr, mask=matches)
 
 


### PR DESCRIPTION
### PR Category
[ Operator]

### Type of Change
[Performance Optimization]

### Description
Optimize performance for radix_sort and unique 

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

Unique performance before optimization
```
test_special_perf.py::test_perf_unique
Operator: unique  Performance Test (dtype=torch.int16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.202208            0.293600               0.689          ([torch.Size([64, 64])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               0.094576            0.374848               0.252          ([torch.Size([256, 256])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               0.155968            0.631616               0.247          ([torch.Size([1024, 1024])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               2.049632            8.635440               0.237          ([torch.Size([4096, 4096])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               8.069056           34.477505               0.234          ([torch.Size([1024, 65536])], {'sorted': True, 'return_inverse': True, 'return_counts': False})


Operator: unique  Performance Test (dtype=torch.int32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.099184            0.318464               0.311          ([torch.Size([64, 64])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               0.121072            0.360576               0.336          ([torch.Size([256, 256])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               0.204624            0.993408               0.206          ([torch.Size([1024, 1024])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               2.532352           13.759792               0.184          ([torch.Size([4096, 4096])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               9.932032           54.601631               0.182          ([torch.Size([1024, 65536])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
```
Unique performance after optimization
```
test_special_perf.py::test_perf_unique
Operator: unique  Performance Test (dtype=torch.int16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.179392            0.241632               0.742          ([torch.Size([64, 64])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               0.082240            0.305920               0.269          ([torch.Size([256, 256])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               0.137344            0.491872               0.279          ([torch.Size([1024, 1024])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               1.979744            7.159248               0.277          ([torch.Size([4096, 4096])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               7.853984           28.702751               0.274          ([torch.Size([1024, 65536])], {'sorted': True, 'return_inverse': True, 'return_counts': False})


Operator: unique  Performance Test (dtype=torch.int32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.088992            0.313200               0.284          ([torch.Size([64, 64])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               0.104784            0.352032               0.298          ([torch.Size([256, 256])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               0.182656            0.897024               0.204          ([torch.Size([1024, 1024])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               2.459328           13.216448               0.186          ([torch.Size([4096, 4096])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
SUCCESS               9.837600           52.386337               0.188          ([torch.Size([1024, 65536])], {'sorted': True, 'return_inverse': True, 'return_counts': False})
```
Radix_sort performance before optimization
```
est_special_perf.py::test_perf_sort

Operator: sort  Performance Test (dtype=torch.int16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.081824            0.282464               0.290          ([torch.Size([64, 64])], {'dim': -1, 'descending': False})
SUCCESS               0.027008            0.317952               0.085          ([torch.Size([256, 256])], {'dim': -1, 'descending': False})
SUCCESS               0.041440            0.460512               0.090          ([torch.Size([1024, 1024])], {'dim': -1, 'descending': False})
SUCCESS               0.382528            4.116640               0.093          ([torch.Size([4096, 4096])], {'dim': -1, 'descending': False})
SUCCESS               2.660960           16.521791               0.161          ([torch.Size([1024, 65536])], {'dim': -1, 'descending': False})



Operator: sort  Performance Test (dtype=torch.int32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.019872            0.334592               0.059          ([torch.Size([64, 64])], {'dim': -1, 'descending': False})
SUCCESS               0.032320            0.333168               0.097          ([torch.Size([256, 256])], {'dim': -1, 'descending': False})
SUCCESS               0.053536            0.896736               0.060          ([torch.Size([1024, 1024])], {'dim': -1, 'descending': False})
SUCCESS               0.604768            7.563504               0.080          ([torch.Size([4096, 4096])], {'dim': -1, 'descending': False})
SUCCESS               5.754400           31.022528               0.185          ([torch.Size([1024, 65536])], {'dim': -1, 'descending': False})


Operator: sort  Performance Test (dtype=torch.float16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.018432            0.086592               0.213          ([torch.Size([64, 64])], {'dim': -1, 'descending': False})
SUCCESS               0.030592            0.147872               0.207          ([torch.Size([256, 256])], {'dim': -1, 'descending': False})
SUCCESS               0.042656            0.458464               0.093          ([torch.Size([1024, 1024])], {'dim': -1, 'descending': False})
SUCCESS               0.401184            4.101344               0.098          ([torch.Size([4096, 4096])], {'dim': -1, 'descending': False})
SUCCESS               2.644960           16.449375               0.161          ([torch.Size([1024, 65536])], {'dim': -1, 'descending': False})


Operator: sort  Performance Test (dtype=torch.float32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.019872            0.322304               0.062          ([torch.Size([64, 64])], {'dim': -1, 'descending': False})
SUCCESS               0.035232            0.331904               0.106          ([torch.Size([256, 256])], {'dim': -1, 'descending': False})
SUCCESS               0.053632            0.911264               0.059          ([torch.Size([1024, 1024])], {'dim': -1, 'descending': False})
SUCCESS               0.608016            6.598080               0.092          ([torch.Size([4096, 4096])], {'dim': -1, 'descending': False})
SUCCESS               5.650304           26.310848               0.215          ([torch.Size([1024, 65536])], {'dim': -1, 'descending': False})
```
Radix_sort performance after optimization
```
test_special_perf.py::test_perf_sort
Operator: sort  Performance Test (dtype=torch.int16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.090304            0.278000               0.325          ([torch.Size([64, 64])], {'dim': -1, 'descending': False})
SUCCESS               0.026880            0.277184               0.097          ([torch.Size([256, 256])], {'dim': -1, 'descending': False})
SUCCESS               0.041472            0.349152               0.119          ([torch.Size([1024, 1024])], {'dim': -1, 'descending': False})
SUCCESS               0.384832            2.903328               0.133          ([torch.Size([4096, 4096])], {'dim': -1, 'descending': False})
SUCCESS               2.668016           11.741632               0.227          ([torch.Size([1024, 65536])], {'dim': -1, 'descending': False})


Operator: sort  Performance Test (dtype=torch.int32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.020704            0.605440               0.034          ([torch.Size([64, 64])], {'dim': -1, 'descending': False})
SUCCESS               0.032720            0.600512               0.054          ([torch.Size([256, 256])], {'dim': -1, 'descending': False})
SUCCESS               0.054144            0.696752               0.078          ([torch.Size([1024, 1024])], {'dim': -1, 'descending': False})
SUCCESS               0.607936            5.568688               0.109          ([torch.Size([4096, 4096])], {'dim': -1, 'descending': False})
SUCCESS               5.765056           23.023968               0.250          ([torch.Size([1024, 65536])], {'dim': -1, 'descending': False})


Operator: sort  Performance Test (dtype=torch.float16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.018880            0.084096               0.225          ([torch.Size([64, 64])], {'dim': -1, 'descending': False})
SUCCESS               0.031168            0.128992               0.242          ([torch.Size([256, 256])], {'dim': -1, 'descending': False})
SUCCESS               0.043264            0.350592               0.123          ([torch.Size([1024, 1024])], {'dim': -1, 'descending': False})
SUCCESS               0.403424            2.895616               0.139          ([torch.Size([4096, 4096])], {'dim': -1, 'descending': False})
SUCCESS               2.654176           11.709728               0.227          ([torch.Size([1024, 65536])], {'dim': -1, 'descending': False})


Operator: sort  Performance Test (dtype=torch.float32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.020448            0.318320               0.064          ([torch.Size([64, 64])], {'dim': -1, 'descending': False})
SUCCESS               0.034368            0.317120               0.108          ([torch.Size([256, 256])], {'dim': -1, 'descending': False})
SUCCESS               0.054464            0.694896               0.078          ([torch.Size([1024, 1024])], {'dim': -1, 'descending': False})
SUCCESS               0.613536            5.531952               0.111          ([torch.Size([4096, 4096])], {'dim': -1, 'descending': False})
SUCCESS               5.649984           22.871440               0.247          ([torch.Size([1024, 65536])], {'dim': -1, 'descending': False})
```