### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -35,6 +35,9 @@ on:
 #  http_proxy: ${{ secrets.HTTP_PROXY }}
 #  https_proxy: ${{ secrets.HTTPS_PROXY }}
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ inputs.runner_label }}


### PR DESCRIPTION
Potential fix for [https://github.com/flagos-ai/FlagGems/security/code-scanning/4](https://github.com/flagos-ai/FlagGems/security/code-scanning/4)

To fix the problem, explicitly declare a `permissions` block so the `GITHUB_TOKEN` used in this workflow is limited to the least privileges required. Since the workflow only checks out code and runs scripts, it only needs `contents: read`. Adding `permissions: contents: read` at the workflow root ensures all jobs inherit these read-only contents permissions unless overridden.

The single best fix with no functional change is:

- Add a root-level `permissions` section after the `on:` block (or before `jobs:`) in `.github/workflows/backend-test.yaml`.
- Set it to:
  ```yaml
  permissions:
    contents: read
  ```
- Do not alter the jobs or steps otherwise.

Concretely, in `.github/workflows/backend-test.yaml`, insert the `permissions` block between the commented-out `env` section (line 34–36) and the `jobs:` key (line 38). No new imports or methods are required; this is purely a YAML configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
