### PR TITLE
Stop using aliyun mirror

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -215,9 +215,9 @@ url = "https://download.pytorch.org/whl/cu118"
 explicit = true
 
 # Source for common packages
-[[tool.uv.index]]
-name = "default"
-url = "https://mirrors.aliyun.com/pypi/simple/"
+# [[tool.uv.index]]
+# name = "default"
+# url = "https://mirrors.aliyun.com/pypi/simple/"
 
 [tool.uv.sources]
 # Mapping from optional groups to index servers


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

Since the actions-runners are configured with international proxy, we should not use aliyun.com mirror for common packages.
