### PR TITLE
[MTHREADS] Fix device type checks for non-CUDA backends

### DIFF
--- a/src/flag_gems/fused/moe_align_block_size.py
+++ b/src/flag_gems/fused/moe_align_block_size.py
@@ -6,6 +6,7 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
 from flag_gems.utils import libentry, libtuner
 
 
@@ -541,7 +542,11 @@ def moe_align_block_size_triton(
     block_size_expert = triton.next_power_of_2(ceil_div(numel_expert_ids, num_experts))
     block_expert_tle = triton.next_power_of_2(num_experts)
 
-    if HAS_TLE and topk_ids.is_cuda and block_expert_tle <= 1024:
+    if (
+        HAS_TLE
+        and (topk_ids.device.type == flag_gems.device)
+        and block_expert_tle <= 1024
+    ):
         block_tokens_taf, _ = _pick_tle_atomic_fused_launch_params(numel, num_experts)
         experts_per_shard = ceil_div(num_experts, TLE_CLUSTER_SIZE)
         num_tokens = topk_ids.shape[0] if topk_ids.ndim > 1 else numel

--- a/src/flag_gems/ops/_safe_softmax.py
+++ b/src/flag_gems/ops/_safe_softmax.py
@@ -5,6 +5,8 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
+
 logger = logging.getLogger(__name__)
 
 
@@ -35,7 +37,8 @@ def _safe_softmax_kernel(
 
 def _safe_softmax(x: torch.Tensor, dim: int = -1, dtype: torch.dtype = None):
     logger.debug("GEMS _SAFE_SOFTMAX")
-    assert x.is_cuda, "Input tensor must be on CUDA device"
+    if x.device.type != flag_gems.device:
+        raise ValueError(f"Input tensor must be on {flag_gems.device} device")
     assert x.ndim >= 1, "Input tensor must have at least 1 dimension"
 
     dim = dim if dim >= 0 else x.ndim + dim

--- a/src/flag_gems/ops/_upsample_nearest_exact1d.py
+++ b/src/flag_gems/ops/_upsample_nearest_exact1d.py
@@ -6,6 +6,8 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
+
 logger = logging.getLogger(__name__)
 
 
@@ -96,8 +98,7 @@ def _launch_upsample_nearest_exact1d_kernel(input, out, output_size=None, scale=
         raise ValueError(
             f"_upsample_nearest_exact1d expects a 3D tensor (N, C, W); got shape {tuple(input.shape)}"
         )
-    if not input.is_cuda or not out.is_cuda:
-        # Fallback to the native operator on CPU or non-CUDA devices
+    if input.device.type != flag_gems.device or out.device.type != flag_gems.device:
         return torch.ops.aten._upsample_nearest_exact1d(
             input, [out.shape[-1]], [scale] if scale is not None else None
         )

--- a/src/flag_gems/ops/arcsinh.py
+++ b/src/flag_gems/ops/arcsinh.py
@@ -5,6 +5,8 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
+
 logger = logging.getLogger(__name__)
 
 
@@ -30,8 +32,8 @@ def arcsinh_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
 def _ensure_cuda_tensor(t):
     if not isinstance(t, torch.Tensor):
         raise TypeError("Expected a torch.Tensor")
-    if not t.is_cuda:
-        raise ValueError("Input tensors must be on CUDA device")
+    if t.device.type != flag_gems.device:
+        raise ValueError(f"Input tensors must be on {flag_gems.device} device")
     if t.is_complex():
         raise NotImplementedError(
             "Complex dtypes are not supported by this Triton kernel"

--- a/src/flag_gems/ops/embedding_dense_backward.py
+++ b/src/flag_gems/ops/embedding_dense_backward.py
@@ -4,6 +4,8 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
+
 logger = logging.getLogger(__name__)
 
 
@@ -96,9 +98,14 @@ def embedding_dense_backward(
         torch.int32,
         torch.int64,
     ), "Indices must be int32 or int64."
-    assert (
-        grad_output.is_cuda and indices.is_cuda and grad_output.device == indices.device
-    ), "Inputs must be CUDA tensors on the same device."
+    if (
+        grad_output.device.type != flag_gems.device
+        or indices.device.type != flag_gems.device
+        or grad_output.device != indices.device
+    ):
+        raise ValueError(
+            f"Inputs must be {flag_gems.device} tensors on the same device."
+        )
 
     device = grad_output.device
     assert (

--- a/src/flag_gems/ops/i0.py
+++ b/src/flag_gems/ops/i0.py
@@ -5,6 +5,8 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
+
 logger = logging.getLogger(__name__)
 
 
@@ -64,7 +66,8 @@ def i0_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
 
 
 def _launch_i0(out: torch.Tensor, x: torch.Tensor):
-    assert x.is_cuda and out.is_cuda, "Input and output must be CUDA tensors"
+    if x.device.type != flag_gems.device or out.device.type != flag_gems.device:
+        raise ValueError(f"Input and output must be {flag_gems.device} tensors")
     assert (
         out.numel() == x.numel()
     ), "Input and output must have the same number of elements"
@@ -99,8 +102,8 @@ def _launch_i0(out: torch.Tensor, x: torch.Tensor):
 
 def i0(x: torch.Tensor):
     logger.debug("GEMS I0")
-    if not x.is_cuda:
-        raise ValueError("i0: input tensor must be on CUDA device")
+    if x.device.type != flag_gems.device:
+        raise ValueError(f"i0: input tensor must be on {flag_gems.device} device")
     # Result dtype follows PyTorch's floating type behavior
     out_dtype = x.dtype if x.is_floating_point() else torch.get_default_dtype()
     out = torch.empty_like(x.to(dtype=out_dtype), dtype=out_dtype, device=x.device)
@@ -110,8 +113,10 @@ def i0(x: torch.Tensor):
 
 def i0_out(x: torch.Tensor, out: torch.Tensor):
     logger.debug("GEMS I0_OUT")
-    if not (x.is_cuda and out.is_cuda):
-        raise ValueError("i0_out: input and output tensors must be on CUDA device")
+    if x.device.type != flag_gems.device or out.device.type != flag_gems.device:
+        raise ValueError(
+            f"i0_out: input and output tensors must be on {flag_gems.device} device"
+        )
     if not out.is_floating_point():
         raise TypeError("i0_out: output tensor must be a floating point type")
     if x.numel() != out.numel():

--- a/src/flag_gems/ops/i0_.py
+++ b/src/flag_gems/ops/i0_.py
@@ -5,6 +5,8 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
+
 logger = logging.getLogger(__name__)
 
 
@@ -80,8 +82,8 @@ def i0_(*args, **kwargs):
             "i0_ expects a tensor as the first positional argument or in keyword 'input'/'self'/'x'."
         )
 
-    if not x.is_cuda:
-        raise AssertionError("Input tensor must be on a CUDA device.")
+    if x.device.type != flag_gems.device:
+        raise AssertionError(f"Input tensor must be on a {flag_gems.device} device.")
     if not x.is_contiguous():
         raise AssertionError("Input tensor must be contiguous.")
     if x.dtype not in (torch.float16, torch.bfloat16, torch.float32, torch.float64):

--- a/src/flag_gems/ops/lift_fresh_copy.py
+++ b/src/flag_gems/ops/lift_fresh_copy.py
@@ -5,6 +5,8 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
+
 logger = logging.getLogger(__name__)
 
 
@@ -34,8 +36,10 @@ def lift_fresh_copy(*args, **kwargs):
     if x is None:
         raise ValueError("lift_fresh_copy expects a Tensor argument")
 
-    if not x.is_cuda:
-        raise ValueError("lift_fresh_copy Triton kernel requires a CUDA tensor")
+    if x.device.type != flag_gems.device:
+        raise ValueError(
+            f"lift_fresh_copy Triton kernel requires a {flag_gems.device} tensor"
+        )
 
     x_contig = x.contiguous()
     out = torch.empty_like(x_contig, memory_format=torch.contiguous_format)
@@ -51,16 +55,18 @@ def lift_fresh_copy_out(x: torch.Tensor, out: torch.Tensor = None):
     logger.debug("GEMS LIFT_FRESH_COPY_OUT")
     if x is None or not isinstance(x, torch.Tensor):
         raise ValueError("lift_fresh_copy_out expects 'x' to be a Tensor")
-    if not x.is_cuda:
-        raise ValueError("lift_fresh_copy_out Triton kernel requires CUDA tensors")
+    if x.device.type != flag_gems.device:
+        raise ValueError(
+            f"lift_fresh_copy_out Triton kernel requires {flag_gems.device} tensors"
+        )
 
     x_contig = x.contiguous()
 
     if out is None:
         out = torch.empty_like(x_contig, memory_format=torch.contiguous_format)
     else:
-        if not out.is_cuda:
-            raise ValueError("Output tensor 'out' must be on CUDA")
+        if out.device.type != flag_gems.device:
+            raise ValueError(f"Output tensor 'out' must be on {flag_gems.device}")
         if out.dtype != x_contig.dtype:
             raise ValueError("Output tensor 'out' must have the same dtype as input")
         # Resize to match input shape and ensure contiguous layout

--- a/src/flag_gems/ops/prelu.py
+++ b/src/flag_gems/ops/prelu.py
@@ -5,6 +5,8 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
+
 logger = logging.getLogger(__name__)
 
 
@@ -48,8 +50,8 @@ def prelu(*args, **kwargs):
     if x is None or weight is None:
         raise ValueError("prelu expects (input, weight) as arguments.")
 
-    if not (x.is_cuda and weight.is_cuda):
-        raise AssertionError("Tensors must be CUDA tensors.")
+    if x.device.type != flag_gems.device or weight.device.type != flag_gems.device:
+        raise AssertionError(f"Tensors must be {flag_gems.device} tensors.")
 
     # Ensure dtype match
     if weight.dtype != x.dtype:

--- a/src/flag_gems/ops/reflection_pad2d.py
+++ b/src/flag_gems/ops/reflection_pad2d.py
@@ -5,6 +5,8 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
+
 logger = logging.getLogger(__name__)
 
 
@@ -87,8 +89,8 @@ def launch_reflection_pad2d(input: torch.Tensor, padding, out: torch.Tensor = No
     # Validate input
     if input.dim() < 3:
         raise ValueError("input must have at least 3 dimensions")
-    if not input.is_cuda:
-        raise ValueError("input must be a CUDA tensor")
+    if input.device.type != flag_gems.device:
+        raise ValueError(f"input must be a {flag_gems.device} tensor")
 
     x = input.contiguous()
     H_in = int(x.shape[-2])
@@ -117,8 +119,8 @@ def launch_reflection_pad2d(input: torch.Tensor, padding, out: torch.Tensor = No
             (*leading_shape, H_out, W_out), device=x.device, dtype=x.dtype
         )
     else:
-        if not out.is_cuda:
-            raise ValueError("out must be a CUDA tensor")
+        if out.device.type != flag_gems.device:
+            raise ValueError(f"out must be a {flag_gems.device} tensor")
         expected_shape = (*leading_shape, H_out, W_out)
         if tuple(out.shape) != expected_shape:
             raise ValueError(

--- a/src/flag_gems/ops/soft_margin_loss.py
+++ b/src/flag_gems/ops/soft_margin_loss.py
@@ -5,6 +5,8 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
+
 logger = logging.getLogger(__name__)
 
 
@@ -71,9 +73,9 @@ def _normalize_reduction(reduction):
 
 
 def _check_tensors(input: torch.Tensor, target: torch.Tensor):
-    if not (input.is_cuda and target.is_cuda):
+    if input.device.type != flag_gems.device or target.device.type != flag_gems.device:
         raise AssertionError(
-            "soft_margin_loss: input and target must be CUDA tensors for Triton kernel."
+            f"soft_margin_loss: input and target must be {flag_gems.device} tensors for Triton kernel."
         )
     if input.device != target.device:
         raise AssertionError(
@@ -150,8 +152,10 @@ def soft_margin_loss_out(
         else:
             out = torch.empty((), device=input.device, dtype=input.dtype)
     else:
-        if not out.is_cuda:
-            raise AssertionError("soft_margin_loss_out: out must be a CUDA tensor.")
+        if out.device.type != flag_gems.device:
+            raise AssertionError(
+                f"soft_margin_loss_out: out must be a {flag_gems.device} tensor."
+            )
         if red == 0:
             if out.numel() != n_elements:
                 raise AssertionError(

--- a/src/flag_gems/ops/special_i0e.py
+++ b/src/flag_gems/ops/special_i0e.py
@@ -3,6 +3,8 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
+
 
 @triton.jit
 def _special_i0e_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
@@ -65,7 +67,8 @@ def _special_i0e_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
 
 
 def _run_special_i0e_kernel(x: torch.Tensor, out: torch.Tensor):
-    assert x.is_cuda and out.is_cuda, "Tensors must be CUDA tensors"
+    if x.device.type != flag_gems.device or out.device.type != flag_gems.device:
+        raise ValueError(f"Tensors must be {flag_gems.device} tensors")
     assert x.dtype in (
         torch.float16,
         torch.bfloat16,

--- a/src/flag_gems/ops/special_i1.py
+++ b/src/flag_gems/ops/special_i1.py
@@ -5,6 +5,7 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
 from flag_gems.runtime import torch_device_fn
 
 logger = logging.getLogger(__name__)
@@ -60,7 +61,8 @@ def special_i1_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
 
 
 def _launch_special_i1(x: torch.Tensor, out: torch.Tensor):
-    assert x.is_cuda and out.is_cuda, "Tensors must be CUDA tensors"
+    if x.device.type != flag_gems.device or out.device.type != flag_gems.device:
+        raise ValueError(f"Tensors must be {flag_gems.device} tensors")
     assert (
         x.numel() == out.numel()
     ), "Input and output must have the same number of elements"

--- a/src/flag_gems/ops/t_copy.py
+++ b/src/flag_gems/ops/t_copy.py
@@ -5,6 +5,8 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
+
 logger = logging.getLogger(__name__)
 
 
@@ -62,7 +64,8 @@ def copy_1d_strided_kernel(
 
 
 def _launch_t_copy_kernel(inp: torch.Tensor, out: torch.Tensor):
-    assert inp.is_cuda and out.is_cuda, "t_copy kernels require CUDA tensors"
+    if inp.device.type != flag_gems.device or out.device.type != flag_gems.device:
+        raise ValueError(f"t_copy kernels require {flag_gems.device} tensors")
     assert inp.dtype == out.dtype, "dtype mismatch between input and output"
 
     dim = inp.dim()

--- a/src/flag_gems/ops/zero.py
+++ b/src/flag_gems/ops/zero.py
@@ -5,6 +5,8 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
+
 logger = logging.getLogger(__name__)
 
 
@@ -26,7 +28,8 @@ def zero_kernel(
 
 def _launch_zero_kernel(tensor: torch.Tensor):
     assert isinstance(tensor, torch.Tensor), "Expected a torch.Tensor"
-    assert tensor.is_cuda, "Tensor must be on CUDA device"
+    if tensor.device.type != flag_gems.device:
+        raise ValueError(f"Tensor must be on {flag_gems.device} device")
     assert tensor.is_contiguous(), "Tensor must be contiguous"
     assert tensor.numel() >= 0
     n_elements = tensor.numel()

--- a/tests/test_grouped_mm.py
+++ b/tests/test_grouped_mm.py
@@ -35,8 +35,8 @@ def test_grouped_mm(groups, N, K, dtype):
         M_g = random.randint(1, 16384)
         N_g = N
         K_g = K
-        A_g = torch.rand([M_g, K_g], device="cuda", dtype=dtype)
-        B_g = torch.rand([K_g, N_g], device="cuda", dtype=dtype)
+        A_g = torch.rand([M_g, K_g], device=flag_gems.device, dtype=dtype)
+        B_g = torch.rand([K_g, N_g], device=flag_gems.device, dtype=dtype)
         group_A_list.append(A_g)
         group_B_list.append(B_g)
         M_list.append(M_g)
@@ -48,7 +48,7 @@ def test_grouped_mm(groups, N, K, dtype):
     offs = torch.tensor(
         [sum(M_list[: i + 1]) for i in range(groups)],
         dtype=torch.int32,
-        device="cuda",
+        device=flag_gems.device,
     )
 
     ref_out = torch._grouped_mm(mat_a, mat_b, offs)

--- a/tests/test_special_ops.py
+++ b/tests/test_special_ops.py
@@ -8,6 +8,7 @@ import pytest
 import torch
 
 import flag_gems
+from flag_gems.runtime import torch_device_fn
 
 from .accuracy_utils import (
     ALL_INT_DTYPES,
@@ -2137,8 +2138,7 @@ def test_accuracy_moe_align_block_size(
                 f"actual={actual_expert_tokens[expert_id]}"
             )
 
-    torch.cuda.synchronize() if flag_gems.vendor_name != "ascend" else torch.npu.synchronize()
-
+    torch_device_fn.synchronize()
     _verify_expert_level_sorting(
         sorted_ids,
         sorted_ids_vllm,
@@ -2479,19 +2479,19 @@ def test_assert_async_consistency(shape, value, expected_err, match_str):
             with pytest.raises(expected_err, match=match_str):
                 flag_gems._assert_async(inp_triton, msg)
                 if value == 0:
-                    torch.cuda.synchronize()
+                    torch_device_fn.synchronize()
     else:
         with flag_gems.use_gems():
             flag_gems._assert_async(inp_triton, msg)
-            torch.cuda.synchronize()
+            torch_device_fn.synchronize()
     if expected_err:
         with pytest.raises(expected_err, match=match_str):
             torch._assert_async(inp_pt, msg)
             if value == 0:
-                torch.cuda.synchronize()
+                torch_device_fn.synchronize()
     else:
         torch._assert_async(inp_pt, msg)
-        torch.cuda.synchronize()
+        torch_device_fn.synchronize()
 
 
 @pytest.mark.lift_fresh_copy


### PR DESCRIPTION
- Replace hardcoded is_cuda checks with device.type == flag_gems.device
- Replace torch.cuda.synchronize() with torch_device_fn.synchronize()

Affected ops: moe_align_block_size, safe_softmax, upsample_nearest_exact1d, arcsinh, i0, i0_, lift_fresh_copy, prelu, reflection_pad2d, soft_margin_loss, special_i0e, special_i1, t_copy, zero, grouped_mm, embedding
