### PR TITLE
Quality: Statistical test is effectively disabled

### DIFF
--- a/ctests/test_triton_exponential_.cpp
+++ b/ctests/test_triton_exponential_.cpp
@@ -90,11 +90,6 @@ void RunExponentialTest(torch::ScalarType dtype) {
 }
 
 TEST(exponential_op_test, exponential_) {
-  // LOG(WARNING) << " test torch::kFloat16";
-  // RunExponentialTest<torch::Half>(torch::kFloat16);
   LOG(WARNING) << " test torch::kFloat32";
-  // Temporarily commented out; does not affect CI/CD. Will fix/implement later.
-  // RunExponentialTest<float>(torch::kFloat32);  // pytest use type of float32 to test
-  // LOG(WARNING) << " test torch::kFloat64";
-  // RunExponentialTest<double>(torch::kFloat64);
+  RunExponentialTest<float>(torch::kFloat32);
 }


### PR DESCRIPTION
## Summary

Quality: Statistical test is effectively disabled

## Problem

**Severity**: `High` | **File**: `ctests/test_triton_exponential_.cpp:L102`

The `exponential_` test logs messages but the actual validation calls are commented out. This means the test passes without asserting correctness, reducing test suite reliability.

## Solution

Re-enable at least one concrete `RunExponentialTest(...)` invocation (ideally multiple dtypes) or mark the test explicitly skipped with a reason (`GTEST_SKIP()`) so test reports are truthful.

## Changes

- `ctests/test_triton_exponential_.cpp` (modified)