### PR TITLE
kunlunxin: modify gather kerner to bind triton api

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/gather.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/gather.py
@@ -104,6 +104,7 @@ def generate_gather_kernel(
 
             code.writeline("dim: tl.constexpr,")
             code.writeline("stride_dim: tl.constexpr,")
+            code.writeline("inp_dim_size: tl.constexpr,")
             code.writeline("M: tl.constexpr,")
             code.writeline("N: tl.constexpr,")
             code.writeline("BLOCK_M: tl.constexpr,")
@@ -151,7 +152,7 @@ def generate_gather_kernel(
 
 
 def parameter_for_wrapper() -> str:
-    # inp_strided, out, index, dim, stride_dim, M, N
+    # inp_strided, out, index, dim, stride_dim, inp_dim_size, M, N
     parameters: List[str] = []
 
     parameters.append("inp_strided")
@@ -159,6 +160,7 @@ def parameter_for_wrapper() -> str:
     parameters.append("index")
     parameters.append("dim")
     parameters.append("stride_dim")
+    parameters.append("inp_dim_size")
     parameters.append("M")
     parameters.append("N")
 
@@ -204,6 +206,7 @@ def generate_gather_wrapper(
 
                 code.writeline("dim,")
                 code.writeline("stride_dim,")
+                code.writeline("inp_dim_size,")
                 code.writeline("M,")
                 code.writeline("N,")
         code.writeline(")")
@@ -218,7 +221,7 @@ def generate_code(
     kernel_name: str,
     code: IndentedBuffer,
 ) -> IndentedBuffer:
-    # inputs: inp_strided, out, index, dim, stride_dim, M, N
+    # inputs: inp_strided, out, index, dim, stride_dim, inp_dim_size, M, N
     shape = inputs[2].shape
     rank = len(shape)
 
@@ -275,6 +278,8 @@ _gather_func = GatherFunction()
 
 def gather(inp, dim, index, out=None, sparse_grad=False):
     logger.debug("GEMS GATHER")
+    if dim < 0:
+        dim += inp.ndim
     inp = inp.contiguous()
     index = index.contiguous()
     if out is None:
@@ -286,8 +291,9 @@ def gather(inp, dim, index, out=None, sparse_grad=False):
     # plain_idx = torch.arange(0, index.numel(), device=inp.device).reshape(index.shape)
     N = list(index.shape)[index.ndim - 1]
     M = index.numel() // N
+    inp_dim_size = inp.size(dim)
 
-    _gather_func(inp_strided, out, index, dim, stride_dim, M, N)
+    _gather_func(inp_strided, out, index, dim, stride_dim, inp_dim_size, M, N)
     return out
 
 

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/scatter.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/scatter.py
@@ -320,6 +320,8 @@ _scatter_func = ScatterFunction()
 
 def scatter(inp, dim, index, src, reduce=None):
     logger.debug("GEMS SCATTER")
+    if dim < 0:
+        dim += inp.ndim
     out = inp.clone()
 
     if reduce is not None:
@@ -355,6 +357,8 @@ def scatter(inp, dim, index, src, reduce=None):
 
 def scatter_(inp, dim, index, src, reduce=None):
     logger.debug("GEMS SCATTER_")
+    if dim < 0:
+        dim += inp.ndim
     out = inp
 
     if reduce is not None:


### PR DESCRIPTION
## Summary

Bind `gather` and `scatter` operators to XPU native API in the KunlunXin Triton backend for accelerated computation.

## Motivation

The default Triton-generated kernels for `gather`/`scatter` on XPU have suboptimal performance due to generic memory access patterns. By binding these operators directly to the optimized XPU native API (`baidu::xpu::api::gather` / `baidu::xpu::api::scatter_element`) through the Triton backend's launch handler mechanism, we bypass the Triton kernel entirely and leverage hardware-optimized implementations, resulting in significant performance improvement.

## Changes

- **gather.py**: Pass `inp_dim_size` (original input size along the gather dimension) as a `constexpr` parameter to the kernel. This is required by the XPU API handler to reconstruct the full input tensor shape, since the restrided input has `stride[dim]=0` which makes shape inference at that dimension impossible.
- **gather.py / scatter.py**: Normalize negative `dim` values (`dim += inp.ndim`) before kernel launch. The XPU API binding handler uses stride-based shape reconstruction which requires non-negative dimension indices to avoid division-by-zero errors.

## How It Works

The Triton-XPU backend supports an operator binding mechanism: when a kernel name matches a registered handler (e.g., `_gather_jit_function`, `_scatter_jit_function`), the backend intercepts the launch and dispatches directly to the corresponding XPU native API instead of executing the Triton kernel. This PR prepares the FlagGems kernel parameters to be compatible with the backend handler's expectations.