### PR TITLE
Bump pytest to 9.0.3 for security reasons

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -123,7 +123,7 @@ test = [
     "distro==1.9.0",
     "coverage==7.13.5",
     "openpyxl==3.1.5",
-    "pytest==9.0.2",
+    "pytest==9.0.3",
     "scipy>=1.15.3",
 ]
 


### PR DESCRIPTION
### PR Category

Other

### Type of Change

Other

### Description

This PR updates the pytest version to 9.0.3.
