### PR TITLE
Fix conftest mode option

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,7 +4,9 @@ import os
 from datetime import datetime
 
 import pytest
-import torch
+
+# TODO(Qiming): Try remove this line
+import torch  # noqa: F401
 import yaml
 
 import flag_gems
@@ -44,16 +46,9 @@ def pytest_addoption(parser):
     )
 
     parser.addoption(
-        (
-            "--mode"
-            if not (flag_gems.vendor_name == "kunlunxin" and torch.__version__ < "2.5")
-            else "--fg_mode"
-        ),  # TODO: fix pytest-* common --mode args,
-        action="store",
-        default="normal",
-        required=False,
-        choices=["normal", "quick"],
-        help="run tests on normal or quick mode",
+        "--quick",
+        action="store_true",
+        help="run tests on quick mode",
     )
 
     parser.addoption(
@@ -85,7 +80,7 @@ def pytest_configure(config):
 
     RECORD_LOG = config.getoption("--record") == "log"
     TO_CPU = config.getoption("--ref") == "cpu"
-    QUICK_MODE = config.getoption("--mode") == "quick"
+    QUICK_MODE = config.getoption("--quick") is True
 
     if RECORD_LOG:
         RUNTEST_INFO = {}

--- a/tools/test-op.sh
+++ b/tools/test-op.sh
@@ -81,7 +81,7 @@ coverage run -m pytest -s ${EXTRA_OPTS} ${TEST_CASES[@]}
 # Run quick-cpu test if necessary
 if [[ ${#TEST_CASES_CPU[@]} -ne 0 ]]; then
   echo "Running quick-cpu mode unit tests for ${TEST_CASES_CPU[@]}"
-  coverage run -m pytest -s ${EXTRA_OPTS} ${TEST_CASES_CPU[@]} --ref=cpu --mode=quick
+  coverage run -m pytest -s ${EXTRA_OPTS} ${TEST_CASES_CPU[@]} --ref=cpu --quick
 fi
 
 # Process coverage data only when full-range testing


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Refactor

### Description

This PR changes the `--mode <normal|quick>` option for pytest when running accuracy tests.
The `--mode` option conflicts now and then with other pytest plugins.
It is even blocking our CI jobs some times.
This PR changes the option to a boolean one `--quick`. Please use `--quick` instead of `--mode quick` from now on. 
