### PR TITLE
Fix pyproject setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -201,6 +201,7 @@ explicit = true
 [[tool.uv.index]]
 name = "metax-pypi"
 url = "https://resource.flagos.net/repository/flagos-pypi-metax/simple"
+explicit = true
 
 # Source for Mthreads packages
 [[tool.uv.index]]


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

Okay, there is a reason that uv is looking up for packages on the wrong site.
