### PR TITLE
[kunlunxin] fix apply_repetition_penalties

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/fused/__init__.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/fused/__init__.py
@@ -1,3 +1,4 @@
+from .apply_repetition_penalties import apply_repetition_penalties
 from .concat_and_cache_mla import concat_and_cache_mla
 from .cross_entropy_loss import cross_entropy_loss
 from .flash_mla import flash_mla
@@ -19,6 +20,7 @@ from .topk_softmax import topk_softmax
 from .weight_norm import weight_norm
 
 __all__ = [
+    "apply_repetition_penalties",
     "apply_rotary_pos_emb",
     "skip_layer_norm",
     "fused_add_rms_norm",

--- a/src/flag_gems/runtime/backend/_kunlunxin/fused/apply_repetition_penalties.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/fused/apply_repetition_penalties.py
@@ -1,0 +1,90 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def _repetition_penalty_kernel(
+    logits_ptr,
+    prompt_mask_ptr,
+    output_mask_ptr,
+    penalties_ptr,
+    num_seqs,
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
+):
+    seq_idx = tl.program_id(0)
+    vocab_offset = tl.program_id(1) * BLOCK_SIZE
+
+    if seq_idx >= num_seqs:
+        return
+
+    penalty = tl.load(penalties_ptr + seq_idx)
+
+    vocab_idx = vocab_offset + tl.arange(0, BLOCK_SIZE)
+
+    valid_vocab = vocab_idx < vocab_size
+
+    logits_idx = seq_idx * vocab_size + vocab_idx
+    mask_idx = logits_idx
+
+    prompt_mask = tl.load(prompt_mask_ptr + mask_idx, mask=valid_vocab, other=False)
+    output_mask = tl.load(output_mask_ptr + mask_idx, mask=valid_vocab, other=False)
+    logits = tl.load(logits_ptr + logits_idx, mask=valid_vocab, other=0.0)
+
+    is_repeated = prompt_mask | output_mask
+
+    logits = tl.where(is_repeated & (logits > 0), logits / penalty, logits)
+    logits = tl.where(is_repeated & (logits <= 0), logits * penalty, logits)
+
+    tl.store(logits_ptr + logits_idx, logits, mask=valid_vocab)
+
+
+def apply_repetition_penalties(logits, prompt_mask, output_mask, repetition_penalties):
+    logger.debug("GEMS APPLY REPETITION PENALTIES")
+    assert logits.is_contiguous(), "logits must be contiguous"
+    assert (
+        prompt_mask.is_contiguous() and prompt_mask.dtype == torch.bool
+    ), "prompt_mask must be contiguous bool tensor"
+    assert (
+        output_mask.is_contiguous() and output_mask.dtype == torch.bool
+    ), "output_mask must be contiguous bool tensor"
+    assert (
+        repetition_penalties.is_contiguous()
+    ), "repetition_penalties must be contiguous"
+    assert logits.dim() == 2, f"logits must be 2D, got {logits.dim()}D"
+    assert (
+        logits.shape == prompt_mask.shape == output_mask.shape
+    ), "shape mismatch between logits and masks"
+    assert (
+        repetition_penalties.dim() == 1
+        and repetition_penalties.numel() == logits.shape[0]
+    ), "repetition_penalties must be 1D with length equal to num_seqs"
+
+    num_seqs, vocab_size = logits.shape
+
+    # XPU arch3 has limited per-core SRAM (buf_len_per_core=2048 bytes).
+    # This kernel holds ~25-30 bytes/element in SRAM simultaneously
+    # (3 tensor loads + multiple intermediate comparison/arithmetic results),
+    # so cap BLOCK_SIZE at 128 to stay within hardware limits.
+    BLOCK_SIZE = min(triton.next_power_of_2(vocab_size), 128)
+
+    grid = (
+        num_seqs,
+        triton.cdiv(vocab_size, BLOCK_SIZE),
+    )
+
+    _repetition_penalty_kernel[grid](
+        logits,
+        prompt_mask,
+        output_mask,
+        repetition_penalties,
+        num_seqs,
+        vocab_size,
+        BLOCK_SIZE=BLOCK_SIZE,
+    )
+    return None


### PR DESCRIPTION
## 问题
apply_repetition_penalties 算子在 XPU (kunlunxin arch3) 上因 SRAM 不足
报 OutOfResources 错误，所有 dtype/shape 组合均失败（126 个用例）。

## 原因
默认实现 BLOCK_SIZE=1024，该 kernel 每元素需要 ~25-30 字节 SRAM
（3 个 tensor load + 多个中间比较/算术结果），超出 XPU 
buf_len_per_core=2048 字节的硬件限制。

## 修复
在 _kunlunxin/fused/ 下新增
专属实现，BLOCK_SIZE 上限设为 128。

## 改动文件
- 新增: src/flag_gems/runtime/backend/_kunlunxin/fused/apply_repetition_penalties.py
- 修改: src/flag_gems/runtime/backend/_kunlunxin/fused/__init__.py
