### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cpp-op-test.yaml
+++ b/.github/workflows/cpp-op-test.yaml
@@ -1,5 +1,8 @@
 name: cpp-ops
 
+permissions:
+  contents: read
+
 on:
   workflow_call:
 


### PR DESCRIPTION
Potential fix for [https://github.com/flagos-ai/FlagGems/security/code-scanning/3](https://github.com/flagos-ai/FlagGems/security/code-scanning/3)

In general, to fix this kind of issue, you add an explicit `permissions:` block either at the top level of the workflow (to apply to all jobs) or within individual jobs, assigning the minimal required scopes (usually `contents: read` for simple CI). This prevents the workflow from inheriting potentially broad repository defaults and clearly documents its permission needs.

For this specific workflow (`.github/workflows/cpp-op-test.yaml`), the steps only check out code and run tests; they do not write to the repository or interact with GitHub resources in a way that requires write permissions. The safest minimal change is to add a root-level `permissions:` block immediately after the `name:` (line 1) and before the `on:` section. Set `contents: read`, which is sufficient for `actions/checkout` to fetch the repository contents and aligns with the “minimal starting point” recommended by CodeQL. No other file changes, imports, or code modifications are needed, and job behavior remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
