### PR TITLE
Skip testing of pad function

### DIFF
--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -836,6 +836,7 @@ def test_accuracy_multinomial_without_replacement(pool, dtype):
 
 
 @pytest.mark.pad
+@pytest.mark.skip("The operator now has infinite recurrsion calls: #2493")
 @pytest.mark.parametrize(
     "shape",
     [[1024, 1024], [64, 64, 64, 64], [1, 64, 112, 112], [4, 64, 128]],


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Other

### Description

See #2493.

This PR temporarily skip the testing of the `pad` operator.
