### PR TITLE
feat: add combination test infrastructure and basic tests

### DIFF
--- a/tests/combination/__init__.py
+++ b/tests/combination/__init__.py
@@ -1,0 +1,2 @@
+# FlagGems Combination Tests
+# This module provides combination tests for operator workflows

--- a/tests/combination/accuracy_utils.py
+++ b/tests/combination/accuracy_utils.py
@@ -1,0 +1,518 @@
+"""
+Accuracy utilities for combination tests.
+
+This module provides reference computation and assertion functions
+tailored for multi-operator combination testing.  It follows the same
+three-level reference strategy as the single-operator tests:
+
+  1. GPU fp64 (default, when device supports fp64 and --ref is not cpu)
+  2. CPU fp32/fp64 (when --ref cpu or device lacks fp64)
+  3. try/except fallback to CPU fp32 (when an operator does not support fp64)
+
+Tolerance is automatically scaled by dtype and the number of chained
+operators (sqrt scaling for independent error accumulation).
+"""
+
+import copy
+import logging
+import math
+
+import torch
+
+import flag_gems
+from flag_gems.testing import RESOLUTION
+
+fp64_is_supported = flag_gems.runtime.device.support_fp64
+bf16_is_supported = flag_gems.runtime.device.support_bf16
+
+# Combination test float dtypes – adapts to backend capabilities.
+COMBO_FLOAT_DTYPES = [torch.float16, torch.float32]
+if bf16_is_supported:
+    COMBO_FLOAT_DTYPES.append(torch.bfloat16)
+
+# Low-precision only (for mixed-precision accumulation tests that compare against fp32).
+COMBO_LOW_PRECISION_DTYPES = [torch.float16]
+if bf16_is_supported:
+    COMBO_LOW_PRECISION_DTYPES.append(torch.bfloat16)
+
+try:
+    from ..conftest import TO_CPU
+except ImportError:
+    TO_CPU = False
+
+device = flag_gems.device
+
+logger = logging.getLogger("flag_gems.combination_test")
+
+# ---------------------------------------------------------------------------
+# Tolerance
+# ---------------------------------------------------------------------------
+
+# Base absolute tolerance per dtype for combination tests.
+# These are intentionally a bit more relaxed than single-operator values
+# because multi-operator chains accumulate rounding errors.
+COMBO_BASE_ATOL = {
+    torch.float16: 5e-3,
+    torch.bfloat16: 1.5e-2,
+    torch.float32: 1e-5,
+    torch.float64: 1e-10,
+}
+
+
+def _get_combo_tolerance(dtype, num_ops=1, atol_override=None, rtol_override=None):
+    """Return (rtol, atol) suitable for a chain of *num_ops* operators.
+
+    * ``rtol`` comes from ``flag_gems.testing.RESOLUTION[dtype]``.
+    * ``atol`` is ``COMBO_BASE_ATOL[dtype] * sqrt(num_ops)``.
+
+    The sqrt scaling reflects that independent rounding errors accumulate
+    proportionally to the square root of the number of steps – tighter
+    than linear (catches real bugs) yet looser than a single-op tolerance
+    (avoids false positives from normal accumulation).
+    """
+    rtol = rtol_override if rtol_override is not None else RESOLUTION.get(dtype, 1e-3)
+    base_atol = COMBO_BASE_ATOL.get(dtype, 1e-4)
+    atol = (
+        atol_override
+        if atol_override is not None
+        else base_atol * math.sqrt(max(num_ops, 1))
+    )
+    return rtol, atol
+
+
+# ---------------------------------------------------------------------------
+# Reference computation (three-level strategy)
+# ---------------------------------------------------------------------------
+
+
+def _ref_device_and_dtype():
+    """Decide the device / dtype to use for the reference computation."""
+    if TO_CPU:
+        # User passed ``--ref cpu``.  Prefer fp64 when the host supports it
+        # (CPU almost always does, but stay safe).
+        ref_dtype = torch.float64
+        return "cpu", ref_dtype
+    if fp64_is_supported:
+        return device, torch.float64
+    # Device does not support fp64 – fall back to CPU fp32.
+    return "cpu", torch.float32
+
+
+def _to_ref(x, ref_device, ref_dtype):
+    """Move a single value to the reference device / dtype."""
+    if isinstance(x, torch.Tensor):
+        if x.is_floating_point():
+            return x.detach().to(device=ref_device, dtype=ref_dtype)
+        else:
+            return x.detach().to(device=ref_device)
+    return x
+
+
+def compute_reference(model, *inputs, **kwargs):
+    """Run *model* on the reference device / dtype and return the output.
+
+    The model is ``deepcopy``-ed so the original is not modified.
+    All ``torch.Tensor`` positional and keyword arguments are moved to the
+    reference device / dtype automatically.  The output tensor(s) are
+    returned on the **original** device so that callers can compare
+    directly.
+
+    If the primary strategy (GPU fp64) raises a ``RuntimeError`` – e.g.
+    because one operator in the combination does not support fp64 – we
+    silently fall back to CPU fp32.
+    """
+    orig_device = None
+
+    def _try_run(ref_device, ref_dtype):
+        nonlocal orig_device
+        ref_model = copy.deepcopy(model).to(ref_device).to(ref_dtype)
+        ref_model.eval()
+        ref_inputs = tuple(_to_ref(x, ref_device, ref_dtype) for x in inputs)
+        ref_kwargs = {k: _to_ref(v, ref_device, ref_dtype) for k, v in kwargs.items()}
+        # Remember the device of the first tensor input.
+        for x in inputs:
+            if isinstance(x, torch.Tensor):
+                orig_device = x.device
+                break
+        with torch.no_grad():
+            return ref_model(*ref_inputs, **ref_kwargs)
+
+    ref_device, ref_dtype = _ref_device_and_dtype()
+    try:
+        output = _try_run(ref_device, ref_dtype)
+    except RuntimeError:
+        # Fallback: CPU fp32
+        output = _try_run("cpu", torch.float32)
+
+    # Move output back to the original device for easy comparison.
+    if orig_device is not None and isinstance(output, torch.Tensor):
+        return output.to(orig_device)
+    if isinstance(output, (tuple, list)):
+        cls = type(output)
+        return cls(
+            o.to(orig_device) if isinstance(o, torch.Tensor) else o for o in output
+        )
+    return output
+
+
+def compute_reference_with_grad(model, *inputs, loss_fn=None, **kwargs):
+    """Run forward + backward on the reference device and return results.
+
+    Returns:
+        (ref_output, ref_input_grads, ref_param_grads)
+
+        * ``ref_output`` – forward output (on the original device).
+        * ``ref_input_grads`` – dict mapping index to gradient for each
+          positional input that had ``requires_grad``.
+        * ``ref_param_grads`` – dict mapping parameter name to gradient.
+    """
+    ref_device, ref_dtype = _ref_device_and_dtype()
+    orig_device = None
+
+    # Identify which inputs need gradients.
+    grad_input_indices = []
+    for i, x in enumerate(inputs):
+        if isinstance(x, torch.Tensor):
+            if orig_device is None:
+                orig_device = x.device
+            if x.requires_grad:
+                grad_input_indices.append(i)
+
+    def _run(r_device, r_dtype):
+        ref_model = copy.deepcopy(model).to(r_device).to(r_dtype)
+        ref_model.train()  # need grad through dropout etc.
+        ref_inputs = []
+        for i, x in enumerate(inputs):
+            if isinstance(x, torch.Tensor):
+                t = x.detach().to(r_device).to(r_dtype)
+                if i in grad_input_indices:
+                    t.requires_grad_(True)
+                ref_inputs.append(t)
+            else:
+                ref_inputs.append(x)
+        ref_inputs = tuple(ref_inputs)
+        ref_kwargs = {k: _to_ref(v, r_device, r_dtype) for k, v in kwargs.items()}
+
+        ref_output = ref_model(*ref_inputs, **ref_kwargs)
+
+        # Backward
+        if loss_fn is not None:
+            loss = loss_fn(ref_output)
+        else:
+            if isinstance(ref_output, torch.Tensor):
+                loss = ref_output.sum()
+            else:
+                loss = ref_output[0].sum()
+        loss.backward()
+
+        # Collect gradients.
+        input_grads = {}
+        for i in grad_input_indices:
+            if ref_inputs[i].grad is not None:
+                input_grads[i] = ref_inputs[i].grad.to(orig_device)
+
+        param_grads = {}
+        for name, p in ref_model.named_parameters():
+            if p.grad is not None:
+                param_grads[name] = p.grad.to(orig_device)
+
+        if isinstance(ref_output, torch.Tensor):
+            ref_output = ref_output.detach().to(orig_device)
+        elif isinstance(ref_output, (tuple, list)):
+            cls = type(ref_output)
+            ref_output = cls(
+                o.detach().to(orig_device) if isinstance(o, torch.Tensor) else o
+                for o in ref_output
+            )
+
+        return ref_output, input_grads, param_grads
+
+    try:
+        return _run(ref_device, ref_dtype)
+    except RuntimeError:
+        return _run("cpu", torch.float32)
+
+
+# ---------------------------------------------------------------------------
+# Assertions
+# ---------------------------------------------------------------------------
+
+
+def combo_assert_close(res, ref, dtype, num_ops=1, atol=None, rtol=None, name=""):
+    """Assert *res* and *ref* are close, with tolerance scaled for *num_ops*.
+
+    This is the primary assertion for **Mode 1 (standard forward comparison)**.
+    """
+    rtol_val, atol_val = _get_combo_tolerance(dtype, num_ops, atol, rtol)
+
+    # Bring both to the same dtype for comparison.
+    if res.dtype != ref.dtype:
+        ref = ref.to(res.dtype)
+    if res.device != ref.device:
+        ref = ref.to(res.device)
+
+    # Compute actual error for logging.
+    with torch.no_grad():
+        diff = (res.float() - ref.float()).abs()
+        max_err = diff.max().item()
+        mean_err = diff.mean().item()
+
+    passed = True
+    try:
+        torch.testing.assert_close(
+            res,
+            ref,
+            atol=atol_val,
+            rtol=rtol_val,
+            msg=lambda m: f"{name}: {m}" if name else m,
+        )
+    except AssertionError:
+        passed = False
+        raise
+    finally:
+        logger.info(
+            "accuracy_check",
+            extra={
+                "test_data": {
+                    "event": "accuracy_check",
+                    "check_type": "forward_comparison",
+                    "name": name,
+                    "dtype": str(dtype),
+                    "num_ops": num_ops,
+                    "expected_atol": atol_val,
+                    "expected_rtol": rtol_val,
+                    "actual_max_error": max_err,
+                    "actual_mean_error": mean_err,
+                    "passed": passed,
+                }
+            },
+        )
+
+
+def assert_accumulation_error(
+    output_low, output_fp32, dtype, num_layers, max_relative_error=None
+):
+    """Assert mixed-precision accumulation error is within bounds.
+
+    This is the primary assertion for **Mode 2 (mixed-precision accumulation)**.
+
+    The maximum allowed relative error defaults to::
+
+        RESOLUTION[dtype] * sqrt(num_layers)
+
+    which lets the tolerance grow sub-linearly with depth.
+    """
+    output_cmp = output_low.to(torch.float32)
+    if output_cmp.device != output_fp32.device:
+        output_cmp = output_cmp.to(output_fp32.device)
+
+    error = (output_cmp - output_fp32).abs()
+    relative_error = (error / (output_fp32.abs() + 1e-6)).mean().item()
+
+    if max_relative_error is None:
+        base = RESOLUTION.get(dtype, 1e-3)
+        max_relative_error = base * math.sqrt(max(num_layers, 1))
+        # Clamp to a reasonable upper bound – even 32 layers should not
+        # exceed ~15% relative error for fp16 / ~30% for bf16.
+        max_relative_error = min(max_relative_error, 0.30)
+
+    passed = relative_error < max_relative_error
+
+    logger.info(
+        "accuracy_check",
+        extra={
+            "test_data": {
+                "event": "accuracy_check",
+                "check_type": "accumulation_error",
+                "dtype": str(dtype),
+                "num_layers": num_layers,
+                "relative_error": relative_error,
+                "max_allowed": max_relative_error,
+                "passed": passed,
+            }
+        },
+    )
+
+    assert passed, (
+        f"Accumulation error too high for {dtype} with {num_layers} layers: "
+        f"{relative_error:.4%} > {max_relative_error:.4%}"
+    )
+
+
+def assert_gradient_close(
+    grad_gems, grad_ref, dtype, num_ops=1, atol=None, rtol=None, name=""
+):
+    """Assert two gradient tensors are close.
+
+    This is the primary assertion for **Mode 3 (gradient comparison)**.
+    Uses the same tolerance logic as ``combo_assert_close``.
+    """
+    # Log via combo_assert_close which already has logging.
+    # Override check_type by logging separately.
+    rtol_val, atol_val = _get_combo_tolerance(dtype, num_ops, atol, rtol)
+
+    if grad_gems.dtype != grad_ref.dtype:
+        grad_ref = grad_ref.to(grad_gems.dtype)
+    if grad_gems.device != grad_ref.device:
+        grad_ref = grad_ref.to(grad_gems.device)
+
+    with torch.no_grad():
+        diff = (grad_gems.float() - grad_ref.float()).abs()
+        max_err = diff.max().item()
+        mean_err = diff.mean().item()
+
+    passed = True
+    try:
+        torch.testing.assert_close(
+            grad_gems,
+            grad_ref,
+            atol=atol_val,
+            rtol=rtol_val,
+            msg=lambda m: f"{name}: {m}" if name else m,
+        )
+    except AssertionError:
+        passed = False
+        raise
+    finally:
+        logger.info(
+            "accuracy_check",
+            extra={
+                "test_data": {
+                    "event": "accuracy_check",
+                    "check_type": "gradient_comparison",
+                    "name": name,
+                    "dtype": str(dtype),
+                    "num_ops": num_ops,
+                    "expected_atol": atol_val,
+                    "expected_rtol": rtol_val,
+                    "actual_max_error": max_err,
+                    "actual_mean_error": mean_err,
+                    "passed": passed,
+                }
+            },
+        )
+
+
+def assert_numerical_consistency(output_gems, output_ref, name=""):
+    """Assert FlagGems and PyTorch produce NaN/Inf in the same positions.
+
+    This is the primary assertion for **Mode 4 (numerical stability +
+    behaviour consistency)**.  For non-NaN positions the values must also
+    be close (using a generous tolerance since edge-case inputs often
+    amplify differences).
+
+    Args:
+        output_gems: Result from FlagGems (GPU).
+        output_ref: Result from PyTorch reference.
+        name: Human-readable label for error messages.
+    """
+    gems = output_gems.detach().float()
+    ref = output_ref.detach().float()
+    if gems.device != ref.device:
+        ref = ref.to(gems.device)
+
+    nan_gems = torch.isnan(gems)
+    nan_ref = torch.isnan(ref)
+
+    nan_match = True
+    non_nan_close = True
+    error_detail = ""
+
+    # Where ref has NaN, gems should also have NaN.
+    ref_nan_but_gems_not = nan_ref & ~nan_gems
+    if ref_nan_but_gems_not.any():
+        count = ref_nan_but_gems_not.sum().item()
+        nan_match = False
+        error_detail = f"Reference has NaN at {count} positions where FlagGems does not"
+
+    # Where ref does NOT have NaN, gems should not have NaN either.
+    if nan_match:
+        gems_nan_but_ref_not = nan_gems & ~nan_ref
+        if gems_nan_but_ref_not.any():
+            count = gems_nan_but_ref_not.sum().item()
+            nan_match = False
+            error_detail = (
+                f"FlagGems has NaN at {count} positions where reference does not"
+            )
+
+    # For non-NaN positions, values should be close.
+    if nan_match:
+        valid = ~nan_gems
+        if valid.any():
+            try:
+                torch.testing.assert_close(
+                    gems[valid],
+                    ref[valid],
+                    atol=1e-2,
+                    rtol=1e-2,
+                    msg=lambda m: f"{name} (non-NaN positions): {m}" if name else m,
+                )
+            except AssertionError:
+                non_nan_close = False
+                error_detail = "Non-NaN values differ beyond tolerance"
+
+    passed = nan_match and non_nan_close
+
+    logger.info(
+        "accuracy_check",
+        extra={
+            "test_data": {
+                "event": "accuracy_check",
+                "check_type": "numerical_consistency",
+                "name": name,
+                "nan_match": nan_match,
+                "non_nan_close": non_nan_close,
+                "passed": passed,
+            }
+        },
+    )
+
+    if not nan_match:
+        raise AssertionError(f"{name}: {error_detail}")
+    if not non_nan_close:
+        raise AssertionError(f"{name}: {error_detail}")
+
+
+def assert_loss_close(loss_gems, loss_ref, dtype, name=""):
+    """Assert two scalar loss values are close.
+
+    This is the primary assertion for **Mode 5 (scalar loss comparison)**.
+    """
+    rtol = RESOLUTION.get(dtype, 1e-3)
+    # For scalar comparison a fixed atol is sufficient.
+    atol = COMBO_BASE_ATOL.get(dtype, 1e-4)
+
+    g = loss_gems.detach().float()
+    r = loss_ref.detach().float()
+    if g.device != r.device:
+        r = r.to(g.device)
+
+    actual_diff = (g - r).abs().item()
+    passed = True
+    try:
+        torch.testing.assert_close(
+            g,
+            r,
+            atol=atol,
+            rtol=rtol,
+            msg=lambda m: f"{name}: {m}" if name else m,
+        )
+    except AssertionError:
+        passed = False
+        raise
+    finally:
+        logger.info(
+            "accuracy_check",
+            extra={
+                "test_data": {
+                    "event": "accuracy_check",
+                    "check_type": "loss_comparison",
+                    "name": name,
+                    "dtype": str(dtype),
+                    "expected_atol": atol,
+                    "expected_rtol": rtol,
+                    "actual_diff": actual_diff,
+                    "passed": passed,
+                }
+            },
+        )

--- a/tests/combination/conftest.py
+++ b/tests/combination/conftest.py
@@ -1,0 +1,311 @@
+"""
+Combination tests configuration and fixtures.
+
+This module provides fixtures and utilities for combination testing
+of FlagGems operators in realistic workflows.
+
+NOTE: This conftest.py is designed to be compatible with the parent
+tests/conftest.py. It inherits TO_CPU, QUICK_MODE, and other global
+configurations.
+"""
+
+import pytest
+import torch
+
+import flag_gems
+
+device = flag_gems.device
+
+# Import global variables from parent conftest
+try:
+    from ..conftest import QUICK_MODE, RECORD_LOG, TO_CPU
+except ImportError:
+    # Default values if parent conftest not available
+    TO_CPU = False
+    QUICK_MODE = False
+    RECORD_LOG = False
+
+# ---------------------------------------------------------------------------
+# Logging (initialised in pytest_configure)
+# ---------------------------------------------------------------------------
+
+_test_logger = None
+
+
+# ============================================================================
+# Pytest option hooks
+# ============================================================================
+
+
+def pytest_addoption(parser):
+    """Add combination-test specific command-line options."""
+    parser.addoption(
+        "--combo-log-dir",
+        action="store",
+        default=None,
+        help="Directory for combination test JSONL log files (default: combination_test_logs/)",
+    )
+
+
+# ============================================================================
+# Register custom markers for combination tests
+# ============================================================================
+
+
+def pytest_configure(config):
+    """Register custom markers and initialise combination-test logging."""
+    # Register markers specific to combination tests
+    config.addinivalue_line(
+        "markers", "integration: mark test as integration test (end-to-end scenarios)"
+    )
+    config.addinivalue_line(
+        "markers", "numerical_stability: mark test as numerical stability test"
+    )
+    config.addinivalue_line("markers", "stress: mark test as stress test (may be slow)")
+    config.addinivalue_line(
+        "markers", "comparison: mark test as comparison test (against PyTorch baseline)"
+    )
+    config.addinivalue_line(
+        "markers", "transformer: mark test related to Transformer models"
+    )
+    config.addinivalue_line(
+        "markers", "attention: mark test related to attention mechanisms"
+    )
+    config.addinivalue_line("markers", "ffn: mark test related to FFN modules")
+
+    # Initialise combination-test logging
+    from .logging_config import TestLogger
+
+    global _test_logger
+    log_dir = config.getoption("--combo-log-dir", default=None)
+    _test_logger = TestLogger(log_dir=log_dir)
+
+
+# ============================================================================
+# Fixtures for common test configurations
+# ============================================================================
+
+
+@pytest.fixture(scope="module")
+def use_gems():
+    """Context manager to enable FlagGems for a test module."""
+    with flag_gems.use_gems():
+        yield
+
+
+# ============================================================================
+# Pytest hooks for test lifecycle logging
+# ============================================================================
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_protocol(item, nextitem):
+    """Log the start of each test with its parameters."""
+    if _test_logger is None:
+        return
+    params = {}
+    if hasattr(item, "_request") and hasattr(item._request, "node"):
+        node = item._request.node
+        if hasattr(node, "callspec"):
+            params = {k: str(v) for k, v in node.callspec.params.items()}
+    _test_logger.log_test_start(item.nodeid, params)
+
+
+@pytest.hookimpl(tryfirst=True)
+def pytest_runtest_logreport(report):
+    """Log the outcome of each test (only for the 'call' phase)."""
+    if _test_logger is None:
+        return
+    if report.when == "call":
+        error_msg = None
+        if report.failed and report.longrepr:
+            error_msg = str(report.longrepr)
+        _test_logger.log_test_result(
+            test_name=report.nodeid,
+            outcome=report.outcome,
+            duration=report.duration,
+            error_msg=error_msg,
+        )
+    elif report.when == "setup" and report.outcome == "skipped":
+        reason = ""
+        if hasattr(report.longrepr, "reprcrash"):
+            reason = report.longrepr.reprcrash.message
+        elif isinstance(report.longrepr, tuple):
+            reason = str(report.longrepr[2])
+        _test_logger.log_test_result(
+            test_name=report.nodeid,
+            outcome="skipped",
+            duration=0,
+            error_msg=reason,
+        )
+
+
+def pytest_sessionfinish(session, exitstatus):
+    """Write session summary and close the logger."""
+    if _test_logger is None:
+        return
+    # Gather counts from the internal _counts tracker
+    passed = _test_logger._counts.get("passed", 0)
+    failed = _test_logger._counts.get("failed", 0)
+    skipped = _test_logger._counts.get("skipped", 0)
+    total = passed + failed + skipped
+    _test_logger.log_session_summary(
+        total=total, passed=passed, failed=failed, skipped=skipped
+    )
+    _test_logger.close()
+
+
+@pytest.fixture
+def Float16():
+    """Fixture for torch.float16 dtype."""
+    return torch.float16
+
+
+@pytest.fixture
+def BFloat16():
+    """Fixture for torch.bfloat16 dtype."""
+    return torch.bfloat16
+
+
+@pytest.fixture
+def Float32():
+    """Fixture for torch.float32 dtype."""
+    return torch.float32
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(torch.float16, id="fp16"),
+        pytest.param(torch.bfloat16, id="bf16"),
+        pytest.param(torch.float32, id="fp32"),
+    ],
+    scope="module",
+)
+def dtype(request):
+    """Parametrized fixture for common dtypes."""
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(1, id="batch1"),
+        pytest.param(
+            4, id="batch4", marks=pytest.mark.skipif(QUICK_MODE, reason="Quick mode")
+        ),
+        pytest.param(
+            16, id="batch16", marks=pytest.mark.skipif(QUICK_MODE, reason="Quick mode")
+        ),
+    ],
+    scope="module",
+)
+def batch_size(request):
+    """Parametrized fixture for batch sizes (respects QUICK_MODE)."""
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        pytest.param(128, id="seq128"),
+        pytest.param(
+            512, id="seq512", marks=pytest.mark.skipif(QUICK_MODE, reason="Quick mode")
+        ),
+        pytest.param(
+            2048,
+            id="seq2048",
+            marks=pytest.mark.skipif(QUICK_MODE, reason="Quick mode"),
+        ),
+    ],
+    scope="module",
+)
+def seq_len(request):
+    """Parametrized fixture for sequence lengths (respects QUICK_MODE)."""
+    return request.param
+
+
+# ============================================================================
+# Transformer configuration fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def transformer_config():
+    """Standard Transformer configuration."""
+    return {
+        "d_model": 768,
+        "nhead": 12,
+        "dim_feedforward": 3072,
+        "dropout": 0.1,
+        "activation": "gelu",
+    }
+
+
+@pytest.fixture
+def llama_config():
+    """LLaMA-style Transformer configuration."""
+    return {
+        "d_model": 4096,
+        "nhead": 32,
+        "dim_feedforward": 11008,
+        "dropout": 0.0,
+        "activation": "silu",
+        "norm": "rms_norm",
+    }
+
+
+# ============================================================================
+# Numerical stability test utilities
+# ============================================================================
+
+
+@pytest.fixture
+def numerical_scenarios():
+    """Scenarios for numerical stability testing."""
+    return {
+        "normal": {
+            "description": "Normal distribution inputs",
+            "generator": lambda shape, dtype, device: torch.randn(
+                shape, dtype=dtype, device=device
+            ),
+        },
+        "all_neg_inf": {
+            "description": "All negative infinity (padding scenario)",
+            "generator": lambda shape, dtype, device: torch.full(
+                shape, float("-inf"), dtype=dtype, device=device
+            ),
+        },
+        "large_values": {
+            "description": "Large values (magnitude > 10)",
+            "generator": lambda shape, dtype, device: torch.randn(
+                shape, dtype=dtype, device=device
+            )
+            * 20,
+        },
+        "mixed_specials": {
+            "description": "Mixed normal, NaN, Inf values",
+            "generator": lambda shape, dtype, device: _generate_mixed_specials(
+                shape, dtype, device
+            ),
+        },
+    }
+
+
+def _generate_mixed_specials(shape, dtype, device):
+    """Generate tensor with mixed normal and special values."""
+    x = torch.randn(shape, dtype=dtype, device=device)
+    # Inject NaN at 1% locations
+    nan_mask = torch.rand(shape, device=device) < 0.01
+    x[nan_mask] = float("nan")
+    # Inject Inf at 0.5% locations
+    inf_mask = torch.rand(shape, device=device) < 0.005
+    x[inf_mask] = float("inf")
+    return x
+
+
+# ============================================================================
+# Helper to respect QUICK_MODE in tests
+# ============================================================================
+
+
+def skip_if_quick_mode(reason="Skipping in QUICK_MODE"):
+    """Decorator/skip marker for tests that should be skipped in quick mode."""
+    return pytest.mark.skipif(QUICK_MODE, reason=reason)

--- a/tests/combination/logging_config.py
+++ b/tests/combination/logging_config.py
@@ -1,0 +1,233 @@
+"""Logging configuration for combination tests.
+
+Provides a structured JSON Lines (JSONL) logging system for combination tests,
+following the same patterns as ``flag_gems.logging_utils``:
+
+* Named logger under the ``flag_gems`` namespace.
+* ``FileHandler`` with a ``_flaggems_owned`` marker for clean teardown.
+* ``JsonFormatter`` that writes one JSON object per line.
+
+Usage::
+
+    # Automatic (via conftest.py pytest hooks):
+    pytest tests/combination/ --combo-log-dir=./my_logs
+
+    # Manual:
+    from tests.combination.logging_config import TestLogger
+    tl = TestLogger(log_dir="./my_logs")
+    tl.log_test_start("test_foo", {"batch": 4})
+    tl.log_test_result("test_foo", "passed", duration=1.23)
+    tl.log_session_summary(total=10, passed=9, failed=1, skipped=0, duration=5.0)
+"""
+
+import json
+import logging
+import time
+from datetime import datetime
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+LOGGER_NAME = "flag_gems.combination_test"
+DEFAULT_LOG_DIR = Path("combination_test_logs")
+
+
+# ---------------------------------------------------------------------------
+# JsonFormatter
+# ---------------------------------------------------------------------------
+
+
+class JsonFormatter(logging.Formatter):
+    """Format each log record as a single-line JSON object (JSONL)."""
+
+    def format(self, record):
+        log_data = {
+            "timestamp": datetime.fromtimestamp(record.created).isoformat(
+                timespec="milliseconds"
+            ),
+            "level": record.levelname,
+            "message": record.getMessage(),
+        }
+        # Merge extra fields injected via ``extra={"test_data": {...}}``
+        if hasattr(record, "test_data") and isinstance(record.test_data, dict):
+            log_data.update(record.test_data)
+        return json.dumps(log_data, ensure_ascii=False, default=str)
+
+
+# ---------------------------------------------------------------------------
+# Setup / Teardown  (mirrors logging_utils.py patterns)
+# ---------------------------------------------------------------------------
+
+
+def _remove_file_handlers(logger):
+    """Remove and close FileHandlers owned by this module."""
+    for h in list(logger.handlers):
+        if isinstance(h, logging.FileHandler) and getattr(h, "_flaggems_owned", False):
+            h.close()
+            logger.removeHandler(h)
+
+
+def setup_combination_logging(log_dir=None, session_id=None):
+    """Initialise the combination-test logger with a JSONL FileHandler.
+
+    Args:
+        log_dir: Directory for log files.  Created automatically.
+        session_id: Optional session identifier embedded in the filename.
+
+    Returns:
+        (logger, log_file_path)
+    """
+    logger = logging.getLogger(LOGGER_NAME)
+    # Avoid duplicate handlers on repeated calls.
+    _remove_file_handlers(logger)
+
+    log_dir = Path(log_dir) if log_dir else DEFAULT_LOG_DIR
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+    suffix = f"_{session_id}" if session_id else ""
+    filename = log_dir / f"combo_test_{ts}{suffix}.jsonl"
+
+    handler = logging.FileHandler(filename, mode="w", encoding="utf-8")
+    handler._flaggems_owned = True  # type: ignore[attr-defined]
+    handler.setFormatter(JsonFormatter())
+
+    logger.setLevel(logging.DEBUG)
+    logger.addHandler(handler)
+    logger.propagate = False
+
+    return logger, filename
+
+
+def teardown_combination_logging():
+    """Remove file handlers for the combination-test logger."""
+    logger = logging.getLogger(LOGGER_NAME)
+    _remove_file_handlers(logger)
+
+
+# ---------------------------------------------------------------------------
+# TestLogger — convenience wrapper
+# ---------------------------------------------------------------------------
+
+
+class TestLogger:
+    """High-level interface for logging combination-test events.
+
+    Each ``log_*`` method writes a structured JSON record via the standard
+    ``logging`` module so that the output is a valid JSONL file.
+    """
+
+    def __init__(self, log_dir=None, session_id=None):
+        self.logger, self.log_file = setup_combination_logging(
+            log_dir=log_dir, session_id=session_id
+        )
+        self._session_start = time.monotonic()
+        self._counts = {"passed": 0, "failed": 0, "skipped": 0, "xfailed": 0}
+
+    # -- test lifecycle -----------------------------------------------------
+
+    def log_test_start(self, test_name, params=None):
+        """Record the start of a test."""
+        self.logger.info(
+            "test_start",
+            extra={
+                "test_data": {
+                    "event": "test_start",
+                    "test_name": test_name,
+                    "params": params or {},
+                }
+            },
+        )
+
+    def log_test_result(self, test_name, outcome, duration=None, error_msg=None):
+        """Record the outcome of a test (passed / failed / skipped / xfailed)."""
+        outcome_key = outcome if outcome in self._counts else "failed"
+        self._counts[outcome_key] = self._counts.get(outcome_key, 0) + 1
+
+        data = {
+            "event": "test_result",
+            "test_name": test_name,
+            "outcome": outcome,
+            "duration": round(duration, 4) if duration is not None else None,
+        }
+        if error_msg:
+            # Truncate long tracebacks for the JSON record.
+            data["error_msg"] = error_msg[:2000]
+
+        level = logging.WARNING if outcome == "failed" else logging.INFO
+        self.logger.log(level, "test_result", extra={"test_data": data})
+
+    # -- accuracy checks ----------------------------------------------------
+
+    def log_accuracy_check(
+        self,
+        name,
+        check_type,
+        dtype=None,
+        num_ops=None,
+        expected_atol=None,
+        expected_rtol=None,
+        actual_max_error=None,
+        actual_mean_error=None,
+        passed=True,
+        **extra,
+    ):
+        """Record the result of an accuracy comparison."""
+        data = {
+            "event": "accuracy_check",
+            "name": name,
+            "check_type": check_type,
+            "dtype": str(dtype) if dtype is not None else None,
+            "num_ops": num_ops,
+            "expected_atol": expected_atol,
+            "expected_rtol": expected_rtol,
+            "actual_max_error": actual_max_error,
+            "actual_mean_error": actual_mean_error,
+            "passed": passed,
+        }
+        data.update(extra)
+        level = logging.WARNING if not passed else logging.INFO
+        self.logger.log(level, "accuracy_check", extra={"test_data": data})
+
+    # -- numerical issues ---------------------------------------------------
+
+    def log_numerical_issue(self, test_name, issue_type, details=None):
+        """Record a numerical problem (NaN / Inf / gradient anomaly)."""
+        self.logger.warning(
+            "numerical_issue",
+            extra={
+                "test_data": {
+                    "event": "numerical_issue",
+                    "test_name": test_name,
+                    "issue_type": issue_type,
+                    "details": details or "",
+                }
+            },
+        )
+
+    # -- session summary ----------------------------------------------------
+
+    def log_session_summary(self, total, passed, failed, skipped, duration=None):
+        """Write an end-of-session summary record."""
+        if duration is None:
+            duration = round(time.monotonic() - self._session_start, 2)
+        self.logger.info(
+            "session_summary",
+            extra={
+                "test_data": {
+                    "event": "session_summary",
+                    "total": total,
+                    "passed": passed,
+                    "failed": failed,
+                    "skipped": skipped,
+                    "pass_rate": round(passed / total * 100, 1) if total else 0,
+                    "duration": duration,
+                }
+            },
+        )
+
+    def close(self):
+        """Flush and remove handlers."""
+        teardown_combination_logging()

--- a/tests/combination/test_attention_numerical_stability.py
+++ b/tests/combination/test_attention_numerical_stability.py
@@ -1,0 +1,376 @@
+"""
+Attention Numerical Stability Combination Tests.
+
+This module tests the numerical stability of attention mechanisms
+under various edge cases and stress conditions.
+"""
+
+import math
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+import flag_gems
+
+from .accuracy_utils import COMBO_FLOAT_DTYPES, assert_numerical_consistency
+from .utils.numerical_stability import check_finite, check_no_nan
+
+device = flag_gems.device
+
+
+class TestAttentionNumericalStability:
+    """
+    Numerical stability tests for attention mechanisms.
+
+    Tests include:
+    - All negative infinity inputs (padding scenarios)
+    - Large value inputs
+    - Mixed normal/special values
+    - Gradient stability
+    """
+
+    @pytest.fixture
+    def attention_config(self):
+        """Default attention configuration."""
+        return {
+            "batch_size": 2,
+            "nhead": 12,
+            "seq_len": 512,
+            "head_dim": 64,
+        }
+
+    def _compute_attention(self, q, k, v, mask=None, scale=None):
+        """
+        Compute attention scores manually for testing.
+
+        Args:
+            q: Query tensor (batch, nhead, seq_len, head_dim)
+            k: Key tensor (batch, nhead, seq_len, head_dim)
+            v: Value tensor (batch, nhead, seq_len, head_dim)
+            mask: Optional attention mask
+            scale: Scaling factor (default: 1/sqrt(head_dim))
+
+        Returns:
+            Attention output tensor
+        """
+        if scale is None:
+            scale = 1.0 / math.sqrt(q.shape[-1])
+
+        # Compute attention scores
+        scores = torch.matmul(q, k.transpose(-2, -1)) * scale
+
+        # Apply mask if provided
+        if mask is not None:
+            scores = scores.masked_fill(mask, float("-inf"))
+
+        # Softmax
+        attn_weights = F.softmax(scores, dim=-1)
+
+        # Compute output
+        output = torch.matmul(attn_weights, v)
+
+        return output, attn_weights
+
+    @pytest.mark.numerical_stability
+    @pytest.mark.parametrize(
+        "scenario",
+        [
+            pytest.param("normal", id="normal_input"),
+            pytest.param("large_values", id="large_values"),
+            pytest.param("small_values", id="small_values"),
+        ],
+    )
+    def test_attention_input_scenarios(self, scenario, attention_config, use_gems):
+        """Test attention with different input value ranges."""
+        B = attention_config["batch_size"]
+        H = attention_config["nhead"]
+        L = attention_config["seq_len"]
+        D = attention_config["head_dim"]
+
+        # Generate inputs based on scenario
+        if scenario == "normal":
+            q = torch.randn(B, H, L, D, device=device, dtype=torch.float16)
+            k = torch.randn(B, H, L, D, device=device, dtype=torch.float16)
+            v = torch.randn(B, H, L, D, device=device, dtype=torch.float16)
+        elif scenario == "large_values":
+            # Large values that might cause overflow
+            q = torch.randn(B, H, L, D, device=device, dtype=torch.float16) * 10
+            k = torch.randn(B, H, L, D, device=device, dtype=torch.float16) * 10
+            v = torch.randn(B, H, L, D, device=device, dtype=torch.float16) * 10
+        elif scenario == "small_values":
+            # Small values that might cause underflow
+            q = torch.randn(B, H, L, D, device=device, dtype=torch.float16) * 0.01
+            k = torch.randn(B, H, L, D, device=device, dtype=torch.float16) * 0.01
+            v = torch.randn(B, H, L, D, device=device, dtype=torch.float16)
+
+        # Compute attention
+        output, attn_weights = self._compute_attention(q, k, v)
+
+        # Verify no NaN in output
+        check_no_nan(output, f"Attention output ({scenario})")
+
+        # Verify attention weights sum to 1
+        attn_sum = attn_weights.sum(dim=-1)
+        expected_sum = torch.ones_like(attn_sum)
+        assert torch.allclose(
+            attn_sum, expected_sum, rtol=1e-2, atol=1e-3
+        ), f"Attention weights don't sum to 1 for {scenario}"
+
+    @pytest.mark.numerical_stability
+    @pytest.mark.parametrize("mask_ratio", [0.0, 0.3, 0.5, 0.7, 0.9])
+    def test_attention_with_padding_mask(self, mask_ratio, attention_config, use_gems):
+        """Test attention with varying amounts of padding (masked positions)."""
+        B = attention_config["batch_size"]
+        H = attention_config["nhead"]
+        L = attention_config["seq_len"]
+        D = attention_config["head_dim"]
+
+        # Create inputs
+        q = torch.randn(B, H, L, D, device=device, dtype=torch.float16)
+        k = torch.randn(B, H, L, D, device=device, dtype=torch.float16)
+        v = torch.randn(B, H, L, D, device=device, dtype=torch.float16)
+
+        # Create padding mask (True = masked/padding)
+        mask = torch.zeros(B, 1, 1, L, dtype=torch.bool, device=device)
+        mask_start = int(L * (1 - mask_ratio))
+        mask[:, :, :, mask_start:] = True  # Mask later positions
+
+        # Expand mask for attention
+        mask_expanded = mask.expand(B, H, L, L)
+
+        # Compute attention
+        output, attn_weights = self._compute_attention(q, k, v, mask=mask_expanded)
+
+        # Verify output is valid
+        check_no_nan(output, f"Attention with {mask_ratio:.0%} padding")
+
+        # Check masked positions have zero attention weight
+        if mask_ratio > 0:
+            # Note: After softmax, masked positions should have 0 weight
+            # but numerical precision might give small values
+            pass
+
+    @pytest.mark.numerical_stability
+    def test_attention_all_masked_row(self, attention_config, use_gems):
+        """
+        Test attention when entire rows are masked (all -inf).
+
+        This is a critical edge case that can cause NaN in naive implementations.
+        """
+        B = attention_config["batch_size"]
+        H = attention_config["nhead"]
+        L = attention_config["seq_len"]
+        D = attention_config["head_dim"]
+
+        # Create inputs
+        q = torch.randn(B, H, L, D, device=device, dtype=torch.float32)
+        k = torch.randn(B, H, L, D, device=device, dtype=torch.float32)
+        _ = torch.randn(B, H, L, D, device=device, dtype=torch.float32)  # v unused
+
+        # Create mask where first row is completely masked
+        mask = torch.zeros(B, H, L, L, dtype=torch.bool, device=device)
+        mask[:, :, 0, :] = True  # First row completely masked
+
+        # Compute attention
+        scale = 1.0 / math.sqrt(D)
+        scores = torch.matmul(q, k.transpose(-2, -1)) * scale
+        scores = scores.masked_fill(mask, float("-inf"))
+
+        # This is where NaN can occur with naive softmax
+        attn_weights = F.softmax(scores, dim=-1)
+
+        # Check for NaN - this is the critical test
+        nan_count = torch.isnan(attn_weights).sum().item()
+
+        # Note: Standard PyTorch softmax may produce NaN for all-inf rows
+        # FlagGems should handle this gracefully
+        if nan_count > 0:
+            pytest.xfail(
+                f"All-masked row produces {nan_count} NaN values (expected for standard softmax)"
+            )
+
+    @pytest.mark.numerical_stability
+    def test_attention_causal_mask_stability(self, attention_config, use_gems):
+        """Test attention with causal mask (autoregressive)."""
+        B = attention_config["batch_size"]
+        H = attention_config["nhead"]
+        L = attention_config["seq_len"]
+        D = attention_config["head_dim"]
+
+        # Create inputs
+        q = torch.randn(B, H, L, D, device=device, dtype=torch.float16)
+        k = torch.randn(B, H, L, D, device=device, dtype=torch.float16)
+        v = torch.randn(B, H, L, D, device=device, dtype=torch.float16)
+
+        # Create causal mask
+        causal_mask = torch.triu(
+            torch.ones(L, L, dtype=torch.bool, device=device), diagonal=1
+        )
+
+        # Compute attention with causal mask
+        output, attn_weights = self._compute_attention(q, k, v, mask=causal_mask)
+
+        # Verify no NaN
+        check_no_nan(output, "Causal attention output")
+
+        # Verify causal property: no attention to future positions (vectorized)
+        row_idx = torch.arange(L, device=attn_weights.device).view(1, 1, L, 1)
+        col_idx = torch.arange(L, device=attn_weights.device).view(1, 1, 1, L)
+        future_mask = col_idx > row_idx
+        assert (
+            attn_weights[future_mask.expand_as(attn_weights)] == 0
+        ).all(), "Some positions attend to future"
+
+    @pytest.mark.numerical_stability
+    @pytest.mark.parametrize("dtype", COMBO_FLOAT_DTYPES)
+    def test_attention_precision_comparison(self, dtype, attention_config, use_gems):
+        """Test attention output precision across different dtypes."""
+        B = attention_config["batch_size"]
+        H = attention_config["nhead"]
+        L = 128  # Smaller for precision comparison
+        D = attention_config["head_dim"]
+
+        # Create inputs in fp32 for reference
+        q_fp32 = torch.randn(B, H, L, D, device=device, dtype=torch.float32)
+        k_fp32 = torch.randn(B, H, L, D, device=device, dtype=torch.float32)
+        v_fp32 = torch.randn(B, H, L, D, device=device, dtype=torch.float32)
+
+        # Reference computation in fp32
+        output_ref, _ = self._compute_attention(q_fp32, k_fp32, v_fp32)
+
+        # Compute in target dtype
+        q = q_fp32.to(dtype)
+        k = k_fp32.to(dtype)
+        v = v_fp32.to(dtype)
+        output, _ = self._compute_attention(q, k, v)
+
+        # Verify finite output
+        check_finite(output, f"Attention {dtype}")
+
+        # Numerical consistency check
+        assert_numerical_consistency(
+            output.to(torch.float32), output_ref, name=f"Attention {dtype} vs fp32"
+        )
+
+    @pytest.mark.numerical_stability
+    def test_attention_gradient_stability(self, attention_config, use_gems):
+        """Test gradient computation stability in attention."""
+        B = attention_config["batch_size"]
+        H = attention_config["nhead"]
+        L = 128
+        D = attention_config["head_dim"]
+
+        # Create inputs with gradients
+        q = torch.randn(
+            B, H, L, D, device=device, dtype=torch.float32, requires_grad=True
+        )
+        k = torch.randn(
+            B, H, L, D, device=device, dtype=torch.float32, requires_grad=True
+        )
+        v = torch.randn(
+            B, H, L, D, device=device, dtype=torch.float32, requires_grad=True
+        )
+
+        # Forward pass
+        output, _ = self._compute_attention(q, k, v)
+
+        # Backward pass
+        loss = output.sum()
+        loss.backward()
+
+        # Check gradients
+        for name, tensor in [("q", q), ("k", k), ("v", v)]:
+            assert tensor.grad is not None, f"Gradient for {name} is None"
+            check_finite(tensor.grad, f"Gradient for {name}")
+
+    @pytest.mark.numerical_stability
+    @pytest.mark.parametrize("seq_len", [64, 256, 1024, 4096])
+    def test_attention_sequence_length_scaling(self, seq_len, use_gems):
+        """Test attention stability across different sequence lengths."""
+        B, H, D = 1, 8, 64
+
+        # Create inputs
+        q = torch.randn(B, H, seq_len, D, device=device, dtype=torch.float16)
+        k = torch.randn(B, H, seq_len, D, device=device, dtype=torch.float16)
+        v = torch.randn(B, H, seq_len, D, device=device, dtype=torch.float16)
+
+        # Compute attention
+        output, attn_weights = self._compute_attention(q, k, v)
+
+        # Verify
+        check_no_nan(output, f"Attention seq_len={seq_len}")
+        assert output.shape == (B, H, seq_len, D)
+
+
+class TestSoftmaxStability:
+    """
+    Tests specifically for softmax numerical stability.
+    """
+
+    @pytest.mark.numerical_stability
+    def test_softmax_normal_input(self, use_gems):
+        """Test softmax with normal inputs."""
+        shape = (4, 8, 128, 128)
+        x = torch.randn(shape, device=device, dtype=torch.float16)
+
+        output = F.softmax(x, dim=-1)
+
+        check_no_nan(output, "Softmax normal input")
+
+        # Verify sum to 1
+        sums = output.sum(dim=-1)
+        assert torch.allclose(sums, torch.ones_like(sums), rtol=1e-2)
+
+    @pytest.mark.numerical_stability
+    def test_softmax_large_values(self, use_gems):
+        """Test softmax with large values (potential overflow)."""
+        shape = (4, 8, 128, 128)
+        x = torch.randn(shape, device=device, dtype=torch.float16) * 50
+
+        output = F.softmax(x, dim=-1)
+
+        check_no_nan(output, "Softmax large values")
+
+    @pytest.mark.numerical_stability
+    def test_softmax_with_neg_inf(self, use_gems):
+        """Test softmax with some negative infinity values."""
+        shape = (4, 128)
+        x = torch.randn(shape, device=device, dtype=torch.float32)
+
+        # Mask half the values
+        x[:, 64:] = float("-inf")
+
+        output = F.softmax(x, dim=-1)
+
+        # Check masked positions are zero
+        assert (output[:, 64:] == 0).all(), "Masked positions should be zero"
+
+        # Check unmasked positions sum to 1
+        unmasked_sum = output[:, :64].sum(dim=-1)
+        assert torch.allclose(unmasked_sum, torch.ones_like(unmasked_sum), rtol=1e-3)
+
+        # Numerical consistency: compare NaN/Inf positions with reference
+        ref_output = F.softmax(x.clone().detach(), dim=-1)
+        assert_numerical_consistency(output, ref_output, name="softmax partial -inf")
+
+    @pytest.mark.numerical_stability
+    def test_softmax_all_neg_inf(self, use_gems):
+        """
+        Test softmax with all negative infinity (critical edge case).
+
+        This tests the behavior when all attention positions are masked.
+        """
+        shape = (4, 128)
+        x = torch.full(shape, float("-inf"), device=device, dtype=torch.float32)
+
+        # Standard softmax behavior with all -inf
+        output = F.softmax(x, dim=-1)
+
+        # Note: This will produce NaN with standard softmax
+        # We document this behavior for awareness
+        nan_count = torch.isnan(output).sum().item()
+        if nan_count > 0:
+            pytest.xfail(
+                f"All -inf input produces NaN (expected behavior: {nan_count} NaN values)"
+            )

--- a/tests/combination/test_convolution_combination.py
+++ b/tests/combination/test_convolution_combination.py
@@ -1,0 +1,328 @@
+"""
+P2级测试：卷积网络组合测试
+
+测试场景：
+- ResNet基础块组合
+- 残差连接组合
+- 池化层组合
+- 卷积反向传播
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import flag_gems
+
+from .accuracy_utils import COMBO_FLOAT_DTYPES, combo_assert_close, compute_reference
+from .conftest import QUICK_MODE
+
+device = flag_gems.device
+
+
+# ========== 简化模型 ==========
+
+
+class ConvBNReLU(nn.Module):
+    """卷积 + BatchNorm + ReLU基础块"""
+
+    def __init__(self, in_channels, out_channels, kernel_size=3, stride=1, padding=1):
+        super().__init__()
+        self.conv = nn.Conv2d(
+            in_channels, out_channels, kernel_size, stride, padding, bias=False
+        )
+        self.bn = nn.BatchNorm2d(out_channels)
+
+    def forward(self, x):
+        x = self.conv(x)
+        x = self.bn(x)
+        x = F.relu(x)
+        return x
+
+
+class ResidualBlock(nn.Module):
+    """ResNet残差块"""
+
+    def __init__(self, channels):
+        super().__init__()
+        self.conv1 = nn.Conv2d(channels, channels, 3, 1, 1, bias=False)
+        self.bn1 = nn.BatchNorm2d(channels)
+        self.conv2 = nn.Conv2d(channels, channels, 3, 1, 1, bias=False)
+        self.bn2 = nn.BatchNorm2d(channels)
+
+    def forward(self, x):
+        residual = x
+        out = F.relu(self.bn1(self.conv1(x)))
+        out = self.bn2(self.conv2(out))
+        out += residual
+        return F.relu(out)
+
+
+class MultiScaleBlock(nn.Module):
+    """多尺度特征提取"""
+
+    def __init__(self, in_channels, out_channels):
+        super().__init__()
+        self.branch1 = nn.Conv2d(in_channels, out_channels // 2, 1)
+        self.branch2 = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels // 4, 1),
+            nn.Conv2d(out_channels // 4, out_channels // 4, 3, padding=1),
+        )
+        self.branch3 = nn.Sequential(
+            nn.Conv2d(in_channels, out_channels // 4, 1),
+            nn.Conv2d(out_channels // 4, out_channels // 4, 5, padding=2),
+        )
+
+    def forward(self, x):
+        b1 = self.branch1(x)
+        b2 = self.branch2(x)
+        b3 = self.branch3(x)
+        return torch.cat([b1, b2, b3], dim=1)
+
+
+# ========== 测试类 ==========
+
+
+class TestConvolutionCombination:
+    """卷积组合测试"""
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize(
+        "batch_size,in_channels,out_channels,spatial_size",
+        [
+            pytest.param(1, 3, 16, 32, id="minimal"),
+            pytest.param(4, 3, 64, 64, id="small"),
+            pytest.param(
+                8,
+                64,
+                128,
+                128,
+                id="medium",
+                marks=pytest.mark.skipif(QUICK_MODE, reason="Quick mode"),
+            ),
+            pytest.param(
+                16,
+                128,
+                256,
+                224,
+                id="large",
+                marks=pytest.mark.skipif(QUICK_MODE, reason="Quick mode"),
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("dtype", COMBO_FLOAT_DTYPES)
+    def test_conv_bn_relu_block(
+        self, batch_size, in_channels, out_channels, spatial_size, dtype, use_gems
+    ):
+        """测试Conv→BN→ReLU基础块"""
+        model = ConvBNReLU(in_channels, out_channels).to(device).to(dtype)
+        x = torch.randn(
+            batch_size,
+            in_channels,
+            spatial_size,
+            spatial_size,
+            device=device,
+            dtype=dtype,
+        )
+
+        model.eval()
+        with torch.no_grad():
+            output = model(x)
+
+        # 验证输出形状
+        assert output.shape == (batch_size, out_channels, spatial_size, spatial_size)
+        # 验证ReLU激活（所有值应>=0）
+        assert (output >= 0).all()
+
+        # Reference comparison (Conv+BN+ReLU ≈ 3 ops)
+        ref_output = compute_reference(model, x)
+        combo_assert_close(output, ref_output, x.dtype, num_ops=3, name="ConvBNReLU")
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("channels", [32, 64, 128])
+    @pytest.mark.parametrize("dtype", COMBO_FLOAT_DTYPES)
+    def test_residual_block_forward(self, channels, dtype, use_gems):
+        """测试ResNet残差块前向传播"""
+        model = ResidualBlock(channels).to(device).to(dtype)
+        batch_size = 4
+        spatial_size = 32
+
+        x = torch.randn(
+            batch_size, channels, spatial_size, spatial_size, device=device, dtype=dtype
+        )
+
+        model.eval()
+        with torch.no_grad():
+            output = model(x)
+
+        # 验证形状
+        assert output.shape == x.shape
+        # 验证ReLU激活
+        assert (output >= 0).all()
+
+        # Reference comparison (ResBlock ≈ 6 ops: conv+bn+relu+conv+bn+add+relu)
+        ref_output = compute_reference(model, x)
+        combo_assert_close(output, ref_output, x.dtype, num_ops=6, name="ResidualBlock")
+
+    @pytest.mark.integration
+    def test_residual_gradient_flow(self, use_gems):
+        """测试残差块梯度流"""
+        channels = 64
+        model = ResidualBlock(channels).to(device)
+        x = torch.randn(2, channels, 32, 32, device=device, requires_grad=True)
+
+        output = model(x)
+        loss = output.sum()
+        loss.backward()
+
+        # 验证梯度存在且有限
+        assert x.grad is not None
+        grad_norm = x.grad.norm().item()
+        assert grad_norm > 0, "Gradient vanished"
+        assert torch.isfinite(x.grad).all()
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize(
+        "in_channels,out_channels",
+        [(32, 64), (64, 128)],
+    )
+    @pytest.mark.parametrize("dtype", COMBO_FLOAT_DTYPES)
+    def test_multi_scale_feature_extraction(
+        self, in_channels, out_channels, dtype, use_gems
+    ):
+        """测试多尺度特征提取"""
+        model = MultiScaleBlock(in_channels, out_channels).to(device).to(dtype)
+        x = torch.randn(2, in_channels, 56, 56, device=device, dtype=dtype)
+
+        model.eval()
+        with torch.no_grad():
+            output = model(x)
+
+        # 验证输出通道数
+        assert output.shape[1] == out_channels
+        # 验证空间尺寸保持
+        assert output.shape[2:] == x.shape[2:]
+
+        # Reference comparison (MultiScale ≈ 6 ops: 3 branches × 2 convs each)
+        ref_output = compute_reference(model, x)
+        combo_assert_close(
+            output, ref_output, x.dtype, num_ops=6, name="MultiScaleBlock"
+        )
+
+
+class TestPoolingCombination:
+    """池化组合测试"""
+
+    @pytest.mark.integration
+    def test_max_pool_after_conv(self, use_gems):
+        """测试卷积后的最大池化"""
+        conv = nn.Conv2d(3, 16, 3, padding=1).to(device)
+        pool = nn.MaxPool2d(2, 2)
+
+        x = torch.randn(4, 3, 64, 64, device=device)
+
+        feature = conv(x)
+        pooled = pool(feature)
+
+        # 验证下采样
+        assert pooled.shape == (4, 16, 32, 32)
+
+    @pytest.mark.integration
+    def test_avg_pool_after_conv(self, use_gems):
+        """测试卷积后的平均池化"""
+        conv = nn.Conv2d(3, 16, 3, padding=1).to(device)
+
+        x = torch.randn(4, 3, 64, 64, device=device)
+        feature = conv(x)
+
+        # 使用functional API测试avg_pool2d
+        pooled = F.avg_pool2d(feature, kernel_size=2)
+
+        assert pooled.shape == (4, 16, 32, 32)
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("pool_type", ["max", "avg", "mixed"])
+    def test_pooling_chain(self, pool_type, use_gems):
+        """测试池化链"""
+        x = torch.randn(2, 16, 128, 128, device=device)
+
+        if pool_type == "max":
+            out = F.max_pool2d(x, 2)
+            out = F.max_pool2d(out, 2)
+        elif pool_type == "avg":
+            out = F.avg_pool2d(x, 2)
+            out = F.avg_pool2d(out, 2)
+        else:  # mixed
+            out = F.max_pool2d(x, 2)
+            out = F.avg_pool2d(out, 2)
+
+        # 验证最终尺寸
+        assert out.shape == (2, 16, 32, 32)
+
+
+class TestConvBackward:
+    """卷积反向传播测试"""
+
+    @pytest.mark.integration
+    def test_conv_gradient_correctness(self, use_gems):
+        """测试卷积梯度正确性"""
+        conv = nn.Conv2d(16, 32, 3, padding=1).to(device)
+        x = torch.randn(2, 16, 32, 32, device=device, requires_grad=True)
+
+        # 前向传播
+        output = conv(x)
+        loss = output.sum()
+        loss.backward()
+
+        # 验证梯度存在
+        assert x.grad is not None
+        assert conv.weight.grad is not None
+        assert torch.isfinite(x.grad).all()
+
+    @pytest.mark.integration
+    @pytest.mark.numerical_stability
+    def test_conv_numerical_stability(self, use_gems):
+        """测试卷积数值稳定性"""
+        conv = nn.Conv2d(3, 16, 3, padding=1).to(device)
+
+        # 大值输入
+        x_large = torch.randn(2, 3, 32, 32, device=device) * 100
+        output_large = conv(x_large)
+        assert torch.isfinite(output_large).all()
+
+        # 小值输入
+        x_small = torch.randn(2, 3, 32, 32, device=device) * 1e-6
+        output_small = conv(x_small)
+        assert torch.isfinite(output_small).all()
+        # 检查没有退化为零
+        assert output_small.abs().max() > 1e-20
+
+
+class TestConv3DCombination:
+    """3D卷积组合测试"""
+
+    @pytest.mark.integration
+    @pytest.mark.skipif(QUICK_MODE, reason="Quick mode")
+    def test_conv3d_forward(self, use_gems):
+        """测试3D卷积前向传播"""
+        conv3d = nn.Conv3d(16, 32, 3, padding=1).to(device)
+        x = torch.randn(2, 16, 8, 32, 32, device=device)
+
+        output = conv3d(x)
+
+        assert output.shape == (2, 32, 8, 32, 32)
+        assert torch.isfinite(output).all()
+
+    @pytest.mark.integration
+    def test_conv3d_gradient(self, use_gems):
+        """测试3D卷积梯度"""
+        conv3d = nn.Conv3d(8, 16, 3, padding=1).to(device)
+        x = torch.randn(1, 8, 4, 16, 16, device=device, requires_grad=True)
+
+        output = conv3d(x)
+        loss = output.sum()
+        loss.backward()
+
+        assert x.grad is not None
+        assert torch.isfinite(x.grad).all()

--- a/tests/combination/test_loss_functions.py
+++ b/tests/combination/test_loss_functions.py
@@ -1,0 +1,363 @@
+"""
+P2级测试：损失函数组合测试
+
+测试场景：
+- CrossEntropy完整实现（softmax → log → nll_loss）
+- MSE损失组合
+- 多任务损失组合
+- 损失函数梯度验证
+"""
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import flag_gems
+
+from .accuracy_utils import assert_loss_close
+from .conftest import QUICK_MODE
+
+device = flag_gems.device
+
+
+# ========== 简化模型 ==========
+
+
+class CrossEntropyImpl(nn.Module):
+    """CrossEntropy分步实现：softmax → log → nll_loss"""
+
+    def __init__(self, reduction="mean"):
+        super().__init__()
+        self.reduction = reduction
+
+    def forward(self, logits, target):
+        # Step 1: softmax
+        probs = F.softmax(logits, dim=-1)
+        # Step 2: log
+        log_probs = torch.log(probs + 1e-10)  # 数值稳定
+        # Step 3: nll_loss
+        loss = F.nll_loss(log_probs, target, reduction=self.reduction)
+        return loss
+
+
+class MultiTaskLoss(nn.Module):
+    """多任务损失组合"""
+
+    def __init__(self, weights=None):
+        super().__init__()
+        if weights is None:
+            weights = [1.0, 1.0, 1.0]
+        self.weights = torch.tensor(weights, device=device)
+        self.ce_loss = nn.CrossEntropyLoss()
+        self.mse_loss = nn.MSELoss()
+        self.margin_loss = nn.MarginRankingLoss(margin=1.0)
+
+    def forward(
+        self, logits_cls, target_cls, pred_reg, target_reg, anchor, positive, label
+    ):
+        loss1 = self.ce_loss(logits_cls, target_cls)
+        loss2 = self.mse_loss(pred_reg, target_reg)
+        loss3 = self.margin_loss(anchor, positive, label)
+
+        # 加权组合
+        total_loss = (
+            self.weights[0] * loss1 + self.weights[1] * loss2 + self.weights[2] * loss3
+        )
+        return total_loss
+
+
+class ContrastiveLoss(nn.Module):
+    """对比学习损失"""
+
+    def __init__(self, temperature=0.07):
+        super().__init__()
+        self.temperature = temperature
+
+    def forward(self, features, labels):
+        # 特征归一化
+        features = F.normalize(features, dim=1)
+        # 计算相似度矩阵
+        similarity = torch.mm(features, features.t())
+        # 除以温度参数
+        similarity = similarity / self.temperature
+        # 构建正样本mask
+        labels = labels.view(-1, 1)
+        mask = torch.eq(labels, labels.t()).float()
+        # 计算损失（简化版，使用 log-sum-exp 避免数值溢出）
+        max_sim = similarity.max(dim=1, keepdim=True)[0].detach()
+        exp_sim = torch.exp(similarity - max_sim)
+        pos = exp_sim * mask
+        neg = exp_sim * (1 - mask)
+        loss = -torch.log(pos.sum(dim=1) / (pos.sum(dim=1) + neg.sum(dim=1) + 1e-10))
+        return loss.mean()
+
+
+# ========== 测试类 ==========
+
+
+class TestCrossEntropyCombination:
+    """CrossEntropy组合测试"""
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize(
+        "batch_size,num_classes,seq_len",
+        [
+            pytest.param(4, 10, 16, id="small"),
+            pytest.param(16, 100, 32, id="medium"),
+            pytest.param(
+                32,
+                1000,
+                64,
+                id="large",
+                marks=pytest.mark.skipif(QUICK_MODE, reason="Quick mode"),
+            ),
+        ],
+    )
+    def test_cross_entropy_step_by_step(
+        self, batch_size, num_classes, seq_len, use_gems
+    ):
+        """测试分步实现的CrossEntropy"""
+        logits = torch.randn(batch_size, seq_len, num_classes, device=device)
+        target = torch.randint(0, num_classes, (batch_size, seq_len), device=device)
+
+        # 分步实现
+        ce_impl = CrossEntropyImpl()
+        loss_step = ce_impl(logits.view(-1, num_classes), target.view(-1))
+
+        # PyTorch标准实现
+        ce_standard = nn.CrossEntropyLoss()
+        loss_standard = ce_standard(logits.view(-1, num_classes), target.view(-1))
+
+        # 验证结果相近（使用 assert_loss_close 替代手写 isclose）
+        assert_loss_close(
+            loss_step, loss_standard, logits.dtype, name="CrossEntropy step-by-step"
+        )
+
+    @pytest.mark.integration
+    @pytest.mark.numerical_stability
+    def test_cross_entropy_large_logits(self, use_gems):
+        """测试大logit值的数值稳定性"""
+        logits = torch.randn(4, 10, device=device) * 100
+        target = torch.randint(0, 10, (4,), device=device)
+
+        ce = nn.CrossEntropyLoss()
+        loss = ce(logits, target)
+
+        # 应该产生有限的损失值
+        assert torch.isfinite(loss)
+        assert loss >= 0  # CrossEntropy总是非负
+
+        # Reference comparison on CPU/fp64
+        ref_logits = logits.detach().to("cpu").to(torch.float64)
+        ref_target = target.to("cpu")
+        ref_loss = nn.CrossEntropyLoss()(ref_logits, ref_target).to(device)
+        assert_loss_close(
+            loss, ref_loss, logits.dtype, name="CrossEntropy large logits"
+        )
+
+    @pytest.mark.integration
+    def test_cross_entropy_gradient(self, use_gems):
+        """测试CrossEntropy梯度"""
+        logits = torch.randn(8, 10, device=device, requires_grad=True)
+        target = torch.randint(0, 10, (8,), device=device)
+
+        ce = nn.CrossEntropyLoss()
+        loss = ce(logits, target)
+        loss.backward()
+
+        assert logits.grad is not None
+        assert torch.isfinite(logits.grad).all()
+
+
+class TestMSELoss:
+    """MSE损失测试"""
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("reduction", ["mean", "sum", "none"])
+    def test_mse_reduction_modes(self, reduction, use_gems):
+        """测试MSE不同归约模式"""
+        pred = torch.randn(16, 64, device=device)
+        target = torch.randn(16, 64, device=device)
+
+        mse = nn.MSELoss(reduction=reduction)
+        loss = mse(pred, target)
+
+        if reduction == "none":
+            assert loss.shape == pred.shape
+        else:
+            assert loss.dim() == 0  # 标量
+            assert loss >= 0
+
+            # Reference comparison for scalar losses
+            ref_pred = pred.detach().to("cpu").to(torch.float64)
+            ref_target = target.detach().to("cpu").to(torch.float64)
+            ref_loss = nn.MSELoss(reduction=reduction)(ref_pred, ref_target).to(device)
+            assert_loss_close(loss, ref_loss, pred.dtype, name=f"MSE {reduction}")
+
+    @pytest.mark.integration
+    def test_mse_gradient_flow(self, use_gems):
+        """测试MSE梯度流"""
+        pred = torch.randn(8, 32, device=device, requires_grad=True)
+        target = torch.randn(8, 32, device=device)
+
+        mse = nn.MSELoss()
+        loss = mse(pred, target)
+        loss.backward()
+
+        assert pred.grad is not None
+        # 梯度应等于 2*(pred-target)/n (mean模式)
+        expected_grad = 2 * (pred - target) / pred.numel()
+        assert torch.allclose(pred.grad, expected_grad, rtol=1e-3)
+
+
+class TestMarginRankingLoss:
+    """Margin Ranking Loss测试"""
+
+    @pytest.mark.integration
+    def test_margin_ranking_basic(self, use_gems):
+        """测试基本功能"""
+        anchor = torch.randn(8, device=device)
+        positive = torch.randn(8, device=device)
+        _ = torch.randn(8, device=device)  # negative unused in this test
+
+        # 正样本应该比负样本得分高
+        target = torch.ones(8, device=device)  # anchor应该 > positive
+
+        loss_fn = nn.MarginRankingLoss(margin=1.0)
+        loss = loss_fn(anchor, positive, target)
+
+        assert torch.isfinite(loss)
+
+    @pytest.mark.integration
+    def test_margin_satisfaction(self, use_gems):
+        """测试margin满足情况"""
+        # 明显满足margin的情况
+        anchor = torch.tensor([2.0, 3.0, 4.0], device=device)
+        positive = torch.tensor([0.0, 0.0, 0.0], device=device)
+        target = torch.ones(3, device=device)
+
+        loss_fn = nn.MarginRankingLoss(margin=1.0)
+        loss = loss_fn(anchor, positive, target)
+
+        # 当anchor > positive + margin时，loss应为0（接近）
+        assert loss < 0.1
+
+
+class TestMultiTaskLossCombination:
+    """多任务损失组合测试"""
+
+    @pytest.mark.integration
+    def test_multi_task_loss_weighted(self, use_gems):
+        """测试加权多任务损失"""
+        model = MultiTaskLoss(weights=[1.0, 2.0, 0.5])
+
+        # 模拟多个任务的输出
+        logits_cls = torch.randn(4, 10, device=device)
+        target_cls = torch.randint(0, 10, (4,), device=device)
+        pred_reg = torch.randn(4, 64, device=device)
+        target_reg = torch.randn(4, 64, device=device)
+        anchor = torch.randn(4, device=device)
+        positive = torch.randn(4, device=device)
+        label = torch.ones(4, device=device)
+
+        total_loss = model(
+            logits_cls, target_cls, pred_reg, target_reg, anchor, positive, label
+        )
+
+        assert torch.isfinite(total_loss)
+        assert total_loss >= 0
+
+    @pytest.mark.integration
+    def test_multi_task_gradient_flow(self, use_gems):
+        """测试多任务损失的梯度流"""
+        model = MultiTaskLoss()
+
+        # 需要梯度的输入
+        logits_cls = torch.randn(4, 10, device=device, requires_grad=True)
+        target_cls = torch.randint(0, 10, (4,), device=device)
+        pred_reg = torch.randn(4, 64, device=device, requires_grad=True)
+        target_reg = torch.randn(4, 64, device=device)
+        anchor = torch.randn(4, device=device, requires_grad=True)
+        positive = torch.randn(4, device=device, requires_grad=True)
+        label = torch.ones(4, device=device)
+
+        total_loss = model(
+            logits_cls, target_cls, pred_reg, target_reg, anchor, positive, label
+        )
+        total_loss.backward()
+
+        # 验证所有输入都有梯度
+        assert logits_cls.grad is not None
+        assert pred_reg.grad is not None
+        assert anchor.grad is not None
+        assert positive.grad is not None
+
+
+class TestContrastiveLoss:
+    """对比学习损失测试"""
+
+    @pytest.mark.integration
+    def test_contrastive_loss_basic(self, use_gems):
+        """测试对比损失基本功能"""
+        features = torch.randn(16, 128, device=device)
+        labels = torch.randint(0, 4, (16,), device=device)  # 4个类别
+
+        loss_fn = ContrastiveLoss(temperature=0.07)
+        loss = loss_fn(features, labels)
+
+        assert torch.isfinite(loss)
+        assert loss >= 0
+
+    @pytest.mark.integration
+    @pytest.mark.numerical_stability
+    def test_contrastive_loss_temperature(self, use_gems):
+        """测试温度参数影响"""
+        features = torch.randn(8, 64, device=device)
+        labels = torch.randint(0, 2, (8,), device=device)
+
+        # 高温度（更平滑）
+        loss_fn_high = ContrastiveLoss(temperature=1.0)
+        loss_high = loss_fn_high(features, labels)
+
+        # 低温度（更尖锐）
+        loss_fn_low = ContrastiveLoss(temperature=0.01)
+        loss_low = loss_fn_low(features, labels)
+
+        # 两者都应该是有限值
+        assert torch.isfinite(loss_high)
+        assert torch.isfinite(loss_low)
+
+
+class TestLossNumericalStability:
+    """损失函数数值稳定性测试"""
+
+    @pytest.mark.integration
+    @pytest.mark.numerical_stability
+    def test_label_smoothing_effect(self, use_gems):
+        """测试标签平滑的数值稳定性"""
+        logits = torch.randn(4, 10, device=device) * 10
+        target = torch.randint(0, 10, (4,), device=device)
+
+        # 无平滑
+        ce_no_smooth = nn.CrossEntropyLoss()
+        loss_no_smooth = ce_no_smooth(logits, target)
+
+        # 有平滑
+        ce_smooth = nn.CrossEntropyLoss(label_smoothing=0.1)
+        loss_smooth = ce_smooth(logits, target)
+
+        # 平滑后的loss应该略高（更保守）
+        assert torch.isfinite(loss_smooth)
+        assert torch.isfinite(loss_no_smooth)
+
+    @pytest.mark.integration
+    def test_loss_with_very_small_predictions(self, use_gems):
+        """测试极小预测值的稳定性"""
+        pred_small = torch.randn(4, 64, device=device) * 1e-8
+        target = torch.randn(4, 64, device=device)
+
+        mse = nn.MSELoss()
+        loss = mse(pred_small, target)
+
+        assert torch.isfinite(loss)

--- a/tests/combination/test_mixed_precision_accumulation.py
+++ b/tests/combination/test_mixed_precision_accumulation.py
@@ -1,0 +1,322 @@
+"""
+Mixed Precision Accumulation Error Tests.
+
+This module tests error accumulation in mixed precision computations,
+verifying numerical stability when chaining multiple fp16/bf16 operations.
+"""
+
+import math
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import flag_gems
+
+from .accuracy_utils import COMBO_LOW_PRECISION_DTYPES, assert_accumulation_error
+from .utils.numerical_stability import check_finite, check_no_nan
+
+device = flag_gems.device
+
+
+class MultiLayerNetwork(nn.Module):
+    """Network with multiple layers for accumulation testing."""
+
+    def __init__(self, num_layers, input_dim, hidden_dim, output_dim):
+        super().__init__()
+        self.layers = nn.ModuleList()
+        self.layers.append(nn.Linear(input_dim, hidden_dim))
+        for _ in range(num_layers - 2):
+            self.layers.append(nn.Linear(hidden_dim, hidden_dim))
+        self.layers.append(nn.Linear(hidden_dim, output_dim))
+        self.activation = F.gelu
+
+        self.num_layers = num_layers
+
+    def forward(self, x):
+        for i, layer in enumerate(self.layers[:-1]):
+            x = layer(x)
+            x = self.activation(x)
+        x = self.layers[-1](x)
+        return x
+
+
+class TestMixedPrecisionAccumulation:
+    """
+    Tests for error accumulation in mixed precision.
+
+    Verify:
+    - Accumulation error across layers
+    - Precision loss estimation
+    - Stability metrics
+    """
+
+    @pytest.mark.numerical_stability
+    @pytest.mark.parametrize("num_layers", [4, 8, 16, 32])
+    def test_error_accumulation_layers(self, num_layers, use_gems):
+        """Test error accumulation with increasing number of layers."""
+        batch_size = 4
+        input_dim = 128
+        hidden_dim = 256
+        output_dim = 128
+
+        # Create model in fp32 (reference)
+        model_fp32 = MultiLayerNetwork(num_layers, input_dim, hidden_dim, output_dim)
+        model_fp32 = model_fp32.to(device).to(torch.float32)
+
+        # Create same model in fp16
+        model_fp16 = MultiLayerNetwork(num_layers, input_dim, hidden_dim, output_dim)
+        model_fp16.load_state_dict(model_fp32.state_dict())
+        model_fp16 = model_fp16.to(device).to(torch.float16)
+
+        # Generate input
+        torch.manual_seed(42)
+        x_fp32 = torch.randn(batch_size, input_dim, device=device, dtype=torch.float32)
+        x_fp16 = x_fp32.to(torch.float16)
+
+        # Compute outputs
+        with torch.no_grad():
+            output_fp32 = model_fp32(x_fp32)
+            output_fp16 = model_fp16(x_fp16)
+
+        # Compute error
+        output_fp16_to_fp32 = output_fp16.to(torch.float32)
+        error = (output_fp16_to_fp32 - output_fp32).abs()
+
+        max_error = error.max().item()
+        mean_error = error.mean().item()
+        relative_error = (error / (output_fp32.abs() + 1e-6)).mean().item()
+
+        print(f"\n{num_layers} layers:")
+        print(f"  Max error: {max_error:.6e}")
+        print(f"  Mean error: {mean_error:.6e}")
+        print(f"  Relative error: {relative_error:.6%}")
+
+        # Use structured assertion with sqrt scaling
+        assert_accumulation_error(output_fp16, output_fp32, torch.float16, num_layers)
+
+    @pytest.mark.numerical_stability
+    @pytest.mark.parametrize("dtype", COMBO_LOW_PRECISION_DTYPES)
+    def test_fp16_vs_bf16_accumulation(self, dtype, use_gems):
+        """Compare error accumulation between fp16 and bf16."""
+        num_layers = 8
+        batch_size = 4
+        input_dim = 128
+        hidden_dim = 256
+        output_dim = 128
+
+        # Create model
+        model = MultiLayerNetwork(num_layers, input_dim, hidden_dim, output_dim)
+
+        # Save FP32 reference (deep copy to avoid in-place modification)
+        import copy
+
+        model_fp32 = copy.deepcopy(model).to(device).to(torch.float32)
+
+        # Test in target dtype (separate copy)
+        model_test = copy.deepcopy(model).to(device).to(dtype)
+
+        # Generate input
+        torch.manual_seed(42)
+        x_fp32 = torch.randn(batch_size, input_dim, device=device, dtype=torch.float32)
+        x_test = x_fp32.to(dtype)
+
+        # Compute
+        with torch.no_grad():
+            output_fp32 = model_fp32(x_fp32)
+            output_test = model_test(x_test)
+
+        # Compute error
+        output_test_fp32 = output_test.to(torch.float32)
+        error = (output_test_fp32 - output_fp32).abs()
+        relative_error = (error / (output_fp32.abs() + 1e-6)).mean().item()
+
+        print(f"\n{dtype}: Relative error: {relative_error:.6%}")
+
+        # Use structured assertion with sqrt scaling
+        assert_accumulation_error(output_test, output_fp32, dtype, num_layers)
+
+    @pytest.mark.numerical_stability
+    def test_layer_norm_accumulation(self, use_gems):
+        """Test accumulated layer norm operations."""
+        num_norms = 16
+        batch_size, seq_len, d_model = 4, 64, 128
+
+        # FP32 reference
+        x_fp32 = torch.randn(
+            batch_size, seq_len, d_model, device=device, dtype=torch.float32
+        )
+
+        layer_norm = nn.LayerNorm(d_model)
+        layer_norm = layer_norm.to(device)
+
+        output_fp32 = x_fp32.clone()
+        for _ in range(num_norms):
+            output_fp32 = layer_norm(output_fp32)
+
+        # FP16 test
+        layer_norm_fp16 = layer_norm.to(torch.float16)
+        x_fp16 = x_fp32.to(torch.float16)
+
+        output_fp16 = x_fp16.clone()
+        for _ in range(num_norms):
+            output_fp16 = layer_norm_fp16(output_fp16)
+
+        # Compare
+        output_fp16_fp32 = output_fp16.to(torch.float32)
+        error = (output_fp16_fp32 - output_fp32).abs().mean().item()
+
+        print(f"\n{num_norms} LayerNorms: Mean error: {error:.6e}")
+
+        # Should remain stable
+        assert error < 0.01, f"LayerNorm accumulation error too high: {error}"
+
+    @pytest.mark.numerical_stability
+    def test_softmax_accumulation(self, use_gems):
+        """Test accumulated softmax operations."""
+        num_softmax = 10
+        batch_size, dim = 4, 128
+
+        x_fp32 = torch.randn(batch_size, dim, device=device, dtype=torch.float32)
+        x_fp16 = x_fp32.to(torch.float16)
+
+        output_fp32 = x_fp32.clone()
+        output_fp16 = x_fp16.clone()
+
+        for i in range(num_softmax):
+            # Apply softmax with scaling (common in attention)
+            scale = 1.0 / math.sqrt(dim)
+            output_fp32 = F.softmax(output_fp32 * scale, dim=-1)
+            output_fp16 = F.softmax(output_fp16 * scale, dim=-1)
+
+        # Compare
+        output_fp16_fp32 = output_fp16.to(torch.float32)
+        error = (output_fp16_fp32 - output_fp32).abs().mean().item()
+
+        print(f"\n{num_softmax} Softmaxes: Mean error: {error:.6e}")
+
+        # Check no NaN
+        check_no_nan(output_fp16, f"{num_softmax} softmaxes")
+
+    @pytest.mark.numerical_stability
+    @pytest.mark.parametrize(
+        "operation_sequence", ["linear_only", "mixed", "norm_only"]
+    )
+    def test_operation_sequence_accumulation(self, operation_sequence, use_gems):
+        """Test different operation sequences."""
+        batch_size, seq_len, d_model = 4, 32, 128
+        num_ops = 10
+
+        x_fp32 = torch.randn(
+            batch_size, seq_len, d_model, device=device, dtype=torch.float32
+        )
+        x_fp16 = x_fp32.to(torch.float16)
+
+        linear = nn.Linear(d_model, d_model)
+        norm = nn.LayerNorm(d_model)
+        linear = linear.to(device)
+        norm = norm.to(device)
+
+        output_fp32 = x_fp32.clone()
+        output_fp16 = x_fp16.clone()
+
+        for i in range(num_ops):
+            if operation_sequence == "linear_only":
+                output_fp32 = linear(output_fp32)
+                output_fp16 = linear(output_fp16.to(torch.float16)).to(torch.float16)
+            elif operation_sequence == "norm_only":
+                output_fp32 = norm(output_fp32)
+                output_fp16 = norm(output_fp16)
+            else:  # mixed
+                if i % 2 == 0:
+                    output_fp32 = linear(output_fp32)
+                    output_fp16 = linear(output_fp16.to(torch.float16)).to(
+                        torch.float16
+                    )
+                else:
+                    output_fp32 = F.gelu(output_fp32)
+                    output_fp16 = F.gelu(output_fp16)
+
+        # Compare
+        output_fp16_fp32 = output_fp16.to(torch.float32)
+        error = (output_fp16_fp32 - output_fp32).abs().mean().item()
+
+        print(f"\n{operation_sequence} sequence: Mean error: {error:.6e}")
+
+
+@pytest.mark.integration
+class TestMixedPrecisionBestPractices:
+    """Test best practices for mixed precision."""
+
+    def test_fp16_master_weights(self, use_gems):
+        """Test fp32 master weights pattern."""
+        batch_size, input_dim, output_dim = 4, 128, 64
+
+        # FP32 master weights
+        weight_fp32 = torch.randn(
+            output_dim, input_dim, device=device, dtype=torch.float32
+        )
+
+        # FP16 copy for computation
+        weight_fp16 = weight_fp32.to(torch.float16)
+
+        x_fp16 = torch.randn(batch_size, input_dim, device=device, dtype=torch.float16)
+
+        # Compute in FP16
+        output_fp16 = F.linear(x_fp16, weight_fp16)
+
+        # Gradients would be computed in FP16, then accumulated to FP32 master
+        # For testing, just verify computation works
+        check_no_nan(output_fp16, "FP16 with FP32 master weights")
+
+    def test_loss_scaling_stability(self, use_gems):
+        """Test that loss scaling prevents underflow."""
+        batch_size = 4
+        dim = 128
+
+        # Create very small values
+        x = torch.randn(batch_size, dim, device=device, dtype=torch.float16) * 1e-3
+
+        loss = F.mse_loss(x, torch.zeros_like(x))
+
+        # With proper loss scaling, gradients would be scaled up
+        # For testing, just verify loss computation is stable
+        check_finite(loss, "Small value loss")
+
+
+@pytest.mark.integration
+class TestPrecisionLossEstimation:
+    """Estimate precision loss in practical scenarios."""
+
+    @pytest.mark.parametrize("hidden_scale", [2, 4, 8])
+    def test_hidden_dimension_scaling(self, hidden_scale, use_gems):
+        """Test precision loss with different hidden dimensions."""
+        batch_size, input_dim = 4, 64
+        hidden_dim = input_dim * hidden_scale
+        output_dim = input_dim
+
+        model = nn.Sequential(
+            nn.Linear(input_dim, hidden_dim),
+            nn.GELU(),
+            nn.Linear(hidden_dim, output_dim),
+        )
+
+        import copy
+
+        model_fp32 = copy.deepcopy(model).to(device).to(torch.float32)
+        model_fp16 = copy.deepcopy(model).to(device).to(torch.float16)
+
+        x_fp32 = torch.randn(batch_size, input_dim, device=device, dtype=torch.float32)
+        x_fp16 = x_fp32.to(torch.float16)
+
+        with torch.no_grad():
+            output_fp32 = model_fp32(x_fp32)
+            output_fp16 = model_fp16(x_fp16)
+
+        # Skip comparison if shapes differ (shouldn't happen but safety check)
+        if output_fp32.shape != output_fp16.shape:
+            pytest.skip("Shape mismatch in precision comparison")
+
+        error = (output_fp16.to(torch.float32) - output_fp32).abs().mean().item()
+        print(f"\nHidden scale {hidden_scale}x: Error {error:.6e}")

--- a/tests/combination/test_sampling_operations.py
+++ b/tests/combination/test_sampling_operations.py
@@ -1,0 +1,366 @@
+"""
+P2级测试：采样与随机操作组合测试
+
+测试场景：
+- Dropout训练模式
+- 权重初始化组合
+- 多项式采样
+- 数据增强pipeline
+"""
+
+import math
+
+import pytest
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+import flag_gems
+
+from .accuracy_utils import assert_loss_close
+
+device = flag_gems.device
+
+
+# ========== 简化模型 ==========
+
+
+class DropoutPipeline(nn.Module):
+    """Dropout完整pipeline"""
+
+    def __init__(self, input_dim, hidden_dim, output_dim, dropout_rate=0.5):
+        super().__init__()
+        self.fc1 = nn.Linear(input_dim, hidden_dim)
+        self.dropout1 = nn.Dropout(dropout_rate)
+        self.fc2 = nn.Linear(hidden_dim, hidden_dim)
+        self.dropout2 = nn.Dropout(dropout_rate)
+        self.fc3 = nn.Linear(hidden_dim, output_dim)
+
+    def forward(self, x, training=True):
+        x = self.fc1(x)
+        x = F.relu(x)
+        x = self.dropout1(x) if training else x
+        x = self.fc2(x)
+        x = F.relu(x)
+        x = self.dropout2(x) if training else x
+        x = self.fc3(x)
+        return x
+
+
+class WeightInitializer:
+    """权重初始化器"""
+
+    @staticmethod
+    def xavier_init(shape):
+        """Xavier初始化"""
+        gain = nn.init.calculate_gain("relu")
+        std = gain * math.sqrt(2.0 / sum(shape))
+        return torch.randn(shape, device=device) * std
+
+    @staticmethod
+    def kaiming_init(shape):
+        """Kaiming初始化"""
+        gain = nn.init.calculate_gain("relu")
+        std = gain / (shape[0] ** 0.5)
+        return torch.randn(shape, device=device) * std
+
+    @staticmethod
+    def normal_init(shape, mean=0, std=0.02):
+        """正态分布初始化"""
+        return torch.randn(shape, device=device) * std + mean
+
+
+class SamplingPolicy(nn.Module):
+    """采样策略"""
+
+    def __init__(self, num_actions, temperature=1.0):
+        super().__init__()
+        self.num_actions = num_actions
+        self.temperature = temperature
+
+    def forward(self, logits):
+        # Softmax得到概率分布
+        probs = F.softmax(logits / self.temperature, dim=-1)
+        # 多项式采样
+        samples = torch.multinomial(probs, num_samples=1)
+        return samples.squeeze(-1), probs
+
+
+class DataAugmentation(nn.Module):
+    """数据增强pipeline"""
+
+    def __init__(self, augment_prob=0.5):
+        super().__init__()
+        self.augment_prob = augment_prob
+
+    def forward(self, x):
+        # 随机决定是否增强
+        if torch.rand(1).item() < self.augment_prob:
+            # 随机翻转
+            if torch.rand(1).item() > 0.5:
+                x = torch.flip(x, dims=[-1])
+            # 随机缩放
+            scale = 0.8 + torch.rand(1).item() * 0.4
+            x = x * scale
+        return x
+
+
+# ========== 测试类 ==========
+
+
+class TestDropoutCombination:
+    """Dropout组合测试"""
+
+    @pytest.mark.integration
+    def test_dropout_training_vs_eval(self, use_gems):
+        """测试训练和评估模式的Dropout"""
+        model = DropoutPipeline(64, 128, 10).to(device)
+        x = torch.randn(8, 64, device=device)
+
+        # 训练模式
+        model.train()
+        _ = model(x, training=True)
+        _ = model(x, training=True)
+        # 多次前向传播应该不同（由于Dropout随机性）
+
+        # 评估模式
+        model.eval()
+        output_eval1 = model(x, training=False)
+        output_eval2 = model(x, training=False)
+        # 评估模式应该一致
+        assert torch.allclose(output_eval1, output_eval2)
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("dropout_rate", [0.1, 0.3, 0.5, 0.7])
+    def test_dropout_rate_effect(self, dropout_rate, use_gems):
+        """测试不同dropout率"""
+        dropout = nn.Dropout(dropout_rate).to(device)
+        x = torch.ones(1000, 1000, device=device)
+
+        dropout.train()
+        output = dropout(x)
+
+        # 统计被置零的比例
+        zero_ratio = (output == 0).float().mean().item()
+        # 应该接近dropout_rate
+        assert abs(zero_ratio - dropout_rate) < 0.05
+
+    @pytest.mark.integration
+    def test_dropout_gradient_flow(self, use_gems):
+        """测试Dropout梯度流"""
+        model = DropoutPipeline(32, 64, 10).to(device)
+        x = torch.randn(4, 32, device=device, requires_grad=True)
+
+        model.train()
+        output = model(x, training=True)
+        loss = output.sum()
+        loss.backward()
+
+        assert x.grad is not None
+        assert torch.isfinite(x.grad).all()
+
+    @pytest.mark.integration
+    def test_dropout_scaling_factor(self, use_gems):
+        """测试Dropout缩放因子"""
+        dropout = nn.Dropout(0.5).to(device)
+        x = torch.ones(1000, 1000, device=device)
+
+        dropout.train()
+        output = dropout(x)
+
+        # 未被置零的元素应该被放大（缩放因子 = 1/(1-p)）
+        non_zero_mask = output != 0
+        expected_scale = 1.0 / (1 - 0.5)  # = 2.0
+
+        if non_zero_mask.any():
+            actual_values = output[non_zero_mask]
+            assert torch.allclose(
+                actual_values, torch.ones_like(actual_values) * expected_scale, rtol=0.1
+            )
+
+
+class TestWeightInitialization:
+    """权重初始化测试"""
+
+    @pytest.mark.integration
+    def test_xavier_initialization(self, use_gems):
+        """测试Xavier初始化"""
+        shape = (256, 512)
+        weight = WeightInitializer.xavier_init(shape)
+
+        # 验证形状
+        assert weight.shape == shape
+        # 验证均值接近0
+        assert abs(weight.mean().item()) < 0.1
+        # 验证方差合理
+        var = weight.var().item()
+        assert var > 0.001 and var < 0.1
+
+    @pytest.mark.integration
+    def test_kaiming_initialization(self, use_gems):
+        """测试Kaiming初始化"""
+        shape = (512, 256)
+        weight = WeightInitializer.kaiming_init(shape)
+
+        assert weight.shape == shape
+        assert abs(weight.mean().item()) < 0.1
+        assert weight.var().item() > 0
+
+    @pytest.mark.integration
+    def test_initialization_affects_training(self, use_gems):
+        """测试初始化对训练的影响"""
+        # Xavier初始化
+        torch.manual_seed(42)
+        linear_xavier = nn.Linear(64, 32)
+        nn.init.xavier_normal_(linear_xavier.weight)
+
+        # Kaiming初始化
+        torch.manual_seed(42)
+        linear_kaiming = nn.Linear(64, 32)
+        nn.init.kaiming_normal_(linear_kaiming.weight)
+
+        x = torch.randn(8, 64, device=device)
+
+        # 两种初始化应该产生不同的输出分布
+        out_xavier = linear_xavier(x.to("cpu"))
+        out_kaiming = linear_kaiming(x.to("cpu"))
+
+        # 两者不应完全相同
+        assert not torch.allclose(out_xavier, out_kaiming, rtol=1e-3)
+
+
+class TestSamplingOperations:
+    """采样操作测试"""
+
+    @pytest.mark.integration
+    def test_multinomial_sampling(self, use_gems):
+        """测试多项式采样"""
+        policy = SamplingPolicy(10).to(device)
+        logits = torch.randn(100, 10, device=device)
+
+        samples, probs = policy(logits)
+
+        # 验证采样在有效范围内
+        assert (samples >= 0).all() and (samples < 10).all()
+        # 验证概率和为1
+        assert torch.allclose(
+            probs.sum(dim=-1), torch.ones(100, device=device), atol=1e-5
+        )
+
+        # Reference comparison for the deterministic part (probabilities)
+        ref_probs = F.softmax(
+            logits.detach().to("cpu").to(torch.float64) / 1.0, dim=-1
+        ).to(device)
+        assert_loss_close(
+            probs.sum(),
+            ref_probs.sum().float(),
+            logits.dtype,
+            name="Sampling probs sum",
+        )
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("temperature", [0.01, 0.1, 1.0, 10.0])
+    def test_temperature_effect(self, temperature, use_gems):
+        """测试温度参数对采样的影响"""
+        logits = torch.tensor([[1.0, 2.0, 3.0]], device=device)
+
+        policy = SamplingPolicy(3, temperature=temperature)
+        _, probs = policy(logits)
+
+        # 高温度 应该使分布更均匀
+        # 低温度 应该使分布更尖锐
+        entropy = -(probs * torch.log(probs + 1e-10)).sum()
+
+        assert entropy > 0  # 应该有不确定度
+
+    @pytest.mark.integration
+    def test_sampling_reproducibility(self, use_gems):
+        """测试采样的可重复性"""
+        policy = SamplingPolicy(5).to(device)
+        logits = torch.randn(10, 5, device=device)
+
+        # 设置随机种子
+        torch.manual_seed(42)
+        samples1, _ = policy(logits)
+
+        torch.manual_seed(42)
+        samples2, _ = policy(logits)
+
+        # 相同种子应该产生相同采样
+        assert torch.equal(samples1, samples2)
+
+
+class TestDataAugmentation:
+    """数据增强测试"""
+
+    @pytest.mark.integration
+    def test_augmentation_randomness(self, use_gems):
+        """测试增强的随机性"""
+        aug = DataAugmentation(augment_prob=1.0).to(device)
+        x = torch.randn(4, 3, 32, 32, device=device)
+
+        # 多次增强应该产生不同结果
+        output1 = aug(x)
+        output2 = aug(x)
+
+        # 由于随机性，两次结果很可能不同
+        # (但不保证总是不同，所以这里只验证形状)
+        assert output1.shape == x.shape
+        assert output2.shape == x.shape
+
+    @pytest.mark.integration
+    def test_augmentation_probability(self, use_gems):
+        """测试增强概率"""
+        aug = DataAugmentation(augment_prob=0.5).to(device)
+        x = torch.ones(100, 3, 32, 32, device=device)
+
+        # 运行多次
+        augmented = []
+        for _ in range(10):
+            aug_out = aug(x.clone())
+            augmented.append(aug_out)
+
+        # 至少有一些应该被增强（不等于原值）
+        # 由于随机性，至少检查形状正确
+        for aug_out in augmented:
+            assert aug_out.shape == x.shape
+
+
+class TestRandomOperations:
+    """其他随机操作测试"""
+
+    @pytest.mark.integration
+    def test_rand_and_randn(self, use_gems):
+        """测试rand和randn"""
+        # 均匀分布
+        uni = torch.rand(1000, device=device)
+        assert uni.min() >= 0 and uni.max() <= 1
+        assert abs(uni.mean().item() - 0.5) < 0.1
+
+        # 标准正态分布
+        norm = torch.randn(1000, device=device)
+        assert abs(norm.mean().item()) < 0.1
+        assert abs(norm.std().item() - 1.0) < 0.1
+
+    @pytest.mark.integration
+    def test_randperm(self, use_gems):
+        """测试随机排列"""
+        perm = torch.randperm(100, device=device)
+
+        # 验证是排列
+        assert perm.shape == (100,)
+        assert torch.sort(perm)[0].equal(torch.arange(100, device=device))
+
+    @pytest.mark.integration
+    def test_normal_distribution_sampling(self, use_gems):
+        """测试正态分布采样"""
+        mean = 5.0
+        std = 2.0
+        samples = torch.normal(mean, std, size=(1000,), device=device)
+
+        # 统计验证
+        sample_mean = samples.mean().item()
+        sample_std = samples.std().item()
+
+        assert abs(sample_mean - mean) < 0.5
+        assert abs(sample_std - std) < 0.5

--- a/tests/combination/test_sequence_operations.py
+++ b/tests/combination/test_sequence_operations.py
@@ -1,0 +1,402 @@
+"""
+P2级测试：序列操作组合测试
+
+测试场景：
+- 序列生成（arange → embedding）
+- 累积操作链
+- 位置编码（sin/cos）
+- 序列索引重排
+"""
+
+import math
+
+import pytest
+import torch
+import torch.nn as nn
+
+import flag_gems
+
+from .accuracy_utils import COMBO_FLOAT_DTYPES, combo_assert_close, compute_reference
+from .conftest import QUICK_MODE
+
+device = flag_gems.device
+
+
+# ========== 简化模型 ==========
+
+
+class PositionalEncoding(nn.Module):
+    """位置编码：arange → sin/cos"""
+
+    def __init__(self, d_model, max_len=5000):
+        super().__init__()
+        self.d_model = d_model
+
+        # 预计算位置编码
+        pe = torch.zeros(max_len, d_model)
+        position = torch.arange(0, max_len, dtype=torch.float).unsqueeze(1)
+        div_term = torch.exp(
+            torch.arange(0, d_model, 2).float() * (-math.log(10000.0) / d_model)
+        )
+
+        pe[:, 0::2] = torch.sin(position * div_term)
+        pe[:, 1::2] = torch.cos(position * div_term)
+
+        self.register_buffer("pe", pe)
+
+    def forward(self, x):
+        seq_len = x.size(1)
+        return x + self.pe[:seq_len].unsqueeze(0)
+
+
+class SequentialStatistics(nn.Module):
+    """序列统计：cumsum → cummax → cummin"""
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x):
+        # 累积和
+        cumsum = torch.cumsum(x, dim=-1)
+        # 累积最大值
+        cummax = torch.cummax(x, dim=-1).values
+        # 累积最小值
+        cummin = torch.cummin(x, dim=-1).values
+
+        return cumsum, cummax, cummin
+
+
+class SequenceShuffle(nn.Module):
+    """序列重排：arange → gather → scatter"""
+
+    def __init__(self):
+        super().__init__()
+
+    def forward(self, x, indices):
+        # 根据索引重排序列
+        shuffled = torch.gather(x, dim=1, index=indices)
+        return shuffled
+
+    def shuffle_and_restore(self, x, indices):
+        """打乱并恢复"""
+        # 打乱
+        shuffled = torch.gather(x, dim=1, index=indices)
+        # 恢复
+        restored = torch.scatter(torch.zeros_like(x), dim=1, index=indices, src=x)
+        return shuffled, restored
+
+
+class SequenceModel(nn.Module):
+    """简单序列模型：arange → embedding → linear"""
+
+    def __init__(self, vocab_size, embed_dim, hidden_dim):
+        super().__init__()
+        self.embedding = nn.Embedding(vocab_size, embed_dim)
+        self.linear = nn.Linear(embed_dim, hidden_dim)
+
+    def forward(self, seq_indices):
+        # 根据索引获取嵌入
+        embedded = self.embedding(seq_indices)
+        # 线性变换
+        output = self.linear(embedded)
+        return output
+
+
+# ========== 测试类 ==========
+
+
+class TestPositionalEncoding:
+    """位置编码测试"""
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize(
+        "batch_size,seq_len,d_model",
+        [
+            pytest.param(2, 16, 64, id="small"),
+            pytest.param(4, 64, 128, id="medium"),
+            pytest.param(
+                8,
+                256,
+                512,
+                id="large",
+                marks=pytest.mark.skipif(QUICK_MODE, reason="Quick mode"),
+            ),
+        ],
+    )
+    @pytest.mark.parametrize("dtype", COMBO_FLOAT_DTYPES)
+    @pytest.mark.integration
+    def test_positional_encoding_shape(
+        self, batch_size, seq_len, d_model, dtype, use_gems
+    ):
+        """测试位置编码形状"""
+        pe = PositionalEncoding(d_model).to(device)
+        x = torch.randn(batch_size, seq_len, d_model, device=device, dtype=dtype)
+
+        pe.eval()
+        with torch.no_grad():
+            output = pe(x)
+
+        assert output.shape == x.shape
+
+        # Reference comparison (PE ≈ 2 ops: buffer lookup + add)
+        ref_output = compute_reference(pe, x)
+        combo_assert_close(
+            output, ref_output, x.dtype, num_ops=2, name="PositionalEncoding"
+        )
+
+    @pytest.mark.integration
+    def test_positional_encoding_values(self, use_gems):
+        """测试位置编码值范围"""
+        pe = PositionalEncoding(64, max_len=100).to(device)
+        x = torch.zeros(1, 50, 64, device=device)
+
+        output = pe(x)
+
+        # 位置编码应该在[-1, 1]范围内（sin/cos）
+        assert output.min() >= -1.0
+        assert output.max() <= 1.0
+        # 由于x是零，输出就是位置编码本身
+        assert not torch.allclose(output, torch.zeros_like(output))
+
+    @pytest.mark.integration
+    def test_positional_encoding_different_positions(self, use_gems):
+        """测试不同位置有不同的编码"""
+        pe = PositionalEncoding(128).to(device)
+        x = torch.zeros(1, 100, 128, device=device)
+
+        output = pe(x)
+
+        # 不同位置的编码应该不同
+        pos_0 = output[0, 0, :]
+        pos_1 = output[0, 1, :]
+        pos_10 = output[0, 10, :]
+
+        assert not torch.allclose(pos_0, pos_1)
+        assert not torch.allclose(pos_0, pos_10)
+        assert not torch.allclose(pos_1, pos_10)
+
+
+class TestCumulativeOperations:
+    """累积操作测试"""
+
+    @pytest.mark.integration
+    def test_cumsum_correctness(self, use_gems):
+        """测试累积和正确性"""
+        x = torch.tensor([[1, 2, 3, 4, 5]], dtype=torch.float, device=device)
+
+        cumsum = torch.cumsum(x, dim=-1)
+        expected = torch.tensor([[1, 3, 6, 10, 15]], dtype=torch.float, device=device)
+
+        assert torch.allclose(cumsum, expected)
+
+    @pytest.mark.integration
+    def test_cummax_correctness(self, use_gems):
+        """测试累积最大值正确性"""
+        x = torch.tensor([[3, 1, 4, 1, 5, 9, 2, 6]], dtype=torch.float, device=device)
+
+        cummax = torch.cummax(x, dim=-1).values
+        expected = torch.tensor(
+            [[3, 3, 4, 4, 5, 9, 9, 9]], dtype=torch.float, device=device
+        )
+
+        assert torch.allclose(cummax, expected)
+
+    @pytest.mark.integration
+    def test_cummin_correctness(self, use_gems):
+        """测试累积最小值正确性"""
+        x = torch.tensor([[5, 3, 4, 1, 2, 0, 6]], dtype=torch.float, device=device)
+
+        cummin = torch.cummin(x, dim=-1).values
+        expected = torch.tensor(
+            [[5, 3, 3, 1, 1, 0, 0]], dtype=torch.float, device=device
+        )
+
+        assert torch.allclose(cummin, expected)
+
+    @pytest.mark.integration
+    def test_cumulative_statistics_chain(self, use_gems):
+        """测试累积统计链"""
+        model = SequentialStatistics().to(device)
+        x = torch.randn(4, 32, device=device)
+
+        cumsum, cummax, cummin = model(x)
+
+        # 验证形状
+        assert cumsum.shape == x.shape
+        assert cummax.shape == x.shape
+        assert cummin.shape == x.shape
+
+        # 验证最后位置的累积和等于总和
+        assert torch.allclose(cumsum[:, -1], x.sum(dim=-1))
+
+        # 验证累积最大值的最后一个位置等于全局最大值
+        assert torch.allclose(cummax[:, -1], x.max(dim=-1).values)
+
+        # 验证累积最小值的最后一个位置等于全局最小值
+        assert torch.allclose(cummin[:, -1], x.min(dim=-1).values)
+
+    @pytest.mark.integration
+    def test_cumulative_gradient(self, use_gems):
+        """测试累积操作梯度"""
+        x = torch.randn(4, 16, device=device, requires_grad=True)
+
+        cumsum = torch.cumsum(x, dim=-1)
+        loss = cumsum.sum()
+        loss.backward()
+
+        assert x.grad is not None
+        # 梯度应该全为1的累积
+        assert torch.isfinite(x.grad).all()
+
+
+class TestSequenceShuffle:
+    """序列重排测试"""
+
+    @pytest.mark.integration
+    def test_sequence_gather(self, use_gems):
+        """测试序列gather"""
+        model = SequenceShuffle().to(device)
+        x = torch.randn(2, 10, 64, device=device)
+
+        # 创建随机索引
+        indices = torch.randperm(10, device=device).unsqueeze(0).expand(2, -1)
+
+        shuffled = model(x, indices)
+
+        # 验证形状相同
+        assert shuffled.shape == x.shape
+
+        # 验证gather正确性
+        expected = torch.gather(
+            x, dim=1, index=indices.unsqueeze(-1).expand(-1, -1, 64)
+        )
+        assert torch.allclose(shuffled, expected)
+
+    @pytest.mark.integration
+    def test_shuffle_and_restore(self, use_gems):
+        """测试打乱并恢复"""
+        model = SequenceShuffle().to(device)
+        x = torch.randn(1, 8, 32, device=device)
+        indices = torch.randperm(8, device=device).unsqueeze(0)
+
+        shuffled, restored = model.shuffle_and_restore(x, indices)
+
+        # 形状应该一致
+        assert shuffled.shape == x.shape
+
+        # 验证恢复（scatter的逆操作）
+        # 原始数据和恢复的数据应该可以对应
+
+
+class TestArangeEmbedding:
+    """Arange → Embedding测试"""
+
+    @pytest.mark.integration
+    def test_arange_as_indices(self, use_gems):
+        """测试arange作为索引"""
+        seq_len = 32
+        indices = torch.arange(seq_len, device=device)
+
+        # 验证是0到seq_len-1的序列
+        assert indices[0] == 0
+        assert indices[-1] == seq_len - 1
+        assert torch.equal(torch.sort(indices)[0], indices)
+
+    @pytest.mark.integration
+    @pytest.mark.parametrize("dtype", COMBO_FLOAT_DTYPES)
+    def test_sequence_embedding(self, dtype, use_gems):
+        """测试序列嵌入"""
+        vocab_size = 1000
+        embed_dim = 256
+        hidden_dim = 128
+
+        model = SequenceModel(vocab_size, embed_dim, hidden_dim).to(device).to(dtype)
+
+        # 创建序列索引（arange）
+        seq_indices = torch.arange(0, 64, device=device).unsqueeze(0)
+
+        model.eval()
+        with torch.no_grad():
+            output = model(seq_indices)
+
+        # 验证输出形状
+        assert output.shape == (1, 64, hidden_dim)
+
+        # Reference comparison (embedding + linear ≈ 2 ops)
+        ref_output = compute_reference(model, seq_indices)
+        combo_assert_close(
+            output, ref_output, dtype, num_ops=2, name=f"SequenceModel {dtype}"
+        )
+
+    @pytest.mark.integration
+    def test_batch_sequence_indices(self, use_gems):
+        """测试批量序列索引"""
+        vocab_size = 500
+        embed_dim = 128
+
+        embedding = nn.Embedding(vocab_size, embed_dim).to(device)
+
+        # 批量不同长度的序列
+        batch_size = 4
+        seq_len = 32
+        indices = torch.randint(0, vocab_size, (batch_size, seq_len), device=device)
+
+        embedded = embedding(indices)
+
+        assert embedded.shape == (batch_size, seq_len, embed_dim)
+
+
+class TestLinspace:
+    """Linspace测试"""
+
+    @pytest.mark.integration
+    def test_linspace_basic(self, use_gems):
+        """测试linspace基本功能"""
+        start = 0.0
+        end = 1.0
+        steps = 10
+
+        values = torch.linspace(start, end, steps, device=device)
+
+        assert values[0] == start
+        assert abs(values[-1].item() - end) < 1e-5
+        assert len(values) == steps
+
+    @pytest.mark.integration
+    def test_linspace_uniform_spacing(self, use_gems):
+        """测试linspace均匀间距"""
+        values = torch.linspace(0, 10, 100, device=device)
+
+        # 计算相邻元素差
+        diffs = values[1:] - values[:-1]
+
+        # 所有差值应该相等
+        assert torch.allclose(diffs, diffs[0].expand_as(diffs), rtol=1e-4)
+
+
+class TestLogspace:
+    """Logspace测试"""
+
+    @pytest.mark.integration
+    def test_logspace_basic(self, use_gems):
+        """测试logspace基本功能"""
+        start = -2
+        end = 2
+        steps = 20
+
+        values = torch.logspace(start, end, steps, device=device)
+
+        # 验证范围
+        assert values.min() >= 10**start
+        assert values.max() <= 10**end
+
+    @pytest.mark.integration
+    def test_logspace_logarithmic_spacing(self, use_gems):
+        """测试logspace对数间距"""
+        values = torch.logspace(0, 2, 10, device=device)  # 1到100
+
+        # 在对数空间应该是均匀的
+        log_values = torch.log10(values)
+        diffs = log_values[1:] - log_values[:-1]
+
+        assert torch.allclose(diffs, diffs[0].expand_as(diffs), rtol=1e-4)

--- a/tests/combination/utils/__init__.py
+++ b/tests/combination/utils/__init__.py
@@ -1,0 +1,1 @@
+# Test utilities for combination testing

--- a/tests/combination/utils/numerical_stability.py
+++ b/tests/combination/utils/numerical_stability.py
@@ -1,0 +1,195 @@
+"""
+Numerical stability utilities for combination testing.
+
+This module provides utilities for testing numerical stability
+in operator combinations.
+"""
+
+import torch
+
+
+def check_no_nan(tensor, name=""):
+    """
+    Check that tensor contains no NaN values.
+
+    Args:
+        tensor: Tensor to check
+        name: Name for error message
+
+    Raises:
+        AssertionError: If NaN values found
+    """
+    nan_count = torch.isnan(tensor).sum().item()
+    if nan_count > 0:
+        raise AssertionError(f"{name}: Found {nan_count} NaN values in tensor")
+
+
+def check_no_inf(tensor, name="", tolerance=0.01):
+    """
+    Check that tensor contains reasonable number of Inf values.
+
+    Args:
+        tensor: Tensor to check
+        name: Name for error message
+        tolerance: Fraction of Inf values allowed (default 1%)
+
+    Raises:
+        AssertionError: If too many Inf values found
+    """
+    inf_count = torch.isinf(tensor).sum().item()
+    total = tensor.numel()
+    inf_fraction = inf_count / total if total > 0 else 0
+
+    if inf_fraction > tolerance:
+        raise AssertionError(
+            f"{name}: Found {inf_count} Inf values ({inf_fraction:.2%} of tensor), exceeds tolerance {tolerance:.2%}"
+        )
+
+
+def check_finite(tensor, name=""):
+    """
+    Check that all values are finite (no NaN or Inf).
+
+    Args:
+        tensor: Tensor to check
+        name: Name for error message
+
+    Raises:
+        AssertionError: If non-finite values found
+    """
+    if not torch.isfinite(tensor).all():
+        nan_count = torch.isnan(tensor).sum().item()
+        inf_count = torch.isinf(tensor).sum().item()
+        raise AssertionError(
+            f"{name}: Tensor contains {nan_count} NaN and {inf_count} Inf values"
+        )
+
+
+def check_gradient_health(model, name=""):
+    """
+    Check that all model gradients are finite.
+
+    Args:
+        model: Model to check
+        name: Name for error message
+
+    Raises:
+        AssertionError: If gradient issues found
+    """
+    for param_name, param in model.named_parameters():
+        if param.grad is not None:
+            if not torch.isfinite(param.grad).all():
+                nan_count = torch.isnan(param.grad).sum().item()
+                inf_count = torch.isinf(param.grad).sum().item()
+                raise AssertionError(
+                    f"{name}: Gradient of {param_name} has {nan_count} NaN and {inf_count} Inf values"
+                )
+
+
+def assert_relative_error(actual, expected, rtol=1e-3, atol=1e-5, name=""):
+    """
+    Assert that actual and expected tensors are close within tolerance.
+
+    Args:
+        actual: Actual tensor
+        expected: Expected tensor
+        rtol: Relative tolerance
+        atol: Absolute tolerance
+        name: Name for error message
+
+    Raises:
+        AssertionError: If tensors are not close enough
+    """
+    if not torch.allclose(actual, expected, rtol=rtol, atol=atol):
+        max_error = (actual - expected).abs().max().item()
+        mean_error = (actual - expected).abs().mean().item()
+        raise AssertionError(
+            f"{name}: Tensors differ - max error: {max_error:.6e}, mean error: {mean_error:.6e}"
+        )
+
+
+def generate_stress_input(shape, dtype, device, stress_type="extreme"):
+    """
+    Generate input data for stress testing.
+
+    Args:
+        shape: Tensor shape
+        dtype: Data type
+        device: Device
+        stress_type: Type of stress ('extreme', 'small', 'mixed')
+
+    Returns:
+        Generated tensor
+    """
+    if stress_type == "extreme":
+        # Large magnitude values
+        return torch.randn(shape, dtype=dtype, device=device) * 100
+
+    elif stress_type == "small":
+        # Small magnitude values
+        return torch.randn(shape, dtype=dtype, device=device) * 1e-6
+
+    elif stress_type == "mixed":
+        # Mix of normal, large, and small values
+        x = torch.randn(shape, dtype=dtype, device=device)
+        # Make some values very large
+        large_mask = torch.rand(shape, device=device) < 0.1
+        x[large_mask] *= 100
+        # Make some values very small
+        small_mask = torch.rand(shape, device=device) < 0.1
+        x[small_mask] *= 1e-4
+        return x
+
+    else:
+        raise ValueError(f"Unknown stress type: {stress_type}")
+
+
+class NumericalMonitor:
+    """
+    Context manager for monitoring numerical stability during operations.
+    """
+
+    def __init__(self, name="", check_interval=1):
+        """
+        Initialize monitor.
+
+        Args:
+            name: Name for logging
+            check_interval: How often to check (every N operations)
+        """
+        self.name = name
+        self.check_interval = check_interval
+        self.operation_count = 0
+        self.issues = []
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if self.issues:
+            print(f"\n[NumericalMonitor] {self.name}: Found {len(self.issues)} issues:")
+            for issue in self.issues[:10]:  # Show first 10 issues
+                print(f"  - {issue}")
+        return False
+
+    def check(self, tensor, operation_name=""):
+        """
+        Check a tensor for numerical issues.
+
+        Args:
+            tensor: Tensor to check
+            operation_name: Name of operation that produced tensor
+        """
+        self.operation_count += 1
+
+        if self.operation_count % self.check_interval != 0:
+            return
+
+        nan_count = torch.isnan(tensor).sum().item()
+        inf_count = torch.isinf(tensor).sum().item()
+
+        if nan_count > 0:
+            self.issues.append(f"{operation_name}: {nan_count} NaN values")
+
+        if inf_count > 0:
+            self.issues.append(f"{operation_name}: {inf_count} Inf values")


### PR DESCRIPTION
## Summary

- Add multi-operator combination testing framework for FlagGems, including shared infrastructure (`accuracy_utils`, `conftest`, `logging_config`, `utils/numerical_stability`)
- Add 6 basic test suites covering: attention numerical stability, convolution combination, loss functions, mixed precision accumulation, sampling operations, and sequence operations
- These tests validate operator behavior when multiple operators are chained together (e.g., softmax → attention → masking, conv → BN → ReLU)

## Files

**Infrastructure (6 files):**
- `tests/combination/__init__.py`
- `tests/combination/conftest.py` — shared fixtures (`use_gems`, `dtype`, `batch_size`, etc.)
- `tests/combination/accuracy_utils.py` — reference computation (GPU fp64 / CPU fallback) and tolerance scaling
- `tests/combination/logging_config.py` — structured JSON test logger
- `tests/combination/utils/__init__.py`
- `tests/combination/utils/numerical_stability.py` — NaN/Inf/gradient health checks

**Test suites (6 files):**
- `test_attention_numerical_stability.py` — softmax/attention edge cases (padding mask, causal mask, precision)
- `test_convolution_combination.py` — conv2d/conv3d + pooling chains, residual blocks
- `test_loss_functions.py` — cross-entropy, MSE, contrastive loss, multi-task gradient flow
- `test_mixed_precision_accumulation.py` — fp16/bf16 error accumulation bounds
- `test_sampling_operations.py` — dropout, weight initialization, multinomial sampling
- `test_sequence_operations.py` — embedding, gather, cumulative ops (cumsum/cummax/cummin)

## Note

This is the first of a series of PRs for the combination testing framework. Subsequent PRs will add:
- MoE routing tests (depends on this PR)
- Model definitions + model-dependent tests (depends on this PR)
- CI workflow and documentation
- Operator extraction tools

## Test plan

- [ ] `pytest tests/combination/test_loss_functions.py -v`
- [ ] `pytest tests/combination/test_sampling_operations.py -v`
- [ ] `pytest tests/combination/test_sequence_operations.py -v`
- [ ] `pytest tests/combination/test_convolution_combination.py -v`
- [ ] `pytest tests/combination/test_mixed_precision_accumulation.py -v`
- [ ] `pytest tests/combination/test_attention_numerical_stability.py -v`