### PR TITLE
[kunlunxin]: fix addmm compute error

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/addmm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/addmm.py
@@ -90,8 +90,16 @@ def addmm_kernel(
 
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
-        a = tl.load(a_ptrs)
-        b = tl.load(b_ptrs)
+        a = tl.load(
+            a_ptrs,
+            mask=(offs_am[:, None] < M) & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
+            other=0.0,
+        )
+        b = tl.load(
+            b_ptrs,
+            mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_bn[None, :] < N),
+            other=0.0,
+        )
         accumulator += tl.dot(a, b, allow_tf32=False)
         a_ptrs += BLOCK_SIZE_K * stride_ak
         b_ptrs += BLOCK_SIZE_K * stride_bk


### PR DESCRIPTION
## Fix: Add boundary masks in KunlunXin addmm kernel tl.load

### Problem

The `addmm` kernel for KunlunXin backend was missing boundary masks in
`tl.load` for matrices `a` and `b`. This caused out-of-bounds memory reads
when input shapes are not aligned to block sizes (e.g. `M=15`, `N=160`),
leading to garbage values being accumulated in `tl.dot` and producing
completely wrong results (~99% elements mismatched).

### Root Cause

```python
# Before: no mask, OOB memory read corrupts dot product
a = tl.load(a_ptrs)
b = tl.load(b_ptrs)
