### PR TITLE
Potential fix for code scanning alert no. 8: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   code-style:
+    permissions:
+      contents: read
     concurrency:
       group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/flagos-ai/FlagGems/security/code-scanning/8](https://github.com/flagos-ai/FlagGems/security/code-scanning/8)

In general, to fix this issue you should explicitly declare a `permissions` block either at the workflow root (to apply to all jobs) or for the specific job, granting only the minimal scopes required. For a linter job that just checks code and doesn’t modify repository content via the GitHub API, `contents: read` is usually sufficient.

The best minimal, non‑disruptive fix here is to add a `permissions` block to the `code-style` job, just under its definition line (`code-style:` and at the same indentation level as `concurrency:`), setting `contents: read`. This documents the intended least privilege and prevents the job from inheriting broader defaults from the repository or organization. No imports or additional methods are needed, as this is purely a YAML configuration change.

Concretely: edit `.github/workflows/linter.yml` so that between line 10 (`code-style:`) and line 11 (`concurrency:`) you insert:

```yaml
    permissions:
      contents: read
```

leaving all existing functionality (checkout, Python setup, pre-commit) unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
