### PR TITLE
[MTHREADS] Refactor ops for multi-backend compatibility and fix index_put again

### DIFF
--- a/src/flag_gems/fused/fused_moe.py
+++ b/src/flag_gems/fused/fused_moe.py
@@ -26,6 +26,8 @@ import yaml
 
 from flag_gems.fused.moe_align_block_size import moe_align_block_size
 from flag_gems.fused.moe_sum import moe_sum
+from flag_gems.runtime import torch_device_fn
+from flag_gems.runtime.backend import vendor_module
 from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
@@ -123,12 +125,15 @@ def dequant_mxfp6(
 
 @functools.lru_cache(maxsize=1)
 def _get_device_name() -> str:
-    """Return the normalised CUDA device name (spaces replaced by underscores).
+    """Return the normalised device name (spaces replaced by underscores).
 
     Matches the naming convention used by vLLM for its per-device config files.
     H800 falls back to H100_80GB_HBM3 (same SM 9.0 architecture).
     """
-    name = torch.cuda.get_device_name().replace(" ", "_")
+    try:
+        name = torch_device_fn.get_device_name().replace(" ", "_")
+    except AttributeError:
+        name = vendor_module.vendor_info.device_name
     # Normalise the H200 product family to a single key, following vLLM.
     if "H200" in name.split("_"):
         name = "NVIDIA_H200"

--- a/src/flag_gems/ops/upsample_linear1d.py
+++ b/src/flag_gems/ops/upsample_linear1d.py
@@ -5,6 +5,8 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
+
 logger = logging.getLogger(__name__)
 
 
@@ -61,7 +63,7 @@ def upsample_linear1d(
 ):
     logger.debug("GEMS UPSAMPLE LINEAR1D OPTIMIZED")
     assert self.ndim == 3, "Input must be [N, C, W]"
-    assert self.is_cuda
+    assert self.device.type == flag_gems.device
 
     N, C, W_in = self.shape
     NC = N * C

--- a/src/flag_gems/runtime/backend/_mthreads/ops/index_put.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/index_put.py
@@ -9,7 +9,7 @@ from flag_gems.utils.code_cache import code_cache_dir
 from flag_gems.utils.code_utils import IndentedBuffer, write_atomic
 
 logger = logging.getLogger(
-    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+    f"flag_gems.runtime.backend._mthreads.ops.{__name__.split('.')[-1]}"
 )
 
 
@@ -296,6 +296,9 @@ def index_put(inp, indices, values, accumulate=False):
         elif values.numel() == K:
             values = values.reshape((K,)).expand(target_shape)
 
+    if not indices:
+        raise ValueError("At least one index tensor is required")
+
     indices = [
         index.to(inp.device)
         if index is not None and index.device != inp.device
@@ -303,21 +306,75 @@ def index_put(inp, indices, values, accumulate=False):
         for index in indices
     ]
 
-    target_shape = get_max_rank_shape(indices)
-    broadcast_indices(indices, target_shape)
-    target_shape += inp.shape[len(indices) :]
-    # Filter out None values for kernel call (only tensor indices)
-    # Must be done AFTER broadcast_indices, as broadcast may create new tensors
-    tensor_indices = [idx for idx in indices if idx is not None]
-    if not tensor_indices:
+    processed_indices = []
+    for idx in indices:
+        if idx is None:
+            processed_indices.append(None)
+        elif idx.dtype in (torch.bool, torch.int8):
+            processed_indices.extend(idx.nonzero(as_tuple=True))
+        elif torch.is_tensor(idx):
+            processed_indices.append(idx)
+        else:
+            raise TypeError(
+                "tensors used as indices must be long, int, byte or bool tensors"
+            )
+
+    indices = processed_indices
+
+    if len(indices) < inp.ndim:
+        indices.extend([None] * (inp.ndim - len(indices)))
+
+    if len(indices) > inp.ndim:
+        raise IndexError("too many indices for tensor of dimension {}".format(inp.ndim))
+
+    tensor_pos = [i for i, x in enumerate(indices) if x is not None]
+    if not tensor_pos:
         raise ValueError("At least one non-None index tensor is required")
 
-    if values.device != inp.device:
-        values = values.to(inp.device)
-    values = torch.broadcast_to(values, target_shape)
+    tensor_indices = [indices[i] for i in tensor_pos]
+    if len(tensor_indices) > 1:
+        broadcasted = torch.broadcast_tensors(*tensor_indices)
+        for i, pos in enumerate(tensor_pos):
+            indices[pos] = broadcasted[i]
+
+    is_contiguous = (tensor_pos[-1] - tensor_pos[0] + 1) == len(tensor_pos)
+    starts_with_none = indices[0] is None
+    need_transpose = not is_contiguous or starts_with_none
 
     out = inp.clone()
-    _index_put_func(out, tensor_indices, values, accumulate)
+    if need_transpose:
+        perm_order = tensor_pos + [i for i, x in enumerate(indices) if x is None]
+        inp_view = out.permute(perm_order)
+        final_indices = [indices[i] for i in tensor_pos] + [None] * (
+            len(indices) - len(tensor_pos)
+        )
+    else:
+        inp_view = out
+        final_indices = indices
+
+    tensors = [x for x in final_indices if x is not None]
+    broadcast_shape = list(tensors[0].shape)
+    slice_shape = [inp_view.shape[i] for i, x in enumerate(final_indices) if x is None]
+
+    target_shape = broadcast_shape + slice_shape
+    values = values.to(inp.device)
+    if need_transpose and is_contiguous:
+        num_before = tensor_pos[0]
+
+        before_dims = slice_shape[:num_before]
+        after_dims = slice_shape[num_before:]
+        natural_shape = before_dims + broadcast_shape + after_dims
+        values = values.broadcast_to(natural_shape)
+
+        B, T = len(before_dims), len(broadcast_shape)
+        val_perm = (
+            list(range(B, B + T)) + list(range(0, B)) + list(range(B + T, values.ndim))
+        )
+        values = values.permute(val_perm)
+    else:
+        values = values.broadcast_to(target_shape)
+
+    _index_put_func(inp_view, tensors, values, accumulate)
     return out
 
 
@@ -343,6 +400,9 @@ def index_put_(inp, indices, values, accumulate=False):
         elif values.numel() == K:
             values = values.reshape((K,)).expand(target_shape)
 
+    if not indices:
+        raise ValueError("At least one index tensor is required")
+
     indices = [
         index.to(inp.device)
         if index is not None and index.device != inp.device
@@ -350,27 +410,72 @@ def index_put_(inp, indices, values, accumulate=False):
         for index in indices
     ]
 
-    target_shape = get_max_rank_shape(indices)
-    broadcast_indices(indices, target_shape)
-    target_shape += inp.shape[len(indices) :]
-    # Filter out None values for kernel call (only tensor indices)
-    # Must be done AFTER broadcast_indices, as broadcast may create new tensors
-    tensor_indices = [idx for idx in indices if idx is not None]
-    if not tensor_indices:
+    processed_indices = []
+    for idx in indices:
+        if idx is None:
+            processed_indices.append(None)
+        elif idx.dtype in (torch.bool, torch.int8):
+            processed_indices.extend(idx.nonzero(as_tuple=True))
+        elif torch.is_tensor(idx):
+            processed_indices.append(idx)
+        else:
+            raise TypeError(
+                "tensors used as indices must be long, int, byte or bool tensors"
+            )
+
+    indices = processed_indices
+
+    if len(indices) < inp.ndim:
+        indices.extend([None] * (inp.ndim - len(indices)))
+
+    if len(indices) > inp.ndim:
+        raise IndexError("too many indices for tensor of dimension {}".format(inp.ndim))
+
+    tensor_pos = [i for i, x in enumerate(indices) if x is not None]
+    if not tensor_pos:
         raise ValueError("At least one non-None index tensor is required")
 
-    if values.device != inp.device:
-        values = values.to(inp.device)
-    try:
-        values = torch.broadcast_to(values, target_shape)
-    except Exception:
-        return torch.ops.aten.index_put_.default.redispatch(
-            torch._C.DispatchKeySet(torch._C.DispatchKey.CompositeExplicitAutograd),
-            inp,
-            tensor_indices,
-            values,
-            accumulate,
-        )
+    tensor_indices = [indices[i] for i in tensor_pos]
+    if len(tensor_indices) > 1:
+        broadcasted = torch.broadcast_tensors(*tensor_indices)
+        for i, pos in enumerate(tensor_pos):
+            indices[pos] = broadcasted[i]
 
-    _index_put_func(inp, tensor_indices, values, accumulate)
+    is_contiguous = (tensor_pos[-1] - tensor_pos[0] + 1) == len(tensor_pos)
+    starts_with_none = indices[0] is None
+    need_transpose = not is_contiguous or starts_with_none
+
+    if need_transpose:
+        perm_order = tensor_pos + [i for i, x in enumerate(indices) if x is None]
+        inp_view = inp.permute(perm_order)
+        final_indices = [indices[i] for i in tensor_pos] + [None] * (
+            len(indices) - len(tensor_pos)
+        )
+    else:
+        inp_view = inp
+        final_indices = indices
+
+    tensors = [x for x in final_indices if x is not None]
+    broadcast_shape = list(tensors[0].shape)
+    slice_shape = [inp_view.shape[i] for i, x in enumerate(final_indices) if x is None]
+
+    target_shape = broadcast_shape + slice_shape
+    values = values.to(inp.device)
+    if need_transpose and is_contiguous:
+        num_before = tensor_pos[0]
+
+        before_dims = slice_shape[:num_before]
+        after_dims = slice_shape[num_before:]
+        natural_shape = before_dims + broadcast_shape + after_dims
+        values = values.broadcast_to(natural_shape)
+
+        B, T = len(before_dims), len(broadcast_shape)
+        val_perm = (
+            list(range(B, B + T)) + list(range(0, B)) + list(range(B + T, values.ndim))
+        )
+        values = values.permute(val_perm)
+    else:
+        values = values.broadcast_to(target_shape)
+
+    _index_put_func(inp_view, tensors, values, accumulate)
     return inp


### PR DESCRIPTION
- fused_moe.py: Replace torch.cuda.get_device_name with backend-agnostic
  torch_device_fn.get_device_name() and add fallback to vendor_info
- upsample_linear1d.py: Replace CUDA-only assertion with device-agnostic
  check using flag_gems.device
- index_put.py (mthreads): Add support for None indices and bool/int8
  index tensors, implement transpose for non-contiguous index positions