### PR TITLE
[FlagGems Operator Development Competition] Add smooth_l1_loss operator with tuned Triton paths

### DIFF
--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -162,6 +162,16 @@ def mse_loss_input_fn(shape, cur_dtype, device):
         yield inp, target, {"reduction": "none"}
 
 
+def smooth_l1_loss_input_fn(shape, cur_dtype, device):
+    inp = generate_tensor_input(shape, cur_dtype, device)
+    target = generate_tensor_input(shape, cur_dtype, device)
+    yield inp, target
+    if Config.bench_level == BenchLevel.COMPREHENSIVE:
+        for reduction in ["mean", "sum", "none"]:
+            for beta in [1.0, 0.1, 0.0]:
+                yield inp, target, {"reduction": reduction, "beta": beta}
+
+
 @pytest.mark.parametrize(
     "op_name, torch_op, input_fn, dtypes",
     [
@@ -220,6 +230,13 @@ def mse_loss_input_fn(shape, cur_dtype, device):
             mse_loss_input_fn,
             FLOAT_DTYPES,
             marks=pytest.mark.mse_loss,
+        ),
+        pytest.param(
+            "smooth_l1_loss",
+            torch.nn.functional.smooth_l1_loss,
+            smooth_l1_loss_input_fn,
+            FLOAT_DTYPES,
+            marks=pytest.mark.smooth_l1_loss,
         ),
     ],
 )

--- a/benchmark/test_smooth_l1_loss_perf.py
+++ b/benchmark/test_smooth_l1_loss_perf.py
@@ -1,0 +1,38 @@
+import pytest
+import torch
+
+from benchmark.attri_util import FLOAT_DTYPES, BenchLevel
+from benchmark.performance_utils import Config, GenericBenchmark2DOnly, generate_tensor_input
+
+
+def smooth_l1_loss_input_fn(shape, cur_dtype, device):
+    inp = generate_tensor_input(shape, cur_dtype, device)
+    target = generate_tensor_input(shape, cur_dtype, device)
+    yield inp, target
+    if Config.bench_level == BenchLevel.COMPREHENSIVE:
+        for reduction in ["mean", "sum", "none"]:
+            for beta in [1.0, 0.1, 0.0]:
+                yield inp, target, {"reduction": reduction, "beta": beta}
+
+
+@pytest.mark.smooth_l1_loss
+def test_perf_smooth_l1_loss():
+    bench = GenericBenchmark2DOnly(
+        input_fn=smooth_l1_loss_input_fn,
+        op_name="smooth_l1_loss",
+        torch_op=torch.nn.functional.smooth_l1_loss,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.smooth_l1_loss
+def test_perf_smooth_l1_loss_backward():
+    bench = GenericBenchmark2DOnly(
+        input_fn=smooth_l1_loss_input_fn,
+        op_name="smooth_l1_loss",
+        torch_op=torch.nn.functional.smooth_l1_loss,
+        dtypes=FLOAT_DTYPES,
+        is_backward=True,
+    )
+    bench.run()

--- a/docs/content/en/references/changelog.md
+++ b/docs/content/en/references/changelog.md
@@ -330,6 +330,7 @@ weight: 90
   `scaled_dot_product_attention_forward`,
   `sigmoid_`,
   `silu_`,
+  `smooth_l1_loss`,
   `upsample_nearest2d`,
   `weight_norm_interface`,
 - Added math operators:

--- a/docs/content/zh-cn/references/changelog.md
+++ b/docs/content/zh-cn/references/changelog.md
@@ -255,6 +255,7 @@ weight: 90
   `scaled_dot_product_attention_forward`,
   `sigmoid_`,
   `silu_`,
+  `smooth_l1_loss`,
   `upsample_nearest2d`,
   `weight_norm_interface`,
 - 新增数学算子：

--- a/docs/content/zh-cn/references/operators.md
+++ b/docs/content/zh-cn/references/operators.md
@@ -193,6 +193,7 @@ weight: 10
 - sin\_
 - skip_layer_norm
 - slice_scatter
+- smooth_l1_loss
 - softmax
 - softplus
 - sort

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -370,6 +370,8 @@ _FULL_CONFIG = (
     ("sinh_", sinh_),
     ("slice_backward", slice_backward),
     ("slice_scatter", slice_scatter),
+    ("smooth_l1_loss", smooth_l1_loss),
+    ("smooth_l1_loss_backward", smooth_l1_loss_backward),
     ("soft_margin_loss", soft_margin_loss),
     ("softplus", softplus),
     ("softshrink", softshrink),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -249,6 +249,7 @@ from flag_gems.ops.sin import sin, sin_
 from flag_gems.ops.sinh_ import sinh_
 from flag_gems.ops.slice_backward import slice_backward
 from flag_gems.ops.slice_scatter import slice_scatter
+from flag_gems.ops.smooth_l1_loss import smooth_l1_loss, smooth_l1_loss_backward
 from flag_gems.ops.soft_margin_loss import soft_margin_loss, soft_margin_loss_out
 from flag_gems.ops.softmax import softmax, softmax_backward
 from flag_gems.ops.softplus import softplus
@@ -609,6 +610,8 @@ __all__ = [
     "sinh_",
     "slice_backward",
     "slice_scatter",
+    "smooth_l1_loss",
+    "smooth_l1_loss_backward",
     "soft_margin_loss",
     "soft_margin_loss_out",
     "softmax",

--- a/src/flag_gems/ops/smooth_l1_loss.py
+++ b/src/flag_gems/ops/smooth_l1_loss.py
@@ -1,0 +1,423 @@
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+logger = logging.getLogger(__name__)
+
+
+_POINTWISE_CONFIGS = [
+    triton.Config({"BLOCK_SIZE": 64}, num_warps=2),
+    triton.Config({"BLOCK_SIZE": 128}, num_warps=2),
+    triton.Config({"BLOCK_SIZE": 256}, num_warps=4),
+    triton.Config({"BLOCK_SIZE": 512}, num_warps=4),
+    triton.Config({"BLOCK_SIZE": 1024}, num_warps=8),
+    triton.Config({"BLOCK_SIZE": 2048}, num_warps=8),
+    triton.Config({"BLOCK_SIZE": 4096}, num_warps=16),
+]
+
+
+@triton.autotune(configs=_POINTWISE_CONFIGS, key=["n_elements"])
+@triton.jit
+def _smooth_l1_loss_abs_kernel(
+    x_ptr,
+    y_ptr,
+    out_ptr,
+    n_elements,
+    COMPUTE_FLOAT32: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0)
+    if COMPUTE_FLOAT32:
+        x = x.to(tl.float32)
+        y = y.to(tl.float32)
+
+    out = tl.abs(x - y)
+    tl.store(out_ptr + offsets, out.to(out_ptr.dtype.element_ty), mask=mask)
+
+
+@triton.autotune(configs=_POINTWISE_CONFIGS, key=["n_elements"])
+@triton.jit
+def _smooth_l1_loss_kernel(
+    x_ptr,
+    y_ptr,
+    out_ptr,
+    n_elements,
+    beta,
+    inv_beta,
+    half_beta,
+    COMPUTE_FLOAT32: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0)
+    if COMPUTE_FLOAT32:
+        x = x.to(tl.float32)
+        y = y.to(tl.float32)
+
+    diff = x - y
+    abs_diff = tl.abs(diff)
+    quadratic = 0.5 * diff * diff * inv_beta
+    linear = abs_diff - half_beta
+    out = tl.where(abs_diff < beta, quadratic, linear)
+
+    tl.store(out_ptr + offsets, out.to(out_ptr.dtype.element_ty), mask=mask)
+
+
+@triton.autotune(configs=_POINTWISE_CONFIGS, key=["n_elements"])
+@triton.jit
+def _smooth_l1_loss_backward_kernel(
+    grad_output_ptr,
+    x_ptr,
+    y_ptr,
+    out_ptr,
+    n_elements,
+    beta,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    grad_output = tl.load(grad_output_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+
+    diff = x - y
+    abs_diff = tl.abs(diff)
+    beta_val = tl.full(abs_diff.shape, beta, tl.float32)
+
+    neg_one = tl.full(abs_diff.shape, -1.0, tl.float32)
+    zero = tl.full(abs_diff.shape, 0.0, tl.float32)
+    pos_one = tl.full(abs_diff.shape, 1.0, tl.float32)
+    sign = tl.where(diff > 0, pos_one, tl.where(diff < 0, neg_one, zero))
+
+    smooth_grad = tl.where(abs_diff < beta_val, diff / beta_val, sign)
+    grad = tl.where(beta_val > 0, smooth_grad, sign)
+    tl.store(out_ptr + offsets, (grad_output * grad).to(out_ptr.dtype.element_ty), mask=mask)
+
+
+@triton.autotune(configs=_POINTWISE_CONFIGS, key=["n_elements"])
+@triton.jit
+def _smooth_l1_loss_backward_reduce_kernel(
+    grad_output_ptr,
+    x_ptr,
+    y_ptr,
+    out_ptr,
+    n_elements,
+    beta,
+    norm,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    grad_output = tl.load(grad_output_ptr).to(tl.float32)
+    x = tl.load(x_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+
+    diff = x - y
+    abs_diff = tl.abs(diff)
+    beta_val = tl.full(abs_diff.shape, beta, tl.float32)
+
+    neg_one = tl.full(abs_diff.shape, -1.0, tl.float32)
+    zero = tl.full(abs_diff.shape, 0.0, tl.float32)
+    pos_one = tl.full(abs_diff.shape, 1.0, tl.float32)
+    sign = tl.where(diff > 0, pos_one, tl.where(diff < 0, neg_one, zero))
+
+    smooth_grad = tl.where(abs_diff < beta_val, diff / beta_val, sign)
+    grad = tl.where(beta_val > 0, smooth_grad, sign)
+    tl.store(
+        out_ptr + offsets,
+        (grad_output * grad / norm).to(out_ptr.dtype.element_ty),
+        mask=mask,
+    )
+
+
+@triton.jit
+def _smooth_l1_loss_reduce_kernel(
+    x_ptr,
+    y_ptr,
+    mid_ptr,
+    n_elements,
+    beta,
+    inv_beta,
+    half_beta,
+    reduction,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0).to(tl.float32)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0).to(tl.float32)
+
+    diff = x - y
+    abs_diff = tl.abs(diff)
+    quadratic = 0.5 * diff * diff * inv_beta
+    linear = abs_diff - half_beta
+    vals = tl.where(abs_diff < beta, quadratic, linear)
+    vals = tl.where(mask, vals, 0.0)
+
+    acc = tl.sum(vals, axis=0)
+    if reduction == 1:
+        acc = acc / n_elements
+    tl.store(mid_ptr + pid, acc)
+
+
+@triton.jit
+def _smooth_l1_loss_abs_reduce_kernel(
+    x_ptr,
+    y_ptr,
+    mid_ptr,
+    n_elements,
+    reduction,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0).to(tl.float32)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0).to(tl.float32)
+
+    vals = tl.abs(x - y)
+    vals = tl.where(mask, vals, 0.0)
+
+    acc = tl.sum(vals, axis=0)
+    if reduction == 1:
+        acc = acc / n_elements
+    tl.store(mid_ptr + pid, acc)
+
+
+@triton.jit
+def _smooth_l1_loss_finalize_kernel(mid_ptr, out_ptr, mid_size, BLOCK_SIZE: tl.constexpr):
+    offsets = tl.arange(0, BLOCK_SIZE)
+    mask = offsets < mid_size
+    vals = tl.load(mid_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    tl.store(out_ptr, tl.sum(vals, axis=0))
+
+
+def _normalize_reduction(reduction):
+    if reduction is None:
+        return "mean"
+    if isinstance(reduction, str):
+        reduction = reduction.lower()
+        if reduction in ("none", "mean", "sum"):
+            return reduction
+        raise ValueError(f"Invalid reduction: {reduction}")
+    if isinstance(reduction, int):
+        mapping = {0: "none", 1: "mean", 2: "sum"}
+        if reduction in mapping:
+            return mapping[reduction]
+        raise ValueError(f"Invalid reduction code: {reduction}")
+    raise ValueError(f"Unsupported reduction type: {type(reduction)}")
+
+
+def _reduction_code(reduction):
+    normalized = _normalize_reduction(reduction)
+    return {"none": 0, "mean": 1, "sum": 2}[normalized]
+
+
+def _prepare_tensor(tensor, dtype):
+    if tensor.dtype != dtype:
+        tensor = tensor.to(dtype=dtype)
+    if not tensor.is_contiguous():
+        tensor = tensor.contiguous()
+    return tensor.view(-1)
+
+
+def smooth_l1_loss(inp, target, reduction="mean", beta=1.0):
+    logger.debug("GEMS SMOOTH_L1_LOSS")
+    reduction = _normalize_reduction(reduction)
+    beta = float(beta)
+
+    if beta < 0:
+        raise RuntimeError("smooth_l1_loss does not support negative values for beta.")
+
+    if inp.device.type != "cuda" or target.device.type != "cuda":
+        return torch.nn.functional.smooth_l1_loss(
+            inp, target, reduction=reduction, beta=beta
+        )
+
+    if inp.shape == target.shape:
+        x, y = inp, target
+        output_shape = inp.shape
+    else:
+        x, y = torch.broadcast_tensors(inp, target)
+        output_shape = x.shape
+    out_dtype = torch.result_type(x, y)
+    if not out_dtype.is_floating_point:
+        out_dtype = torch.get_default_dtype()
+
+    x = _prepare_tensor(x, out_dtype)
+    y = _prepare_tensor(y, out_dtype)
+    n_elements = x.numel()
+    if n_elements == 0:
+        if reduction == "none":
+            return torch.empty(output_shape, device=x.device, dtype=out_dtype)
+        if reduction == "sum":
+            return torch.zeros((), device=x.device, dtype=out_dtype)
+        return torch.full((), float("nan"), device=x.device, dtype=out_dtype)
+
+    compute_fp32 = out_dtype != torch.float16
+
+    if reduction == "none":
+        out = torch.empty_like(x)
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        if beta == 0.0:
+            _smooth_l1_loss_abs_kernel[grid](
+                x,
+                y,
+                out,
+                n_elements,
+                COMPUTE_FLOAT32=compute_fp32,
+            )
+        else:
+            _smooth_l1_loss_kernel[grid](
+                x,
+                y,
+                out,
+                n_elements,
+                float(beta),
+                1.0 / float(beta),
+                0.5 * float(beta),
+                COMPUTE_FLOAT32=compute_fp32,
+            )
+        return out.view(output_shape)
+
+    # Large reductions benefit from avoiding a full-sized temporary output tensor.
+    # Keep the float16 path narrowly scoped to the largest workloads so we do not
+    # regress the smaller cases that are already near parity.
+    use_fused_reduction = (
+        (out_dtype == torch.float32 and n_elements > (1 << 20))
+        or (out_dtype == torch.float16 and n_elements >= (1 << 24))
+    )
+    if use_fused_reduction:
+        reduction_code = _reduction_code(reduction)
+        block_size = triton.next_power_of_2(math.ceil(math.sqrt(n_elements)))
+        mid_size = triton.cdiv(n_elements, block_size)
+        mid = torch.empty((mid_size,), dtype=torch.float32, device=x.device)
+        out = torch.empty((), dtype=torch.float32, device=x.device)
+
+        if beta == 0.0:
+            _smooth_l1_loss_abs_reduce_kernel[(mid_size,)](
+                x,
+                y,
+                mid,
+                n_elements,
+                reduction_code,
+                BLOCK_SIZE=block_size,
+            )
+        else:
+            _smooth_l1_loss_reduce_kernel[(mid_size,)](
+                x,
+                y,
+                mid,
+                n_elements,
+                float(beta),
+                1.0 / float(beta),
+                0.5 * float(beta),
+                reduction_code,
+                BLOCK_SIZE=block_size,
+            )
+        _smooth_l1_loss_finalize_kernel[(1,)](
+            mid,
+            out,
+            mid_size,
+            BLOCK_SIZE=triton.next_power_of_2(mid_size),
+        )
+        return out.to(dtype=out_dtype)
+
+    out = torch.empty_like(x)
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    if beta == 0.0:
+        _smooth_l1_loss_abs_kernel[grid](
+            x,
+            y,
+            out,
+            n_elements,
+            COMPUTE_FLOAT32=compute_fp32,
+        )
+    else:
+        _smooth_l1_loss_kernel[grid](
+            x,
+            y,
+            out,
+            n_elements,
+            float(beta),
+            1.0 / float(beta),
+            0.5 * float(beta),
+            COMPUTE_FLOAT32=compute_fp32,
+        )
+    if reduction == "sum":
+        return out.sum()
+    return out.mean()
+
+
+def smooth_l1_loss_backward(grad_output, self, target, reduction, beta):
+    logger.debug("GEMS SMOOTH_L1_LOSS_BACKWARD")
+    beta = float(beta)
+    reduction = _reduction_code(reduction)
+
+    if beta < 0:
+        raise RuntimeError("smooth_l1_loss does not support negative values for beta.")
+
+    if (
+        grad_output.device.type != "cuda"
+        or self.device.type != "cuda"
+        or target.device.type != "cuda"
+    ):
+        return torch.ops.aten.smooth_l1_loss_backward(
+            grad_output, self, target, reduction, beta
+        )
+
+    self_b, target_b = torch.broadcast_tensors(self, target)
+    if self_b.numel() == 0:
+        return torch.empty_like(self)
+
+    x = self_b.contiguous()
+    y = target_b.contiguous()
+    n_elements = x.numel()
+    grad_input = torch.empty_like(x)
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
+    if reduction == 0:
+        grad_output_b, _, _ = torch.broadcast_tensors(grad_output, self_b, target_b)
+        _smooth_l1_loss_backward_kernel[grid](
+            grad_output_b.contiguous(),
+            x,
+            y,
+            grad_input,
+            n_elements,
+            float(beta),
+        )
+    else:
+        norm = float(n_elements) if reduction == 1 else 1.0
+        grad_output_scalar = grad_output.contiguous().view(-1)
+        _smooth_l1_loss_backward_reduce_kernel[grid](
+            grad_output_scalar,
+            x,
+            y,
+            grad_input,
+            n_elements,
+            float(beta),
+            norm,
+        )
+
+    if grad_input.shape != self.shape:
+        grad_input = grad_input.sum_to_size(self.shape)
+    return grad_input

--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -2162,6 +2162,145 @@ def test_accuracy_mse_loss(shape, dtype, reduction):
     gems_assert_close(res_out, ref_out, dtype, equal_nan=True, reduce_dim=shape[dim])
 
 
+@pytest.mark.smooth_l1_loss
+@pytest.mark.parametrize("reduction", ["mean", "none", "sum"])
+@pytest.mark.parametrize("beta", [1.0, 0.1, 0.0])
+@pytest.mark.parametrize("shape", REDUCTION_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_smooth_l1_loss(shape, dtype, reduction, beta):
+    dim = 1
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+
+    ref_out = torch.nn.functional.smooth_l1_loss(
+        ref_inp, ref_target, reduction=reduction, beta=beta
+    )
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.smooth_l1_loss(
+            inp, target, reduction=reduction, beta=beta
+        )
+    gems_assert_close(res_out, ref_out, dtype, equal_nan=True, reduce_dim=shape[dim])
+
+
+@pytest.mark.smooth_l1_loss
+@pytest.mark.parametrize("reduction", ["mean", "none", "sum"])
+@pytest.mark.parametrize("beta", [1.0, 0.1, 0.0])
+@pytest.mark.parametrize("shape", REDUCTION_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_smooth_l1_loss_backward(shape, dtype, reduction, beta):
+    dim = 1
+    inp = torch.randn(
+        shape, dtype=dtype, device=flag_gems.device, requires_grad=True
+    )
+    target = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+
+    ref_out = torch.nn.functional.smooth_l1_loss(
+        ref_inp, ref_target, reduction=reduction, beta=beta
+    )
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.smooth_l1_loss(
+            inp, target, reduction=reduction, beta=beta
+        )
+
+    out_grad = torch.randn_like(res_out)
+    ref_grad = to_reference(out_grad, True)
+    (ref_in_grad,) = torch.autograd.grad(ref_out, ref_inp, ref_grad)
+    with flag_gems.use_gems():
+        (res_in_grad,) = torch.autograd.grad(res_out, inp, out_grad)
+
+    gems_assert_close(
+        res_in_grad, ref_in_grad, dtype, equal_nan=True, reduce_dim=shape[dim]
+    )
+
+
+@pytest.mark.smooth_l1_loss
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_smooth_l1_loss_broadcast(dtype):
+    inp = torch.randn((16, 37), dtype=dtype, device=flag_gems.device)
+    target = torch.randn((37,), dtype=dtype, device=flag_gems.device)
+
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+
+    ref_out = torch.nn.functional.smooth_l1_loss(
+        ref_inp, ref_target, reduction="none", beta=0.5
+    )
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.smooth_l1_loss(
+            inp, target, reduction="none", beta=0.5
+        )
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.smooth_l1_loss
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_smooth_l1_loss_backward_broadcast(dtype):
+    inp = torch.randn(
+        (16, 37), dtype=dtype, device=flag_gems.device, requires_grad=True
+    )
+    target = torch.randn((37,), dtype=dtype, device=flag_gems.device)
+
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+
+    ref_out = torch.nn.functional.smooth_l1_loss(
+        ref_inp, ref_target, reduction="none", beta=0.5
+    )
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.smooth_l1_loss(
+            inp, target, reduction="none", beta=0.5
+        )
+
+    out_grad = torch.randn_like(res_out)
+    ref_grad = to_reference(out_grad, True)
+    (ref_in_grad,) = torch.autograd.grad(ref_out, ref_inp, ref_grad)
+    with flag_gems.use_gems():
+        (res_in_grad,) = torch.autograd.grad(res_out, inp, out_grad)
+
+    gems_assert_close(res_in_grad, ref_in_grad, dtype)
+
+
+@pytest.mark.smooth_l1_loss
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_smooth_l1_loss_negative_beta(dtype):
+    inp = torch.randn((32, 16), dtype=dtype, device=flag_gems.device)
+    target = torch.randn((32, 16), dtype=dtype, device=flag_gems.device)
+
+    with flag_gems.use_gems():
+        with pytest.raises(
+            RuntimeError, match="smooth_l1_loss does not support negative values for beta"
+        ):
+            torch.nn.functional.smooth_l1_loss(inp, target, beta=-0.5)
+
+
+@pytest.mark.smooth_l1_loss
+@pytest.mark.parametrize("reduction", ["mean", "none", "sum"])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_smooth_l1_loss_empty_input(dtype, reduction):
+    inp = torch.empty((0,), dtype=dtype, device=flag_gems.device)
+    target = torch.empty((0,), dtype=dtype, device=flag_gems.device)
+
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+
+    ref_out = torch.nn.functional.smooth_l1_loss(
+        ref_inp, ref_target, reduction=reduction, beta=1.0
+    )
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.smooth_l1_loss(
+            inp, target, reduction=reduction, beta=1.0
+        )
+
+    gems_assert_close(res_out, ref_out, dtype, equal_nan=True)
+
+
 def generate_test_params():
     params = [torch.int32, torch.int64]
     if SkipVersion("torch", ">2.2"):


### PR DESCRIPTION
## Summary

Add `smooth_l1_loss` / `smooth_l1_loss_backward` support with Triton kernels and wire them into the default FlagGems registration path.

This version keeps the implementation localized while adding targeted tuning for the cases that matter most in the core matrix:
- direct Triton backward kernels
- tuned forward paths for `float16`
- better small-shape and large-shape `reduction="none"` forward behavior
- a dedicated `beta == 0` fast path
- reduction-aware forward handling without changing operator semantics

## Why This Version Is Easier To Merge

- The optimization is localized to the operator implementation in `src/flag_gems/ops/smooth_l1_loss.py`.
- Validation follows the repo’s existing reduction test and benchmark workflow instead of introducing a separate test structure.
- Same-machine comparisons show forward wins in several core cases while preserving the stronger backward path.
- Behavior is aligned with PyTorch for broadcast, empty tensors, reduction modes, and invalid `beta`.

## Implementation Notes

- Added autotuned forward kernels for `reduction="none"` and the non-fused fallback path.
- Added a dedicated `beta == 0` fast path to avoid unnecessary smooth-L1 branching.
- Kept `float16` forward on a lighter execution path instead of always forcing fp32 compute.
- Reworked backward to use direct Triton kernels, including reduced-backward handling with scalar `grad_output` consumed in-kernel.
- Extended fused reduction to the largest `float16` reduction workloads to remove the most visible remaining forward bottleneck.

## Correctness Coverage

Covered in the reduction suite:
- `reduction in {"none", "mean", "sum"}`
- `beta in {1.0, 0.1, 0.0}`
- forward and backward correctness
- broadcast forward/backward
- empty input behavior
- negative `beta` error handling

## Same-Machine Benchmark Notes

On the same `hx` machine and benchmark harness, this version outperforms PR #1888 in several forward cases that matter for review:
- `float16` core forward: stronger results at `256x256`, `1024x1024`, and `4096x4096`
- `float32 256x256 none`: this version is faster while PR #1888 regresses
- `float32 4096x4096 mean`: this version shows a clear win
- `float32 4096x4096 none`: this version also stays ahead
- the largest `float16` reduction case is no longer near-parity after the final forward-only fused reduction pass

## Validation

- `PYTHONPATH=src pytest tests/test_reduction_ops.py -k smooth_l1_loss -q`
- `PYTHONPATH=src pytest benchmark/test_smooth_l1_loss_perf.py::test_perf_smooth_l1_loss --level core --mode kernel --dtypes float16 --shape_file ... -s`
- `PYTHONPATH=src pytest benchmark/test_smooth_l1_loss_perf.py::test_perf_smooth_l1_loss --level comprehensive --mode kernel --dtypes float32 --shape_file ... -s`
