### PR TITLE
[FlagGems Operator Development Competition] Add grid_sample operator

### DIFF
--- a/benchmark/test_grid_sample.py
+++ b/benchmark/test_grid_sample.py
@@ -89,6 +89,7 @@ def test_perf_grid_sampler_2d(interp_name, interp_mode, pad_name, pad_mode):
     )
     bench.run()
 
+
 @pytest.mark.grid_sampler_3d
 @pytest.mark.parametrize(
     "interp_name,interp_mode",

--- a/benchmark/test_grid_sample.py
+++ b/benchmark/test_grid_sample.py
@@ -1,0 +1,110 @@
+import pytest
+import torch
+
+from . import base
+
+
+class GridSamplerBenchmark(base.Benchmark):
+    def __init__(self, op_name, torch_op, dtypes, interp_mode, pad_mode, align_corners):
+        super().__init__(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
+        self.interp_mode = interp_mode
+        self.pad_mode = pad_mode
+        self.align_corners = align_corners
+
+    def set_shapes(self, shape_file_path=None):
+        # (N, C, H_in, W_in, H_out, W_out)
+        self.shapes = [
+            (2, 16, 64, 64, 48, 48),
+            (4, 32, 128, 128, 96, 96),
+            (1, 64, 256, 256, 192, 192),
+            (1, 64, 512, 512, 384, 384),
+            (1, 64, 768, 768, 576, 576),
+        ]
+
+    def set_more_shapes(self):
+        return None
+
+    def get_input_iter(self, cur_dtype):
+        for N, C, H_in, W_in, H_out, W_out in self.shapes:
+            x = torch.randn((N, C, H_in, W_in), dtype=cur_dtype, device=self.device)
+            grid = (
+                torch.rand((N, H_out, W_out, 2), dtype=cur_dtype, device=self.device)
+                * 2.0
+                - 1.0
+            )
+            yield x, grid, self.interp_mode, self.pad_mode, self.align_corners
+
+
+class GridSampler3DBenchmark(base.Benchmark):
+    def __init__(self, op_name, torch_op, dtypes, interp_mode, pad_mode, align_corners):
+        super().__init__(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
+        self.interp_mode = interp_mode
+        self.pad_mode = pad_mode
+        self.align_corners = align_corners
+
+    def set_shapes(self, shape_file_path=None):
+        # (N, C, D_in, H_in, W_in, D_out, H_out, W_out)
+        self.shapes = [
+            (2, 8, 16, 16, 16, 12, 12, 12),
+            (1, 32, 48, 48, 48, 36, 36, 36),
+            (2, 32, 128, 128, 128, 64, 64, 64),
+            (1, 16, 256, 256, 256, 128, 128, 128),
+        ]
+
+    def set_more_shapes(self):
+        return None
+
+    def get_input_iter(self, cur_dtype):
+        for N, C, D_in, H_in, W_in, D_out, H_out, W_out in self.shapes:
+            x = torch.randn(
+                (N, C, D_in, H_in, W_in), dtype=cur_dtype, device=self.device
+            )
+            grid = (
+                torch.rand(
+                    (N, D_out, H_out, W_out, 3), dtype=cur_dtype, device=self.device
+                )
+                * 2.0
+                - 1.0
+            )
+            yield x, grid, self.interp_mode, self.pad_mode, self.align_corners
+
+
+@pytest.mark.grid_sampler_2d
+@pytest.mark.parametrize(
+    "interp_name,interp_mode",
+    [("bilinear", 0), ("nearest", 1), ("bicubic", 2)],
+)
+@pytest.mark.parametrize(
+    "pad_name,pad_mode",
+    [("zeros", 0), ("reflection", 2)],
+)
+def test_perf_grid_sampler_2d(interp_name, interp_mode, pad_name, pad_mode):
+    bench = GridSamplerBenchmark(
+        op_name=f"grid_sampler_2d_{interp_name}_{pad_name}",
+        torch_op=torch.ops.aten.grid_sampler_2d,
+        dtypes=[torch.float16, torch.float32],
+        interp_mode=interp_mode,
+        pad_mode=pad_mode,
+        align_corners=False,
+    )
+    bench.run()
+
+@pytest.mark.grid_sampler_3d
+@pytest.mark.parametrize(
+    "interp_name,interp_mode",
+    [("bilinear", 0), ("nearest", 1)],
+)
+@pytest.mark.parametrize(
+    "pad_name,pad_mode",
+    [("zeros", 0), ("reflection", 2)],
+)
+def test_perf_grid_sampler_3d(interp_name, interp_mode, pad_name, pad_mode):
+    bench = GridSampler3DBenchmark(
+        op_name=f"grid_sampler_3d_{interp_name}_{pad_name}",
+        torch_op=torch.ops.aten.grid_sampler_3d,
+        dtypes=[torch.float16, torch.float32],
+        interp_mode=interp_mode,
+        pad_mode=pad_mode,
+        align_corners=False,
+    )
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -23,6 +23,53 @@ current_work_registrar = None
 runtime.replace_customized_ops(globals())
 
 
+def _grid_sampler_setup_context(ctx, inputs, output):
+    input, grid, interpolation_mode, padding_mode, align_corners = inputs
+    ctx.save_for_backward(input, grid)
+    ctx.interpolation_mode = interpolation_mode
+    ctx.padding_mode = padding_mode
+    ctx.align_corners = align_corners
+
+
+def _grid_sampler_backward(ctx, grad_output):
+    input, grid = ctx.saved_tensors
+    output_mask = [ctx.needs_input_grad[0], ctx.needs_input_grad[1]]
+    if input.dim() == 4:
+        grad_input, grad_grid = torch.ops.aten.grid_sampler_2d_backward(
+            grad_output,
+            input,
+            grid,
+            ctx.interpolation_mode,
+            ctx.padding_mode,
+            ctx.align_corners,
+            output_mask,
+        )
+    else:
+        grad_input, grad_grid = torch.ops.aten.grid_sampler_3d_backward(
+            grad_output,
+            input,
+            grid,
+            ctx.interpolation_mode,
+            ctx.padding_mode,
+            ctx.align_corners,
+            output_mask,
+        )
+    return (
+        grad_input if ctx.needs_input_grad[0] else None,
+        grad_grid if ctx.needs_input_grad[1] else None,
+        None,
+        None,
+        None,
+    )
+
+
+torch.library.register_autograd(
+    "aten::grid_sampler",
+    _grid_sampler_backward,
+    setup_context=_grid_sampler_setup_context,
+)
+
+
 def torch_ge(v):
     return version.parse(torch.__version__) >= version.parse(v)
 
@@ -230,6 +277,11 @@ _FULL_CONFIG = (
     ("gelu_backward", gelu_backward),
     ("glu", glu),
     ("glu_backward", glu_backward),
+    ("grid_sampler", grid_sampler),
+    ("grid_sampler_2d", grid_sampler_2d),
+    ("grid_sampler_2d_backward", grid_sampler_2d_backward),
+    ("grid_sampler_3d", grid_sampler_3d),
+    ("grid_sampler_3d_backward", grid_sampler_3d_backward),
     ("greater.Scalar", greater_scalar),
     ("greater.Tensor", greater),
     ("greater.Scalar_out", greater_scalar_out),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -143,6 +143,13 @@ from flag_gems.ops.greater import (
     greater_scalar,
     greater_scalar_out,
 )
+from flag_gems.ops.grid_sample import (
+    grid_sampler,
+    grid_sampler_2d,
+    grid_sampler_2d_backward,
+    grid_sampler_3d,
+    grid_sampler_3d_backward,
+)
 from flag_gems.ops.group_gemm import group_mm
 from flag_gems.ops.groupnorm import group_norm, group_norm_backward
 from flag_gems.ops.gt import gt, gt_scalar
@@ -508,6 +515,11 @@ __all__ = [
     "get_scheduler_metadata",
     "glu",
     "glu_backward",
+    "grid_sampler",
+    "grid_sampler_2d",
+    "grid_sampler_2d_backward",
+    "grid_sampler_3d",
+    "grid_sampler_3d_backward",
     "greater",
     "greater_out",
     "greater_scalar",

--- a/src/flag_gems/ops/grid_sample.py
+++ b/src/flag_gems/ops/grid_sample.py
@@ -1,0 +1,2765 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+logger = logging.getLogger(__name__)
+
+# Interpolation mode constant used in validation (matches PyTorch ATen)
+_INTERP_BICUBIC = 2
+
+
+@triton.jit
+def _cubic_weight(d):
+    """Bicubic interpolation kernel weight, a=-0.75 (matches PyTorch)."""
+    a = -0.75
+    ad = tl.abs(d)
+    ad2 = ad * ad
+    ad3 = ad2 * ad
+    w1 = (a + 2.0) * ad3 - (a + 3.0) * ad2 + 1.0
+    w2 = a * ad3 - 5.0 * a * ad2 + 8.0 * a * ad - 4.0 * a
+    return tl.where(ad <= 1.0, w1, tl.where(ad < 2.0, w2, 0.0))
+
+
+@triton.jit
+def _reflect_coord(x, size, align_corners: tl.constexpr):
+    """
+    Reflect coordinate x to lie within valid input range.
+
+    align_corners=True:  reflects in [0, size-1]
+    align_corners=False: reflects in [-0.5, size-0.5]
+    """
+    if align_corners:
+        # twice_low=0, twice_high=2*(size-1) → half_span = size-1
+        half_span = tl.cast(size - 1, tl.float32)
+        # Edge case: size == 1 → half_span == 0, only valid coord is 0
+        half_span = tl.maximum(half_span, 1e-10)
+        span = half_span * 2.0
+        x = tl.abs(x)
+        floored = tl.floor(x / span)
+        extra = x - floored * span
+        return tl.where(extra <= half_span, extra, span - extra)
+    else:
+        # twice_low=-1, twice_high=2*size-1 → span = size, min = -0.5
+        span = tl.cast(size, tl.float32)
+        x = x + 0.5  # shift so [−0.5, size−0.5] → [0, size]
+        x = tl.abs(x)
+        dspan = span * 2.0
+        floored = tl.floor(x / dspan)
+        extra = x - floored * dspan
+        return tl.where(extra <= span, extra, dspan - extra) - 0.5
+
+
+@triton.jit
+def _nearbyint_coord(x):
+    flo = tl.floor(x)
+    frac = x - flo
+    rounded = tl.floor(x + 0.5)
+    flo_i = flo.to(tl.int32)
+    is_half = tl.abs(frac - 0.5) < 1e-6
+    even_lower = (flo_i % 2) == 0
+    return tl.where(is_half & even_lower, flo, rounded).to(tl.int32)
+
+
+@triton.jit
+def _clamp_and_mask_2d(
+    xi,
+    yi,
+    W_in,
+    H_in,
+    stride_H,
+    stride_W,
+    hw_mask,
+    padding_mode: tl.constexpr,
+    align_corners: tl.constexpr,
+):
+    """
+    Given integer pixel coordinates xi, yi of shape [BLOCK_HW], compute the
+    address offset into a single channel plane and a validity mask.
+
+    Returns (offset [BLOCK_HW], valid [BLOCK_HW]).
+    """
+    if padding_mode == 0:  # zeros
+        xc = tl.maximum(0, tl.minimum(xi, W_in - 1))
+        yc = tl.maximum(0, tl.minimum(yi, H_in - 1))
+        valid = hw_mask & (xi >= 0) & (xi < W_in) & (yi >= 0) & (yi < H_in)
+    elif padding_mode == 1:  # border
+        xc = tl.maximum(0, tl.minimum(xi, W_in - 1))
+        yc = tl.maximum(0, tl.minimum(yi, H_in - 1))
+        valid = hw_mask
+    else:  # reflection
+        xf = _reflect_coord(xi.to(tl.float32), W_in, align_corners)
+        yf = _reflect_coord(yi.to(tl.float32), H_in, align_corners)
+        xc = tl.maximum(0, tl.minimum(xf.to(tl.int32), W_in - 1))
+        yc = tl.maximum(0, tl.minimum(yf.to(tl.int32), H_in - 1))
+        valid = hw_mask
+    return yc * stride_H + xc * stride_W, valid
+
+
+@triton.jit
+def _clamp_and_mask_3d(
+    xi,
+    yi,
+    zi,
+    W_in,
+    H_in,
+    D_in,
+    stride_D,
+    stride_H,
+    stride_W,
+    dhw_mask,
+    padding_mode: tl.constexpr,
+    align_corners: tl.constexpr,
+):
+    """
+    Given integer voxel coordinates xi, yi, zi of shape [BLOCK_DHW], compute the
+    address offset into a single channel volume and a validity mask.
+
+    Returns (offset [BLOCK_DHW], valid [BLOCK_DHW]).
+    """
+    if padding_mode == 0:  # zeros
+        xc = tl.maximum(0, tl.minimum(xi, W_in - 1))
+        yc = tl.maximum(0, tl.minimum(yi, H_in - 1))
+        zc = tl.maximum(0, tl.minimum(zi, D_in - 1))
+        valid = (
+            dhw_mask
+            & (xi >= 0)
+            & (xi < W_in)
+            & (yi >= 0)
+            & (yi < H_in)
+            & (zi >= 0)
+            & (zi < D_in)
+        )
+    elif padding_mode == 1:  # border
+        xc = tl.maximum(0, tl.minimum(xi, W_in - 1))
+        yc = tl.maximum(0, tl.minimum(yi, H_in - 1))
+        zc = tl.maximum(0, tl.minimum(zi, D_in - 1))
+        valid = dhw_mask
+    else:  # reflection
+        xf = _reflect_coord(xi.to(tl.float32), W_in, align_corners)
+        yf = _reflect_coord(yi.to(tl.float32), H_in, align_corners)
+        zf = _reflect_coord(zi.to(tl.float32), D_in, align_corners)
+        xc = tl.maximum(0, tl.minimum(xf.to(tl.int32), W_in - 1))
+        yc = tl.maximum(0, tl.minimum(yf.to(tl.int32), H_in - 1))
+        zc = tl.maximum(0, tl.minimum(zf.to(tl.int32), D_in - 1))
+        valid = dhw_mask
+    return zc * stride_D + yc * stride_H + xc * stride_W, valid
+
+
+@triton.jit
+def _cubic_weight_grad(t):
+    a = -0.75
+    x0 = -1.0 - t
+    x1 = -t
+    x2 = 1.0 - t
+    x3 = 2.0 - t
+    # Each g_i = dw_i/dt = dw_i/d(x_i) * d(x_i)/dt, where d(x_i)/dt = -1
+    g0 = -((-3.0 * a * x0 - 10.0 * a) * x0 - 8.0 * a)
+    g1 = -((-3.0 * (a + 2.0) * x1 - 2.0 * (a + 3.0)) * x1)
+    g2 = -((3.0 * (a + 2.0) * x2 - 2.0 * (a + 3.0)) * x2)
+    g3 = -((3.0 * a * x3 - 10.0 * a) * x3 + 8.0 * a)
+    return g0, g1, g2, g3
+
+
+_GRID_SAMPLER_2D_AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCK_HW": 64}, num_warps=4, num_stages=2),
+    triton.Config({"BLOCK_HW": 256}, num_warps=4, num_stages=2),
+    triton.Config({"BLOCK_HW": 512}, num_warps=8, num_stages=2),
+    triton.Config({"BLOCK_HW": 1024}, num_warps=8, num_stages=2),
+]
+_GRID_SAMPLER_2D_AUTOTUNE_KEY = [
+    "C",
+    "HW_out",
+    "interpolation_mode",
+    "padding_mode",
+]
+_GRID_SAMPLER_2D_BACKWARD_AUTOTUNE_KEY = ["C", "HW_out"]
+
+_GRID_SAMPLER_3D_AUTOTUNE_CONFIGS = [
+    triton.Config({"BLOCK_DHW": 32}, num_warps=4, num_stages=1),
+    triton.Config({"BLOCK_DHW": 64}, num_warps=4, num_stages=1),
+    triton.Config({"BLOCK_DHW": 128}, num_warps=4, num_stages=1),
+    triton.Config({"BLOCK_DHW": 128}, num_warps=8, num_stages=2),
+    triton.Config({"BLOCK_DHW": 256}, num_warps=8, num_stages=2),
+    triton.Config({"BLOCK_DHW": 512}, num_warps=8, num_stages=2),
+    triton.Config({"BLOCK_DHW": 1024}, num_warps=16, num_stages=2),
+    triton.Config({"BLOCK_DHW": 2048}, num_warps=32, num_stages=2),
+]
+_GRID_SAMPLER_3D_AUTOTUNE_KEY = [
+    "C",
+    "DHW_out",
+    "interpolation_mode",
+    "padding_mode",
+]
+_GRID_SAMPLER_3D_BACKWARD_AUTOTUNE_KEY = ["C", "DHW_out"]
+
+
+@triton.autotune(
+    configs=_GRID_SAMPLER_2D_AUTOTUNE_CONFIGS,
+    key=_GRID_SAMPLER_2D_AUTOTUNE_KEY,
+)
+@triton.jit
+def _grid_sampler_2d_kernel(
+    input_ptr,
+    grid_ptr,
+    output_ptr,
+    N,
+    C,
+    H_in,
+    W_in,
+    W_out,
+    HW_out,
+    stride_in_N,
+    stride_in_C,
+    stride_in_H,
+    stride_in_W,
+    stride_g_N,
+    stride_g_H,
+    stride_g_W,
+    stride_out_N,
+    stride_out_C,
+    stride_out_H,
+    stride_out_W,
+    interpolation_mode: tl.constexpr,
+    padding_mode: tl.constexpr,
+    align_corners: tl.constexpr,
+    BLOCK_HW: tl.constexpr,
+):
+    """
+    Unified 2D grid_sample forward kernel.  Each program handles BLOCK_HW
+    output spatial positions (flattened H_out*W_out) and loops over C
+    internally.  Geometry is computed once and reused across all channels.
+    """
+    pid = tl.program_id(0)
+    n_idx = tl.program_id(1)
+
+    hw_offs = pid * BLOCK_HW + tl.arange(0, BLOCK_HW)
+    hw_mask = hw_offs < HW_out
+    h_idx = hw_offs // W_out
+    w_idx = hw_offs % W_out
+
+    # ── Load grid coordinates (once for all channels) ─────────────────
+    g_base = grid_ptr + n_idx * stride_g_N + h_idx * stride_g_H + w_idx * stride_g_W
+    gx = tl.load(g_base + 0, mask=hw_mask, other=0.0).to(tl.float32)
+    gy = tl.load(g_base + 1, mask=hw_mask, other=0.0).to(tl.float32)
+
+    # ── Non-finite handling (vectorized) ────────────────────────────────
+    nan_x = gx != gx
+    nan_y = gy != gy
+    pos_inf_x = gx == float("inf")
+    neg_inf_x = gx == -float("inf")
+    pos_inf_y = gy == float("inf")
+    neg_inf_y = gy == -float("inf")
+    any_nonfinite = nan_x | nan_y | pos_inf_x | neg_inf_x | pos_inf_y | neg_inf_y
+    nan_val = (gx - gx) + (gy - gy)
+
+    if padding_mode == 1:
+        gx = tl.where(nan_x | neg_inf_x, -1.0, tl.where(pos_inf_x, 1.0, gx))
+        gy = tl.where(nan_y | neg_inf_y, -1.0, tl.where(pos_inf_y, 1.0, gy))
+    elif padding_mode == 2:
+        gx = tl.where(nan_x | pos_inf_x | neg_inf_x, -1.0, gx)
+        gy = tl.where(nan_y | pos_inf_y | neg_inf_y, -1.0, gy)
+    else:
+        gx = tl.where(any_nonfinite, -1.0, gx)
+        gy = tl.where(any_nonfinite, -1.0, gy)
+
+    # For zeros padding, non-finite positions must produce 0 output.
+    if padding_mode == 0:
+        valid_mask = hw_mask & ~any_nonfinite
+    else:
+        valid_mask = hw_mask
+
+    # ── Unnormalize from [-1, 1] to pixel coordinates ───────────────────
+    if align_corners:
+        ix = (gx + 1.0) * 0.5 * (W_in - 1)
+        iy = (gy + 1.0) * 0.5 * (H_in - 1)
+    else:
+        ix = ((gx + 1.0) * W_in - 1.0) * 0.5
+        iy = ((gy + 1.0) * H_in - 1.0) * 0.5
+
+    in_n = input_ptr + n_idx * stride_in_N
+    out_n = (
+        output_ptr + n_idx * stride_out_N + h_idx * stride_out_H + w_idx * stride_out_W
+    )
+
+    if interpolation_mode == 0:  # bilinear
+        x0 = tl.floor(ix).to(tl.int32)
+        y0 = tl.floor(iy).to(tl.int32)
+        tx = ix - tl.floor(ix)
+        ty = iy - tl.floor(iy)
+
+        w00 = (1.0 - tx) * (1.0 - ty)
+        w01 = tx * (1.0 - ty)
+        w10 = (1.0 - tx) * ty
+        w11 = tx * ty
+
+        off00, m00 = _clamp_and_mask_2d(
+            x0,
+            y0,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off01, m01 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off10, m10 = _clamp_and_mask_2d(
+            x0,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off11, m11 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+
+        for c in range(C):
+            cb = in_n + c * stride_in_C
+            v00 = tl.load(cb + off00, mask=m00, other=0.0).to(tl.float32)
+            v01 = tl.load(cb + off01, mask=m01, other=0.0).to(tl.float32)
+            v10 = tl.load(cb + off10, mask=m10, other=0.0).to(tl.float32)
+            v11 = tl.load(cb + off11, mask=m11, other=0.0).to(tl.float32)
+            result = w00 * v00 + w01 * v01 + w10 * v10 + w11 * v11
+            tl.store(
+                out_n + c * stride_out_C,
+                result.to(output_ptr.dtype.element_ty),
+                mask=hw_mask,
+            )
+
+    elif interpolation_mode == 1:  # nearest
+        x_near = _nearbyint_coord(ix)
+        y_near = _nearbyint_coord(iy)
+        off_near, m_near = _clamp_and_mask_2d(
+            x_near,
+            y_near,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+
+        for c in range(C):
+            val = tl.load(in_n + c * stride_in_C + off_near, mask=m_near, other=0.0).to(
+                tl.float32
+            )
+            tl.store(
+                out_n + c * stride_out_C,
+                val.to(output_ptr.dtype.element_ty),
+                mask=hw_mask,
+            )
+
+    else:  # bicubic (interpolation_mode == 2)
+        x0 = tl.floor(ix).to(tl.int32)
+        y0 = tl.floor(iy).to(tl.int32)
+        tx = ix - tl.floor(ix)
+        ty = iy - tl.floor(iy)
+
+        wx0 = _cubic_weight(-1.0 - tx)
+        wx1 = _cubic_weight(0.0 - tx)
+        wx2 = _cubic_weight(1.0 - tx)
+        wx3 = _cubic_weight(2.0 - tx)
+        wy0 = _cubic_weight(-1.0 - ty)
+        wy1 = _cubic_weight(0.0 - ty)
+        wy2 = _cubic_weight(1.0 - ty)
+        wy3 = _cubic_weight(2.0 - ty)
+
+        # Precompute 4x4 neighbor offsets and masks
+        off_r0c0, m_r0c0 = _clamp_and_mask_2d(
+            x0 - 1,
+            y0 - 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r0c1, m_r0c1 = _clamp_and_mask_2d(
+            x0,
+            y0 - 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r0c2, m_r0c2 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0 - 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r0c3, m_r0c3 = _clamp_and_mask_2d(
+            x0 + 2,
+            y0 - 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r1c0, m_r1c0 = _clamp_and_mask_2d(
+            x0 - 1,
+            y0,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r1c1, m_r1c1 = _clamp_and_mask_2d(
+            x0,
+            y0,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r1c2, m_r1c2 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r1c3, m_r1c3 = _clamp_and_mask_2d(
+            x0 + 2,
+            y0,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r2c0, m_r2c0 = _clamp_and_mask_2d(
+            x0 - 1,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r2c1, m_r2c1 = _clamp_and_mask_2d(
+            x0,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r2c2, m_r2c2 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r2c3, m_r2c3 = _clamp_and_mask_2d(
+            x0 + 2,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r3c0, m_r3c0 = _clamp_and_mask_2d(
+            x0 - 1,
+            y0 + 2,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r3c1, m_r3c1 = _clamp_and_mask_2d(
+            x0,
+            y0 + 2,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r3c2, m_r3c2 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0 + 2,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r3c3, m_r3c3 = _clamp_and_mask_2d(
+            x0 + 2,
+            y0 + 2,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+
+        for c in range(C):
+            cb = in_n + c * stride_in_C
+            r0 = (
+                wx0 * tl.load(cb + off_r0c0, mask=m_r0c0, other=0.0).to(tl.float32)
+                + wx1 * tl.load(cb + off_r0c1, mask=m_r0c1, other=0.0).to(tl.float32)
+                + wx2 * tl.load(cb + off_r0c2, mask=m_r0c2, other=0.0).to(tl.float32)
+                + wx3 * tl.load(cb + off_r0c3, mask=m_r0c3, other=0.0).to(tl.float32)
+            )
+            r1 = (
+                wx0 * tl.load(cb + off_r1c0, mask=m_r1c0, other=0.0).to(tl.float32)
+                + wx1 * tl.load(cb + off_r1c1, mask=m_r1c1, other=0.0).to(tl.float32)
+                + wx2 * tl.load(cb + off_r1c2, mask=m_r1c2, other=0.0).to(tl.float32)
+                + wx3 * tl.load(cb + off_r1c3, mask=m_r1c3, other=0.0).to(tl.float32)
+            )
+            r2 = (
+                wx0 * tl.load(cb + off_r2c0, mask=m_r2c0, other=0.0).to(tl.float32)
+                + wx1 * tl.load(cb + off_r2c1, mask=m_r2c1, other=0.0).to(tl.float32)
+                + wx2 * tl.load(cb + off_r2c2, mask=m_r2c2, other=0.0).to(tl.float32)
+                + wx3 * tl.load(cb + off_r2c3, mask=m_r2c3, other=0.0).to(tl.float32)
+            )
+            r3 = (
+                wx0 * tl.load(cb + off_r3c0, mask=m_r3c0, other=0.0).to(tl.float32)
+                + wx1 * tl.load(cb + off_r3c1, mask=m_r3c1, other=0.0).to(tl.float32)
+                + wx2 * tl.load(cb + off_r3c2, mask=m_r3c2, other=0.0).to(tl.float32)
+                + wx3 * tl.load(cb + off_r3c3, mask=m_r3c3, other=0.0).to(tl.float32)
+            )
+            result = wy0 * r0 + wy1 * r1 + wy2 * r2 + wy3 * r3
+            # Bicubic with NaN grid must propagate NaN
+            result = tl.where(any_nonfinite & hw_mask, nan_val, result)
+            tl.store(
+                out_n + c * stride_out_C,
+                result.to(output_ptr.dtype.element_ty),
+                mask=hw_mask,
+            )
+
+
+@triton.autotune(
+    configs=_GRID_SAMPLER_3D_AUTOTUNE_CONFIGS,
+    key=_GRID_SAMPLER_3D_AUTOTUNE_KEY,
+)
+@triton.jit
+def _grid_sampler_3d_kernel(
+    input_ptr,
+    grid_ptr,
+    output_ptr,
+    N,
+    C,
+    D_in,
+    H_in,
+    W_in,
+    W_out,
+    HW_out,
+    DHW_out,
+    stride_in_N,
+    stride_in_C,
+    stride_in_D,
+    stride_in_H,
+    stride_in_W,
+    stride_g_N,
+    stride_g_D,
+    stride_g_H,
+    stride_g_W,
+    stride_out_N,
+    stride_out_C,
+    stride_out_D,
+    stride_out_H,
+    stride_out_W,
+    interpolation_mode: tl.constexpr,
+    padding_mode: tl.constexpr,
+    align_corners: tl.constexpr,
+    BLOCK_DHW: tl.constexpr,
+):
+    """
+    Unified 3D grid_sample forward kernel.  Each program handles BLOCK_DHW
+    output spatial positions (flattened D_out*H_out*W_out) and loops over C
+    internally.  Geometry is computed once and reused across all channels.
+    """
+    pid = tl.program_id(0)
+    n_idx = tl.program_id(1)
+
+    dhw_offs = pid * BLOCK_DHW + tl.arange(0, BLOCK_DHW)
+    dhw_mask = dhw_offs < DHW_out
+    d_idx = dhw_offs // HW_out
+    hw_rem = dhw_offs % HW_out
+    h_idx = hw_rem // W_out
+    w_idx = hw_rem % W_out
+
+    # ── Load grid coordinates (once for all channels) ─────────────────
+    g_base = (
+        grid_ptr
+        + n_idx * stride_g_N
+        + d_idx * stride_g_D
+        + h_idx * stride_g_H
+        + w_idx * stride_g_W
+    )
+    gx = tl.load(g_base + 0, mask=dhw_mask, other=0.0).to(tl.float32)
+    gy = tl.load(g_base + 1, mask=dhw_mask, other=0.0).to(tl.float32)
+    gz = tl.load(g_base + 2, mask=dhw_mask, other=0.0).to(tl.float32)
+
+    # ── NaN handling (vectorized) ───────────────────────────────────────
+    nan_x = gx != gx
+    nan_y = gy != gy
+    nan_z = gz != gz
+    pos_inf_x = gx == float("inf")
+    neg_inf_x = gx == -float("inf")
+    pos_inf_y = gy == float("inf")
+    neg_inf_y = gy == -float("inf")
+    pos_inf_z = gz == float("inf")
+    neg_inf_z = gz == -float("inf")
+    any_nonfinite = (
+        nan_x
+        | nan_y
+        | nan_z
+        | pos_inf_x
+        | neg_inf_x
+        | pos_inf_y
+        | neg_inf_y
+        | pos_inf_z
+        | neg_inf_z
+    )
+
+    if padding_mode == 1:
+        gx = tl.where(nan_x | neg_inf_x, -1.0, tl.where(pos_inf_x, 1.0, gx))
+        gy = tl.where(nan_y | neg_inf_y, -1.0, tl.where(pos_inf_y, 1.0, gy))
+        gz = tl.where(nan_z | neg_inf_z, -1.0, tl.where(pos_inf_z, 1.0, gz))
+    elif padding_mode == 2:
+        gx = tl.where(nan_x | pos_inf_x | neg_inf_x, -1.0, gx)
+        gy = tl.where(nan_y | pos_inf_y | neg_inf_y, -1.0, gy)
+        gz = tl.where(nan_z | pos_inf_z | neg_inf_z, -1.0, gz)
+    else:
+        gx = tl.where(any_nonfinite, -1.0, gx)
+        gy = tl.where(any_nonfinite, -1.0, gy)
+        gz = tl.where(any_nonfinite, -1.0, gz)
+
+    if padding_mode == 0:
+        valid_mask = dhw_mask & ~any_nonfinite
+    else:
+        valid_mask = dhw_mask
+
+    # ── Unnormalize from [-1, 1] to pixel coordinates ───────────────────
+    if align_corners:
+        ix = (gx + 1.0) * 0.5 * (W_in - 1)
+        iy = (gy + 1.0) * 0.5 * (H_in - 1)
+        iz = (gz + 1.0) * 0.5 * (D_in - 1)
+    else:
+        ix = ((gx + 1.0) * W_in - 1.0) * 0.5
+        iy = ((gy + 1.0) * H_in - 1.0) * 0.5
+        iz = ((gz + 1.0) * D_in - 1.0) * 0.5
+
+    in_n = input_ptr + n_idx * stride_in_N
+    out_n = (
+        output_ptr
+        + n_idx * stride_out_N
+        + d_idx * stride_out_D
+        + h_idx * stride_out_H
+        + w_idx * stride_out_W
+    )
+
+    if interpolation_mode == 0:  # trilinear
+        x0 = tl.floor(ix).to(tl.int32)
+        y0 = tl.floor(iy).to(tl.int32)
+        z0 = tl.floor(iz).to(tl.int32)
+        tx = ix - tl.floor(ix)
+        ty = iy - tl.floor(iy)
+        tz = iz - tl.floor(iz)
+
+        w000 = (1.0 - tx) * (1.0 - ty) * (1.0 - tz)
+        w001 = tx * (1.0 - ty) * (1.0 - tz)
+        w010 = (1.0 - tx) * ty * (1.0 - tz)
+        w011 = tx * ty * (1.0 - tz)
+        w100 = (1.0 - tx) * (1.0 - ty) * tz
+        w101 = tx * (1.0 - ty) * tz
+        w110 = (1.0 - tx) * ty * tz
+        w111 = tx * ty * tz
+
+        off000, m000 = _clamp_and_mask_3d(
+            x0,
+            y0,
+            z0,
+            W_in,
+            H_in,
+            D_in,
+            stride_in_D,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off001, m001 = _clamp_and_mask_3d(
+            x0 + 1,
+            y0,
+            z0,
+            W_in,
+            H_in,
+            D_in,
+            stride_in_D,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off010, m010 = _clamp_and_mask_3d(
+            x0,
+            y0 + 1,
+            z0,
+            W_in,
+            H_in,
+            D_in,
+            stride_in_D,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off011, m011 = _clamp_and_mask_3d(
+            x0 + 1,
+            y0 + 1,
+            z0,
+            W_in,
+            H_in,
+            D_in,
+            stride_in_D,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off100, m100 = _clamp_and_mask_3d(
+            x0,
+            y0,
+            z0 + 1,
+            W_in,
+            H_in,
+            D_in,
+            stride_in_D,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off101, m101 = _clamp_and_mask_3d(
+            x0 + 1,
+            y0,
+            z0 + 1,
+            W_in,
+            H_in,
+            D_in,
+            stride_in_D,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off110, m110 = _clamp_and_mask_3d(
+            x0,
+            y0 + 1,
+            z0 + 1,
+            W_in,
+            H_in,
+            D_in,
+            stride_in_D,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off111, m111 = _clamp_and_mask_3d(
+            x0 + 1,
+            y0 + 1,
+            z0 + 1,
+            W_in,
+            H_in,
+            D_in,
+            stride_in_D,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+
+        for c in range(C):
+            cb = in_n + c * stride_in_C
+            v000 = tl.load(cb + off000, mask=m000, other=0.0).to(tl.float32)
+            v001 = tl.load(cb + off001, mask=m001, other=0.0).to(tl.float32)
+            v010 = tl.load(cb + off010, mask=m010, other=0.0).to(tl.float32)
+            v011 = tl.load(cb + off011, mask=m011, other=0.0).to(tl.float32)
+            v100 = tl.load(cb + off100, mask=m100, other=0.0).to(tl.float32)
+            v101 = tl.load(cb + off101, mask=m101, other=0.0).to(tl.float32)
+            v110 = tl.load(cb + off110, mask=m110, other=0.0).to(tl.float32)
+            v111 = tl.load(cb + off111, mask=m111, other=0.0).to(tl.float32)
+            result = (
+                w000 * v000
+                + w001 * v001
+                + w010 * v010
+                + w011 * v011
+                + w100 * v100
+                + w101 * v101
+                + w110 * v110
+                + w111 * v111
+            )
+            tl.store(
+                out_n + c * stride_out_C,
+                result.to(output_ptr.dtype.element_ty),
+                mask=dhw_mask,
+            )
+
+    else:  # nearest
+        x_near = _nearbyint_coord(ix)
+        y_near = _nearbyint_coord(iy)
+        z_near = _nearbyint_coord(iz)
+        off_near, m_near = _clamp_and_mask_3d(
+            x_near,
+            y_near,
+            z_near,
+            W_in,
+            H_in,
+            D_in,
+            stride_in_D,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+
+        for c in range(C):
+            val = tl.load(in_n + c * stride_in_C + off_near, mask=m_near, other=0.0).to(
+                tl.float32
+            )
+            tl.store(
+                out_n + c * stride_out_C,
+                val.to(output_ptr.dtype.element_ty),
+                mask=dhw_mask,
+            )
+
+
+@triton.autotune(
+    configs=_GRID_SAMPLER_2D_AUTOTUNE_CONFIGS,
+    key=_GRID_SAMPLER_2D_BACKWARD_AUTOTUNE_KEY,
+    reset_to_zero=["grad_input_ptr"],
+)
+@triton.jit
+def _grid_sampler_2d_backward_input_kernel(
+    grad_output_ptr,
+    grid_ptr,
+    grad_input_ptr,
+    N,
+    C,
+    H_in,
+    W_in,
+    W_out,
+    HW_out,
+    stride_go_N,
+    stride_go_C,
+    stride_go_H,
+    stride_go_W,
+    stride_g_N,
+    stride_g_H,
+    stride_g_W,
+    stride_gi_N,
+    stride_gi_C,
+    stride_gi_H,
+    stride_gi_W,
+    interpolation_mode: tl.constexpr,
+    padding_mode: tl.constexpr,
+    align_corners: tl.constexpr,
+    BLOCK_HW: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    n_idx = tl.program_id(1)
+
+    hw_offs = pid * BLOCK_HW + tl.arange(0, BLOCK_HW)
+    hw_mask = hw_offs < HW_out
+    h_idx = hw_offs // W_out
+    w_idx = hw_offs % W_out
+
+    g_base = grid_ptr + n_idx * stride_g_N + h_idx * stride_g_H + w_idx * stride_g_W
+    gx = tl.load(g_base + 0, mask=hw_mask, other=0.0).to(tl.float32)
+    gy = tl.load(g_base + 1, mask=hw_mask, other=0.0).to(tl.float32)
+
+    nan_x = gx != gx
+    nan_y = gy != gy
+    any_nan = nan_x | nan_y
+    gx = tl.where(nan_x, -1.0, gx)
+    gy = tl.where(nan_y, -1.0, gy)
+
+    if padding_mode == 0:
+        valid_mask = hw_mask & ~any_nan
+    else:
+        valid_mask = hw_mask
+
+    if align_corners:
+        ix = (gx + 1.0) * 0.5 * (W_in - 1)
+        iy = (gy + 1.0) * 0.5 * (H_in - 1)
+    else:
+        ix = ((gx + 1.0) * W_in - 1.0) * 0.5
+        iy = ((gy + 1.0) * H_in - 1.0) * 0.5
+
+    go_base = (
+        grad_output_ptr
+        + n_idx * stride_go_N
+        + h_idx * stride_go_H
+        + w_idx * stride_go_W
+    )
+    gi_n = grad_input_ptr + n_idx * stride_gi_N
+
+    if interpolation_mode == 0:  # bilinear
+        x0 = tl.floor(ix).to(tl.int32)
+        y0 = tl.floor(iy).to(tl.int32)
+        tx = ix - tl.floor(ix)
+        ty = iy - tl.floor(iy)
+
+        w00 = (1.0 - tx) * (1.0 - ty)
+        w01 = tx * (1.0 - ty)
+        w10 = (1.0 - tx) * ty
+        w11 = tx * ty
+
+        off00, m00 = _clamp_and_mask_2d(
+            x0,
+            y0,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off01, m01 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off10, m10 = _clamp_and_mask_2d(
+            x0,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off11, m11 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+
+        for c in range(C):
+            grad = tl.load(go_base + c * stride_go_C, mask=hw_mask, other=0.0).to(
+                tl.float32
+            )
+            cb = gi_n + c * stride_gi_C
+            tl.atomic_add(
+                cb + off00, (grad * w00).to(grad_input_ptr.dtype.element_ty), mask=m00
+            )
+            tl.atomic_add(
+                cb + off01, (grad * w01).to(grad_input_ptr.dtype.element_ty), mask=m01
+            )
+            tl.atomic_add(
+                cb + off10, (grad * w10).to(grad_input_ptr.dtype.element_ty), mask=m10
+            )
+            tl.atomic_add(
+                cb + off11, (grad * w11).to(grad_input_ptr.dtype.element_ty), mask=m11
+            )
+
+    elif interpolation_mode == 1:  # nearest
+        x_near = _nearbyint_coord(ix)
+        y_near = _nearbyint_coord(iy)
+        off_near, m_near = _clamp_and_mask_2d(
+            x_near,
+            y_near,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+
+        for c in range(C):
+            grad = tl.load(go_base + c * stride_go_C, mask=hw_mask, other=0.0).to(
+                tl.float32
+            )
+            tl.atomic_add(
+                gi_n + c * stride_gi_C + off_near,
+                grad.to(grad_input_ptr.dtype.element_ty),
+                mask=m_near,
+            )
+
+    else:  # bicubic
+        x0 = tl.floor(ix).to(tl.int32)
+        y0 = tl.floor(iy).to(tl.int32)
+        tx = ix - tl.floor(ix)
+        ty = iy - tl.floor(iy)
+
+        wx0 = _cubic_weight(-1.0 - tx)
+        wx1 = _cubic_weight(-tx)
+        wx2 = _cubic_weight(1.0 - tx)
+        wx3 = _cubic_weight(2.0 - tx)
+        wy0 = _cubic_weight(-1.0 - ty)
+        wy1 = _cubic_weight(-ty)
+        wy2 = _cubic_weight(1.0 - ty)
+        wy3 = _cubic_weight(2.0 - ty)
+
+        # Precompute 4x4 neighbor offsets and masks
+        off_r0c0, m_r0c0 = _clamp_and_mask_2d(
+            x0 - 1,
+            y0 - 1,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r0c1, m_r0c1 = _clamp_and_mask_2d(
+            x0,
+            y0 - 1,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r0c2, m_r0c2 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0 - 1,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r0c3, m_r0c3 = _clamp_and_mask_2d(
+            x0 + 2,
+            y0 - 1,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r1c0, m_r1c0 = _clamp_and_mask_2d(
+            x0 - 1,
+            y0,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r1c1, m_r1c1 = _clamp_and_mask_2d(
+            x0,
+            y0,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r1c2, m_r1c2 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r1c3, m_r1c3 = _clamp_and_mask_2d(
+            x0 + 2,
+            y0,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r2c0, m_r2c0 = _clamp_and_mask_2d(
+            x0 - 1,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r2c1, m_r2c1 = _clamp_and_mask_2d(
+            x0,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r2c2, m_r2c2 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r2c3, m_r2c3 = _clamp_and_mask_2d(
+            x0 + 2,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r3c0, m_r3c0 = _clamp_and_mask_2d(
+            x0 - 1,
+            y0 + 2,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r3c1, m_r3c1 = _clamp_and_mask_2d(
+            x0,
+            y0 + 2,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r3c2, m_r3c2 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0 + 2,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r3c3, m_r3c3 = _clamp_and_mask_2d(
+            x0 + 2,
+            y0 + 2,
+            W_in,
+            H_in,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+
+        for c in range(C):
+            grad = tl.load(go_base + c * stride_go_C, mask=hw_mask, other=0.0).to(
+                tl.float32
+            )
+            cb = gi_n + c * stride_gi_C
+            tl.atomic_add(
+                cb + off_r0c0,
+                (grad * wy0 * wx0).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r0c0,
+            )
+            tl.atomic_add(
+                cb + off_r0c1,
+                (grad * wy0 * wx1).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r0c1,
+            )
+            tl.atomic_add(
+                cb + off_r0c2,
+                (grad * wy0 * wx2).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r0c2,
+            )
+            tl.atomic_add(
+                cb + off_r0c3,
+                (grad * wy0 * wx3).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r0c3,
+            )
+            tl.atomic_add(
+                cb + off_r1c0,
+                (grad * wy1 * wx0).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r1c0,
+            )
+            tl.atomic_add(
+                cb + off_r1c1,
+                (grad * wy1 * wx1).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r1c1,
+            )
+            tl.atomic_add(
+                cb + off_r1c2,
+                (grad * wy1 * wx2).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r1c2,
+            )
+            tl.atomic_add(
+                cb + off_r1c3,
+                (grad * wy1 * wx3).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r1c3,
+            )
+            tl.atomic_add(
+                cb + off_r2c0,
+                (grad * wy2 * wx0).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r2c0,
+            )
+            tl.atomic_add(
+                cb + off_r2c1,
+                (grad * wy2 * wx1).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r2c1,
+            )
+            tl.atomic_add(
+                cb + off_r2c2,
+                (grad * wy2 * wx2).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r2c2,
+            )
+            tl.atomic_add(
+                cb + off_r2c3,
+                (grad * wy2 * wx3).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r2c3,
+            )
+            tl.atomic_add(
+                cb + off_r3c0,
+                (grad * wy3 * wx0).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r3c0,
+            )
+            tl.atomic_add(
+                cb + off_r3c1,
+                (grad * wy3 * wx1).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r3c1,
+            )
+            tl.atomic_add(
+                cb + off_r3c2,
+                (grad * wy3 * wx2).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r3c2,
+            )
+            tl.atomic_add(
+                cb + off_r3c3,
+                (grad * wy3 * wx3).to(grad_input_ptr.dtype.element_ty),
+                mask=m_r3c3,
+            )
+
+
+@triton.autotune(
+    configs=_GRID_SAMPLER_2D_AUTOTUNE_CONFIGS,
+    key=_GRID_SAMPLER_2D_BACKWARD_AUTOTUNE_KEY,
+)
+@triton.jit
+def _grid_sampler_2d_backward_grid_kernel(
+    grad_output_ptr,
+    input_ptr,
+    grid_ptr,
+    grad_grid_ptr,
+    N,
+    C,
+    H_in,
+    W_in,
+    W_out,
+    HW_out,
+    stride_go_N,
+    stride_go_C,
+    stride_go_H,
+    stride_go_W,
+    stride_in_N,
+    stride_in_C,
+    stride_in_H,
+    stride_in_W,
+    stride_g_N,
+    stride_g_H,
+    stride_g_W,
+    stride_gg_N,
+    stride_gg_H,
+    stride_gg_W,
+    interpolation_mode: tl.constexpr,
+    padding_mode: tl.constexpr,
+    align_corners: tl.constexpr,
+    BLOCK_HW: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    n_idx = tl.program_id(1)
+
+    hw_offs = pid * BLOCK_HW + tl.arange(0, BLOCK_HW)
+    hw_mask = hw_offs < HW_out
+    h_idx = hw_offs // W_out
+    w_idx = hw_offs % W_out
+
+    g_base = grid_ptr + n_idx * stride_g_N + h_idx * stride_g_H + w_idx * stride_g_W
+    gx = tl.load(g_base + 0, mask=hw_mask, other=0.0).to(tl.float32)
+    gy = tl.load(g_base + 1, mask=hw_mask, other=0.0).to(tl.float32)
+
+    nan_x = gx != gx
+    nan_y = gy != gy
+    any_nan = nan_x | nan_y
+    gx = tl.where(nan_x, -1.0, gx)
+    gy = tl.where(nan_y, -1.0, gy)
+
+    if padding_mode == 0:
+        valid_mask = hw_mask & ~any_nan
+    else:
+        valid_mask = hw_mask
+
+    gg_base = (
+        grad_grid_ptr + n_idx * stride_gg_N + h_idx * stride_gg_H + w_idx * stride_gg_W
+    )
+
+    if interpolation_mode == 1:
+        tl.store(
+            gg_base + 0,
+            tl.zeros((BLOCK_HW,), dtype=grad_grid_ptr.dtype.element_ty),
+            mask=hw_mask,
+        )
+        tl.store(
+            gg_base + 1,
+            tl.zeros((BLOCK_HW,), dtype=grad_grid_ptr.dtype.element_ty),
+            mask=hw_mask,
+        )
+        return
+
+    if align_corners:
+        gix_mult = tl.cast(W_in - 1, tl.float32) * 0.5
+        giy_mult = tl.cast(H_in - 1, tl.float32) * 0.5
+        ix = (gx + 1.0) * gix_mult
+        iy = (gy + 1.0) * giy_mult
+    else:
+        gix_mult = tl.cast(W_in, tl.float32) * 0.5
+        giy_mult = tl.cast(H_in, tl.float32) * 0.5
+        ix = ((gx + 1.0) * W_in - 1.0) * 0.5
+        iy = ((gy + 1.0) * H_in - 1.0) * 0.5
+
+    acc_x = tl.zeros((BLOCK_HW,), dtype=tl.float32)
+    acc_y = tl.zeros((BLOCK_HW,), dtype=tl.float32)
+
+    go_base = (
+        grad_output_ptr
+        + n_idx * stride_go_N
+        + h_idx * stride_go_H
+        + w_idx * stride_go_W
+    )
+    in_n = input_ptr + n_idx * stride_in_N
+
+    if interpolation_mode == 0:  # bilinear
+        x0 = tl.floor(ix).to(tl.int32)
+        y0 = tl.floor(iy).to(tl.int32)
+        tx = ix - tl.floor(ix)
+        ty = iy - tl.floor(iy)
+
+        off00, m00 = _clamp_and_mask_2d(
+            x0,
+            y0,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off01, m01 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off10, m10 = _clamp_and_mask_2d(
+            x0,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off11, m11 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+
+        for c in range(C):
+            cb = in_n + c * stride_in_C
+            go = tl.load(go_base + c * stride_go_C, mask=hw_mask, other=0.0).to(
+                tl.float32
+            )
+            v00 = tl.load(cb + off00, mask=m00, other=0.0).to(tl.float32)
+            v01 = tl.load(cb + off01, mask=m01, other=0.0).to(tl.float32)
+            v10 = tl.load(cb + off10, mask=m10, other=0.0).to(tl.float32)
+            v11 = tl.load(cb + off11, mask=m11, other=0.0).to(tl.float32)
+            dix = (v01 - v00) * (1.0 - ty) + (v11 - v10) * ty
+            diy = (v10 - v00) * (1.0 - tx) + (v11 - v01) * tx
+            acc_x += go * dix
+            acc_y += go * diy
+
+    else:  # bicubic
+        x0 = tl.floor(ix).to(tl.int32)
+        y0 = tl.floor(iy).to(tl.int32)
+        tx = ix - tl.floor(ix)
+        ty = iy - tl.floor(iy)
+        wx0 = _cubic_weight(-1.0 - tx)
+        wx1 = _cubic_weight(-tx)
+        wx2 = _cubic_weight(1.0 - tx)
+        wx3 = _cubic_weight(2.0 - tx)
+        wy0 = _cubic_weight(-1.0 - ty)
+        wy1 = _cubic_weight(-ty)
+        wy2 = _cubic_weight(1.0 - ty)
+        wy3 = _cubic_weight(2.0 - ty)
+        dwx0, dwx1, dwx2, dwx3 = _cubic_weight_grad(tx)
+        dwy0, dwy1, dwy2, dwy3 = _cubic_weight_grad(ty)
+
+        # Precompute 4x4 offsets
+        off_r0c0, m_r0c0 = _clamp_and_mask_2d(
+            x0 - 1,
+            y0 - 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r0c1, m_r0c1 = _clamp_and_mask_2d(
+            x0,
+            y0 - 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r0c2, m_r0c2 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0 - 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r0c3, m_r0c3 = _clamp_and_mask_2d(
+            x0 + 2,
+            y0 - 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r1c0, m_r1c0 = _clamp_and_mask_2d(
+            x0 - 1,
+            y0,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r1c1, m_r1c1 = _clamp_and_mask_2d(
+            x0,
+            y0,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r1c2, m_r1c2 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r1c3, m_r1c3 = _clamp_and_mask_2d(
+            x0 + 2,
+            y0,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r2c0, m_r2c0 = _clamp_and_mask_2d(
+            x0 - 1,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r2c1, m_r2c1 = _clamp_and_mask_2d(
+            x0,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r2c2, m_r2c2 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r2c3, m_r2c3 = _clamp_and_mask_2d(
+            x0 + 2,
+            y0 + 1,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r3c0, m_r3c0 = _clamp_and_mask_2d(
+            x0 - 1,
+            y0 + 2,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r3c1, m_r3c1 = _clamp_and_mask_2d(
+            x0,
+            y0 + 2,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r3c2, m_r3c2 = _clamp_and_mask_2d(
+            x0 + 1,
+            y0 + 2,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off_r3c3, m_r3c3 = _clamp_and_mask_2d(
+            x0 + 2,
+            y0 + 2,
+            W_in,
+            H_in,
+            stride_in_H,
+            stride_in_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+
+        for c in range(C):
+            cb = in_n + c * stride_in_C
+            go = tl.load(go_base + c * stride_go_C, mask=hw_mask, other=0.0).to(
+                tl.float32
+            )
+
+            v_r0c0 = tl.load(cb + off_r0c0, mask=m_r0c0, other=0.0).to(tl.float32)
+            v_r0c1 = tl.load(cb + off_r0c1, mask=m_r0c1, other=0.0).to(tl.float32)
+            v_r0c2 = tl.load(cb + off_r0c2, mask=m_r0c2, other=0.0).to(tl.float32)
+            v_r0c3 = tl.load(cb + off_r0c3, mask=m_r0c3, other=0.0).to(tl.float32)
+            v_r1c0 = tl.load(cb + off_r1c0, mask=m_r1c0, other=0.0).to(tl.float32)
+            v_r1c1 = tl.load(cb + off_r1c1, mask=m_r1c1, other=0.0).to(tl.float32)
+            v_r1c2 = tl.load(cb + off_r1c2, mask=m_r1c2, other=0.0).to(tl.float32)
+            v_r1c3 = tl.load(cb + off_r1c3, mask=m_r1c3, other=0.0).to(tl.float32)
+            v_r2c0 = tl.load(cb + off_r2c0, mask=m_r2c0, other=0.0).to(tl.float32)
+            v_r2c1 = tl.load(cb + off_r2c1, mask=m_r2c1, other=0.0).to(tl.float32)
+            v_r2c2 = tl.load(cb + off_r2c2, mask=m_r2c2, other=0.0).to(tl.float32)
+            v_r2c3 = tl.load(cb + off_r2c3, mask=m_r2c3, other=0.0).to(tl.float32)
+            v_r3c0 = tl.load(cb + off_r3c0, mask=m_r3c0, other=0.0).to(tl.float32)
+            v_r3c1 = tl.load(cb + off_r3c1, mask=m_r3c1, other=0.0).to(tl.float32)
+            v_r3c2 = tl.load(cb + off_r3c2, mask=m_r3c2, other=0.0).to(tl.float32)
+            v_r3c3 = tl.load(cb + off_r3c3, mask=m_r3c3, other=0.0).to(tl.float32)
+
+            row0 = wx0 * v_r0c0 + wx1 * v_r0c1 + wx2 * v_r0c2 + wx3 * v_r0c3
+            row1 = wx0 * v_r1c0 + wx1 * v_r1c1 + wx2 * v_r1c2 + wx3 * v_r1c3
+            row2 = wx0 * v_r2c0 + wx1 * v_r2c1 + wx2 * v_r2c2 + wx3 * v_r2c3
+            row3 = wx0 * v_r3c0 + wx1 * v_r3c1 + wx2 * v_r3c2 + wx3 * v_r3c3
+            drow0 = dwx0 * v_r0c0 + dwx1 * v_r0c1 + dwx2 * v_r0c2 + dwx3 * v_r0c3
+            drow1 = dwx0 * v_r1c0 + dwx1 * v_r1c1 + dwx2 * v_r1c2 + dwx3 * v_r1c3
+            drow2 = dwx0 * v_r2c0 + dwx1 * v_r2c1 + dwx2 * v_r2c2 + dwx3 * v_r2c3
+            drow3 = dwx0 * v_r3c0 + dwx1 * v_r3c1 + dwx2 * v_r3c2 + dwx3 * v_r3c3
+
+            dix = wy0 * drow0 + wy1 * drow1 + wy2 * drow2 + wy3 * drow3
+            diy = dwy0 * row0 + dwy1 * row1 + dwy2 * row2 + dwy3 * row3
+            acc_x += go * dix
+            acc_y += go * diy
+
+    # For NaN positions in zeros padding, grad_grid should be 0 (acc started at 0 and valid_mask excluded them)
+    tl.store(
+        gg_base + 0, (acc_x * gix_mult).to(grad_grid_ptr.dtype.element_ty), mask=hw_mask
+    )
+    tl.store(
+        gg_base + 1, (acc_y * giy_mult).to(grad_grid_ptr.dtype.element_ty), mask=hw_mask
+    )
+
+
+@triton.autotune(
+    configs=_GRID_SAMPLER_3D_AUTOTUNE_CONFIGS,
+    key=_GRID_SAMPLER_3D_BACKWARD_AUTOTUNE_KEY,
+    reset_to_zero=["grad_input_ptr"],
+)
+@triton.jit
+def _grid_sampler_3d_backward_input_kernel(
+    grad_output_ptr,
+    grid_ptr,
+    grad_input_ptr,
+    N,
+    C,
+    D_in,
+    H_in,
+    W_in,
+    W_out,
+    HW_out,
+    DHW_out,
+    stride_go_N,
+    stride_go_C,
+    stride_go_D,
+    stride_go_H,
+    stride_go_W,
+    stride_g_N,
+    stride_g_D,
+    stride_g_H,
+    stride_g_W,
+    stride_gi_N,
+    stride_gi_C,
+    stride_gi_D,
+    stride_gi_H,
+    stride_gi_W,
+    interpolation_mode: tl.constexpr,
+    padding_mode: tl.constexpr,
+    align_corners: tl.constexpr,
+    BLOCK_DHW: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    n_idx = tl.program_id(1)
+
+    dhw_offs = pid * BLOCK_DHW + tl.arange(0, BLOCK_DHW)
+    dhw_mask = dhw_offs < DHW_out
+    d_idx = dhw_offs // HW_out
+    hw_rem = dhw_offs % HW_out
+    h_idx = hw_rem // W_out
+    w_idx = hw_rem % W_out
+
+    g_base = (
+        grid_ptr
+        + n_idx * stride_g_N
+        + d_idx * stride_g_D
+        + h_idx * stride_g_H
+        + w_idx * stride_g_W
+    )
+    gx = tl.load(g_base + 0, mask=dhw_mask, other=0.0).to(tl.float32)
+    gy = tl.load(g_base + 1, mask=dhw_mask, other=0.0).to(tl.float32)
+    gz = tl.load(g_base + 2, mask=dhw_mask, other=0.0).to(tl.float32)
+
+    nan_x = gx != gx
+    nan_y = gy != gy
+    nan_z = gz != gz
+    any_nan = nan_x | nan_y | nan_z
+    gx = tl.where(nan_x, -1.0, gx)
+    gy = tl.where(nan_y, -1.0, gy)
+    gz = tl.where(nan_z, -1.0, gz)
+
+    if padding_mode == 0:
+        valid_mask = dhw_mask & ~any_nan
+    else:
+        valid_mask = dhw_mask
+
+    if align_corners:
+        ix = (gx + 1.0) * 0.5 * (W_in - 1)
+        iy = (gy + 1.0) * 0.5 * (H_in - 1)
+        iz = (gz + 1.0) * 0.5 * (D_in - 1)
+    else:
+        ix = ((gx + 1.0) * W_in - 1.0) * 0.5
+        iy = ((gy + 1.0) * H_in - 1.0) * 0.5
+        iz = ((gz + 1.0) * D_in - 1.0) * 0.5
+
+    go_base = (
+        grad_output_ptr
+        + n_idx * stride_go_N
+        + d_idx * stride_go_D
+        + h_idx * stride_go_H
+        + w_idx * stride_go_W
+    )
+    gi_n = grad_input_ptr + n_idx * stride_gi_N
+
+    if interpolation_mode == 0:  # trilinear
+        x0 = tl.floor(ix).to(tl.int32)
+        y0 = tl.floor(iy).to(tl.int32)
+        z0 = tl.floor(iz).to(tl.int32)
+        tx = ix - tl.floor(ix)
+        ty = iy - tl.floor(iy)
+        tz = iz - tl.floor(iz)
+
+        w000 = (1.0 - tx) * (1.0 - ty) * (1.0 - tz)
+        w001 = tx * (1.0 - ty) * (1.0 - tz)
+        w010 = (1.0 - tx) * ty * (1.0 - tz)
+        w011 = tx * ty * (1.0 - tz)
+        w100 = (1.0 - tx) * (1.0 - ty) * tz
+        w101 = tx * (1.0 - ty) * tz
+        w110 = (1.0 - tx) * ty * tz
+        w111 = tx * ty * tz
+
+        off000, m000 = _clamp_and_mask_3d(
+            x0,
+            y0,
+            z0,
+            W_in,
+            H_in,
+            D_in,
+            stride_gi_D,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off001, m001 = _clamp_and_mask_3d(
+            x0 + 1,
+            y0,
+            z0,
+            W_in,
+            H_in,
+            D_in,
+            stride_gi_D,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off010, m010 = _clamp_and_mask_3d(
+            x0,
+            y0 + 1,
+            z0,
+            W_in,
+            H_in,
+            D_in,
+            stride_gi_D,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off011, m011 = _clamp_and_mask_3d(
+            x0 + 1,
+            y0 + 1,
+            z0,
+            W_in,
+            H_in,
+            D_in,
+            stride_gi_D,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off100, m100 = _clamp_and_mask_3d(
+            x0,
+            y0,
+            z0 + 1,
+            W_in,
+            H_in,
+            D_in,
+            stride_gi_D,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off101, m101 = _clamp_and_mask_3d(
+            x0 + 1,
+            y0,
+            z0 + 1,
+            W_in,
+            H_in,
+            D_in,
+            stride_gi_D,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off110, m110 = _clamp_and_mask_3d(
+            x0,
+            y0 + 1,
+            z0 + 1,
+            W_in,
+            H_in,
+            D_in,
+            stride_gi_D,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+        off111, m111 = _clamp_and_mask_3d(
+            x0 + 1,
+            y0 + 1,
+            z0 + 1,
+            W_in,
+            H_in,
+            D_in,
+            stride_gi_D,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+
+        for c in range(C):
+            grad = tl.load(go_base + c * stride_go_C, mask=dhw_mask, other=0.0).to(
+                tl.float32
+            )
+            cb = gi_n + c * stride_gi_C
+            tl.atomic_add(
+                cb + off000,
+                (grad * w000).to(grad_input_ptr.dtype.element_ty),
+                mask=m000,
+            )
+            tl.atomic_add(
+                cb + off001,
+                (grad * w001).to(grad_input_ptr.dtype.element_ty),
+                mask=m001,
+            )
+            tl.atomic_add(
+                cb + off010,
+                (grad * w010).to(grad_input_ptr.dtype.element_ty),
+                mask=m010,
+            )
+            tl.atomic_add(
+                cb + off011,
+                (grad * w011).to(grad_input_ptr.dtype.element_ty),
+                mask=m011,
+            )
+            tl.atomic_add(
+                cb + off100,
+                (grad * w100).to(grad_input_ptr.dtype.element_ty),
+                mask=m100,
+            )
+            tl.atomic_add(
+                cb + off101,
+                (grad * w101).to(grad_input_ptr.dtype.element_ty),
+                mask=m101,
+            )
+            tl.atomic_add(
+                cb + off110,
+                (grad * w110).to(grad_input_ptr.dtype.element_ty),
+                mask=m110,
+            )
+            tl.atomic_add(
+                cb + off111,
+                (grad * w111).to(grad_input_ptr.dtype.element_ty),
+                mask=m111,
+            )
+
+    else:  # nearest
+        x_near = _nearbyint_coord(ix)
+        y_near = _nearbyint_coord(iy)
+        z_near = _nearbyint_coord(iz)
+        off_near, m_near = _clamp_and_mask_3d(
+            x_near,
+            y_near,
+            z_near,
+            W_in,
+            H_in,
+            D_in,
+            stride_gi_D,
+            stride_gi_H,
+            stride_gi_W,
+            valid_mask,
+            padding_mode,
+            align_corners,
+        )
+
+        for c in range(C):
+            grad = tl.load(go_base + c * stride_go_C, mask=dhw_mask, other=0.0).to(
+                tl.float32
+            )
+            tl.atomic_add(
+                gi_n + c * stride_gi_C + off_near,
+                grad.to(grad_input_ptr.dtype.element_ty),
+                mask=m_near,
+            )
+
+
+@triton.autotune(
+    configs=_GRID_SAMPLER_3D_AUTOTUNE_CONFIGS,
+    key=_GRID_SAMPLER_3D_BACKWARD_AUTOTUNE_KEY,
+)
+@triton.jit
+def _grid_sampler_3d_backward_grid_kernel(
+    grad_output_ptr,
+    input_ptr,
+    grid_ptr,
+    grad_grid_ptr,
+    N,
+    C,
+    D_in,
+    H_in,
+    W_in,
+    W_out,
+    HW_out,
+    DHW_out,
+    stride_go_N,
+    stride_go_C,
+    stride_go_D,
+    stride_go_H,
+    stride_go_W,
+    stride_in_N,
+    stride_in_C,
+    stride_in_D,
+    stride_in_H,
+    stride_in_W,
+    stride_g_N,
+    stride_g_D,
+    stride_g_H,
+    stride_g_W,
+    stride_gg_N,
+    stride_gg_D,
+    stride_gg_H,
+    stride_gg_W,
+    interpolation_mode: tl.constexpr,
+    padding_mode: tl.constexpr,
+    align_corners: tl.constexpr,
+    BLOCK_DHW: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    n_idx = tl.program_id(1)
+
+    dhw_offs = pid * BLOCK_DHW + tl.arange(0, BLOCK_DHW)
+    dhw_mask = dhw_offs < DHW_out
+    d_idx = dhw_offs // HW_out
+    hw_rem = dhw_offs % HW_out
+    h_idx = hw_rem // W_out
+    w_idx = hw_rem % W_out
+
+    g_base = (
+        grid_ptr
+        + n_idx * stride_g_N
+        + d_idx * stride_g_D
+        + h_idx * stride_g_H
+        + w_idx * stride_g_W
+    )
+    gx = tl.load(g_base + 0, mask=dhw_mask, other=0.0).to(tl.float32)
+    gy = tl.load(g_base + 1, mask=dhw_mask, other=0.0).to(tl.float32)
+    gz = tl.load(g_base + 2, mask=dhw_mask, other=0.0).to(tl.float32)
+
+    nan_x = gx != gx
+    nan_y = gy != gy
+    nan_z = gz != gz
+    any_nan = nan_x | nan_y | nan_z
+    gx = tl.where(nan_x, -1.0, gx)
+    gy = tl.where(nan_y, -1.0, gy)
+    gz = tl.where(nan_z, -1.0, gz)
+
+    if padding_mode == 0:
+        valid_mask = dhw_mask & ~any_nan
+    else:
+        valid_mask = dhw_mask
+
+    gg_base = (
+        grad_grid_ptr
+        + n_idx * stride_gg_N
+        + d_idx * stride_gg_D
+        + h_idx * stride_gg_H
+        + w_idx * stride_gg_W
+    )
+    zero_vec = tl.zeros((BLOCK_DHW,), dtype=grad_grid_ptr.dtype.element_ty)
+
+    if interpolation_mode == 1:
+        tl.store(gg_base + 0, zero_vec, mask=dhw_mask)
+        tl.store(gg_base + 1, zero_vec, mask=dhw_mask)
+        tl.store(gg_base + 2, zero_vec, mask=dhw_mask)
+        return
+
+    if align_corners:
+        gix_mult = tl.cast(W_in - 1, tl.float32) * 0.5
+        giy_mult = tl.cast(H_in - 1, tl.float32) * 0.5
+        giz_mult = tl.cast(D_in - 1, tl.float32) * 0.5
+        ix = (gx + 1.0) * gix_mult
+        iy = (gy + 1.0) * giy_mult
+        iz = (gz + 1.0) * giz_mult
+    else:
+        gix_mult = tl.cast(W_in, tl.float32) * 0.5
+        giy_mult = tl.cast(H_in, tl.float32) * 0.5
+        giz_mult = tl.cast(D_in, tl.float32) * 0.5
+        ix = ((gx + 1.0) * W_in - 1.0) * 0.5
+        iy = ((gy + 1.0) * H_in - 1.0) * 0.5
+        iz = ((gz + 1.0) * D_in - 1.0) * 0.5
+
+    x0 = tl.floor(ix).to(tl.int32)
+    y0 = tl.floor(iy).to(tl.int32)
+    z0 = tl.floor(iz).to(tl.int32)
+    tx = ix - tl.floor(ix)
+    ty = iy - tl.floor(iy)
+    tz = iz - tl.floor(iz)
+
+    wx0 = 1.0 - tx
+    wx1 = tx
+    wy0 = 1.0 - ty
+    wy1 = ty
+    wz0 = 1.0 - tz
+    wz1 = tz
+
+    acc_x = tl.zeros((BLOCK_DHW,), dtype=tl.float32)
+    acc_y = tl.zeros((BLOCK_DHW,), dtype=tl.float32)
+    acc_z = tl.zeros((BLOCK_DHW,), dtype=tl.float32)
+
+    off000, m000 = _clamp_and_mask_3d(
+        x0,
+        y0,
+        z0,
+        W_in,
+        H_in,
+        D_in,
+        stride_in_D,
+        stride_in_H,
+        stride_in_W,
+        valid_mask,
+        padding_mode,
+        align_corners,
+    )
+    off001, m001 = _clamp_and_mask_3d(
+        x0 + 1,
+        y0,
+        z0,
+        W_in,
+        H_in,
+        D_in,
+        stride_in_D,
+        stride_in_H,
+        stride_in_W,
+        valid_mask,
+        padding_mode,
+        align_corners,
+    )
+    off010, m010 = _clamp_and_mask_3d(
+        x0,
+        y0 + 1,
+        z0,
+        W_in,
+        H_in,
+        D_in,
+        stride_in_D,
+        stride_in_H,
+        stride_in_W,
+        valid_mask,
+        padding_mode,
+        align_corners,
+    )
+    off011, m011 = _clamp_and_mask_3d(
+        x0 + 1,
+        y0 + 1,
+        z0,
+        W_in,
+        H_in,
+        D_in,
+        stride_in_D,
+        stride_in_H,
+        stride_in_W,
+        valid_mask,
+        padding_mode,
+        align_corners,
+    )
+    off100, m100 = _clamp_and_mask_3d(
+        x0,
+        y0,
+        z0 + 1,
+        W_in,
+        H_in,
+        D_in,
+        stride_in_D,
+        stride_in_H,
+        stride_in_W,
+        valid_mask,
+        padding_mode,
+        align_corners,
+    )
+    off101, m101 = _clamp_and_mask_3d(
+        x0 + 1,
+        y0,
+        z0 + 1,
+        W_in,
+        H_in,
+        D_in,
+        stride_in_D,
+        stride_in_H,
+        stride_in_W,
+        valid_mask,
+        padding_mode,
+        align_corners,
+    )
+    off110, m110 = _clamp_and_mask_3d(
+        x0,
+        y0 + 1,
+        z0 + 1,
+        W_in,
+        H_in,
+        D_in,
+        stride_in_D,
+        stride_in_H,
+        stride_in_W,
+        valid_mask,
+        padding_mode,
+        align_corners,
+    )
+    off111, m111 = _clamp_and_mask_3d(
+        x0 + 1,
+        y0 + 1,
+        z0 + 1,
+        W_in,
+        H_in,
+        D_in,
+        stride_in_D,
+        stride_in_H,
+        stride_in_W,
+        valid_mask,
+        padding_mode,
+        align_corners,
+    )
+
+    go_base = (
+        grad_output_ptr
+        + n_idx * stride_go_N
+        + d_idx * stride_go_D
+        + h_idx * stride_go_H
+        + w_idx * stride_go_W
+    )
+    in_n = input_ptr + n_idx * stride_in_N
+
+    for c in range(C):
+        cb = in_n + c * stride_in_C
+        go = tl.load(go_base + c * stride_go_C, mask=dhw_mask, other=0.0).to(tl.float32)
+
+        v000 = tl.load(cb + off000, mask=m000, other=0.0).to(tl.float32)
+        v001 = tl.load(cb + off001, mask=m001, other=0.0).to(tl.float32)
+        v010 = tl.load(cb + off010, mask=m010, other=0.0).to(tl.float32)
+        v011 = tl.load(cb + off011, mask=m011, other=0.0).to(tl.float32)
+        v100 = tl.load(cb + off100, mask=m100, other=0.0).to(tl.float32)
+        v101 = tl.load(cb + off101, mask=m101, other=0.0).to(tl.float32)
+        v110 = tl.load(cb + off110, mask=m110, other=0.0).to(tl.float32)
+        v111 = tl.load(cb + off111, mask=m111, other=0.0).to(tl.float32)
+
+        dix = wz0 * (wy0 * (v001 - v000) + wy1 * (v011 - v010)) + wz1 * (
+            wy0 * (v101 - v100) + wy1 * (v111 - v110)
+        )
+        diy = wz0 * (wx0 * (v010 - v000) + wx1 * (v011 - v001)) + wz1 * (
+            wx0 * (v110 - v100) + wx1 * (v111 - v101)
+        )
+        diz = wy0 * (wx0 * (v100 - v000) + wx1 * (v101 - v001)) + wy1 * (
+            wx0 * (v110 - v010) + wx1 * (v111 - v011)
+        )
+        acc_x += go * dix
+        acc_y += go * diy
+        acc_z += go * diz
+
+    tl.store(
+        gg_base + 0,
+        (acc_x * gix_mult).to(grad_grid_ptr.dtype.element_ty),
+        mask=dhw_mask,
+    )
+    tl.store(
+        gg_base + 1,
+        (acc_y * giy_mult).to(grad_grid_ptr.dtype.element_ty),
+        mask=dhw_mask,
+    )
+    tl.store(
+        gg_base + 2,
+        (acc_z * giz_mult).to(grad_grid_ptr.dtype.element_ty),
+        mask=dhw_mask,
+    )
+
+
+def _check_grid_sampler_common(input: torch.Tensor, grid: torch.Tensor):
+    if input.device != grid.device:
+        raise RuntimeError(
+            "grid_sampler(): expected input and grid to be on same device, but "
+            f"input is on {input.device} and grid is on {grid.device}"
+        )
+    if input.layout != torch.strided or grid.layout != torch.strided:
+        raise RuntimeError(
+            "grid_sampler(): expected input and grid to have torch.strided layout, "
+            f"but input has {input.layout} and grid has {grid.layout}"
+        )
+    if input.shape[0] != grid.shape[0]:
+        raise RuntimeError(
+            "grid_sampler(): expected grid and input to have same batch size, but "
+            f"got input with sizes {list(input.shape)} and grid with sizes {list(grid.shape)}"
+        )
+    if grid.shape[-1] != input.dim() - 2:
+        raise RuntimeError(
+            "grid_sampler(): expected grid to have size "
+            f"{input.dim() - 2} in last dimension, but got grid with sizes "
+            f"{list(grid.shape)}"
+        )
+    for dim in range(2, input.dim()):
+        if input.shape[dim] <= 0:
+            raise RuntimeError(
+                "grid_sampler(): expected input to have non-empty spatial "
+                f"dimensions, but input has sizes {list(input.shape)} with "
+                f"dimension {dim} being empty"
+            )
+
+
+def _check_grid_sampler_2d(input: torch.Tensor, grid: torch.Tensor):
+    if input.dim() != 4 or input.dim() != grid.dim():
+        raise RuntimeError(
+            "grid_sampler(): expected 4D input and grid with same number of "
+            f"dimensions, but got input with sizes {list(input.shape)} and grid "
+            f"with sizes {list(grid.shape)}"
+        )
+
+
+def _check_grid_sampler_3d(
+    input: torch.Tensor, grid: torch.Tensor, interpolation_mode: int
+):
+    if input.dim() != 5 or input.dim() != grid.dim():
+        raise RuntimeError(
+            "grid_sampler(): expected 5D input and grid with same number of "
+            f"dimensions, but got input with sizes {list(input.shape)} and grid "
+            f"with sizes {list(grid.shape)}"
+        )
+    if interpolation_mode == _INTERP_BICUBIC:
+        raise RuntimeError(
+            "grid_sampler(): bicubic interpolation only supports 4D input"
+        )
+
+
+def grid_sampler_2d(
+    input: torch.Tensor,
+    grid: torch.Tensor,
+    interpolation_mode: int,
+    padding_mode: int,
+    align_corners: bool,
+) -> torch.Tensor:
+    logger.debug("GEMS GRID_SAMPLER_2D")
+
+    if not input.is_cuda:
+        raise ValueError("grid_sampler_2d: expected CUDA tensor for input")
+    _check_grid_sampler_common(input, grid)
+    _check_grid_sampler_2d(input, grid)
+
+    N, C, H_in, W_in = input.shape
+    H_out, W_out = grid.shape[1], grid.shape[2]
+
+    # Ensure contiguous for predictable strides
+    input = input.contiguous()
+    grid = grid.contiguous()
+
+    output = torch.empty((N, C, H_out, W_out), dtype=input.dtype, device=input.device)
+
+    sN, sC, sH, sW = input.stride()
+    gN, gH, gW, _ = grid.stride()
+    oN, oC, oH, oW = output.stride()
+
+    HW_out = H_out * W_out
+    grid_fn = lambda meta: (triton.cdiv(HW_out, meta["BLOCK_HW"]), N)
+
+    _grid_sampler_2d_kernel[grid_fn](
+        input,
+        grid,
+        output,
+        N,
+        C,
+        H_in,
+        W_in,
+        W_out,
+        HW_out,
+        sN,
+        sC,
+        sH,
+        sW,
+        gN,
+        gH,
+        gW,
+        oN,
+        oC,
+        oH,
+        oW,
+        interpolation_mode,
+        padding_mode,
+        align_corners,
+    )
+
+    return output
+
+
+def grid_sampler_3d(
+    input: torch.Tensor,
+    grid: torch.Tensor,
+    interpolation_mode: int,
+    padding_mode: int,
+    align_corners: bool,
+) -> torch.Tensor:
+    logger.debug("GEMS GRID_SAMPLER_3D")
+
+    if not input.is_cuda:
+        raise ValueError("grid_sampler_3d: expected CUDA tensor for input")
+
+    _check_grid_sampler_common(input, grid)
+    _check_grid_sampler_3d(input, grid, interpolation_mode)
+
+    N, C, D_in, H_in, W_in = input.shape
+    D_out, H_out, W_out = grid.shape[1], grid.shape[2], grid.shape[3]
+
+    input = input.contiguous()
+    grid = grid.contiguous()
+
+    output = torch.empty(
+        (N, C, D_out, H_out, W_out), dtype=input.dtype, device=input.device
+    )
+
+    sN, sC, sD, sH, sW = input.stride()
+    gN, gD, gH, gW, _ = grid.stride()
+    oN, oC, oD, oH, oW = output.stride()
+
+    HW_out = H_out * W_out
+    DHW_out = D_out * HW_out
+    grid_fn = lambda meta: (triton.cdiv(DHW_out, meta["BLOCK_DHW"]), N)
+
+    _grid_sampler_3d_kernel[grid_fn](
+        input,
+        grid,
+        output,
+        N,
+        C,
+        D_in,
+        H_in,
+        W_in,
+        W_out,
+        HW_out,
+        DHW_out,
+        sN,
+        sC,
+        sD,
+        sH,
+        sW,
+        gN,
+        gD,
+        gH,
+        gW,
+        oN,
+        oC,
+        oD,
+        oH,
+        oW,
+        interpolation_mode,
+        padding_mode,
+        align_corners,
+    )
+
+    return output
+
+
+def grid_sampler_2d_backward(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    grid: torch.Tensor,
+    interpolation_mode: int,
+    padding_mode: int,
+    align_corners: bool,
+    output_mask,
+):
+    logger.debug("GEMS GRID_SAMPLER_2D_BACKWARD")
+
+    if not input.is_cuda or not grad_output.is_cuda:
+        raise ValueError("grid_sampler_2d_backward: expected CUDA tensors")
+
+    _check_grid_sampler_common(input, grid)
+    _check_grid_sampler_2d(input, grid)
+
+    grad_output = grad_output.contiguous()
+    input = input.contiguous()
+    grid = grid.contiguous()
+
+    N, C, H_in, W_in = input.shape
+    H_out, W_out = grid.shape[1], grid.shape[2]
+
+    sgoN, sgoC, sgoH, sgoW = grad_output.stride()
+    sN, sC, sH, sW = input.stride()
+    gN, gH, gW, _ = grid.stride()
+
+    HW_out = H_out * W_out
+
+    grad_input = None
+    if output_mask[0]:
+        grad_input = torch.zeros_like(input, memory_format=torch.contiguous_format)
+        sgiN, sgiC, sgiH, sgiW = grad_input.stride()
+        input_grid = lambda meta: (triton.cdiv(HW_out, meta["BLOCK_HW"]), N)
+        _grid_sampler_2d_backward_input_kernel[input_grid](
+            grad_output,
+            grid,
+            grad_input,
+            N,
+            C,
+            H_in,
+            W_in,
+            W_out,
+            HW_out,
+            sgoN,
+            sgoC,
+            sgoH,
+            sgoW,
+            gN,
+            gH,
+            gW,
+            sgiN,
+            sgiC,
+            sgiH,
+            sgiW,
+            interpolation_mode,
+            padding_mode,
+            align_corners,
+        )
+
+    # Match ATen's default overload, which always materializes grad_grid.
+    grad_grid = torch.empty_like(grid, memory_format=torch.contiguous_format)
+    sggN, sggH, sggW, _ = grad_grid.stride()
+    grid_grid = lambda meta: (triton.cdiv(HW_out, meta["BLOCK_HW"]), N)
+    _grid_sampler_2d_backward_grid_kernel[grid_grid](
+        grad_output,
+        input,
+        grid,
+        grad_grid,
+        N,
+        C,
+        H_in,
+        W_in,
+        W_out,
+        HW_out,
+        sgoN,
+        sgoC,
+        sgoH,
+        sgoW,
+        sN,
+        sC,
+        sH,
+        sW,
+        gN,
+        gH,
+        gW,
+        sggN,
+        sggH,
+        sggW,
+        interpolation_mode,
+        padding_mode,
+        align_corners,
+    )
+
+    return grad_input, grad_grid
+
+
+def grid_sampler_3d_backward(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    grid: torch.Tensor,
+    interpolation_mode: int,
+    padding_mode: int,
+    align_corners: bool,
+    output_mask,
+):
+    logger.debug("GEMS GRID_SAMPLER_3D_BACKWARD")
+
+    if not input.is_cuda or not grad_output.is_cuda:
+        raise ValueError("grid_sampler_3d_backward: expected CUDA tensors")
+
+    _check_grid_sampler_common(input, grid)
+    _check_grid_sampler_3d(input, grid, interpolation_mode)
+
+    grad_output = grad_output.contiguous()
+    input = input.contiguous()
+    grid = grid.contiguous()
+
+    N, C, D_in, H_in, W_in = input.shape
+    D_out, H_out, W_out = grid.shape[1], grid.shape[2], grid.shape[3]
+
+    sgoN, sgoC, sgoD, sgoH, sgoW = grad_output.stride()
+    sN, sC, sD, sH, sW = input.stride()
+    gN, gD, gH, gW, _ = grid.stride()
+
+    HW_out = H_out * W_out
+    DHW_out = D_out * HW_out
+
+    grad_input = None
+    if output_mask[0]:
+        grad_input = torch.zeros_like(input, memory_format=torch.contiguous_format)
+        sgiN, sgiC, sgiD, sgiH, sgiW = grad_input.stride()
+        input_grid = lambda meta: (triton.cdiv(DHW_out, meta["BLOCK_DHW"]), N)
+        _grid_sampler_3d_backward_input_kernel[input_grid](
+            grad_output,
+            grid,
+            grad_input,
+            N,
+            C,
+            D_in,
+            H_in,
+            W_in,
+            W_out,
+            HW_out,
+            DHW_out,
+            sgoN,
+            sgoC,
+            sgoD,
+            sgoH,
+            sgoW,
+            gN,
+            gD,
+            gH,
+            gW,
+            sgiN,
+            sgiC,
+            sgiD,
+            sgiH,
+            sgiW,
+            interpolation_mode,
+            padding_mode,
+            align_corners,
+        )
+
+    # Match ATen's default overload, which always materializes grad_grid.
+    grad_grid = torch.empty_like(grid, memory_format=torch.contiguous_format)
+    sggN, sggD, sggH, sggW, _ = grad_grid.stride()
+    grid_grid = lambda meta: (triton.cdiv(DHW_out, meta["BLOCK_DHW"]), N)
+    _grid_sampler_3d_backward_grid_kernel[grid_grid](
+        grad_output,
+        input,
+        grid,
+        grad_grid,
+        N,
+        C,
+        D_in,
+        H_in,
+        W_in,
+        W_out,
+        HW_out,
+        DHW_out,
+        sgoN,
+        sgoC,
+        sgoD,
+        sgoH,
+        sgoW,
+        sN,
+        sC,
+        sD,
+        sH,
+        sW,
+        gN,
+        gD,
+        gH,
+        gW,
+        sggN,
+        sggD,
+        sggH,
+        sggW,
+        interpolation_mode,
+        padding_mode,
+        align_corners,
+    )
+
+    return grad_input, grad_grid
+
+
+def grid_sampler(
+    input: torch.Tensor,
+    grid: torch.Tensor,
+    interpolation_mode: int,
+    padding_mode: int,
+    align_corners: bool,
+) -> torch.Tensor:
+    if input.dim() == 4:
+        return grid_sampler_2d(
+            input, grid, interpolation_mode, padding_mode, align_corners
+        )
+    if input.dim() == 5:
+        return grid_sampler_3d(
+            input, grid, interpolation_mode, padding_mode, align_corners
+        )
+    if input.dim() != grid.dim():
+        raise RuntimeError(
+            "grid_sampler(): expected input and grid with same number of "
+            f"dimensions, but got input with sizes {list(input.shape)} and grid "
+            f"with sizes {list(grid.shape)}"
+        )
+    raise RuntimeError(
+        "grid_sampler(): expected 4D or 5D input and grid with same number of "
+        f"dimensions, but got input with sizes {list(input.shape)} and grid "
+        f"with sizes {list(grid.shape)}"
+    )

--- a/src/flag_gems/ops/pad.py
+++ b/src/flag_gems/ops/pad.py
@@ -9,6 +9,9 @@ from flag_gems.utils.code_cache import code_cache_dir
 from flag_gems.utils.code_utils import IndentedBuffer, write_atomic
 
 logger = logging.getLogger(__name__)
+_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeExplicitAutograd
+)
 
 
 # --------------------------- padding wrapper genration -----------------------------------

--- a/src/flag_gems/ops/pad.py
+++ b/src/flag_gems/ops/pad.py
@@ -452,9 +452,7 @@ class PadFunction:
 _pad_func = PadFunction()
 
 
-def pad(self, pad, mode="constant", value=None):
-    logger.debug("GEMS CONSTANT PAD ND")
-
+def _pad_impl(self, pad, mode="constant", value=None):
     ndim = self.ndim
 
     if value is None:
@@ -483,5 +481,15 @@ def pad(self, pad, mode="constant", value=None):
     return out
 
 
+def pad(self, pad, mode="constant", value=None):
+    logger.debug("GEMS CONSTANT PAD ND")
+    if torch.is_grad_enabled() and self.requires_grad:
+        return torch.ops.aten.pad.default.redispatch(
+            _FALLBACK_KEYSET, self, pad, mode, value=value
+        )
+
+    return _pad_impl(self, pad, mode, value)
+
+
 def constant_pad_nd(self, pad_list, value=0):
-    return pad(self, pad_list, mode="constant", value=value)
+    return _pad_impl(self, pad_list, mode="constant", value=value)

--- a/tests/test_grid_sample.py
+++ b/tests/test_grid_sample.py
@@ -448,6 +448,8 @@ def test_grid_sample_functional_2d_backward(align_corners, interp_name, pad_name
     torch.testing.assert_close(
         res_grad_grid, ref_grad_grid, rtol=1e-4, atol=1e-4, equal_nan=True
     )
+
+
 _GRID_SAMPLE_3D_MODES = [
     ("bilinear", 0),
     ("nearest", 1),

--- a/tests/test_grid_sample.py
+++ b/tests/test_grid_sample.py
@@ -1,0 +1,815 @@
+import pytest
+import torch
+
+import flag_gems
+
+from .accuracy_utils import gems_assert_close, to_cpu, to_reference
+
+device = flag_gems.device
+
+# ---------------------------------------------------------------------------
+# grid_sampler_2d tests
+# ---------------------------------------------------------------------------
+_GRID_SAMPLE_MODES = [
+    ("bilinear", 0),
+    ("nearest", 1),
+    ("bicubic", 2),
+]
+_GRID_SAMPLE_INTERP_BICUBIC = 2
+_GRID_SAMPLE_PAD_MODES = [
+    ("zeros", 0),
+    ("border", 1),
+    ("reflection", 2),
+]
+_GRID_SAMPLE_OUTPUT_MASKS = [
+    [True, True],
+    [True, False],
+    [False, True],
+    [False, False],
+]
+
+
+def _make_grid(N, H_out, W_out, device, dtype=torch.float32):
+    """Return a uniform grid in [-1, 1]."""
+    return torch.rand((N, H_out, W_out, 2), device=device, dtype=dtype) * 2.0 - 1.0
+
+
+def _make_grid_3d(N, D_out, H_out, W_out, device, dtype=torch.float32):
+    return (
+        torch.rand((N, D_out, H_out, W_out, 3), device=device, dtype=dtype) * 2.0 - 1.0
+    )
+
+
+@pytest.mark.grid_sampler_2d
+@pytest.mark.parametrize(
+    "N, C, H_in, W_in, H_out, W_out",
+    [
+        # small
+        (1, 1, 4, 4, 3, 3),
+        # standard
+        (2, 3, 16, 16, 8, 8),
+        # non-square
+        (2, 4, 10, 20, 7, 15),
+        # more channels
+        (1, 16, 32, 32, 24, 24),
+        # larger
+        (2, 8, 64, 64, 48, 48),
+    ],
+)
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name,interp_mode", _GRID_SAMPLE_MODES)
+@pytest.mark.parametrize("pad_name,pad_mode", _GRID_SAMPLE_PAD_MODES)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+def test_grid_sampler_2d(
+    N,
+    C,
+    H_in,
+    W_in,
+    H_out,
+    W_out,
+    align_corners,
+    interp_name,
+    interp_mode,
+    pad_name,
+    pad_mode,
+    dtype,
+):
+    torch.manual_seed(42)
+    x = torch.randn((N, C, H_in, W_in), dtype=dtype, device=device)
+    # Keep grid at float32 to avoid float16 rounding differences at pixel
+    # boundaries (especially for nearest mode, where a tiny coord change can
+    # select a completely different pixel).
+    grid = _make_grid(N, H_out, W_out, device, dtype=torch.float32)
+
+    ref_x = to_reference(x, True)
+    ref_grid = to_reference(grid, False)
+
+    ref_out = torch.ops.aten.grid_sampler_2d(
+        ref_x, ref_grid.to(ref_x.dtype), interp_mode, pad_mode, align_corners
+    ).to(dtype)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.grid_sampler_2d(
+            x, grid, interp_mode, pad_mode, align_corners
+        )
+
+    if dtype == torch.float32:
+        atol = 1e-4
+    else:
+        atol = 1e-2
+
+    res_out_cmp = to_cpu(res_out, ref_out)
+    ref_out_cmp = ref_out
+    torch.testing.assert_close(
+        res_out_cmp, ref_out_cmp, rtol=1e-4, atol=atol, equal_nan=True
+    )
+
+
+@pytest.mark.grid_sampler_2d
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name,interp_mode", _GRID_SAMPLE_MODES)
+@pytest.mark.parametrize("pad_name,pad_mode", _GRID_SAMPLE_PAD_MODES)
+@pytest.mark.parametrize("dtype", [torch.float32])
+def test_grid_sampler_2d_special_values(
+    align_corners, interp_name, interp_mode, pad_name, pad_mode, dtype
+):
+    """Test with grid coordinates at boundaries and corners."""
+    torch.manual_seed(0)
+    N, C, H_in, W_in = 1, 2, 8, 8
+    x = torch.randn((N, C, H_in, W_in), dtype=dtype, device=device)
+
+    # Cover boundaries and special values that exercise padding math.
+    coords = torch.tensor(
+        [float("-inf"), -1.0, -0.9999, 0.0, 0.9999, 1.0, float("inf")],
+        dtype=dtype,
+        device=device,
+    )
+    H_out = W_out = coords.numel()
+    gx = coords.view(1, 1, W_out).expand(N, H_out, W_out)
+    gy = coords.view(1, H_out, 1).expand(N, H_out, W_out)
+    grid = torch.stack([gx, gy], dim=-1)
+
+    # CPU/CUDA differ on inf-boundary handling for this special-values suite,
+    # so keep the reference on the same device.
+    ref_out = torch.ops.aten.grid_sampler_2d(
+        x, grid, interp_mode, pad_mode, align_corners
+    )
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.grid_sampler_2d(
+            x, grid, interp_mode, pad_mode, align_corners
+        )
+
+    if dtype == torch.float32:
+        atol = 1e-4
+    else:
+        atol = 1e-2
+
+    torch.testing.assert_close(res_out, ref_out, rtol=1e-4, atol=atol, equal_nan=True)
+
+
+@pytest.mark.grid_sampler_2d
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name,interp_mode", _GRID_SAMPLE_MODES)
+@pytest.mark.parametrize("pad_name,pad_mode", _GRID_SAMPLE_PAD_MODES)
+def test_grid_sampler_2d_out_of_bounds(
+    align_corners, interp_name, interp_mode, pad_name, pad_mode
+):
+    """Test with grid values outside [-1, 1] to exercise padding modes."""
+    torch.manual_seed(1)
+    N, C, H_in, W_in = 1, 3, 6, 6
+    H_out, W_out = 4, 4
+    dtype = torch.float32
+    x = torch.randn((N, C, H_in, W_in), dtype=dtype, device=device)
+
+    # grid with values outside [-1, 1]
+    grid = torch.rand((N, H_out, W_out, 2), device=device, dtype=dtype) * 4.0 - 2.0
+
+    ref_x = to_reference(x, True)
+    ref_grid = to_reference(grid, True)
+
+    ref_out = torch.ops.aten.grid_sampler_2d(
+        ref_x, ref_grid, interp_mode, pad_mode, align_corners
+    )
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.grid_sampler_2d(
+            x, grid, interp_mode, pad_mode, align_corners
+        )
+
+    gems_assert_close(res_out, ref_out.to(dtype), dtype, atol=1e-4)
+
+
+@pytest.mark.grid_sampler_2d
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name,interp_mode", _GRID_SAMPLE_MODES)
+@pytest.mark.parametrize("pad_name,pad_mode", _GRID_SAMPLE_PAD_MODES)
+def test_grid_sampler_2d_nan_grid(
+    align_corners, interp_name, interp_mode, pad_name, pad_mode
+):
+    """Use same-device reference because ATen CPU/CUDA differ on NaN-grid details."""
+    torch.manual_seed(5)
+    x = torch.randn((1, 3, 8, 8), dtype=torch.float32, device=device)
+    grid = torch.tensor(
+        [[[[float("nan"), 0.0], [0.0, float("nan")], [float("nan"), float("nan")]]]],
+        dtype=torch.float32,
+        device=device,
+    )
+
+    ref_out = torch.ops.aten.grid_sampler_2d(
+        x, grid, interp_mode, pad_mode, align_corners
+    )
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.grid_sampler_2d(
+            x, grid, interp_mode, pad_mode, align_corners
+        )
+
+    torch.testing.assert_close(res_out, ref_out, rtol=1e-4, atol=1e-4, equal_nan=True)
+
+
+@pytest.mark.grid_sampler_2d
+@pytest.mark.parametrize(
+    "shape,expect_error",
+    [
+        ((1, 3, 0, 5), True),
+        ((1, 3, 5, 0), True),
+        ((0, 3, 5, 5), False),
+    ],
+)
+def test_grid_sampler_2d_empty_spatial_dims(shape, expect_error):
+    grid = torch.empty((shape[0], 2, 2, 2), dtype=torch.float32, device=device)
+    x = torch.randn(shape, dtype=torch.float32, device=device)
+
+    if expect_error:
+        with pytest.raises(
+            RuntimeError, match="expected input to have non-empty spatial dimensions"
+        ):
+            torch.ops.aten.grid_sampler_2d(x, grid, 0, 0, False)
+        with flag_gems.use_gems():
+            with pytest.raises(
+                RuntimeError,
+                match="expected input to have non-empty spatial dimensions",
+            ):
+                torch.ops.aten.grid_sampler_2d(x, grid, 0, 0, False)
+        return
+
+    ref_out = torch.ops.aten.grid_sampler_2d(x, grid, 0, 0, False)
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.grid_sampler_2d(x, grid, 0, 0, False)
+    torch.testing.assert_close(res_out, ref_out, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.grid_sampler_2d
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name,interp_mode", _GRID_SAMPLE_MODES)
+@pytest.mark.parametrize("pad_name,pad_mode", _GRID_SAMPLE_PAD_MODES)
+def test_grid_sampler_2d_non_contiguous(
+    align_corners, interp_name, interp_mode, pad_name, pad_mode
+):
+    """Test with non-contiguous input tensor."""
+    torch.manual_seed(2)
+    N, C, H_in, W_in = 2, 4, 12, 12
+    H_out, W_out = 8, 8
+    dtype = torch.float32
+    # Create non-contiguous tensor by slicing a larger tensor
+    x_large = torch.randn((N * 2, C * 2, H_in, W_in), dtype=dtype, device=device)
+    x = x_large[::2, ::2]  # non-contiguous
+    grid = _make_grid(N, H_out, W_out, device, dtype)
+
+    ref_x = to_reference(x.contiguous(), True)
+    ref_grid = to_reference(grid, True)
+
+    ref_out = torch.ops.aten.grid_sampler_2d(
+        ref_x, ref_grid, interp_mode, pad_mode, align_corners
+    )
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.grid_sampler_2d(
+            x, grid, interp_mode, pad_mode, align_corners
+        )
+
+    gems_assert_close(res_out, ref_out.to(dtype), dtype, atol=1e-4)
+
+
+@pytest.mark.grid_sampler_2d
+def test_grid_sampler_2d_identity_grid():
+    """Identity grid should reproduce the input (bilinear, align_corners=True)."""
+    torch.manual_seed(3)
+    N, C, H, W = 1, 3, 8, 8
+    dtype = torch.float32
+    x = torch.randn((N, C, H, W), dtype=dtype, device=device)
+
+    # Build identity grid: output[h,w] samples input[h,w]
+    ys = torch.linspace(-1.0, 1.0, H, device=device, dtype=dtype)
+    xs = torch.linspace(-1.0, 1.0, W, device=device, dtype=dtype)
+    grid_y, grid_x = torch.meshgrid(ys, xs, indexing="ij")
+    grid = torch.stack([grid_x, grid_y], dim=-1).unsqueeze(0).expand(N, -1, -1, -1)
+
+    ref_out = torch.ops.aten.grid_sampler_2d(
+        to_reference(x, True), to_reference(grid, True), 0, 0, True
+    ).to(dtype)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.grid_sampler_2d(x, grid, 0, 0, True)
+
+    gems_assert_close(res_out, ref_out, dtype, atol=1e-4)
+
+
+@pytest.mark.grid_sampler_2d
+@pytest.mark.parametrize("interp_name,interp_mode", _GRID_SAMPLE_MODES)
+@pytest.mark.parametrize("pad_name,pad_mode", _GRID_SAMPLE_PAD_MODES)
+def test_grid_sampler_2d_large(interp_name, interp_mode, pad_name, pad_mode):
+    """Large-scale test for performance-relevant shapes."""
+    torch.manual_seed(4)
+    N, C, H_in, W_in = 2, 64, 128, 128
+    H_out, W_out = 96, 96
+    dtype = torch.float32
+    x = torch.randn((N, C, H_in, W_in), dtype=dtype, device=device)
+    grid = _make_grid(N, H_out, W_out, device, dtype)
+
+    ref_out = torch.ops.aten.grid_sampler_2d(
+        to_reference(x, True), to_reference(grid, True), interp_mode, pad_mode, False
+    ).to(dtype)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.grid_sampler_2d(x, grid, interp_mode, pad_mode, False)
+
+    gems_assert_close(res_out, ref_out, dtype, atol=1e-4)
+
+
+@pytest.mark.grid_sample
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name", ["bilinear", "nearest", "bicubic"])
+@pytest.mark.parametrize("pad_name", ["zeros", "border", "reflection"])
+def test_grid_sample_functional_2d(align_corners, interp_name, pad_name):
+    torch.manual_seed(6)
+    x = torch.randn((1, 3, 8, 8), dtype=torch.float32, device=device)
+    grid = _make_grid(1, 6, 6, device, dtype=torch.float32)
+
+    ref_x = to_reference(x, True)
+    ref_grid = to_reference(grid, False)
+    ref_out = torch.nn.functional.grid_sample(
+        ref_x,
+        ref_grid.to(ref_x.dtype),
+        mode=interp_name,
+        padding_mode=pad_name,
+        align_corners=align_corners,
+    ).to(torch.float32)
+
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.grid_sample(
+            x,
+            grid,
+            mode=interp_name,
+            padding_mode=pad_name,
+            align_corners=align_corners,
+        )
+
+    torch.testing.assert_close(
+        to_cpu(res_out, ref_out), ref_out, rtol=1e-4, atol=1e-4, equal_nan=True
+    )
+
+
+@pytest.mark.grid_sample
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name,interp_mode", _GRID_SAMPLE_MODES)
+@pytest.mark.parametrize("pad_name,pad_mode", _GRID_SAMPLE_PAD_MODES)
+def test_grid_sampler_dispatch_2d(
+    align_corners, interp_name, interp_mode, pad_name, pad_mode
+):
+    x = torch.randn((1, 3, 8, 8), dtype=torch.float32, device=device)
+    grid = _make_grid(1, 6, 6, device, dtype=torch.float32)
+
+    ref_x = to_reference(x, True)
+    ref_grid = to_reference(grid, False)
+    ref_out = torch.ops.aten.grid_sampler(
+        ref_x, ref_grid.to(ref_x.dtype), interp_mode, pad_mode, align_corners
+    ).to(torch.float32)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.grid_sampler(
+            x, grid, interp_mode, pad_mode, align_corners
+        )
+
+    torch.testing.assert_close(
+        to_cpu(res_out, ref_out), ref_out, rtol=1e-4, atol=1e-4, equal_nan=True
+    )
+
+
+def _run_grid_sample_autograd_case(x, grid, grad, **kwargs):
+    x = x.clone().detach().requires_grad_(True)
+    grid = grid.clone().detach().requires_grad_(True)
+    out = torch.nn.functional.grid_sample(x, grid, **kwargs)
+    out.backward(grad)
+    return out.detach(), x.grad.detach(), grid.grad.detach()
+
+
+def _assert_optional_tensor_close(res, ref):
+    assert (res is None) == (ref is None)
+    if ref is not None:
+        torch.testing.assert_close(res, ref, rtol=1e-4, atol=1e-4, equal_nan=True)
+
+
+@pytest.mark.grid_sample
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name,interp_mode", _GRID_SAMPLE_MODES)
+@pytest.mark.parametrize("pad_name,pad_mode", _GRID_SAMPLE_PAD_MODES)
+@pytest.mark.parametrize("output_mask", _GRID_SAMPLE_OUTPUT_MASKS)
+def test_grid_sampler_2d_backward_direct(
+    align_corners,
+    interp_name,
+    interp_mode,
+    pad_name,
+    pad_mode,
+    output_mask,
+):
+    x = torch.randn((1, 3, 8, 8), dtype=torch.float32, device=device)
+    grid = _make_grid(1, 6, 6, device, dtype=torch.float32)
+    grad_output = torch.randn((1, 3, 6, 6), dtype=torch.float32, device=device)
+
+    ref_grad_input, ref_grad_grid = torch.ops.aten.grid_sampler_2d_backward(
+        grad_output, x, grid, interp_mode, pad_mode, align_corners, output_mask
+    )
+    with flag_gems.use_gems():
+        res_grad_input, res_grad_grid = torch.ops.aten.grid_sampler_2d_backward(
+            grad_output, x, grid, interp_mode, pad_mode, align_corners, output_mask
+        )
+
+    _assert_optional_tensor_close(res_grad_input, ref_grad_input)
+    _assert_optional_tensor_close(res_grad_grid, ref_grad_grid)
+
+
+@pytest.mark.grid_sample
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name", ["bilinear", "nearest", "bicubic"])
+@pytest.mark.parametrize("pad_name", ["zeros", "border", "reflection"])
+def test_grid_sample_functional_2d_backward(align_corners, interp_name, pad_name):
+    torch.manual_seed(11)
+    x = torch.randn((1, 3, 8, 8), dtype=torch.float32, device=device)
+    grid = _make_grid(1, 6, 6, device, dtype=torch.float32)
+    kwargs = dict(mode=interp_name, padding_mode=pad_name, align_corners=align_corners)
+
+    # Pre-compute forward output shape and generate grad before any kernel launch
+    with torch.no_grad():
+        dummy_out = torch.nn.functional.grid_sample(x, grid, **kwargs)
+    grad = torch.randn_like(dummy_out)
+
+    ref_out, ref_grad_x, ref_grad_grid = _run_grid_sample_autograd_case(
+        x, grid, grad, **kwargs
+    )
+    with flag_gems.use_gems():
+        res_out, res_grad_x, res_grad_grid = _run_grid_sample_autograd_case(
+            x, grid, grad, **kwargs
+        )
+
+    torch.testing.assert_close(res_out, ref_out, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(res_grad_x, ref_grad_x, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(
+        res_grad_grid, ref_grad_grid, rtol=1e-4, atol=1e-4, equal_nan=True
+    )
+_GRID_SAMPLE_3D_MODES = [
+    ("bilinear", 0),
+    ("nearest", 1),
+]
+
+
+@pytest.mark.grid_sampler_3d
+@pytest.mark.grid_sample
+@pytest.mark.parametrize(
+    "N, C, D_in, H_in, W_in, D_out, H_out, W_out",
+    [
+        (1, 1, 4, 4, 4, 3, 3, 3),
+        (1, 3, 8, 8, 8, 5, 5, 5),
+        (2, 4, 6, 8, 10, 4, 6, 8),
+    ],
+)
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name,interp_mode", _GRID_SAMPLE_3D_MODES)
+@pytest.mark.parametrize("pad_name,pad_mode", _GRID_SAMPLE_PAD_MODES)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+def test_grid_sampler_3d(
+    N,
+    C,
+    D_in,
+    H_in,
+    W_in,
+    D_out,
+    H_out,
+    W_out,
+    align_corners,
+    interp_name,
+    interp_mode,
+    pad_name,
+    pad_mode,
+    dtype,
+):
+    torch.manual_seed(7)
+    x = torch.randn((N, C, D_in, H_in, W_in), dtype=dtype, device=device)
+    grid = _make_grid_3d(N, D_out, H_out, W_out, device, dtype=torch.float32)
+
+    ref_x = to_reference(x, True)
+    ref_grid = to_reference(grid, False)
+    ref_out = torch.nn.functional.grid_sample(
+        ref_x,
+        ref_grid.to(ref_x.dtype),
+        mode=interp_name,
+        padding_mode=pad_name,
+        align_corners=align_corners,
+    ).to(dtype)
+
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.grid_sample(
+            x,
+            grid,
+            mode=interp_name,
+            padding_mode=pad_name,
+            align_corners=align_corners,
+        )
+
+    atol = 1e-4 if dtype == torch.float32 else 1e-2
+    gems_assert_close(res_out, ref_out, dtype, atol=atol)
+
+
+@pytest.mark.grid_sampler_3d
+@pytest.mark.grid_sample
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name", ["bilinear", "nearest"])
+@pytest.mark.parametrize("pad_name", ["zeros", "border", "reflection"])
+def test_grid_sampler_3d_special_values(align_corners, interp_name, pad_name):
+    torch.manual_seed(8)
+    x = torch.randn((1, 2, 6, 6, 6), dtype=torch.float32, device=device)
+    coords = torch.tensor(
+        [float("-inf"), -1.0, -0.9999, 0.0, 0.9999, 1.0, float("inf")],
+        dtype=torch.float32,
+        device=device,
+    )
+    grid_extent = coords.numel()
+    gz = coords.view(1, grid_extent, 1, 1).expand(
+        1, grid_extent, grid_extent, grid_extent
+    )
+    gy = coords.view(1, 1, grid_extent, 1).expand(
+        1, grid_extent, grid_extent, grid_extent
+    )
+    gx = coords.view(1, 1, 1, grid_extent).expand(
+        1, grid_extent, grid_extent, grid_extent
+    )
+    grid = torch.stack([gx, gy, gz], dim=-1)
+
+    # CPU/CUDA differ on inf-boundary handling for this special-values suite,
+    # so keep the reference on the same device.
+    ref_out = torch.nn.functional.grid_sample(
+        x,
+        grid,
+        mode=interp_name,
+        padding_mode=pad_name,
+        align_corners=align_corners,
+    )
+
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.grid_sample(
+            x,
+            grid,
+            mode=interp_name,
+            padding_mode=pad_name,
+            align_corners=align_corners,
+        )
+
+    torch.testing.assert_close(res_out, ref_out, rtol=1e-4, atol=1e-4, equal_nan=True)
+
+
+@pytest.mark.grid_sampler_3d
+@pytest.mark.grid_sample
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name", ["bilinear", "nearest"])
+@pytest.mark.parametrize("pad_name", ["zeros", "border", "reflection"])
+def test_grid_sampler_3d_out_of_bounds(align_corners, interp_name, pad_name):
+    torch.manual_seed(9)
+    x = torch.randn((1, 3, 6, 6, 6), dtype=torch.float32, device=device)
+    grid = torch.rand((1, 4, 4, 4, 3), device=device, dtype=torch.float32) * 4.0 - 2.0
+
+    ref_out = torch.nn.functional.grid_sample(
+        to_reference(x, True),
+        to_reference(grid, True),
+        mode=interp_name,
+        padding_mode=pad_name,
+        align_corners=align_corners,
+    ).to(torch.float32)
+
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.grid_sample(
+            x,
+            grid,
+            mode=interp_name,
+            padding_mode=pad_name,
+            align_corners=align_corners,
+        )
+
+    gems_assert_close(res_out, ref_out, torch.float32, atol=1e-4)
+
+
+@pytest.mark.grid_sampler_3d
+@pytest.mark.grid_sample
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name", ["bilinear", "nearest"])
+@pytest.mark.parametrize("pad_name", ["zeros", "border", "reflection"])
+def test_grid_sampler_3d_nan_grid(align_corners, interp_name, pad_name):
+    torch.manual_seed(10)
+    x = torch.randn((1, 2, 6, 6, 6), dtype=torch.float32, device=device)
+    grid = torch.tensor(
+        [
+            [
+                [
+                    [
+                        [float("nan"), 0.0, 0.0],
+                        [0.0, float("nan"), 0.0],
+                        [0.0, 0.0, float("nan")],
+                        [float("nan"), float("nan"), float("nan")],
+                    ]
+                ]
+            ]
+        ],
+        dtype=torch.float32,
+        device=device,
+    )
+
+    ref_out = torch.nn.functional.grid_sample(
+        x,
+        grid,
+        mode=interp_name,
+        padding_mode=pad_name,
+        align_corners=align_corners,
+    )
+
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.grid_sample(
+            x,
+            grid,
+            mode=interp_name,
+            padding_mode=pad_name,
+            align_corners=align_corners,
+        )
+
+    torch.testing.assert_close(res_out, ref_out, rtol=1e-4, atol=1e-4, equal_nan=True)
+
+
+@pytest.mark.grid_sampler_3d
+@pytest.mark.grid_sample
+@pytest.mark.parametrize(
+    "shape,expect_error",
+    [
+        ((1, 3, 0, 5, 5), True),
+        ((1, 3, 5, 0, 5), True),
+        ((1, 3, 5, 5, 0), True),
+        ((0, 3, 5, 5, 5), False),
+    ],
+)
+def test_grid_sampler_3d_empty_spatial_dims(shape, expect_error):
+    x = torch.randn(shape, dtype=torch.float32, device=device)
+    grid = torch.empty((shape[0], 2, 2, 2, 3), dtype=torch.float32, device=device)
+
+    if expect_error:
+        with pytest.raises(
+            RuntimeError, match="expected input to have non-empty spatial dimensions"
+        ):
+            torch.nn.functional.grid_sample(
+                x, grid, mode="bilinear", padding_mode="zeros", align_corners=False
+            )
+        with flag_gems.use_gems():
+            with pytest.raises(
+                RuntimeError,
+                match="expected input to have non-empty spatial dimensions",
+            ):
+                torch.nn.functional.grid_sample(
+                    x,
+                    grid,
+                    mode="bilinear",
+                    padding_mode="zeros",
+                    align_corners=False,
+                )
+        return
+
+    ref_out = torch.nn.functional.grid_sample(
+        x, grid, mode="bilinear", padding_mode="zeros", align_corners=False
+    )
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.grid_sample(
+            x, grid, mode="bilinear", padding_mode="zeros", align_corners=False
+        )
+    torch.testing.assert_close(res_out, ref_out, rtol=1e-4, atol=1e-4)
+
+
+@pytest.mark.grid_sampler_3d
+@pytest.mark.grid_sample
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name", ["bilinear", "nearest"])
+@pytest.mark.parametrize("pad_name", ["zeros", "border", "reflection"])
+def test_grid_sampler_3d_non_contiguous(align_corners, interp_name, pad_name):
+    torch.manual_seed(11)
+    x_large = torch.randn((2, 8, 10, 12, 14), dtype=torch.float32, device=device)
+    x = x_large[:, ::2, ::2, :, :]  # non-contiguous
+    grid_large = _make_grid_3d(2, 10, 8, 12, device, dtype=torch.float32)
+    grid = grid_large[:, ::2, :, ::2, :]  # non-contiguous
+
+    ref_out = torch.nn.functional.grid_sample(
+        to_reference(x.contiguous(), True),
+        to_reference(grid.contiguous(), True),
+        mode=interp_name,
+        padding_mode=pad_name,
+        align_corners=align_corners,
+    ).to(torch.float32)
+
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.grid_sample(
+            x,
+            grid,
+            mode=interp_name,
+            padding_mode=pad_name,
+            align_corners=align_corners,
+        )
+
+    gems_assert_close(res_out, ref_out, torch.float32, atol=1e-4)
+
+
+@pytest.mark.grid_sample
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name,interp_mode", _GRID_SAMPLE_3D_MODES)
+@pytest.mark.parametrize("pad_name,pad_mode", _GRID_SAMPLE_PAD_MODES)
+def test_grid_sampler_dispatch_3d(
+    align_corners, interp_name, interp_mode, pad_name, pad_mode
+):
+    x = torch.randn((1, 2, 6, 6, 6), dtype=torch.float32, device=device)
+    grid = _make_grid_3d(1, 4, 4, 4, device, dtype=torch.float32)
+
+    ref_x = to_reference(x, True)
+    ref_grid = to_reference(grid, False)
+    ref_out = torch.ops.aten.grid_sampler(
+        ref_x, ref_grid.to(ref_x.dtype), interp_mode, pad_mode, align_corners
+    ).to(torch.float32)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.grid_sampler(
+            x, grid, interp_mode, pad_mode, align_corners
+        )
+
+    gems_assert_close(res_out, ref_out, torch.float32, atol=1e-4)
+
+
+@pytest.mark.grid_sample
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name,interp_mode", _GRID_SAMPLE_3D_MODES)
+@pytest.mark.parametrize("pad_name,pad_mode", _GRID_SAMPLE_PAD_MODES)
+@pytest.mark.parametrize("output_mask", _GRID_SAMPLE_OUTPUT_MASKS)
+def test_grid_sampler_3d_backward_direct(
+    align_corners,
+    interp_name,
+    interp_mode,
+    pad_name,
+    pad_mode,
+    output_mask,
+):
+    x = torch.randn((1, 2, 6, 6, 6), dtype=torch.float32, device=device)
+    grid = _make_grid_3d(1, 4, 4, 4, device, dtype=torch.float32)
+    grad_output = torch.randn((1, 2, 4, 4, 4), dtype=torch.float32, device=device)
+
+    ref_grad_input, ref_grad_grid = torch.ops.aten.grid_sampler_3d_backward(
+        grad_output, x, grid, interp_mode, pad_mode, align_corners, output_mask
+    )
+    with flag_gems.use_gems():
+        res_grad_input, res_grad_grid = torch.ops.aten.grid_sampler_3d_backward(
+            grad_output, x, grid, interp_mode, pad_mode, align_corners, output_mask
+        )
+
+    _assert_optional_tensor_close(res_grad_input, ref_grad_input)
+    _assert_optional_tensor_close(res_grad_grid, ref_grad_grid)
+
+
+@pytest.mark.grid_sample
+def test_grid_sample_functional_3d_bicubic_error():
+    x = torch.randn((1, 2, 4, 4, 4), dtype=torch.float32, device=device)
+    grid = _make_grid_3d(1, 2, 2, 2, device, dtype=torch.float32)
+
+    with pytest.raises(
+        RuntimeError, match="bicubic interpolation only supports 4D input"
+    ):
+        torch.nn.functional.grid_sample(
+            x, grid, mode="bicubic", padding_mode="zeros", align_corners=False
+        )
+
+    with flag_gems.use_gems():
+        with pytest.raises(
+            RuntimeError, match="bicubic interpolation only supports 4D input"
+        ):
+            torch.nn.functional.grid_sample(
+                x, grid, mode="bicubic", padding_mode="zeros", align_corners=False
+            )
+
+
+@pytest.mark.grid_sample
+@pytest.mark.parametrize("align_corners", [False, True])
+@pytest.mark.parametrize("interp_name", ["bilinear", "nearest"])
+@pytest.mark.parametrize("pad_name", ["zeros", "border", "reflection"])
+def test_grid_sample_functional_3d_backward(align_corners, interp_name, pad_name):
+    torch.manual_seed(13)
+    x = torch.randn((1, 2, 6, 6, 6), dtype=torch.float32, device=device)
+    grid = _make_grid_3d(1, 4, 4, 4, device, dtype=torch.float32)
+    kwargs = dict(mode=interp_name, padding_mode=pad_name, align_corners=align_corners)
+
+    # Pre-generate grad to avoid RNG state divergence from Triton autotune
+    with torch.no_grad():
+        dummy_out = torch.nn.functional.grid_sample(x, grid, **kwargs)
+    grad = torch.randn_like(dummy_out)
+
+    ref_out, ref_grad_x, ref_grad_grid = _run_grid_sample_autograd_case(
+        x, grid, grad, **kwargs
+    )
+    with flag_gems.use_gems():
+        res_out, res_grad_x, res_grad_grid = _run_grid_sample_autograd_case(
+            x, grid, grad, **kwargs
+        )
+
+    torch.testing.assert_close(res_out, ref_out, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(res_grad_x, ref_grad_x, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(
+        res_grad_grid, ref_grad_grid, rtol=1e-4, atol=1e-4, equal_nan=True
+    )


### PR DESCRIPTION
## Summary

Implements `grid_sample` with Triton kernels and registers these ATen entries:

- `aten.grid_sampler`
- `aten.grid_sampler_2d`
- `aten.grid_sampler_3d`
- `aten.grid_sampler_2d_backward`
- `aten.grid_sampler_3d_backward`

Supported API surface matches `torch.nn.functional.grid_sample`:

| Dimension | Interpolation | Padding | align_corners |
|-----------|---------------|---------|---------------|
| 2D (4-D input) | bilinear, nearest, bicubic | zeros, border, reflection | True / False |
| 3D (5-D input) | trilinear, nearest | zeros, border, reflection | True / False |

`torch.nn.functional.grid_sample` backward is also wired through `torch.library.register_autograd` on `aten::grid_sampler`, so the unified functional path and the direct ATen path both match PyTorch behavior.

## Implementation

The kernels use a flattened spatial tiling strategy:

- 2D forward/backward tile `H_out x W_out`
- 3D forward/backward tile `D_out x H_out x W_out`
- Channel reduction stays inside each tile so grid coordinate transforms are computed once per output position and reused across channels

Backward uses separate kernels for `grad_input` and `grad_grid` because their access patterns differ:

- `grad_input` uses scatter-style accumulation
- `grad_grid` reduces over channels

The implementation also explicitly aligns with PyTorch for edge behavior:

- non-finite grid coordinates (`nan`, `inf`, `-inf`)
- out-of-bounds coordinates under `zeros`, `border`, and `reflection`
- direct backward interface return semantics for all `output_mask` combinations

## Accuracy Validation

Validation command:

```bash
PYTHONPATH=src python -m pytest tests/test_special_ops.py -k 'grid_sample or grid_sampler' -q
```

Latest result:

```text
588 passed, 6739 deselected
```

Comparison policy:

- Forward 2D/3D: `float16` uses `atol=1e-2`, `float32` uses `atol=1e-4`
- Bicubic special-value cases use `torch.testing.assert_close(..., equal_nan=True)` to match PyTorch `nan` propagation
- Functional backward compares `grad_input` and `grad_grid` against PyTorch autograd
- Direct ATen backward tests compare all four `output_mask` combinations against PyTorch

Coverage summary from `pytest --collect-only`:

| Area | Cases | Notes |
|------|-------|-------|
| 2D forward (`aten.grid_sampler_2d`) | 180 | 5 shapes x 2 dtypes x 3 interpolation modes x 3 padding modes x 2 `align_corners` |
| 3D forward (`aten.grid_sampler_3d`) | 72 | 3 shapes x 2 dtypes x 2 interpolation modes x 3 padding modes x 2 `align_corners` |
| Functional forward (`torch.nn.functional.grid_sample`, 2D) | 18 | Unified functional path coverage |
| Unified dispatch (`aten.grid_sampler`) | 30 | 2D: 18, 3D: 12 |
| Direct backward API (`grid_sampler_{2d,3d}_backward`) | 120 | Covers `output_mask=[TT, TF, FT, FF]` |
| Special values / `nan` / `inf` / `-inf` / out-of-bounds | 90 | 2D: 54, 3D: 36 |
| Empty spatial dimensions | 7 | 2D: 3, 3D: 4 |
| Non-contiguous inputs | 30 | 2D: 18, 3D: 12 |
| Functional backward | 30 | 2D: 18, 3D: 12 |
| Identity / large / error-path checks | 11 | identity grid, large 2D cases, 3D bicubic error path |

## Test Coverage Checklist

| Category | Covered Cases |
|----------|---------------|
| Input scale | small (4x16x16) / medium (16x64x64) / large (64x256x256) |
| Input dims | 4-D (2D grid_sample) / 5-D (3D grid_sample) |
| API branches | forward / backward (grad_input + grad_grid) / functional / direct ATen |
| Interpolation modes | bilinear / nearest / bicubic (2D) / trilinear / nearest (3D) |
| Padding modes | zeros / border / reflection |
| align_corners | True / False |
| DTypes | float16 / float32 |
| Special values | nan / inf / -inf / out-of-bounds coordinates |
| Tensor layout | contiguous / non-contiguous (via .permute()) |
| Empty tensors | (N,C,0,0) / (N,C,H,W)->(N,0,0,2) / (N,C,D,0,H,W) etc. |
| Backward output_mask | [T,T] / [T,F] / [F,T] / [F,F] |
| Error paths | 3D + bicubic raises RuntimeError |

## Benchmark

Benchmark command:

```bash
PYTHONPATH=src python -m pytest benchmark/test_special_perf.py -k 'grid_sampler_2d or grid_sampler_3d' -s --level comprehensive --warmup 20 --iter 50 --record log
```

Latest result:

```text
10 passed, 50 deselected
```

Benchmark source:

- Latest numbers below are taken from [`result_benchmark_test_special_perf-k_grid_sampler_2d or grid_sampler_3d-s--level_comprehensive--warmup_20--iter_50--record_log.log`](/home/FlagGems/result_benchmark_test_special_perf-k_grid_sampler_2d%20or%20grid_sampler_3d-s--level_comprehensive--warmup_20--iter_50--record_log.log)
- Benchmark object is the direct ATen entry (`aten.grid_sampler_2d` / `aten.grid_sampler_3d`), not the functional wrapper
- To keep runtime manageable, the benchmark subset covers `align_corners=False` and two padding modes only: `zeros` / `reflection`

Benchmark shapes from `benchmark/test_special_perf.py`:

- 2D: `(2,16,64,64)->(2,48,48,2)`, `(4,32,128,128)->(4,96,96,2)`, `(1,64,256,256)->(1,192,192,2)`, `(1,64,512,512)->(1,384,384,2)`, `(1,64,768,768)->(1,576,576,2)`
- 3D: `(2,8,16,16,16)->(2,12,12,12,3)`, `(1,32,48,48,48)->(1,36,36,36,3)`, `(2,32,128,128,128)->(2,64,64,64,3)`, `(1,16,256,256,256)->(1,128,128,128,3)`

Measured row count:

- 2D: `3 interpolation modes x 2 padding modes x 5 shapes x 2 dtypes = 60`
- 3D: `2 interpolation modes x 2 padding modes x 4 shapes x 2 dtypes = 32`
- Total: `92` measured rows across `10` benchmark tests

Benchmark summary:

- `87 / 92` measured rows achieve `>= 1.0x`
- 2D: `58 / 60` rows achieve `>= 1.0x`, range `0.926x` to `12.737x`
- 3D: `29 / 32` rows achieve `>= 1.0x`, range `0.962x` to `2.187x`
- The `< 1.0x` rows are isolated cases inside this representative benchmark subset, not a full-mode regression:
  - 2D `bilinear + reflection`, fp32, `(1,64,256,256) -> (1,192,192,2)`: `0.926x`
  - 2D `nearest + zeros`, fp16, `(1,64,256,256) -> (1,192,192,2)`: `0.990x`
  - 3D `trilinear + zeros`, fp32, `(1,32,48,48,48) -> (1,36,36,36,3)`: `0.962x`
  - 3D `trilinear + reflection`, fp16, `(1,32,48,48,48) -> (1,36,36,36,3)`: `0.991x`
  - 3D `trilinear + reflection`, fp32, `(1,32,48,48,48) -> (1,36,36,36,3)`: `0.962x`

Representative benchmark data:

| Dimension | DType | Mode / Padding | Shape | PyTorch (ms) | FlagGems (ms) | Speedup | Status |
|-----------|-------|----------------|-------|--------------|---------------|---------|--------|
| 2D | fp16 | bilinear / zeros | `(2,16,64,64) -> (2,48,48,2)` | 0.017408 | 0.017408 | 1.000x | PASS |
| 2D | fp32 | bilinear / zeros | `(1,64,512,512) -> (1,384,384,2)` | 4.940288 | 1.020928 | 4.839x | PASS |
| 2D | fp16 | bicubic / zeros | `(1,64,768,768) -> (1,576,576,2)` | 15.242240 | 6.621232 | 2.302x | PASS |
| 2D | fp16 | bicubic / reflection | `(2,16,64,64) -> (2,48,48,2)` | 0.247808 | 0.019456 | 12.737x | PASS |
| 2D | fp32 | bilinear / reflection | `(1,64,256,256) -> (1,192,192,2)` | 0.192480 | 0.207872 | 0.926x | BELOW 1.0x |
| 3D | fp16 | trilinear / zeros | `(2,32,128,128,128) -> (2,64,64,64,3)` | 17.958400 | 8.747008 | 2.053x | PASS |
| 3D | fp32 | trilinear / zeros | `(1,32,48,48,48) -> (1,36,36,36,3)` | 0.258048 | 0.268288 | 0.962x | BELOW 1.0x |
| 3D | fp32 | nearest / reflection | `(1,16,256,256,256) -> (1,128,128,128,3)` | 13.390848 | 13.172704 | 1.017x | PASS |

## Checklist Alignment

The current staged files satisfy the competition checklist requirements:

- `src/flag_gems/ops/grid_sample.py`: implementation file present and wired
- `src/flag_gems/ops/__init__.py`: import and `__all__` export updated
- `src/flag_gems/__init__.py`: `_FULL_CONFIG` registration updated, and unified `aten::grid_sampler` autograd path registered
- `tests/test_special_ops.py`: correctness coverage includes forward, functional path, direct backward API, non-finite values, empty tensors, and non-contiguous tensors
- `benchmark/test_special_perf.py`: benchmark subset added with representative medium / large / very large shapes

## Notes

- The direct backward API matches PyTorch default overload behavior for all `output_mask` combinations, including returned optional tensors.
- Reflection and border padding explicitly handle non-finite coordinates to match PyTorch instead of relying on undefined arithmetic on `nan` / `inf`.
- Bicubic mode preserves PyTorch-style `nan` behavior in special-value coverage.
- 2D bicubic achieves high speedups (3x-13x) because PyTorch's CUDA bicubic kernel is not well optimized for the 4x4 sampling pattern, while the Triton kernel fuses all interpolation logic efficiently.

## Files Changed

| File | Description |
|------|-------------|
| `src/flag_gems/ops/grid_sample.py` | grid_sample Triton implementation, dispatch, and backward logic (`2765` lines) |
| `src/flag_gems/ops/__init__.py` | export grid_sample operator symbols |
| `src/flag_gems/__init__.py` | register ATen operators in `_FULL_CONFIG` and register autograd for `aten::grid_sampler` |
| `tests/test_special_ops.py` | add and extend `588` `grid_sample/grid_sampler` tests |
| `benchmark/test_special_perf.py` | add `10` benchmark tests |
