### PR TITLE
[TsingMicro] Fix the failure of the performance utils module

### DIFF
--- a/benchmark/performance_utils.py
+++ b/benchmark/performance_utils.py
@@ -37,7 +37,11 @@ elif device == "npu":
     torch.backends.cuda.matmul.allow_tf32 = False
     torch.backends.cudnn.allow_tf32 = False
 else:
-    torch_backend_device.matmul.allow_tf32 = False
+    # Attempt to disallow tf32
+    try:
+        torch_backend_device.matmul.allow_tf32 = False
+    except Exception:
+        pass
 
 
 def SkipVersion(module_name, skip_pattern):


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

The `performance_utils` module is trying to disable tf32 support.
The code doesn't work on some backends such as TsingMicro.
