### PR TITLE
[KernelGen] Add reciprocal operator for Iluvatar platform

### DIFF
--- a/src/flag_gems/runtime/backend/_iluvatar/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/__init__.py
@@ -1,6 +1,9 @@
 from .div import div_mode, div_mode_
+from .reciprocal import reciprocal, reciprocal_
 
 __all__ = [
     "div_mode",
     "div_mode_",
+    "reciprocal",
+    "reciprocal_",
 ]

--- a/src/flag_gems/runtime/backend/_iluvatar/ops/reciprocal.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/reciprocal.py
@@ -1,0 +1,37 @@
+import logging
+
+import torch
+import triton
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=[(0, "DEFAULT")])
+@triton.jit
+def reciprocal_kernel(x):
+    return 1.0 / x
+
+
+def reciprocal(input: torch.Tensor) -> torch.Tensor:
+    """Compute reciprocal of input tensor: output = 1.0 / input"""
+    logger.debug("GEMS RECIPROCAL - Iluvatar")
+    # Empty tensor protection (Rule GR-030)
+    if input.numel() == 0:
+        return torch.empty_like(input)
+
+    output = reciprocal_kernel(input)
+    return output
+
+
+def reciprocal_(input: torch.Tensor) -> torch.Tensor:
+    """In-place reciprocal: input = 1.0 / input"""
+    logger.debug("GEMS RECIPROCAL_ - Iluvatar in-place")
+    # Empty tensor protection (Rule GR-030)
+    if input.numel() == 0:
+        return input
+
+    # In-place variant
+    out = reciprocal_kernel(input, out0=input)
+    return out


### PR DESCRIPTION
## Summary
- Implement reciprocal/reciprocal_ operators with Triton kernel for Iluvatar platform
- Use @pointwise_dynamic decorator for element-wise computation
- Add empty tensor protection (Rule GR-030)
- Pure Triton implementation with 1.0 / x (Rule GR-033 compliant)

## MCP Autotune Results
- Total versions: v1-v9
- Best speedup: 0.84x (v7)
- All 8/8 accuracy tests passed
- Target speedup 1.5x not achieved, but kernel is functional

## Files Changed
- src/flag_gems/runtime/backend/_iluvatar/ops/reciprocal.py (new)
- src/flag_gems/runtime/backend/_iluvatar/ops/__init__.py (updated)

## Generated with
kernelgen MCP v2.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)