### PR TITLE
Potential fix for code scanning alert no. 23: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -1,4 +1,6 @@
 name: unit-test
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/flagos-ai/FlagGems/security/code-scanning/23](https://github.com/flagos-ai/FlagGems/security/code-scanning/23)

In general, the problem is fixed by adding a `permissions` block that explicitly scopes the `GITHUB_TOKEN` to the least privilege needed. Since this workflow appears to be for unit tests and related CI checks, it likely only needs read access to repository contents (and possibly nothing else). The safest, least-disruptive fix is to set `permissions: contents: read` at the top level of the workflow so that it applies to all jobs that don’t override it.

Concretely, in `.github/workflows/unittest.yaml`, add a root-level `permissions` section just below the `name: unit-test` line (and above the `on:` block). This will ensure that every job in this workflow, including `alpha-ops` and other jobs that use reusable workflows, runs with a read-only `GITHUB_TOKEN` for repository contents. No changes are required to individual jobs or scripts, and no new imports or methods are needed because this is purely a YAML configuration change in the workflow file.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
