### PR TITLE
Fix NVIDIA CI setup

### DIFF
--- a/tools/setup_nvidia.sh
+++ b/tools/setup_nvidia.sh
@@ -12,6 +12,7 @@ if [ -n "${USE_FLAGTREE}" ]; then
   uv pip install --index ${FLAGOS_PYPI} \
     "flagtree==0.5.0+3.5"
 else
+  uv pip uninstall flagtree
   uv pip install --index ${FLAGOS_PYPI} \
     "triton==3.5"
 fi

--- a/tools/test_backends.sh
+++ b/tools/test_backends.sh
@@ -49,6 +49,8 @@ uv pip install \
   "cmake>=3.20,<4" \
   "ninja==1.13.0"
 
+export USE_FLAGTREE=1
+
 ## Vendor-specific installation steps
 source tools/setup_${VENDOR}.sh
 [ "$?" == 0 ] || { echo "Failed to setup FlagGems" ; exit 1; }


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

It looks like `triton` and `flagtree` cannot coexist. There could be behavioral mess when both are installed.
