### PR TITLE
Fix some marks related to `fused_moe`

### DIFF
--- a/tests/test_vllm_ops.py
+++ b/tests/test_vllm_ops.py
@@ -311,7 +311,7 @@ def torch_fused_moe_reference(
     return output
 
 
-@pytest.mark.fused_moe
+@pytest.mark.fused_experts_impl
 @pytest.mark.parametrize("config", FUSED_MOE_CONFIGS)
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 def test_accuracy_fused_moe_vs_ref(config, dtype):
@@ -374,7 +374,7 @@ except ImportError:
     HAS_VLLM_FUSED_MOE = False
 
 
-@pytest.mark.fused_moe
+@pytest.mark.fused_experts_impl
 @pytest.mark.parametrize("config", FUSED_MOE_CONFIGS)
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 @pytest.mark.skipif(not HAS_VLLM_FUSED_MOE, reason="vllm not installed")
@@ -656,7 +656,7 @@ def torch_w8a8_block_fp8_moe(
     ).sum(dim=1)
 
 
-@pytest.mark.fused_moe
+@pytest.mark.fused_experts_impl
 @pytest.mark.parametrize("config", FUSED_MOE_QUANT_CONFIGS)
 @pytest.mark.skipif(
     not is_cuda_available(),
@@ -752,7 +752,7 @@ def test_accuracy_fused_moe_fp8(config):
     torch.testing.assert_close(result, ref, rtol=rtol, atol=atol)
 
 
-@pytest.mark.fused_moe
+@pytest.mark.fused_experts_impl
 @pytest.mark.parametrize("config", FUSED_MOE_FP8_BLOCKWISE_CONFIGS)
 @pytest.mark.parametrize("block_shape", [[128, 128]])
 @pytest.mark.skipif(
@@ -842,7 +842,7 @@ def test_accuracy_fused_moe_fp8_blockwise(config, block_shape):
     torch.testing.assert_close(result, ref, rtol=rtol, atol=atol)
 
 
-@pytest.mark.fused_moe
+@pytest.mark.fused_experts_impl
 @pytest.mark.parametrize("config", FUSED_MOE_QUANT_CONFIGS)
 def test_accuracy_fused_moe_int8(config):
     """Test FlagGems fused_moe with INT8 W8A8 per-channel quantization."""
@@ -954,7 +954,7 @@ def torch_fused_moe_weight_only_reference(
     return output
 
 
-@pytest.mark.fused_moe
+@pytest.mark.fused_experts_impl
 @pytest.mark.parametrize("config", FUSED_MOE_QUANT_CONFIGS)
 def test_accuracy_fused_moe_int8_w8a16(config):
     """Test FlagGems fused_moe with INT8 W8A16 (weight-only) quantization."""
@@ -1029,7 +1029,7 @@ def test_accuracy_fused_moe_int8_w8a16(config):
     torch.testing.assert_close(result, ref, rtol=rtol, atol=atol)
 
 
-@pytest.mark.fused_moe
+@pytest.mark.fused_experts_impl
 @pytest.mark.parametrize("config", FUSED_MOE_QUANT_CONFIGS)
 def test_accuracy_fused_moe_int4_w4a16(config):
     """Test FlagGems fused_moe with INT4 W4A16 (weight-only) quantization."""
@@ -1105,7 +1105,7 @@ def test_accuracy_fused_moe_int4_w4a16(config):
     torch.testing.assert_close(result, ref, rtol=rtol, atol=atol)
 
 
-@pytest.mark.fused_moe
+@pytest.mark.fused_experts_impl
 @pytest.mark.parametrize(
     "config",
     [
@@ -1162,7 +1162,7 @@ def test_fused_moe_inplace(config, dtype):
     torch.testing.assert_close(result, ref, rtol=1e-3, atol=1e-3)
 
 
-@pytest.mark.fused_moe
+@pytest.mark.fused_experts_impl
 @pytest.mark.parametrize(
     "config",
     [


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

This PR fixes the marks used in some unit (accuracy) tests. The `fused_moe` is an concept rather than a kernel/operator/function. We are using marks for identify operators or functions, including fused ones.

In the foreseeable future, we may anticipate more and more operators in this camp. It is better to make sure that we are properly claiming the identity of an operator/function.
