### PR TITLE
Update marks for bucket_sort_topk

### DIFF
--- a/tests/test_DSA/test_bin_topk.py
+++ b/tests/test_DSA/test_bin_topk.py
@@ -137,7 +137,7 @@ def debug_topk_results(actual, expected, inputs, test_name=""):
 @pytest.mark.skip(
     "RuntimeError: Cannot call @triton.jit'd outside of the scope of a kernel"
 )
-@pytest.mark.bucket_sort_topk_forward
+@pytest.mark.bucket_sort_topk
 @pytest.mark.parametrize("batch_size", [1, 4, 16])
 @pytest.mark.parametrize("seq_len", [256, 1024, 8192])
 @pytest.mark.parametrize("topk", [16, 64, 256])
@@ -172,7 +172,7 @@ def test_bucket_sort_topk_forward(
 @pytest.mark.skip(
     "RuntimeError: Cannot call @triton.jit'd outside of the scope of a kernel"
 )
-@pytest.mark.bucket_sort_topk_edge_cases
+@pytest.mark.bucket_sort_topk
 @pytest.mark.parametrize(
     "config",
     [
@@ -207,7 +207,7 @@ def test_bucket_sort_topk_edge_cases(config):
 @pytest.mark.skip(
     "RuntimeError: Cannot call @triton.jit'd outside of the scope of a kernel"
 )
-@pytest.mark.bucket_sort_topk_large_scale
+@pytest.mark.bucket_sort_topk
 @pytest.mark.parametrize(
     "config",
     [
@@ -245,7 +245,7 @@ def test_bucket_sort_topk_large_scale(config):
 @pytest.mark.skip(
     "RuntimeError: Cannot call @triton.jit'd outside of the scope of a kernel"
 )
-@pytest.mark.bucket_sort_topk_variable_length
+@pytest.mark.bucket_sort_topk
 def test_bucket_sort_topk_variable_length():
     """Test variable length sequence processing"""
     batch_size = 4
@@ -276,7 +276,7 @@ def test_bucket_sort_topk_variable_length():
 @pytest.mark.skip(
     "RuntimeError: Cannot call @triton.jit'd outside of the scope of a kernel"
 )
-@pytest.mark.bucket_sort_topk_correctness
+@pytest.mark.bucket_sort_topk
 def test_bucket_sort_topk_correctness():
     """Correctness test - using your original test logic"""
     batch_size = 96


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

This PR fixes the incorrect usage of `pytest.mark`. We use this idiom to differentiate test cases based on the operators/kernels/functions we support. Marks are not supposed to be used as identification of specific test cases. If you want to run a specific test case, you can name the test case directly, e.g.

```
pytest tests/test_DSA/test_bin_topk.py::test_bucket_sort_topk_forward
```
