### PR TITLE
Fix pytest mark for max_pool2d_with_indices

### DIFF
--- a/tests/test_reduction_ops.py
+++ b/tests/test_reduction_ops.py
@@ -1629,7 +1629,7 @@ MAXPOOL2D_CONFIGS = [
 ]
 
 
-@pytest.mark.max_pool2d
+@pytest.mark.max_pool2d_with_indices
 @pytest.mark.parametrize(
     "shape, kernel_size, stride, padding, dilation, ceil_mode", MAXPOOL2D_CONFIGS
 )


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

The target operator and the implementation function are both named `max_pool2d_with_indices`. We are not supposed to mark the test case with `max_pool2d`.
