### PR TITLE
[MTHREADS] update 3 ops for mthreads backend

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/gather.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/gather.py
@@ -12,7 +12,7 @@ from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry
 
 logger = logging.getLogger(
-    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+    f"flag_gems.runtime.backend._mthreads.ops.{__name__.split('.')[-1]}"
 )
 
 _SUPPORTED_DTYPES = {torch.float16, torch.bfloat16, torch.float32}
@@ -123,6 +123,11 @@ def _launch_triton(
 
 def gather(inp, dim, index, out=None, sparse_grad=False):
     logger.debug("GEMS_MTHREADS GATHER")
+    if inp.ndim != index.ndim:
+        raise IndexError(
+            f"self and index must have the same number of dimensions, "
+            f"got self.ndim = {inp.ndim} and index.ndim = {index.ndim}"
+        )
     if not _use_triton_kernel(inp, dim, index, out):
         return default_gather(inp, dim, index, out, sparse_grad)
 

--- a/src/flag_gems/runtime/backend/_mthreads/ops/repeat_interleave.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/repeat_interleave.py
@@ -15,6 +15,14 @@ logger = logging.getLogger(
     f"flag_gems.runtime.backend._mthreads.ops.{__name__.split('.')[-1]}"
 )
 
+# repeat_interleave.self_{int,Tensor} are CompositeImplicitAutograd;
+# Direct coverage will cause the gradient to break;
+# Redispatch to this keyset to run the decomposed forward (and backward)
+# when gradients may be needed.
+_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeImplicitAutograd
+)
+
 
 @pointwise_dynamic(num_inputs=1, promotion_methods=[(0, "DEFAULT")])
 @triton.jit
@@ -24,6 +32,10 @@ def copy_func(x):
 
 def repeat_interleave_self_int(inp, repeats, dim=None, *, output_size=None):
     logger.debug("GEMS_MTHREADS REPEAT_INTERLEAVE_SELF_INT")
+    if torch.is_grad_enabled():
+        return torch.ops.aten.repeat_interleave.self_int.redispatch(
+            _FALLBACK_KEYSET, inp, repeats, dim, output_size=output_size
+        )
     if dim is None:
         inp = inp.flatten()
         dim = 0
@@ -436,6 +448,10 @@ def fused_repeat_interleave_dim0(inp, repeats, dim):
 
 def repeat_interleave_self_tensor(inp, repeats, dim=None, *, output_size=None):
     logger.debug("GEMS_MTHREADS REPEAT_INTERLEAVE_SELF_TENSOR")
+    if torch.is_grad_enabled():
+        return torch.ops.aten.repeat_interleave.self_Tensor.redispatch(
+            _FALLBACK_KEYSET, inp, repeats, dim, output_size=output_size
+        )
 
     if repeats.numel() == 0:
         return inp.clone()

--- a/src/flag_gems/runtime/backend/_mthreads/ops/tile.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/tile.py
@@ -10,6 +10,10 @@ from flag_gems.utils.libentry import libentry
 
 logger = logging.getLogger(__name__)
 
+_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeImplicitAutograd
+)
+
 
 @libentry()
 @triton.autotune(
@@ -347,6 +351,8 @@ def tile_kernel_nd_flat(
 
 def tile(inp: torch.Tensor, dims) -> torch.Tensor:
     logger.debug("GEMS TILE")
+    if torch.is_grad_enabled():
+        return torch.ops.aten.tile.default.redispatch(_FALLBACK_KEYSET, inp, dims)
 
     in0_rank = inp.dim()
     dims_rank = len(dims)


### PR DESCRIPTION
Custom operators adapted:
- gather: Add dimension check (inp.ndim != index.ndim)
- repeat_interleave: Add gradient check and redispatch for CompositeImplicitAutograd
- tile: Add gradient check and redispatch for CompositeImplicitAutograd
