### PR TITLE
[KUNLUNXIN] Optimize zero op for XPU backend

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/__init__.py
@@ -217,6 +217,7 @@ from .vector_norm import vector_norm
 from .vstack import vstack
 from .weightnorm import weight_norm_interface, weight_norm_interface_backward
 from .where import where_scalar_other, where_scalar_self, where_self, where_self_out
+from .zero import zero, zero_out
 from .zeros import zeros
 from .zeros_like import zeros_like
 
@@ -519,6 +520,8 @@ __all__ = [
     "where_scalar_self",
     "where_self",
     "where_self_out",
+    "zero",
+    "zero_out",
     "zeros",
     "zeros_like",
 ]

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/zero.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/zero.py
@@ -1,0 +1,60 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
+
+logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
+
+# Kunlunxin XPU has 12 compute clusters; distribute work evenly across them.
+CLUSTER_NUM = 12
+
+
+@libentry()
+@triton.jit
+def zero_kernel(
+    out_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Write-only kernel: no dummy load, stores 0 directly with dtype handled by Triton."""
+    pid = tle.program_id(axis=0)
+    block_start = pid * BLOCK_SIZE
+    offsets = block_start + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    tl.store(out_ptr + offsets, 0.0, mask=mask)
+
+
+def _launch_zero_kernel(tensor: torch.Tensor) -> torch.Tensor:
+    n_elements = tensor.numel()
+    if n_elements == 0:
+        return tensor
+    # BLOCK_SIZE: distribute n_elements evenly across CLUSTER_NUM clusters,
+    # rounded up to the next power of 2 for aligned vectorised stores.
+    block_size = triton.next_power_of_2(triton.cdiv(n_elements, CLUSTER_NUM))
+    grid = (CLUSTER_NUM, 1, 1)
+    with torch_device_fn.device(tensor.device):
+        zero_kernel[grid](
+            tensor,
+            n_elements,
+            BLOCK_SIZE=block_size,
+            buffer_size_limit=2048,
+            isCloseDtypeConvert=True,
+        )
+    return tensor
+
+
+def zero(self: torch.Tensor) -> torch.Tensor:
+    """aten::zero(Tensor self) -> Tensor  — in-place zero-fill, returns self."""
+    logger.debug("GEMS_KUNLUNXIN ZERO")
+    return _launch_zero_kernel(self)
+
+
+def zero_out(self: torch.Tensor, *, out: torch.Tensor) -> torch.Tensor:
+    """aten::zero.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)  — writes zeros to out."""
+    logger.debug("GEMS_KUNLUNXIN ZERO_OUT")
+    return _launch_zero_kernel(out)


### PR DESCRIPTION
- Add dedicated zero.py for Kunlunxin XPU backend
- Remove unnecessary dummy load that caused read+write instead of write-only
- Use fixed (12,1,1) grid matching XPU's 12 compute clusters
- Adaptive BLOCK_SIZE via next_power_of_2(N/12) for better cluster utilization
- Add XPU-specific launch params: buffer_size_limit=2048, isCloseDtypeConvert=True
- Use @libentry() decorator and tle.program_id() for XPU compatibility

The original generic zero.py used a tl.load to infer dtype, turning a
write-only memset into a read+write operation and halving throughput.

### Performance
speedup from 0.59 to 2.1
