### PR TITLE
Fix the registration of the new_full operator

### DIFF
--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -307,7 +307,7 @@ _FULL_CONFIG = (
     ("ne.Tensor", ne),
     ("neg", neg),
     ("neg_", neg_),
-    ("new_full", new_full),
+    ("new_full.Tensor", new_full),
     ("nll_loss_backward", nll_loss_backward),
     ("nll_loss_forward", nll_loss_forward),
     ("nll_loss_nd_forward", nll_loss_nd_forward),


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

The `new_full` operation is defined on a Tensor.
When registering such an operation, we use a `.Tensor` suffix.
