### PR TITLE
[KernelGen][KunlunXin] Optimize logical_and, log_softmax, multinomial…

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/log_softmax.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/log_softmax.py
@@ -4,8 +4,6 @@ import logging
 import torch
 import triton
 import triton.language as tl
-
-# from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry
 from flag_gems.utils import triton_lang_extension as tle
@@ -14,17 +12,18 @@ logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 
 
 def heur_block_n(args):
-    if args["N"] > 8192:
+    N = args["N"]
+    if N > 8192:
         return 64
-    return builtins.min(args["N"], 8192)
+    return builtins.min(triton.next_power_of_2(N), 8192)
 
 
 def heur_block_m(args):
-    return triton.next_power_of_2(triton.cdiv(args["M"], 12))
+    # Cap BLOCK_M at 8 for better parallelism and occupancy
+    return builtins.min(triton.next_power_of_2(triton.cdiv(args["M"], 12)), 8)
 
 
 @libentry()
-# @triton.autotune(configs=runtime.get_triton_config("log_softmax"), key=["M", "N"])
 @triton.heuristics(
     {
         "BLOCK_M": heur_block_m,
@@ -45,7 +44,6 @@ def log_softmax_kernel(
     pid_k = tle.program_id(1)
     m_offset = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
 
-    # TODO(chenfeiyu): consider float64 add add a utility function to get accumulator type
     m = tl.full([BLOCK_M, BLOCK_N], value=float("-inf"), dtype=tl.float32)
     z = tl.full([BLOCK_M, BLOCK_N], value=0.0, dtype=tl.float32)
     for start_n in range(0, N, BLOCK_N):
@@ -53,7 +51,9 @@ def log_softmax_kernel(
         offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
         mask = m_offset[:, None] < M and n_offset[None, :] < N
         input_ptrs = input_ptr + offset
-        inp = tl.load(input_ptrs, mask=mask, other=-float("inf")).to(tl.float32)
+        inp = tl.load(
+            input_ptrs, mask=mask, other=-float("inf"), eviction_policy="evict_last"
+        ).to(tl.float32)
         m_new = tl.maximum(inp, m)
         all_neg_inf = m_new == float("-inf")
         z = tl.where(all_neg_inf, z, z * tl.exp(m - m_new) + tl.exp(inp - m_new))
@@ -62,19 +62,21 @@ def log_softmax_kernel(
     m_reduced = tl.max(m, 1)
     z = tl.sum(z * tl.exp(m - m_reduced[:, None]), 1)
     m = m_reduced
+    log_z = tl.log(z)
 
     for start_n in range(0, N, BLOCK_N):
         n_offset = start_n + tl.arange(0, BLOCK_N)
         offset = m_offset[:, None] * N * K + n_offset[None, :] * K + pid_k
         mask = m_offset[:, None] < M and n_offset[None, :] < N
         input_ptrs = input_ptr + offset
-        inp = tl.load(input_ptrs, mask=mask, other=-float("inf")).to(tl.float32)
-        o = inp - m[:, None] - tl.log(z[:, None])
-        tl.store(output_ptr + offset, o, mask=mask)
+        inp = tl.load(
+            input_ptrs, mask=mask, other=-float("inf"), eviction_policy="evict_first"
+        ).to(tl.float32)
+        o = inp - m[:, None] - log_z[:, None]
+        tl.store(output_ptr + offset, o, mask=mask, eviction_policy="evict_first")
 
 
 @libentry()
-# @triton.autotune(configs=runtime.get_tuned_config("log_softmax"), key=["M", "N"])
 @triton.heuristics(
     {
         "BLOCK_M": heur_block_m,
@@ -136,6 +138,21 @@ def log_softmax(self, dim, half_to_float=False):
     out = torch.empty_like(inp, dtype=dtype)
     K = inp.numel() // M // N
 
+    # Select num_warps and num_stages based on N
+    # Use higher num_stages for better pipelining
+    if N <= 256:
+        nw = 2
+        ns = 4
+    elif N <= 1024:
+        nw = 4
+        ns = 4
+    elif N <= 4096:
+        nw = 8
+        ns = 3
+    else:
+        nw = 16
+        ns = 2
+
     grid = lambda meta: (
         triton.cdiv(M, meta["BLOCK_M"]),
         K,
@@ -148,7 +165,8 @@ def log_softmax(self, dim, half_to_float=False):
             N,
             K,
             isCloseCoreTiling=True,
-            num_warps=8,
+            num_warps=nw,
+            num_stages=ns,
         )
     return out
 
@@ -167,6 +185,21 @@ def log_softmax_backward(grad_output, output, dim, input_dtype):
     in_grad = torch.empty_like(output, dtype=input_dtype)
     K = output.numel() // M // N
 
+    # Select num_warps and num_stages based on N
+    # Use higher num_stages for better pipelining
+    if N <= 256:
+        nw = 2
+        ns = 4
+    elif N <= 1024:
+        nw = 4
+        ns = 4
+    elif N <= 4096:
+        nw = 8
+        ns = 3
+    else:
+        nw = 16
+        ns = 2
+
     grid = lambda meta: (
         triton.cdiv(M, meta["BLOCK_M"]),
         K,
@@ -180,5 +213,7 @@ def log_softmax_backward(grad_output, output, dim, input_dtype):
             N,
             K,
             isCloseCoreTiling=True,
+            num_warps=nw,
+            num_stages=ns,
         )
     return in_grad

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/logical_and.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/logical_and.py
@@ -2,13 +2,25 @@ import logging
 
 import triton
 import triton.language as tl
+from _kunlunxin.utils.codegen_config_utils import CodeGenConfig
 
 from ..utils.pointwise_dynamic import pointwise_dynamic
 
 logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 
+config_ = CodeGenConfig(
+    512,
+    (65536, 65536, 65536),
+    32,
+    True,
+    prefer_1d_tile=True,
+    isCloseMemoryAsync=False,
+    kunlunAutoGrid=True,
+    unroll_num=8,
+)
 
-@pointwise_dynamic(promotion_methods=[(0, 1, "ALWAYS_BOOL")])
+
+@pointwise_dynamic(promotion_methods=[(0, 1, "ALWAYS_BOOL")], config=config_)
 @triton.jit
 def logical_and_func(x, y):
     return x.to(tl.int1).logical_and(y.to(tl.int1))

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/multinomial.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/multinomial.py
@@ -3,7 +3,6 @@ import logging
 import torch
 import triton
 import triton.language as tl
-
 from flag_gems.utils import libentry
 from flag_gems.utils.random_utils import philox_backend_seed_offset, uniform
 
@@ -59,6 +58,16 @@ def multinomial(prob, n_samples, with_replacement=False, *, gen=None):
     assert (
         with_replacement or n_samples <= n_categories
     ), "cannot sample n_samples > prob.size(-1) samples without replacement."
+
+    # Fast path: when there's only 1 category, all samples must be 0
+    if n_categories == 1:
+        if prob.dim() == 1:
+            return torch.zeros((n_samples,), device=prob.device, dtype=torch.int64)
+        else:
+            n_dist = prob.size(0)
+            return torch.zeros(
+                (n_dist, n_samples), device=prob.device, dtype=torch.int64
+            )
 
     # Sampling without replacement
     if (not with_replacement) or n_samples == 1:


### PR DESCRIPTION
## Batch 06

**Branch:** `optimize/kunlunxin-batch-06`

**PR Title:** [KernelGen][KunlunXin] Optimize logical_and, log_softmax, multinomial operators


**PR Body (copy below):**


## Summary

Optimize KunlunXin XPU-specific `logical_and`, `log_softmax`, `multinomial` operators using KernelGen-generated Triton kernels, improving performance over the baseline implementations.

## Changes

- Replace baseline Triton kernel implementations with KernelGen-optimized versions
- Optimized kernel parameters (BLOCK_SIZE, num_warps) for KunlunXin XPU architecture
- Modified: `src/flag_gems/runtime/backend/_kunlunxin/ops/logical_and.py`
- Modified: `src/flag_gems/runtime/backend/_kunlunxin/ops/log_softmax.py`
- Modified: `src/flag_gems/runtime/backend/_kunlunxin/ops/multinomial.py`

## Performance

Speedup vs `torch` native ops on KunlunXin XPU:

| Operator | Before | After | Best Version | Improvement |
|----------|--------|-------|--------------|-------------|
| logical_and | 0.7549 | 0.8981 | v1 | +19.0% |
| log_softmax | 0.0272 | 0.0317 | v10 | +16.3% |
| multinomial | 2.1273 | 2.4168 | v1 | +13.6% |
