### PR TITLE
[SiliconFlow] add Upsample bicubic2d aa backward

### DIFF
--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -1391,51 +1391,48 @@ def test_perf_t_copy():
 
 
 class UpsampleBicubic2dAaBackwardBenchmark(Benchmark):
-    def set_more_shapes(self):
-        shapes = [(512, 1024, 32, 32), (256, 512, 64, 64)]
-        shapes_4d = [(4, 16, 2**i, 2**i) for i in range(2, 8, 2)]
-        shapes_rect = [(4, 16, 2**i, 2 ** (i + 1)) for i in range(2, 7, 2)]
-        return shapes + shapes_4d + shapes_rect
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._cfgs = [
+            # Small / medium — fused path targets
+            (4,  16,   4,   4,   1,   1, False, "tiny 4x down"),
+            (4,  16,   4,   4,  16,  16, False, "small 4x up"),
+            (4,  16,  16,  16,   4,   4, False, "small 4x down"),
+            (4,  16,  16,  32,  64, 128, False, "small->med 4x up"),
+            (1,   1,  64,  64,  16,  16, False, "C=1 4x down"),
+            (1,   1,  64,  64,  32,  32, False, "C=1 2x down"),
+            (1,   1,  64,  64, 128, 128, False, "C=1 2x up"),
+            (4,   3, 256, 256, 128, 128, False, "C=3 2x down"),
+            (4,   3, 128, 128, 256, 256, False, "C=3 2x up"),
+            (4,  64,  64,  64,  32,  32, False, "C=64 2x down"),
+            # Large — 2-pass path targets
+            (1,  64, 512, 512, 128, 128, False, "C=64 4x down"),
+            (1,  64, 512, 512,1024,1024, False, "C=64 2x up"),
+            (512, 1024, 32, 32,  8,  8, False, "NC=524K 4x down"),
+            (256,  512, 64, 64, 16, 16, False, "NC=131K 4x down"),
+            (256,  512, 64, 64, 32, 32, False, "NC=131K 2x down"),
+            (256,  512, 64, 64,128,128, False, "NC=131K 2x up"),
+        ]
 
     def get_input_iter(self, cur_dtype):
-        for shape in self.shapes:
-            if len(shape) == 1:
-                # Treat flat shape as a square spatial dim: (1, 1, sqrt(N), sqrt(N))
-                side = int(shape[0] ** 0.5)
-                shape_4d = (1, 1, side, side)
-            elif len(shape) == 2:
-                shape_4d = (1, 1, shape[0], shape[1])
-            elif len(shape) == 3:
-                shape_4d = (1, shape[0], shape[1], shape[2])
-            else:
-                shape_4d = shape
-            for scale_factor in [0.25, 0.5, 2.0]:
-                for align_corners in [False, True]:
-                    N, C, H_in, W_in = shape_4d
-                    H_out = max(1, int(H_in * scale_factor))
-                    W_out = max(1, int(W_in * scale_factor))
-                    if N * C * max(H_in * W_in, H_out * W_out) >= 2**30:
-                        continue
-                    grad = torch.randn(
-                        [N, C, H_out, W_out], device=self.device, dtype=cur_dtype
-                    )
-                    yield grad, [H_out, W_out], [N, C, H_in, W_in], align_corners, None, None
+        for N, C, Hi, Wi, Ho, Wo, ac, label in self._cfgs:
+            grad = torch.randn(
+                [N, C, Ho, Wo], device=self.device, dtype=cur_dtype
+            )
+            yield grad, [Ho, Wo], [N, C, Hi, Wi], ac, None, None, label
 
     def get_tflops(self, op, *args, **kwargs):
-        grad, output_size, input_size, align_corners, scales_h, scales_w = args
+        grad = args[0]
         return grad.numel() * 2
 
 
 @pytest.mark.upsample_bicubic2d_aa_backward
-@pytest.mark.parametrize(
-    "dtype",
-    [torch.float32], #FLOAT_DTYPES,
-)
-def test_upsample_bicubic2d_aa_backward_perf(dtype):
+def test_upsample_bicubic2d_aa_backward():
     bench = UpsampleBicubic2dAaBackwardBenchmark(
         op_name="upsample_bicubic2d_aa_backward",
         torch_op=torch.ops.aten._upsample_bicubic2d_aa_backward,
-        dtypes=[dtype],
+        dtypes=FLOAT_DTYPES,
     )
 
     bench.run()
+

--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -1390,45 +1390,51 @@ def test_perf_t_copy():
     bench.run()
 
 
-class SelectBackwardBenchmark(Benchmark):
-    """
-    Benchmark for select_backward operator.
-    """
-
+class UpsampleBicubic2dAaBackwardBenchmark(Benchmark):
     def set_more_shapes(self):
-        special_shapes_2d = [(1024, 2**i) for i in range(0, 20, 4)]
-        sp_shapes_3d = [(64, 64, 2**i) for i in range(0, 15, 4)]
-        return special_shapes_2d + sp_shapes_3d
+        shapes = [(512, 1024, 32, 32), (256, 512, 64, 64)]
+        shapes_4d = [(4, 16, 2**i, 2**i) for i in range(2, 8, 2)]
+        shapes_rect = [(4, 16, 2**i, 2 ** (i + 1)) for i in range(2, 7, 2)]
+        return shapes + shapes_4d + shapes_rect
 
     def get_input_iter(self, cur_dtype):
         for shape in self.shapes:
-            x = generate_tensor_input(shape, cur_dtype, self.device)
-            ndim = len(shape)
-
-            dim = 1 if ndim > 1 else 0
-            actual_dim = dim if dim >= 0 else dim + ndim
-
-            index = shape[actual_dim] // 2
-
-            y = torch.select(x, actual_dim, index)
-            grad = torch.randn_like(y)
-
-            yield grad, shape, actual_dim, index
+            if len(shape) == 1:
+                # Treat flat shape as a square spatial dim: (1, 1, sqrt(N), sqrt(N))
+                side = int(shape[0] ** 0.5)
+                shape_4d = (1, 1, side, side)
+            elif len(shape) == 2:
+                shape_4d = (1, 1, shape[0], shape[1])
+            elif len(shape) == 3:
+                shape_4d = (1, shape[0], shape[1], shape[2])
+            else:
+                shape_4d = shape
+            for scale_factor in [0.25, 0.5, 2.0]:
+                for align_corners in [False, True]:
+                    N, C, H_in, W_in = shape_4d
+                    H_out = max(1, int(H_in * scale_factor))
+                    W_out = max(1, int(W_in * scale_factor))
+                    if N * C * max(H_in * W_in, H_out * W_out) >= 2**30:
+                        continue
+                    grad = torch.randn(
+                        [N, C, H_out, W_out], device=self.device, dtype=cur_dtype
+                    )
+                    yield grad, [H_out, W_out], [N, C, H_in, W_in], align_corners, None, None
 
     def get_tflops(self, op, *args, **kwargs):
-        grad, shape, _, _ = args
-        return grad.numel()
+        grad, output_size, input_size, align_corners, scales_h, scales_w = args
+        return grad.numel() * 2
 
 
-@pytest.mark.select_backward
+@pytest.mark.upsample_bicubic2d_aa_backward
 @pytest.mark.parametrize(
     "dtype",
-    FLOAT_DTYPES,
+    [torch.float32], #FLOAT_DTYPES,
 )
-def test_select_backward_perf(dtype):
-    bench = SelectBackwardBenchmark(
-        op_name="select_backward",
-        torch_op=torch.ops.aten.select_backward,
+def test_upsample_bicubic2d_aa_backward_perf(dtype):
+    bench = UpsampleBicubic2dAaBackwardBenchmark(
+        op_name="upsample_bicubic2d_aa_backward",
+        torch_op=torch.ops.aten._upsample_bicubic2d_aa_backward,
         dtypes=[dtype],
     )
 

--- a/benchmark/test_special_perf.py
+++ b/benchmark/test_special_perf.py
@@ -1395,30 +1395,28 @@ class UpsampleBicubic2dAaBackwardBenchmark(Benchmark):
         super().__init__(*args, **kwargs)
         self._cfgs = [
             # Small / medium — fused path targets
-            (4,  16,   4,   4,   1,   1, False, "tiny 4x down"),
-            (4,  16,   4,   4,  16,  16, False, "small 4x up"),
-            (4,  16,  16,  16,   4,   4, False, "small 4x down"),
-            (4,  16,  16,  32,  64, 128, False, "small->med 4x up"),
-            (1,   1,  64,  64,  16,  16, False, "C=1 4x down"),
-            (1,   1,  64,  64,  32,  32, False, "C=1 2x down"),
-            (1,   1,  64,  64, 128, 128, False, "C=1 2x up"),
-            (4,   3, 256, 256, 128, 128, False, "C=3 2x down"),
-            (4,   3, 128, 128, 256, 256, False, "C=3 2x up"),
-            (4,  64,  64,  64,  32,  32, False, "C=64 2x down"),
+            (4, 16, 4, 4, 1, 1, False, "tiny 4x down"),
+            (4, 16, 4, 4, 16, 16, False, "small 4x up"),
+            (4, 16, 16, 16, 4, 4, False, "small 4x down"),
+            (4, 16, 16, 32, 64, 128, False, "small->med 4x up"),
+            (1, 1, 64, 64, 16, 16, False, "C=1 4x down"),
+            (1, 1, 64, 64, 32, 32, False, "C=1 2x down"),
+            (1, 1, 64, 64, 128, 128, False, "C=1 2x up"),
+            (4, 3, 256, 256, 128, 128, False, "C=3 2x down"),
+            (4, 3, 128, 128, 256, 256, False, "C=3 2x up"),
+            (4, 64, 64, 64, 32, 32, False, "C=64 2x down"),
             # Large — 2-pass path targets
-            (1,  64, 512, 512, 128, 128, False, "C=64 4x down"),
-            (1,  64, 512, 512,1024,1024, False, "C=64 2x up"),
-            (512, 1024, 32, 32,  8,  8, False, "NC=524K 4x down"),
-            (256,  512, 64, 64, 16, 16, False, "NC=131K 4x down"),
-            (256,  512, 64, 64, 32, 32, False, "NC=131K 2x down"),
-            (256,  512, 64, 64,128,128, False, "NC=131K 2x up"),
+            (1, 64, 512, 512, 128, 128, False, "C=64 4x down"),
+            (1, 64, 512, 512, 1024, 1024, False, "C=64 2x up"),
+            (512, 1024, 32, 32, 8, 8, False, "NC=524K 4x down"),
+            (256, 512, 64, 64, 16, 16, False, "NC=131K 4x down"),
+            (256, 512, 64, 64, 32, 32, False, "NC=131K 2x down"),
+            (256, 512, 64, 64, 128, 128, False, "NC=131K 2x up"),
         ]
 
     def get_input_iter(self, cur_dtype):
         for N, C, Hi, Wi, Ho, Wo, ac, label in self._cfgs:
-            grad = torch.randn(
-                [N, C, Ho, Wo], device=self.device, dtype=cur_dtype
-            )
+            grad = torch.randn([N, C, Ho, Wo], device=self.device, dtype=cur_dtype)
             yield grad, [Ho, Wo], [N, C, Hi, Wi], ac, None, None, label
 
     def get_tflops(self, op, *args, **kwargs):
@@ -1435,4 +1433,3 @@ def test_upsample_bicubic2d_aa_backward():
     )
 
     bench.run()
-

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -45,6 +45,7 @@ _FULL_CONFIG = (
     ),
     ("_unique2", _unique2),
     ("_upsample_bicubic2d_aa", _upsample_bicubic2d_aa),
+    ("_upsample_bicubic2d_aa_backward", _upsample_bicubic2d_aa_backward),
     ("_upsample_nearest_exact1d", _upsample_nearest_exact1d),
     ("_weight_norm_interface", weight_norm_interface),
     ("_weight_norm_interface_backward", weight_norm_interface_backward),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -278,6 +278,7 @@ from flag_gems.ops.uniform import uniform_
 from flag_gems.ops.unique import _unique2
 from flag_gems.ops.upsample_bicubic2d import upsample_bicubic2d
 from flag_gems.ops.upsample_bicubic2d_aa import _upsample_bicubic2d_aa
+from flag_gems.ops.upsample_bicubic2d_aa_backward import _upsample_bicubic2d_aa_backward
 from flag_gems.ops.upsample_linear1d import upsample_linear1d
 from flag_gems.ops.upsample_nearest1d import upsample_nearest1d
 from flag_gems.ops.upsample_nearest2d import upsample_nearest2d
@@ -307,6 +308,7 @@ __all__ = [
     "_safe_softmax",
     "_unique2",
     "_upsample_bicubic2d_aa",
+    "_upsample_bicubic2d_aa_backward",
     "_upsample_nearest_exact1d",
     "abs",
     "abs_",

--- a/src/flag_gems/ops/upsample_bicubic2d_aa_backward.py
+++ b/src/flag_gems/ops/upsample_bicubic2d_aa_backward.py
@@ -1,0 +1,628 @@
+import math
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def cubic_keys(x):
+    """Keys cubic filter with a = -0.5.
+
+    |x| < 1 : 1.5|x|^3 - 2.5|x|^2 + 1
+    1 <= |x| < 2 : -0.5|x|^3 + 2.5|x|^2 - 4|x| + 2
+    otherwise : 0
+    """
+    ax = tl.abs(x)
+    ax2 = ax * ax
+    ax3 = ax2 * ax
+    w_inner = 1.5 * ax3 - 2.5 * ax2 + 1.0
+    w_outer = -0.5 * ax3 + 2.5 * ax2 - 4.0 * ax + 2.0
+    return tl.where(ax < 1.0, w_inner, tl.where(ax < 2.0, w_outer, 0.0))
+
+
+# ============================================================
+# Kernel A: fp32 path
+# grad_out / grad_in 均为 fp32，直接 atomic_add，无需额外 cast
+# ============================================================
+
+@triton.jit
+def _upsample_bicubic2d_aa_backward_kernel_fp32(
+    grad_out_ptr,
+    grad_in_ptr,
+    n, c, in_h, in_w, out_h, out_w,
+    go_stride_n, go_stride_c, go_stride_h, go_stride_w,
+    gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w,
+    scale_y, scale_x,
+    scale_y_aa, scale_x_aa,
+    SH: tl.constexpr,
+    SW: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    total = n * c * out_h * out_w
+    mask = offs < total
+
+    x_out = offs % out_w
+    tmp   = offs // out_w
+    y_out = tmp % out_h
+    tmp   = tmp // out_h
+    c_idx = tmp % c
+    n_idx = tmp // c
+
+    y_out_f = y_out.to(tl.float32)
+    x_out_f = x_out.to(tl.float32)
+
+    y_real = (y_out_f + 0.5) * scale_y - 0.5
+    x_real = (x_out_f + 0.5) * scale_x - 0.5
+
+    support_h = 2.0 / scale_y_aa
+    support_w = 2.0 / scale_x_aa
+
+    y_in_start = (tl.floor(y_real - support_h) + 1).to(tl.int32)
+    x_in_start = (tl.floor(x_real - support_w) + 1).to(tl.int32)
+
+    go_off = (
+        n_idx.to(tl.int64) * go_stride_n
+        + c_idx.to(tl.int64) * go_stride_c
+        + y_out.to(tl.int64) * go_stride_h
+        + x_out.to(tl.int64) * go_stride_w
+    )
+    go_val = tl.load(grad_out_ptr + go_off, mask=mask, other=0.0)  # fp32
+
+    gi_base = (
+        grad_in_ptr
+        + n_idx.to(tl.int64) * gi_stride_n
+        + c_idx.to(tl.int64) * gi_stride_c
+    )
+
+    norm = tl.zeros([BLOCK], dtype=tl.float32)
+    for dh in range(SH):
+        y_in   = y_in_start + dh
+        y_in_f = y_in.to(tl.float32)
+        dist_h = (y_in_f - y_real) * scale_y_aa
+        valid_h = (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
+        w_h = tl.where(valid_h, cubic_keys(dist_h), 0.0)
+
+        for dw in range(SW):
+            x_in   = x_in_start + dw
+            x_in_f = x_in.to(tl.float32)
+            dist_w = (x_in_f - x_real) * scale_x_aa
+            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
+            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
+            norm  += w_h * w_w
+
+    norm = tl.where(norm == 0.0, 1.0, norm)
+
+    for dh in range(SH):
+        y_in   = y_in_start + dh
+        y_in_f = y_in.to(tl.float32)
+        dist_h = (y_in_f - y_real) * scale_y_aa
+        valid_h = mask & (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
+        w_h     = tl.where(valid_h, cubic_keys(dist_h), 0.0)
+
+        for dw in range(SW):
+            x_in   = x_in_start + dw
+            x_in_f = x_in.to(tl.float32)
+            dist_w = (x_in_f - x_real) * scale_x_aa
+            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
+            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
+
+            weight  = (w_h * w_w) / norm
+            contrib = go_val * weight  # fp32
+
+            gi_off = (
+                y_in.to(tl.int64) * gi_stride_h
+                + x_in.to(tl.int64) * gi_stride_w
+            )
+            tl.atomic_add(gi_base + gi_off, contrib, mask=valid)
+
+
+# ============================================================
+# Kernel B1: lowp 下采样路径（scale_y_aa < 1 或 scale_x_aa < 1）
+#
+# AA 窗口宽于一个像素，支持域 > 2，SH/SW 较大。
+# grad_out 低精度读入后立即 cast 到 fp32；
+# grad_in 是 fp32 临时 buffer，atomic_add 全程在 fp32 完成，
+# 最后由调用方 cast 回低精度。
+# 精度已满足要求，逻辑与原 lowp kernel 保持一致。
+# ============================================================
+
+@triton.jit
+def _upsample_bicubic2d_aa_backward_kernel_lowp_downsample(
+    grad_out_ptr,
+    grad_in_ptr,                        # fp32 临时 buffer
+    n, c, in_h, in_w, out_h, out_w,
+    go_stride_n, go_stride_c, go_stride_h, go_stride_w,
+    gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w,
+    scale_y, scale_x,
+    scale_y_aa, scale_x_aa,
+    SH: tl.constexpr,
+    SW: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    total = n * c * out_h * out_w
+    mask = offs < total
+
+    x_out = offs % out_w
+    tmp   = offs // out_w
+    y_out = tmp % out_h
+    tmp   = tmp // out_h
+    c_idx = tmp % c
+    n_idx = tmp // c
+
+    y_out_f = y_out.to(tl.float32)
+    x_out_f = x_out.to(tl.float32)
+
+    y_real = (y_out_f + 0.5) * scale_y - 0.5
+    x_real = (x_out_f + 0.5) * scale_x - 0.5
+
+    support_h = 2.0 / scale_y_aa
+    support_w = 2.0 / scale_x_aa
+
+    y_in_start = (tl.floor(y_real - support_h) + 1).to(tl.int32)
+    x_in_start = (tl.floor(x_real - support_w) + 1).to(tl.int32)
+
+    go_off = (
+        n_idx.to(tl.int64) * go_stride_n
+        + c_idx.to(tl.int64) * go_stride_c
+        + y_out.to(tl.int64) * go_stride_h
+        + x_out.to(tl.int64) * go_stride_w
+    )
+    # 低精度读入，立即 cast 到 fp32，后续所有计算在 fp32 完成
+    go_val = tl.load(grad_out_ptr + go_off, mask=mask, other=0.0).to(tl.float32)
+
+    gi_base = (
+        grad_in_ptr
+        + n_idx.to(tl.int64) * gi_stride_n
+        + c_idx.to(tl.int64) * gi_stride_c
+    )
+
+    norm = tl.zeros([BLOCK], dtype=tl.float32)
+    for dh in range(SH):
+        y_in   = y_in_start + dh
+        y_in_f = y_in.to(tl.float32)
+        dist_h = (y_in_f - y_real) * scale_y_aa
+        valid_h = (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
+        w_h = tl.where(valid_h, cubic_keys(dist_h), 0.0)
+
+        for dw in range(SW):
+            x_in   = x_in_start + dw
+            x_in_f = x_in.to(tl.float32)
+            dist_w = (x_in_f - x_real) * scale_x_aa
+            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
+            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
+            norm  += w_h * w_w
+
+    norm = tl.where(norm == 0.0, 1.0, norm)
+
+    for dh in range(SH):
+        y_in   = y_in_start + dh
+        y_in_f = y_in.to(tl.float32)
+        dist_h = (y_in_f - y_real) * scale_y_aa
+        valid_h = mask & (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
+        w_h     = tl.where(valid_h, cubic_keys(dist_h), 0.0)
+
+        for dw in range(SW):
+            x_in   = x_in_start + dw
+            x_in_f = x_in.to(tl.float32)
+            dist_w = (x_in_f - x_real) * scale_x_aa
+            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
+            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
+
+            weight  = (w_h * w_w) / norm
+            contrib = go_val * weight       # fp32 * fp32 = fp32
+
+            gi_off = (
+                y_in.to(tl.int64) * gi_stride_h
+                + x_in.to(tl.int64) * gi_stride_w
+            )
+            # atomic_add 写入 fp32 buffer，避免低精度累加误差
+            tl.atomic_add(gi_base + gi_off, contrib, mask=valid)
+
+
+# ============================================================
+# Kernel B2: lowp 上采样路径（scale_y_aa == 1 且 scale_x_aa == 1）
+#
+# 上采样时 AA 缩放因子恒为 1，支持域固定为 2（SH=SW=4），
+# 与下采样路径的数值行为完全相同，但单独拆出以便后续针对
+# 上采样的精度问题独立修复（TODO）。
+# ============================================================
+
+@triton.jit
+def bak_upsample_bicubic2d_aa_backward_kernel_lowp_upsample(
+    grad_out_ptr,
+    grad_in_ptr,                        # fp32 临时 buffer
+    n, c, in_h, in_w, out_h, out_w,
+    go_stride_n, go_stride_c, go_stride_h, go_stride_w,
+    gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w,
+    scale_y, scale_x,
+    scale_y_aa, scale_x_aa,
+    SH: tl.constexpr,
+    SW: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    # TODO: 上采样低精度路径精度尚未达标，待后续专项修复。
+    #       当前实现与下采样路径逻辑一致，作为占位。
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    total = n * c * out_h * out_w
+    mask = offs < total
+
+    x_out = offs % out_w
+    tmp   = offs // out_w
+    y_out = tmp % out_h
+    tmp   = tmp // out_h
+    c_idx = tmp % c
+    n_idx = tmp // c
+
+    y_out_f = y_out.to(tl.float32)
+    x_out_f = x_out.to(tl.float32)
+
+    y_real = (y_out_f + 0.5) * scale_y - 0.5
+    x_real = (x_out_f + 0.5) * scale_x - 0.5
+
+    support_h = 2.0 / scale_y_aa
+    support_w = 2.0 / scale_x_aa
+
+    y_in_start = (tl.floor(y_real - support_h) + 1).to(tl.int32)
+    x_in_start = (tl.floor(x_real - support_w) + 1).to(tl.int32)
+
+    go_off = (
+        n_idx.to(tl.int64) * go_stride_n
+        + c_idx.to(tl.int64) * go_stride_c
+        + y_out.to(tl.int64) * go_stride_h
+        + x_out.to(tl.int64) * go_stride_w
+    )
+    go_val = tl.load(grad_out_ptr + go_off, mask=mask, other=0.0).to(tl.float32)
+
+    gi_base = (
+        grad_in_ptr
+        + n_idx.to(tl.int64) * gi_stride_n
+        + c_idx.to(tl.int64) * gi_stride_c
+    )
+
+    norm = tl.zeros([BLOCK], dtype=tl.float32)
+    for dh in range(SH):
+        y_in   = y_in_start + dh
+        y_in_f = y_in.to(tl.float32)
+        dist_h = (y_in_f - y_real) * scale_y_aa
+        valid_h = (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
+        w_h = tl.where(valid_h, cubic_keys(dist_h), 0.0)
+
+        for dw in range(SW):
+            x_in   = x_in_start + dw
+            x_in_f = x_in.to(tl.float32)
+            dist_w = (x_in_f - x_real) * scale_x_aa
+            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
+            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
+            norm  += w_h * w_w
+
+    norm = tl.where(norm == 0.0, 1.0, norm)
+
+    for dh in range(SH):
+        y_in   = y_in_start + dh
+        y_in_f = y_in.to(tl.float32)
+        dist_h = (y_in_f - y_real) * scale_y_aa
+        valid_h = mask & (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
+        w_h     = tl.where(valid_h, cubic_keys(dist_h), 0.0)
+
+        for dw in range(SW):
+            x_in   = x_in_start + dw
+            x_in_f = x_in.to(tl.float32)
+            dist_w = (x_in_f - x_real) * scale_x_aa
+            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
+            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
+
+            weight  = (w_h * w_w) / norm
+            contrib = go_val * weight
+
+            gi_off = (
+                y_in.to(tl.int64) * gi_stride_h
+                + x_in.to(tl.int64) * gi_stride_w
+            )
+            tl.atomic_add(gi_base + gi_off, contrib, mask=valid)
+
+@triton.jit
+def _upsample_bicubic2d_aa_backward_kernel_lowp_upsample(
+    grad_out_ptr,
+    grad_in_ptr,
+    n, c, in_h, in_w, out_h, out_w,
+    go_stride_n, go_stride_c, go_stride_h, go_stride_w,
+    gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w,
+    scale_y, scale_x,
+    scale_y_aa, scale_x_aa,
+    SH: tl.constexpr,
+    SW: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    total = n * c * out_h * out_w
+    mask = offs < total
+
+    x_out = offs % out_w
+    tmp   = offs // out_w
+    y_out = tmp % out_h
+    tmp   = tmp // out_h
+    c_idx = tmp % c
+    n_idx = tmp // c
+
+    # ✅ Fix 1: 坐标全程用 fp32 计算，避免 bf16 的 7-bit 尾数问题
+    y_out_f = y_out.to(tl.float32)
+    x_out_f = x_out.to(tl.float32)
+
+    # scale_y/scale_x 在上采样时 < 1，用 fp32 字面量保持精度
+    y_real = (y_out_f + 0.5) * scale_y.to(tl.float32) - 0.5
+    x_real = (x_out_f + 0.5) * scale_x.to(tl.float32) - 0.5
+
+    # 上采样时 scale_y_aa == 1.0，support == 2.0
+    support_h = 2.0 / scale_y_aa
+    support_w = 2.0 / scale_x_aa
+
+    y_in_start = (tl.math.floor(y_real - support_h) + 1.0).to(tl.int32)
+    x_in_start = (tl.math.floor(x_real - support_w) + 1.0).to(tl.int32)
+
+    go_off = (
+        n_idx.to(tl.int64) * go_stride_n
+        + c_idx.to(tl.int64) * go_stride_c
+        + y_out.to(tl.int64) * go_stride_h
+        + x_out.to(tl.int64) * go_stride_w
+    )
+    go_val = tl.load(grad_out_ptr + go_off, mask=mask, other=0.0).to(tl.float32)
+
+    gi_base = (
+        grad_in_ptr
+        + n_idx.to(tl.int64) * gi_stride_n
+        + c_idx.to(tl.int64) * gi_stride_c
+    )
+
+    # ✅ Fix 2: 缓存每个 (dh, dw) 的权重，避免两次循环结果不一致
+    # SH=SW=4，共 16 个权重，全部缓存在寄存器里
+    # Triton 不支持动态索引寄存器数组，用展开的方式处理
+    # ✅ Fix 3: norm 循环加入 mask 保护，防止越界 lane 污染
+    norm = tl.zeros([BLOCK], dtype=tl.float32)
+
+    for dh in tl.static_range(SH):
+        y_in   = y_in_start + dh
+        y_in_f = y_in.to(tl.float32)
+        dist_h = (y_in_f - y_real) * scale_y_aa
+        # ✅ 加入 mask，越界 lane 不参与 norm 累积
+        valid_h = mask & (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
+        w_h = tl.where(valid_h, cubic_keys(dist_h), 0.0)
+
+        for dw in tl.static_range(SW):
+            x_in   = x_in_start + dw
+            x_in_f = x_in.to(tl.float32)
+            dist_w = (x_in_f - x_real) * scale_x_aa
+            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
+            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
+            norm  += w_h * w_w
+
+    # ✅ Fix 4: norm 为 0 时用 1.0 替代，与 PyTorch 行为一致
+    norm_safe = tl.where(norm == 0.0, 1.0, norm)
+
+    for dh in tl.static_range(SH):
+        y_in   = y_in_start + dh
+        y_in_f = y_in.to(tl.float32)
+        dist_h = (y_in_f - y_real) * scale_y_aa
+        valid_h = mask & (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
+        w_h     = tl.where(valid_h, cubic_keys(dist_h), 0.0)
+
+        for dw in tl.static_range(SW):
+            x_in   = x_in_start + dw
+            x_in_f = x_in.to(tl.float32)
+            dist_w = (x_in_f - x_real) * scale_x_aa
+            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
+            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
+
+            # ✅ Fix 5: weight 和 contrib 全程 fp32，最后再除以 norm_safe
+            weight  = (w_h * w_w) / norm_safe
+            contrib = go_val * weight
+
+            gi_off = (
+                y_in.to(tl.int64) * gi_stride_h
+                + x_in.to(tl.int64) * gi_stride_w
+            )
+            tl.atomic_add(gi_base + gi_off, contrib, mask=valid)
+
+@triton.jit
+def v2_upsample_bicubic2d_aa_backward_kernel_lowp_upsample(
+    grad_out_ptr,
+    grad_in_ptr,
+    n, c, in_h, in_w, out_h, out_w,
+    go_stride_n, go_stride_c, go_stride_h, go_stride_w,
+    gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w,
+    scale_y, scale_x,
+    scale_y_aa, scale_x_aa,
+    SH: tl.constexpr,
+    SW: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    total = n * c * out_h * out_w
+    mask = offs < total
+
+    x_out = offs % out_w
+    tmp   = offs // out_w
+    y_out = tmp % out_h
+    tmp   = tmp // out_h
+    c_idx = tmp % c
+    n_idx = tmp // c
+
+    y_out_f = y_out.to(tl.float32)
+    x_out_f = x_out.to(tl.float32)
+
+    y_real = (y_out_f + 0.5) * scale_y - 0.5
+    x_real = (x_out_f + 0.5) * scale_x - 0.5
+
+    # 上采样时 scale_y_aa == scale_x_aa == 1.0，support 固定为 2.0
+    support_h = 2.0 / scale_y_aa
+    support_w = 2.0 / scale_x_aa
+
+    y_in_start = (tl.floor(y_real - support_h) + 1).to(tl.int32)
+    x_in_start = (tl.floor(x_real - support_w) + 1).to(tl.int32)
+
+    go_off = (
+        n_idx.to(tl.int64) * go_stride_n
+        + c_idx.to(tl.int64) * go_stride_c
+        + y_out.to(tl.int64) * go_stride_h
+        + x_out.to(tl.int64) * go_stride_w
+    )
+    go_val = tl.load(grad_out_ptr + go_off, mask=mask, other=0.0).to(tl.float32)
+
+    gi_base = (
+        grad_in_ptr
+        + n_idx.to(tl.int64) * gi_stride_n
+        + c_idx.to(tl.int64) * gi_stride_c
+    )
+
+    # ── Pass 1: 计算 norm ─────────────────────────────────────────
+    # Fix 1: valid_h 必须包含外层 mask，与 scatter 循环保持完全一致
+    # 否则越界 lane 的垃圾坐标会产生非零 cubic_keys 值污染 norm
+    norm = tl.zeros([BLOCK], dtype=tl.float32)
+    for dh in tl.static_range(SH):   # Fix 4: constexpr 循环用 static_range
+        y_in   = y_in_start + dh
+        y_in_f = y_in.to(tl.float32)
+        dist_h = (y_in_f - y_real) * scale_y_aa
+        valid_h = mask & (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
+        w_h = tl.where(valid_h, cubic_keys(dist_h), 0.0)
+
+        for dw in tl.static_range(SW):
+            x_in   = x_in_start + dw
+            x_in_f = x_in.to(tl.float32)
+            dist_w = (x_in_f - x_real) * scale_x_aa
+            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
+            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
+            norm  += w_h * w_w
+
+    # Fix 3: 分离 norm_safe，不覆盖 norm（虽然 pass 1 结束后 norm 本身
+    # 不再被读写，但显式分离变量名可防止后续维护时意外引入 Bug）
+    norm_safe = tl.where(norm == 0.0, 1.0, norm)
+
+    # ── Pass 2: scatter 梯度 ──────────────────────────────────────
+    # valid_h 定义与 Pass 1 完全一致（含 mask），保证两次 cubic_keys
+    # 的输入相同，weight = (w_h * w_w) / norm_safe 分子分母匹配
+    for dh in tl.static_range(SH):
+        y_in   = y_in_start + dh
+        y_in_f = y_in.to(tl.float32)
+        dist_h = (y_in_f - y_real) * scale_y_aa
+        valid_h = mask & (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
+        w_h     = tl.where(valid_h, cubic_keys(dist_h), 0.0)
+
+        for dw in tl.static_range(SW):
+            x_in   = x_in_start + dw
+            x_in_f = x_in.to(tl.float32)
+            dist_w = (x_in_f - x_real) * scale_x_aa
+            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
+            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
+
+            weight  = (w_h * w_w) / norm_safe
+            contrib = go_val * weight
+
+            gi_off = (
+                y_in.to(tl.int64) * gi_stride_h
+                + x_in.to(tl.int64) * gi_stride_w
+            )
+            tl.atomic_add(gi_base + gi_off, contrib, mask=valid)
+# ============================================================
+# Python 入口
+# ============================================================
+
+def _upsample_bicubic2d_aa_backward(
+    grad_output: torch.Tensor,
+    output_size,
+    input_size,
+    align_corners: bool,
+    scales_h=None,
+    scales_w=None,
+):
+    assert grad_output.is_cuda
+
+    n, c, in_h, in_w = input_size
+    out_h, out_w = output_size
+
+    grad_out = grad_output.contiguous()
+    src_dtype = grad_output.dtype
+
+    if align_corners:
+        scale_y = (in_h - 1) / (out_h - 1) if (in_h > 1 and out_h > 1) else 0.0
+        scale_x = (in_w - 1) / (out_w - 1) if (in_w > 1 and out_w > 1) else 0.0
+    else:
+        scale_y = in_h / out_h
+        scale_x = in_w / out_w
+
+    scale_y_aa = min(1.0 / scale_y, 1.0) if scale_y > 0 else 1.0
+    scale_x_aa = min(1.0 / scale_x, 1.0) if scale_x > 0 else 1.0
+
+    SH = int(math.ceil(4.0 / scale_y_aa)) + 2
+    SW = int(math.ceil(4.0 / scale_x_aa)) + 2
+
+    BLOCK = 128
+    grid = (triton.cdiv(n * c * out_h * out_w, BLOCK),)
+
+    is_lowp = src_dtype in (torch.float16, torch.bfloat16)
+
+    # 判断是否为上采样：两个方向的 AA 缩放因子均为 1.0 时为上采样。
+    # （下采样时至少有一个方向 scale_y_aa < 1 或 scale_x_aa < 1）
+    is_upsample = (scale_y_aa == 1.0) and (scale_x_aa == 1.0)
+
+    if is_lowp:
+        # fp32 临时 buffer，kernel 内 atomic_add 全程 fp32
+        grad_in = torch.zeros((n, c, in_h, in_w), device=grad_output.device, dtype=torch.float32)
+
+        go_stride_n, go_stride_c, go_stride_h, go_stride_w = grad_out.stride()
+        gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w = grad_in.stride()
+
+        common_args = (
+            grad_out,
+            grad_in,
+            n, c, in_h, in_w, out_h, out_w,
+            go_stride_n, go_stride_c, go_stride_h, go_stride_w,
+            gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w,
+            scale_y, scale_x,
+            scale_y_aa, scale_x_aa,
+        )
+        common_kwargs = dict(SH=SH, SW=SW, BLOCK=BLOCK)
+
+        if is_upsample:
+            _upsample_bicubic2d_aa_backward_kernel_lowp_upsample[grid](
+                *common_args, **common_kwargs,
+            )
+            # bicubic2d_aa_backward_gather_kernel[grid](
+            #     *common_args, **common_kwargs,
+            # )
+        else:
+            _upsample_bicubic2d_aa_backward_kernel_lowp_downsample[grid](
+                *common_args, **common_kwargs,
+            )
+
+        # 计算完毕后 cast 回原始低精度
+        return grad_in.to(src_dtype)
+
+    else:
+        # fp32 path：grad_in 直接用 fp32，原地 atomic_add
+        grad_in = torch.zeros((n, c, in_h, in_w), device=grad_output.device, dtype=torch.float32)
+
+        go_stride_n, go_stride_c, go_stride_h, go_stride_w = grad_out.stride()
+        gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w = grad_in.stride()
+
+        _upsample_bicubic2d_aa_backward_kernel_fp32[grid](
+            grad_out,
+            grad_in,
+            n, c, in_h, in_w, out_h, out_w,
+            go_stride_n, go_stride_c, go_stride_h, go_stride_w,
+            gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w,
+            scale_y, scale_x,
+            scale_y_aa, scale_x_aa,
+            SH=SH, SW=SW, BLOCK=BLOCK,
+        )
+
+        return grad_in  # 已经是 fp32

--- a/src/flag_gems/ops/upsample_bicubic2d_aa_backward.py
+++ b/src/flag_gems/ops/upsample_bicubic2d_aa_backward.py
@@ -9,620 +9,393 @@ logger = logging.getLogger(__name__)
 
 
 @triton.jit
-def cubic_keys(x):
-    """Keys cubic filter with a = -0.5.
+def _cubic_aa_filter(x):
+    """Keys cubic filter with a = -0.5 (PIL-compatible).  x must be >= 0."""
+    return tl.where(
+        x < 1.0,
+        (1.5 * x - 2.5) * x * x + 1.0,
+        tl.where(
+            x < 2.0,
+            ((-0.5 * x + 2.5) * x - 4.0) * x + 2.0,
+            0.0,
+        ),
+    )
 
-    |x| < 1 : 1.5|x|^3 - 2.5|x|^2 + 1
-    1 <= |x| < 2 : -0.5|x|^3 + 2.5|x|^2 - 4|x| + 2
-    otherwise : 0
-    """
-    ax = tl.abs(x)
-    ax2 = ax * ax
-    ax3 = ax2 * ax
-    w_inner = 1.5 * ax3 - 2.5 * ax2 + 1.0
-    w_outer = -0.5 * ax3 + 2.5 * ax2 - 4.0 * ax + 2.0
-    return tl.where(ax < 1.0, w_inner, tl.where(ax < 2.0, w_outer, 0.0))
-
-
-# ============================================================
-# Kernel A: fp32 path
-# grad_out / grad_in 均为 fp32，直接 atomic_add，无需额外 cast
-# ============================================================
 
 @triton.jit
-def _upsample_bicubic2d_aa_backward_kernel_fp32(
-    grad_out_ptr,
-    grad_in_ptr,
-    n, c, in_h, in_w, out_h, out_w,
-    go_stride_n, go_stride_c, go_stride_h, go_stride_w,
-    gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w,
-    scale_y, scale_x,
-    scale_y_aa, scale_x_aa,
-    SH: tl.constexpr,
-    SW: tl.constexpr,
-    BLOCK: tl.constexpr,
-):
-    pid = tl.program_id(0)
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
-    total = n * c * out_h * out_w
-    mask = offs < total
+def _f2i(x):
+    """float -> int32 with clamping to avoid undefined overflow."""
+    _LO: tl.constexpr = -2147483648.0
+    _HI: tl.constexpr =  2147483520.0
+    return tl.minimum(tl.maximum(x, _LO), _HI).to(tl.int32)
 
-    x_out = offs % out_w
-    tmp   = offs // out_w
-    y_out = tmp % out_h
-    tmp   = tmp // out_h
-    c_idx = tmp % c
-    n_idx = tmp // c
-
-    y_out_f = y_out.to(tl.float32)
-    x_out_f = x_out.to(tl.float32)
-
-    y_real = (y_out_f + 0.5) * scale_y - 0.5
-    x_real = (x_out_f + 0.5) * scale_x - 0.5
-
-    support_h = 2.0 / scale_y_aa
-    support_w = 2.0 / scale_x_aa
-
-    y_in_start = (tl.floor(y_real - support_h) + 1).to(tl.int32)
-    x_in_start = (tl.floor(x_real - support_w) + 1).to(tl.int32)
-
-    go_off = (
-        n_idx.to(tl.int64) * go_stride_n
-        + c_idx.to(tl.int64) * go_stride_c
-        + y_out.to(tl.int64) * go_stride_h
-        + x_out.to(tl.int64) * go_stride_w
-    )
-    go_val = tl.load(grad_out_ptr + go_off, mask=mask, other=0.0)  # fp32
-
-    gi_base = (
-        grad_in_ptr
-        + n_idx.to(tl.int64) * gi_stride_n
-        + c_idx.to(tl.int64) * gi_stride_c
-    )
-
-    norm = tl.zeros([BLOCK], dtype=tl.float32)
-    for dh in range(SH):
-        y_in   = y_in_start + dh
-        y_in_f = y_in.to(tl.float32)
-        dist_h = (y_in_f - y_real) * scale_y_aa
-        valid_h = (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
-        w_h = tl.where(valid_h, cubic_keys(dist_h), 0.0)
-
-        for dw in range(SW):
-            x_in   = x_in_start + dw
-            x_in_f = x_in.to(tl.float32)
-            dist_w = (x_in_f - x_real) * scale_x_aa
-            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
-            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
-            norm  += w_h * w_w
-
-    norm = tl.where(norm == 0.0, 1.0, norm)
-
-    for dh in range(SH):
-        y_in   = y_in_start + dh
-        y_in_f = y_in.to(tl.float32)
-        dist_h = (y_in_f - y_real) * scale_y_aa
-        valid_h = mask & (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
-        w_h     = tl.where(valid_h, cubic_keys(dist_h), 0.0)
-
-        for dw in range(SW):
-            x_in   = x_in_start + dw
-            x_in_f = x_in.to(tl.float32)
-            dist_w = (x_in_f - x_real) * scale_x_aa
-            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
-            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
-
-            weight  = (w_h * w_w) / norm
-            contrib = go_val * weight  # fp32
-
-            gi_off = (
-                y_in.to(tl.int64) * gi_stride_h
-                + x_in.to(tl.int64) * gi_stride_w
-            )
-            tl.atomic_add(gi_base + gi_off, contrib, mask=valid)
-
-
-# ============================================================
-# Kernel B1: lowp 下采样路径（scale_y_aa < 1 或 scale_x_aa < 1）
-#
-# AA 窗口宽于一个像素，支持域 > 2，SH/SW 较大。
-# grad_out 低精度读入后立即 cast 到 fp32；
-# grad_in 是 fp32 临时 buffer，atomic_add 全程在 fp32 完成，
-# 最后由调用方 cast 回低精度。
-# 精度已满足要求，逻辑与原 lowp kernel 保持一致。
-# ============================================================
 
 @triton.jit
-def _upsample_bicubic2d_aa_backward_kernel_lowp_downsample(
-    grad_out_ptr,
-    grad_in_ptr,                        # fp32 临时 buffer
-    n, c, in_h, in_w, out_h, out_w,
-    go_stride_n, go_stride_c, go_stride_h, go_stride_w,
-    gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w,
-    scale_y, scale_x,
-    scale_y_aa, scale_x_aa,
-    SH: tl.constexpr,
-    SW: tl.constexpr,
-    BLOCK: tl.constexpr,
+def _fused_backward_kernel(
+    grad_out_ptr,       # [NC, H_out, W_out] flat
+    grad_in_ptr,        # [NC, H_in,  W_in]  flat (output)
+    # H params
+    H_in, H_out,
+    h_scale, support_h, invscale_h, inv_h_scale,
+    # W params
+    W_in, W_out,
+    w_scale, support_w, invscale_w, inv_w_scale,
+    # Stride
+    stride_go_nc,       # = H_out * W_out
+    # Compile-time constants
+    BLOCK_IW: tl.constexpr,
+    MAX_OH: tl.constexpr,
+    MAX_OW: tl.constexpr,
+    MAX_KSIZE_H: tl.constexpr,
+    MAX_KSIZE_W: tl.constexpr,
 ):
-    pid = tl.program_id(0)
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
-    total = n * c * out_h * out_w
-    mask = offs < total
+    pid_row = tl.program_id(0)          # nc * H_in + ih
+    pid_col = tl.program_id(1)          # iw tile
 
-    x_out = offs % out_w
-    tmp   = offs // out_w
-    y_out = tmp % out_h
-    tmp   = tmp // out_h
-    c_idx = tmp % c
-    n_idx = tmp // c
+    nc = pid_row // H_in
+    ih = pid_row %  H_in
+    ih_f = ih.to(tl.float32)
 
-    y_out_f = y_out.to(tl.float32)
-    x_out_f = x_out.to(tl.float32)
+    iw_base = pid_col * BLOCK_IW
+    iws = iw_base + tl.arange(0, BLOCK_IW)
+    iw_mask = iws < W_in
+    iw_f = iws.to(tl.float32)
 
-    y_real = (y_out_f + 0.5) * scale_y - 0.5
-    x_real = (x_out_f + 0.5) * scale_x - 0.5
+    # Scalar: which oh values contribute to this ih
+    oh_start = tl.maximum(
+        _f2i((ih_f + 0.5 - support_h) * inv_h_scale - 0.5), 0)
 
-    support_h = 2.0 / scale_y_aa
-    support_w = 2.0 / scale_x_aa
+    # Vector: which ow values contribute to each iw
+    ow_starts = tl.maximum(
+        _f2i((iw_f + 0.5 - support_w) * inv_w_scale - 0.5), 0)
 
-    y_in_start = (tl.floor(y_real - support_h) + 1).to(tl.int32)
-    x_in_start = (tl.floor(x_real - support_w) + 1).to(tl.int32)
+    go_nc_base = nc.to(tl.int64) * stride_go_nc
 
-    go_off = (
-        n_idx.to(tl.int64) * go_stride_n
-        + c_idx.to(tl.int64) * go_stride_c
-        + y_out.to(tl.int64) * go_stride_h
-        + x_out.to(tl.int64) * go_stride_w
-    )
-    # 低精度读入，立即 cast 到 fp32，后续所有计算在 fp32 完成
-    go_val = tl.load(grad_out_ptr + go_off, mask=mask, other=0.0).to(tl.float32)
+    accum = tl.zeros([BLOCK_IW], dtype=tl.float32)
 
-    gi_base = (
-        grad_in_ptr
-        + n_idx.to(tl.int64) * gi_stride_n
-        + c_idx.to(tl.int64) * gi_stride_c
-    )
+    # --- d_ow OUTER loop: wx computed once per d_ow, reused across d_oh ---
+    for d_ow in tl.static_range(MAX_OW):
+        ow = ow_starts + d_ow                          # vector
+        ow_valid_base = iw_mask & (ow >= 0) & (ow < W_out)
 
-    norm = tl.zeros([BLOCK], dtype=tl.float32)
-    for dh in range(SH):
-        y_in   = y_in_start + dh
-        y_in_f = y_in.to(tl.float32)
-        dist_h = (y_in_f - y_real) * scale_y_aa
-        valid_h = (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
-        w_h = tl.where(valid_h, cubic_keys(dist_h), 0.0)
+        # Compute wx (vector) — only once per d_ow
+        center_w = w_scale * (ow.to(tl.float32) + 0.5)
+        xmin_w = tl.maximum(_f2i(center_w - support_w + 0.5), 0)
+        xsize_w = tl.minimum(_f2i(center_w + support_w + 0.5), W_in) - xmin_w
+        xsize_w_pos = tl.maximum(xsize_w, 0)
+        iw_in_range = ow_valid_base & (iws >= xmin_w) & (iws < xmin_w + xsize_w_pos)
 
-        for dw in range(SW):
-            x_in   = x_in_start + dw
-            x_in_f = x_in.to(tl.float32)
-            dist_w = (x_in_f - x_real) * scale_x_aa
-            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
-            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
-            norm  += w_h * w_w
+        # Inline total_wx computation (vector)
+        xmin_w_f = xmin_w.to(tl.float32)
+        total_wx = tl.zeros([BLOCK_IW], dtype=tl.float32)
+        for j_w in tl.static_range(MAX_KSIZE_W):
+            arg_w = tl.abs((j_w + xmin_w_f - center_w + 0.5) * invscale_w)
+            w_w = _cubic_aa_filter(arg_w)
+            total_wx += tl.where(j_w < xsize_w_pos, w_w, 0.0)
 
-    norm = tl.where(norm == 0.0, 1.0, norm)
+        raw_wx = _cubic_aa_filter(tl.abs((iw_f - center_w + 0.5) * invscale_w))
+        wx = tl.where(iw_in_range & (total_wx != 0.0), raw_wx / total_wx, 0.0)
 
-    for dh in range(SH):
-        y_in   = y_in_start + dh
-        y_in_f = y_in.to(tl.float32)
-        dist_h = (y_in_f - y_real) * scale_y_aa
-        valid_h = mask & (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
-        w_h     = tl.where(valid_h, cubic_keys(dist_h), 0.0)
+        ow_safe = tl.maximum(tl.minimum(ow, W_out - 1), 0)
 
-        for dw in range(SW):
-            x_in   = x_in_start + dw
-            x_in_f = x_in.to(tl.float32)
-            dist_w = (x_in_f - x_real) * scale_x_aa
-            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
-            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
+        # --- d_oh INNER loop: wy is scalar, cheap to recompute ---
+        for d_oh in tl.static_range(MAX_OH):
+            oh = oh_start + d_oh                        # scalar
+            oh_valid = (oh >= 0) & (oh < H_out)
 
-            weight  = (w_h * w_w) / norm
-            contrib = go_val * weight       # fp32 * fp32 = fp32
+            # Compute wy (scalar)
+            center_h = h_scale * (oh + 0.5)
+            ymin_h = tl.maximum(_f2i(center_h - support_h + 0.5), 0)
+            ysize_h = tl.minimum(_f2i(center_h + support_h + 0.5), H_in) - ymin_h
+            ysize_h_pos = tl.maximum(ysize_h, 0)
+            ih_in_range = oh_valid & (ih >= ymin_h) & (ih < ymin_h + ysize_h_pos)
 
-            gi_off = (
-                y_in.to(tl.int64) * gi_stride_h
-                + x_in.to(tl.int64) * gi_stride_w
+            # Inline total_wy computation (scalar, very cheap)
+            ymin_h_f = ymin_h.to(tl.float32)
+            total_wy = 0.0
+            for j_h in tl.static_range(MAX_KSIZE_H):
+                arg_h = tl.abs((j_h + ymin_h_f - center_h + 0.5) * invscale_h)
+                w_h = _cubic_aa_filter(arg_h)
+                total_wy += tl.where(j_h < ysize_h_pos, w_h, 0.0)
+
+            raw_wy = _cubic_aa_filter(tl.abs((ih_f - center_h + 0.5) * invscale_h))
+            wy = tl.where(ih_in_range & (total_wy != 0.0), raw_wy / total_wy, 0.0)
+
+            # Load grad_out and accumulate
+            valid = iw_in_range & ih_in_range
+            oh_safe = tl.maximum(tl.minimum(oh, H_out - 1), 0)
+            g = tl.load(
+                grad_out_ptr + go_nc_base
+                + oh_safe.to(tl.int64) * W_out
+                + ow_safe.to(tl.int64),
+                mask=valid, other=0.0,
             )
-            # atomic_add 写入 fp32 buffer，避免低精度累加误差
-            tl.atomic_add(gi_base + gi_off, contrib, mask=valid)
+            accum += wy * wx * g
 
+    gi_off = pid_row.to(tl.int64) * W_in + iws.to(tl.int64)
+    tl.store(
+        grad_in_ptr + gi_off,
+        accum.to(grad_in_ptr.dtype.element_ty),
+        mask=iw_mask,
+    )
 
-# ============================================================
-# Kernel B2: lowp 上采样路径（scale_y_aa == 1 且 scale_x_aa == 1）
-#
-# 上采样时 AA 缩放因子恒为 1，支持域固定为 2（SH=SW=4），
-# 与下采样路径的数值行为完全相同，但单独拆出以便后续针对
-# 上采样的精度问题独立修复（TODO）。
-# ============================================================
 
 @triton.jit
-def bak_upsample_bicubic2d_aa_backward_kernel_lowp_upsample(
-    grad_out_ptr,
-    grad_in_ptr,                        # fp32 临时 buffer
-    n, c, in_h, in_w, out_h, out_w,
-    go_stride_n, go_stride_c, go_stride_h, go_stride_w,
-    gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w,
-    scale_y, scale_x,
-    scale_y_aa, scale_x_aa,
-    SH: tl.constexpr,
-    SW: tl.constexpr,
-    BLOCK: tl.constexpr,
+def _precompute_weight_sums_kernel(
+    total_w_ptr,
+    output_size, input_size,
+    scale, support, invscale,
+    MAX_KSIZE: tl.constexpr,
 ):
-    # TODO: 上采样低精度路径精度尚未达标，待后续专项修复。
-    #       当前实现与下采样路径逻辑一致，作为占位。
-    pid = tl.program_id(0)
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
-    total = n * c * out_h * out_w
-    mask = offs < total
+    oi = tl.program_id(0)
+    if oi >= output_size:
+        return
+    center = scale * (oi + 0.5)
+    xmin = tl.maximum(_f2i(center - support + 0.5), 0)
+    xsize = tl.minimum(_f2i(center + support + 0.5), input_size) - xmin
+    xsize = tl.minimum(tl.maximum(xsize, 0), MAX_KSIZE)
+    xmin_f = xmin.to(tl.float32)
+    total = 0.0
+    for j in tl.static_range(MAX_KSIZE):
+        arg = tl.abs((j + xmin_f - center + 0.5) * invscale)
+        w = _cubic_aa_filter(arg)
+        total += tl.where(j < xsize, w, 0.0)
+    tl.store(total_w_ptr + oi, total)
 
-    x_out = offs % out_w
-    tmp   = offs // out_w
-    y_out = tmp % out_h
-    tmp   = tmp // out_h
-    c_idx = tmp % c
-    n_idx = tmp // c
-
-    y_out_f = y_out.to(tl.float32)
-    x_out_f = x_out.to(tl.float32)
-
-    y_real = (y_out_f + 0.5) * scale_y - 0.5
-    x_real = (x_out_f + 0.5) * scale_x - 0.5
-
-    support_h = 2.0 / scale_y_aa
-    support_w = 2.0 / scale_x_aa
-
-    y_in_start = (tl.floor(y_real - support_h) + 1).to(tl.int32)
-    x_in_start = (tl.floor(x_real - support_w) + 1).to(tl.int32)
-
-    go_off = (
-        n_idx.to(tl.int64) * go_stride_n
-        + c_idx.to(tl.int64) * go_stride_c
-        + y_out.to(tl.int64) * go_stride_h
-        + x_out.to(tl.int64) * go_stride_w
-    )
-    go_val = tl.load(grad_out_ptr + go_off, mask=mask, other=0.0).to(tl.float32)
-
-    gi_base = (
-        grad_in_ptr
-        + n_idx.to(tl.int64) * gi_stride_n
-        + c_idx.to(tl.int64) * gi_stride_c
-    )
-
-    norm = tl.zeros([BLOCK], dtype=tl.float32)
-    for dh in range(SH):
-        y_in   = y_in_start + dh
-        y_in_f = y_in.to(tl.float32)
-        dist_h = (y_in_f - y_real) * scale_y_aa
-        valid_h = (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
-        w_h = tl.where(valid_h, cubic_keys(dist_h), 0.0)
-
-        for dw in range(SW):
-            x_in   = x_in_start + dw
-            x_in_f = x_in.to(tl.float32)
-            dist_w = (x_in_f - x_real) * scale_x_aa
-            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
-            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
-            norm  += w_h * w_w
-
-    norm = tl.where(norm == 0.0, 1.0, norm)
-
-    for dh in range(SH):
-        y_in   = y_in_start + dh
-        y_in_f = y_in.to(tl.float32)
-        dist_h = (y_in_f - y_real) * scale_y_aa
-        valid_h = mask & (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
-        w_h     = tl.where(valid_h, cubic_keys(dist_h), 0.0)
-
-        for dw in range(SW):
-            x_in   = x_in_start + dw
-            x_in_f = x_in.to(tl.float32)
-            dist_w = (x_in_f - x_real) * scale_x_aa
-            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
-            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
-
-            weight  = (w_h * w_w) / norm
-            contrib = go_val * weight
-
-            gi_off = (
-                y_in.to(tl.int64) * gi_stride_h
-                + x_in.to(tl.int64) * gi_stride_w
-            )
-            tl.atomic_add(gi_base + gi_off, contrib, mask=valid)
 
 @triton.jit
-def _upsample_bicubic2d_aa_backward_kernel_lowp_upsample(
-    grad_out_ptr,
-    grad_in_ptr,
-    n, c, in_h, in_w, out_h, out_w,
-    go_stride_n, go_stride_c, go_stride_h, go_stride_w,
-    gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w,
-    scale_y, scale_x,
-    scale_y_aa, scale_x_aa,
-    SH: tl.constexpr,
-    SW: tl.constexpr,
-    BLOCK: tl.constexpr,
+def _pass1_w_gather_nchw_kernel(
+    grad_out_ptr,       # [NC, H_out, W_out] flat
+    buf_ptr,            # [NC, H_out, W_in]  flat (output)
+    total_wx_ptr,       # [W_out]
+    W_in, W_out,
+    w_scale, support_w, invscale_w, inv_w_scale,
+    BLOCK_IW: tl.constexpr,
+    MAX_OW: tl.constexpr,
 ):
-    pid = tl.program_id(0)
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
-    total = n * c * out_h * out_w
-    mask = offs < total
+    pid_row = tl.program_id(0)
+    pid_col = tl.program_id(1)
 
-    x_out = offs % out_w
-    tmp   = offs // out_w
-    y_out = tmp % out_h
-    tmp   = tmp // out_h
-    c_idx = tmp % c
-    n_idx = tmp // c
+    iw_base = pid_col * BLOCK_IW
+    iws = iw_base + tl.arange(0, BLOCK_IW)
+    iw_mask = iws < W_in
+    iw_f = iws.to(tl.float32)
 
-    # ✅ Fix 1: 坐标全程用 fp32 计算，避免 bf16 的 7-bit 尾数问题
-    y_out_f = y_out.to(tl.float32)
-    x_out_f = x_out.to(tl.float32)
+    go_base = pid_row.to(tl.int64) * W_out
+    buf_base = pid_row.to(tl.int64) * W_in
 
-    # scale_y/scale_x 在上采样时 < 1，用 fp32 字面量保持精度
-    y_real = (y_out_f + 0.5) * scale_y.to(tl.float32) - 0.5
-    x_real = (x_out_f + 0.5) * scale_x.to(tl.float32) - 0.5
+    ow_starts = tl.maximum(
+        _f2i((iw_f + 0.5 - support_w) * inv_w_scale - 0.5), 0)
 
-    # 上采样时 scale_y_aa == 1.0，support == 2.0
-    support_h = 2.0 / scale_y_aa
-    support_w = 2.0 / scale_x_aa
+    accum = tl.zeros([BLOCK_IW], dtype=tl.float32)
 
-    y_in_start = (tl.math.floor(y_real - support_h) + 1.0).to(tl.int32)
-    x_in_start = (tl.math.floor(x_real - support_w) + 1.0).to(tl.int32)
+    for d_ow in tl.static_range(MAX_OW):
+        ow = ow_starts + d_ow
+        ow_valid = iw_mask & (ow >= 0) & (ow < W_out)
 
-    go_off = (
-        n_idx.to(tl.int64) * go_stride_n
-        + c_idx.to(tl.int64) * go_stride_c
-        + y_out.to(tl.int64) * go_stride_h
-        + x_out.to(tl.int64) * go_stride_w
-    )
-    go_val = tl.load(grad_out_ptr + go_off, mask=mask, other=0.0).to(tl.float32)
+        center_w = w_scale * (ow.to(tl.float32) + 0.5)
+        xmin  = tl.maximum(_f2i(center_w - support_w + 0.5), 0)
+        xsize = tl.minimum(_f2i(center_w + support_w + 0.5), W_in) - xmin
+        in_range = ow_valid & (iws >= xmin) & (iws < xmin + tl.maximum(xsize, 0))
 
-    gi_base = (
-        grad_in_ptr
-        + n_idx.to(tl.int64) * gi_stride_n
-        + c_idx.to(tl.int64) * gi_stride_c
-    )
+        raw_wx  = _cubic_aa_filter(tl.abs((iw_f - center_w + 0.5) * invscale_w))
+        ow_safe = tl.maximum(tl.minimum(ow, W_out - 1), 0)
+        tw_x    = tl.load(total_wx_ptr + ow_safe, mask=in_range, other=1.0)
+        wx      = tl.where(in_range & (tw_x != 0.0), raw_wx / tw_x, 0.0)
 
-    # ✅ Fix 2: 缓存每个 (dh, dw) 的权重，避免两次循环结果不一致
-    # SH=SW=4，共 16 个权重，全部缓存在寄存器里
-    # Triton 不支持动态索引寄存器数组，用展开的方式处理
-    # ✅ Fix 3: norm 循环加入 mask 保护，防止越界 lane 污染
-    norm = tl.zeros([BLOCK], dtype=tl.float32)
+        g = tl.load(grad_out_ptr + go_base + ow_safe.to(tl.int64),
+                     mask=in_range, other=0.0)
+        accum += wx * g
 
-    for dh in tl.static_range(SH):
-        y_in   = y_in_start + dh
-        y_in_f = y_in.to(tl.float32)
-        dist_h = (y_in_f - y_real) * scale_y_aa
-        # ✅ 加入 mask，越界 lane 不参与 norm 累积
-        valid_h = mask & (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
-        w_h = tl.where(valid_h, cubic_keys(dist_h), 0.0)
+    tl.store(buf_ptr + buf_base + iws.to(tl.int64), accum, mask=iw_mask)
 
-        for dw in tl.static_range(SW):
-            x_in   = x_in_start + dw
-            x_in_f = x_in.to(tl.float32)
-            dist_w = (x_in_f - x_real) * scale_x_aa
-            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
-            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
-            norm  += w_h * w_w
-
-    # ✅ Fix 4: norm 为 0 时用 1.0 替代，与 PyTorch 行为一致
-    norm_safe = tl.where(norm == 0.0, 1.0, norm)
-
-    for dh in tl.static_range(SH):
-        y_in   = y_in_start + dh
-        y_in_f = y_in.to(tl.float32)
-        dist_h = (y_in_f - y_real) * scale_y_aa
-        valid_h = mask & (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
-        w_h     = tl.where(valid_h, cubic_keys(dist_h), 0.0)
-
-        for dw in tl.static_range(SW):
-            x_in   = x_in_start + dw
-            x_in_f = x_in.to(tl.float32)
-            dist_w = (x_in_f - x_real) * scale_x_aa
-            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
-            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
-
-            # ✅ Fix 5: weight 和 contrib 全程 fp32，最后再除以 norm_safe
-            weight  = (w_h * w_w) / norm_safe
-            contrib = go_val * weight
-
-            gi_off = (
-                y_in.to(tl.int64) * gi_stride_h
-                + x_in.to(tl.int64) * gi_stride_w
-            )
-            tl.atomic_add(gi_base + gi_off, contrib, mask=valid)
 
 @triton.jit
-def v2_upsample_bicubic2d_aa_backward_kernel_lowp_upsample(
-    grad_out_ptr,
-    grad_in_ptr,
-    n, c, in_h, in_w, out_h, out_w,
-    go_stride_n, go_stride_c, go_stride_h, go_stride_w,
-    gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w,
-    scale_y, scale_x,
-    scale_y_aa, scale_x_aa,
-    SH: tl.constexpr,
-    SW: tl.constexpr,
-    BLOCK: tl.constexpr,
+def _pass2_h_gather_nchw_kernel(
+    buf_ptr,            # [NC, H_out, W_in] flat (input)
+    grad_in_ptr,        # [NC, H_in,  W_in] flat (output)
+    total_wy_ptr,       # [H_out]
+    H_in, W_in, H_out,
+    h_scale, support_h, invscale_h, inv_h_scale,
+    stride_buf_hw,      # = H_out * W_in
+    BLOCK_IW: tl.constexpr,
+    MAX_OH: tl.constexpr,
 ):
-    pid = tl.program_id(0)
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
-    total = n * c * out_h * out_w
-    mask = offs < total
+    pid_row = tl.program_id(0)
+    pid_col = tl.program_id(1)
 
-    x_out = offs % out_w
-    tmp   = offs // out_w
-    y_out = tmp % out_h
-    tmp   = tmp // out_h
-    c_idx = tmp % c
-    n_idx = tmp // c
+    nc = pid_row // H_in
+    ih = pid_row %  H_in
+    ih_f = ih.to(tl.float32)
 
-    y_out_f = y_out.to(tl.float32)
-    x_out_f = x_out.to(tl.float32)
+    iw_base = pid_col * BLOCK_IW
+    iws = iw_base + tl.arange(0, BLOCK_IW)
+    iw_mask = iws < W_in
 
-    y_real = (y_out_f + 0.5) * scale_y - 0.5
-    x_real = (x_out_f + 0.5) * scale_x - 0.5
+    oh_start = tl.maximum(
+        _f2i((ih_f + 0.5 - support_h) * inv_h_scale - 0.5), 0)
 
-    # 上采样时 scale_y_aa == scale_x_aa == 1.0，support 固定为 2.0
-    support_h = 2.0 / scale_y_aa
-    support_w = 2.0 / scale_x_aa
+    buf_nc_base = nc.to(tl.int64) * stride_buf_hw
 
-    y_in_start = (tl.floor(y_real - support_h) + 1).to(tl.int32)
-    x_in_start = (tl.floor(x_real - support_w) + 1).to(tl.int32)
+    accum = tl.zeros([BLOCK_IW], dtype=tl.float32)
 
-    go_off = (
-        n_idx.to(tl.int64) * go_stride_n
-        + c_idx.to(tl.int64) * go_stride_c
-        + y_out.to(tl.int64) * go_stride_h
-        + x_out.to(tl.int64) * go_stride_w
+    for d_oh in tl.static_range(MAX_OH):
+        oh = oh_start + d_oh
+        oh_valid = (oh >= 0) & (oh < H_out)
+
+        center_h = h_scale * (oh + 0.5)
+        ymin  = tl.maximum(_f2i(center_h - support_h + 0.5), 0)
+        ysize = tl.minimum(_f2i(center_h + support_h + 0.5), H_in) - ymin
+        ih_in_range = oh_valid & (ih >= ymin) & (ih < ymin + tl.maximum(ysize, 0))
+
+        raw_wy  = _cubic_aa_filter(tl.abs((ih_f - center_h + 0.5) * invscale_h))
+        oh_safe = tl.maximum(tl.minimum(oh, H_out - 1), 0)
+        tw_y    = tl.load(total_wy_ptr + oh_safe)
+        wy      = tl.where(ih_in_range & (tw_y != 0.0), raw_wy / tw_y, 0.0)
+
+        buf_off = buf_nc_base + oh_safe.to(tl.int64) * W_in + iws.to(tl.int64)
+        b = tl.load(buf_ptr + buf_off, mask=iw_mask & ih_in_range, other=0.0)
+
+        accum += wy * b
+
+    gi_off = pid_row.to(tl.int64) * W_in + iws.to(tl.int64)
+    tl.store(
+        grad_in_ptr + gi_off,
+        accum.to(grad_in_ptr.dtype.element_ty),
+        mask=iw_mask,
     )
-    go_val = tl.load(grad_out_ptr + go_off, mask=mask, other=0.0).to(tl.float32)
 
-    gi_base = (
-        grad_in_ptr
-        + n_idx.to(tl.int64) * gi_stride_n
-        + c_idx.to(tl.int64) * gi_stride_c
-    )
 
-    # ── Pass 1: 计算 norm ─────────────────────────────────────────
-    # Fix 1: valid_h 必须包含外层 mask，与 scatter 循环保持完全一致
-    # 否则越界 lane 的垃圾坐标会产生非零 cubic_keys 值污染 norm
-    norm = tl.zeros([BLOCK], dtype=tl.float32)
-    for dh in tl.static_range(SH):   # Fix 4: constexpr 循环用 static_range
-        y_in   = y_in_start + dh
-        y_in_f = y_in.to(tl.float32)
-        dist_h = (y_in_f - y_real) * scale_y_aa
-        valid_h = mask & (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
-        w_h = tl.where(valid_h, cubic_keys(dist_h), 0.0)
+def _compute_scale(input_size, output_size, align_corners, scale=None):
+    if align_corners:
+        return float(input_size - 1) / (output_size - 1) if output_size > 1 else 0.0
+    else:
+        return (1.0 / scale) if (scale is not None and scale > 0) \
+            else float(input_size) / output_size
 
-        for dw in tl.static_range(SW):
-            x_in   = x_in_start + dw
-            x_in_f = x_in.to(tl.float32)
-            dist_w = (x_in_f - x_real) * scale_x_aa
-            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
-            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
-            norm  += w_h * w_w
 
-    # Fix 3: 分离 norm_safe，不覆盖 norm（虽然 pass 1 结束后 norm 本身
-    # 不再被读写，但显式分离变量名可防止后续维护时意外引入 Bug）
-    norm_safe = tl.where(norm == 0.0, 1.0, norm)
+# Threshold: when total elements (across the larger of input / output spatial)
+# is below this, the fused single-kernel path is used (1 launch instead of 4).
+# Above this, the 2-pass separable path is more memory-bandwidth efficient.
+_FUSE_THRESHOLD = 1 << 20       # 1M elements
 
-    # ── Pass 2: scatter 梯度 ──────────────────────────────────────
-    # valid_h 定义与 Pass 1 完全一致（含 mask），保证两次 cubic_keys
-    # 的输入相同，weight = (w_h * w_w) / norm_safe 分子分母匹配
-    for dh in tl.static_range(SH):
-        y_in   = y_in_start + dh
-        y_in_f = y_in.to(tl.float32)
-        dist_h = (y_in_f - y_real) * scale_y_aa
-        valid_h = mask & (y_in >= 0) & (y_in < in_h) & (tl.abs(dist_h) < 2.0)
-        w_h     = tl.where(valid_h, cubic_keys(dist_h), 0.0)
-
-        for dw in tl.static_range(SW):
-            x_in   = x_in_start + dw
-            x_in_f = x_in.to(tl.float32)
-            dist_w = (x_in_f - x_real) * scale_x_aa
-            valid  = valid_h & (x_in >= 0) & (x_in < in_w) & (tl.abs(dist_w) < 2.0)
-            w_w    = tl.where(valid, cubic_keys(dist_w), 0.0)
-
-            weight  = (w_h * w_w) / norm_safe
-            contrib = go_val * weight
-
-            gi_off = (
-                y_in.to(tl.int64) * gi_stride_h
-                + x_in.to(tl.int64) * gi_stride_w
-            )
-            tl.atomic_add(gi_base + gi_off, contrib, mask=valid)
-# ============================================================
-# Python 入口
-# ============================================================
 
 def _upsample_bicubic2d_aa_backward(
     grad_output: torch.Tensor,
-    output_size,
-    input_size,
+    output_size,        # [H_out, W_out]
+    input_size,         # [N, C, H_in, W_in]
     align_corners: bool,
     scales_h=None,
     scales_w=None,
-):
-    assert grad_output.is_cuda
+) -> torch.Tensor:
+    N, C, H_in, W_in = input_size
+    H_out, W_out = output_size
 
-    n, c, in_h, in_w = input_size
-    out_h, out_w = output_size
+    assert grad_output.shape == (N, C, H_out, W_out), (
+        f"grad_output shape {grad_output.shape} != "
+        f"expected ({N}, {C}, {H_out}, {W_out})"
+    )
 
-    grad_out = grad_output.contiguous()
-    src_dtype = grad_output.dtype
+    NC = N * C
+    if NC == 0 or H_in == 0 or W_in == 0 or H_out == 0 or W_out == 0:
+        return grad_output.new_zeros(input_size)
 
-    if align_corners:
-        scale_y = (in_h - 1) / (out_h - 1) if (in_h > 1 and out_h > 1) else 0.0
-        scale_x = (in_w - 1) / (out_w - 1) if (in_w > 1 and out_w > 1) else 0.0
-    else:
-        scale_y = in_h / out_h
-        scale_x = in_w / out_w
+    # ---- Work in NCHW — zero-copy reshape to [NC, H, W] ----
+    grad_out_flat = grad_output.contiguous().reshape(NC, H_out, W_out)
 
-    scale_y_aa = min(1.0 / scale_y, 1.0) if scale_y > 0 else 1.0
-    scale_x_aa = min(1.0 / scale_x, 1.0) if scale_x > 0 else 1.0
+    # ---- Scales & filter parameters ----
+    h_scale = _compute_scale(H_in, H_out, align_corners, scales_h)
+    w_scale = _compute_scale(W_in, W_out, align_corners, scales_w)
 
-    SH = int(math.ceil(4.0 / scale_y_aa)) + 2
-    SW = int(math.ceil(4.0 / scale_x_aa)) + 2
+    INTERP_SIZE = 4
+    support_h = (INTERP_SIZE * 0.5) * h_scale if h_scale >= 1.0 else INTERP_SIZE * 0.5
+    support_w = (INTERP_SIZE * 0.5) * w_scale if w_scale >= 1.0 else INTERP_SIZE * 0.5
+    invscale_h = 1.0 / h_scale if h_scale >= 1.0 else 1.0
+    invscale_w = 1.0 / w_scale if w_scale >= 1.0 else 1.0
 
-    BLOCK = 128
-    grid = (triton.cdiv(n * c * out_h * out_w, BLOCK),)
+    MAX_KSIZE_H = math.ceil(support_h) * 2 + 1
+    MAX_KSIZE_W = math.ceil(support_w) * 2 + 1
 
-    is_lowp = src_dtype in (torch.float16, torch.bfloat16)
+    _EPS = 1e-10
+    inv_h_scale = 1.0 / max(h_scale, _EPS)
+    inv_w_scale = 1.0 / max(w_scale, _EPS)
 
-    # 判断是否为上采样：两个方向的 AA 缩放因子均为 1.0 时为上采样。
-    # （下采样时至少有一个方向 scale_y_aa < 1 或 scale_x_aa < 1）
-    is_upsample = (scale_y_aa == 1.0) and (scale_x_aa == 1.0)
+    MAX_OH = min(math.ceil(2 * support_h * inv_h_scale) + 2, max(H_out, 1))
+    MAX_OW = min(math.ceil(2 * support_w * inv_w_scale) + 2, max(W_out, 1))
 
-    if is_lowp:
-        # fp32 临时 buffer，kernel 内 atomic_add 全程 fp32
-        grad_in = torch.zeros((n, c, in_h, in_w), device=grad_output.device, dtype=torch.float32)
+    # ---- BLOCK_IW & num_warps ----
+    BLOCK_IW = min(triton.next_power_of_2(max(W_in, 1)), 256)
+    if BLOCK_IW < 32:
+        BLOCK_IW = 32
+    nw = 1 if BLOCK_IW <= 32 else (2 if BLOCK_IW <= 64 else 4)
 
-        go_stride_n, go_stride_c, go_stride_h, go_stride_w = grad_out.stride()
-        gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w = grad_in.stride()
+    # ---- Choose fused vs 2-pass ----
+    total_elems = NC * max(H_in * W_in, H_out * W_out)
+    use_fused = total_elems <= _FUSE_THRESHOLD
 
-        common_args = (
-            grad_out,
-            grad_in,
-            n, c, in_h, in_w, out_h, out_w,
-            go_stride_n, go_stride_c, go_stride_h, go_stride_w,
-            gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w,
-            scale_y, scale_x,
-            scale_y_aa, scale_x_aa,
+    if use_fused:
+        # ============================================================
+        # FUSED PATH — single kernel launch, no intermediate buffer
+        # ============================================================
+        grad_in_flat = torch.empty(NC, H_in, W_in, dtype=grad_output.dtype,
+                                   device=grad_output.device)
+        grid = (NC * H_in, triton.cdiv(W_in, BLOCK_IW))
+        _fused_backward_kernel[grid](
+            grad_out_flat, grad_in_flat,
+            H_in, H_out,
+            h_scale, support_h, invscale_h, inv_h_scale,
+            W_in, W_out,
+            w_scale, support_w, invscale_w, inv_w_scale,
+            H_out * W_out,          # stride_go_nc
+            BLOCK_IW=BLOCK_IW, MAX_OH=MAX_OH, MAX_OW=MAX_OW,
+            MAX_KSIZE_H=MAX_KSIZE_H, MAX_KSIZE_W=MAX_KSIZE_W,
+            num_warps=nw,
         )
-        common_kwargs = dict(SH=SH, SW=SW, BLOCK=BLOCK)
-
-        if is_upsample:
-            _upsample_bicubic2d_aa_backward_kernel_lowp_upsample[grid](
-                *common_args, **common_kwargs,
-            )
-            # bicubic2d_aa_backward_gather_kernel[grid](
-            #     *common_args, **common_kwargs,
-            # )
-        else:
-            _upsample_bicubic2d_aa_backward_kernel_lowp_downsample[grid](
-                *common_args, **common_kwargs,
-            )
-
-        # 计算完毕后 cast 回原始低精度
-        return grad_in.to(src_dtype)
+        return grad_in_flat.reshape(N, C, H_in, W_in)
 
     else:
-        # fp32 path：grad_in 直接用 fp32，原地 atomic_add
-        grad_in = torch.zeros((n, c, in_h, in_w), device=grad_output.device, dtype=torch.float32)
+        # ============================================================
+        # 2-PASS PATH — separable, memory-bandwidth efficient for big tensors
+        # ============================================================
 
-        go_stride_n, go_stride_c, go_stride_h, go_stride_w = grad_out.stride()
-        gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w = grad_in.stride()
+        # Phase 0: precompute weight sums
+        total_wy = torch.empty(max(H_out, 1), dtype=torch.float32,
+                               device=grad_output.device)
+        total_wx = torch.empty(max(W_out, 1), dtype=torch.float32,
+                               device=grad_output.device)
+        if H_out > 0:
+            _precompute_weight_sums_kernel[(H_out,)](
+                total_wy, H_out, H_in, h_scale, support_h, invscale_h,
+                MAX_KSIZE=MAX_KSIZE_H)
+        if W_out > 0:
+            _precompute_weight_sums_kernel[(W_out,)](
+                total_wx, W_out, W_in, w_scale, support_w, invscale_w,
+                MAX_KSIZE=MAX_KSIZE_W)
 
-        _upsample_bicubic2d_aa_backward_kernel_fp32[grid](
-            grad_out,
-            grad_in,
-            n, c, in_h, in_w, out_h, out_w,
-            go_stride_n, go_stride_c, go_stride_h, go_stride_w,
-            gi_stride_n, gi_stride_c, gi_stride_h, gi_stride_w,
-            scale_y, scale_x,
-            scale_y_aa, scale_x_aa,
-            SH=SH, SW=SW, BLOCK=BLOCK,
+        # Phase 1: W-gather -> buf [NC, H_out, W_in]
+        buf = torch.empty(NC, H_out, W_in, dtype=torch.float32,
+                          device=grad_output.device)
+        grid1 = (NC * H_out, triton.cdiv(W_in, BLOCK_IW))
+        _pass1_w_gather_nchw_kernel[grid1](
+            grad_out_flat, buf, total_wx,
+            W_in, W_out,
+            w_scale, support_w, invscale_w, inv_w_scale,
+            BLOCK_IW=BLOCK_IW, MAX_OW=MAX_OW,
+            num_warps=nw,
         )
 
-        return grad_in  # 已经是 fp32
+        # Phase 2: H-gather -> grad_in [NC, H_in, W_in]
+        grad_in_flat = torch.empty(NC, H_in, W_in, dtype=grad_output.dtype,
+                                   device=grad_output.device)
+        grid2 = (NC * H_in, triton.cdiv(W_in, BLOCK_IW))
+        _pass2_h_gather_nchw_kernel[grid2](
+            buf, grad_in_flat, total_wy,
+            H_in, W_in, H_out,
+            h_scale, support_h, invscale_h, inv_h_scale,
+            H_out * W_in,           # stride_buf_hw
+            BLOCK_IW=BLOCK_IW, MAX_OH=MAX_OH,
+            num_warps=nw,
+        )
+
+        return grad_in_flat.reshape(N, C, H_in, W_in)
+

--- a/src/flag_gems/ops/upsample_bicubic2d_aa_backward.py
+++ b/src/flag_gems/ops/upsample_bicubic2d_aa_backward.py
@@ -1,5 +1,5 @@
-import math
 import logging
+import math
 
 import torch
 import triton
@@ -26,22 +26,30 @@ def _cubic_aa_filter(x):
 def _f2i(x):
     """float -> int32 with clamping to avoid undefined overflow."""
     _LO: tl.constexpr = -2147483648.0
-    _HI: tl.constexpr =  2147483520.0
+    _HI: tl.constexpr = 2147483520.0
     return tl.minimum(tl.maximum(x, _LO), _HI).to(tl.int32)
 
 
 @triton.jit
 def _fused_backward_kernel(
-    grad_out_ptr,       # [NC, H_out, W_out] flat
-    grad_in_ptr,        # [NC, H_in,  W_in]  flat (output)
+    grad_out_ptr,  # [NC, H_out, W_out] flat
+    grad_in_ptr,  # [NC, H_in,  W_in]  flat (output)
     # H params
-    H_in, H_out,
-    h_scale, support_h, invscale_h, inv_h_scale,
+    H_in,
+    H_out,
+    h_scale,
+    support_h,
+    invscale_h,
+    inv_h_scale,
     # W params
-    W_in, W_out,
-    w_scale, support_w, invscale_w, inv_w_scale,
+    W_in,
+    W_out,
+    w_scale,
+    support_w,
+    invscale_w,
+    inv_w_scale,
     # Stride
-    stride_go_nc,       # = H_out * W_out
+    stride_go_nc,  # = H_out * W_out
     # Compile-time constants
     BLOCK_IW: tl.constexpr,
     MAX_OH: tl.constexpr,
@@ -49,11 +57,11 @@ def _fused_backward_kernel(
     MAX_KSIZE_H: tl.constexpr,
     MAX_KSIZE_W: tl.constexpr,
 ):
-    pid_row = tl.program_id(0)          # nc * H_in + ih
-    pid_col = tl.program_id(1)          # iw tile
+    pid_row = tl.program_id(0)  # nc * H_in + ih
+    pid_col = tl.program_id(1)  # iw tile
 
     nc = pid_row // H_in
-    ih = pid_row %  H_in
+    ih = pid_row % H_in
     ih_f = ih.to(tl.float32)
 
     iw_base = pid_col * BLOCK_IW
@@ -62,12 +70,10 @@ def _fused_backward_kernel(
     iw_f = iws.to(tl.float32)
 
     # Scalar: which oh values contribute to this ih
-    oh_start = tl.maximum(
-        _f2i((ih_f + 0.5 - support_h) * inv_h_scale - 0.5), 0)
+    oh_start = tl.maximum(_f2i((ih_f + 0.5 - support_h) * inv_h_scale - 0.5), 0)
 
     # Vector: which ow values contribute to each iw
-    ow_starts = tl.maximum(
-        _f2i((iw_f + 0.5 - support_w) * inv_w_scale - 0.5), 0)
+    ow_starts = tl.maximum(_f2i((iw_f + 0.5 - support_w) * inv_w_scale - 0.5), 0)
 
     go_nc_base = nc.to(tl.int64) * stride_go_nc
 
@@ -75,7 +81,7 @@ def _fused_backward_kernel(
 
     # --- d_ow OUTER loop: wx computed once per d_ow, reused across d_oh ---
     for d_ow in tl.static_range(MAX_OW):
-        ow = ow_starts + d_ow                          # vector
+        ow = ow_starts + d_ow  # vector
         ow_valid_base = iw_mask & (ow >= 0) & (ow < W_out)
 
         # Compute wx (vector) — only once per d_ow
@@ -100,7 +106,7 @@ def _fused_backward_kernel(
 
         # --- d_oh INNER loop: wy is scalar, cheap to recompute ---
         for d_oh in tl.static_range(MAX_OH):
-            oh = oh_start + d_oh                        # scalar
+            oh = oh_start + d_oh  # scalar
             oh_valid = (oh >= 0) & (oh < H_out)
 
             # Compute wy (scalar)
@@ -125,10 +131,12 @@ def _fused_backward_kernel(
             valid = iw_in_range & ih_in_range
             oh_safe = tl.maximum(tl.minimum(oh, H_out - 1), 0)
             g = tl.load(
-                grad_out_ptr + go_nc_base
+                grad_out_ptr
+                + go_nc_base
                 + oh_safe.to(tl.int64) * W_out
                 + ow_safe.to(tl.int64),
-                mask=valid, other=0.0,
+                mask=valid,
+                other=0.0,
             )
             accum += wy * wx * g
 
@@ -143,8 +151,11 @@ def _fused_backward_kernel(
 @triton.jit
 def _precompute_weight_sums_kernel(
     total_w_ptr,
-    output_size, input_size,
-    scale, support, invscale,
+    output_size,
+    input_size,
+    scale,
+    support,
+    invscale,
     MAX_KSIZE: tl.constexpr,
 ):
     oi = tl.program_id(0)
@@ -165,11 +176,15 @@ def _precompute_weight_sums_kernel(
 
 @triton.jit
 def _pass1_w_gather_nchw_kernel(
-    grad_out_ptr,       # [NC, H_out, W_out] flat
-    buf_ptr,            # [NC, H_out, W_in]  flat (output)
-    total_wx_ptr,       # [W_out]
-    W_in, W_out,
-    w_scale, support_w, invscale_w, inv_w_scale,
+    grad_out_ptr,  # [NC, H_out, W_out] flat
+    buf_ptr,  # [NC, H_out, W_in]  flat (output)
+    total_wx_ptr,  # [W_out]
+    W_in,
+    W_out,
+    w_scale,
+    support_w,
+    invscale_w,
+    inv_w_scale,
     BLOCK_IW: tl.constexpr,
     MAX_OW: tl.constexpr,
 ):
@@ -184,8 +199,7 @@ def _pass1_w_gather_nchw_kernel(
     go_base = pid_row.to(tl.int64) * W_out
     buf_base = pid_row.to(tl.int64) * W_in
 
-    ow_starts = tl.maximum(
-        _f2i((iw_f + 0.5 - support_w) * inv_w_scale - 0.5), 0)
+    ow_starts = tl.maximum(_f2i((iw_f + 0.5 - support_w) * inv_w_scale - 0.5), 0)
 
     accum = tl.zeros([BLOCK_IW], dtype=tl.float32)
 
@@ -194,17 +208,18 @@ def _pass1_w_gather_nchw_kernel(
         ow_valid = iw_mask & (ow >= 0) & (ow < W_out)
 
         center_w = w_scale * (ow.to(tl.float32) + 0.5)
-        xmin  = tl.maximum(_f2i(center_w - support_w + 0.5), 0)
+        xmin = tl.maximum(_f2i(center_w - support_w + 0.5), 0)
         xsize = tl.minimum(_f2i(center_w + support_w + 0.5), W_in) - xmin
         in_range = ow_valid & (iws >= xmin) & (iws < xmin + tl.maximum(xsize, 0))
 
-        raw_wx  = _cubic_aa_filter(tl.abs((iw_f - center_w + 0.5) * invscale_w))
+        raw_wx = _cubic_aa_filter(tl.abs((iw_f - center_w + 0.5) * invscale_w))
         ow_safe = tl.maximum(tl.minimum(ow, W_out - 1), 0)
-        tw_x    = tl.load(total_wx_ptr + ow_safe, mask=in_range, other=1.0)
-        wx      = tl.where(in_range & (tw_x != 0.0), raw_wx / tw_x, 0.0)
+        tw_x = tl.load(total_wx_ptr + ow_safe, mask=in_range, other=1.0)
+        wx = tl.where(in_range & (tw_x != 0.0), raw_wx / tw_x, 0.0)
 
-        g = tl.load(grad_out_ptr + go_base + ow_safe.to(tl.int64),
-                     mask=in_range, other=0.0)
+        g = tl.load(
+            grad_out_ptr + go_base + ow_safe.to(tl.int64), mask=in_range, other=0.0
+        )
         accum += wx * g
 
     tl.store(buf_ptr + buf_base + iws.to(tl.int64), accum, mask=iw_mask)
@@ -212,12 +227,17 @@ def _pass1_w_gather_nchw_kernel(
 
 @triton.jit
 def _pass2_h_gather_nchw_kernel(
-    buf_ptr,            # [NC, H_out, W_in] flat (input)
-    grad_in_ptr,        # [NC, H_in,  W_in] flat (output)
-    total_wy_ptr,       # [H_out]
-    H_in, W_in, H_out,
-    h_scale, support_h, invscale_h, inv_h_scale,
-    stride_buf_hw,      # = H_out * W_in
+    buf_ptr,  # [NC, H_out, W_in] flat (input)
+    grad_in_ptr,  # [NC, H_in,  W_in] flat (output)
+    total_wy_ptr,  # [H_out]
+    H_in,
+    W_in,
+    H_out,
+    h_scale,
+    support_h,
+    invscale_h,
+    inv_h_scale,
+    stride_buf_hw,  # = H_out * W_in
     BLOCK_IW: tl.constexpr,
     MAX_OH: tl.constexpr,
 ):
@@ -225,15 +245,14 @@ def _pass2_h_gather_nchw_kernel(
     pid_col = tl.program_id(1)
 
     nc = pid_row // H_in
-    ih = pid_row %  H_in
+    ih = pid_row % H_in
     ih_f = ih.to(tl.float32)
 
     iw_base = pid_col * BLOCK_IW
     iws = iw_base + tl.arange(0, BLOCK_IW)
     iw_mask = iws < W_in
 
-    oh_start = tl.maximum(
-        _f2i((ih_f + 0.5 - support_h) * inv_h_scale - 0.5), 0)
+    oh_start = tl.maximum(_f2i((ih_f + 0.5 - support_h) * inv_h_scale - 0.5), 0)
 
     buf_nc_base = nc.to(tl.int64) * stride_buf_hw
 
@@ -244,14 +263,14 @@ def _pass2_h_gather_nchw_kernel(
         oh_valid = (oh >= 0) & (oh < H_out)
 
         center_h = h_scale * (oh + 0.5)
-        ymin  = tl.maximum(_f2i(center_h - support_h + 0.5), 0)
+        ymin = tl.maximum(_f2i(center_h - support_h + 0.5), 0)
         ysize = tl.minimum(_f2i(center_h + support_h + 0.5), H_in) - ymin
         ih_in_range = oh_valid & (ih >= ymin) & (ih < ymin + tl.maximum(ysize, 0))
 
-        raw_wy  = _cubic_aa_filter(tl.abs((ih_f - center_h + 0.5) * invscale_h))
+        raw_wy = _cubic_aa_filter(tl.abs((ih_f - center_h + 0.5) * invscale_h))
         oh_safe = tl.maximum(tl.minimum(oh, H_out - 1), 0)
-        tw_y    = tl.load(total_wy_ptr + oh_safe)
-        wy      = tl.where(ih_in_range & (tw_y != 0.0), raw_wy / tw_y, 0.0)
+        tw_y = tl.load(total_wy_ptr + oh_safe)
+        wy = tl.where(ih_in_range & (tw_y != 0.0), raw_wy / tw_y, 0.0)
 
         buf_off = buf_nc_base + oh_safe.to(tl.int64) * W_in + iws.to(tl.int64)
         b = tl.load(buf_ptr + buf_off, mask=iw_mask & ih_in_range, other=0.0)
@@ -270,20 +289,23 @@ def _compute_scale(input_size, output_size, align_corners, scale=None):
     if align_corners:
         return float(input_size - 1) / (output_size - 1) if output_size > 1 else 0.0
     else:
-        return (1.0 / scale) if (scale is not None and scale > 0) \
+        return (
+            (1.0 / scale)
+            if (scale is not None and scale > 0)
             else float(input_size) / output_size
+        )
 
 
 # Threshold: when total elements (across the larger of input / output spatial)
 # is below this, the fused single-kernel path is used (1 launch instead of 4).
 # Above this, the 2-pass separable path is more memory-bandwidth efficient.
-_FUSE_THRESHOLD = 1 << 20       # 1M elements
+_FUSE_THRESHOLD = 1 << 20  # 1M elements
 
 
 def _upsample_bicubic2d_aa_backward(
     grad_output: torch.Tensor,
-    output_size,        # [H_out, W_out]
-    input_size,         # [N, C, H_in, W_in]
+    output_size,  # [H_out, W_out]
+    input_size,  # [N, C, H_in, W_in]
     align_corners: bool,
     scales_h=None,
     scales_w=None,
@@ -337,18 +359,31 @@ def _upsample_bicubic2d_aa_backward(
         # ============================================================
         # FUSED PATH — single kernel launch, no intermediate buffer
         # ============================================================
-        grad_in_flat = torch.empty(NC, H_in, W_in, dtype=grad_output.dtype,
-                                   device=grad_output.device)
+        grad_in_flat = torch.empty(
+            NC, H_in, W_in, dtype=grad_output.dtype, device=grad_output.device
+        )
         grid = (NC * H_in, triton.cdiv(W_in, BLOCK_IW))
         _fused_backward_kernel[grid](
-            grad_out_flat, grad_in_flat,
-            H_in, H_out,
-            h_scale, support_h, invscale_h, inv_h_scale,
-            W_in, W_out,
-            w_scale, support_w, invscale_w, inv_w_scale,
-            H_out * W_out,          # stride_go_nc
-            BLOCK_IW=BLOCK_IW, MAX_OH=MAX_OH, MAX_OW=MAX_OW,
-            MAX_KSIZE_H=MAX_KSIZE_H, MAX_KSIZE_W=MAX_KSIZE_W,
+            grad_out_flat,
+            grad_in_flat,
+            H_in,
+            H_out,
+            h_scale,
+            support_h,
+            invscale_h,
+            inv_h_scale,
+            W_in,
+            W_out,
+            w_scale,
+            support_w,
+            invscale_w,
+            inv_w_scale,
+            H_out * W_out,  # stride_go_nc
+            BLOCK_IW=BLOCK_IW,
+            MAX_OH=MAX_OH,
+            MAX_OW=MAX_OW,
+            MAX_KSIZE_H=MAX_KSIZE_H,
+            MAX_KSIZE_W=MAX_KSIZE_W,
             num_warps=nw,
         )
         return grad_in_flat.reshape(N, C, H_in, W_in)
@@ -359,43 +394,73 @@ def _upsample_bicubic2d_aa_backward(
         # ============================================================
 
         # Phase 0: precompute weight sums
-        total_wy = torch.empty(max(H_out, 1), dtype=torch.float32,
-                               device=grad_output.device)
-        total_wx = torch.empty(max(W_out, 1), dtype=torch.float32,
-                               device=grad_output.device)
+        total_wy = torch.empty(
+            max(H_out, 1), dtype=torch.float32, device=grad_output.device
+        )
+        total_wx = torch.empty(
+            max(W_out, 1), dtype=torch.float32, device=grad_output.device
+        )
         if H_out > 0:
             _precompute_weight_sums_kernel[(H_out,)](
-                total_wy, H_out, H_in, h_scale, support_h, invscale_h,
-                MAX_KSIZE=MAX_KSIZE_H)
+                total_wy,
+                H_out,
+                H_in,
+                h_scale,
+                support_h,
+                invscale_h,
+                MAX_KSIZE=MAX_KSIZE_H,
+            )
         if W_out > 0:
             _precompute_weight_sums_kernel[(W_out,)](
-                total_wx, W_out, W_in, w_scale, support_w, invscale_w,
-                MAX_KSIZE=MAX_KSIZE_W)
+                total_wx,
+                W_out,
+                W_in,
+                w_scale,
+                support_w,
+                invscale_w,
+                MAX_KSIZE=MAX_KSIZE_W,
+            )
 
         # Phase 1: W-gather -> buf [NC, H_out, W_in]
-        buf = torch.empty(NC, H_out, W_in, dtype=torch.float32,
-                          device=grad_output.device)
+        buf = torch.empty(
+            NC, H_out, W_in, dtype=torch.float32, device=grad_output.device
+        )
         grid1 = (NC * H_out, triton.cdiv(W_in, BLOCK_IW))
         _pass1_w_gather_nchw_kernel[grid1](
-            grad_out_flat, buf, total_wx,
-            W_in, W_out,
-            w_scale, support_w, invscale_w, inv_w_scale,
-            BLOCK_IW=BLOCK_IW, MAX_OW=MAX_OW,
+            grad_out_flat,
+            buf,
+            total_wx,
+            W_in,
+            W_out,
+            w_scale,
+            support_w,
+            invscale_w,
+            inv_w_scale,
+            BLOCK_IW=BLOCK_IW,
+            MAX_OW=MAX_OW,
             num_warps=nw,
         )
 
         # Phase 2: H-gather -> grad_in [NC, H_in, W_in]
-        grad_in_flat = torch.empty(NC, H_in, W_in, dtype=grad_output.dtype,
-                                   device=grad_output.device)
+        grad_in_flat = torch.empty(
+            NC, H_in, W_in, dtype=grad_output.dtype, device=grad_output.device
+        )
         grid2 = (NC * H_in, triton.cdiv(W_in, BLOCK_IW))
         _pass2_h_gather_nchw_kernel[grid2](
-            buf, grad_in_flat, total_wy,
-            H_in, W_in, H_out,
-            h_scale, support_h, invscale_h, inv_h_scale,
-            H_out * W_in,           # stride_buf_hw
-            BLOCK_IW=BLOCK_IW, MAX_OH=MAX_OH,
+            buf,
+            grad_in_flat,
+            total_wy,
+            H_in,
+            W_in,
+            H_out,
+            h_scale,
+            support_h,
+            invscale_h,
+            inv_h_scale,
+            H_out * W_in,  # stride_buf_hw
+            BLOCK_IW=BLOCK_IW,
+            MAX_OH=MAX_OH,
             num_warps=nw,
         )
 
         return grad_in_flat.reshape(N, C, H_in, W_in)
-

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -2684,3 +2684,108 @@ def test_accuracy_select_backward_small_and_edge(dtype):
         )
 
     gems_assert_close(res_out, ref_out, dtype)
+
+
+def upsample_bicubic2d_aa_backward_call(grad, input_size, align_corners):
+    orig_shape = tuple(input_size)
+    n = 1
+    for s in orig_shape[:-2]:
+        n *= s
+    c = orig_shape[-2] if len(orig_shape) >= 2 else 1
+    in_h = orig_shape[-2] if len(orig_shape) >= 3 else 1
+    in_w = orig_shape[-1]
+    if len(orig_shape) >= 4:
+        c = orig_shape[-3]
+        in_h = orig_shape[-2]
+        in_w = orig_shape[-1]
+        n = 1
+        for s in orig_shape[:-3]:
+            n *= s
+    else:
+        # For 4D input: (N, C, H, W)
+        n, c, in_h, in_w = orig_shape
+
+    shape_4d = (n, c, in_h, in_w)
+    out_h = grad.shape[-2]
+    out_w = grad.shape[-1]
+
+    grad_4d = grad.reshape(n, c, out_h, out_w)
+
+    out = torch.ops.aten._upsample_bicubic2d_aa_backward(
+        grad_4d,
+        [out_h, out_w],
+        list(shape_4d),
+        align_corners,
+        None,
+        None,
+    )
+
+    return out.reshape(orig_shape)
+
+
+@pytest.mark.upsample_bicubic2d_aa_backward
+@pytest.mark.parametrize(
+    "shape",
+    [
+        (1, 1, 1, 1),
+        (1, 1, 4, 4),
+        (1, 3, 8, 8),
+        (2, 1, 5, 7),
+        (2, 3, 16, 16),
+        (3, 7, 17, 13),
+        (2, 3, 33, 33),
+        (4, 8, 16, 32),
+        (8, 16, 64, 64),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("scale_factor", [1.5, 2])
+@pytest.mark.parametrize("align_corners", [False, True])
+def test_upsample_bicubic2d_aa_backward(
+    shape, dtype, scale_factor, align_corners
+):
+    in_h = shape[-2]
+    in_w = shape[-1]
+    out_h = max(1, int(in_h * scale_factor))
+    out_w = max(1, int(in_w * scale_factor))
+
+    grad_shape = list(shape)
+    grad_shape[-2] = out_h
+    grad_shape[-1] = out_w
+
+    res_grad = torch.randn(
+        grad_shape,
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+    ref_grad = to_reference(res_grad)
+
+    ref_out = upsample_bicubic2d_aa_backward_call(
+        ref_grad,
+        shape,
+        align_corners,
+    )
+
+    with flag_gems.use_gems():
+        res_out = upsample_bicubic2d_aa_backward_call(
+            res_grad,
+            shape,
+            align_corners,
+        )
+
+    assert res_out.shape == tuple(shape)
+    assert res_out.dtype == res_grad.dtype
+
+    if dtype == torch.float32:
+        atol = 1e-4
+    elif dtype == torch.float16:
+        atol = 1e-2
+        # fp16 has ~1e-3 relative precision (10-bit mantissa).
+        # Considering bicubic interpolation and gradient accumulation in backward,
+        # the effective error can be several times larger, so 1e-2 is a safe margin.
+    else:  # bfloat16
+        atol = 2e-2
+        # bf16 has ~8e-3 relative precision (7-bit mantissa).
+        # With accumulation and interpolation effects, errors can grow further,
+        # making 2e-2 a reasonable lower bound.
+    gems_assert_close(res_out, ref_out, dtype, atol=atol)

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -2725,37 +2725,41 @@ def upsample_bicubic2d_aa_backward_call(grad, input_size, align_corners):
 
 @pytest.mark.upsample_bicubic2d_aa_backward
 @pytest.mark.parametrize(
-    "shape",
+    "N,C,H_in,W_in,H_out,W_out,align_corners",
     [
-        (1, 1, 1, 1),
-        (1, 1, 4, 4),
-        (1, 3, 8, 8),
-        (2, 1, 5, 7),
-        (2, 3, 16, 16),
-        (3, 7, 17, 13),
-        (2, 3, 33, 33),
-        (4, 8, 16, 32),
-        (8, 16, 64, 64),
+        (1, 3, 16, 16, 8, 8, False),
+        (2, 4, 8, 8, 16, 16, False),
+        (1, 3, 32, 32, 10, 10, False),
+        (1, 1, 10, 10, 23, 23, False),
+        (1, 3, 16, 16, 8, 8, True),
+        (1, 3, 8, 8, 16, 16, True),
+        (2, 64, 32, 32, 16, 16, False),
+        (1, 3, 7, 11, 13, 5, False),
+        (1, 1, 4, 4, 4, 4, False),
+        (1, 1, 8, 8, 1, 1, True),
+        # Extra cases
+        (1, 1, 64, 64, 16, 16, False),
+        (1, 1, 64, 64, 128, 128, False),
+        (512, 1024, 32, 32, 8, 8, False),
+        (256, 512, 64, 64, 16, 16, False),
+        (4, 16, 16, 16, 4, 4, False),
+        (4, 16, 4, 4, 16, 16, False),
+        (4, 16, 64, 128, 32, 64, False),
+        (4, 16, 64, 128, 128, 256, True),
+        (1, 1, 4096, 4096, 1024, 1024, False),
     ],
 )
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-@pytest.mark.parametrize("scale_factor", [1.5, 2])
-@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_upsample_bicubic2d_aa_backward(
-    shape, dtype, scale_factor, align_corners
+    N, C, H_in, W_in, H_out, W_out, align_corners, dtype
 ):
-    in_h = shape[-2]
-    in_w = shape[-1]
-    out_h = max(1, int(in_h * scale_factor))
-    out_w = max(1, int(in_w * scale_factor))
+    shape = (N, C, H_in, W_in)
 
-    grad_shape = list(shape)
-    grad_shape[-2] = out_h
-    grad_shape[-1] = out_w
+    grad_shape = (N, C, H_out, W_out)
 
     res_grad = torch.randn(
         grad_shape,
-        dtype=dtype,
+        dtype=torch.float32,
         device=flag_gems.device,
     )
     ref_grad = to_reference(res_grad)
@@ -2764,28 +2768,23 @@ def test_upsample_bicubic2d_aa_backward(
         ref_grad,
         shape,
         align_corners,
-    )
+    ).to(dtype)
 
     with flag_gems.use_gems():
         res_out = upsample_bicubic2d_aa_backward_call(
-            res_grad,
+            res_grad.to(dtype),
             shape,
             align_corners,
         )
 
-    assert res_out.shape == tuple(shape)
-    assert res_out.dtype == res_grad.dtype
+    assert res_out.shape == shape
 
+    # dtype-specific tolerance
     if dtype == torch.float32:
         atol = 1e-4
     elif dtype == torch.float16:
-        atol = 1e-2
-        # fp16 has ~1e-3 relative precision (10-bit mantissa).
-        # Considering bicubic interpolation and gradient accumulation in backward,
-        # the effective error can be several times larger, so 1e-2 is a safe margin.
+        atol = 3e-3
     else:  # bfloat16
         atol = 2e-2
-        # bf16 has ~8e-3 relative precision (7-bit mantissa).
-        # With accumulation and interpolation effects, errors can grow further,
-        # making 2e-2 a reasonable lower bound.
+
     gems_assert_close(res_out, ref_out, dtype, atol=atol)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator , OP Test , Benchmark

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Implemented an upsample_bicubic2d_aa_backward operation using triton. Registered the new operation, added it to the benchmark suite, and included accuracy tests for various shapes and dtypes.

For upsample_bicubic2d_aa_backward, the reference is always computed in float32, regardless of the tested dtype (fp16 / bf16).

This is because PyTorch’s low-precision implementations introduce noticeable numerical errors and are not reliable as a ground truth. In addition, their performance is not optimized.

Therefore, we use float32 for the reference and cast to the target dtype for comparison, ensuring stable and accurate validation.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

```bash
(flag) xiexuan@oneflow-24:/data/xiexuan/git-repos/FlagGems$ python -m pytest tests/test_special_ops.py::test_upsample_bicubic2d_aa_backward
==================================== test session starts ====================================
platform linux -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0
rootdir: /data/xiexuan/git-repos/FlagGems
configfile: pytest.ini
collected 57 items

tests/test_special_ops.py .........................................................   [100%]

===================================== warnings summary ======================================
../../miniconda3/envs/flag/lib/python3.12/site-packages/triton/runtime/autotuner.py:101: 28 warnings
  /data/xiexuan/miniconda3/envs/flag/lib/python3.12/site-packages/triton/runtime/autotuner.py:101: DeprecationWarning: warmup, rep, and use_cuda_graph parameters are deprecated. See https://github.com/triton-lang/triton/pull/4496 for details.
    warnings.warn(("warmup, rep, and use_cuda_graph parameters are deprecated. See "

tests/test_special_ops.py::test_upsample_bicubic2d_aa_backward[dtype0-1-3-16-16-8-8-False]
  /data/xiexuan/miniconda3/envs/flag/lib/python3.12/site-packages/torch/library.py:357: UserWarning: Warning only once for all operators,  other operators may also be overridden.
    Overriding a previously registered kernel for the same operator and the same dispatch key
    operator: aten::_flash_attention_forward(Tensor query, Tensor key, Tensor value, Tensor? cum_seq_q, Tensor? cum_seq_k, SymInt max_q, SymInt max_k, float dropout_p, bool is_causal, bool return_debug_mask, *, float? scale=None, SymInt? window_size_left=None, SymInt? window_size_right=None, Tensor? seqused_k=None, Tensor? alibi_slopes=None) -> (Tensor output, Tensor softmax_logsumexp, Tensor rng_state, Tensor unused, Tensor debug_attn_mask)
      registered at /pytorch/build/aten/src/ATen/RegisterSchema.cpp:6
    dispatch key: CUDA
    previous kernel: registered at /pytorch/torch/csrc/autograd/generated/VariableType_0.cpp:18396
         new kernel: registered at /data/xiexuan/git-repos/FlagGems/src/flag_gems/__init__.py:542 (Triggered internally at /pytorch/aten/src/ATen/core/dispatch/OperatorEntry.cpp:208.)
    self.m.impl(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================= 57 passed, 29 warnings in 27.75s ==============================
(flag) xiexuan@oneflow-24:/data/xiexuan/git-repos/FlagGems$ python -m pytest -s benchmark/test_special_perf.py::test_upsample_bicubic2d_aa_backward
==================================== test session starts ====================================
platform linux -- Python 3.12.13, pytest-9.0.2, pluggy-1.6.0
rootdir: /data/xiexuan/git-repos/FlagGems
configfile: pytest.ini
collected 1 item

benchmark/test_special_perf.py
Operator: upsample_bicubic2d_aa_backward  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.025600            0.007168               3.571          [torch.Size([4, 16, 1, 1]), [1, 1], [4, 16, 4, 4], False, None, None]
SUCCESS               0.802816            0.028672              28.000          [torch.Size([4, 16, 16, 16]), [16, 16], [4, 16, 4, 4], False, None, None]
SUCCESS               0.218112            0.015360              14.200          [torch.Size([4, 16, 4, 4]), [4, 4], [4, 16, 16, 16], False, None, None]
SUCCESS               4.190208            0.158720              26.400          [torch.Size([4, 16, 64, 128]), [64, 128], [4, 16, 16, 32], False, None, None]
SUCCESS               0.279552            0.014336              19.500          [torch.Size([1, 1, 16, 16]), [16, 16], [1, 1, 64, 64], False, None, None]
SUCCESS               0.087040            0.019456               4.474          [torch.Size([1, 1, 32, 32]), [32, 32], [1, 1, 64, 64], False, None, None]
SUCCESS               0.119808            0.012288               9.750          [torch.Size([1, 1, 128, 128]), [128, 128], [1, 1, 64, 64], False, None, None]
SUCCESS               0.177152            0.173056               1.024          [torch.Size([4, 3, 128, 128]), [128, 128], [4, 3, 256, 256], False, None, None]
SUCCESS               1.018880            0.114688               8.884          [torch.Size([4, 3, 256, 256]), [256, 256], [4, 3, 128, 128], False, None, None]
SUCCESS               0.206848            0.215040               0.962          [torch.Size([4, 64, 32, 32]), [32, 32], [4, 64, 64, 64], False, None, None]
SUCCESS               3.739648            0.368640              10.144          [torch.Size([1, 64, 128, 128]), [128, 128], [1, 64, 512, 512], False, None, None]
SUCCESS              94.518272            2.108416              44.829          [torch.Size([1, 64, 1024, 1024]), [1024, 1024], [1, 64, 512, 512], False, None, None]
SUCCESS             250.321915           19.353600              12.934          [torch.Size([512, 1024, 8, 8]), [8, 8], [512, 1024, 32, 32], False, None, None]
SUCCESS             161.492996           18.854912               8.565          [torch.Size([256, 512, 16, 16]), [16, 16], [256, 512, 64, 64], False, None, None]
SUCCESS              81.961983           22.279680               3.679          [torch.Size([256, 512, 32, 32]), [32, 32], [256, 512, 64, 64], False, None, None]
SUCCESS            2386.428955           72.551422              32.893          [torch.Size([256, 512, 128, 128]), [128, 128], [256, 512, 64, 64], False, None, None]


Operator: upsample_bicubic2d_aa_backward  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.011264            0.007168               1.571          [torch.Size([4, 16, 1, 1]), [1, 1], [4, 16, 4, 4], False, None, None]
SUCCESS               0.029696            0.030720               0.967          [torch.Size([4, 16, 16, 16]), [16, 16], [4, 16, 4, 4], False, None, None]
SUCCESS               0.027648            0.015360               1.800          [torch.Size([4, 16, 4, 4]), [4, 4], [4, 16, 16, 16], False, None, None]
SUCCESS               0.114688            0.106496               1.077          [torch.Size([4, 16, 64, 128]), [64, 128], [4, 16, 16, 32], False, None, None]
SUCCESS               0.038912            0.014336               2.714          [torch.Size([1, 1, 16, 16]), [16, 16], [1, 1, 64, 64], False, None, None]
SUCCESS               0.019456            0.018432               1.056          [torch.Size([1, 1, 32, 32]), [32, 32], [1, 1, 64, 64], False, None, None]
SUCCESS               0.024576            0.013312               1.846          [torch.Size([1, 1, 128, 128]), [128, 128], [1, 1, 64, 64], False, None, None]
SUCCESS               0.075776            0.161792               0.468          [torch.Size([4, 3, 128, 128]), [128, 128], [4, 3, 256, 256], False, None, None]
SUCCESS               0.080896            0.061440               1.317          [torch.Size([4, 3, 256, 256]), [256, 256], [4, 3, 128, 128], False, None, None]
SUCCESS               0.101376            0.212992               0.476          [torch.Size([4, 64, 32, 32]), [32, 32], [4, 64, 64, 64], False, None, None]
SUCCESS               2.355200            0.368128               6.398          [torch.Size([1, 64, 128, 128]), [128, 128], [1, 64, 512, 512], False, None, None]
SUCCESS               5.749248            2.070528               2.777          [torch.Size([1, 64, 1024, 1024]), [1024, 1024], [1, 64, 512, 512], False, None, None]
SUCCESS              86.936577           19.245056               4.517          [torch.Size([512, 1024, 8, 8]), [8, 8], [512, 1024, 32, 32], False, None, None]
SUCCESS              83.732483           18.864128               4.439          [torch.Size([256, 512, 16, 16]), [16, 16], [256, 512, 64, 64], False, None, None]
SUCCESS              42.536959           22.473728               1.893          [torch.Size([256, 512, 32, 32]), [32, 32], [256, 512, 64, 64], False, None, None]
SUCCESS             167.238663           73.919487               2.262          [torch.Size([256, 512, 128, 128]), [128, 128], [256, 512, 64, 64], False, None, None]


Operator: upsample_bicubic2d_aa_backward  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.022528            0.007168               3.143          [torch.Size([4, 16, 1, 1]), [1, 1], [4, 16, 4, 4], False, None, None]
SUCCESS               1.105920            0.028672              38.571          [torch.Size([4, 16, 16, 16]), [16, 16], [4, 16, 4, 4], False, None, None]
SUCCESS               0.217088            0.015360              14.133          [torch.Size([4, 16, 4, 4]), [4, 4], [4, 16, 16, 16], False, None, None]
SUCCESS              10.021888            0.159744              62.737          [torch.Size([4, 16, 64, 128]), [64, 128], [4, 16, 16, 32], False, None, None]
SUCCESS               0.253952            0.014336              17.714          [torch.Size([1, 1, 16, 16]), [16, 16], [1, 1, 64, 64], False, None, None]
SUCCESS               0.096256            0.019456               4.947          [torch.Size([1, 1, 32, 32]), [32, 32], [1, 1, 64, 64], False, None, None]
SUCCESS               0.269312            0.012288              21.917          [torch.Size([1, 1, 128, 128]), [128, 128], [1, 1, 64, 64], False, None, None]
SUCCESS               0.223232            0.173056               1.290          [torch.Size([4, 3, 128, 128]), [128, 128], [4, 3, 256, 256], False, None, None]
SUCCESS               3.158528            0.113664              27.788          [torch.Size([4, 3, 256, 256]), [256, 256], [4, 3, 128, 128], False, None, None]
SUCCESS               0.257024            0.215040               1.195          [torch.Size([4, 64, 32, 32]), [32, 32], [4, 64, 64, 64], False, None, None]
SUCCESS               3.874304            0.365568              10.598          [torch.Size([1, 64, 128, 128]), [128, 128], [1, 64, 512, 512], False, None, None]
SUCCESS             314.830841            2.109440             149.249          [torch.Size([1, 64, 1024, 1024]), [1024, 1024], [1, 64, 512, 512], False, None, None]
SUCCESS             284.175354           19.142656              14.845          [torch.Size([512, 1024, 8, 8]), [8, 8], [512, 1024, 32, 32], False, None, None]
SUCCESS             177.574905           18.616320               9.539          [torch.Size([256, 512, 16, 16]), [16, 16], [256, 512, 64, 64], False, None, None]
SUCCESS             116.175873           22.284800               5.213          [torch.Size([256, 512, 32, 32]), [32, 32], [256, 512, 64, 64], False, None, None]
SUCCESS            7021.789062           72.238083              97.203          [torch.Size([256, 512, 128, 128]), [128, 128], [256, 512, 64, 64], False, None, None]

.

===================================================================================== warnings summary ======================================================================================
../../miniconda3/envs/flag/lib/python3.12/site-packages/triton/runtime/autotuner.py:101: 28 warnings
  /data/xiexuan/miniconda3/envs/flag/lib/python3.12/site-packages/triton/runtime/autotuner.py:101: DeprecationWarning: warmup, rep, and use_cuda_graph parameters are deprecated. See https://github.com/triton-lang/triton/pull/4496 for details.
    warnings.warn(("warmup, rep, and use_cuda_graph parameters are deprecated. See "

benchmark/test_special_perf.py::test_upsample_bicubic2d_aa_backward
  /data/xiexuan/miniconda3/envs/flag/lib/python3.12/site-packages/torch/library.py:357: UserWarning: Warning only once for all operators,  other operators may also be overridden.
    Overriding a previously registered kernel for the same operator and the same dispatch key
    operator: aten::_flash_attention_forward(Tensor query, Tensor key, Tensor value, Tensor? cum_seq_q, Tensor? cum_seq_k, SymInt max_q, SymInt max_k, float dropout_p, bool is_causal, bool return_debug_mask, *, float? scale=None, SymInt? window_size_left=None, SymInt? window_size_right=None, Tensor? seqused_k=None, Tensor? alibi_slopes=None) -> (Tensor output, Tensor softmax_logsumexp, Tensor rng_state, Tensor unused, Tensor debug_attn_mask)
      registered at /pytorch/build/aten/src/ATen/RegisterSchema.cpp:6
    dispatch key: CUDA
    previous kernel: registered at /pytorch/torch/csrc/autograd/generated/VariableType_0.cpp:18396
         new kernel: registered at /data/xiexuan/git-repos/FlagGems/src/flag_gems/__init__.py:542 (Triggered internally at /pytorch/aten/src/ATen/core/dispatch/OperatorEntry.cpp:208.)
    self.m.impl(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================================================== 1 passed, 29 warnings in 885.71s (0:14:45) =========================================================================
```