### PR TITLE
Revert "all operators of the CompositeImplicitAutograd type will fallback to the native implementation."

### DIFF
--- a/src/flag_gems/ops/conv1d.py
+++ b/src/flag_gems/ops/conv1d.py
@@ -1,41 +1,13 @@
 import logging
 import math
 
-import torch
-
 from flag_gems.ops.conv2d import conv2d
 
 logger = logging.getLogger(__name__)
 
-_FALLBACK_KEYSET = torch._C.DispatchKeySet(
-    torch._C.DispatchKey.CompositeImplicitAutograd
-)
-
 
 def conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
     logger.debug("GEMS CONV1D")
-    if torch.is_grad_enabled():
-        if isinstance(padding, str):
-            return torch.ops.aten.conv1d.padding.redispatch(
-                _FALLBACK_KEYSET,
-                input,
-                weight,
-                bias,
-                stride,
-                padding,
-                dilation,
-                groups,
-            )
-        return torch.ops.aten.conv1d.default.redispatch(
-            _FALLBACK_KEYSET,
-            input,
-            weight,
-            bias,
-            stride,
-            padding,
-            dilation,
-            groups,
-        )
     if isinstance(stride, (list, tuple)):
         stride_width = stride[0]
     else:

--- a/src/flag_gems/ops/conv2d.py
+++ b/src/flag_gems/ops/conv2d.py
@@ -10,10 +10,6 @@ from flag_gems.utils import libentry
 
 logger = logging.getLogger(__name__)
 
-_FALLBACK_KEYSET = torch._C.DispatchKeySet(
-    torch._C.DispatchKey.CompositeImplicitAutograd
-)
-
 
 def conv2d_output_size(
     in_size: int,
@@ -596,28 +592,6 @@ class Conv2d(torch.autograd.Function):
 
 # todo test SymInt[2] of stride or padding
 def conv2d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
-    if torch.is_grad_enabled():
-        if isinstance(padding, str):
-            return torch.ops.aten.conv2d.padding.redispatch(
-                _FALLBACK_KEYSET,
-                input,
-                weight,
-                bias,
-                stride,
-                padding,
-                dilation,
-                groups,
-            )
-        return torch.ops.aten.conv2d.default.redispatch(
-            _FALLBACK_KEYSET,
-            input,
-            weight,
-            bias,
-            stride,
-            padding,
-            dilation,
-            groups,
-        )
     if isinstance(padding, str):
         if padding == "same":
             assert (

--- a/src/flag_gems/ops/conv3d.py
+++ b/src/flag_gems/ops/conv3d.py
@@ -11,10 +11,6 @@ from flag_gems.utils import libentry
 
 logger = logging.getLogger(__name__)
 
-_FALLBACK_KEYSET = torch._C.DispatchKeySet(
-    torch._C.DispatchKey.CompositeImplicitAutograd
-)
-
 
 def conv3d_output_size(
     in_size: int,
@@ -226,28 +222,6 @@ def conv3d_forward_kernel(
 
 def conv3d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
     logger.debug("GEMS CONV3D")
-    if torch.is_grad_enabled():
-        if isinstance(padding, str):
-            return torch.ops.aten.conv3d.padding.redispatch(
-                _FALLBACK_KEYSET,
-                input,
-                weight,
-                bias,
-                stride,
-                padding,
-                dilation,
-                groups,
-            )
-        return torch.ops.aten.conv3d.default.redispatch(
-            _FALLBACK_KEYSET,
-            input,
-            weight,
-            bias,
-            stride,
-            padding,
-            dilation,
-            groups,
-        )
     assert weight.ndim == 5, "Weights must be 5D, received shape {weight.shape}"
     assert (
         bias is None or bias.ndim == 1

--- a/src/flag_gems/ops/embedding.py
+++ b/src/flag_gems/ops/embedding.py
@@ -10,10 +10,6 @@ from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 
-_FALLBACK_KEYSET = torch._C.DispatchKeySet(
-    torch._C.DispatchKey.CompositeImplicitAutograd
-)
-
 
 @libentry()
 @triton.jit
@@ -142,16 +138,6 @@ def embedding_backward(
     sparse=False,
 ):
     logger.debug("GEMS EMBEDDING BACKWARD")
-    if torch.is_grad_enabled():
-        return torch.ops.aten.embedding_backward.default.redispatch(
-            _FALLBACK_KEYSET,
-            grad_outputs,
-            indices,
-            num_weights,
-            padding_idx,
-            scale_grad_by_freq,
-            sparse,
-        )
     assert not sparse, "Currently do not support sparse format"
 
     M = indices.numel()

--- a/src/flag_gems/ops/pad.py
+++ b/src/flag_gems/ops/pad.py
@@ -10,10 +10,6 @@ from flag_gems.utils.code_utils import IndentedBuffer, write_atomic
 
 logger = logging.getLogger(__name__)
 
-_FALLBACK_KEYSET = torch._C.DispatchKeySet(
-    torch._C.DispatchKey.CompositeImplicitAutograd
-)
-
 
 # --------------------------- padding wrapper genration -----------------------------------
 def parameter_for_wrapper() -> str:
@@ -458,10 +454,6 @@ _pad_func = PadFunction()
 
 def pad(self, pad, mode="constant", value=None):
     logger.debug("GEMS CONSTANT PAD ND")
-    if torch.is_grad_enabled():
-        return torch.ops.aten.pad.default.redispatch(
-            _FALLBACK_KEYSET, self, pad, mode, value=value
-        )
 
     ndim = self.ndim
 

--- a/src/flag_gems/ops/repeat_interleave.py
+++ b/src/flag_gems/ops/repeat_interleave.py
@@ -11,14 +11,6 @@ from flag_gems.utils.tensor_wrapper import StridedBuffer
 
 logger = logging.getLogger(__name__)
 
-# repeat_interleave.self_{int,Tensor} are CompositeImplicitAutograd;
-# Direct coverage will cause the gradient to break;
-# Redispatch to this keyset to run the decomposed forward (and backward)
-# when gradients may be needed.
-_FALLBACK_KEYSET = torch._C.DispatchKeySet(
-    torch._C.DispatchKey.CompositeImplicitAutograd
-)
-
 
 @pointwise_dynamic(num_inputs=1, promotion_methods=[(0, "DEFAULT")])
 @triton.jit
@@ -28,10 +20,6 @@ def copy_func(x):
 
 def repeat_interleave_self_int(inp, repeats, dim=None, *, output_size=None):
     logger.debug("GEMS REPEAT_INTERLEAVE_SELF_INT")
-    if torch.is_grad_enabled():
-        return torch.ops.aten.repeat_interleave.self_int.redispatch(
-            _FALLBACK_KEYSET, inp, repeats, dim, output_size=output_size
-        )
     if dim is None:
         inp = inp.flatten()
         dim = 0
@@ -121,10 +109,6 @@ def repeat_interleave_tensor(repeats, *, output_size=None):
 
 def repeat_interleave_self_tensor(inp, repeats, dim=None, *, output_size=None):
     logger.debug("GEMS REPEAT_INTERLEAVE_SELF_TENSOR")
-    if torch.is_grad_enabled():
-        return torch.ops.aten.repeat_interleave.self_Tensor.redispatch(
-            _FALLBACK_KEYSET, inp, repeats, dim, output_size=output_size
-        )
 
     if repeats.numel() == 0:
         return inp.clone()

--- a/src/flag_gems/ops/rms_norm.py
+++ b/src/flag_gems/ops/rms_norm.py
@@ -12,10 +12,6 @@ from flag_gems.utils import triton_lang_extension as tle
 
 logger = logging.getLogger(__name__)
 
-_FALLBACK_KEYSET = torch._C.DispatchKeySet(
-    torch._C.DispatchKey.CompositeImplicitAutograd
-)
-
 
 @triton.jit
 def prev_multiple_of(a, b):
@@ -328,8 +324,4 @@ class RmsNorm(torch.autograd.Function):
 
 
 def rms_norm(x, normalized_shape, weight, eps=1e-5):
-    if torch.is_grad_enabled():
-        return torch.ops.aten.rms_norm.default.redispatch(
-            _FALLBACK_KEYSET, x, normalized_shape, weight, eps
-        )
     return RmsNorm.apply(x, normalized_shape, weight, eps)

--- a/src/flag_gems/ops/silu.py
+++ b/src/flag_gems/ops/silu.py
@@ -1,6 +1,5 @@
 import logging
 
-import torch
 import triton
 import triton.language as tl
 
@@ -8,10 +7,6 @@ from flag_gems.utils import pointwise_dynamic
 from flag_gems.utils.triton_lang_extension import div_rn
 
 logger = logging.getLogger(__name__)
-
-_FALLBACK_KEYSET = torch._C.DispatchKeySet(
-    torch._C.DispatchKey.CompositeImplicitAutograd
-)
 
 
 @pointwise_dynamic(promotion_methods=[(0, "DEFAULT")])
@@ -40,10 +35,6 @@ def silu(self):
 
 def silu_backward(grad_output, self):
     logger.debug("GEMS SILU BACKWARD")
-    if torch.is_grad_enabled():
-        return torch.ops.aten.silu_backward.default.redispatch(
-            _FALLBACK_KEYSET, grad_output, self
-        )
     grad_input = silu_backward_kernel(self, grad_output)
     return grad_input
 

--- a/src/flag_gems/ops/tile.py
+++ b/src/flag_gems/ops/tile.py
@@ -10,10 +10,6 @@ from flag_gems.utils.code_utils import IndentedBuffer, write_atomic
 
 logger = logging.getLogger(__name__)
 
-_FALLBACK_KEYSET = torch._C.DispatchKeySet(
-    torch._C.DispatchKey.CompositeImplicitAutograd
-)
-
 
 # --------------------------- tile wrapper genration -----------------------------------
 def parameter_for_wrapper() -> str:
@@ -442,8 +438,6 @@ _tile_func = TileFunction()
 
 def tile(inp: torch.Tensor, dims) -> torch.Tensor:
     logger.debug("GEMS TILE")
-    if torch.is_grad_enabled():
-        return torch.ops.aten.tile.default.redispatch(_FALLBACK_KEYSET, inp, dims)
 
     out = _tile_func(inp, dims)
     return out


### PR DESCRIPTION
Reverts flagos-ai/FlagGems#2395

This PR was causing regression in the CI gate. The conv1d, conv2d, conv3d operators are all broken.
