### PR TITLE
[PerfXLab] optimize fused_recurrent op

### DIFF
--- a/src/flag_gems/fused/FLA/fused_recurrent.py
+++ b/src/flag_gems/fused/FLA/fused_recurrent.py
@@ -333,6 +333,166 @@ def fused_recurrent_gated_delta_rule_fwd_kernel(
         p_beta += HV * (V if IS_BETA_HEADWISE else 1)
 
 
+@triton.heuristics(
+    {
+        "USE_INITIAL_STATE": lambda args: args["h0"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+        "IS_CONTINUOUS_BATCHING": lambda args: args["ssm_state_indices"] is not None,
+        "IS_SPEC_DECODING": lambda args: args["num_accepted_tokens"] is not None,
+    }
+)
+@triton.jit(do_not_specialize=["N", "T"])
+def fused_recurrent_gated_delta_rule_large_t_fwd_kernel(
+    q,
+    k,
+    v,
+    g,
+    beta,
+    o,
+    h0,
+    ht,
+    cu_seqlens,
+    ssm_state_indices,
+    num_accepted_tokens,
+    scale,
+    N: tl.int64,  # num of sequences
+    T: tl.int64,  # num of tokens
+    B: tl.constexpr,
+    H: tl.constexpr,
+    HV: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    stride_init_state_token: tl.constexpr,
+    stride_final_state_token: tl.constexpr,
+    stride_indices_seq: tl.constexpr,
+    stride_indices_tok: tl.constexpr,
+    USE_INITIAL_STATE: tl.constexpr,  # whether to use initial state
+    INPLACE_FINAL_STATE: tl.constexpr,  # whether to store final state inplace
+    IS_BETA_HEADWISE: tl.constexpr,  # whether beta is headwise vector or scalar,
+    USE_QK_L2NORM_IN_KERNEL: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+    IS_CONTINUOUS_BATCHING: tl.constexpr,
+    IS_SPEC_DECODING: tl.constexpr,
+    IS_KDA: tl.constexpr,
+):
+    i_k, i_v, i_nh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_n, i_hv = i_nh // HV, i_nh % HV
+    i_h = i_hv // (HV // H)
+    if IS_VARLEN:
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int64),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int64),
+        )
+        all = T
+        T = eos - bos
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        all = B * T
+
+    if T == 0:
+        # no tokens to process for this sequence
+        return
+
+    o_k = i_k * BK + tl.arange(0, BK)
+    o_v = i_v * BV + tl.arange(0, BV)
+
+    p_q = q + (bos * H + i_h) * K + o_k
+    p_k = k + (bos * H + i_h) * K + o_k
+    p_v = v + (bos * HV + i_hv) * V + o_v
+    if IS_BETA_HEADWISE:
+        p_beta = beta + (bos * HV + i_hv) * V + o_v
+    else:
+        p_beta = beta + bos * HV + i_hv
+
+    if not IS_KDA:
+        p_g = g + bos * HV + i_hv
+    else:
+        p_gk = g + (bos * HV + i_hv) * K + o_k
+
+    p_o = o + ((i_k * all + bos) * HV + i_hv) * V + o_v
+
+    mask_k = o_k < K
+    mask_v = o_v < V
+    mask_h = mask_v[:, None] & mask_k[None, :]
+
+    b_h = tl.zeros([BV, BK], dtype=tl.float32)
+    if USE_INITIAL_STATE:
+        if IS_CONTINUOUS_BATCHING:
+            if IS_SPEC_DECODING:
+                i_t = tl.load(num_accepted_tokens + i_n).to(tl.int64) - 1
+            else:
+                i_t = 0
+            # Load state index and check for PAD_SLOT_ID (-1)
+            state_idx = tl.load(ssm_state_indices + i_n * stride_indices_seq + i_t).to(
+                tl.int64
+            )
+            # Skip if state index is invalid (PAD_SLOT_ID = -1)
+            if state_idx < 0:
+                return
+            p_h0 = h0 + state_idx * stride_init_state_token
+        else:
+            p_h0 = h0 + bos * HV * V * K
+        p_h0 = p_h0 + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
+        b_h += tl.load(p_h0, mask=mask_h, other=0).to(tl.float32)
+
+    for i_t in range(0, T):
+        b_q = tl.load(p_q, mask=mask_k, other=0).to(tl.float32)
+        b_k = tl.load(p_k, mask=mask_k, other=0).to(tl.float32)
+        b_v = tl.load(p_v, mask=mask_v, other=0).to(tl.float32)
+
+        if USE_QK_L2NORM_IN_KERNEL:
+            b_q = b_q / tl.sqrt(tl.sum(b_q * b_q) + 1e-6)
+            b_k = b_k / tl.sqrt(tl.sum(b_k * b_k) + 1e-6)
+        b_q = b_q * scale
+        # [BV, BK]
+        if not IS_KDA:
+            b_g = tl.load(p_g).to(tl.float32)
+            b_h *= exp(b_g)
+        else:
+            b_gk = tl.load(p_gk).to(tl.float32)
+            b_h *= exp(b_gk[None, :])
+        # [BV]
+        b_v -= tl.sum(b_h * b_k[None, :], 1)
+        if IS_BETA_HEADWISE:
+            b_beta = tl.load(p_beta, mask=mask_v, other=0).to(tl.float32)
+        else:
+            b_beta = tl.load(p_beta).to(tl.float32)
+        b_v *= b_beta
+        # [BV, BK]
+        b_h += b_v[:, None] * b_k[None, :]
+        # [BV]
+        b_o = tl.sum(b_h * b_q[None, :], 1)
+        tl.store(p_o, b_o.to(p_o.dtype.element_ty), mask=mask_v)
+
+        # keep the states for multi-query tokens
+        if INPLACE_FINAL_STATE:
+            # Load state index and check for PAD_SLOT_ID (-1)
+            final_state_idx = tl.load(
+                ssm_state_indices + i_n * stride_indices_seq + i_t
+            ).to(tl.int64)
+            # Only store if state index is valid (not PAD_SLOT_ID)
+            if final_state_idx >= 0:
+                p_ht = ht + final_state_idx * stride_final_state_token
+                p_ht = p_ht + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
+                tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
+        else:
+            p_ht = ht + (bos + i_t) * stride_final_state_token
+            p_ht = p_ht + i_hv * V * K + o_v[:, None] * K + o_k[None, :]
+            tl.store(p_ht, b_h.to(p_ht.dtype.element_ty), mask=mask_h)
+
+        p_q += H * K
+        p_k += H * K
+        p_o += HV * V
+        p_v += HV * V
+        if not IS_KDA:
+            p_g += HV
+        else:
+            p_gk += HV * K
+        p_beta += HV * (V if IS_BETA_HEADWISE else 1)
+
+
 def fused_recurrent_gated_delta_rule_fwd(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -439,54 +599,88 @@ def fused_recurrent_gated_delta_rule_fwd(
             K,
             V,
         )
-        fused_recurrent_gated_delta_rule_fwd_sp_for_qwen3_next_kernel[grid](
-            q=q,
-            k=k,
-            v=v,
-            g=g,
-            beta=beta,
-            o=o,
-            h0=initial_state,
-            ht=final_state,
-            cu_seqlens=cu_seqlens,
-            ssm_state_indices=ssm_state_indices,
-            num_accepted_tokens=num_accepted_tokens,
-            scale=scale,
-            N=N,
-            T=T,
-            B=B,
-            H=H,
-            HV=HV,
-            K=K,
-            V=V,
-            BK=BK,
-            BV=BV,
-            stride_init_state_token=stride_init_state_token,
-            stride_final_state_token=stride_final_state_token,
-            stride_indices_seq=stride_indices_seq,
-            stride_indices_tok=stride_indices_tok,
-            # stride_q_b=q.stride(0),
-            stride_q_t=q.stride(1),
-            stride_q_h=q.stride(2),
-            stride_q_k=q.stride(3),
-            # stride_k_b=k.stride(0),
-            stride_k_t=k.stride(1),
-            stride_k_h=k.stride(2),
-            stride_k_k=k.stride(3),
-            # stride_v_b=v.stride(0),
-            stride_v_t=v.stride(1),
-            stride_v_hv=v.stride(2),
-            stride_v_v=v.stride(3),
-            IS_BETA_HEADWISE=beta.ndim == v.ndim,
-            USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
-            INPLACE_FINAL_STATE=inplace_final_state,
-            IS_SPEC_DECODING=num_accepted_tokens is not None,
-            IS_CONTINUOUS_BATCHING=ssm_state_indices is not None,
-            IS_VARLEN=cu_seqlens is not None,
-            USE_INITIAL_STATE=initial_state is not None,
-            num_warps=num_warps,
-            num_stages=num_stages,
-        )
-
+        if T <= 64:
+            fused_recurrent_gated_delta_rule_fwd_sp_for_qwen3_next_kernel[grid](
+                q=q,
+                k=k,
+                v=v,
+                g=g,
+                beta=beta,
+                o=o,
+                h0=initial_state,
+                ht=final_state,
+                cu_seqlens=cu_seqlens,
+                ssm_state_indices=ssm_state_indices,
+                num_accepted_tokens=num_accepted_tokens,
+                scale=scale,
+                N=N,
+                T=T,
+                B=B,
+                H=H,
+                HV=HV,
+                K=K,
+                V=V,
+                BK=BK,
+                BV=BV,
+                stride_init_state_token=stride_init_state_token,
+                stride_final_state_token=stride_final_state_token,
+                stride_indices_seq=stride_indices_seq,
+                stride_indices_tok=stride_indices_tok,
+                # stride_q_b=q.stride(0),
+                stride_q_t=q.stride(1),
+                stride_q_h=q.stride(2),
+                stride_q_k=q.stride(3),
+                # stride_k_b=k.stride(0),
+                stride_k_t=k.stride(1),
+                stride_k_h=k.stride(2),
+                stride_k_k=k.stride(3),
+                # stride_v_b=v.stride(0),
+                stride_v_t=v.stride(1),
+                stride_v_hv=v.stride(2),
+                stride_v_v=v.stride(3),
+                IS_BETA_HEADWISE=beta.ndim == v.ndim,
+                USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+                INPLACE_FINAL_STATE=inplace_final_state,
+                IS_SPEC_DECODING=num_accepted_tokens is not None,
+                IS_CONTINUOUS_BATCHING=ssm_state_indices is not None,
+                IS_VARLEN=cu_seqlens is not None,
+                USE_INITIAL_STATE=initial_state is not None,
+                num_warps=num_warps,
+                num_stages=num_stages,
+            )
+        else:
+            fused_recurrent_gated_delta_rule_large_t_fwd_kernel[grid](
+                q=q.contiguous(),
+                k=k.contiguous(),
+                v=v.contiguous(),
+                g=g.contiguous(),
+                beta=beta.contiguous(),
+                o=o,
+                h0=initial_state,
+                ht=final_state,
+                cu_seqlens=cu_seqlens,
+                ssm_state_indices=ssm_state_indices,
+                num_accepted_tokens=num_accepted_tokens,
+                scale=scale,
+                N=N,
+                T=T,
+                B=B,
+                H=H,
+                HV=HV,
+                K=K,
+                V=V,
+                BK=BK,
+                BV=BV,
+                stride_init_state_token=stride_init_state_token,
+                stride_final_state_token=stride_final_state_token,
+                stride_indices_seq=stride_indices_seq,
+                stride_indices_tok=stride_indices_tok,
+                IS_BETA_HEADWISE=beta.ndim == v.ndim,
+                USE_QK_L2NORM_IN_KERNEL=use_qk_l2norm_in_kernel,
+                INPLACE_FINAL_STATE=inplace_final_state,
+                IS_KDA=False,
+                num_warps=num_warps,
+                num_stages=num_stages,
+            )
     o = o.squeeze(0)
     return o, final_state


### PR DESCRIPTION
### PR Category
[ Operator]

### Type of Change
 [ Performance Optimization] 

### Description
Optimize fused_recurrent_gated_delta_rule_fwd for fused_recurrent op .

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
```
test_FLA/test_fused_recurrent_gated_delta_rule_perf.py::test_perf_fused_recurrent_gated_delta_rule[False] 

Operator: fused_recurrent_gated_delta_rule  Performance Test (dtype=torch.bfloat16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.278208            0.012144              22.909          [torch.Size([1, 1, 4, 128]), torch.Size([1, 1, 4, 128]), torch.Size([1, 1, 8, 128]), torch.Size([1, 1, 8]), torch.Size([1, 1, 8]), 0.08838834764831845, torch.Size([1024, 8, 128, 128]), True, torch.Size([2]), torch.Size([1]), None, True]
SUCCESS               0.044000            0.024528               1.794          [torch.Size([1, 64, 4, 128]), torch.Size([1, 64, 4, 128]), torch.Size([1, 64, 8, 128]), torch.Size([1, 64, 8]), torch.Size([1, 64, 8]), 0.08838834764831845, torch.Size([1024, 8, 128, 128]), True, torch.Size([65]), torch.Size([64]), None, True]
SUCCESS               0.054144            0.054368               0.996          [torch.Size([1, 184, 4, 128]), torch.Size([1, 184, 4, 128]), torch.Size([1, 184, 8, 128]), torch.Size([1, 184, 8]), torch.Size([1, 184, 8]), 0.08838834764831845, torch.Size([1024, 8, 128, 128]), True, torch.Size([185]), torch.Size([184]), None, True]
SUCCESS               0.063200            0.063136               1.001          [torch.Size([1, 256, 4, 128]), torch.Size([1, 256, 4, 128]), torch.Size([1, 256, 8, 128]), torch.Size([1, 256, 8]), torch.Size([1, 256, 8]), 0.08838834764831845, torch.Size([1024, 8, 128, 128]), True, torch.Size([257]), torch.Size([256]), None, True]
SUCCESS               0.098672            0.098688               1.000          [torch.Size([1, 512, 4, 128]), torch.Size([1, 512, 4, 128]), torch.Size([1, 512, 8, 128]), torch.Size([1, 512, 8]), torch.Size([1, 512, 8]), 0.08838834764831845, torch.Size([1024, 8, 128, 128]), True, torch.Size([513]), torch.Size([512]), None, True]
```
