### PR TITLE
Fix for code scanning alert- Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -5,6 +5,9 @@ on:
     tags:
       - 'v*'
 
+permissions:
+  contents: read
+
 jobs:
   build-wheels:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/flagos-ai/FlagGems/security/code-scanning/12](https://github.com/flagos-ai/FlagGems/security/code-scanning/12)

In general, the fix is to add an explicit `permissions` block restricting the GITHUB_TOKEN to the minimal scope needed for the workflow. You can set it at the workflow root (applies to all jobs unless overridden) or per job. Since the `publish` job already has its own `permissions` block, the cleanest fix is to add a `permissions` section at the workflow root with read-only contents access, which is sufficient for `actions/checkout` and normal read operations. The `publish` job’s explicit `permissions` will continue to override the root-level settings for that job.

Concretely, in `.github/workflows/release.yaml`, add:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–6) and the `jobs:` block (line 8). This introduces minimal, explicit permissions for `build-wheels` while leaving the existing `publish` job’s `permissions` unchanged. No imports or additional methods are needed, as this is purely a YAML workflow configuration change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
