### PR TITLE
[PerfXLab] Optimize exponential  op

### DIFF
--- a/src/flag_gems/ops/exponential_.py
+++ b/src/flag_gems/ops/exponential_.py
@@ -84,8 +84,6 @@ def transform_exponential_f64(u, inv_lambd, eps_minus):
         triton.Config({"BLOCK": 128}, num_warps=4, num_stages=3),
         triton.Config({"BLOCK": 256}, num_warps=4, num_stages=3),
         triton.Config({"BLOCK": 512}, num_warps=8, num_stages=3),
-        triton.Config({"BLOCK": 1024}, num_warps=8, num_stages=4),
-        triton.Config({"BLOCK": 2048}, num_warps=16, num_stages=4),
     ],
     key=["N"],
 )
@@ -146,8 +144,6 @@ def fused_exponential_kernel_f32_unroll8(
         triton.Config({"BLOCK": 128}, num_warps=4, num_stages=3),
         triton.Config({"BLOCK": 256}, num_warps=4, num_stages=3),
         triton.Config({"BLOCK": 512}, num_warps=8, num_stages=3),
-        triton.Config({"BLOCK": 1024}, num_warps=8, num_stages=4),
-        triton.Config({"BLOCK": 2048}, num_warps=16, num_stages=4),
     ],
     key=["N"],
 )
@@ -232,8 +228,6 @@ def fused_exponential_kernel_f32_small(
         triton.Config({"BLOCK": 128}, num_warps=4, num_stages=3),
         triton.Config({"BLOCK": 256}, num_warps=4, num_stages=3),
         triton.Config({"BLOCK": 512}, num_warps=8, num_stages=3),
-        triton.Config({"BLOCK": 1024}, num_warps=8, num_stages=4),
-        triton.Config({"BLOCK": 2048}, num_warps=16, num_stages=4),
     ],
     key=["N"],
 )

--- a/src/flag_gems/ops/exponential_.py
+++ b/src/flag_gems/ops/exponential_.py
@@ -80,11 +80,12 @@ def transform_exponential_f64(u, inv_lambd, eps_minus):
 @libentry()
 @libtuner(
     configs=[
-        triton.Config({"BLOCK": 64}, num_warps=2, num_stages=2),
-        triton.Config({"BLOCK": 128}, num_warps=2, num_stages=2),
-        triton.Config({"BLOCK": 256}, num_warps=4, num_stages=2),
-        triton.Config({"BLOCK": 512}, num_warps=4, num_stages=3),
-        triton.Config({"BLOCK": 1024}, num_warps=8, num_stages=3),
+        triton.Config({"BLOCK": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK": 128}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK": 256}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK": 512}, num_warps=8, num_stages=3),
+        triton.Config({"BLOCK": 1024}, num_warps=8, num_stages=4),
+        triton.Config({"BLOCK": 2048}, num_warps=16, num_stages=4),
     ],
     key=["N"],
 )
@@ -98,35 +99,53 @@ def fused_exponential_kernel_f32(
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
 
     pid = tl.program_id(0)
-    i = pid * BLOCK + tl.arange(0, BLOCK)
-    c0 += i
-    z = c0 * 0
-    r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, z, z)
+    base_idx = pid * BLOCK * 8
+    # i= base_idx + tl.arange(0, BLOCK)
 
-    y0 = transform_exponential_f32(uint_to_uniform_float(r0), inv_lambd, eps_minus)
-    y1 = transform_exponential_f32(uint_to_uniform_float(r1), inv_lambd, eps_minus)
-    y2 = transform_exponential_f32(uint_to_uniform_float(r2), inv_lambd, eps_minus)
-    y3 = transform_exponential_f32(uint_to_uniform_float(r3), inv_lambd, eps_minus)
+    c0_i = c0 + tl.arange(0, BLOCK)
+    z = c0_i * 0
 
-    start = pid.to(tl.uint64) * BLOCK * 4
-    off0 = start + tl.arange(0, BLOCK)
+    r0_0, r1_0, r2_0, r3_0 = tl.philox(philox_seed, c0_i, c1, z, z)
+    r0_1, r1_1, r2_1, r3_1 = tl.philox(philox_seed, c0_i, c1 + 4, z, z)
+
+    y0_0 = transform_exponential_f32(uint_to_uniform_float(r0_0), inv_lambd, eps_minus)
+    y1_0 = transform_exponential_f32(uint_to_uniform_float(r1_0), inv_lambd, eps_minus)
+    y2_0 = transform_exponential_f32(uint_to_uniform_float(r2_0), inv_lambd, eps_minus)
+    y3_0 = transform_exponential_f32(uint_to_uniform_float(r3_0), inv_lambd, eps_minus)
+
+    y0_1 = transform_exponential_f32(uint_to_uniform_float(r0_1), inv_lambd, eps_minus)
+    y1_1 = transform_exponential_f32(uint_to_uniform_float(r1_1), inv_lambd, eps_minus)
+    y2_1 = transform_exponential_f32(uint_to_uniform_float(r2_1), inv_lambd, eps_minus)
+    y3_1 = transform_exponential_f32(uint_to_uniform_float(r3_1), inv_lambd, eps_minus)
+
+    off0 = base_idx + tl.arange(0, BLOCK)
     off1 = off0 + BLOCK
     off2 = off1 + BLOCK
     off3 = off2 + BLOCK
+    off4 = off3 + BLOCK
+    off5 = off4 + BLOCK
+    off6 = off5 + BLOCK
+    off7 = off6 + BLOCK
 
-    tl.store(out_ptr + off0, y0, mask=off0 < N)
-    tl.store(out_ptr + off1, y1, mask=off1 < N)
-    tl.store(out_ptr + off2, y2, mask=off2 < N)
-    tl.store(out_ptr + off3, y3, mask=off3 < N)
+    tl.store(out_ptr + off0, y0_0, mask=off0 < N)
+    tl.store(out_ptr + off1, y1_0, mask=off1 < N)
+    tl.store(out_ptr + off2, y2_0, mask=off2 < N)
+    tl.store(out_ptr + off3, y3_0, mask=off3 < N)
+    tl.store(out_ptr + off4, y0_1, mask=off4 < N)
+    tl.store(out_ptr + off5, y1_1, mask=off5 < N)
+    tl.store(out_ptr + off6, y2_1, mask=off6 < N)
+    tl.store(out_ptr + off7, y3_1, mask=off7 < N)
 
 
 @libentry()
 @libtuner(
     configs=[
-        triton.Config({"BLOCK": 64}, num_warps=2, num_stages=2),
-        triton.Config({"BLOCK": 128}, num_warps=2, num_stages=2),
-        triton.Config({"BLOCK": 256}, num_warps=4, num_stages=2),
-        triton.Config({"BLOCK": 512}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK": 128}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK": 256}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK": 512}, num_warps=8, num_stages=3),
+        triton.Config({"BLOCK": 1024}, num_warps=8, num_stages=4),
+        triton.Config({"BLOCK": 2048}, num_warps=16, num_stages=4),
     ],
     key=["N"],
 )
@@ -140,23 +159,34 @@ def fused_exponential_kernel_f64(
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
 
     pid = tl.program_id(0)
-    i = pid * BLOCK + tl.arange(0, BLOCK)
-    c0 += i
-    z = c0 * 0
-    r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, z, z)
+    base_idx = pid * BLOCK * 4
+    # i = base_idx + tl.arange(0, BLOCK)
 
-    u0 = uint_to_uniform_float(paste_u64(r0, r2))
-    u1 = uint_to_uniform_float(paste_u64(r1, r3))
+    c0_i = c0 + tl.arange(0, BLOCK)
+    z = c0_i * 0
 
-    y0 = transform_exponential_f64(u0, inv_lambd, eps_minus)
-    y1 = transform_exponential_f64(u1, inv_lambd, eps_minus)
+    r0_0, r1_0, r2_0, r3_0 = tl.philox(philox_seed, c0_i, c1, z, z)
+    r0_1, r1_1, r2_1, r3_1 = tl.philox(philox_seed, c0_i, c1 + 4, z, z)
 
-    start = pid.to(tl.uint64) * BLOCK * 2
-    off0 = start + tl.arange(0, BLOCK)
+    u0_0 = uint_to_uniform_float(paste_u64(r0_0, r2_0))
+    u1_0 = uint_to_uniform_float(paste_u64(r1_0, r3_0))
+    u0_1 = uint_to_uniform_float(paste_u64(r0_1, r2_1))
+    u1_1 = uint_to_uniform_float(paste_u64(r1_1, r3_1))
+
+    y0_0 = transform_exponential_f64(u0_0, inv_lambd, eps_minus)
+    y1_0 = transform_exponential_f64(u1_0, inv_lambd, eps_minus)
+    y0_1 = transform_exponential_f64(u0_1, inv_lambd, eps_minus)
+    y1_1 = transform_exponential_f64(u1_1, inv_lambd, eps_minus)
+
+    off0 = base_idx + tl.arange(0, BLOCK)
     off1 = off0 + BLOCK
+    off2 = off1 + BLOCK
+    off3 = off2 + BLOCK
 
-    tl.store(out_ptr + off0, y0, mask=off0 < N)
-    tl.store(out_ptr + off1, y1, mask=off1 < N)
+    tl.store(out_ptr + off0, y0_0, mask=off0 < N)
+    tl.store(out_ptr + off1, y1_0, mask=off1 < N)
+    tl.store(out_ptr + off2, y0_1, mask=off2 < N)
+    tl.store(out_ptr + off3, y1_1, mask=off3 < N)
 
 
 def exponential_(x, lambd: float = 1.0, *, generator=None):
@@ -184,8 +214,19 @@ def exponential_(x, lambd: float = 1.0, *, generator=None):
             fused_exponential_kernel_f64[grid](
                 out, N, inv_lambd, eps_minus, philox_seed, philox_offset
             )
+    elif dtype in (torch.float16, torch.bfloat16):
+        UNROLL = 4 if N < 65536 else 8
+        grid = lambda meta: (triton.cdiv(N, meta["BLOCK"] * UNROLL),)
+        increment = triton.cdiv(N, UNROLL)
+        philox_seed, philox_offset = philox_backend_seed_offset(
+            increment, generator=generator
+        )
+        with torch_device_fn.device(device):
+            fused_exponential_kernel_f32[grid](
+                out, N, inv_lambd, eps_minus, philox_seed, philox_offset
+            )
     else:
-        UNROLL = 4
+        UNROLL = 8
         grid = lambda meta: (triton.cdiv(N, meta["BLOCK"] * UNROLL),)
         increment = triton.cdiv(N, UNROLL)
         philox_seed, philox_offset = philox_backend_seed_offset(

--- a/src/flag_gems/ops/exponential_.py
+++ b/src/flag_gems/ops/exponential_.py
@@ -90,7 +90,7 @@ def transform_exponential_f64(u, inv_lambd, eps_minus):
     key=["N"],
 )
 @triton.jit(do_not_specialize=["philox_seed", "philox_offset", "N"])
-def fused_exponential_kernel_f32(
+def fused_exponential_kernel_f32_unroll8(
     out_ptr, N, inv_lambd, eps_minus, philox_seed, philox_offset, BLOCK: tl.constexpr
 ):
     philox_seed = philox_seed.to(tl.int64)
@@ -99,14 +99,15 @@ def fused_exponential_kernel_f32(
     c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
 
     pid = tl.program_id(0)
-    base_idx = pid * BLOCK * 8
-    # i= base_idx + tl.arange(0, BLOCK)
+    block_start = pid * BLOCK
+    offsets = block_start + tl.arange(0, BLOCK)
 
-    c0_i = c0 + tl.arange(0, BLOCK)
-    z = c0_i * 0
+    c0_first = c0 + offsets * 4
+    c0_second = c0_first + BLOCK * 4
+    z = c0_first * 0
 
-    r0_0, r1_0, r2_0, r3_0 = tl.philox(philox_seed, c0_i, c1, z, z)
-    r0_1, r1_1, r2_1, r3_1 = tl.philox(philox_seed, c0_i, c1 + 4, z, z)
+    r0_0, r1_0, r2_0, r3_0 = tl.philox(philox_seed, c0_first, c1, z, z)
+    r0_1, r1_1, r2_1, r3_1 = tl.philox(philox_seed, c0_second, c1, z, z)
 
     y0_0 = transform_exponential_f32(uint_to_uniform_float(r0_0), inv_lambd, eps_minus)
     y1_0 = transform_exponential_f32(uint_to_uniform_float(r1_0), inv_lambd, eps_minus)
@@ -118,7 +119,8 @@ def fused_exponential_kernel_f32(
     y2_1 = transform_exponential_f32(uint_to_uniform_float(r2_1), inv_lambd, eps_minus)
     y3_1 = transform_exponential_f32(uint_to_uniform_float(r3_1), inv_lambd, eps_minus)
 
-    off0 = base_idx + tl.arange(0, BLOCK)
+    base_off = pid.to(tl.uint64) * BLOCK * 8
+    off0 = base_off + tl.arange(0, BLOCK)
     off1 = off0 + BLOCK
     off2 = off1 + BLOCK
     off3 = off2 + BLOCK
@@ -150,6 +152,92 @@ def fused_exponential_kernel_f32(
     key=["N"],
 )
 @triton.jit(do_not_specialize=["philox_seed", "philox_offset", "N"])
+def fused_exponential_kernel_f32(
+    out_ptr, N, inv_lambd, eps_minus, philox_seed, philox_offset, BLOCK: tl.constexpr
+):
+    philox_seed = philox_seed.to(tl.int64)
+    philox_offset = philox_offset.to(tl.int64)
+    c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
+    c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
+
+    pid = tl.program_id(0)
+    i = pid * BLOCK + tl.arange(0, BLOCK)
+    c0 += i
+    z = c0 * 0
+    r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, z, z)
+
+    y0 = transform_exponential_f32(uint_to_uniform_float(r0), inv_lambd, eps_minus)
+    y1 = transform_exponential_f32(uint_to_uniform_float(r1), inv_lambd, eps_minus)
+    y2 = transform_exponential_f32(uint_to_uniform_float(r2), inv_lambd, eps_minus)
+    y3 = transform_exponential_f32(uint_to_uniform_float(r3), inv_lambd, eps_minus)
+
+    start = pid.to(tl.uint64) * BLOCK * 4
+    off0 = start + tl.arange(0, BLOCK)
+    off1 = off0 + BLOCK
+    off2 = off1 + BLOCK
+    off3 = off2 + BLOCK
+
+    tl.store(out_ptr + off0, y0, mask=off0 < N)
+    tl.store(out_ptr + off1, y1, mask=off1 < N)
+    tl.store(out_ptr + off2, y2, mask=off2 < N)
+    tl.store(out_ptr + off3, y3, mask=off3 < N)
+
+
+@libentry()
+@libtuner(
+    configs=[
+        triton.Config({"BLOCK": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK": 128}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK": 256}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK": 512}, num_warps=8, num_stages=3),
+    ],
+    key=["N"],
+)
+@triton.jit(do_not_specialize=["philox_seed", "philox_offset", "N"])
+def fused_exponential_kernel_f32_small(
+    out_ptr, N, inv_lambd, eps_minus, philox_seed, philox_offset, BLOCK: tl.constexpr
+):
+    philox_seed = philox_seed.to(tl.int64)
+    philox_offset = philox_offset.to(tl.int64)
+    c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
+    c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
+
+    pid = tl.program_id(0)
+    base_idx = pid * BLOCK * 4
+    c0_i = c0 + tl.arange(0, BLOCK)
+    z = c0_i * 0
+
+    r0, r1, r2, r3 = tl.philox(philox_seed, c0_i, c1, z, z)
+
+    y0 = transform_exponential_f32(uint_to_uniform_float(r0), inv_lambd, eps_minus)
+    y1 = transform_exponential_f32(uint_to_uniform_float(r1), inv_lambd, eps_minus)
+    y2 = transform_exponential_f32(uint_to_uniform_float(r2), inv_lambd, eps_minus)
+    y3 = transform_exponential_f32(uint_to_uniform_float(r3), inv_lambd, eps_minus)
+
+    off0 = base_idx + tl.arange(0, BLOCK)
+    off1 = off0 + BLOCK
+    off2 = off1 + BLOCK
+    off3 = off2 + BLOCK
+
+    tl.store(out_ptr + off0, y0, mask=off0 < N)
+    tl.store(out_ptr + off1, y1, mask=off1 < N)
+    tl.store(out_ptr + off2, y2, mask=off2 < N)
+    tl.store(out_ptr + off3, y3, mask=off3 < N)
+
+
+@libentry()
+@libtuner(
+    configs=[
+        triton.Config({"BLOCK": 64}, num_warps=4, num_stages=2),
+        triton.Config({"BLOCK": 128}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK": 256}, num_warps=4, num_stages=3),
+        triton.Config({"BLOCK": 512}, num_warps=8, num_stages=3),
+        triton.Config({"BLOCK": 1024}, num_warps=8, num_stages=4),
+        triton.Config({"BLOCK": 2048}, num_warps=16, num_stages=4),
+    ],
+    key=["N"],
+)
+@triton.jit(do_not_specialize=["philox_seed", "philox_offset", "N"])
 def fused_exponential_kernel_f64(
     out_ptr, N, inv_lambd, eps_minus, philox_seed, philox_offset, BLOCK: tl.constexpr
 ):
@@ -160,13 +248,12 @@ def fused_exponential_kernel_f64(
 
     pid = tl.program_id(0)
     base_idx = pid * BLOCK * 4
-    # i = base_idx + tl.arange(0, BLOCK)
+    block_offset = tl.arange(0, BLOCK)
+    c0_base = c0 + block_offset
+    z = c0_base * 0
 
-    c0_i = c0 + tl.arange(0, BLOCK)
-    z = c0_i * 0
-
-    r0_0, r1_0, r2_0, r3_0 = tl.philox(philox_seed, c0_i, c1, z, z)
-    r0_1, r1_1, r2_1, r3_1 = tl.philox(philox_seed, c0_i, c1 + 4, z, z)
+    r0_0, r1_0, r2_0, r3_0 = tl.philox(philox_seed, c0_base, c1, z, z)
+    r0_1, r1_1, r2_1, r3_1 = tl.philox(philox_seed, c0_base + BLOCK, c1, z, z)
 
     u0_0 = uint_to_uniform_float(paste_u64(r0_0, r2_0))
     u1_0 = uint_to_uniform_float(paste_u64(r1_0, r3_0))
@@ -214,15 +301,15 @@ def exponential_(x, lambd: float = 1.0, *, generator=None):
             fused_exponential_kernel_f64[grid](
                 out, N, inv_lambd, eps_minus, philox_seed, philox_offset
             )
-    elif dtype in (torch.float16, torch.bfloat16):
-        UNROLL = 4 if N < 65536 else 8
+    elif dtype in (torch.float16, torch.bfloat16) and N < 65536:
+        UNROLL = 4
         grid = lambda meta: (triton.cdiv(N, meta["BLOCK"] * UNROLL),)
         increment = triton.cdiv(N, UNROLL)
         philox_seed, philox_offset = philox_backend_seed_offset(
             increment, generator=generator
         )
         with torch_device_fn.device(device):
-            fused_exponential_kernel_f32[grid](
+            fused_exponential_kernel_f32_small[grid](
                 out, N, inv_lambd, eps_minus, philox_seed, philox_offset
             )
     else:
@@ -233,7 +320,7 @@ def exponential_(x, lambd: float = 1.0, *, generator=None):
             increment, generator=generator
         )
         with torch_device_fn.device(device):
-            fused_exponential_kernel_f32[grid](
+            fused_exponential_kernel_f32_unroll8[grid](
                 out, N, inv_lambd, eps_minus, philox_seed, philox_offset
             )
 


### PR DESCRIPTION
### PR Category
[ Operator] 

### Type of Change
[Performance Optimization]

### Description
Optimize exponential_ to make average performance up to 1.0 

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
```

test_distribution_perf.py::test_distribution_benchmark[exponential_-exponential_-unary_input_fn] 
Operator: exponential_  Performance Test (dtype=torch.float16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.822656            1.929424               0.945          [torch.Size([1073741824])]
SUCCESS               0.005504            0.005024               1.096          [torch.Size([64, 64])]
SUCCESS               0.036192            0.035328               1.024          [torch.Size([4096, 4096])]
SUCCESS               0.036256            0.035392               1.024          [torch.Size([64, 512, 512])]
SUCCESS               1.836480            1.929680               0.952          [torch.Size([1024, 1024, 1024])]


Operator: exponential_  Performance Test (dtype=torch.float32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.812112            1.867488               0.970          [torch.Size([1073741824])]
SUCCESS               0.005504            0.005088               1.082          [torch.Size([64, 64])]
SUCCESS               0.035840            0.034496               1.039          [torch.Size([4096, 4096])]
SUCCESS               0.035680            0.034336               1.039          [torch.Size([64, 512, 512])]
SUCCESS               1.812240            1.883744               0.962          [torch.Size([1024, 1024, 1024])]


Operator: exponential_  Performance Test (dtype=torch.bfloat16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.836384            1.929584               0.952          [torch.Size([1073741824])]
SUCCESS               0.005504            0.004960               1.110          [torch.Size([64, 64])]
SUCCESS               0.036224            0.035392               1.024          [torch.Size([4096, 4096])]
SUCCESS               0.036288            0.035456               1.023          [torch.Size([64, 512, 512])]
SUCCESS               1.836640            1.930176               0.952          [torch.Size([1024, 1024, 1024])]

```
