### PR TITLE
Fix for code scanning alert- Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code_scan.yaml
+++ b/.github/workflows/code_scan.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   scan-code-and-report:
     runs-on: scan
+    permissions:
+      contents: read
     if: ${{ github.repository == 'flagos-ai/FlagGems' }}
     concurrency:
       group: scan-code-and-report-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
Potential fix for [https://github.com/flagos-ai/FlagGems/security/code-scanning/2](https://github.com/flagos-ai/FlagGems/security/code-scanning/2)

To fix the problem, explicitly declare a `permissions:` block that grants only the least privileges needed for this job. This job checks out the repository (which requires `contents: read`) and then runs scans and prints a report URL; it does not need to write to the repo, issues, PRs, or other resources. Therefore, setting `contents: read` at the job level is sufficient and keeps scope minimal.

The best single change without altering functionality is to add a `permissions:` section under the `scan-code-and-report` job in `.github/workflows/code_scan.yaml`, at the same indentation level as `runs-on`, `if`, and `concurrency`. For example:

```yaml
jobs:
  scan-code-and-report:
    runs-on: scan
    permissions:
      contents: read
    if: ${{ github.repository == 'flagos-ai/FlagGems' }}
    ...
```

No additional imports, methods, or definitions are needed, since this is a YAML configuration change only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
