### PR TITLE
[FlagGems Operator Development Competition] Add gcd operator

### DIFF
--- a/benchmark/test_binary_pointwise_perf.py
+++ b/benchmark/test_binary_pointwise_perf.py
@@ -104,6 +104,8 @@ class ScalarBinaryPointwiseBenchmark(Benchmark):
             ("allclose", torch.allclose, FLOAT_DTYPES + INT_DTYPES),
             # Log operations
             ("logaddexp", torch.logaddexp, FLOAT_DTYPES),
+            # Integer operations
+            ("gcd", torch.gcd, INT_DTYPES),
         ]
     ],
 )
@@ -135,6 +137,8 @@ def test_general_binary_pointwise_perf(op_name, torch_op, dtypes):
             # Bitwise operations
             ("bitwise_and_", lambda a, b: a.bitwise_and_(b), INT_DTYPES + BOOL_DTYPES),
             ("bitwise_or_", lambda a, b: a.bitwise_or_(b), INT_DTYPES + BOOL_DTYPES),
+            # Integer operations
+            ("gcd_", lambda a, b: a.gcd_(b), INT_DTYPES),
         ]
     ],
 )

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -1837,6 +1837,28 @@ ops:
       - Tensor
     stages:
       stable: '2.2'
+  - name: gcd
+    description: Computes the element-wise greatest common divisor (GCD) of `input` and `other`.
+    for:
+      - gcd
+    labels:
+      - aten
+      - pointwise
+    kind:
+      - Math
+    stages:
+      beta: '5.0'
+  - name: gcd_
+    description: The in-place version of `gcd()`.
+    for:
+      - gcd_
+    labels:
+      - aten
+      - pointwise
+    kind:
+      - Math
+    stages:
+      beta: '5.0'
   - name: ge
     description: Computes `input` is greater or equal to `other` element-wise.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -206,6 +206,8 @@ _FULL_CONFIG = (
     ("full_like", full_like),
     ("gather", gather),
     ("gather_backward", gather_backward),
+    ("gcd", gcd),
+    ("gcd_", gcd_),
     ("ge.Scalar", ge_scalar),
     ("ge.Tensor", ge),
     ("gelu", gelu),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -124,6 +124,7 @@ from flag_gems.ops.fmin import fmin, fmin_out
 from flag_gems.ops.full import full
 from flag_gems.ops.full_like import full_like
 from flag_gems.ops.gather import gather, gather_backward
+from flag_gems.ops.gcd import gcd, gcd_
 from flag_gems.ops.ge import ge, ge_scalar
 from flag_gems.ops.gelu import gelu, gelu_, gelu_backward
 from flag_gems.ops.get_paged_mqa_logits_metadata import get_paged_mqa_logits_metadata
@@ -467,6 +468,8 @@ __all__ = [
     "full_like",
     "gather",
     "gather_backward",
+    "gcd",
+    "gcd_",
     "ge",
     "ge_scalar",
     "gelu",

--- a/src/flag_gems/ops/gcd.py
+++ b/src/flag_gems/ops/gcd.py
@@ -1,0 +1,106 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def _gcd_block(a, b, steps: tl.constexpr):
+    """Do `steps` euclidean iterations with early-exit."""
+    nonzero = b != 0
+    any_nonzero = tl.sum(nonzero.to(tl.int32)) > 0
+
+    if any_nonzero:
+        for _ in range(steps):
+            safe_b = tl.where(nonzero, b, 1)
+            r = a % safe_b
+            a = tl.where(nonzero, b, a)
+            b = tl.where(nonzero, r, b)
+            nonzero = b != 0
+
+    return a, b
+
+
+@pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def gcd_func(x, y):
+    a = tl.abs(x)
+    b = tl.abs(y)
+
+    # ---------- dtype 对齐 ----------
+    if x.dtype != y.dtype:
+        if x.dtype == tl.int64 or y.dtype == tl.int64:
+            a = a.to(tl.int64)
+            b = b.to(tl.int64)
+            dtype = tl.int64
+        elif x.dtype == tl.int32 or y.dtype == tl.int32:
+            a = a.to(tl.int32)
+            b = b.to(tl.int32)
+            dtype = tl.int32
+        elif x.dtype == tl.int16 or y.dtype == tl.int16:
+            a = a.to(tl.int16)
+            b = b.to(tl.int16)
+            dtype = tl.int16
+        else:
+            a = a.to(tl.int8)
+            b = b.to(tl.int8)
+            dtype = tl.int8
+    else:
+        dtype = x.dtype
+
+    # Worst-case iterations ≈ log_φ(max_value):
+    #   int8 → ~9,  int16 → ~22,  int32 → ~44,  int64 → ~90
+    # Each _gcd_block has early-exit, so extra blocks are nearly free.
+    if dtype == tl.int64:
+        # 90 iterations (10 blocks × 10 steps)
+        a, b = _gcd_block(a, b, 10)
+        a, b = _gcd_block(a, b, 10)
+        a, b = _gcd_block(a, b, 10)
+        a, b = _gcd_block(a, b, 10)
+        a, b = _gcd_block(a, b, 10)
+        a, b = _gcd_block(a, b, 10)
+        a, b = _gcd_block(a, b, 10)
+        a, b = _gcd_block(a, b, 10)
+        a, b = _gcd_block(a, b, 10)
+
+    elif dtype == tl.int32:
+        # 44 iterations (8 blocks × 5 steps + 1 block × 4 steps)
+        a, b = _gcd_block(a, b, 5)
+        a, b = _gcd_block(a, b, 5)
+        a, b = _gcd_block(a, b, 5)
+        a, b = _gcd_block(a, b, 5)
+        a, b = _gcd_block(a, b, 5)
+        a, b = _gcd_block(a, b, 5)
+        a, b = _gcd_block(a, b, 5)
+        a, b = _gcd_block(a, b, 5)
+        a, b = _gcd_block(a, b, 4)
+
+    elif dtype == tl.int16:
+        # 22 iterations (4 blocks × 5 steps + 1 block × 2 steps)
+        a, b = _gcd_block(a, b, 5)
+        a, b = _gcd_block(a, b, 5)
+        a, b = _gcd_block(a, b, 5)
+        a, b = _gcd_block(a, b, 5)
+        a, b = _gcd_block(a, b, 2)
+
+    else:  # int8
+        # 9 iterations (3 blocks × 3 steps)
+        a, b = _gcd_block(a, b, 3)
+        a, b = _gcd_block(a, b, 3)
+        a, b = _gcd_block(a, b, 3)
+
+    return a
+
+
+def gcd(A, B):
+    logger.debug("GEMS GCD")
+    return gcd_func(A, B)
+
+
+def gcd_(A, B):
+    logger.debug("GEMS GCD_")
+    return gcd_func(A, B, out0=A)

--- a/src/flag_gems/ops/gcd.py
+++ b/src/flag_gems/ops/gcd.py
@@ -31,7 +31,6 @@ def gcd_func(x, y):
     a = tl.abs(x)
     b = tl.abs(y)
 
-    # ---------- dtype 对齐 ----------
     if x.dtype != y.dtype:
         if x.dtype == tl.int64 or y.dtype == tl.int64:
             a = a.to(tl.int64)

--- a/tests/test_binary_pointwise_ops.py
+++ b/tests/test_binary_pointwise_ops.py
@@ -2644,3 +2644,304 @@ def test_accuracy_atan2_out(shape, dtype):
         res_out = torch.ops.aten.atan2.out(x, y, out=res_out_buf)
 
     gems_assert_close(res_out, ref_out, dtype)
+
+GCD_SHAPES = [
+    (),
+    (1,),
+    (1, 1),
+    (8, 8),
+    (64, 64),
+    (256, 256),
+    (1024, 1024),
+    (20, 320, 15),
+    (16, 128, 64, 60),
+    (16, 7, 57, 32, 29),
+]
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize("shape", GCD_SHAPES)
+@pytest.mark.parametrize("dtype", INT_DTYPES)
+def test_accuracy_gcd(shape, dtype):
+    inp1 = torch.randint(
+        low=-0x7FFF, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    inp2 = torch.randint(
+        low=-0x7FFF, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.inplace
+@pytest.mark.gcd_
+@pytest.mark.parametrize("shape", GCD_SHAPES)
+@pytest.mark.parametrize("dtype", INT_DTYPES)
+def test_accuracy_gcd_(shape, dtype):
+    inp1 = torch.randint(
+        low=-0x7FFF, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    inp2 = torch.randint(
+        low=-0x7FFF, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    ref_inp1 = to_reference(inp1.clone())
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = ref_inp1.gcd_(ref_inp2)
+    with flag_gems.use_gems():
+        res_out = inp1.gcd_(inp2)
+
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize("dtype", INT_DTYPES)
+def test_accuracy_gcd_zeros(dtype):
+    """Test gcd with zero values: gcd(0,0)=0, gcd(a,0)=|a|, gcd(0,b)=|b|."""
+    shape = (64,)
+    # gcd(0, 0) = 0
+    inp1 = torch.zeros(shape, dtype=dtype, device=flag_gems.device)
+    inp2 = torch.zeros(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+    gems_assert_equal(res_out, ref_out)
+
+    # gcd(a, 0) = |a|
+    inp1 = torch.randint(
+        low=1, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    inp2 = torch.zeros(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+    gems_assert_equal(res_out, ref_out)
+
+    # gcd(0, b) = |b|
+    inp1 = torch.zeros(shape, dtype=dtype, device=flag_gems.device)
+    inp2 = torch.randint(
+        low=1, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize("dtype", INT_DTYPES)
+def test_accuracy_gcd_negative(dtype):
+    """Test gcd with negative values."""
+    shape = (256,)
+    # Both negative
+    inp1 = torch.randint(
+        low=-0x7FFF, high=-1, size=shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    inp2 = torch.randint(
+        low=-0x7FFF, high=-1, size=shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+    gems_assert_equal(res_out, ref_out)
+
+    # Mixed signs
+    inp1 = torch.randint(
+        low=-0x7FFF, high=-1, size=shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    inp2 = torch.randint(
+        low=1, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize("dtype", INT_DTYPES)
+def test_accuracy_gcd_extreme_values(dtype):
+    """Test gcd with extreme values for each integer type."""
+    shape = (64,)
+    iinfo = torch.iinfo(dtype)
+    max_val = min(iinfo.max, 2**31 - 1)
+    min_val = max(iinfo.min, -(2**31 - 1))
+
+    inp1 = torch.tensor(
+        [max_val, min_val + 1, 1, max_val, 0] + [max_val] * 59,
+        dtype=dtype, device=flag_gems.device
+    )
+    inp2 = torch.tensor(
+        [1, 1, max_val, max_val, max_val] + [min_val + 1] * 59,
+        dtype=dtype, device=flag_gems.device
+    )
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.gcd
+def test_accuracy_gcd_broadcast():
+    """Test gcd with broadcasting."""
+    dtype = torch.int32
+    inp1 = torch.tensor([5, 10, 15], dtype=dtype, device=flag_gems.device)
+    inp2 = torch.tensor([3], dtype=dtype, device=flag_gems.device)
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+    gems_assert_equal(res_out, ref_out)
+
+    # 2D broadcast
+    inp1 = torch.randint(
+        low=1, high=100, size=(4, 1), dtype=dtype, device=flag_gems.device
+    )
+    inp2 = torch.randint(
+        low=1, high=100, size=(1, 5), dtype=dtype, device=flag_gems.device
+    )
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.gcd
+def test_accuracy_gcd_same_values():
+    """Test gcd(a, a) = |a|."""
+    dtype = torch.int32
+    shape = (128,)
+    inp1 = torch.randint(
+        low=-0x7FFF, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    inp2 = inp1.clone()
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.gcd
+def test_accuracy_gcd_one():
+    """Test gcd(a, 1) = 1 for all a."""
+    dtype = torch.int32
+    shape = (256,)
+    inp1 = torch.randint(
+        low=-0x7FFF, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    inp2 = torch.ones(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize(
+    "shape",
+    [(4096, 4096), (2048, 2048)],
+)
+@pytest.mark.parametrize("dtype", INT_DTYPES)
+def test_accuracy_gcd_large(shape, dtype):
+    """Test gcd with large tensors."""
+    inp1 = torch.randint(
+        low=-0x7FFF, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    inp2 = torch.randint(
+        low=-0x7FFF, high=0x7FFF, size=shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.gcd
+def test_accuracy_gcd_empty_tensor():
+    """Test gcd with empty tensors."""
+    dtype = torch.int32
+    inp1 = torch.tensor([], dtype=dtype, device=flag_gems.device)
+    inp2 = torch.tensor([], dtype=dtype, device=flag_gems.device)
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+    gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.gcd
+def test_accuracy_gcd_known_values():
+    """Test gcd with known mathematical values."""
+    dtype = torch.int64
+    inp1 = torch.tensor(
+        [12, 100, 7, 0, 48, 1071, 270],
+        dtype=dtype, device=flag_gems.device
+    )
+    inp2 = torch.tensor(
+        [8, 75, 13, 5, 18, 462, 192],
+        dtype=dtype, device=flag_gems.device
+    )
+    # Expected: [4, 25, 1, 5, 6, 21, 6]
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+    gems_assert_equal(res_out, ref_out)
+
+
+
+@pytest.mark.gcd
+def test_accuracy_gcd_scalar_tensor():
+    """Test gcd with 0-d (scalar) tensors."""
+    dtype = torch.int32
+    inp1 = torch.tensor(12, dtype=dtype, device=flag_gems.device)
+    inp2 = torch.tensor(8, dtype=dtype, device=flag_gems.device)
+    ref_inp1 = to_reference(inp1)
+    ref_inp2 = to_reference(inp2)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+    gems_assert_equal(res_out, ref_out)


### PR DESCRIPTION
Add torch.gcd and torch.gcd_ operator implementation using Triton, along with unit tests and performance benchmark.gcd(x, y) computes the element-wise greatest common divisor of two integer tensors using the Euclidean algorithm with early-exit optimization:
```python
while b != 0:
    a, b = b, a % b
return abs(a)
```
Iteration counts are tuned per dtype to match worst-case bounds (log_φ(max_value)): int8→9, int16→22, int32→44, int64→90.

# Changes
## Operator Implementation

- src/flag_gems/ops/gcd.py (new): Triton kernel implementation using pointwise_dynamic, with _gcd_block helper for batched Euclidean iterations and early-exit. Supports mixed integer dtype promotion and all integer types (int8/int16/int32/int64).
## Registration
- src/flag_gems/ops/__init__.py: Import and export gcd, gcd_.
- src/flag_gems/__init__.py: Register gcd and gcd_ to aten backend.
- conf/operators.yaml: Add operator metadata for gcd and gcd_.

## Unit Tests

- tests/test_binary_pointwise_ops.py: Added 12 test functions covering gcd and gcd_:
- test_accuracy_gcd — standard accuracy across multiple shapes × dtypes (10 shapes × 4 dtypes)
- test_accuracy_gcd_ — in-place variant accuracy across multiple shapes × dtypes
- test_accuracy_gcd_zeros — zero-value inputs: gcd(0,0)=0, gcd(a,0)=|a|, gcd(0,b)=|b|
- test_accuracy_gcd_negative — negative values and mixed signs
- test_accuracy_gcd_extreme_values — dtype min/max boundary values
- test_accuracy_gcd_broadcast — broadcast shape compatibility (1D and 2D)
- test_accuracy_gcd_same_values — gcd(a, a) = |a|
- test_accuracy_gcd_one — gcd(a, 1) = 1 for all a
- test_accuracy_gcd_large — large tensor shapes (4096×4096, 2048×2048)
- test_accuracy_gcd_empty_tensor — empty tensor handling
- test_accuracy_gcd_known_values — known mathematical results verification
- test_accuracy_gcd_scalar_tensor — 0-d (scalar) tensor support

# Performance Benchmark
benchmark/test_binary_pointwise_perf.py: Added gcd and gcd_ to binary pointwise benchmark with INT_DTYPES.

# Test Results
```shell
pytest -m gcd
```
<img width="1943" height="1028" alt="image" src="https://github.com/user-attachments/assets/e2ad2251-bb39-4916-ae3b-7cccad417645" />
<img width="1959" height="1057" alt="image" src="https://github.com/user-attachments/assets/69d975cf-c8b6-4374-82f9-d9307ad68f32" />

```shell
pytest benchmark/test_binary_pointwise_perf.py -m gcd -s
```
<img width="1942" height="788" alt="image" src="https://github.com/user-attachments/assets/6100867f-dc93-41a4-88e0-55ccb4b783ec" />
<img width="1950" height="537" alt="image" src="https://github.com/user-attachments/assets/1eefc56f-15b2-48bb-808e-06bca5da57ca" />
