### PR TITLE
[Cambricon] Optimize gelu_, rsqrt_, sqrt_, nan_to_num operators

### DIFF
--- a/src/flag_gems/runtime/backend/_cambricon/ops/gelu.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/gelu.py
@@ -1,25 +1,46 @@
 import logging
 
+import torch
 import triton
 import triton.language as tl
+from triton.language.extra.mlu.libdevice import fast_erf, fast_tanh
 
-from flag_gems.utils import tl_extra_shim
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, libtuner, tl_extra_shim
 
+from ..utils import TOTAL_CORE_NUM
 from ..utils.pointwise_dynamic import pointwise_dynamic
 
 logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
-fast_erf = tl_extra_shim.fast_erf
+
 exp = tl_extra_shim.exp
-fast_tanh = tl_extra_shim.fast_tanh
 
 
-@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, "DEFAULT")])
+@libentry()
+@libtuner(
+    configs=[
+        triton.Config(kwargs={"BLOCK_SIZE": 4096}, num_stages=1, num_warps=1),
+        triton.Config(kwargs={"BLOCK_SIZE": 16384}, num_stages=1, num_warps=1),
+        triton.Config(kwargs={"BLOCK_SIZE": 65536}, num_stages=1, num_warps=1),
+        triton.Config(kwargs={"BLOCK_SIZE": 131072}, num_stages=1, num_warps=1),
+    ],
+    key=["n_elements"],
+)
 @triton.jit
-def gelu_none(x, inplace):
+def gelu_none_kernel(X_ptr, OUT_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    num_jobs = tl.num_programs(0)
+    block_start = pid * BLOCK_SIZE
+    step = num_jobs * BLOCK_SIZE
+    block_start = block_start.to(tl.int64)
     scale: tl.constexpr = 0.7071067811
-    x_f32 = x.to(tl.float32)
-    output = 0.5 * x_f32 + 0.5 * x_f32 * fast_erf(x_f32 * scale)
-    return output
+    for off in range(block_start, n_elements, step):
+        offsets = off + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(X_ptr + offsets, mask=mask)
+        x_f32 = x.to(tl.float32)
+        result = 0.5 * x_f32 + 0.5 * x_f32 * fast_erf(x_f32 * scale)
+        tl.store(OUT_ptr + offsets, result.to(x.dtype), mask=mask)
 
 
 @pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, "DEFAULT")])
@@ -35,8 +56,8 @@ def gelu_tanh(x, inplace):
 @pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
 @triton.jit
 def gelu_backward_none(x, dy):
-    scale1: tl.constexpr = 0.7071067811  # 1 / math.sqrt(2)
-    scale2: tl.constexpr = 0.3989422803  # 1 / math.sqrt(2 * math.pi)
+    scale1: tl.constexpr = 0.7071067811
+    scale2: tl.constexpr = 0.3989422803
     x_fp32 = x.to(tl.float32)
     x_sqrt = scale1 * x_fp32
     dydx = scale2 * x_fp32 * exp(-x_sqrt * x_sqrt) + 0.5 * fast_erf(x_sqrt) + 0.5
@@ -48,12 +69,9 @@ def gelu_backward_none(x, dy):
 @triton.jit
 def gelu_backward_tanh(x, dy):
     x_fp32 = x.to(tl.float32)
-    c1 = 0.79788456  # math.sqrt(2 / math.pi)
+    c1 = 0.79788456
     c2 = 0.044715
-    # z = c1 * (x + c2 * x**3)
     tanh_out = fast_tanh(c1 * x_fp32 + c1 * x_fp32 * c2 * x_fp32 * x_fp32)
-    # dz_dx = c1 * (1 + 3 * c2 * x * x)
-    # 0.1070322243 = c1 * 3 *c2
     dydx = (
         0.5 * ((x - x * tanh_out * tanh_out) * (c1 + 0.1070322243 * x_fp32 * x_fp32))
         + 0.5
@@ -66,25 +84,43 @@ def gelu_backward_tanh(x, dy):
 def gelu(self, *, approximate="none"):
     logger.debug("GEMS_CAMBRICON GELU FORWARD")
     if approximate == "tanh":
-        out = gelu_tanh(self, False)
+        return gelu_tanh(self, False)
     else:
-        out = gelu_none(self, False)
-    return out
+        A = self.contiguous()
+        out = torch.empty_like(A)
+        N = A.numel()
+        if N == 0:
+            return out
+        grid_fn = lambda meta: (
+            min(triton.cdiv(N, meta["BLOCK_SIZE"]), TOTAL_CORE_NUM),
+        )
+        with torch_device_fn.device(A.device):
+            gelu_none_kernel[grid_fn](A, out, N)
+        return out
 
 
 def gelu_backward(grad_output, self, *, approximate="none"):
     logger.debug("GEMS_CAMBRICON GELU BACKWARD")
     if approximate == "tanh":
-        in_grad = gelu_backward_tanh(self, grad_output)
+        return gelu_backward_tanh(self, grad_output)
     else:
-        in_grad = gelu_backward_none(self, grad_output)
-    return in_grad
+        return gelu_backward_none(self, grad_output)
 
 
 def gelu_(A, *, approximate="none"):
     logger.debug("GEMS_CAMBRICON GELU_ FORWARD")
     if approximate == "tanh":
-        out = gelu_tanh(A, True, out0=A)
+        return gelu_tanh(A, True, out0=A)
     else:
-        out = gelu_none(A, True, out0=A)
-    return out
+        A_contig = A.contiguous()
+        N = A_contig.numel()
+        if N == 0:
+            return A
+        grid_fn = lambda meta: (
+            min(triton.cdiv(N, meta["BLOCK_SIZE"]), TOTAL_CORE_NUM),
+        )
+        with torch_device_fn.device(A.device):
+            gelu_none_kernel[grid_fn](A_contig, A_contig, N)
+        if not A.is_contiguous():
+            A.copy_(A_contig)
+        return A

--- a/src/flag_gems/runtime/backend/_cambricon/ops/nan_to_num.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/nan_to_num.py
@@ -3,7 +3,7 @@ import logging
 import torch
 import triton
 import triton.language as tl
-from triton.language.extra.mlu.libdevice import rsqrt as _rsqrt
+from triton.language.extra.mlu.libdevice import isnan as _isnan
 
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry, libtuner
@@ -24,7 +24,15 @@ logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
     key=["n_elements"],
 )
 @triton.jit
-def rsqrt_kernel(X_ptr, OUT_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+def nan_to_num_kernel(
+    X_ptr,
+    OUT_ptr,
+    nan_val,
+    posinf_val,
+    neginf_val,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
     pid = tl.program_id(0)
     num_jobs = tl.num_programs(0)
     block_start = pid * BLOCK_SIZE
@@ -34,12 +42,24 @@ def rsqrt_kernel(X_ptr, OUT_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
         offsets = off + tl.arange(0, BLOCK_SIZE)
         mask = offsets < n_elements
         x = tl.load(X_ptr + offsets, mask=mask)
-        result = _rsqrt(x.to(tl.float32))
-        tl.store(OUT_ptr + offsets, result.to(x.dtype), mask=mask)
+        x_nan = _isnan(x)
+        x_posinf = x == float("inf")
+        x_neginf = x == float("-inf")
+        result = tl.where(x_nan, nan_val, x)
+        result = tl.where(x_posinf, posinf_val, result)
+        result = tl.where(x_neginf, neginf_val, result)
+        tl.store(OUT_ptr + offsets, result, mask=mask)
 
 
-def rsqrt(A):
-    logger.debug("GEMS_CAMBRICON RSQRT")
+def nan_to_num(A, nan=None, posinf=None, neginf=None):
+    logger.debug("GEMS_CAMBRICON NAN_TO_NUM")
+    if posinf is None:
+        posinf = torch.finfo(A.dtype).max
+    if neginf is None:
+        neginf = torch.finfo(A.dtype).min
+    if nan is None:
+        nan = 0.0
+
     A = A.contiguous()
     out = torch.empty_like(A)
     N = A.numel()
@@ -47,19 +67,5 @@ def rsqrt(A):
         return out
     grid_fn = lambda meta: (min(triton.cdiv(N, meta["BLOCK_SIZE"]), TOTAL_CORE_NUM),)
     with torch_device_fn.device(A.device):
-        rsqrt_kernel[grid_fn](A, out, N)
+        nan_to_num_kernel[grid_fn](A, out, nan, posinf, neginf, N)
     return out
-
-
-def rsqrt_(A):
-    logger.debug("GEMS_CAMBRICON RSQRT_")
-    A_contig = A.contiguous()
-    N = A_contig.numel()
-    if N == 0:
-        return A
-    grid_fn = lambda meta: (min(triton.cdiv(N, meta["BLOCK_SIZE"]), TOTAL_CORE_NUM),)
-    with torch_device_fn.device(A.device):
-        rsqrt_kernel[grid_fn](A_contig, A_contig, N)
-    if not A.is_contiguous():
-        A.copy_(A_contig)
-    return A

--- a/src/flag_gems/runtime/backend/_cambricon/ops/sqrt.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/sqrt.py
@@ -1,25 +1,65 @@
 import logging
 
+import torch
 import triton
 import triton.language as tl
+from triton.language.extra.mlu.libdevice import sqrt as _sqrt
 
-from ..utils.pointwise_dynamic import pointwise_dynamic
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry, libtuner
+
+from ..utils import TOTAL_CORE_NUM
 
 logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 
 
-@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, "INT_TO_FLOAT")])
+@libentry()
+@libtuner(
+    configs=[
+        triton.Config(kwargs={"BLOCK_SIZE": 4096}, num_stages=1, num_warps=1),
+        triton.Config(kwargs={"BLOCK_SIZE": 16384}, num_stages=1, num_warps=1),
+        triton.Config(kwargs={"BLOCK_SIZE": 65536}, num_stages=1, num_warps=1),
+        triton.Config(kwargs={"BLOCK_SIZE": 131072}, num_stages=1, num_warps=1),
+    ],
+    key=["n_elements"],
+)
 @triton.jit
-def sqrt_func(x, inplace):
-    return tl.sqrt(x.to(tl.float32))
+def sqrt_kernel(X_ptr, OUT_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
+    pid = tl.program_id(0)
+    num_jobs = tl.num_programs(0)
+    block_start = pid * BLOCK_SIZE
+    step = num_jobs * BLOCK_SIZE
+    block_start = block_start.to(tl.int64)
+    for off in range(block_start, n_elements, step):
+        offsets = off + tl.arange(0, BLOCK_SIZE)
+        mask = offsets < n_elements
+        x = tl.load(X_ptr + offsets, mask=mask)
+        result = _sqrt(x.to(tl.float32))
+        tl.store(OUT_ptr + offsets, result.to(x.dtype), mask=mask)
 
 
 def sqrt(A):
     logger.debug("GEMS_CAMBRICON SQRT")
-    return sqrt_func(A, False)
+    A = A.contiguous()
+    out = torch.empty_like(A)
+    N = A.numel()
+    if N == 0:
+        return out
+    grid_fn = lambda meta: (min(triton.cdiv(N, meta["BLOCK_SIZE"]), TOTAL_CORE_NUM),)
+    with torch_device_fn.device(A.device):
+        sqrt_kernel[grid_fn](A, out, N)
+    return out
 
 
 def sqrt_(A):
     logger.debug("GEMS_CAMBRICON SQRT_")
-    sqrt_func(A, True, out0=A)
+    A_contig = A.contiguous()
+    N = A_contig.numel()
+    if N == 0:
+        return A
+    grid_fn = lambda meta: (min(triton.cdiv(N, meta["BLOCK_SIZE"]), TOTAL_CORE_NUM),)
+    with torch_device_fn.device(A.device):
+        sqrt_kernel[grid_fn](A_contig, A_contig, N)
+    if not A.is_contiguous():
+        A.copy_(A_contig)
     return A


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Performance Optimization
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Optimize gelu_, rsqrt_, sqrt_ and nan_to_num operators for Cambricon MLU backend.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
#### Performance Results (MLU590)

| Operator | Avg Baseline | Avg Optimized | Speedup |
|----------|-------------|---------------|---------|
| gelu_ | 0.537455 | 0.602914667 | +12.18% |
| nan_to_num | 0.263335333 | 0.318595 | +20.98% |
| rsqrt_ | 0.432146 | 0.726054 | +68.01% |
| sqrt_ | 0.429047333 | 0.675145667 | +57.36% |

<img width="1407" height="97" alt="image" src="https://github.com/user-attachments/assets/3d0b6a12-cd59-4171-85ba-a8548343cedc" />