### PR TITLE
Fix for code scanning alert - Workflow does not contain permissions

### DIFF
--- a/.github/workflows/mkdocs.yaml
+++ b/.github/workflows/mkdocs.yaml
@@ -1,4 +1,6 @@
 name: mkdocs
+permissions:
+  contents: read
 
 on:
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/flagos-ai/FlagGems/security/code-scanning/11](https://github.com/flagos-ai/FlagGems/security/code-scanning/11)

To fix the problem, explicitly define `permissions` so that the `GITHUB_TOKEN` is limited to the least privilege needed. For a documentation build that just checks out code and runs `mkdocs`, read access to repository contents is sufficient.

The best fix without changing existing functionality is to add a root-level `permissions` block (applies to all jobs) with `contents: read`. This documents the intended privileges and ensures the workflow keeps minimal permissions even if repository defaults change or the workflow is reused elsewhere.

Concretely:
- Edit `.github/workflows/mkdocs.yaml`.
- Insert a root-level `permissions:` block immediately after the `name: mkdocs` line (line 1).
- Set `contents: read` under it, correctly indented.
No additional imports or other definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
