### PR TITLE
Fix for code scanning alert- Environment variable built from user-controlled sources

### DIFF
--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -75,7 +75,15 @@ jobs:
         shell: bash
         run: |
           COV_ID=$(cat ${{ runner.temp }}/artifacts/COVERAGE_ID)
-          echo "COV_ID=${COV_ID}" > $GITHUB_ENV
+          # Strip any newline characters to prevent environment variable injection
+          COV_ID=${COV_ID//$'\r'/}
+          COV_ID=${COV_ID//$'\n'/}
+          # Ensure COV_ID only contains safe characters (alphanumerics, underscore, dash)
+          if ! [[ "$COV_ID" =~ ^[A-Za-z0-9_-]+$ ]]; then
+            echo "Invalid COVERAGE_ID value: '$COV_ID'" >&2
+            exit 1
+          fi
+          echo "COV_ID=${COV_ID}" > "$GITHUB_ENV"
           DATE=${COV_ID:0:8}
 
           rm -fr docs/static/coverage/${COV_ID}*


### PR DESCRIPTION
Potential fix for [https://github.com/flagos-ai/FlagGems/security/code-scanning/1](https://github.com/flagos-ai/FlagGems/security/code-scanning/1)

General approach: Treat the contents of `COVERAGE_ID` as untrusted and sanitize or validate it before using it, especially before writing to `$GITHUB_ENV`. Ensure that no newlines or `=` characters can be injected, and constrain `COV_ID` to a safe pattern (e.g., alphanumerics, dash, underscore). If the value does not conform, fail the job instead of proceeding.

Concrete fix for this workflow:

- In the `prepare-changes` step, after reading `COV_ID` from the file, normalize it by:
  - Stripping any carriage returns/newlines.
  - Optionally restricting it to a safe character set (e.g., `^[A-Za-z0-9_-]+$`).
- Only then echo it to `$GITHUB_ENV`.
- Keep `DATE` derived from `COV_ID` as before, but now `DATE` is based on the sanitized value.
- This single change will address:
  - Environment variable injection via `$GITHUB_ENV`.
  - Path and filename injection in the subsequent `rm`, `mkdir`, `mv` commands and `git commit` message, since those now use the sanitized `COV_ID`/`DATE`.

We only need to edit the Bash run block of the `prepare-changes` step in `.github/workflows/coverage.yaml`. No new imports or external actions are required; we can use standard shell tools (`tr` and `grep` or a bash pattern) that are available in the GitHub Actions Ubuntu runner.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
