### PR TITLE
Fix for code scanning alert - Workflow does not contain permissions

### DIFF
--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -11,6 +11,8 @@
 # TODO(Qiming): Enable daily tests for benchmark and all backends
 
 name: daily
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/flagos-ai/FlagGems/security/code-scanning/10](https://github.com/flagos-ai/FlagGems/security/code-scanning/10)

In general, the fix is to add an explicit `permissions` block to the workflow (and/or to individual jobs) that grants only the minimal scopes required. Since the shown jobs only need to check out code and upload artifacts (no writing to contents, issues, or PRs), we can safely restrict `contents` to `read` at the workflow level so it applies to all jobs.

The best minimal fix without changing functionality is:

- Add a root‑level `permissions` block (between `name: daily` and `on:`) with `contents: read`.
- This is enough for `actions/checkout@v6` to function (it needs read access to `contents`) and does not interfere with `actions/upload-artifact@v7` (which uses a separate artifact service and does not require repository write permissions).
- We do not need per‑job permissions overrides because all jobs share the same minimal needs in the provided snippet.

Concretely, in `.github/workflows/daily.yaml`, insert:

```yaml
permissions:
  contents: read
```

after line 13 (`name: daily`) and before line 15 (`on:`). No additional imports, methods, or other definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
