### PR TITLE
Support complex number for add/sub ops with accuracy tests and benchm…

### DIFF
--- a/benchmark/test_binary_pointwise_perf.py
+++ b/benchmark/test_binary_pointwise_perf.py
@@ -48,10 +48,10 @@ class BinaryPointwiseBenchmark(Benchmark):
         )
         for name, op, dtype in [
             # Arithmetic operations
-            ("add", torch.add, FLOAT_DTYPES),
+            ("add", torch.add, FLOAT_DTYPES + COMPLEX_DTYPES),
             ("div", torch.div, FLOAT_DTYPES),
             ("mul", torch.mul, FLOAT_DTYPES + COMPLEX_DTYPES),
-            ("sub", torch.sub, FLOAT_DTYPES),
+            ("sub", torch.sub, FLOAT_DTYPES + COMPLEX_DTYPES),
             ("pow", torch.pow, FLOAT_DTYPES),
             ("polar", torch.polar, [torch.float32]),
             ("floor_divide", torch.floor_divide, INT_DTYPES),

--- a/src/flag_gems/ops/add.py
+++ b/src/flag_gems/ops/add.py
@@ -32,7 +32,45 @@ def add_func_scalar_tensor(x, y, alpha):
 
 def add(A, B, *, alpha=1):
     logger.debug("GEMS ADD")
-    if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
+    A_is_complex = (isinstance(A, torch.Tensor) and A.is_complex()) or isinstance(
+        A, complex
+    )
+    B_is_complex = (isinstance(B, torch.Tensor) and B.is_complex()) or isinstance(
+        B, complex
+    )
+    if A_is_complex or B_is_complex:
+        if A_is_complex and B_is_complex:
+            Ar = torch.view_as_real(A)
+            Br = torch.view_as_real(B)
+            common_dtype = torch.promote_types(Ar.dtype, Br.dtype)
+            Ar, Br = Ar.to(common_dtype), Br.to(common_dtype)
+            out_real = add_func(Ar, Br, alpha)
+            return torch.view_as_complex(out_real).to(torch.result_type(A, B))
+        elif A_is_complex and not B_is_complex:
+            Ar = torch.view_as_real(A)
+            if isinstance(B, torch.Tensor):
+                Br = torch.view_as_real(B.to(A.dtype))
+            else:
+                Br = torch.view_as_real(
+                    torch.tensor(B, dtype=A.dtype, device=A.device).expand_as(A)
+                )
+            common_dtype = torch.promote_types(Ar.dtype, Br.dtype)
+            Ar, Br = Ar.to(common_dtype), Br.to(common_dtype)
+            out_real = add_func(Ar, Br, alpha)
+            return torch.view_as_complex(out_real).to(torch.result_type(A, B))
+        else:
+            Br = torch.view_as_real(B)
+            if isinstance(A, torch.Tensor):
+                Ar = torch.view_as_real(A.to(B.dtype))
+            else:
+                Ar = torch.view_as_real(
+                    torch.tensor(A, dtype=B.dtype, device=B.device).expand_as(B)
+                )
+            common_dtype = torch.promote_types(Ar.dtype, Br.dtype)
+            Ar, Br = Ar.to(common_dtype), Br.to(common_dtype)
+            out_real = add_func(Ar, Br, alpha)
+            return torch.view_as_complex(out_real).to(torch.result_type(A, B))
+    elif isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         if B.device != A.device:
             B = B.to(A.device)
         return add_func(A, B, alpha)

--- a/src/flag_gems/ops/sub.py
+++ b/src/flag_gems/ops/sub.py
@@ -32,7 +32,45 @@ def sub_func_scalar_tensor(x, y, alpha):
 
 def sub(A, B, *, alpha=1):
     logger.debug("GEMS SUB")
-    if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
+    A_is_complex = (isinstance(A, torch.Tensor) and A.is_complex()) or isinstance(
+        A, complex
+    )
+    B_is_complex = (isinstance(B, torch.Tensor) and B.is_complex()) or isinstance(
+        B, complex
+    )
+    if A_is_complex or B_is_complex:
+        if A_is_complex and B_is_complex:
+            Ar = torch.view_as_real(A)
+            Br = torch.view_as_real(B)
+            common_dtype = torch.promote_types(Ar.dtype, Br.dtype)
+            Ar, Br = Ar.to(common_dtype), Br.to(common_dtype)
+            out_real = sub_func(Ar, Br, alpha)
+            return torch.view_as_complex(out_real).to(torch.result_type(A, B))
+        elif A_is_complex and not B_is_complex:
+            Ar = torch.view_as_real(A)
+            if isinstance(B, torch.Tensor):
+                Br = torch.view_as_real(B.to(A.dtype))
+            else:
+                Br = torch.view_as_real(
+                    torch.tensor(B, dtype=A.dtype, device=A.device).expand_as(A)
+                )
+            common_dtype = torch.promote_types(Ar.dtype, Br.dtype)
+            Ar, Br = Ar.to(common_dtype), Br.to(common_dtype)
+            out_real = sub_func(Ar, Br, alpha)
+            return torch.view_as_complex(out_real).to(torch.result_type(A, B))
+        else:
+            Br = torch.view_as_real(B)
+            if isinstance(A, torch.Tensor):
+                Ar = torch.view_as_real(A.to(B.dtype))
+            else:
+                Ar = torch.view_as_real(
+                    torch.tensor(A, dtype=B.dtype, device=B.device).expand_as(B)
+                )
+            common_dtype = torch.promote_types(Ar.dtype, Br.dtype)
+            Ar, Br = Ar.to(common_dtype), Br.to(common_dtype)
+            out_real = sub_func(Ar, Br, alpha)
+            return torch.view_as_complex(out_real).to(torch.result_type(A, B))
+    elif isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return sub_func(A, B, alpha)
     elif isinstance(A, torch.Tensor):
         return sub_func_tensor_scalar(A, B, alpha)

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -46,6 +46,42 @@ def test_accuracy_add(shape, alpha, dtype):
     gems_assert_close(res_out, ref_out, dtype)
 
 
+@pytest.mark.add
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("complex_dtype", COMPLEX_DTYPES)
+@pytest.mark.parametrize(
+    "other_type", ["complex", "float_tensor", "int_tensor", "int_scalar"]
+)
+def test_accuracy_add_complex(shape, complex_dtype, other_type):
+    inp1 = torch.randn(shape, dtype=complex_dtype, device=flag_gems.device)
+
+    if other_type == "complex":
+        inp2 = torch.randn(shape, dtype=complex_dtype, device=flag_gems.device)
+    elif other_type == "float_tensor":
+        if complex_dtype == torch.complex64:
+            float_dtype = torch.float32
+        elif complex_dtype == torch.complex32:
+            float_dtype = torch.float16
+        else:
+            raise ValueError(f"Unsupported complex_dtype: {complex_dtype}")
+        inp2 = torch.randn(shape, dtype=float_dtype, device=flag_gems.device)
+    elif other_type == "int_tensor":
+        inp2 = torch.randint(10, 20, shape, device=flag_gems.device)
+    elif other_type == "int_scalar":
+        inp2 = 3
+    else:
+        raise ValueError(f"Unknown other_type: {other_type}")
+
+    ref_inp1 = to_reference(inp1, True)
+    ref_inp2 = to_reference(inp2, True) if isinstance(inp2, torch.Tensor) else inp2
+
+    ref_out = torch.add(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.add(inp1, inp2)
+
+    gems_assert_close(res_out, ref_out, complex_dtype)
+
+
 @pytest.mark.inplace
 @pytest.mark.add_
 @pytest.mark.parametrize("shape", POINTWISE_SHAPES)
@@ -1547,6 +1583,42 @@ def test_accuracy_sub_tensor_scalar(shape, scalar, alpha, dtype):
         res_out = torch.sub(inp1, inp2, alpha=alpha)
 
     gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.sub
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("complex_dtype", COMPLEX_DTYPES)
+@pytest.mark.parametrize(
+    "other_type", ["complex", "float_tensor", "int_tensor", "int_scalar"]
+)
+def test_accuracy_sub_complex(shape, complex_dtype, other_type):
+    inp1 = torch.randn(shape, dtype=complex_dtype, device=flag_gems.device)
+
+    if other_type == "complex":
+        inp2 = torch.randn(shape, dtype=complex_dtype, device=flag_gems.device)
+    elif other_type == "float_tensor":
+        if complex_dtype == torch.complex64:
+            float_dtype = torch.float32
+        elif complex_dtype == torch.complex32:
+            float_dtype = torch.float16
+        else:
+            raise ValueError(f"Unsupported complex_dtype: {complex_dtype}")
+        inp2 = torch.randn(shape, dtype=float_dtype, device=flag_gems.device)
+    elif other_type == "int_tensor":
+        inp2 = torch.randint(10, 20, shape, device=flag_gems.device)
+    elif other_type == "int_scalar":
+        inp2 = 3
+    else:
+        raise ValueError(f"Unknown other_type: {other_type}")
+
+    ref_inp1 = to_reference(inp1, True)
+    ref_inp2 = to_reference(inp2, True) if isinstance(inp2, torch.Tensor) else inp2
+
+    ref_out = torch.sub(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.sub(inp1, inp2)
+
+    gems_assert_close(res_out, ref_out, complex_dtype)
 
 
 @pytest.mark.inplace


### PR DESCRIPTION

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
1.add, sub op support complex dtype
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
performance on Nvidia H20 140G
```
Operator: add  Performance Test (dtype=torch.complex64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               6.212112            7.476960               0.831               0.287          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.005280            0.005152               1.025               0.002          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.099648            0.101888               0.978               0.329          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.099776            0.102240               0.976               0.328          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               6.216384            7.077248               0.878               0.303          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.005248            0.005024               1.045               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.005440            0.005408               1.006               0.006          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.007232            0.007520               0.962               0.070          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.030720            0.031184               0.985               0.269          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.396640            0.442752               0.896               0.303          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.005280            0.005216               1.012               0.002          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.005760            0.005760               1.000               0.023          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.011904            0.012160               0.979               0.172          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.099776            0.102672               0.972               0.327          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               1.558368            1.821184               0.856               0.295          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]
```

```
Operator: sub  Performance Test (dtype=torch.complex64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               6.166400            7.067152               0.873               0.304          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.005280            0.005152               1.025               0.002          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.099680            0.101872               0.978               0.329          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.099776            0.122944               0.812               0.273          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               6.212912            7.039792               0.883               0.305          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.005248            0.005056               1.038               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.005408            0.005408               1.000               0.006          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.007232            0.007488               0.966               0.070          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.030720            0.031200               0.985               0.269          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.455584            0.444480               1.025               0.302          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.005280            0.005152               1.025               0.002          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.005760            0.005760               1.000               0.023          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.011936            0.012160               0.982               0.172          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.099712            0.102368               0.974               0.328          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               1.558400            1.866304               0.835               0.288          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]

```