### PR TITLE
Mask out test_upsample_linear1d due to assertion failure

### DIFF
--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -4701,7 +4701,7 @@ ops:
     kind:
       - NeuralNetwork
     stages:
-      stable: '5.0'
+      beta: '5.0'
   - name: upsample_nearest1d
     description: |
       Upsamples the `input`, using nearest neighbours' pixel values.

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -998,6 +998,7 @@ def test_upsample_linear1d_boundaries(dtype, case):
         gems_assert_close(res_out, ref_out, dtype)
 
 
+@pytest.mark.skip("AssertionError: Mismatched elements 2/53697")
 @pytest.mark.upsample_linear1d
 @pytest.mark.parametrize("align_corners", [False, True])
 @pytest.mark.parametrize("scale", [2, 2.5, 0.3, 0.7])

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -998,7 +998,6 @@ def test_upsample_linear1d_boundaries(dtype, case):
         gems_assert_close(res_out, ref_out, dtype)
 
 
-@pytest.mark.skip("AssertionError: Mismatched elements 2/53697")
 @pytest.mark.upsample_linear1d
 @pytest.mark.parametrize("align_corners", [False, True])
 @pytest.mark.parametrize("scale", [2, 2.5, 0.3, 0.7])


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

The `upsample_linear1d` is not stable.

### Description

This PR skips the testing and demote the operator to `beta`.
