### PR TITLE
[FlagGems Operator Development Competition] Add avg_pool3d operator

### DIFF
--- a/benchmark/test_reduction_perf.py
+++ b/benchmark/test_reduction_perf.py
@@ -440,6 +440,85 @@ def test_perf_avg_pool2d_backward():
     bench.run()
 
 
+def avg_pool3d_input_fn(shape, dtype, device):
+    inp = generate_tensor_input(shape, dtype, device)
+    # Common case
+    yield inp, {
+        "kernel_size": 3,
+        "stride": 2,
+        "padding": 1,
+        "ceil_mode": False,
+        "count_include_pad": True,
+        "divisor_override": None,
+    }
+    if Config.bench_level == BenchLevel.COMPREHENSIVE:
+        # With count_include_pad=False
+        yield inp, {
+            "kernel_size": 3,
+            "stride": 2,
+            "padding": 1,
+            "ceil_mode": False,
+            "count_include_pad": False,
+            "divisor_override": None,
+        }
+        # With ceil_mode
+        yield inp, {
+            "kernel_size": 3,
+            "stride": 2,
+            "padding": 1,
+            "ceil_mode": True,
+            "count_include_pad": True,
+            "divisor_override": None,
+        }
+        # With divisor_override
+        if shape[-3] >= 2 and shape[-2] >= 2 and shape[-1] >= 2:
+            yield inp, {
+                "kernel_size": 2,
+                "stride": 1,
+                "padding": 0,
+                "ceil_mode": False,
+                "count_include_pad": True,
+                "divisor_override": 3,
+            }
+
+
+class AvgPool3dBenchmark(GenericBenchmark):
+    def get_input_iter(self, cur_dtype) -> Generator:
+        shapes_5d = [
+            (4, 3, 16, 224, 224),   # Typical 3D input
+            (16, 64, 8, 56, 56),    # Early 3D ResNet layer output
+            (32, 128, 4, 28, 28),   # Mid 3D ResNet layer output
+            (64, 256, 4, 14, 14),   # Later 3D ResNet layer output (depth >= kernel_size)
+            (128, 512, 4, 7, 7),    # Final 3D ResNet layer output (depth >= kernel_size)
+        ]
+
+        for shape in shapes_5d:
+            yield from self.input_fn(shape, cur_dtype, self.device)
+
+
+@pytest.mark.avg_pool3d
+def test_perf_avg_pool3d():
+    bench = AvgPool3dBenchmark(
+        input_fn=avg_pool3d_input_fn,
+        op_name="avg_pool3d",
+        torch_op=torch.ops.aten.avg_pool3d,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.avg_pool3d_backward
+def test_perf_avg_pool3d_backward():
+    bench = AvgPool3dBenchmark(
+        input_fn=avg_pool3d_input_fn,
+        op_name="avg_pool3d_backward",
+        torch_op=torch.ops.aten.avg_pool3d,
+        dtypes=[torch.float32] if vendor_name == "mthreads" else FLOAT_DTYPES,
+        is_backward=True,
+    )
+    bench.run()
+
+
 def max_pool2d_input_fn(shape, dtype, device):
     inp = generate_tensor_input(shape, dtype, device)
     yield inp, {

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -100,6 +100,8 @@ _FULL_CONFIG = (
     ("arctanh_", arctanh_),
     ("avg_pool2d", avg_pool2d),
     ("avg_pool2d_backward", avg_pool2d_backward),
+    ("avg_pool3d", avg_pool3d),
+    ("avg_pool3d_backward", avg_pool3d_backward),
     ("baddbmm", baddbmm),
     ("bernoulli_.float", bernoulli_),
     ("bincount", bincount),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -41,6 +41,7 @@ from flag_gems.ops.attention import (
     scaled_dot_product_attention_forward,
 )
 from flag_gems.ops.avg_pool2d import avg_pool2d, avg_pool2d_backward
+from flag_gems.ops.avg_pool3d import avg_pool3d, avg_pool3d_backward
 from flag_gems.ops.baddbmm import baddbmm
 from flag_gems.ops.batch_norm import batch_norm, batch_norm_backward
 from flag_gems.ops.bernoulli_ import bernoulli_
@@ -388,6 +389,8 @@ __all__ = [
     "atan2_out",
     "avg_pool2d",
     "avg_pool2d_backward",
+    "avg_pool3d",
+    "avg_pool3d_backward",
     "baddbmm",
     "batch_norm",
     "batch_norm_backward",

--- a/src/flag_gems/ops/avg_pool3d.py
+++ b/src/flag_gems/ops/avg_pool3d.py
@@ -1,0 +1,484 @@
+import logging
+import torch
+import triton
+import triton.language as tl
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+def pool3d_output_size(
+    in_size: int,
+    kernel_size: int,
+    stride: int,
+    padding: int,
+    dilation: int,
+    ceil_mode: bool = False,
+) -> int:
+    effective_kernel_size = (kernel_size - 1) * dilation + 1
+    numerator = in_size + 2 * padding - effective_kernel_size
+    if ceil_mode:
+        output_size = (numerator + stride - 1) // stride + 1
+        if (output_size - 1) * stride >= in_size + padding:
+            output_size -= 1
+    else:
+        output_size = numerator // stride + 1
+    return output_size
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_D": 4, "BLOCK_H": 8,  "BLOCK_W": 8},  num_stages=4, num_warps=4),
+        triton.Config({"BLOCK_D": 4, "BLOCK_H": 16, "BLOCK_W": 16}, num_stages=3, num_warps=4),
+        triton.Config({"BLOCK_D": 8, "BLOCK_H": 8,  "BLOCK_W": 8},  num_stages=3, num_warps=4),
+        triton.Config({"BLOCK_D": 8, "BLOCK_H": 16, "BLOCK_W": 8},  num_stages=2, num_warps=8),
+        triton.Config({"BLOCK_D": 8, "BLOCK_H": 8,  "BLOCK_W": 16}, num_stages=2, num_warps=8),
+        triton.Config({"BLOCK_D": 2, "BLOCK_H": 16, "BLOCK_W": 16}, num_stages=5, num_warps=2),
+        triton.Config({"BLOCK_D": 2, "BLOCK_H": 32, "BLOCK_W": 16}, num_stages=4, num_warps=4),
+        triton.Config({"BLOCK_D": 4, "BLOCK_H": 32, "BLOCK_W": 16}, num_stages=2, num_warps=8),
+        triton.Config({"BLOCK_D": 4, "BLOCK_H": 16, "BLOCK_W": 32}, num_stages=2, num_warps=8),
+    ],
+    key=["out_d", "out_h", "out_w", "kernel_d", "kernel_h", "kernel_w",
+         "stride_d", "stride_h", "stride_w"],
+)
+@triton.jit
+def avg_pool3d_forward_kernel(
+    input_ptr,
+    output_ptr,
+    # Input tensor strides
+    in_stride_n,
+    in_stride_c,
+    in_stride_d,
+    in_stride_h,
+    in_stride_w,
+    # Input/Output shapes
+    in_c,
+    in_d,
+    in_h,
+    in_w,
+    out_d,
+    out_h,
+    out_w,
+    # Pooling parameters
+    kernel_d: tl.constexpr,
+    kernel_h: tl.constexpr,
+    kernel_w: tl.constexpr,
+    stride_d: tl.constexpr,
+    stride_h: tl.constexpr,
+    stride_w: tl.constexpr,
+    padding_d: tl.constexpr,
+    padding_h: tl.constexpr,
+    padding_w: tl.constexpr,
+    dilation_d: tl.constexpr,
+    dilation_h: tl.constexpr,
+    dilation_w: tl.constexpr,
+    # AvgPool specific
+    COUNT_INCLUDE_PAD: tl.constexpr,
+    divisor_override,
+    # Tiling
+    BLOCK_D: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_W: tl.constexpr,
+):
+    pid_nc = tl.program_id(0)
+    pid_dhw = tl.program_id(1)
+
+    num_d_blocks = tl.cdiv(out_d, BLOCK_D)
+    num_w_blocks = tl.cdiv(out_w, BLOCK_W)
+    num_hw_blocks = tl.cdiv(out_h, BLOCK_H) * num_w_blocks
+
+    d_block_idx  = pid_dhw // num_hw_blocks
+    hw_remainder = pid_dhw % num_hw_blocks
+    h_block_idx  = hw_remainder // num_w_blocks
+    w_block_idx  = hw_remainder % num_w_blocks
+
+    n_idx = pid_nc // in_c
+    c_idx = pid_nc % in_c
+
+    d_out_offsets = d_block_idx * BLOCK_D + tl.arange(0, BLOCK_D)   # (BLOCK_D,)
+    h_out_offsets = h_block_idx * BLOCK_H + tl.arange(0, BLOCK_H)   # (BLOCK_H,)
+    w_out_offsets = w_block_idx * BLOCK_W + tl.arange(0, BLOCK_W)   # (BLOCK_W,)
+
+    sum_acc   = tl.zeros((BLOCK_D, BLOCK_H, BLOCK_W), dtype=tl.float32)
+    count_acc = tl.zeros((BLOCK_D, BLOCK_H, BLOCK_W), dtype=tl.int32)
+
+    input_base_ptr = input_ptr + n_idx * in_stride_n + c_idx * in_stride_c
+
+    for kd in range(0, kernel_d):
+        for kh in range(0, kernel_h):
+            for kw in range(0, kernel_w):
+                d_in = d_out_offsets[:, None, None] * stride_d - padding_d + kd * dilation_d
+                h_in = h_out_offsets[None, :, None] * stride_h - padding_h + kh * dilation_h
+                w_in = w_out_offsets[None, None, :] * stride_w - padding_w + kw * dilation_w
+
+                in_mask = (
+                    (d_in >= 0) & (d_in < in_d) &
+                    (h_in >= 0) & (h_in < in_h) &
+                    (w_in >= 0) & (w_in < in_w)
+                )
+
+                input_offset = (
+                    d_in * in_stride_d +
+                    h_in * in_stride_h +
+                    w_in * in_stride_w
+                )
+                current_val = tl.load(
+                    input_base_ptr + input_offset, mask=in_mask, other=0.0
+                )
+                sum_acc   += tl.where(in_mask, current_val, 0.0)
+                count_acc += in_mask.to(tl.int32)
+
+    if divisor_override != 0:
+        divisor = tl.full((BLOCK_D, BLOCK_H, BLOCK_W), divisor_override, dtype=tl.float32)
+    elif COUNT_INCLUDE_PAD:
+        divisor = tl.full(
+            (BLOCK_D, BLOCK_H, BLOCK_W),
+            kernel_d * kernel_h * kernel_w,
+            dtype=tl.float32,
+        )
+    else:
+        divisor = count_acc.to(tl.float32)
+
+    output_vals = tl.where(divisor != 0, sum_acc / divisor, 0.0)
+
+    out_base_ptr = output_ptr + pid_nc * out_d * out_h * out_w
+
+    out_d_offsets = d_block_idx * BLOCK_D + tl.arange(0, BLOCK_D)
+    out_h_offsets = h_block_idx * BLOCK_H + tl.arange(0, BLOCK_H)
+    out_w_offsets = w_block_idx * BLOCK_W + tl.arange(0, BLOCK_W)
+
+    output_block_ptr = (
+        out_base_ptr
+        + out_d_offsets[:, None, None] * out_h * out_w
+        + out_h_offsets[None, :, None] * out_w
+        + out_w_offsets[None, None, :]
+    )
+    out_mask = (
+        (out_d_offsets[:, None, None] < out_d) &
+        (out_h_offsets[None, :, None] < out_h) &
+        (out_w_offsets[None, None, :] < out_w)
+    )
+    tl.store(
+        output_block_ptr,
+        output_vals.to(output_ptr.type.element_ty),
+        mask=out_mask,
+    )
+
+
+@libentry()
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_D": 4, "BLOCK_H": 8,  "BLOCK_W": 8},  num_stages=4, num_warps=4),
+        triton.Config({"BLOCK_D": 4, "BLOCK_H": 16, "BLOCK_W": 16}, num_stages=3, num_warps=4),
+        triton.Config({"BLOCK_D": 8, "BLOCK_H": 8,  "BLOCK_W": 8},  num_stages=3, num_warps=4),
+        triton.Config({"BLOCK_D": 8, "BLOCK_H": 16, "BLOCK_W": 8},  num_stages=2, num_warps=8),
+        triton.Config({"BLOCK_D": 8, "BLOCK_H": 8,  "BLOCK_W": 16}, num_stages=2, num_warps=8),
+        triton.Config({"BLOCK_D": 2, "BLOCK_H": 32, "BLOCK_W": 16}, num_stages=3, num_warps=4),
+        triton.Config({"BLOCK_D": 4, "BLOCK_H": 32, "BLOCK_W": 16}, num_stages=2, num_warps=8),
+        triton.Config({"BLOCK_D": 4, "BLOCK_H": 16, "BLOCK_W": 32}, num_stages=2, num_warps=8),
+    ],
+    key=["in_d", "in_h", "in_w", "kernel_d", "kernel_h", "kernel_w",
+         "stride_d", "stride_h", "stride_w"],
+)
+@triton.jit
+def avg_pool3d_backward_kernel(
+    grad_output_ptr,
+    grad_input_ptr,
+    # Shapes
+    in_c,
+    in_d,
+    in_h,
+    in_w,
+    out_d,
+    out_h,
+    out_w,
+    # grad_input strides
+    in_stride_n,
+    in_stride_c,
+    in_stride_d,
+    in_stride_h,
+    in_stride_w,
+    # grad_output strides
+    out_stride_n,
+    out_stride_c,
+    out_stride_d,
+    out_stride_h,
+    out_stride_w,
+    # Pooling parameters
+    kernel_d: tl.constexpr,
+    kernel_h: tl.constexpr,
+    kernel_w: tl.constexpr,
+    stride_d: tl.constexpr,
+    stride_h: tl.constexpr,
+    stride_w: tl.constexpr,
+    padding_d: tl.constexpr,
+    padding_h: tl.constexpr,
+    padding_w: tl.constexpr,
+    dilation_d: tl.constexpr,
+    dilation_h: tl.constexpr,
+    dilation_w: tl.constexpr,
+    # AvgPool specific
+    COUNT_INCLUDE_PAD: tl.constexpr,
+    divisor_override,
+    # Tiling
+    BLOCK_D: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_W: tl.constexpr,
+):
+    pid_nc  = tl.program_id(0)
+    pid_dhw = tl.program_id(1)
+
+    num_w_blocks  = tl.cdiv(in_w, BLOCK_W)
+    num_hw_blocks = tl.cdiv(in_h, BLOCK_H) * num_w_blocks
+
+    d_block_idx  = pid_dhw // num_hw_blocks
+    hw_remainder = pid_dhw % num_hw_blocks
+    h_block_idx  = hw_remainder // num_w_blocks
+    w_block_idx  = hw_remainder % num_w_blocks
+
+    n_idx = pid_nc // in_c
+    c_idx = pid_nc % in_c
+
+    grad_input_block_ptr  = grad_input_ptr  + n_idx * in_stride_n  + c_idx * in_stride_c
+    grad_output_base_ptr  = grad_output_ptr + n_idx * out_stride_n + c_idx * out_stride_c
+
+    d_in_offsets = d_block_idx * BLOCK_D + tl.arange(0, BLOCK_D)
+    h_in_offsets = h_block_idx * BLOCK_H + tl.arange(0, BLOCK_H)
+    w_in_offsets = w_block_idx * BLOCK_W + tl.arange(0, BLOCK_W)
+
+    grad_acc = tl.zeros((BLOCK_D, BLOCK_H, BLOCK_W), dtype=tl.float32)
+
+    for kd_loop in range(kernel_d):
+        for kh_loop in range(kernel_h):
+            for kw_loop in range(kernel_w):
+                d_out_num = d_in_offsets[:, None, None] + padding_d - kd_loop * dilation_d
+                h_out_num = h_in_offsets[None, :, None] + padding_h - kh_loop * dilation_h
+                w_out_num = w_in_offsets[None, None, :] + padding_w - kw_loop * dilation_w
+
+                d_valid = (d_out_num >= 0) & ((d_out_num % stride_d) == 0)
+                h_valid = (h_out_num >= 0) & ((h_out_num % stride_h) == 0)
+                w_valid = (w_out_num >= 0) & ((w_out_num % stride_w) == 0)
+
+                d_out = d_out_num // stride_d
+                h_out = h_out_num // stride_h
+                w_out = w_out_num // stride_w
+
+                out_mask = (
+                    d_valid & (d_out < out_d) &
+                    h_valid & (h_out < out_h) &
+                    w_valid & (w_out < out_w)
+                )
+
+                if divisor_override != 0:
+                    divisor = tl.full(
+                        (BLOCK_D, BLOCK_H, BLOCK_W), divisor_override, dtype=tl.float32
+                    )
+                elif COUNT_INCLUDE_PAD:
+                    divisor = tl.full(
+                        (BLOCK_D, BLOCK_H, BLOCK_W),
+                        kernel_d * kernel_h * kernel_w,
+                        dtype=tl.float32,
+                    )
+                else:
+                    d_start = d_out * stride_d - padding_d
+                    h_start = h_out * stride_h - padding_h
+                    w_start = w_out * stride_w - padding_w
+                    count = tl.zeros((BLOCK_D, BLOCK_H, BLOCK_W), dtype=tl.int32)
+                    for kd_c in range(0, kernel_d):
+                        for kh_c in range(0, kernel_h):
+                            for kw_c in range(0, kernel_w):
+                                d_in_c = d_start + kd_c * dilation_d
+                                h_in_c = h_start + kh_c * dilation_h
+                                w_in_c = w_start + kw_c * dilation_w
+                                is_valid = (
+                                    (d_in_c >= 0) & (d_in_c < in_d) &
+                                    (h_in_c >= 0) & (h_in_c < in_h) &
+                                    (w_in_c >= 0) & (w_in_c < in_w)
+                                )
+                                count += is_valid.to(tl.int32)
+                    divisor = count.to(tl.float32)
+
+                divisor = tl.where(divisor == 0, 1.0, divisor)
+
+                grad_out_ptr = (
+                    grad_output_base_ptr
+                    + d_out * out_stride_d
+                    + h_out * out_stride_h
+                    + w_out * out_stride_w
+                )
+                grad_out_val = tl.load(grad_out_ptr, mask=out_mask, other=0.0)
+                grad_acc += tl.where(out_mask, grad_out_val / divisor, 0.0)
+
+    grad_input_store_ptr = (
+        grad_input_block_ptr
+        + d_in_offsets[:, None, None] * in_stride_d
+        + h_in_offsets[None, :, None] * in_stride_h
+        + w_in_offsets[None, None, :] * in_stride_w
+    )
+    in_write_mask = (
+        (d_in_offsets[:, None, None] < in_d) &
+        (h_in_offsets[None, :, None] < in_h) &
+        (w_in_offsets[None, None, :] < in_w)
+    )
+    tl.store(
+        grad_input_store_ptr,
+        grad_acc.to(grad_input_ptr.type.element_ty),
+        mask=in_write_mask,
+    )
+
+
+def _parse_pool3d_params(kernel_size, stride, padding):
+    def _to_triple(x, name):
+        if isinstance(x, int):
+            return x, x, x
+        if len(x) == 3:
+            return x[0], x[1], x[2]
+        raise ValueError(f"{name} must be int or 3-element sequence")
+
+    kernel_d, kernel_h, kernel_w = _to_triple(kernel_size, "kernel_size")
+
+    if stride is None or (isinstance(stride, (list, tuple)) and not stride):
+        stride_d, stride_h, stride_w = kernel_d, kernel_h, kernel_w
+    else:
+        stride_d, stride_h, stride_w = _to_triple(stride, "stride")
+
+    padding_d, padding_h, padding_w = _to_triple(padding, "padding")
+
+    if stride_d <= 0 or stride_h <= 0 or stride_w <= 0:
+        raise ValueError("stride must be greater than zero")
+    if padding_d < 0 or padding_h < 0 or padding_w < 0:
+        raise ValueError("padding must be non-negative")
+    if padding_d > kernel_d // 2 or padding_h > kernel_h // 2 or padding_w > kernel_w // 2:
+        raise ValueError("pad should be smaller than or equal to half of kernel size")
+
+    return kernel_d, kernel_h, kernel_w, stride_d, stride_h, stride_w, padding_d, padding_h, padding_w
+
+
+def avg_pool3d(
+    input: torch.Tensor,
+    kernel_size,
+    stride=None,
+    padding=0,
+    ceil_mode=False,
+    count_include_pad=True,
+    divisor_override=None,
+):
+    """
+    FlagGems avg_pool3d forward.
+
+    input: (N, C, D, H, W)
+    """
+    logger.debug("GEMS AVG_POOL3D FORWARD")
+    if not input.is_cuda:
+        raise ValueError("avg_pool3d: input must be a CUDA tensor")
+    if divisor_override is not None and divisor_override == 0:
+        raise ValueError("divisor_override cannot be zero")
+
+    input = input.contiguous()
+    (
+        kernel_d, kernel_h, kernel_w,
+        stride_d, stride_h, stride_w,
+        padding_d, padding_h, padding_w,
+    ) = _parse_pool3d_params(kernel_size, stride, padding)
+
+    dilation_d = dilation_h = dilation_w = 1
+    in_n, in_c, in_d, in_h, in_w = input.shape
+
+    out_d = pool3d_output_size(in_d, kernel_d, stride_d, padding_d, dilation_d, ceil_mode)
+    out_h = pool3d_output_size(in_h, kernel_h, stride_h, padding_h, dilation_h, ceil_mode)
+    out_w = pool3d_output_size(in_w, kernel_w, stride_w, padding_w, dilation_w, ceil_mode)
+
+    output = torch.empty(
+        (in_n, in_c, out_d, out_h, out_w), device=input.device, dtype=input.dtype
+    )
+    if output.numel() == 0:
+        return output
+
+    def grid(meta):
+        return (
+            in_n * in_c,
+            triton.cdiv(out_d, meta["BLOCK_D"])
+            * triton.cdiv(out_h, meta["BLOCK_H"])
+            * triton.cdiv(out_w, meta["BLOCK_W"]),
+        )
+
+    avg_pool3d_forward_kernel[grid](
+        input,
+        output,
+        input.stride(0), input.stride(1), input.stride(2),
+        input.stride(3), input.stride(4),
+        in_c, in_d, in_h, in_w,
+        out_d, out_h, out_w,
+        kernel_d, kernel_h, kernel_w,
+        stride_d, stride_h, stride_w,
+        padding_d, padding_h, padding_w,
+        dilation_d, dilation_h, dilation_w,
+        COUNT_INCLUDE_PAD=count_include_pad,
+        divisor_override=float(divisor_override) if divisor_override is not None else 0.0,
+    )
+    return output
+
+
+def avg_pool3d_backward(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    kernel_size,
+    stride,
+    padding,
+    ceil_mode,
+    count_include_pad,
+    divisor_override,
+):
+    """
+    FlagGems avg_pool3d backward.
+
+    grad_output: (N, C, out_D, out_H, out_W)
+    input:       (N, C, in_D,  in_H,  in_W)   — used only for shape
+    """
+    logger.debug("GEMS AVG_POOL3D BACKWARD")
+    if divisor_override is not None and divisor_override == 0:
+        raise ValueError("divisor_override cannot be zero")
+
+    grad_output = grad_output.contiguous()
+    (
+        kernel_d, kernel_h, kernel_w,
+        stride_d, stride_h, stride_w,
+        padding_d, padding_h, padding_w,
+    ) = _parse_pool3d_params(kernel_size, stride, padding)
+
+    dilation_d = dilation_h = dilation_w = 1
+    in_n, in_c, in_d, in_h, in_w = input.shape
+    out_d, out_h, out_w = (
+        grad_output.shape[2], grad_output.shape[3], grad_output.shape[4]
+    )
+
+    grad_input = torch.zeros_like(input, dtype=torch.float32)
+    if grad_output.numel() == 0:
+        return grad_input.to(grad_output.dtype)
+
+    def grid(meta):
+        return (
+            in_n * in_c,
+            triton.cdiv(in_d, meta["BLOCK_D"])
+            * triton.cdiv(in_h, meta["BLOCK_H"])
+            * triton.cdiv(in_w, meta["BLOCK_W"]),
+        )
+
+    avg_pool3d_backward_kernel[grid](
+        grad_output,
+        grad_input,
+        in_c, in_d, in_h, in_w,
+        out_d, out_h, out_w,
+        grad_input.stride(0), grad_input.stride(1),
+        grad_input.stride(2), grad_input.stride(3), grad_input.stride(4),
+        grad_output.stride(0), grad_output.stride(1),
+        grad_output.stride(2), grad_output.stride(3), grad_output.stride(4),
+        kernel_d, kernel_h, kernel_w,
+        stride_d, stride_h, stride_w,
+        padding_d, padding_h, padding_w,
+        dilation_d, dilation_h, dilation_w,
+        COUNT_INCLUDE_PAD=count_include_pad,
+        divisor_override=float(divisor_override) if divisor_override is not None else 0.0,
+    )
+    return grad_input.to(grad_output.dtype)

--- a/tests/accuracy_utils.py
+++ b/tests/accuracy_utils.py
@@ -220,9 +220,9 @@ def to_reference(inp, upcast=False):
         ref_inp = ref_inp.to("cpu")
     if upcast:
         if ref_inp.is_complex():
-            ref_inp = ref_inp.to(torch.complex128)
+            ref_inp = ref_inp.to(torch.complex64 if not fp64_is_supported else torch.complex128)
         else:
-            ref_inp = ref_inp.to(torch.float64)
+            ref_inp = ref_inp.to(torch.float32 if not fp64_is_supported else torch.float64)
     return ref_inp
 
 

--- a/tests/test_avg_pool3d.py
+++ b/tests/test_avg_pool3d.py
@@ -1,0 +1,131 @@
+import random
+import time
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+if cfg.QUICK_MODE:
+    FLOAT_DTYPES = [torch.float32]
+else:
+    FLOAT_DTYPES = utils.FLOAT_DTYPES
+
+AVGPOOL3D_CONFIGS = [
+    # 3x3x3 kernel, stride 2, padding 1
+    ((4, 3, 16, 32, 32), 3, 2, 1, False, True, None),
+    # Test count_include_pad=False
+    ((4, 3, 16, 32, 32), 3, 2, 1, False, False, None),
+    # Non-cubic kernel and stride
+    ((8, 16, 14, 28, 28), (3, 4, 5), (1, 1, 2), 1, False, True, None),
+    # Test ceil_mode
+    ((2, 4, 15, 15, 15), 3, 2, 1, True, True, None),
+    # Test divisor_override
+    ((1, 1, 7, 7, 7), 2, 1, 0, False, True, 1),
+    # Larger case from a typical CNN
+    ((1, 64, 28, 56, 56), 3, 2, 1, False, True, None),
+    # No padding, count_include_pad=False
+    ((2, 8, 8, 16, 16), 2, 2, 0, False, False, None),
+    # Non-square padding
+    ((2, 8, 16, 16, 20), 2, 2, (1, 0, 1), False, True, None),
+]
+
+
+@pytest.mark.avg_pool3d
+@pytest.mark.parametrize(
+    "shape, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override",
+    AVGPOOL3D_CONFIGS,
+)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_avg_pool3d_forward(
+    shape,
+    kernel_size,
+    stride,
+    padding,
+    ceil_mode,
+    count_include_pad,
+    divisor_override,
+    dtype,
+):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.ops.aten.avg_pool3d(
+        ref_inp,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        ceil_mode=ceil_mode,
+        count_include_pad=count_include_pad,
+        divisor_override=divisor_override,
+    )
+
+    res_out = flag_gems.avg_pool3d(
+        inp,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        ceil_mode=ceil_mode,
+        count_include_pad=count_include_pad,
+        divisor_override=divisor_override,
+    )
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.avg_pool3d_backward
+@pytest.mark.parametrize(
+    "shape, kernel_size, stride, padding, ceil_mode, count_include_pad, divisor_override",
+    AVGPOOL3D_CONFIGS,
+)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_avg_pool3d_backward(
+    shape,
+    kernel_size,
+    stride,
+    padding,
+    ceil_mode,
+    count_include_pad,
+    divisor_override,
+    dtype,
+):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.ops.aten.avg_pool3d(
+        ref_inp,
+        kernel_size=kernel_size,
+        stride=stride,
+        padding=padding,
+        ceil_mode=ceil_mode,
+        count_include_pad=count_include_pad,
+        divisor_override=divisor_override,
+    )
+    out_grad = torch.randn_like(ref_out, dtype=inp.dtype, device=flag_gems.device)
+    ref_out_grad = utils.to_reference(out_grad, True)
+    ref_inp_grad = torch.ops.aten.avg_pool3d_backward(
+        ref_out_grad,
+        ref_inp,
+        kernel_size,
+        stride,
+        padding,
+        ceil_mode,
+        count_include_pad,
+        divisor_override,
+    )
+
+    with flag_gems.use_gems():
+        res_inp_grad = torch.ops.aten.avg_pool3d_backward(
+            out_grad,
+            inp,
+            kernel_size,
+            stride,
+            padding,
+            ceil_mode,
+            count_include_pad,
+            divisor_override,
+        )
+    utils.gems_assert_close(res_inp_grad, ref_inp_grad, dtype)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
- Operator 
- OP Test
- Benchmark

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
- New Feature

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
实现avg_pool3d算子，同时适配nvidia和主办方提供的iluvatar BI-V150加速卡

| File | Change |
|------|--------|
| `src/flag_gems/ops/avg_pool3d.py` | New |
| `src/flag_gems/__init__.py` | Register avg_pool3d/ avg_pool3d_backward |
| `src/flag_gems/ops/__init__.py` | Import and `__all__` |
| `tests/test_avg_pool3d.py` | Add accuracy tests for avg_pool3d, avg_pool3d_backward|
| `benchmark/test_reduction_perf.py` | Add avg_pool3d performance tests | 

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->
New operator for Operator Development Competition.  
基于PR #2665 的更改进行的测试，该PR所做更改是在不支持float64的机器上使用float32，因为测试时，会将部分结果转为高精度的float64，导致在主办方提供的iluvatar等加速卡上无法通过任何测试，除非使用cpu运算ref

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

#### Benchmark

##### iluvatar BI-V150

截图
forward
<img width="1825" height="695" alt="image" src="https://github.com/user-attachments/assets/8531946d-80bc-4ad3-8b82-b944e7071ba5" />
<img width="1824" height="701" alt="image" src="https://github.com/user-attachments/assets/808afe02-1369-403b-8323-e7f203f78135" />
<img width="1818" height="723" alt="image" src="https://github.com/user-attachments/assets/1cccdda8-e1fe-47aa-bfbe-5288f24fb389" />
<img width="1826" height="701" alt="image" src="https://github.com/user-attachments/assets/af740fd7-3009-4b91-b3d2-6ded078ac5ff" />
<img width="1820" height="620" alt="image" src="https://github.com/user-attachments/assets/afb0e251-bc54-4599-b161-d4f27a29a7df" />

backward

<img width="1825" height="751" alt="image" src="https://github.com/user-attachments/assets/e05b7f58-d9a3-47cf-8b6f-e0e34efe9989" />
<img width="1825" height="714" alt="image" src="https://github.com/user-attachments/assets/4141ae35-98a4-4a4e-824f-b2780a9982b9" />
<img width="1820" height="722" alt="image" src="https://github.com/user-attachments/assets/33847188-e334-4d66-8f38-e3dfd8da6942" />
<img width="1827" height="705" alt="image" src="https://github.com/user-attachments/assets/58a59e98-3242-4e57-8679-743233a845fa" />
<img width="1838" height="699" alt="image" src="https://github.com/user-attachments/assets/96c14fe6-42b0-4f2d-9971-d0c13995af46" />

1. forward dtype = float16

| 状态 | Torch延迟(ms) | Gems延迟(ms) | Gems加速比 | 输入Shape | kernel_size | stride | padding | ceil_mode | count_include_pad | divisor_override |
| ---- | ------------- | ------------ | ---------- | --------- | ----------- | ------ | ------- | --------- | ----------------- | ----------------|
| SUCCESS | 0.192450 | 0.489500 | 0.393 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.182692 | 0.527077 | 0.347 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.190750 | 0.545173 | 0.350 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.514904 | 0.224212 | 2.297 | [4, 3, 16, 224, 224] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.501519 | 1.412923 | 0.355 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.507250 | 1.517769 | 0.334 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.559212 | 1.644481 | 0.340 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.437615 | 1.340308 | 1.073 | [16, 64, 8, 56, 56] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.534808 | 0.526788 | 1.015 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.541019 | 0.646769 | 0.836 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.577231 | 0.675519 | 0.854 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.709923 | 0.392846 | 1.807 | [32, 128, 4, 28, 28] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.055231 | 0.549077 | 1.922 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.066808 | 0.584135 | 1.826 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 1.137077 | 0.552942 | 2.056 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.396865 | 0.368923 | 3.786 | [64, 256, 4, 14, 14] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 2.172481 | 1.295077 | 1.677 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 2.198365 | 1.650442 | 1.332 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 2.343442 | 1.294885 | 1.810 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 2.136461 | 0.606077 | 3.525 | [128, 512, 4, 7, 7] | 2 | 1 | 0 | False | True | 3 |

2. forward dtype = float32

| 状态 | Torch延迟(ms) | Gems延迟(ms) | Gems加速比 | 输入Shape | kernel_size | stride | padding | ceil_mode | count_include_pad | divisor_override |
| ---- | ------------- | ------------ | ---------- | --------- | ----------- | ------ | ------- | --------- | ----------------- | ---------------- |
| SUCCESS | 0.197769 | 0.587519 | 0.337 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.198577 | 0.594404 | 0.334 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.206923 | 0.630269 | 0.328 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.483558 | 0.226327 | 2.137 | [4, 3, 16, 224, 224] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.491885 | 2.206423 | 0.223 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.496269 | 2.688288 | 0.185 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.543654 | 2.550865 | 0.213 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.355135 | 6.807577 | 0.199 | [16, 64, 8, 56, 56] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.509769 | 0.564731 | 0.903 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.515365 | 0.674462 | 0.764 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.551462 | 0.757769 | 0.728 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.670250 | 0.524577 | 1.278 | [32, 128, 4, 28, 28] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.002808 | 0.613115 | 1.636 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.014038 | 0.643038 | 1.577 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 1.076981 | 0.615692 | 1.749 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.320885 | 0.355423 | 3.716 | [64, 256, 4, 14, 14] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 2.063135 | 1.233769 | 1.672 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 2.084231 | 1.588942 | 1.312 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 2.223135 | 1.233750 | 1.802 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 2.025750 | 0.599423 | 3.379 | [128, 512, 4, 7, 7] | 2 | 1 | 0 | False | True | 3 |

3. forward dtype = bfloat16

| 状态 | Torch延迟(ms) | Gems延迟(ms) | Gems加速比 | 输入Shape | kernel_size | stride | padding | ceil_mode | count_include_pad | divisor_override |
| ---- | ------------- | ------------ | ---------- | --------- | ----------- | ------ | ------- | --------- | ----------------- | ---------------- |
| SUCCESS | 0.180712 | 0.489462 | 0.369 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.182538 | 0.526192 | 0.347 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.190327 | 0.544827 | 0.349 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.515019 | 0.224250 | 2.297 | [4, 3, 16, 224, 224] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.501481 | 1.410808 | 0.355 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.506962 | 1.521039 | 0.333 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.559962 | 1.642769 | 0.341 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.437058 | 1.340885 | 1.072 | [16, 64, 8, 56, 56] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.534981 | 0.526538 | 1.016 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.540865 | 0.646904 | 0.836 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.577481 | 0.675865 | 0.854 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.710250 | 0.391981 | 1.812 | [32, 128, 4, 28, 28] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.055077 | 0.549577 | 1.920 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.067039 | 0.583654 | 1.828 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 1.136808 | 0.552654 | 2.057 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.396885 | 0.368942 | 3.786 | [64, 256, 4, 14, 14] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 2.170346 | 1.295269 | 1.676 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 2.197788 | 1.650346 | 1.332 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 2.341692 | 1.294961 | 1.808 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 2.136308 | 0.606173 | 3.524 | [128, 512, 4, 7, 7] | 2 | 1 | 0 | False | True | 3 |

4. backward dtype = float16

| 状态 | Torch延迟(ms) | Gems延迟(ms) | Gems加速比 | 输入Shape | kernel_size | stride | padding | ceil_mode | count_include_pad | divisor_override |
| ---- | ------------- | ------------ | ---------- | --------- | ----------- | ------ | ------- | --------- | ----------------- | ---------------- |
| SUCCESS | 0.343585 | 0.831462 | 0.413 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.326038 | 9.955750 | 0.033 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.342077 | 0.823462 | 0.415 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.459173 | 0.419750 | 1.094 | [4, 3, 16, 224, 224] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.070519 | 3.134250 | 0.342 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.070711 | 20.241577 | 0.053 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 1.172615 | 3.140654 | 0.373 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.324173 | 2.561231 | 0.517 | [16, 64, 8, 56, 56] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.855481 | 1.854096 | 0.461 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.856750 | 18.466192 | 0.046 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.917365 | 1.852500 | 0.495 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.727692 | 0.629327 | 1.156 | [32, 128, 4, 28, 28] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.652673 | 1.843923 | 0.896 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.654308 | 17.091381 | 0.097 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 1.830742 | 1.844846 | 0.992 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.397269 | 0.631808 | 2.212 | [64, 256, 4, 14, 14] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 3.527769 | 1.995942 | 1.767 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 3.532346 | 13.082980 | 0.270 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 3.719923 | 1.994115 | 1.865 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 2.888019 | 0.909096 | 3.177 | [128, 512, 4, 7, 7] | 2 | 1 | 0 | False | True | 3 |

5. backward dtype = float32

| 状态 | Torch延迟(ms) | Gems延迟(ms) | Gems加速比 | 输入Shape | kernel_size | stride | padding | ceil_mode | count_include_pad | divisor_override |
| ---- | ------------- | ------------ | ---------- | --------- | ----------- | ------ | ------- | --------- | ----------------- | ---------------- |
| SUCCESS | 0.333904 | 0.659000 | 0.507 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.332750 | 9.651019 | 0.034 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.351558 | 0.658750 | 0.534 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.485154 | 0.303462 | 1.599 | [4, 3, 16, 224, 224] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.890846 | 2.736481 | 0.326 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.892404 | 19.748653 | 0.045 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.941904 | 2.743096 | 0.343 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.399462 | 5.117980 | 0.273 | [16, 64, 8, 56, 56] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.551423 | 1.636461 | 0.337 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.551058 | 18.069250 | 0.030 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.514654 | 1.647577 | 0.312 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.763385 | 0.456577 | 1.672 | [32, 128, 4, 28, 28] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.778481 | 1.621385 | 0.480 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.787635 | 16.426538 | 0.048 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.864058 | 1.622154 | 0.533 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.435039 | 0.457462 | 3.137 | [64, 256, 4, 14, 14] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.508038 | 1.762577 | 0.856 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.528750 | 12.641769 | 0.121 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 1.711962 | 1.762788 | 0.971 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 2.925731 | 0.730981 | 4.002 | [128, 512, 4, 7, 7] | 2 | 1 | 0 | False | True | 3 |

6. backward dtype = bfloat16

| 状态 | Torch延迟(ms) | Gems延迟(ms) | Gems加速比 | 输入Shape | kernel_size | stride | padding | ceil_mode | count_include_pad | divisor_override |
| ---- | ------------- | ------------ | ---------- | --------- | ----------- | ------ | ------- | --------- | ----------------- | ---------------- |
| SUCCESS | 0.324827 | 0.831019 | 0.391 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.325173 | 10.017538 | 0.032 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.338385 | 0.822692 | 0.411 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.458885 | 0.419173 | 1.095 | [4, 3, 16, 224, 224] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.077654 | 3.133712 | 0.344 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.078423 | 19.493269 | 0.055 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 1.182115 | 3.138038 | 0.377 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.324173 | 2.600619 | 0.509 | [16, 64, 8, 56, 56] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.821577 | 1.853135 | 0.443 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.822000 | 18.414635 | 0.045 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.865538 | 1.852462 | 0.467 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.727327 | 0.629731 | 1.155 | [32, 128, 4, 28, 28] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.437981 | 1.844058 | 0.780 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.439212 | 16.593941 | 0.087 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 1.551519 | 1.845269 | 0.841 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.395346 | 0.631308 | 2.210 | [64, 256, 4, 14, 14] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 3.014442 | 1.995692 | 1.510 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 3.032634 | 12.702442 | 0.239 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 3.207808 | 1.995019 | 1.608 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 2.888192 | 0.909481 | 3.176 | [128, 512, 4, 7, 7] | 2 | 1 | 0 | False | True | 3 |

##### nvidia RTX4090
截图

<img width="1901" height="3850" alt="avg_pool3d_backward_on_rtx4090" src="https://github.com/user-attachments/assets/92f59cc7-2c66-4e1f-a10c-e9a5cbd8d70e" />

1. forward dtype = torch.float16

| 状态 | Torch延迟(ms) | Gems延迟(ms) | Gems加速比 | 输入Shape | 核大小 | 步长 | 填充 | 向上取整 | 包含填充 | 除数覆盖 |
| ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
| SUCCESS | 0.234496 | 0.517120 | 0.453 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.187392 | 0.523264 | 0.358 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.196608 | 0.551936 | 0.356 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.583696 | 0.287744 | 2.029 | [4, 3, 16, 224, 224] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.454656 | 0.609280 | 0.746 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.453632 | 0.669696 | 0.677 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.507904 | 0.706560 | 0.719 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.615872 | 1.024000 | 1.578 | [16, 64, 8, 56, 56] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.416768 | 0.197632 | 2.109 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.415744 | 0.244736 | 1.699 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.526336 | 0.332800 | 1.582 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.704512 | 0.475184 | 1.483 | [32, 128, 4, 28, 28] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.744448 | 0.291840 | 2.551 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.744464 | 0.475136 | 1.567 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 1.001472 | 0.292864 | 3.420 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.342464 | 0.480256 | 2.795 | [64, 256, 4, 14, 14] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.603584 | 1.112064 | 1.442 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.604608 | 1.868800 | 0.859 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 2.068480 | 1.112064 | 1.860 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 2.452480 | 0.560128 | 4.378 | [128, 512, 4, 7, 7] | 2 | 1 | 0 | False | True | 3 |

2. forward dtype = torch.float32

| 状态 | Torch延迟(ms) | Gems延迟(ms) | Gems加速比 | 输入Shape | 核大小 | 步长 | 填充 | 向上取整 | 包含填充 | 除数覆盖 |
| ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
| SUCCESS | 0.258048 | 0.517088 | 0.499 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.257056 | 0.538624 | 0.477 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.261120 | 0.553984 | 0.471 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.573440 | 0.359424 | 1.595 | [4, 3, 16, 224, 224] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.568320 | 0.958992 | 0.593 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.568320 | 1.002496 | 0.567 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.590336 | 0.972800 | 0.607 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.570816 | 1.377792 | 1.140 | [16, 64, 8, 56, 56] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.430080 | 0.334848 | 1.284 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.429056 | 0.452608 | 0.948 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.519168 | 0.354304 | 1.465 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.688128 | 0.481280 | 1.430 | [32, 128, 4, 28, 28] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.777216 | 0.336896 | 2.307 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.776192 | 0.454656 | 1.707 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.990752 | 0.346144 | 2.862 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.319936 | 0.451584 | 2.923 | [64, 256, 4, 14, 14] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.556480 | 1.003520 | 1.551 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.555456 | 1.736704 | 0.896 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 2.006016 | 1.003520 | 1.999 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 2.375680 | 0.540672 | 4.394 | [128, 512, 4, 7, 7] | 2 | 1 | 0 | False | True | 3 |

3. forward dtype = torch.bfloat16

| 状态 | Torch延迟(ms) | Gems延迟(ms) | Gems加速比 | 输入Shape | 核大小 | 步长 | 填充 | 向上取整 | 包含填充 | 除数覆盖 |
| ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
| SUCCESS | 0.186368 | 0.516096 | 0.361 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.186368 | 0.524288 | 0.355 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.195584 | 0.551936 | 0.354 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.577536 | 0.288768 | 2.000 | [4, 3, 16, 224, 224] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.448512 | 0.611232 | 0.734 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.450032 | 0.670720 | 0.671 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.502784 | 0.705536 | 0.713 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.602560 | 1.028096 | 1.559 | [16, 64, 8, 56, 56] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.414720 | 0.197632 | 2.098 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.411648 | 0.245760 | 1.675 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.520192 | 0.337920 | 1.539 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.699392 | 0.477728 | 1.464 | [32, 128, 4, 28, 28] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.737280 | 0.292864 | 2.517 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.736256 | 0.477184 | 1.543 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.990208 | 0.293888 | 3.369 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.333248 | 0.483328 | 2.758 | [64, 256, 4, 14, 14] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.588224 | 1.118208 | 1.420 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.589248 | 1.879040 | 0.846 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 2.054144 | 1.118208 | 1.837 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 2.428928 | 0.562176 | 4.321 | [128, 512, 4, 7, 7] | 2 | 1 | 0 | False | True | 3 |

截图
<img width="1894" height="3857" alt="image" src="https://github.com/user-attachments/assets/e2b2109b-609b-4100-b8c1-bbd619399047" />

4. backward dtype = torch.float16

| 状态 | Torch延迟(ms) | Gems延迟(ms) | Gems加速比 | 输入Shape | 核大小 | 步长 | 填充 | 向上取整 | 包含填充 | 除数覆盖 |
| ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
| SUCCESS | 0.424960 | 1.064960 | 0.399 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.345088 | 7.952480 | 0.043 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.362496 | 1.068032 | 0.339 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.508928 | 0.629760 | 0.808 | [4, 3, 16, 224, 224] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.789952 | 2.844160 | 0.629 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.790976 | 20.884993 | 0.086 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 1.956864 | 2.855424 | 0.685 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.459200 | 2.162688 | 0.675 | [16, 64, 8, 56, 56] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.908288 | 1.787904 | 0.508 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.906240 | 14.836736 | 0.061 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 1.118208 | 1.790976 | 0.624 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.706560 | 1.051648 | 0.672 | [32, 128, 4, 28, 28] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.673232 | 1.824768 | 0.917 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.673216 | 14.883840 | 0.112 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 2.107392 | 1.825792 | 1.154 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.285120 | 1.062912 | 1.209 | [64, 256, 4, 14, 14] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 3.397632 | 1.876992 | 1.810 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 3.395456 | 17.512447 | 0.194 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 4.234240 | 1.875968 | 2.257 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 2.352640 | 1.132992 | 2.076 | [128, 512, 4, 7, 7] | 2 | 1 | 0 | False | True | 3 |

5. backward dtype = torch.float32

| 状态 | Torch延迟(ms) | Gems延迟(ms) | Gems加速比 | 输入Shape | 核大小 | 步长 | 填充 | 向上取整 | 包含填充 | 除数覆盖 |
| ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
| SUCCESS | 0.659392 | 0.813120 | 0.811 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.659456 | 7.519232 | 0.088 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.668672 | 0.814080 | 0.821 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.599040 | 0.486400 | 1.232 | [4, 3, 16, 224, 224] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.690592 | 2.251728 | 0.751 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.689088 | 20.147712 | 0.084 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 1.739264 | 2.253824 | 0.772 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.657856 | 1.600512 | 1.036 | [16, 64, 8, 56, 56] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.870400 | 1.439744 | 0.605 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.870400 | 14.447616 | 0.060 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.934912 | 1.465472 | 0.638 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.811008 | 0.711584 | 1.140 | [32, 128, 4, 28, 28] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 0.955392 | 1.447936 | 0.660 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.956448 | 14.238720 | 0.067 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 1.074176 | 1.440768 | 0.746 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.384448 | 0.703488 | 1.968 | [64, 256, 4, 14, 14] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.329152 | 1.448960 | 0.917 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.330176 | 17.066496 | 0.078 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 1.682912 | 1.449984 | 1.161 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 2.423792 | 0.772096 | 3.139 | [128, 512, 4, 7, 7] | 2 | 1 | 0 | False | True | 3 |

6. backward dtype = torch.bfloat16

| 状态 | Torch延迟(ms) | Gems延迟(ms) | Gems加速比 | 输入Shape | 核大小 | 步长 | 填充 | 向上取整 | 包含填充 | 除数覆盖 |
| ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
| SUCCESS | 0.541696 | 1.064960 | 0.509 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 0.541696 | 8.166400 | 0.066 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 0.603136 | 1.065536 | 0.566 | [4, 3, 16, 224, 224] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.509952 | 0.629760 | 0.810 | [4, 3, 16, 224, 224] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.661952 | 2.842112 | 0.585 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.662976 | 20.984320 | 0.079 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 2.063360 | 2.850816 | 0.724 | [16, 64, 8, 56, 56] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.465344 | 2.146304 | 0.683 | [16, 64, 8, 56, 56] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 1.125376 | 1.765376 | 0.637 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 1.124800 | 14.826496 | 0.076 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 1.456128 | 1.769472 | 0.823 | [32, 128, 4, 28, 28] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 0.707584 | 1.049600 | 0.674 | [32, 128, 4, 28, 28] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 2.049024 | 1.802240 | 1.137 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 2.049024 | 14.646272 | 0.140 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 2.716672 | 1.801248 | 1.508 | [64, 256, 4, 14, 14] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 1.289216 | 1.063936 | 1.212 | [64, 256, 4, 14, 14] | 2 | 1 | 0 | False | True | 3 |
| SUCCESS | 5.269504 | 1.881088 | 2.801 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | True | None |
| SUCCESS | 5.266432 | 17.397247 | 0.303 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | False | False | None |
| SUCCESS | 6.331904 | 1.888256 | 3.353 | [128, 512, 4, 7, 7] | 3 | 2 | 1 | True | True | None |
| SUCCESS | 2.356224 | 1.134592 | 2.077 | [128, 512, 4, 7, 7] | 2 | 1 | 0 | False | True | 3 |

#### 在主办方提供的iluvatar BI-V150加速卡的测试结果

<img width="1829" height="678" alt="image" src="https://github.com/user-attachments/assets/4fe05b49-6753-44f2-9647-eb4daf79a616" />
<img width="1818" height="613" alt="image" src="https://github.com/user-attachments/assets/a28c952f-a7f4-49ef-a570-4d986bff98fd" />

| 测试类型 | 数据类型 | 输入形状 | 卷积核大小 | 步长 | 填充 | 向上取整模式 | 包含填充计数 | 除数覆盖 | 测试结果 |
| ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
| forward | torch.float16 | [4,3,16,32,32] | 3 | 2 | 1 | False | True | None | passed |
| forward | torch.float16 | [4,3,16,32,32] | 3 | 2 | 1 | False | False | None | passed |
| forward | torch.float16 | [8,16,14,28,28] | [3,4,5] | [1,1,2] | 1 | False | True | None | passed |
| forward | torch.float16 | [2,4,15,15,15] | 3 | 2 | 1 | True | True | None | passed |
| forward | torch.float16 | [1,1,7,7,7] | 2 | 1 | 0 | False | True | 1 | passed |
| forward | torch.float16 | [1,64,28,56,56] | 3 | 2 | 1 | False | True | None | passed |
| forward | torch.float16 | [2,8,8,16,16] | 2 | 2 | 0 | False | False | None | passed |
| forward | torch.float16 | [2,8,16,16,20] | 2 | 2 | [1,0,1] | False | True | None | passed |
| forward | torch.float32 | [4,3,16,32,32] | 3 | 2 | 1 | False | True | None | passed |
| forward | torch.float32 | [4,3,16,32,32] | 3 | 2 | 1 | False | False | None | passed |
| forward | torch.float32 | [8,16,14,28,28] | [3,4,5] | [1,1,2] | 1 | False | True | None | passed |
| forward | torch.float32 | [2,4,15,15,15] | 3 | 2 | 1 | True | True | None | passed |
| forward | torch.float32 | [1,1,7,7,7] | 2 | 1 | 0 | False | True | 1 | passed |
| forward | torch.float32 | [1,64,28,56,56] | 3 | 2 | 1 | False | True | None | passed |
| forward | torch.float32 | [2,8,8,16,16] | 2 | 2 | 0 | False | False | None | passed |
| forward | torch.float32 | [2,8,16,16,20] | 2 | 2 | [1,0,1] | False | True | None | passed |
| forward | torch.bfloat16 | [4,3,16,32,32] | 3 | 2 | 1 | False | True | None | passed |
| forward | torch.bfloat16 | [4,3,16,32,32] | 3 | 2 | 1 | False | False | None | passed |
| forward | torch.bfloat16 | [8,16,14,28,28] | [3,4,5] | [1,1,2] | 1 | False | True | None | passed |
| forward | torch.bfloat16 | [2,4,15,15,15] | 3 | 2 | 1 | True | True | None | passed |
| forward | torch.bfloat16 | [1,1,7,7,7] | 2 | 1 | 0 | False | True | 1 | passed |
| forward | torch.bfloat16 | [1,64,28,56,56] | 3 | 2 | 1 | False | True | None | passed |
| forward | torch.bfloat16 | [2,8,8,16,16] | 2 | 2 | 0 | False | False | None | passed |
| forward | torch.bfloat16 | [2,8,16,16,20] | 2 | 2 | [1,0,1] | False | True | None | passed |
| backward | torch.float16 | [4,3,16,32,32] | 3 | 2 | 1 | False | True | None | passed |
| backward | torch.float16 | [4,3,16,32,32] | 3 | 2 | 1 | False | False | None | passed |
| backward | torch.float16 | [8,16,14,28,28] | [3,4,5] | [1,1,2] | 1 | False | True | None | passed |
| backward | torch.float16 | [2,4,15,15,15] | 3 | 2 | 1 | True | True | None | passed |
| backward | torch.float16 | [1,1,7,7,7] | 2 | 1 | 0 | False | True | 1 | passed |
| backward | torch.float16 | [1,64,28,56,56] | 3 | 2 | 1 | False | True | None | passed |
| backward | torch.float16 | [2,8,8,16,16] | 2 | 2 | 0 | False | False | None | passed |
| backward | torch.float16 | [2,8,16,16,20] | 2 | 2 | [1,0,1] | False | True | None | passed |
| backward | torch.float32 | [4,3,16,32,32] | 3 | 2 | 1 | False | True | None | passed |
| backward | torch.float32 | [4,3,16,32,32] | 3 | 2 | 1 | False | False | None | passed |
| backward | torch.float32 | [8,16,14,28,28] | [3,4,5] | [1,1,2] | 1 | False | True | None | passed |
| backward | torch.float32 | [2,4,15,15,15] | 3 | 2 | 1 | True | True | None | passed |
| backward | torch.float32 | [1,1,7,7,7] | 2 | 1 | 0 | False | True | 1 | passed |
| backward | torch.float32 | [1,64,28,56,56] | 3 | 2 | 1 | False | True | None | passed |
| backward | torch.float32 | [2,8,8,16,16] | 2 | 2 | 0 | False | False | None | passed |
| backward | torch.float32 | [2,8,16,16,20] | 2 | 2 | [1,0,1] | False | True | None | passed |
| backward | torch.bfloat16 | [4,3,16,32,32] | 3 | 2 | 1 | False | True | None | passed |
| backward | torch.bfloat16 | [4,3,16,32,32] | 3 | 2 | 1 | False | False | None | passed |
| backward | torch.bfloat16 | [8,16,14,28,28] | [3,4,5] | [1,1,2] | 1 | False | True | None | passed |
| backward | torch.bfloat16 | [2,4,15,15,15] | 3 | 2 | 1 | True | True | None | passed |
| backward | torch.bfloat16 | [1,1,7,7,7] | 2 | 1 | 0 | False | True | 1 | passed |
| backward | torch.bfloat16 | [1,64,28,56,56] | 3 | 2 | 1 | False | True | None | passed |
| backward | torch.bfloat16 | [2,8,8,16,16] | 2 | 2 | 0 | False | False | None | passed |
| backward | torch.bfloat16 | [2,8,16,16,20] | 2 | 2 | [1,0,1] | False | True | None | passed |

#### 在nvidia RTX 4090测试结果

<img width="1893" height="1594" alt="image" src="https://github.com/user-attachments/assets/9f31e254-65d3-41bd-9620-19b6978077fa" />

| 测试类型 | 数据类型 | 输入形状 | 核大小 | 步长 | 填充 | 向上取整 | 包含填充 | 除数覆盖 | 测试结果 |
| ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- | ---- |
| forward | torch.float16 | [4,3,16,32,32] | 3 | 2 | 1 | False | True | None | passed |
| forward | torch.float16 | [4,3,16,32,32] | 3 | 2 | 1 | False | False | None | passed |
| forward | torch.float16 | [8,16,14,28,28] | [3,4,5] | [1,1,2] | 1 | False | True | None | passed |
| forward | torch.float16 | [2,4,15,15,15] | 3 | 2 | 1 | True | True | None | passed |
| forward | torch.float16 | [1,1,7,7,7] | 2 | 1 | 0 | False | True | 1 | passed |
| forward | torch.float16 | [1,64,28,56,56] | 3 | 2 | 1 | False | True | None | passed |
| forward | torch.float16 | [2,8,8,16,16] | 2 | 2 | 0 | False | False | None | passed |
| forward | torch.float16 | [2,8,16,16,20] | 2 | 2 | [1,0,1] | False | True | None | passed |
| forward | torch.float32 | [4,3,16,32,32] | 3 | 2 | 1 | False | True | None | passed |
| forward | torch.float32 | [4,3,16,32,32] | 3 | 2 | 1 | False | False | None | passed |
| forward | torch.float32 | [8,16,14,28,28] | [3,4,5] | [1,1,2] | 1 | False | True | None | passed |
| forward | torch.float32 | [2,4,15,15,15] | 3 | 2 | 1 | True | True | None | passed |
| forward | torch.float32 | [1,1,7,7,7] | 2 | 1 | 0 | False | True | 1 | passed |
| forward | torch.float32 | [1,64,28,56,56] | 3 | 2 | 1 | False | True | None | passed |
| forward | torch.float32 | [2,8,8,16,16] | 2 | 2 | 0 | False | False | None | passed |
| forward | torch.float32 | [2,8,16,16,20] | 2 | 2 | [1,0,1] | False | True | None | passed |
| forward | torch.bfloat16 | [4,3,16,32,32] | 3 | 2 | 1 | False | True | None | passed |
| forward | torch.bfloat16 | [4,3,16,32,32] | 3 | 2 | 1 | False | False | None | passed |
| forward | torch.bfloat16 | [8,16,14,28,28] | [3,4,5] | [1,1,2] | 1 | False | True | None | passed |
| forward | torch.bfloat16 | [2,4,15,15,15] | 3 | 2 | 1 | True | True | None | passed |
| forward | torch.bfloat16 | [1,1,7,7,7] | 2 | 1 | 0 | False | True | 1 | passed |
| forward | torch.bfloat16 | [1,64,28,56,56] | 3 | 2 | 1 | False | True | None | passed |
| forward | torch.bfloat16 | [2,8,8,16,16] | 2 | 2 | 0 | False | False | None | passed |
| forward | torch.bfloat16 | [2,8,16,16,20] | 2 | 2 | [1,0,1] | False | True | None | passed |
| backward | torch.float16 | [4,3,16,32,32] | 3 | 2 | 1 | False | True | None | passed |
| backward | torch.float16 | [4,3,16,32,32] | 3 | 2 | 1 | False | False | None | passed |
| backward | torch.float16 | [8,16,14,28,28] | [3,4,5] | [1,1,2] | 1 | False | True | None | passed |
| backward | torch.float16 | [2,4,15,15,15] | 3 | 2 | 1 | True | True | None | passed |
| backward | torch.float16 | [1,1,7,7,7] | 2 | 1 | 0 | False | True | 1 | passed |
| backward | torch.float16 | [1,64,28,56,56] | 3 | 2 | 1 | False | True | None | passed |
| backward | torch.float16 | [2,8,8,16,16] | 2 | 2 | 0 | False | False | None | passed |
| backward | torch.float16 | [2,8,16,16,20] | 2 | 2 | [1,0,1] | False | True | None | passed |
| backward | torch.float32 | [4,3,16,32,32] | 3 | 2 | 1 | False | True | None | passed |
| backward | torch.float32 | [4,3,16,32,32] | 3 | 2 | 1 | False | False | None | passed |
| backward | torch.float32 | [8,16,14,28,28] | [3,4,5] | [1,1,2] | 1 | False | True | None | passed |
| backward | torch.float32 | [2,4,15,15,15] | 3 | 2 | 1 | True | True | None | passed |
| backward | torch.float32 | [1,1,7,7,7] | 2 | 1 | 0 | False | True | 1 | passed |
| backward | torch.float32 | [1,64,28,56,56] | 3 | 2 | 1 | False | True | None | passed |
| backward | torch.float32 | [2,8,8,16,16] | 2 | 2 | 0 | False | False | None | passed |
| backward | torch.float32 | [2,8,16,16,20] | 2 | 2 | [1,0,1] | False | True | None | passed |
| backward | torch.bfloat16 | [4,3,16,32,32] | 3 | 2 | 1 | False | True | None | passed |
| backward | torch.bfloat16 | [4,3,16,32,32] | 3 | 2 | 1 | False | False | None | passed |
| backward | torch.bfloat16 | [8,16,14,28,28] | [3,4,5] | [1,1,2] | 1 | False | True | None | passed |
| backward | torch.bfloat16 | [2,4,15,15,15] | 3 | 2 | 1 | True | True | None | passed |
| backward | torch.bfloat16 | [1,1,7,7,7] | 2 | 1 | 0 | False | True | 1 | passed |
| backward | torch.bfloat16 | [1,64,28,56,56] | 3 | 2 | 1 | False | True | None | passed |
| backward | torch.bfloat16 | [2,8,8,16,16] | 2 | 2 | 0 | False | False | None | passed |
| backward | torch.bfloat16 | [2,8,16,16,20] | 2 | 2 | [1,0,1] | False | True | None | passed |
