### PR TITLE
Fix mark for baddbmm and baddbmm_backward

### DIFF
--- a/tests/test_blas_ops.py
+++ b/tests/test_blas_ops.py
@@ -315,8 +315,6 @@ def test_w8a8_block_fp8_matmul(M, N, K):
 
 
 @pytest.mark.baddbmm
-@pytest.mark.linear
-@pytest.mark.matmul
 @pytest.mark.parametrize("M, N, K", MNK_SHAPES)
 @pytest.mark.parametrize("scalar", SCALARS)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
@@ -342,9 +340,7 @@ def test_baddbmm(M, N, K, scalar, dtype):
         del os.environ["MUSA_ENABLE_SQMMA"]
 
 
-@pytest.mark.baddbmm_backward
-@pytest.mark.linear
-@pytest.mark.matmul
+@pytest.mark.baddbmm
 @pytest.mark.parametrize("M, N, K", MNK_SHAPES)
 @pytest.mark.parametrize("scalar", SCALARS)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

This PR fixes the incorrect usage of `pytest.mark` for `baddbmm` and `baddbmm_backward`. We use `pytest.mark` to identify specific operators/kernels/functions we support. The `baddbmm` and `baddbmm_backward` operations are inseparable, both from the perspective PyTorch exposed API and from the viewpoint of implementation.

In addition to that, we only mark a test case for the top-level operator/kernel we are testing. There is no need to list other marks even for nested operators. It is unfair to treat such a test case as a test case for the nested operations.
