### PR TITLE
Fix marks used by the DSA operations

### DIFF
--- a/tests/test_DSA/test_indexer_k_tiled.py
+++ b/tests/test_DSA/test_indexer_k_tiled.py
@@ -152,7 +152,7 @@ def reference_lighting_indexer_implementation(q, kv, weights, ks, ke):
 @pytest.mark.skip(
     "RuntimeError: Cannot call @triton.jit'd outside of the scope of a kernel"
 )
-@pytest.mark.lighting_indexer_forward
+@pytest.mark.triton_lighting_indexer_k_tiled_interface
 @pytest.mark.parametrize("seq_len_q", [1024, 2048, 4096])
 @pytest.mark.parametrize("seq_len_kv", [2048, 4096, 8192])
 @pytest.mark.parametrize("num_heads", [16, 32, 64])
@@ -180,8 +180,3 @@ def test_lighting_indexer_forward(
 
     # Accuracy comparison
     assert_close_inf(your_output, ref_output, 1e-2)
-
-
-if __name__ == "__main__":
-    # Can directly run this file for testing
-    pytest.main([__file__, "-v"])

--- a/tests/test_DSA/test_sparse_mla_ops.py
+++ b/tests/test_DSA/test_sparse_mla_ops.py
@@ -105,7 +105,7 @@ def reference_sparse_mla_implementation(q, kv, indices, sm_scale=None, d_v=512):
     return ref_sparse_mla_fwd_interface(q, kv, indices, sm_scale=sm_scale, d_v=d_v)
 
 
-@pytest.mark.sparse_mla_forward
+@pytest.mark.sparse_mla_fwd_interface
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("seq_len_q", [64, 128, 512])
 @pytest.mark.parametrize("seq_len_kv", [1024, 2048, 4096])
@@ -163,7 +163,7 @@ def test_sparse_mla_forward(
     gems_assert_close(your_output, ref_output, dtype, atol=1e-2)
 
 
-@pytest.mark.sparse_mla_forward_edge_cases
+@pytest.mark.sparse_mla_fwd_interface
 @pytest.mark.parametrize(
     "config",
     [
@@ -225,7 +225,7 @@ def test_sparse_mla_forward_edge_cases(config):
 
 # Device compatibility test
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA device required")
-@pytest.mark.sparse_mla_device
+@pytest.mark.sparse_mla_fwd_interface
 def test_sparse_mla_device_compatibility():
     """Test device compatibility"""
     config = {


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

We use marks (`pytest.mark`) to identify operators/kernels/operations in various manual/auto workflows. We have to get the marks set properly. A mark has to be the target operator/kernel we are replacing, or the name of the fused operation. Marks are not supposed to be used as an identification for a test case.