### PR TITLE
[KernelGen] Optimize mean on Ascend

### DIFF
--- a/src/flag_gems/runtime/backend/_ascend/ops/mean.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/mean.py
@@ -17,24 +17,29 @@ logger = logging.getLogger(f'flag_gems.runtime._ascend.ops.{__name__.split(".")[
 @triton.jit
 def mean_kernel_1(
     inp,
-    out,
+    mid,
     M,
     BLOCK_SIZE: tl.constexpr,
 ):
     pid = tl.program_id(0)
     num_jobs = tl.num_programs(axis=0)
-    block_start = pid * BLOCK_SIZE
-    step = num_jobs * BLOCK_SIZE
-    _tmp = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
-    block_start = block_start.to(tl.int64)
-    for off in range(block_start, M, step):
+    _sum = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+    for off in range(pid * BLOCK_SIZE, M, num_jobs * BLOCK_SIZE):
         offset = off + tl.arange(0, BLOCK_SIZE)
         mask = offset < M
         inp_val = tl.load(inp + offset, mask=mask, other=0.0)
-        _tmp = inp_val + _tmp
+        _sum += inp_val.to(tl.float32)
+    tl.store(mid + pid, tl.sum(_sum, axis=0))
 
-    mean_val = tl.sum(_tmp, axis=0) / M
-    tl.atomic_add(out, mean_val)
+
+@libentry()
+@triton.jit
+def mean_kernel_2(mid, out, M, MID_SIZE, BLOCK_MID: tl.constexpr):
+    offset = tl.arange(0, BLOCK_MID)
+    mask = offset < MID_SIZE
+    mid_val = tl.load(mid + offset, mask=mask, other=0.0)
+    mean_val = tl.sum(mid_val) / M
+    tl.store(out, mean_val)
 
 
 def mean(inp, *, dtype=None):
@@ -43,12 +48,18 @@ def mean(inp, *, dtype=None):
     if dtype is None:
         dtype = inp.dtype
     block_size = triton.next_power_of_2(math.ceil(math.sqrt(M)))
-    out = torch.zeros([], dtype=dtype, device=inp.device)
+    block_size = min(block_size, 1024)
+    mid_size = triton.cdiv(M, block_size)
+    mid_size = min(mid_size, 4096)
+    block_mid = triton.next_power_of_2(mid_size)
+
+    mid = torch.empty((mid_size,), dtype=torch.float32, device=inp.device)
+    out = torch.empty([], dtype=torch.float32, device=inp.device)
 
     with torch_device_fn.device(inp.device):
-        mean_kernel_1[(triton.cdiv(M, block_size), 1, 1)](inp, out, M, block_size)
-        # mean_kernel_2[(1, 1, 1)](mid, out, M, mid_size, block_mid)
-    return out
+        mean_kernel_1[(mid_size, 1, 1)](inp, mid, M, block_size)
+        mean_kernel_2[(1, 1, 1)](mid, out, M, mid_size, block_mid)
+    return out.to(dtype)
 
 
 @libentry()
@@ -58,24 +69,28 @@ def mean(inp, *, dtype=None):
 )
 @triton.jit
 def mean_dim_kernel(X, Mean, M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr):
-    # Map the program id to the row of X it should compute.
-    pid = tle.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
-    X = X + pid * N
-    Mean = Mean + pid
-    row_mask = pid < M
+    workers = tle.num_programs(0)
+    pid = tle.program_id(0)
+    total_workloads = tl.cdiv(M, BLOCK_M)
+    workloads = tl.cdiv(total_workloads, workers)
 
-    # Compute mean
-    _mean = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
-    for off in range(0, N, BLOCK_N):
-        cols = off + tl.arange(0, BLOCK_N)[None, :]
-        col_mask = cols < N
-        mask = row_mask and col_mask
+    for w in range(workloads):
+        work_id = pid + w * workers
+        rows = work_id * BLOCK_M + tl.arange(0, BLOCK_M)[:, None]
+        X_ptr = X + rows * N
+        Mean_ptr = Mean + rows
+        row_mask = rows < M
 
-        a = tl.load(X + cols, mask, other=0.0).to(tl.float32)
-        _mean += a
-    mean = tl.sum(_mean, axis=1) / N
-    mean = mean[:, None]
-    tl.store(Mean, mean, row_mask)
+        _mean = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+        for off in range(0, N, BLOCK_N):
+            cols = off + tl.arange(0, BLOCK_N)[None, :]
+            col_mask = cols < N
+            mask = row_mask and col_mask
+            a = tl.load(X_ptr + cols, mask, other=0.0).to(tl.float32)
+            _mean += a
+        mean = tl.sum(_mean, axis=1) / N
+        mean = mean[:, None]
+        tl.store(Mean_ptr, mean, row_mask)
 
 
 def mean_dim(x, dim, keepdim=False, *, dtype=None):
@@ -98,7 +113,11 @@ def mean_dim(x, dim, keepdim=False, *, dtype=None):
         shape[i] = 1
     M = x.numel() // N
     out = torch.empty(shape, dtype=dtype, device=x.device)
-    grid = lambda META: (triton.cdiv(M, META["BLOCK_M"]),)
+
+    def grid(meta):
+        axis0 = triton.cdiv(M, meta["BLOCK_M"])
+        axis0 = axis0 if axis0 < 4096 else 4096
+        return (axis0,)
 
     with torch_device_fn.device(x.device):
         mean_dim_kernel[grid](x, out, M, N)

--- a/src/flag_gems/runtime/backend/_ascend/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_ascend/tune_configs.yaml
@@ -306,11 +306,15 @@ mean:
   param_map:
     META:
       BLOCK_M: block_m
-      BLOCK_N: 256
+      BLOCK_N: block_n
   block_m:
+  - 1
+  - 4
+  - 8
+  - 32
   - 64
-  - 128
-  - 256
+  block_n:
+  - 1024
 
 instancenorm:
 - gen: true


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Fix mean on Ascend

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

# ascend/mean 分支评测结果

## mean 精度测试
- 结果: 45 passed
- 命令: `pytest tests/test_general_reduction_ops.py -m mean -s -x`

## mean 性能测试 (benchmark)

### float32
| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|--------------------:|-------------------:|--------:|
| [1048576] | 0.017720 | 0.041740 | 0.425 |
| [64, 64] | 0.015280 | 0.002600 | 5.877 |
| [4096, 4096] | 0.116400 | 0.107580 | 1.082 |
| [64, 512, 512] | 0.118900 | 0.322880 | 0.368 |
| [1024, 1024, 1024] | 3.008020 | 10.013020 | 0.300 |
| [1049600] | 0.017600 | 0.041800 | 0.421 |
| [1073741824] | 3.002100 | 8.310280 | 0.361 |
| [1024, 1] | 0.014580 | 0.011680 | 1.248 |
| [1024, 16] | 0.010500 | 0.006760 | 1.553 |
| [1024, 256] | 0.013200 | 0.007500 | 1.760 |
| [1024, 4096] | 0.027960 | 0.021820 | 1.281 |
| [1024, 65536] | 0.377460 | 0.374840 | 1.007 |
| [1024, 1048576] | 3.000180 | 3.103440 | 0.967 |
| [64, 1, 64] | 0.013400 | 0.028400 | 0.472 |
| [64, 16, 64] | 0.014820 | 0.033380 | 0.444 |
| [64, 256, 64] | 0.013840 | 0.041380 | 0.334 |
| [64, 4096, 64] | 0.114820 | 0.214440 | 0.535 |

**float32 算术平均加速比: 1.084**

### bfloat16
| Shape | Torch Latency (ms) | Gems Latency (ms) | Speedup |
|-------|--------------------:|-------------------:|--------:|
| [1048576] | 0.013700 | 0.042640 | 0.321 |
| [64, 64] | 0.014880 | 0.002700 | 5.511 |
| [4096, 4096] | 0.064780 | 0.061140 | 1.060 |
| [64, 512, 512] | 0.061860 | 0.268820 | 0.230 |
| [1024, 1024, 1024] | 1.612120 | 8.124760 | 0.198 |
| [1049600] | 0.013620 | 0.042420 | 0.321 |
| [1073741824] | 1.808020 | 7.735580 | 0.234 |
| [1024, 1] | 0.012280 | 0.013240 | 0.927 |
| [1024, 16] | 0.013580 | 0.007400 | 1.835 |
| [1024, 256] | 0.015300 | 0.007460 | 2.051 |
| [1024, 4096] | 0.022440 | 0.016100 | 1.394 |
| [1024, 65536] | 0.235680 | 0.253260 | 0.931 |
| [1024, 1048576] | 1.800200 | 2.322340 | 0.775 |
| [64, 1, 64] | 0.016520 | 0.038900 | 0.425 |
| [64, 16, 64] | 0.014780 | 0.033780 | 0.438 |
| [64, 256, 64] | 0.014640 | 0.041660 | 0.351 |
| [64, 4096, 64] | 0.061260 | 0.178340 | 0.344 |

**bfloat16 算术平均加速比: 1.020**

## 总体算术平均加速比: 1.052
