### PR TITLE
Add coverage package to dependency for test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,6 +119,7 @@ tsingmicro = [
 # Test packages
 test = [
     "distro==1.9.0",
+    "coverage==7.13.5",
     "openpyxl==3.1.5",
     "pytest==9.0.2",
     "scipy>=1.15.3",


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

We need `coverage` for running tests on all platforms, while it is not always installed.
