### PR TITLE
Fix moore threads setup script

### DIFF
--- a/tools/setup_mthreads.sh
+++ b/tools/setup_mthreads.sh
@@ -7,6 +7,8 @@ uv pip install --index $FLAGOS_PYPI \
    "flagtree==0.5.0+mthreads3.1"
 
 uv pip install -e .[mthreads,test]
+uv pip install --index $FLAGOS_PYPI \
+   "torch_musa==2.7.1"
 
 export MUSA_HOME=/usr/local/musa
 export PATH=$MUSA_HOME/bin:$PATH


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

This is NOT A BUG FIX.
It is weird that `uv` would uninstall `torch_musa` when installing `[mthreads]` group.
It is crazy.
