### PR TITLE
Add FlagTree lib path for mthreads

### DIFF
--- a/tools/run_backend_tests_mthreads.sh
+++ b/tools/run_backend_tests_mthreads.sh
@@ -33,6 +33,8 @@ export PATH=$MUSA_HOME/bin:$PATH
 export LD_LIBRARY_PATH=$MUSA_HOME/lib:$LD_LIBRARY_PATH
 # For the intel math library
 export LD_LIBRARY_PATH=$VIRTUAL_ENV/lib:$LD_LIBRARY_PATH
+# For the Flagtree dynamic library
+export LD_LIBRARY_PATH=$VIRTUAL_ENV/lib/python3.10/site-packages/triton/_C:$LD_LIBRARY_PATH
 
 echo "LD_LIBRARY_PATH=$LD_LIBRARY_PATH"
 


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Add flagtree path to LD_LIBRARY_PATH on mthreads platforms.
