### PR TITLE
[Cambricon] Make allow_override backward-compatible

### DIFF
--- a/src/flag_gems/runtime/register.py
+++ b/src/flag_gems/runtime/register.py
@@ -123,7 +123,11 @@ class Register:
                 )
             except Exception:
                 pass
-            self.lib.impl(key, fn, device_key, allow_override=True)
+            try:
+                self.lib.impl(key, fn, device_key, allow_override=True)
+            except TypeError:
+                # Older torch versions don't support allow_override
+                self.lib.impl(key, fn, device_key)
         else:
             self.lib.impl(key, fn, device_key)
 


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator 
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Fix TypeError on older torch_mlu versions that don't support the `allow_override` kwarg for `Library.impl()`. Catch the TypeError and retry without it so Cambricon operators register successfully on both old and new torch_mlu.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
