### PR TITLE
Don't GC if dtype input generator fails

### DIFF
--- a/benchmark/performance_utils.py
+++ b/benchmark/performance_utils.py
@@ -404,8 +404,6 @@ class Benchmark:
                         "dtype={dtype} err=<<<{e}>>>"
                     )
                     pytest.fail(str(e))
-                finally:
-                    gc.collect()
 
                 metric = BenchmarkMetrics()
                 try:


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

We treat GC a dangerous function that is supposed to be invoked only when necessary.
