### PR TITLE
[MTHREADS] Fix one_hot test and add index validation

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/one_hot.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/one_hot.py
@@ -137,6 +137,10 @@ def one_hot(tensor: torch.Tensor, num_classes: int = -1) -> torch.Tensor:
     if (tensor < 0).any():
         raise RuntimeError("Class values must be non-negative.")
 
+    # Validate that all indices are within num_classes range
+    if (tensor >= num_classes).any():
+        raise RuntimeError("Class values must be smaller than num_classes.")
+
     if num_classes < 1:
         raise RuntimeError("num_classes should be positive")
 

--- a/tests/test_tensor_constructor_ops.py
+++ b/tests/test_tensor_constructor_ops.py
@@ -297,7 +297,7 @@ def test_accuracy_eye(shape, dtype):
 
 @pytest.mark.one_hot
 def test_accuracy_one_hot():
-    from flag_gems.ops.one_hot import one_hot as gems_one_hot
+    gems_one_hot = flag_gems.one_hot
 
     dev_type = torch.device(device).type
     expected_device = "cpu" if TO_CPU else device


### PR DESCRIPTION
1. Fixed test import path to use backend replacement mechanism
   - Original test imported directly from `flag_gems.ops.one_hot`, bypassing the `runtime.replace_customized_ops()` mechanism
   - This caused tests to use generic implementation instead of vendor-specific implementation with proper validation

2. Added index range validation to mthreads one_hot implementation
   - Commit 59459940 added negative index validation but missed validation for indices exceeding num_classes range
   - Added check: `if (tensor >= num_classes).any()` to ensure all indices are within valid range
