### PR TITLE
Add openpyxl to test group

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ tsingmicro = [
 # Test packages
 test = [
     "distro==1.9.0",
+    "openpyxl==3.1.5",
     "pytest==9.0.2",
     "scipy>=1.15.3",
 ]


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Other

### Description

This PR adds the `pyopenxl` package to the `test` group in `pyproject.toml`.
The intent is to generate excel files for operator tests.
