### PR TITLE
Fix/mixed dtype mm fill slice

### DIFF
--- a/benchmark/bench_fused_add_rms_norm.py
+++ b/benchmark/bench_fused_add_rms_norm.py
@@ -3,15 +3,19 @@ Benchmark: fused_add_rms_norm
 Compares: FlagGems vs torch.compile vs vLLM (if available)
 """
 
-import torch
 import time
+
+import torch
+
 import flag_gems
+
 
 # ── reference: naive torch ──────────────────────────────────────────────
 def torch_fused_add_rms_norm(x, residual, weight, eps=1e-5):
     x = x + residual
     variance = x.pow(2).mean(-1, keepdim=True)
     return x * torch.rsqrt(variance + eps) * weight, x
+
 
 # ── reference: torch.compile ────────────────────────────────────────────
 @torch.compile
@@ -20,15 +24,19 @@ def compiled_fused_add_rms_norm(x, residual, weight, eps=1e-5):
     variance = x.pow(2).mean(-1, keepdim=True)
     return x * torch.rsqrt(variance + eps) * weight, x
 
+
 # ── reference: vLLM ─────────────────────────────────────────────────────
 try:
     import os
+
     os.environ["VLLM_CONFIGURE_LOGGING"] = "0"
     from vllm._custom_ops import fused_add_rms_norm as vllm_fused_add_rms_norm
+
     HAS_VLLM = True
 except (ImportError, AttributeError):
     HAS_VLLM = False
     print("vLLM not available, skipping vLLM baseline\n")
+
 
 # ── benchmark helper ────────────────────────────────────────────────────
 def bench_fn(fn, warmup=20, rep=100):
@@ -41,6 +49,7 @@ def bench_fn(fn, warmup=20, rep=100):
     torch.cuda.synchronize()
     t1 = time.perf_counter()
     return (t1 - t0) / rep * 1000  # ms
+
 
 # ── main ────────────────────────────────────────────────────────────────
 shapes = [
@@ -90,6 +99,7 @@ for shape in shapes:
                 xc = x_ref.clone()
                 rc = r_ref.clone()
                 vllm_fused_add_rms_norm(xc, rc, w, eps)
+
             t_vllm = bench_fn(run_vllm)
 
         # ── FlagGems ──
@@ -97,6 +107,7 @@ for shape in shapes:
             xc = x_ref.clone()
             rc = r_ref.clone()
             flag_gems.fused_add_rms_norm(xc, rc, (N,), w, eps)
+
         t_gems = bench_fn(run_gems)
 
         # ── print ──

--- a/benchmark/bench_fused_add_rms_norm.py
+++ b/benchmark/bench_fused_add_rms_norm.py
@@ -1,0 +1,107 @@
+"""
+Benchmark: fused_add_rms_norm
+Compares: FlagGems vs torch.compile vs vLLM (if available)
+"""
+
+import torch
+import time
+import flag_gems
+
+# ── reference: naive torch ──────────────────────────────────────────────
+def torch_fused_add_rms_norm(x, residual, weight, eps=1e-5):
+    x = x + residual
+    variance = x.pow(2).mean(-1, keepdim=True)
+    return x * torch.rsqrt(variance + eps) * weight, x
+
+# ── reference: torch.compile ────────────────────────────────────────────
+@torch.compile
+def compiled_fused_add_rms_norm(x, residual, weight, eps=1e-5):
+    x = x + residual
+    variance = x.pow(2).mean(-1, keepdim=True)
+    return x * torch.rsqrt(variance + eps) * weight, x
+
+# ── reference: vLLM ─────────────────────────────────────────────────────
+try:
+    import os
+    os.environ["VLLM_CONFIGURE_LOGGING"] = "0"
+    from vllm._custom_ops import fused_add_rms_norm as vllm_fused_add_rms_norm
+    HAS_VLLM = True
+except (ImportError, AttributeError):
+    HAS_VLLM = False
+    print("vLLM not available, skipping vLLM baseline\n")
+
+# ── benchmark helper ────────────────────────────────────────────────────
+def bench_fn(fn, warmup=20, rep=100):
+    for _ in range(warmup):
+        fn()
+    torch.cuda.synchronize()
+    t0 = time.perf_counter()
+    for _ in range(rep):
+        fn()
+    torch.cuda.synchronize()
+    t1 = time.perf_counter()
+    return (t1 - t0) / rep * 1000  # ms
+
+# ── main ────────────────────────────────────────────────────────────────
+shapes = [
+    (1, 4096),
+    (32, 4096),
+    (128, 4096),
+    (512, 4096),
+    (1024, 4096),
+    (4096, 4096),
+    (128, 8192),
+    (128, 11008),
+]
+dtypes = [torch.float16, torch.bfloat16]
+
+print(f"{'shape':>18s} {'dtype':>10s} | {'naive':>8s} {'compile':>8s}", end="")
+if HAS_VLLM:
+    print(f" {'vllm':>8s}", end="")
+print(f" {'flaggems':>8s}  (ms)")
+print("-" * 80)
+
+for shape in shapes:
+    for dtype in dtypes:
+        M, N = shape
+        device = "cuda"
+        eps = 1e-5
+
+        x_ref = torch.randn(M, N, dtype=dtype, device=device)
+        r_ref = torch.randn(M, N, dtype=dtype, device=device)
+        w = torch.randn(N, dtype=dtype, device=device)
+
+        # ── naive torch ──
+        t_naive = bench_fn(
+            lambda: torch_fused_add_rms_norm(x_ref.clone(), r_ref.clone(), w, eps)
+        )
+
+        # ── torch.compile ──
+        # warmup compile
+        _ = compiled_fused_add_rms_norm(x_ref.clone(), r_ref.clone(), w, eps)
+        t_compile = bench_fn(
+            lambda: compiled_fused_add_rms_norm(x_ref.clone(), r_ref.clone(), w, eps)
+        )
+
+        # ── vLLM ──
+        if HAS_VLLM:
+            # vLLM's fused_add_rms_norm is in-place: (x, residual) modified
+            def run_vllm():
+                xc = x_ref.clone()
+                rc = r_ref.clone()
+                vllm_fused_add_rms_norm(xc, rc, w, eps)
+            t_vllm = bench_fn(run_vllm)
+
+        # ── FlagGems ──
+        def run_gems():
+            xc = x_ref.clone()
+            rc = r_ref.clone()
+            flag_gems.fused_add_rms_norm(xc, rc, (N,), w, eps)
+        t_gems = bench_fn(run_gems)
+
+        # ── print ──
+        tag = f"({M}, {N})"
+        print(f"{tag:>18s} {str(dtype):>10s} | {t_naive:8.3f} {t_compile:8.3f}", end="")
+        if HAS_VLLM:
+            print(f" {t_vllm:8.3f}", end="")
+        print(f" {t_gems:8.3f}")

--- a/src/flag_gems/ops/addmm.py
+++ b/src/flag_gems/ops/addmm.py
@@ -7,6 +7,7 @@ import triton.language as tl
 
 from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
+from flag_gems.ops.mm import get_higher_dtype
 from flag_gems.utils import broadcastable_to, libentry, libtuner
 from flag_gems.utils import triton_lang_extension as tle
 
@@ -69,6 +70,9 @@ def addmm_kernel(
             mask=(offs_k[:, None] < K - k * BLOCK_SIZE_K) & (offs_bn[None, :] < N),
             other=0.0,
         )
+        if a.dtype != b.dtype:
+            a = a.to(c_ptr.dtype.element_ty)
+            b = b.to(c_ptr.dtype.element_ty)
         accumulator += tl.dot(a, b, allow_tf32=False)
         a_ptrs += BLOCK_SIZE_K * stride_ak
         b_ptrs += BLOCK_SIZE_K * stride_bk
@@ -105,7 +109,8 @@ def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
     )
     mat1 = mat1.contiguous()
     # mat2 = mat2.contiguous()
-    out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
+    c_dtype = get_higher_dtype(mat1.dtype, mat2.dtype)
+    out = torch.empty((M, N), device=mat1.device, dtype=c_dtype)
     bias = bias.broadcast_to(out.shape)
 
     grid = lambda META: (
@@ -143,7 +148,8 @@ def addmm_out(bias, mat1, mat2, *, beta=1, alpha=1, out=None):
     M, K = mat1.shape
     _, N = mat2.shape
     if out is None:
-        out = torch.empty((M, N), device=mat1.device, dtype=mat1.dtype)
+        c_dtype = get_higher_dtype(mat1.dtype, mat2.dtype)
+        out = torch.empty((M, N), device=mat1.device, dtype=c_dtype)
     else:
         assert out.shape == (M, N), "Incompatible output shape"
     logger.debug(

--- a/src/flag_gems/ops/addmm.py
+++ b/src/flag_gems/ops/addmm.py
@@ -6,8 +6,8 @@ import triton
 import triton.language as tl
 
 from flag_gems import runtime
-from flag_gems.runtime import torch_device_fn
 from flag_gems.ops.mm import get_higher_dtype
+from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import broadcastable_to, libentry, libtuner
 from flag_gems.utils import triton_lang_extension as tle
 

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/mm.py
@@ -20,6 +20,15 @@ EXPAND_CONFIG_FILENAME = os.path.normpath(
 )
 
 
+def _has_valid_tma_stride(t):
+    """Check that tensor has no zero strides (e.g. from expand) and that
+    either row-major or column-major layout has a contiguous inner dim."""
+    if any(s == 0 for s in t.stride()):
+        return False
+    # At least one of the two dims must have stride == 1
+    return t.stride(0) == 1 or t.stride(1) == 1
+
+
 def is_tma_compatible(a, b, N, K):
     """
     Check if tensors are compatible with TMA (Tensor Memory Accelerator).
@@ -30,13 +39,18 @@ def is_tma_compatible(a, b, N, K):
     - For FP32 (4 bytes/element): N and K must be multiples of 4
       (4 elements × 4 bytes = 16 bytes)
 
+    Additionally, tensors must have valid strides (no zero strides from
+    expand) and a contiguous inner dimension.
+
     Args:
         a, b: Input tensors
         N, K: Matrix dimensions
 
     Returns:
-        bool: True if compatible with TMA's 128-bit alignment requirement
+        bool: True if compatible with TMA's alignment and stride requirements
     """
+    if not (_has_valid_tma_stride(a) and _has_valid_tma_stride(b)):
+        return False
     return (
         a.dtype in (torch.float16, torch.bfloat16)
         and b.dtype in (torch.float16, torch.bfloat16)
@@ -100,6 +114,7 @@ def mm_kernel_general(
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
     GROUP_M: tl.constexpr,
+    dtype: tl.constexpr = "float32",
 ):
     # matrix multiplication
     pid = tle.program_id(0)
@@ -394,6 +409,7 @@ def general_mm(a, b, c, M, N, K):
                 c.stride(0),
                 c.stride(1),
                 GROUP_M=8,
+                dtype=str(a.dtype).split(".")[-1],
             )
     return c
 

--- a/src/flag_gems/runtime/backend/_tsingmicro/utils/pointwise_dynamic.py
+++ b/src/flag_gems/runtime/backend/_tsingmicro/utils/pointwise_dynamic.py
@@ -881,7 +881,7 @@ class WrapperGenerator:
                 code.writeline(f"tile_size = {max_tile_size}")
             code.writeline("")
             code.writeline(
-                f"num_tensors = {self.fx.num_input_tensors() +  self.fx.num_output_tensors()}"
+                f"num_tensors = {self.fx.num_input_tensors() + self.fx.num_output_tensors()}"
             )
             code.writeline(
                 f"available_spm_size = {SPM_SIZE} - {SYS_SPM_RESERVED_SIZE} - {OPS_SPM_RESERVED_SIZE}"

--- a/src/flag_gems/utils/pointwise_dynamic.py
+++ b/src/flag_gems/utils/pointwise_dynamic.py
@@ -825,7 +825,7 @@ class WrapperGenerator:
             max_tile_size = self.config.max_tile_size
             major, _ = get_device_capability()
             if self.name.find("fill_scalar") != -1 and major >= 9:
-                code.writeline("tile_sizes = tuple([64])")
+                code.writeline("tile_sizes = heuristics_for_tile_size(64, *shape)")
             else:
                 code.writeline(
                     f"tile_sizes = heuristics_for_tile_size({max_tile_size}, *shape)"

--- a/tests/test_blas_ops.py
+++ b/tests/test_blas_ops.py
@@ -32,6 +32,13 @@ else:
     ]
     FLOAT_DTYPES = ORIG_FLOAT_DTYPES
 
+MIXED_DTYPE_PAIRS = [
+    (torch.float16, torch.float32),
+    (torch.float32, torch.float16),
+    (torch.bfloat16, torch.float32),
+    (torch.float32, torch.bfloat16),
+]
+
 
 @pytest.mark.addmm
 @pytest.mark.parametrize("M, N, K", MNK_SHAPES)
@@ -73,6 +80,28 @@ def test_accuracy_addmm(M, N, K, scalar, dtype, b_column_major):
 
     if flag_gems.vendor_name == "mthreads":
         del os.environ["MUSA_ENABLE_SQMMA"]
+
+
+@pytest.mark.addmm
+@pytest.mark.parametrize("M, N, K", MNK_SHAPES)
+@pytest.mark.parametrize("scalar", SCALARS)
+@pytest.mark.parametrize("dtype_a, dtype_b", MIXED_DTYPE_PAIRS)
+def test_accuracy_addmm_mixed_dtype(M, N, K, scalar, dtype_a, dtype_b):
+    mat1 = torch.randn((M, K), dtype=dtype_a, device=flag_gems.device)
+    mat2 = torch.randn((K, N), dtype=dtype_b, device=flag_gems.device)
+    out_dtype = torch.promote_types(dtype_a, dtype_b)
+    bias1 = torch.randn((N,), dtype=out_dtype, device=flag_gems.device)
+    ref_mat1 = to_reference(mat1, True)
+    ref_mat2 = to_reference(mat2, True)
+    ref_bias1 = to_reference(bias1, True)
+
+    alpha = beta = scalar
+
+    ref_out = torch.addmm(ref_bias1, ref_mat1, ref_mat2, alpha=alpha, beta=beta)
+    with flag_gems.use_gems():
+        res_out = torch.addmm(bias1, mat1, mat2, alpha=alpha, beta=beta)
+
+    gems_assert_close(res_out, ref_out, out_dtype, reduce_dim=K)
 
 
 @pytest.mark.addmm_out
@@ -368,6 +397,33 @@ def test_accuracy_mm(M, N, K, dtype, b_column_major):
         res_out = torch.mm(mat1, mat2)
 
     gems_assert_close(res_out, ref_out, dtype, reduce_dim=K)
+
+
+@pytest.mark.mm
+@pytest.mark.parametrize("M, N, K", MNK_SHAPES)
+@pytest.mark.parametrize("dtype_a, dtype_b", MIXED_DTYPE_PAIRS)
+@pytest.mark.parametrize("b_column_major", [True, False])
+def test_accuracy_mm_mixed_dtype(M, N, K, dtype_a, dtype_b, b_column_major):
+    torch.manual_seed(0)
+    torch.cuda.manual_seed_all(0)
+    np.random.seed(0)
+    random.seed(0)
+
+    mat1 = torch.randn((M, K), dtype=dtype_a, device=flag_gems.device)
+    if b_column_major:
+        mat2 = torch.randn((N, K), dtype=dtype_b, device=flag_gems.device).t()
+    else:
+        mat2 = torch.randn((K, N), dtype=dtype_b, device=flag_gems.device)
+    ref_mat1 = to_reference(mat1, True)
+    ref_mat2 = to_reference(mat2, True)
+
+    out_dtype = torch.promote_types(dtype_a, dtype_b)
+
+    ref_out = torch.mm(ref_mat1, ref_mat2)
+    with flag_gems.use_gems():
+        res_out = torch.mm(mat1, mat2)
+
+    gems_assert_close(res_out, ref_out, out_dtype, reduce_dim=K)
 
 
 @pytest.mark.mv

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -1286,6 +1286,34 @@ def test_fill_out(value, shape, dtype):
     ), "fill.Tensor_out should return the out tensor"
 
 
+FILL_SLICE_CASES = [
+    # (shape, slice)
+    ((4, 128), (slice(None), slice(64, None))),
+    ((2, 1, 1, 512), (slice(None), slice(None), slice(None), slice(358, None))),
+    ((8, 32, 64), (slice(None), slice(16, None))),
+]
+
+
+@pytest.mark.fill
+@pytest.mark.parametrize("shape, slc", FILL_SLICE_CASES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES + BOOL_TYPES)
+@pytest.mark.parametrize(
+    "value", [0, 1, True, float("-inf")], ids=["zero", "one", "true", "neginf"]
+)
+def test_fill_sliced_view(shape, slc, dtype, value):
+    if dtype == torch.bool and value == float("-inf"):
+        pytest.skip("bool tensor does not support -inf")
+
+    x = torch.randn(shape, device=flag_gems.device).to(dtype)
+    ref_x = to_reference(x.clone(), False)
+
+    ref_x[slc] = value
+    with flag_gems.use_gems():
+        x[slc] = value
+
+    gems_assert_equal(x, ref_x)
+
+
 CAMBRICON_STACK_SHAPES = [
     [
         (8, 8, 128),


### PR DESCRIPTION

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

    fix: mixed-dtype mm, hopper TMA stride check, fill slice view IndexError
    
    - addmm: cast inputs to common dtype before tl.dot for mixed-precision (fp16 x fp32)
    - hopper mm: add stride validation in is_tma_compatible to reject expand/zero-stride tensors
    - hopper mm: add missing dtype param to mm_kernel_general fallback path
    - pointwise_dynamic: use heuristics_for_tile_size(64, *shape) for fill_scalar to match ndim
    - tests: add mixed-dtype mm/addmm tests, fill sliced view tests
### Issue
fix issue #2349
fix issue #2338
fix issue #2347
<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
