### PR TITLE
Fix pytest mark for quantile

### DIFF
--- a/src/flag_gems/ops/quantile.py
+++ b/src/flag_gems/ops/quantile.py
@@ -152,7 +152,7 @@ def quantile_bitonic_kernel(
 def quantile(
     inp, q, dim=None, keepdim=False, interpolation="linear", out=None
 ) -> Tensor:
-    logger.debug("GEMS QUANTILE DIM")
+    logger.debug("GEMS QUANTILE")
     assert torch.is_floating_point(inp)
     assert dim is None or isinstance(dim, int)
     assert isinstance(q, (float, torch.Tensor))


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

The test case for `quantile` is logging an incorrect op name.
