### PR TITLE
fix: avoid Hopper TMA matmul shared-memory OOR by filtering oversized configs

### DIFF
--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/mm.py
@@ -18,6 +18,25 @@ CACHE_USAGE_THRESHOLD = 0.8
 EXPAND_CONFIG_FILENAME = os.path.normpath(
     os.path.join(os.path.dirname(__file__), "..", "mm_hopper_expand.yaml")
 )
+_SHARED_MEM_SAFETY_MARGIN_BYTES = 1024
+
+
+def _get_shared_memory_limit_bytes():
+    """Return per-block opt-in shared-memory limit for current CUDA device."""
+    try:
+        if not torch.cuda.is_available():
+            return None
+        return torch.cuda.get_device_properties(
+            torch.cuda.current_device()
+        ).shared_memory_per_block_optin
+    except Exception:
+        return None
+
+
+def _estimate_tma_shared_memory_bytes(block_m, block_n, block_k, num_stages):
+    bytes_per_element = 4
+    tile_bytes = (block_m * block_k + block_k * block_n) * bytes_per_element
+    return tile_bytes * num_stages + _SHARED_MEM_SAFETY_MARGIN_BYTES
 
 
 def is_tma_compatible(a, b, N, K):
@@ -207,7 +226,7 @@ def mm_kernel_general(
 
 
 def matmul_get_configs(pre_hook=matmul_tma_set_block_size_hook):
-    return [
+    configs = [
         triton.Config(
             {"BLOCK_M": BM, "BLOCK_N": BN, "BLOCK_K": BK},
             num_stages=s,
@@ -220,6 +239,28 @@ def matmul_get_configs(pre_hook=matmul_tma_set_block_size_hook):
         for s in [2, 3, 4]
         for w in [4, 8]
     ]
+    shared_mem_limit = _get_shared_memory_limit_bytes()
+    if shared_mem_limit is None:
+        return configs
+
+    filtered_configs = [
+        cfg
+        for cfg in configs
+        if _estimate_tma_shared_memory_bytes(
+            cfg.kwargs["BLOCK_M"],
+            cfg.kwargs["BLOCK_N"],
+            cfg.kwargs["BLOCK_K"],
+            cfg.num_stages,
+        )
+        <= shared_mem_limit
+    ]
+    if not filtered_configs:
+        logger.warning(
+            "No mm_general_tma config fits shared memory limit (%s bytes); falling back to unfiltered configs.",
+            shared_mem_limit,
+        )
+        return configs
+    return filtered_configs
 
 
 @libentry()


### PR DESCRIPTION
## Summary
Fix shared-memory OutOfResources in Hopper TMA matmul (`mm_kernel_general_host_tma`) by filtering oversized autotune configs in `matmul_get_configs()`.

## Root Cause
Static autotune candidates include some `(BLOCK_M, BLOCK_N, BLOCK_K, num_stages)` combinations that exceed Hopper shared-memory hardware limit (e.g. H20: 232448 bytes). Under load, these configs can be selected and trigger Triton `OutOfResources`.

## Changes
- Add device shared-memory limit query helper.
- Add conservative shared-memory estimator for TMA configs.
- Filter out configs exceeding hardware limit before autotune.
- Keep fallback to original config set if filtering results in empty set.

## Validation
Validated locally on H20 (SM90), torch 2.8.0+cu128, triton 3.4.0:
- Filter sanity: known oversized config `(256,128,128,s4)` is removed.
- Numerical correctness: `general_mm` matches `torch.matmul` on tested shapes.
- Runtime smoke: multiple large shapes run without shared-memory OOR.
- Control check: forcing oversized raw config still reproduces expected `OutOfResources`.

## Related Issue
Related to flagos-ai/FlagTree#352
