### PR TITLE
Fix/mthreads  SQMMA environment variable restoration logic in mm.py

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/mm.py
@@ -474,9 +474,11 @@ def mm(a, b):
     b_dtype = b.dtype
     M, K = a.shape
     _, N = b.shape
-    prev_sqmma = os.environ.get("MUSA_ENABLE_SQMMA")
-    # fp32 does not support MMA instructions, keep SQMMA disabled for FMA path
-    if a_dtype != torch.float32 and b_dtype != torch.float32:
+    # fp32 does not support MMA instructions, only enable SQMMA for fp16/bf16
+    need_sqmma = a_dtype != torch.float32 and b_dtype != torch.float32
+    prev_sqmma = None
+    if need_sqmma:
+        prev_sqmma = os.environ.get("MUSA_ENABLE_SQMMA")
         os.environ["MUSA_ENABLE_SQMMA"] = "1"
     try:
         if N == 1:
@@ -497,7 +499,8 @@ def mm(a, b):
         else:
             return mm_fma(a, b)
     finally:
-        if prev_sqmma is None:
-            os.environ.pop("MUSA_ENABLE_SQMMA", None)
-        else:
-            os.environ["MUSA_ENABLE_SQMMA"] = prev_sqmma
+        if need_sqmma:
+            if prev_sqmma is None:
+                os.environ.pop("MUSA_ENABLE_SQMMA", None)
+            else:
+                os.environ["MUSA_ENABLE_SQMMA"] = prev_sqmma


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Fix the SQMMA enable/disable logic in the matrix multiplication operator for the MThreads backend. Reducing unnecessary host-side os.environ read/write overhead on the FP32 path.
### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
