### PR TITLE
fix: resolve operator registration failure

### DIFF
--- a/src/flag_gems/runtime/error.py
+++ b/src/flag_gems/runtime/error.py
@@ -10,9 +10,9 @@ def device_not_found():
 
 
 def register_error(e):
-    raise RuntimeError(
-        e, "An error was encountered while registering the triton operator."
-    )
+    import logging
+
+    logging.warning(f"Skipped registering operator: {e}")
 
 
 def customized_op_replace_error(e):


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Change register_error from raising RuntimeError to logging a warning, so that duplicate operator registration (e.g. replication_pad3d) does not block the loading of other Cambricon specialized operators.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
