### PR TITLE
[FlagGems Operator Development Competition] add roll

### DIFF
--- a/benchmark/test_unary_pointwise_perf.py
+++ b/benchmark/test_unary_pointwise_perf.py
@@ -47,6 +47,16 @@ class UnaryPointwiseOutBenchmark(UnaryPointwiseBenchmark):
             yield inp, {"out": out}
 
 
+class RollBenchmark(UnaryPointwiseBenchmark):
+    def get_input_iter(self, cur_dtype) -> Generator:
+        for shape in self.shapes:
+            inp = generate_tensor_input(shape, cur_dtype, self.device)
+            if len(shape) > 1:
+                yield inp, {"shifts": (1, -2), "dims": (0, len(shape) - 1)}
+            else:
+                yield inp, {"shifts": 1, "dims": 0}
+
+
 forward_operations = [
     ("abs", torch.abs, FLOAT_DTYPES),
     ("absolute", torch.absolute, FLOAT_DTYPES),
@@ -248,6 +258,12 @@ def test_exp_out():
         torch_op=torch.exp,
         dtypes=FLOAT_DTYPES,
     )
+    bench.run()
+
+
+@pytest.mark.roll
+def test_roll_perf():
+    bench = RollBenchmark(op_name="roll", torch_op=torch.roll, dtypes=FLOAT_DTYPES)
     bench.run()
 
 

--- a/src/flag_gems/ops/roll.py
+++ b/src/flag_gems/ops/roll.py
@@ -1,105 +1,156 @@
 import logging
+from typing import List, Optional, Sequence, Union
 
 import torch
 import triton
 import triton.language as tl
 
-from flag_gems.utils import libentry
+from flag_gems.runtime import torch_device_fn
 
 logger = logging.getLogger(__name__)
 
 
-@libentry()
 @triton.jit
-def roll_kernel(
-    inp_ptr,
+def _roll_single_dim_kernel(
+    in_ptr,
     out_ptr,
-    N,
+    numel,
     dim_size,
     shift,
     inner_size,
-    BLOCK_SIZE: tl.constexpr,
+    BLOCK: tl.constexpr,
 ):
     pid = tl.program_id(0)
-    offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE).to(tl.int64)
-    mask = offset < N
+    offsets = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < numel
 
-    # Decompose flat index into (outer, dim_idx, inner)
     outer_stride = dim_size * inner_size
-    outer_idx = offset // outer_stride
-    remainder = offset % outer_stride
+    outer_idx = offsets // outer_stride
+    remainder = offsets % outer_stride
     dim_idx = remainder // inner_size
     inner_idx = remainder % inner_size
 
-    # Apply roll: source_dim_idx = (dim_idx - shift) % dim_size
-    source_dim_idx = (dim_idx - shift + dim_size) % dim_size
+    src_dim_idx = (dim_idx - shift + dim_size) % dim_size
+    src_offsets = outer_idx * outer_stride + src_dim_idx * inner_size + inner_idx
 
-    # Reconstruct source flat index
-    source_offset = outer_idx * outer_stride + source_dim_idx * inner_size + inner_idx
-
-    val = tl.load(inp_ptr + source_offset, mask=mask, other=0.0)
-    tl.store(out_ptr + offset, val, mask=mask)
+    values = tl.load(in_ptr + src_offsets, mask=mask)
+    tl.store(out_ptr + offsets, values, mask=mask)
 
 
-def _roll_single_dim(inp: torch.Tensor, shift: int, dim: int) -> torch.Tensor:
-    size = inp.size(dim)
-    if size == 0:
-        return inp.clone()
+def _canonicalize_dim(dim: int, ndim: int) -> int:
+    if ndim == 0:
+        raise IndexError(f"Dimension specified as {dim} but tensor has no dimensions")
+    if dim < -ndim or dim >= ndim:
+        raise IndexError(
+            f"Dimension out of range (expected to be in range of [{-ndim}, {ndim - 1}], but got {dim})"
+        )
+    return dim % ndim
 
-    shift = shift % size
+
+def _normalize_shifts_dims(
+    input: torch.Tensor,
+    shifts: Union[int, Sequence[int]],
+    dims: Optional[Union[int, Sequence[int]]],
+):
+    if dims is None:
+        if isinstance(shifts, int):
+            return [shifts], [0], True
+        shifts = list(shifts)
+        if len(shifts) == 0:
+            raise RuntimeError("`shifts` required")
+        if len(shifts) == 1:
+            return shifts, [0], True
+        raise RuntimeError(
+            f"shifts and dimensions must align. shifts: {len(shifts)}, dims:0"
+        )
+
+    dims_list = [dims] if isinstance(dims, int) else list(dims)
+    if isinstance(shifts, int):
+        shifts_list = [shifts]
+    else:
+        shifts_list = list(shifts)
+        if len(shifts_list) == 0:
+            raise RuntimeError("`shifts` required")
+
+    if len(shifts_list) != len(dims_list):
+        raise RuntimeError(
+            f"shifts and dimensions must align. shifts: {len(shifts_list)}, dims:{len(dims_list)}"
+        )
+
+    dims_list = [_canonicalize_dim(dim, input.ndim) for dim in dims_list]
+    return shifts_list, dims_list, False
+
+
+def _collapse_shifts_dims(
+    input: torch.Tensor, shifts: List[int], dims: List[int]
+) -> tuple[List[int], List[int]]:
+    merged_shifts = {}
+    merged_dims = []
+    for shift, dim in zip(shifts, dims):
+        if dim not in merged_shifts:
+            merged_dims.append(dim)
+            merged_shifts[dim] = 0
+        merged_shifts[dim] += shift
+
+    normalized_shifts = []
+    normalized_dims = []
+    for dim in merged_dims:
+        dim_size = input.shape[dim]
+        shift = 0 if dim_size == 0 else merged_shifts[dim] % dim_size
+        if shift != 0:
+            normalized_shifts.append(shift)
+            normalized_dims.append(dim)
+    return normalized_shifts, normalized_dims
+
+
+def _roll_single_dim(input: torch.Tensor, shift: int, dim: int) -> torch.Tensor:
+    input_c = input if input.is_contiguous() else input.contiguous()
+    dim_size = input_c.shape[dim]
+    if input_c.numel() == 0 or dim_size <= 1:
+        return input_c.clone()
+
+    shift %= dim_size
     if shift == 0:
-        return inp.clone()
-
-    inp_contig = inp.contiguous()
-    out = torch.empty_like(inp_contig)
+        return input_c.clone()
 
     inner_size = 1
-    for i in range(dim + 1, inp.ndim):
-        inner_size *= inp.size(i)
+    for axis in range(dim + 1, input_c.ndim):
+        inner_size *= input_c.shape[axis]
 
-    N = inp.numel()
-    BLOCK_SIZE = 512
-    grid = lambda meta: (triton.cdiv(N, BLOCK_SIZE),)
+    out = torch.empty_like(input_c)
+    numel = input_c.numel()
+    block = 1024
+    grid = (triton.cdiv(numel, block),)
 
-    roll_kernel[grid](
-        inp_contig,
-        out,
-        N,
-        size,
-        shift,
-        inner_size,
-        BLOCK_SIZE=BLOCK_SIZE,
-    )
+    with torch_device_fn.device(input.device):
+        _roll_single_dim_kernel[grid](
+            input_c,
+            out,
+            numel,
+            dim_size,
+            shift,
+            inner_size,
+            BLOCK=block,
+        )
     return out
 
 
-def roll(inp: torch.Tensor, shifts, dims=None) -> torch.Tensor:
+def roll(
+    input: torch.Tensor,
+    shifts: Union[int, List[int]],
+    dims: Optional[Union[int, List[int]]] = None,
+) -> torch.Tensor:
     logger.debug("GEMS ROLL")
 
-    if inp.numel() == 0:
-        return inp.clone()
+    shifts, dims, flatten = _normalize_shifts_dims(input, shifts, dims)
+    if flatten:
+        flat = input.contiguous().reshape(-1)
+        return _roll_single_dim(flat, shifts[0], 0).reshape(input.shape)
 
-    if dims is None:
-        if isinstance(shifts, (list, tuple)):
-            shift = shifts[0] if len(shifts) == 1 else sum(shifts)
-        else:
-            shift = shifts
-        original_shape = inp.shape
-        flat = inp.contiguous().reshape(-1)
-        out_flat = _roll_single_dim(flat, shift, 0)
-        return out_flat.reshape(original_shape)
-
-    if isinstance(dims, int):
-        dims = [dims]
-    if isinstance(shifts, int):
-        shifts = [shifts]
-
-    assert len(shifts) == len(dims), "shifts and dims must have the same length"
-
-    ndim = inp.ndim
-    dims = [d % ndim for d in dims]
-
-    result = inp
+    shifts, dims = _collapse_shifts_dims(input, shifts, dims)
+    if len(shifts) == 0:
+        return input.contiguous().clone()
+    result = input
     for shift, dim in zip(shifts, dims):
         result = _roll_single_dim(result, shift, dim)
     return result

--- a/tests/test_roll.py
+++ b/tests/test_roll.py
@@ -5,102 +5,139 @@ import flag_gems
 
 from . import accuracy_utils as utils
 
-ROLL_SHIFTS_DIMS = [
+ROLL_SINGLE_DIM_CASES = [
     (1, 0),
     (-1, 0),
     (2, -1),
     (3, 1),
 ]
 
-
-@pytest.mark.roll
-@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
-@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES + utils.ALL_INT_DTYPES)
-@pytest.mark.parametrize("shifts_dims", ROLL_SHIFTS_DIMS)
-def test_roll_single_dim(shape, dtype, shifts_dims):
-    shifts, dims = shifts_dims
-    ndim = len(shape)
-    # Adjust dims if it's out of range for this shape
-    if dims >= ndim or dims < -ndim:
-        pytest.skip(f"dims {dims} out of range for shape {shape}")
-
-    if dtype in utils.ALL_FLOAT_DTYPES:
-        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
-    else:
-        inp = torch.randint(-1000, 1000, shape, device=flag_gems.device).to(dtype)
-    ref_inp = utils.to_reference(inp, False)
-
-    ref_out = torch.roll(ref_inp, shifts, dims)
-    with flag_gems.use_gems():
-        res_out = torch.roll(inp, shifts, dims)
-
-    utils.gems_assert_equal(res_out, ref_out)
-
-
-ROLL_MULTI_DIMS = [
+ROLL_MULTI_DIM_CASES = [
     ((1, 2), (0, 1)),
     ((-1, 1), (0, -1)),
     ((2, -2), (-2, -1)),
+    ((1, 2), (0, 0)),
 ]
-
-
-@pytest.mark.roll
-@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
-@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
-@pytest.mark.parametrize("shifts_dims", ROLL_MULTI_DIMS)
-def test_roll_multi_dims(shape, dtype, shifts_dims):
-    shifts, dims = shifts_dims
-    ndim = len(shape)
-    # Check all dims are valid for this shape
-    for d in dims:
-        if d >= ndim or d < -ndim:
-            pytest.skip(f"dims {d} out of range for shape {shape}")
-
-    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
-    ref_inp = utils.to_reference(inp, False)
-
-    ref_out = torch.roll(ref_inp, shifts, dims)
-    with flag_gems.use_gems():
-        res_out = torch.roll(inp, shifts, dims)
-
-    utils.gems_assert_equal(res_out, ref_out)
-
 
 ROLL_FLATTEN_SHIFTS = [1, -1, 5, -3]
 
 
-@pytest.mark.roll
-@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
-@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
-@pytest.mark.parametrize("shifts", ROLL_FLATTEN_SHIFTS)
-def test_roll_flatten(shape, dtype, shifts):
-    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
-    ref_inp = utils.to_reference(inp, False)
-
-    # Roll without specifying dims (flatten case)
-    ref_out = torch.roll(ref_inp, shifts)
-    with flag_gems.use_gems():
-        res_out = torch.roll(inp, shifts)
-
-    utils.gems_assert_equal(res_out, ref_out)
+def _make_input(shape, dtype):
+    if dtype == torch.bool:
+        return torch.randint(
+            0, 2, shape, device=flag_gems.device, dtype=torch.int32
+        ).to(torch.bool)
+    if dtype in utils.ALL_FLOAT_DTYPES:
+        return torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    return torch.randint(-1000, 1000, shape, device=flag_gems.device).to(dtype)
 
 
 @pytest.mark.roll
 @pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
-@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
-def test_roll_with_non_dense_input(shape, dtype):
-    if len(shape) < 2:
-        pytest.skip("Need at least 2D for non-dense test")
+@pytest.mark.parametrize("dtype", utils.ALL_FLOAT_DTYPES + utils.ALL_INT_DTYPES)
+@pytest.mark.parametrize("shifts,dims", ROLL_SINGLE_DIM_CASES)
+def test_roll_single_dim(shape, dtype, shifts, dims):
+    ndim = len(shape)
+    if dims >= ndim or dims < -ndim:
+        pytest.skip(f"dims {dims} out of range for shape {shape}")
 
-    shape_dilated = tuple(item * 2 for item in shape)
-    inp = torch.randn(shape_dilated, dtype=dtype, device=flag_gems.device)[::2, ::2]
+    inp = _make_input(shape, dtype)
     ref_inp = utils.to_reference(inp, False)
 
-    shifts = 2
-    dims = 0
-
-    ref_out = torch.roll(ref_inp, shifts, dims)
     with flag_gems.use_gems():
         res_out = torch.roll(inp, shifts, dims)
+    ref_out = torch.roll(ref_inp, shifts, dims)
 
     utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.roll
+@pytest.mark.parametrize("shape", [s for s in utils.POINTWISE_SHAPES if len(s) >= 2])
+@pytest.mark.parametrize(
+    "dtype", utils.ALL_FLOAT_DTYPES + utils.ALL_INT_DTYPES + utils.BOOL_TYPES
+)
+@pytest.mark.parametrize("shifts,dims", ROLL_MULTI_DIM_CASES)
+def test_roll_multi_dims(shape, dtype, shifts, dims):
+    inp = _make_input(shape, dtype)
+    ref_inp = utils.to_reference(inp, False)
+
+    with flag_gems.use_gems():
+        res_out = torch.roll(inp, shifts, dims)
+    ref_out = torch.roll(ref_inp, shifts, dims)
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.roll
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize(
+    "dtype", utils.ALL_FLOAT_DTYPES + utils.ALL_INT_DTYPES + utils.BOOL_TYPES
+)
+@pytest.mark.parametrize("shifts", ROLL_FLATTEN_SHIFTS)
+def test_roll_flatten(shape, dtype, shifts):
+    inp = _make_input(shape, dtype)
+    ref_inp = utils.to_reference(inp, False)
+
+    with flag_gems.use_gems():
+        res_out = torch.roll(inp, shifts)
+    ref_out = torch.roll(ref_inp, shifts)
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.roll
+@pytest.mark.parametrize(
+    "dtype", utils.ALL_FLOAT_DTYPES + utils.ALL_INT_DTYPES + utils.BOOL_TYPES
+)
+def test_roll_with_non_dense_input(dtype):
+    base = _make_input((8, 10, 12), dtype)
+    inp = base[:, ::2, :].transpose(0, 2)
+    ref_inp = utils.to_reference(inp, False)
+
+    with flag_gems.use_gems():
+        res_out = torch.roll(inp, shifts=(2, -3), dims=(0, 2))
+    ref_out = torch.roll(ref_inp, shifts=(2, -3), dims=(0, 2))
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.roll
+def test_roll_empty_tensor():
+    inp = torch.randn((2, 0, 3), device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, False)
+
+    with flag_gems.use_gems():
+        res_out = torch.roll(inp, shifts=5, dims=1)
+    ref_out = torch.roll(ref_inp, shifts=5, dims=1)
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.roll
+def test_roll_scalar_tensor():
+    inp = torch.tensor(5, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, False)
+
+    with flag_gems.use_gems():
+        res_out = torch.roll(inp, shifts=3)
+    ref_out = torch.roll(ref_inp, shifts=3)
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.roll
+@pytest.mark.parametrize(
+    "kwargs, error_type",
+    [
+        ({"shifts": (1, 2)}, RuntimeError),
+        ({"shifts": 1, "dims": (0, 1)}, RuntimeError),
+        ({"shifts": (1, 2, 3), "dims": (0, 1)}, RuntimeError),
+        ({"shifts": 1, "dims": 3}, IndexError),
+        ({"shifts": 1, "dims": -4}, IndexError),
+    ],
+)
+def test_roll_invalid_args(kwargs, error_type):
+    inp = torch.randn((2, 3, 4), device=flag_gems.device)
+    with flag_gems.use_gems():
+        with pytest.raises(error_type):
+            torch.roll(inp, **kwargs)


### PR DESCRIPTION
### PR Category
  <!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
  Operator

  ### Type of Change
  <!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
  New Feature

  ### Description

  It provides Triton kernel support and benchmark integration for the following aten schema:

  - `roll(Tensor self, SymInt[1] shifts, int[1]? dims=None) -> Tensor`

  It also improves semantic compatibility and performance for multi-dimensional `roll` cases.

  **Implementation details:**

  - **Kernel:** Adds a Triton single-dimension fast path in `src/flag_gems/ops/roll.py`.
  - **Semantic behavior:** Aligns with PyTorch for `dims=None`, negative dims, repeated dims, scalar tensors, empty tensors, and invalid `shifts`/`dims` combinations.
  - **Performance strategy:** Uses a chained single-dimension fast path for multi-dimensional roll instead of a generic per-element index decomposition path, which significantly improves large-shape performance on the target GPU.
  - **Benchmark coverage:** Adds `roll` benchmark coverage in `benchmark/test_unary_pointwise_perf.py` so the operator can be measured through the unary pointwise benchmark entry.
  - **Accuracy coverage:** Expands `tests/test_roll.py` with single-dim, multi-dim, flatten, non-contiguous input, empty tensor, scalar tensor, repeated dims, bool/int/float dtypes, and invalid-argument coverage.

  **Files changed:**

  | File | Change |
  |------|--------|
  | `src/flag_gems/ops/roll.py` | Triton `roll` implementation with PyTorch-compatible argument normalization and optimized multi-dim path |
  | `tests/test_roll.py` | Add accuracy tests and edge-case coverage for `roll` |
  | `benchmark/test_unary_pointwise_perf.py` | Add `roll` benchmark entry |

  ### Issue

  Implement and validate `roll` operator support for Operator Development Competition.

  ### Correctness

  Accuracy tests result:

  `468 passed, 35 skipped, 39 warnings`

  Command:

  ```bash
  TX8_DEPS_ROOT=/tmp/tx8_deps python3 -m pytest tests/test_roll.py -q
  ```
  ### Performance

  Environment: python3, TX8_DEPS_ROOT=/tmp/tx8_deps

  Command:
 ```bash
  TX8_DEPS_ROOT=/tmp/tx8_deps python3 -m pytest benchmark/test_unary_pointwise_perf.py -k 'roll' -s --level core --warmup 5 --iter 10
 ```
  Speedup = Torch latency / Gems latency; > 1.0 means Gems is faster.

  ### roll float16

  | Shape | Torch (ms) | Gems (ms) | Speedup | TFLOPS |
  |-------|------------|-----------|---------|--------|
  | (1073741824,) | 9.807872 | 5.079040 | 1.931 | 0.211 |
  | (64, 64) | 0.007168 | 0.007168 | 1.000 | 0.001 |
  | (4096, 4096) | 0.264192 | 0.167936 | 1.573 | 0.100 |
  | (64, 512, 512) | 0.264192 | 0.167936 | 1.573 | 0.100 |
  | (1024, 1024, 1024) | 18.584576 | 10.519552 | 1.767 | 0.102 |

  ### roll float32

  | Shape | Torch (ms) | Gems (ms) | Speedup | TFLOPS |
  |-------|------------|-----------|---------|--------|
  | (1073741824,) | 11.282432 | 10.188800 | 1.107 | 0.105 |
  | (64, 64) | 0.007168 | 0.007168 | 1.000 | 0.001 |
  | (4096, 4096) | 0.339968 | 0.327680 | 1.038 | 0.051 |
  | (64, 512, 512) | 0.338944 | 0.326656 | 1.038 | 0.051 |
  | (1024, 1024, 1024) | 22.428673 | 20.387840 | 1.100 | 0.053 |

  ### roll bfloat16

  | Shape | Torch (ms) | Gems (ms) | Speedup | TFLOPS |
  |-------|------------|-----------|---------|--------|
  | (1073741824,) | 9.720832 | 5.094400 | 1.908 | 0.211 |
  | (64, 64) | 0.008192 | 0.007168 | 1.143 | 0.001 |
  | (4096, 4096) | 0.265216 | 0.167936 | 1.579 | 0.100 |
  | (64, 512, 512) | 0.266240 | 0.167936 | 1.585 | 0.100 |
  | (1024, 1024, 1024) | 18.631680 | 10.165248 | 1.833 | 0.106 |