### PR TITLE
[FlagGems Operator Development Competition]  add gcd

### DIFF
--- a/benchmark/test_binary_pointwise_perf.py
+++ b/benchmark/test_binary_pointwise_perf.py
@@ -10,7 +10,7 @@ from benchmark.attri_util import (
     FLOAT_DTYPES,
     INT_DTYPES,
 )
-from benchmark.performance_utils import Benchmark, generate_tensor_input
+from benchmark.performance_utils import Benchmark, Config, generate_tensor_input
 
 
 class BinaryPointwiseBenchmark(Benchmark):
@@ -35,6 +35,93 @@ class BinaryPointwiseBenchmark(Benchmark):
         shape1 = list(args[0].shape)
         shape2 = list(args[0].shape)
         return torch.tensor(shape1).prod().item() + torch.tensor(shape2).prod().item()
+
+
+class GcdBenchmark(BinaryPointwiseBenchmark):
+    # gcd has data-dependent iteration counts, so memory throughput is more
+    # interpretable than a synthetic tflops number here.
+    DEFAULT_METRICS = DEFAULT_METRICS[:] + ["gbps"]
+
+    def get_gbps(self, args, latency):
+        numel = args[0].numel()
+        bytes_moved = numel * (args[0].element_size() + args[1].element_size())
+        bytes_moved += numel * torch.empty((), dtype=args[0].dtype).element_size()
+        return bytes_moved / latency * 1e-6
+
+
+def _make_power_of_two_tensor(shape, dtype, device):
+    max_exp = torch.iinfo(dtype).bits - 2
+    exponents = torch.randint(0, max_exp + 1, shape, device=device, dtype=torch.int64)
+    return torch.bitwise_left_shift(
+        torch.ones(shape, dtype=dtype, device=device), exponents.to(dtype)
+    )
+
+
+class GcdDistributionBenchmark(GcdBenchmark):
+    DISTRIBUTIONS = ("random", "equal", "unit", "power_of_two", "multiples")
+    DISTRIBUTION_SHAPES = [(64, 64), (4096, 4096), (64, 512, 512)]
+    _current_distribution = None
+
+    def init_default_config(self):
+        self.shapes = self.DISTRIBUTION_SHAPES
+
+    def init_user_config(self):
+        self.mode = Config.mode
+        self.set_dtypes(Config.user_desired_dtypes)
+        self.set_metrics(Config.user_desired_metrics)
+        self.shapes = self.DISTRIBUTION_SHAPES
+
+    def _make_distribution_pair(self, shape, cur_dtype, distribution):
+        lhs = generate_tensor_input(shape, cur_dtype, self.device)
+        rhs = generate_tensor_input(shape, cur_dtype, self.device)
+
+        if distribution == "random":
+            return lhs, rhs
+        if distribution == "equal":
+            return lhs, lhs.clone()
+        if distribution == "unit":
+            lhs = torch.where(lhs >= 0, 1, -1).to(cur_dtype)
+            return lhs, rhs
+        if distribution == "power_of_two":
+            return (
+                _make_power_of_two_tensor(shape, cur_dtype, self.device),
+                _make_power_of_two_tensor(shape, cur_dtype, self.device),
+            )
+        if distribution == "multiples":
+            base = torch.randint(1, 32, shape, dtype=cur_dtype, device=self.device)
+            lhs_scale = torch.randint(1, 16, shape, dtype=cur_dtype, device=self.device)
+            rhs_scale = torch.randint(1, 16, shape, dtype=cur_dtype, device=self.device)
+            return base * lhs_scale, base * rhs_scale
+        raise ValueError(f"unsupported gcd distribution: {distribution}")
+
+    def get_input_iter(self, cur_dtype) -> Generator:
+        for shape in self.shapes:
+            for distribution in self.DISTRIBUTIONS:
+                lhs, rhs = self._make_distribution_pair(shape, cur_dtype, distribution)
+                yield lhs, rhs, {"distribution": distribution}
+
+    def unpack_to_args_kwargs(self, input_tuple):
+        args, kwargs = super().unpack_to_args_kwargs(input_tuple)
+        self._current_distribution = kwargs.pop("distribution", None)
+        return args, kwargs
+
+    def record_shapes(self, *args, **kwargs):
+        recorded = super().record_shapes(*args, **kwargs)
+        distribution = self._current_distribution
+        if distribution is None:
+            return recorded
+        if isinstance(recorded, list):
+            return recorded + [f"distribution={distribution}"]
+        return [recorded, f"distribution={distribution}"]
+
+
+class GcdOutBenchmark(GcdBenchmark):
+    def get_input_iter(self, cur_dtype) -> Generator:
+        for shape in self.shapes:
+            lhs = generate_tensor_input(shape, cur_dtype, self.device)
+            rhs = generate_tensor_input(shape, cur_dtype, self.device)
+            out = torch.empty_like(lhs)
+            yield lhs, rhs, {"out": out}
 
 
 class ScalarBinaryPointwiseBenchmark(Benchmark):
@@ -80,6 +167,7 @@ class ScalarBinaryPointwiseBenchmark(Benchmark):
             ("equal", torch.equal, FLOAT_DTYPES),
             ("floor_divide", torch.floor_divide, INT_DTYPES),
             ("fmin", torch.fmin, FLOAT_DTYPES),
+            ("gcd", torch.gcd, INT_DTYPES),
             ("ge", torch.ge, FLOAT_DTYPES),
             ("greater", torch.greater, FLOAT_DTYPES),
             ("gt", torch.gt, FLOAT_DTYPES),
@@ -103,7 +191,28 @@ class ScalarBinaryPointwiseBenchmark(Benchmark):
     ],
 )
 def test_general_binary_pointwise(op_name, torch_op, dtypes):
-    bench = BinaryPointwiseBenchmark(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
+    benchmark_cls = GcdBenchmark if op_name == "gcd" else BinaryPointwiseBenchmark
+    bench = benchmark_cls(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
+    bench.run()
+
+
+@pytest.mark.gcd
+def test_gcd_distribution_binary_pointwise():
+    bench = GcdDistributionBenchmark(
+        op_name="gcd_distribution",
+        torch_op=torch.gcd,
+        dtypes=INT_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.gcd
+def test_gcd_out_binary_pointwise():
+    bench = GcdOutBenchmark(
+        op_name="gcd_out",
+        torch_op=torch.gcd,
+        dtypes=INT_DTYPES,
+    )
     bench.run()
 
 

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -219,6 +219,8 @@ _FULL_CONFIG = (
     ("full_like", full_like),
     ("gather", gather),
     ("gather_backward", gather_backward),
+    ("gcd", gcd),
+    ("gcd.out", gcd_out),
     ("ge.Scalar", ge_scalar),
     ("ge.Tensor", ge),
     ("gelu", gelu),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -128,6 +128,7 @@ from flag_gems.ops.fmin import fmin, fmin_out
 from flag_gems.ops.full import full
 from flag_gems.ops.full_like import full_like
 from flag_gems.ops.gather import gather, gather_backward
+from flag_gems.ops.gcd import gcd, gcd_out
 from flag_gems.ops.ge import ge, ge_scalar
 from flag_gems.ops.gelu import gelu, gelu_, gelu_backward
 from flag_gems.ops.get_paged_mqa_logits_metadata import get_paged_mqa_logits_metadata
@@ -483,6 +484,8 @@ __all__ = [
     "full_like",
     "gather",
     "gather_backward",
+    "gcd",
+    "gcd_out",
     "ge",
     "ge_scalar",
     "gelu",

--- a/src/flag_gems/ops/gcd.py
+++ b/src/flag_gems/ops/gcd.py
@@ -1,0 +1,240 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+import triton.language.extra.libdevice as libdevice
+
+logger = logging.getLogger(__name__)
+_I16_MIN_LUT_CACHE = {}
+_COPY_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeExplicitAutograd
+)
+
+
+@triton.jit
+def _ctz(x):
+    return libdevice.ffs(x) - 1
+
+
+@triton.jit
+def _abs_u32(x):
+    ux = x.to(tl.uint32)
+    return tl.where(x < 0, 0 - ux, ux)
+
+
+@triton.jit
+def _abs_u64(x):
+    ux = x.to(tl.uint64)
+    return tl.where(x < 0, 0 - ux, ux)
+
+
+@triton.jit
+def _c_rem_i32(a, b):
+    mag = _abs_u32(a) % _abs_u32(b)
+    rem = mag.to(tl.int32)
+    return tl.where((a < 0) & (mag != 0), -rem, rem)
+
+
+@triton.jit
+def _c_rem_i64(a, b):
+    mag = _abs_u64(a) % _abs_u64(b)
+    rem = mag.to(tl.int64)
+    return tl.where((a < 0) & (mag != 0), -rem, rem)
+
+
+@triton.jit
+def _binary_gcd(ax, ay, normal):
+    zero_ax = ax == 0
+    zero_ay = ay == 0
+    res = tl.where(zero_ax, ay, ax)
+    both_nonzero = normal & (~zero_ax) & (~zero_ay)
+    common = _ctz(tl.where(both_nonzero, ax | ay, 1))
+    u = tl.where(both_nonzero, ax >> _ctz(tl.where(both_nonzero, ax, 1)), ax)
+    v = ay
+    active = both_nonzero
+
+    while tl.sum(active.to(tl.int32), axis=0) > 0:
+        v_shifted = tl.where(active, v >> _ctz(tl.where(active, v, 1)), v)
+        swap = active & (u > v_shifted)
+        small = tl.where(swap, v_shifted, u)
+        large = tl.where(swap, u, v_shifted)
+        u = tl.where(active, small, u)
+        v = tl.where(active, large - small, v)
+        active = active & (v != 0)
+
+    return tl.where(both_nonzero, u << common, res)
+
+
+@triton.jit
+def gcd_kernel_i16(x_ptr, y_ptr, lut_ptr, out_ptr, n_elements, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0)
+    x_i32 = x.to(tl.int32)
+    y_i32 = y.to(tl.int32)
+    min_value: tl.constexpr = -32768
+    min_x = x_i32 == min_value
+    min_y = y_i32 == min_value
+    special_mask = mask & (min_x | min_y)
+    normal = mask & (~special_mask)
+    ax = tl.abs(x_i32)
+    ay = tl.abs(y_i32)
+    normal_res = _binary_gcd(ax, ay, normal)
+
+    both_min = special_mask & min_x & min_y
+    one_min = special_mask & (~both_min)
+    other_abs = tl.where(min_x, tl.abs(y_i32), tl.abs(x_i32))
+    special_res = tl.load(lut_ptr + other_abs, mask=one_min, other=0).to(tl.int32)
+    special_res = tl.where(both_min, min_value, special_res)
+
+    out = tl.where(special_mask, special_res, normal_res)
+    tl.store(out_ptr + offsets, out.to(out_ptr.type.element_ty), mask=mask)
+
+
+@triton.jit
+def gcd_kernel_i32(x_ptr, y_ptr, out_ptr, n_elements, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0)
+    min_value: tl.constexpr = -(1 << 31)
+    min_x = x == min_value
+    min_y = y == min_value
+    ax_native = tl.where(min_x, x, tl.abs(x))
+    ay_native = tl.where(min_y, y, tl.abs(y))
+    ax = ax_native.to(tl.int32)
+    ay = ay_native.to(tl.int32)
+
+    special_mask = mask & (min_x | min_y)
+    normal = mask & (~special_mask)
+    normal_res = _binary_gcd(ax, ay, normal)
+
+    sa = ax_native.to(tl.int32)
+    sb = ay_native.to(tl.int32)
+    special = special_mask & (sa != 0)
+    while tl.sum(special.to(tl.int32), axis=0) > 0:
+        next_sa = tl.where(special, _c_rem_i32(sb, tl.where(special, sa, 1)), sa)
+        sb = tl.where(special, sa, sb)
+        sa = next_sa
+        special = special & (sa != 0)
+
+    out = tl.where(mask & (~normal), sb, normal_res)
+    tl.store(out_ptr + offsets, out.to(out_ptr.type.element_ty), mask=mask)
+
+
+@triton.jit
+def gcd_kernel_i64(x_ptr, y_ptr, out_ptr, n_elements, BLOCK: tl.constexpr):
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < n_elements
+
+    x = tl.load(x_ptr + offsets, mask=mask, other=0)
+    y = tl.load(y_ptr + offsets, mask=mask, other=0)
+    min_x = x == -(1 << 63)
+    min_y = y == -(1 << 63)
+    ax = tl.where(min_x, x, tl.abs(x)).to(tl.int64)
+    ay = tl.where(min_y, y, tl.abs(y)).to(tl.int64)
+
+    special_mask = mask & (min_x | min_y)
+    normal = mask & (~special_mask)
+    normal_res = _binary_gcd(ax, ay, normal)
+
+    sa = ax
+    sb = ay
+    special = special_mask & (sa != 0)
+    while tl.sum(special.to(tl.int32), axis=0) > 0:
+        next_sa = tl.where(special, _c_rem_i64(sb, tl.where(special, sa, 1)), sa)
+        sb = tl.where(special, sa, sb)
+        sa = next_sa
+        special = special & (sa != 0)
+
+    out = tl.where(mask & (~normal), sb, normal_res)
+    tl.store(out_ptr + offsets, out.to(out_ptr.type.element_ty), mask=mask)
+
+
+def _kernel_meta(dtype):
+    if dtype == torch.int16:
+        return gcd_kernel_i16, 512, 4
+    if dtype == torch.int32:
+        return gcd_kernel_i32, 512, 4
+    if dtype == torch.int64:
+        return gcd_kernel_i64, 256, 4
+    raise TypeError(f"unsupported dtype for gcd: {dtype}")
+
+
+def _get_i16_min_lut(device):
+    key = (device.type, device.index)
+    lut = _I16_MIN_LUT_CACHE.get(key)
+    if lut is None:
+        info = torch.iinfo(torch.int16)
+        lhs = torch.full((info.max + 1,), info.min, dtype=torch.int16)
+        rhs = torch.arange(info.max + 1, dtype=torch.int16)
+        lut = torch.gcd(lhs, rhs).to(device=device)
+        _I16_MIN_LUT_CACHE[key] = lut
+    return lut
+
+
+def _materialize_inputs(self, other):
+    promoted_dtype = torch.promote_types(self.dtype, other.dtype)
+    lhs = self if self.dtype == promoted_dtype else self.to(promoted_dtype)
+    rhs = other if other.dtype == promoted_dtype else other.to(promoted_dtype)
+    lhs, rhs = torch.broadcast_tensors(lhs, rhs)
+    return lhs.contiguous(), rhs.contiguous(), promoted_dtype
+
+
+def _maybe_get_direct_out(out, expected_shape, expected_dtype, expected_device):
+    if out is None:
+        return None
+    if out.device != expected_device or out.dtype != expected_dtype:
+        return None
+    if tuple(out.shape) != tuple(expected_shape) or not out.is_contiguous():
+        return None
+    return out
+
+
+def _copy_result_to_out(out, result):
+    torch.ops.aten.copy_.default.redispatch(_COPY_FALLBACK_KEYSET, out, result, False)
+    return out
+
+
+def _launch_gcd(lhs, rhs, out):
+    numel = out.numel()
+    if numel == 0:
+        return out
+
+    kernel, block, num_warps = _kernel_meta(out.dtype)
+    grid = (triton.cdiv(numel, block),)
+    if out.dtype == torch.int16:
+        lut = _get_i16_min_lut(out.device)
+        kernel[grid](lhs, rhs, lut, out, numel, BLOCK=block, num_warps=num_warps)
+    else:
+        kernel[grid](lhs, rhs, out, numel, BLOCK=block, num_warps=num_warps)
+    return out
+
+
+def gcd(self, other, *, out=None):
+    logger.debug("GEMS GCD")
+    lhs, rhs, promoted_dtype = _materialize_inputs(self, other)
+    result = _maybe_get_direct_out(out, lhs.shape, promoted_dtype, lhs.device)
+    if result is None:
+        result = torch.empty_like(lhs, dtype=promoted_dtype)
+    _launch_gcd(lhs.reshape(-1), rhs.reshape(-1), result.reshape(-1))
+    if out is None:
+        return result.view(lhs.shape)
+
+    if result is not out:
+        _copy_result_to_out(out, result.view(lhs.shape))
+    return out
+
+
+def gcd_out(self, other, *, out=None):
+    logger.debug("GEMS GCD_OUT")
+    if out is None:
+        return gcd(self, other)
+    return gcd(self, other, out=out)

--- a/src/flag_gems/ops/gcd.py
+++ b/src/flag_gems/ops/gcd.py
@@ -221,6 +221,10 @@ def _launch_gcd(lhs, rhs, out):
 def gcd(self, other, *, out=None):
     logger.debug("GEMS GCD")
     lhs, rhs, promoted_dtype = _materialize_inputs(self, other)
+    if out is not None and not torch.can_cast(promoted_dtype, out.dtype):
+        raise RuntimeError(
+            f"result type {promoted_dtype} can't be cast to the desired output type {out.dtype}"
+        )
     result = _maybe_get_direct_out(out, lhs.shape, promoted_dtype, lhs.device)
     if result is None:
         result = torch.empty_like(lhs, dtype=promoted_dtype)

--- a/tests/test_gcd.py
+++ b/tests/test_gcd.py
@@ -192,3 +192,51 @@ def test_gcd_noncontiguous_broadcast(dtype):
         res_out = torch.gcd(lhs, rhs)
 
     utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.gcd
+def test_gcd_invalid_dtype():
+    lhs = torch.ones((4, 4), dtype=torch.float32, device=flag_gems.device)
+    rhs = torch.ones((4, 4), dtype=torch.float32, device=flag_gems.device)
+
+    with flag_gems.use_gems():
+        with pytest.raises(TypeError, match="unsupported dtype for gcd"):
+            torch.gcd(lhs, rhs)
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize("dtype", utils.ALL_INT_DTYPES)
+def test_gcd_broadcast_error(dtype):
+    lhs = torch.ones((2, 3), dtype=dtype, device=flag_gems.device)
+    rhs = torch.ones((4,), dtype=dtype, device=flag_gems.device)
+
+    with flag_gems.use_gems():
+        with pytest.raises(RuntimeError, match="must match"):
+            torch.gcd(lhs, rhs)
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize("dtype", utils.ALL_INT_DTYPES)
+def test_gcd_out_shape_mismatch(dtype):
+    lhs = torch.ones((2, 3), dtype=dtype, device=flag_gems.device)
+    rhs = torch.ones((2, 3), dtype=dtype, device=flag_gems.device)
+    out = torch.empty((5,), dtype=dtype, device=flag_gems.device)
+
+    with flag_gems.use_gems():
+        with pytest.raises(RuntimeError, match="must match"):
+            torch.gcd(lhs, rhs, out=out)
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize("dtype", utils.ALL_INT_DTYPES)
+def test_gcd_out_dtype_mismatch(dtype):
+    lhs = torch.ones((2, 3), dtype=dtype, device=flag_gems.device)
+    rhs = torch.ones((2, 3), dtype=dtype, device=flag_gems.device)
+    out = torch.empty((2, 3), dtype=torch.bool, device=flag_gems.device)
+
+    with flag_gems.use_gems():
+        with pytest.raises(
+            RuntimeError,
+            match="can't be cast to the desired output type",
+        ):
+            torch.gcd(lhs, rhs, out=out)

--- a/tests/test_gcd.py
+++ b/tests/test_gcd.py
@@ -1,0 +1,194 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+def make_gcd_tensor(shape, dtype, values):
+    info = torch.iinfo(dtype)
+    tensor = torch.randint(info.min, info.max, shape, dtype=dtype, device="cpu").to(
+        flag_gems.device
+    )
+    flat = tensor.reshape(-1)
+    if flat.numel() > 0:
+        boundary = torch.tensor(values, dtype=dtype, device=flag_gems.device)
+        flat[: min(flat.numel(), boundary.numel())] = boundary[: flat.numel()]
+    return tensor
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.ALL_INT_DTYPES)
+def test_gcd(shape, dtype):
+    info = torch.iinfo(dtype)
+    inp1 = make_gcd_tensor(shape, dtype, [0, -12, info.min, -27, 81])
+    inp2 = make_gcd_tensor(shape, dtype, [6, 18, 0, -9, info.min])
+    ref_inp1 = utils.to_reference(inp1, False)
+    ref_inp2 = utils.to_reference(inp2, False)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.ALL_INT_DTYPES)
+def test_gcd_out(shape, dtype):
+    info = torch.iinfo(dtype)
+    inp1 = make_gcd_tensor(shape, dtype, [0, -12, info.min, -27, 81])
+    inp2 = make_gcd_tensor(shape, dtype, [6, 18, 0, -9, info.min])
+    out = torch.empty_like(inp1)
+
+    ref_inp1 = utils.to_reference(inp1, False)
+    ref_inp2 = utils.to_reference(inp2, False)
+    ref_out = torch.empty_like(ref_inp1)
+
+    torch.gcd(ref_inp1, ref_inp2, out=ref_out)
+    with flag_gems.use_gems():
+        torch.gcd(inp1, inp2, out=out)
+
+    utils.gems_assert_equal(out, ref_out)
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize("dtype", utils.ALL_INT_DTYPES)
+def test_gcd_out_alias_input(dtype):
+    info = torch.iinfo(dtype)
+    inp1 = make_gcd_tensor((17, 19), dtype, [0, -12, info.min, -27, 81]).clone()
+    inp2 = make_gcd_tensor((17, 19), dtype, [6, 18, 0, -9, info.min])
+
+    ref_inp1 = utils.to_reference(inp1, False)
+    ref_inp2 = utils.to_reference(inp2, False)
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+
+    with flag_gems.use_gems():
+        torch.gcd(inp1, inp2, out=inp1)
+
+    utils.gems_assert_equal(inp1, ref_out)
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize("dtype", utils.ALL_INT_DTYPES)
+def test_gcd_out_noncontiguous(dtype):
+    info = torch.iinfo(dtype)
+    inp1 = make_gcd_tensor((5, 7), dtype, [0, -12, info.min, -27, 81]).T
+    inp2 = make_gcd_tensor((1, 5), dtype, [6, 18, 0, -9, info.min])
+    out = torch.empty((5, 7), dtype=dtype, device=flag_gems.device).T
+
+    assert not out.is_contiguous()
+
+    ref_inp1 = utils.to_reference(inp1, False)
+    ref_inp2 = utils.to_reference(inp2, False)
+    ref_out = torch.empty_like(ref_inp1)
+    torch.gcd(ref_inp1, ref_inp2, out=ref_out)
+
+    with flag_gems.use_gems():
+        torch.gcd(inp1, inp2, out=out)
+
+    utils.gems_assert_equal(out, ref_out)
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize("dtype", utils.ALL_INT_DTYPES)
+def test_gcd_special_values(dtype):
+    info = torch.iinfo(dtype)
+    inp1 = torch.tensor(
+        [0, 0, -12, -27, info.min, info.min, info.min, info.max],
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+    inp2 = torch.tensor(
+        [0, 6, 18, -9, 0, info.min, 2, info.min],
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+    ref_inp1 = utils.to_reference(inp1, False)
+    ref_inp2 = utils.to_reference(inp2, False)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize("dtype", utils.ALL_INT_DTYPES)
+def test_gcd_distribution_samples(dtype):
+    info = torch.iinfo(dtype)
+    max_pow = min(info.bits - 2, 14)
+    pow_values = [1 << i for i in range(max_pow + 1)]
+
+    equal = torch.tensor(
+        [0, 7, -12, info.min + 1, info.max],
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+    unit = torch.tensor(
+        [1, -1, 1, -1, 1],
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+    pow2 = torch.tensor(
+        pow_values[:5],
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+    pow2_other = torch.tensor(
+        pow_values[1:6],
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+
+    cases = [
+        (equal, equal.clone()),
+        (unit, make_gcd_tensor((5,), dtype, [6, 18, 25, info.min + 3, 49])),
+        (pow2, pow2_other),
+    ]
+
+    for lhs, rhs in cases:
+        ref_lhs = utils.to_reference(lhs, False)
+        ref_rhs = utils.to_reference(rhs, False)
+        ref_out = torch.gcd(ref_lhs, ref_rhs)
+        with flag_gems.use_gems():
+            res_out = torch.gcd(lhs, rhs)
+        utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize("dtype", utils.ALL_INT_DTYPES)
+def test_gcd_empty(dtype):
+    inp1 = torch.empty((2, 0, 3), dtype=dtype, device=flag_gems.device)
+    inp2 = torch.empty((2, 0, 3), dtype=dtype, device=flag_gems.device)
+    ref_inp1 = utils.to_reference(inp1, False)
+    ref_inp2 = utils.to_reference(inp2, False)
+
+    ref_out = torch.gcd(ref_inp1, ref_inp2)
+    with flag_gems.use_gems():
+        res_out = torch.gcd(inp1, inp2)
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.gcd
+@pytest.mark.parametrize("dtype", utils.ALL_INT_DTYPES)
+def test_gcd_noncontiguous_broadcast(dtype):
+    info = torch.iinfo(dtype)
+    lhs = make_gcd_tensor((5, 7), dtype, [0, -12, info.min, -27, 81]).T
+    rhs = make_gcd_tensor((1, 5), dtype, [6, 18, 0, -9, info.min])
+
+    assert not lhs.is_contiguous()
+
+    ref_lhs = utils.to_reference(lhs, False)
+    ref_rhs = utils.to_reference(rhs, False)
+    ref_out = torch.gcd(ref_lhs, ref_rhs)
+
+    with flag_gems.use_gems():
+        res_out = torch.gcd(lhs, rhs)
+
+    utils.gems_assert_equal(res_out, ref_out)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator 
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature

### Description

  This PR implements torch.gcd for FlagGems and adds full integration, validation, and benchmarking support. It covers the following aten schemas:

  - gcd(Tensor self, Tensor other) -> Tensor
  - gcd.out(Tensor self, Tensor other, *, Tensor(a!) out) -> Tensor(a!)

  ### Implementation Details

  - Kernel file: src/flag_gems/ops/gcd.py
  - Registration: src/flag_gems/__init__.py registers gcd and gcd.out
  - Exports: src/flag_gems/ops/__init__.py imports and exports gcd, gcd_out
  - Tests: tests/test_gcd.py adds both functional and error-path coverage
  - Benchmark: benchmark/test_binary_pointwise_perf.py adds gcd, gcd_distribution, and gcd_out benchmark entries

  ### Algorithm

  The implementation uses different strategies depending on dtype and value range, because gcd on signed integers is dominated by overflow-sensitive edge cases around INT_MIN.

  #### 1. Main path: binary GCD for regular values

  For the normal path, the kernel uses the binary GCD algorithm (Stein's algorithm).

  For nonzero a and b, it relies on:

  - gcd(a, b) = gcd(|a|, |b|)
  - factor out the common power of two
  - repeatedly subtract the smaller odd value from the larger odd value until one becomes zero

  This is implemented in _binary_gcd(ax, ay, normal):

  - ctz is computed with libdevice.ffs(x) - 1
  - common factors of two are removed first
  - active lanes iterate with subtraction rather than division/modulo
  - the final result is reconstructed by left-shifting back with the common factor

  This is the fast path for regular signed integers after converting them to nonnegative magnitudes.

  #### 2. Why INT_MIN needs special handling

  For signed integer dtypes, abs(INT_MIN) is not representable in the same signed dtype:

  - abs(-32768) does not fit in int16
  - abs(-(1 << 31)) does not fit in int32
  - abs(-(1 << 63)) does not fit in int64

  So a naive abs + gcd implementation is incorrect for boundary values. The kernel therefore splits execution into:

  - normal lanes: values whose absolute values are representable and can use the binary GCD path
  - special lanes: lanes where either input is INT_MIN

  #### 3. int16: lookup-table path for INT16_MIN

  For int16, the implementation uses a cached lookup table:

  - _get_i16_min_lut(device) materializes gcd(INT16_MIN, x) for all x in [0, INT16_MAX] using PyTorch reference computation
  - the LUT is cached per device in _I16_MIN_LUT_CACHE
  - in gcd_kernel_i16, lanes involving INT16_MIN bypass the regular path and read the answer directly from the LUT

  This keeps the int16 boundary handling simple and avoids overflow-sensitive control flow in the kernel.

  #### 4. int32 and int64: C-style remainder fallback for INT_MIN

  For int32 and int64, a LUT would be too large, so the implementation uses a fallback Euclidean-style reduction on the special lanes only.

  This path is built around:

  - _abs_u32 / _abs_u64: compute magnitudes in unsigned arithmetic, avoiding overflow on INT_MIN
  - _c_rem_i32 / _c_rem_i64: emulate C-style signed remainder, not Python modulo semantics

  For special lanes, the kernel iteratively applies Euclidean reduction using overflow-safe signed remainder until the remainder becomes zero.

  This preserves PyTorch-compatible behavior even when one or both operands are equal to the minimal signed value.

  #### 5. Type promotion and broadcasting

  The wrapper does not assume equal dtype or equal shape.

  _materialize_inputs(self, other) performs:

  - torch.promote_types(self.dtype, other.dtype) for the computation dtype
  - explicit casts when needed
  - torch.broadcast_tensors(lhs, rhs)
  - contiguous materialization before launching the Triton kernel

  So the operator follows the normal binary pointwise promotion-and-broadcast flow before flattening to a 1D launch.

  #### 6. out= behavior

  The gcd(..., out=...) path preserves PyTorch-style .out semantics rather than requiring a perfectly matched output tensor.

  The wrapper first checks whether out can be used directly:

  - same device
  - same dtype as the promoted result
  - same shape
  - contiguous

  If all of those hold, the kernel writes into out directly.

  Otherwise, it computes into a temporary result buffer and then copies into out via torch.ops.aten.copy_.default.redispatch(...).

  This supports cases such as:

  - aliased out
  - noncontiguous out
  - out tensors that require fallback copy semantics

  The follow-up commit adds one important guard here:

  - if out exists but torch.can_cast(promoted_dtype, out.dtype) is false, the operator now raises a RuntimeError

  This is necessary because invalid out dtypes should be rejected, not silently accepted.

  ### Tests

  tests/test_gcd.py covers:

  - basic correctness across pointwise shapes and integer dtypes
  - out= correctness
  - aliasing with out=inp1
  - noncontiguous out tensors
  - boundary-value correctness including 0, negative values, dtype.min, and dtype.max
  - representative distribution-style samples: equal inputs, unit inputs, power-of-two inputs
  - empty tensors
  - noncontiguous broadcast inputs

  The follow-up update also adds explicit negative-path coverage for:

  - invalid dtype
  - broadcast failure
  - out shape mismatch
  - incompatible out dtype

  ### Benchmark

  This PR adds three benchmark entry points in benchmark/test_binary_pointwise_perf.py:

  - gcd as a standard binary pointwise benchmark
  - gcd_out for .out performance
  
A dedicated GcdBenchmark class reports GBPS rather than TFLOPS, because gcd is a data-dependent iterative integer operator and memory throughput is more interpretable than a synthetic FLOPS metric.

  ### Files Changed

  | File | Change |
  |------|--------|
  | src/flag_gems/ops/gcd.py | New Triton implementation for gcd and gcd.out |
  | src/flag_gems/__init__.py | Register gcd / gcd.out |
  | src/flag_gems/ops/__init__.py | Import and export gcd, gcd_out |
  | tests/test_gcd.py | Add accuracy tests, boundary tests, out tests, and negative-path tests |
  | benchmark/test_binary_pointwise_perf.py | Add gcd, gcd_distribution, and gcd_out benchmark coverage |

  ### Issue

  New operator implementation and follow-up semantic hardening for the Operator Development Competition.

  ### Performance

  Environment: benchmark/test_binary_pointwise_perf.py, mode=kernel, level=core
  Speedup = Torch latency / Gems latency; > 1.0 means Gems is faster.

  #### int16

  | Shape | Torch (ms) | Gems (ms) | Speedup | GBPS |
  |-------|------------|-----------|---------|------|
  | (1073741824,) | 31.575 | 26.747 | 1.181 | 240.867 |
  | (64, 64) | 0.0143 | 0.00819 | 1.750 | 3.000 |
  | (4096, 4096) | 0.437 | 0.383 | 1.142 | 262.845 |
  | (64, 512, 512) | 0.437 | 0.378 | 1.157 | 266.407 |
  | (1024, 1024, 1024) | 31.295 | 26.745 | 1.170 | 240.886 |

  #### int32

  | Shape | Torch (ms) | Gems (ms) | Speedup | GBPS |
  |-------|------------|-----------|---------|------|
  | (1073741824,) | 55.096 | 47.089 | 1.170 | 273.631 |
  | (64, 64) | 0.0225 | 0.0113 | 2.000 | 4.364 |
  | (4096, 4096) | 0.740 | 0.684 | 1.082 | 294.323 |
  | (64, 512, 512) | 0.739 | 0.701 | 1.054 | 287.019 |
  | (1024, 1024, 1024) | 55.284 | 47.514 | 1.164 | 271.183 |