### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/image-builder.yaml
+++ b/.github/workflows/image-builder.yaml
@@ -1,5 +1,8 @@
 name: image-builder
 
+permissions:
+  contents: read
+
 on:
   schedule:
     - cron: '0 3 * * *'


### PR DESCRIPTION
Potential fix for [https://github.com/flagos-ai/FlagGems/security/code-scanning/9](https://github.com/flagos-ai/FlagGems/security/code-scanning/9)

In general, the fix is to define an explicit `permissions:` block in the workflow (either at the top level or within the specific job) so that the `GITHUB_TOKEN` gets only the minimal scopes required. A safe starting point for most build workflows that don’t need to write to the repo is `permissions: contents: read`. If later you discover the workflow needs more (for example, to create releases or comment on pull requests), you can add only those specific write scopes.

For this workflow, the simplest and least intrusive fix is to add a top-level `permissions:` block right after the `name:` (before the `on:` section), setting `contents: read`. That will apply to all jobs in the workflow, including `build-matrix`, and it won’t alter any existing behavior besides restricting `GITHUB_TOKEN` from any unnecessary write operations. No additional imports or methods are needed, as this is pure YAML configuration.

Concretely:
- Edit `.github/workflows/image-builder.yaml`.
- Insert:

```yaml
permissions:
  contents: read
```

between line 1 (`name: image-builder`) and line 3 (`on:`).  
No other changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
