### PR TITLE
[FlagGems Operator Development Competition] Optimize conv_transpose2d forward

### DIFF
--- a/benchmark/test_conv_transpose2d.py
+++ b/benchmark/test_conv_transpose2d.py
@@ -1,0 +1,76 @@
+from typing import Generator
+
+import pytest
+import torch
+
+import flag_gems
+from benchmark.attri_util import FLOAT_DTYPES
+from benchmark.performance_utils import GenericBenchmark
+
+
+class ConvTranspose2DBenchmark(GenericBenchmark):
+    def set_more_shapes(self):
+        return [
+            (16, 32, 24, 24, 24, 3, 3, 1, 1, 0, 2, 1),
+            (16, 32, 24, 24, 24, 3, 3, 2, 1, 1, 2, 1),
+            (32, 64, 64, 64, 32, 3, 3, 2, 1, 1, 1, 1),
+            (32, 64, 128, 128, 32, 5, 5, 2, 2, 1, 1, 1),
+            (4, 32, 128, 128, 32, 5, 5, 3, 2, 0, 1, 1),
+            (16, 32, 24, 24, 24, 3, 3, 3, 1, 0, 2, 1),
+            (16, 32, 24, 24, 24, 3, 3, 4, 1, 0, 2, 1),
+            (8, 32, 32, 32, 32, 3, 3, 4, 1, 0, 1, 1),
+            (4, 32, 32, 32, 32, 3, 3, 8, 1, 0, 1, 1),
+        ]
+
+    def get_input_iter(self, cur_dtype) -> Generator:
+        for shape in self.set_more_shapes():
+            yield from self.input_fn(shape, cur_dtype, self.device)
+
+
+def _input_fn(shape, dtype, device):
+    (
+        batch,
+        input_c,
+        input_h,
+        input_w,
+        out_c,
+        kernel_h,
+        kernel_w,
+        stride,
+        padding,
+        output_padding,
+        groups,
+        dilation,
+    ) = shape
+    input_shape = (batch, input_c, input_h, input_w)
+    weight_shape = (input_c, out_c // groups, kernel_h, kernel_w)
+    input = torch.randn(size=input_shape, device=device, dtype=dtype)
+    weight = torch.randn(size=weight_shape, device=device, dtype=dtype)
+
+    yield {
+        "input": input,
+        "weight": weight,
+        "bias": None,
+        "stride": stride,
+        "padding": padding,
+        "output_padding": output_padding,
+        "groups": groups,
+        "dilation": dilation,
+    },
+
+
+@pytest.mark.conv_transpose2d
+def test_conv_transpose2d():
+    def gems_conv_transpose2d(**kwargs):
+        with torch.no_grad():
+            return flag_gems.conv_transpose2d(**kwargs)
+
+    torch.backends.cudnn.allow_tf32 = False
+    bench = ConvTranspose2DBenchmark(
+        input_fn=_input_fn,
+        op_name="conv_transpose2d",
+        torch_op=torch.nn.functional.conv_transpose2d,
+        dtypes=FLOAT_DTYPES,
+    )
+    bench.set_gems(gems_conv_transpose2d)
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -140,6 +140,7 @@ _FULL_CONFIG = (
     ("conv1d.padding", conv1d),
     ("conv2d", conv2d),
     ("conv2d.padding", conv2d),
+    ("conv_transpose2d.input", conv_transpose2d),
     ("conv3d", conv3d),
     ("conv3d.padding", conv3d),
     (

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -80,6 +80,7 @@ from flag_gems.ops.conv1d import conv1d
 from flag_gems.ops.conv2d import conv2d
 from flag_gems.ops.conv3d import conv3d
 from flag_gems.ops.conv_depthwise2d import _conv_depthwise2d
+from flag_gems.ops.conv_transpose2d import conv_transpose2d
 from flag_gems.ops.copy import copy, copy_
 from flag_gems.ops.copysign import copysign, copysign_out
 from flag_gems.ops.cos import cos, cos_
@@ -427,6 +428,7 @@ __all__ = [
     "conv1d",
     "conv2d",
     "conv3d",
+    "conv_transpose2d",
     "copy",
     "copy_",
     "copysign",

--- a/src/flag_gems/ops/conv_transpose2d.py
+++ b/src/flag_gems/ops/conv_transpose2d.py
@@ -1,0 +1,1359 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeImplicitAutograd
+)
+
+_CONV_TRANSPOSE2D_DIRECT_KEYS = [
+    "in_n",
+    "weight_c",
+    "input_height",
+    "input_width",
+    "out_c",
+    "out_height",
+    "out_width",
+    "weight_height",
+    "weight_width",
+    "stride_height",
+    "stride_width",
+    "padding_height",
+    "padding_width",
+    "groups",
+]
+
+_CONV_TRANSPOSE2D_RESIDUE_KEYS = [
+    "in_n",
+    "weight_c",
+    "input_height",
+    "input_width",
+    "out_c",
+    "out_height",
+    "out_width",
+    "weight_height",
+    "weight_width",
+    "padding_height",
+    "padding_width",
+    "groups",
+]
+
+_CONV_TRANSPOSE2D_RESIDUE_FP16_CONFIGS = [
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 128, "BLOCK_CO": 32, "BLOCK_CI": 32},
+        num_warps=4,
+        num_stages=3,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 128, "BLOCK_CO": 32, "BLOCK_CI": 32},
+        num_warps=4,
+        num_stages=4,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 256, "BLOCK_CO": 32, "BLOCK_CI": 32},
+        num_warps=4,
+        num_stages=3,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 256, "BLOCK_CO": 32, "BLOCK_CI": 32},
+        num_warps=4,
+        num_stages=4,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 512, "BLOCK_CO": 32, "BLOCK_CI": 32},
+        num_warps=8,
+        num_stages=3,
+    ),
+]
+
+
+_CONV_TRANSPOSE2D_RESIDUE_LOW_PRECISION_CONFIGS = _CONV_TRANSPOSE2D_RESIDUE_FP16_CONFIGS
+
+
+_CONV_TRANSPOSE2D_RESIDUE_LOW_PRECISION_LARGE_KERNEL_CONFIGS = (
+    _CONV_TRANSPOSE2D_RESIDUE_FP16_CONFIGS
+    + [
+        triton.Config(
+            {"BLOCK_NI_HO_WO": 128, "BLOCK_CO": 16, "BLOCK_CI": 32},
+            num_warps=4,
+            num_stages=3,
+        ),
+        triton.Config(
+            {"BLOCK_NI_HO_WO": 256, "BLOCK_CO": 16, "BLOCK_CI": 32},
+            num_warps=4,
+            num_stages=3,
+        ),
+        triton.Config(
+            {"BLOCK_NI_HO_WO": 512, "BLOCK_CO": 16, "BLOCK_CI": 32},
+            num_warps=8,
+            num_stages=3,
+        ),
+        triton.Config(
+            {"BLOCK_NI_HO_WO": 128, "BLOCK_CO": 32, "BLOCK_CI": 16},
+            num_warps=4,
+            num_stages=2,
+        ),
+        triton.Config(
+            {"BLOCK_NI_HO_WO": 256, "BLOCK_CO": 32, "BLOCK_CI": 16},
+            num_warps=4,
+            num_stages=2,
+        ),
+        triton.Config(
+            {"BLOCK_NI_HO_WO": 512, "BLOCK_CO": 32, "BLOCK_CI": 16},
+            num_warps=8,
+            num_stages=2,
+        ),
+    ]
+)
+
+
+_CONV_TRANSPOSE2D_RESIDUE_COMPACT_CONFIGS = [
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 64, "BLOCK_CO": 32, "BLOCK_CI": 16},
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 128, "BLOCK_CO": 32, "BLOCK_CI": 16},
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 256, "BLOCK_CO": 32, "BLOCK_CI": 16},
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 64, "BLOCK_CO": 32, "BLOCK_CI": 32},
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 128, "BLOCK_CO": 32, "BLOCK_CI": 32},
+        num_warps=4,
+        num_stages=2,
+    ),
+]
+
+
+_CONV_TRANSPOSE2D_RESIDUE_FP32_CONFIGS = runtime.get_tuned_config("conv2d_forward")
+
+
+_CONV_TRANSPOSE2D_RESIDUE_FP32_LARGE_KERNEL_CONFIGS = (
+    runtime.get_tuned_config("conv2d_forward")
+    + _CONV_TRANSPOSE2D_RESIDUE_COMPACT_CONFIGS
+)
+
+
+_CONV_TRANSPOSE2D_DIRECT_CONFIGS = [
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 32, "BLOCK_CO": 16, "BLOCK_CI": 16},
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 32, "BLOCK_CO": 32, "BLOCK_CI": 16},
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 64, "BLOCK_CO": 16, "BLOCK_CI": 16},
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 64, "BLOCK_CO": 32, "BLOCK_CI": 16},
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 64, "BLOCK_CO": 32, "BLOCK_CI": 32},
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 128, "BLOCK_CO": 16, "BLOCK_CI": 16},
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 128, "BLOCK_CO": 32, "BLOCK_CI": 16},
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 128, "BLOCK_CO": 32, "BLOCK_CI": 32},
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 256, "BLOCK_CO": 32, "BLOCK_CI": 16},
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HO_WO": 256, "BLOCK_CO": 32, "BLOCK_CI": 32},
+        num_warps=4,
+        num_stages=2,
+    ),
+]
+
+
+_CONV_TRANSPOSE2D_SCATTER_CONFIGS = [
+    triton.Config(
+        {"BLOCK_NI_HI_WI": 64, "BLOCK_CO": 32, "BLOCK_CI": 16},
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HI_WI": 128, "BLOCK_CO": 32, "BLOCK_CI": 16},
+        num_warps=4,
+        num_stages=2,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HI_WI": 128, "BLOCK_CO": 32, "BLOCK_CI": 32},
+        num_warps=4,
+        num_stages=3,
+    ),
+    triton.Config(
+        {"BLOCK_NI_HI_WI": 256, "BLOCK_CO": 32, "BLOCK_CI": 32},
+        num_warps=4,
+        num_stages=3,
+    ),
+]
+
+
+_CONV_TRANSPOSE2D_SCATTER_KEYS = [
+    "in_n",
+    "weight_c",
+    "input_height",
+    "input_width",
+    "out_c",
+    "out_height",
+    "out_width",
+    "weight_height",
+    "weight_width",
+    "stride_height",
+    "stride_width",
+    "padding_height",
+    "padding_width",
+    "groups",
+]
+
+
+def conv_transpose2d_output_size(
+    in_size: int,
+    kernel_size: int,
+    stride: int,
+    padding: int,
+    output_padding: int,
+    dilation: int,
+) -> int:
+    return (
+        (in_size - 1) * stride
+        - 2 * padding
+        + dilation * (kernel_size - 1)
+        + output_padding
+        + 1
+    )
+
+
+def _to_pair(value):
+    if isinstance(value, (list, tuple)):
+        assert len(value) == 2, f"Expected length-2 value, got {value}"
+        return int(value[0]), int(value[1])
+    return int(value), int(value)
+
+
+def _validate_conv_transpose2d_params(
+    stride_height,
+    stride_width,
+    padding_height,
+    padding_width,
+    output_padding_height,
+    output_padding_width,
+    dilation_height,
+    dilation_width,
+    groups,
+):
+    assert groups > 0, f"groups must be positive, got {groups}"
+    assert (
+        stride_height > 0 and stride_width > 0
+    ), f"stride must be positive, got {(stride_height, stride_width)}"
+    assert (
+        padding_height >= 0 and padding_width >= 0
+    ), f"padding must be non-negative, got {(padding_height, padding_width)}"
+    assert output_padding_height >= 0 and output_padding_width >= 0, (
+        "output_padding must be non-negative, "
+        f"got {(output_padding_height, output_padding_width)}"
+    )
+    assert (
+        dilation_height > 0 and dilation_width > 0
+    ), f"dilation must be positive, got {(dilation_height, dilation_width)}"
+    assert (
+        output_padding_height < stride_height or output_padding_height < dilation_height
+    ), (
+        "output_padding height must be smaller than either stride or dilation, "
+        f"got output_padding={output_padding_height}, stride={stride_height}, "
+        f"dilation={dilation_height}"
+    )
+    assert (
+        output_padding_width < stride_width or output_padding_width < dilation_width
+    ), (
+        "output_padding width must be smaller than either stride or dilation, "
+        f"got output_padding={output_padding_width}, stride={stride_width}, "
+        f"dilation={dilation_width}"
+    )
+
+
+@libentry()
+@triton.autotune(
+    configs=_CONV_TRANSPOSE2D_DIRECT_CONFIGS,
+    key=_CONV_TRANSPOSE2D_DIRECT_KEYS,
+)
+@triton.jit
+def conv_transpose2d_forward_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    bias_pointer,
+    in_n,
+    input_height,
+    input_width,
+    out_c,
+    out_height,
+    out_width,
+    input_n_stride,
+    input_c_stride,
+    input_height_stride,
+    input_width_stride,
+    weight_n_stride,
+    weight_c_stride,
+    weight_height_stride,
+    weight_width_stride,
+    output_n_stride,
+    output_c_stride,
+    output_height_stride,
+    output_width_stride,
+    weight_c: tl.constexpr,
+    weight_height: tl.constexpr,
+    weight_width: tl.constexpr,
+    stride_height: tl.constexpr,
+    stride_width: tl.constexpr,
+    padding_height: tl.constexpr,
+    padding_width: tl.constexpr,
+    dilation_height: tl.constexpr,
+    dilation_width: tl.constexpr,
+    groups: tl.constexpr,
+    BLOCK_NI_HO_WO: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    pid_ni_ho_wo = tl.program_id(0)
+    pid_co = tl.program_id(1)
+    pid_group = tl.program_id(2)
+
+    ni_ho_wo_offset = pid_ni_ho_wo * BLOCK_NI_HO_WO + tl.arange(0, BLOCK_NI_HO_WO)
+    ni_ho_offset = ni_ho_wo_offset // out_width
+    in_n_point_value = ni_ho_offset // out_height
+    output_height_point_value = ni_ho_offset % out_height
+    output_width_point_value = ni_ho_wo_offset % out_width
+
+    out_per_group_c = out_c // groups
+    output_c_offset = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
+
+    input_pointer += (
+        input_n_stride * in_n_point_value + input_c_stride * pid_group * weight_c
+    )[:, None]
+    weight_pointer += weight_n_stride * pid_group * weight_c
+
+    accum = tl.zeros((BLOCK_NI_HO_WO, BLOCK_CO), dtype=tl.float32)
+    BLOCK_CI_COUNT = (weight_c + BLOCK_CI - 1) // BLOCK_CI
+    for hwc in range(weight_height * weight_width * BLOCK_CI_COUNT):
+        c = (hwc % BLOCK_CI_COUNT) * BLOCK_CI
+        hw = hwc // BLOCK_CI_COUNT
+        h = hw // weight_width
+        w = hw % weight_width
+
+        input_c_offset = c + tl.arange(0, BLOCK_CI)
+        input_height_numerator = (
+            output_height_point_value + padding_height - (h * dilation_height)
+        )
+        input_width_numerator = (
+            output_width_point_value + padding_width - (w * dilation_width)
+        )
+
+        height_aligned = input_height_numerator % stride_height == 0
+        width_aligned = input_width_numerator % stride_width == 0
+        input_height_offset = tl.where(
+            height_aligned, input_height_numerator // stride_height, 0
+        )
+        input_width_offset = tl.where(
+            width_aligned, input_width_numerator // stride_width, 0
+        )
+
+        curr_input_pointer = (
+            input_pointer
+            + (input_c_stride * input_c_offset)[None, :]
+            + (input_height_stride * input_height_offset)[:, None]
+            + (input_width_stride * input_width_offset)[:, None]
+        )
+        curr_weight_pointer = (
+            weight_pointer
+            + (weight_n_stride * input_c_offset)[:, None]
+            + (weight_c_stride * output_c_offset)[None, :]
+            + (weight_height_stride * h)
+            + (weight_width_stride * w)
+        )
+
+        input_mask = (
+            (in_n_point_value < in_n)[:, None]
+            & (input_c_offset < weight_c)[None, :]
+            & (input_height_numerator >= 0)[:, None]
+            & height_aligned[:, None]
+            & (input_height_offset < input_height)[:, None]
+            & (input_width_numerator >= 0)[:, None]
+            & width_aligned[:, None]
+            & (input_width_offset < input_width)[:, None]
+        )
+        weight_mask = (input_c_offset < weight_c)[:, None] & (
+            output_c_offset < out_per_group_c
+        )[None, :]
+
+        input_block = tl.load(curr_input_pointer, mask=input_mask, other=0.0)
+        weight_block = tl.load(curr_weight_pointer, mask=weight_mask, other=0.0)
+        accum += tl.dot(input_block, weight_block, input_precision="ieee")
+
+    bias_pointer += (pid_group[None] * out_per_group_c)[None, :] + output_c_offset[
+        None, :
+    ]
+    mask_bias = (output_c_offset < out_per_group_c)[None, :]
+    bias = tl.load(bias_pointer, mask=mask_bias, other=0.0).to(tl.float32)
+    accum += bias
+
+    output_pointer += (
+        (output_n_stride * in_n_point_value)[:, None]
+        + (output_c_stride * (pid_group * out_per_group_c + output_c_offset))[None, :]
+        + (output_height_stride * output_height_point_value)[:, None]
+        + (output_width_stride * output_width_point_value)[:, None]
+    )
+    output_mask = (
+        (in_n_point_value < in_n)[:, None]
+        & (output_c_offset < out_per_group_c)[None, :]
+        & (output_height_point_value < out_height)[:, None]
+        & (output_width_point_value < out_width)[:, None]
+    )
+    tl.store(output_pointer, accum, mask=output_mask)
+
+
+@triton.jit
+def _conv_transpose2d_forward_residue_body(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    bias_pointer,
+    in_n,
+    input_height,
+    input_width,
+    out_c,
+    out_height,
+    out_width,
+    compact_out_height: tl.constexpr,
+    compact_out_width: tl.constexpr,
+    input_n_stride,
+    input_c_stride,
+    input_height_stride,
+    input_width_stride,
+    weight_n_stride,
+    weight_c_stride,
+    weight_height_stride,
+    weight_width_stride,
+    output_n_stride,
+    output_c_stride,
+    output_height_stride,
+    output_width_stride,
+    weight_c: tl.constexpr,
+    weight_height: tl.constexpr,
+    weight_width: tl.constexpr,
+    stride_height: tl.constexpr,
+    stride_width: tl.constexpr,
+    dilation_height: tl.constexpr,
+    dilation_width: tl.constexpr,
+    padding_height: tl.constexpr,
+    padding_width: tl.constexpr,
+    groups: tl.constexpr,
+    output_residue_height: tl.constexpr,
+    output_residue_width: tl.constexpr,
+    BLOCK_NI_HO_WO: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    pid_ni_ho_wo = tl.program_id(0)
+    pid_co = tl.program_id(1)
+    pid_group = tl.program_id(2)
+
+    compact_offset = pid_ni_ho_wo * BLOCK_NI_HO_WO + tl.arange(0, BLOCK_NI_HO_WO)
+    compact_plane = compact_out_height * compact_out_width
+    compact_ni_ho_offset = compact_offset // compact_out_width
+    in_n_point_value = compact_offset // compact_plane
+    compact_height_value = compact_ni_ho_offset % compact_out_height
+    compact_width_value = compact_offset % compact_out_width
+    output_height_point_value = (
+        compact_height_value * stride_height + output_residue_height
+    )
+    output_width_point_value = compact_width_value * stride_width + output_residue_width
+
+    out_per_group_c = out_c // groups
+    output_c_offset = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
+
+    input_pointer += (
+        input_n_stride * in_n_point_value + input_c_stride * pid_group * weight_c
+    )[:, None]
+    weight_pointer += weight_n_stride * pid_group * weight_c
+
+    height_residue: tl.constexpr = (
+        output_residue_height + padding_height
+    ) % stride_height
+    width_residue: tl.constexpr = (output_residue_width + padding_width) % stride_width
+    accum = tl.zeros((BLOCK_NI_HO_WO, BLOCK_CO), dtype=tl.float32)
+    BLOCK_CI_COUNT: tl.constexpr = (weight_c + BLOCK_CI - 1) // BLOCK_CI
+    for h in range(weight_height):
+        if (h * dilation_height) % stride_height == height_residue:
+            input_height_numerator = (
+                output_height_point_value + padding_height - h * dilation_height
+            )
+            input_height_offset = input_height_numerator // stride_height
+            for w in range(weight_width):
+                if (w * dilation_width) % stride_width == width_residue:
+                    input_width_numerator = (
+                        output_width_point_value + padding_width - w * dilation_width
+                    )
+                    input_width_offset = input_width_numerator // stride_width
+                    for c_iter in range(BLOCK_CI_COUNT):
+                        input_c_offset = c_iter * BLOCK_CI + tl.arange(0, BLOCK_CI)
+
+                        curr_input_pointer = (
+                            input_pointer
+                            + (input_c_stride * input_c_offset)[None, :]
+                            + (input_height_stride * input_height_offset)[:, None]
+                            + (input_width_stride * input_width_offset)[:, None]
+                        )
+                        curr_weight_pointer = (
+                            weight_pointer
+                            + (weight_n_stride * input_c_offset)[:, None]
+                            + (weight_c_stride * output_c_offset)[None, :]
+                            + (weight_height_stride * h)
+                            + (weight_width_stride * w)
+                        )
+
+                        input_mask = (
+                            (in_n_point_value < in_n)[:, None]
+                            & (input_c_offset < weight_c)[None, :]
+                            & (input_height_numerator >= 0)[:, None]
+                            & (input_height_offset < input_height)[:, None]
+                            & (input_width_numerator >= 0)[:, None]
+                            & (input_width_offset < input_width)[:, None]
+                        )
+                        weight_mask = (input_c_offset < weight_c)[:, None] & (
+                            output_c_offset < out_per_group_c
+                        )[None, :]
+
+                        input_block = tl.load(
+                            curr_input_pointer, mask=input_mask, other=0.0
+                        )
+                        weight_block = tl.load(
+                            curr_weight_pointer, mask=weight_mask, other=0.0
+                        )
+                        accum += tl.dot(
+                            input_block, weight_block, input_precision="ieee"
+                        )
+
+    bias_pointer += (pid_group[None] * out_per_group_c)[None, :] + output_c_offset[
+        None, :
+    ]
+    mask_bias = (output_c_offset < out_per_group_c)[None, :]
+    bias = tl.load(bias_pointer, mask=mask_bias, other=0.0).to(tl.float32)
+    accum += bias
+
+    output_pointer += (
+        (output_n_stride * in_n_point_value)[:, None]
+        + (output_c_stride * (pid_group * out_per_group_c + output_c_offset))[None, :]
+        + (output_height_stride * output_height_point_value)[:, None]
+        + (output_width_stride * output_width_point_value)[:, None]
+    )
+    output_mask = (
+        (in_n_point_value < in_n)[:, None]
+        & (output_c_offset < out_per_group_c)[None, :]
+        & (output_height_point_value < out_height)[:, None]
+        & (output_width_point_value < out_width)[:, None]
+    )
+    tl.store(output_pointer, accum, mask=output_mask)
+
+
+@libentry()
+@triton.autotune(
+    configs=_CONV_TRANSPOSE2D_RESIDUE_FP32_CONFIGS,
+    key=_CONV_TRANSPOSE2D_RESIDUE_KEYS,
+)
+@triton.jit
+def conv_transpose2d_forward_residue_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    bias_pointer,
+    in_n,
+    input_height,
+    input_width,
+    out_c,
+    out_height,
+    out_width,
+    compact_out_height: tl.constexpr,
+    compact_out_width: tl.constexpr,
+    input_n_stride,
+    input_c_stride,
+    input_height_stride,
+    input_width_stride,
+    weight_n_stride,
+    weight_c_stride,
+    weight_height_stride,
+    weight_width_stride,
+    output_n_stride,
+    output_c_stride,
+    output_height_stride,
+    output_width_stride,
+    weight_c: tl.constexpr,
+    weight_height: tl.constexpr,
+    weight_width: tl.constexpr,
+    stride_height: tl.constexpr,
+    stride_width: tl.constexpr,
+    dilation_height: tl.constexpr,
+    dilation_width: tl.constexpr,
+    padding_height: tl.constexpr,
+    padding_width: tl.constexpr,
+    groups: tl.constexpr,
+    output_residue_height: tl.constexpr,
+    output_residue_width: tl.constexpr,
+    BLOCK_NI_HO_WO: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    _conv_transpose2d_forward_residue_body(
+        input_pointer,
+        weight_pointer,
+        output_pointer,
+        bias_pointer,
+        in_n,
+        input_height,
+        input_width,
+        out_c,
+        out_height,
+        out_width,
+        compact_out_height,
+        compact_out_width,
+        input_n_stride,
+        input_c_stride,
+        input_height_stride,
+        input_width_stride,
+        weight_n_stride,
+        weight_c_stride,
+        weight_height_stride,
+        weight_width_stride,
+        output_n_stride,
+        output_c_stride,
+        output_height_stride,
+        output_width_stride,
+        weight_c,
+        weight_height,
+        weight_width,
+        stride_height,
+        stride_width,
+        dilation_height,
+        dilation_width,
+        padding_height,
+        padding_width,
+        groups,
+        output_residue_height,
+        output_residue_width,
+        BLOCK_NI_HO_WO,
+        BLOCK_CI,
+        BLOCK_CO,
+    )
+
+
+@libentry()
+@triton.autotune(
+    configs=_CONV_TRANSPOSE2D_RESIDUE_FP32_LARGE_KERNEL_CONFIGS,
+    key=_CONV_TRANSPOSE2D_RESIDUE_KEYS,
+)
+@triton.jit
+def conv_transpose2d_forward_residue_fp32_large_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    bias_pointer,
+    in_n,
+    input_height,
+    input_width,
+    out_c,
+    out_height,
+    out_width,
+    compact_out_height: tl.constexpr,
+    compact_out_width: tl.constexpr,
+    input_n_stride,
+    input_c_stride,
+    input_height_stride,
+    input_width_stride,
+    weight_n_stride,
+    weight_c_stride,
+    weight_height_stride,
+    weight_width_stride,
+    output_n_stride,
+    output_c_stride,
+    output_height_stride,
+    output_width_stride,
+    weight_c: tl.constexpr,
+    weight_height: tl.constexpr,
+    weight_width: tl.constexpr,
+    stride_height: tl.constexpr,
+    stride_width: tl.constexpr,
+    dilation_height: tl.constexpr,
+    dilation_width: tl.constexpr,
+    padding_height: tl.constexpr,
+    padding_width: tl.constexpr,
+    groups: tl.constexpr,
+    output_residue_height: tl.constexpr,
+    output_residue_width: tl.constexpr,
+    BLOCK_NI_HO_WO: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    _conv_transpose2d_forward_residue_body(
+        input_pointer,
+        weight_pointer,
+        output_pointer,
+        bias_pointer,
+        in_n,
+        input_height,
+        input_width,
+        out_c,
+        out_height,
+        out_width,
+        compact_out_height,
+        compact_out_width,
+        input_n_stride,
+        input_c_stride,
+        input_height_stride,
+        input_width_stride,
+        weight_n_stride,
+        weight_c_stride,
+        weight_height_stride,
+        weight_width_stride,
+        output_n_stride,
+        output_c_stride,
+        output_height_stride,
+        output_width_stride,
+        weight_c,
+        weight_height,
+        weight_width,
+        stride_height,
+        stride_width,
+        dilation_height,
+        dilation_width,
+        padding_height,
+        padding_width,
+        groups,
+        output_residue_height,
+        output_residue_width,
+        BLOCK_NI_HO_WO,
+        BLOCK_CI,
+        BLOCK_CO,
+    )
+
+
+@libentry()
+@triton.autotune(
+    configs=_CONV_TRANSPOSE2D_RESIDUE_LOW_PRECISION_CONFIGS,
+    key=_CONV_TRANSPOSE2D_RESIDUE_KEYS,
+)
+@triton.jit
+def conv_transpose2d_forward_residue_fp16_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    bias_pointer,
+    in_n,
+    input_height,
+    input_width,
+    out_c,
+    out_height,
+    out_width,
+    compact_out_height: tl.constexpr,
+    compact_out_width: tl.constexpr,
+    input_n_stride,
+    input_c_stride,
+    input_height_stride,
+    input_width_stride,
+    weight_n_stride,
+    weight_c_stride,
+    weight_height_stride,
+    weight_width_stride,
+    output_n_stride,
+    output_c_stride,
+    output_height_stride,
+    output_width_stride,
+    weight_c: tl.constexpr,
+    weight_height: tl.constexpr,
+    weight_width: tl.constexpr,
+    stride_height: tl.constexpr,
+    stride_width: tl.constexpr,
+    dilation_height: tl.constexpr,
+    dilation_width: tl.constexpr,
+    padding_height: tl.constexpr,
+    padding_width: tl.constexpr,
+    groups: tl.constexpr,
+    output_residue_height: tl.constexpr,
+    output_residue_width: tl.constexpr,
+    BLOCK_NI_HO_WO: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    _conv_transpose2d_forward_residue_body(
+        input_pointer,
+        weight_pointer,
+        output_pointer,
+        bias_pointer,
+        in_n,
+        input_height,
+        input_width,
+        out_c,
+        out_height,
+        out_width,
+        compact_out_height,
+        compact_out_width,
+        input_n_stride,
+        input_c_stride,
+        input_height_stride,
+        input_width_stride,
+        weight_n_stride,
+        weight_c_stride,
+        weight_height_stride,
+        weight_width_stride,
+        output_n_stride,
+        output_c_stride,
+        output_height_stride,
+        output_width_stride,
+        weight_c,
+        weight_height,
+        weight_width,
+        stride_height,
+        stride_width,
+        dilation_height,
+        dilation_width,
+        padding_height,
+        padding_width,
+        groups,
+        output_residue_height,
+        output_residue_width,
+        BLOCK_NI_HO_WO,
+        BLOCK_CI,
+        BLOCK_CO,
+    )
+
+
+@libentry()
+@triton.autotune(
+    configs=_CONV_TRANSPOSE2D_RESIDUE_LOW_PRECISION_LARGE_KERNEL_CONFIGS,
+    key=_CONV_TRANSPOSE2D_RESIDUE_KEYS,
+)
+@triton.jit
+def conv_transpose2d_forward_residue_low_precision_large_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    bias_pointer,
+    in_n,
+    input_height,
+    input_width,
+    out_c,
+    out_height,
+    out_width,
+    compact_out_height: tl.constexpr,
+    compact_out_width: tl.constexpr,
+    input_n_stride,
+    input_c_stride,
+    input_height_stride,
+    input_width_stride,
+    weight_n_stride,
+    weight_c_stride,
+    weight_height_stride,
+    weight_width_stride,
+    output_n_stride,
+    output_c_stride,
+    output_height_stride,
+    output_width_stride,
+    weight_c: tl.constexpr,
+    weight_height: tl.constexpr,
+    weight_width: tl.constexpr,
+    stride_height: tl.constexpr,
+    stride_width: tl.constexpr,
+    dilation_height: tl.constexpr,
+    dilation_width: tl.constexpr,
+    padding_height: tl.constexpr,
+    padding_width: tl.constexpr,
+    groups: tl.constexpr,
+    output_residue_height: tl.constexpr,
+    output_residue_width: tl.constexpr,
+    BLOCK_NI_HO_WO: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    _conv_transpose2d_forward_residue_body(
+        input_pointer,
+        weight_pointer,
+        output_pointer,
+        bias_pointer,
+        in_n,
+        input_height,
+        input_width,
+        out_c,
+        out_height,
+        out_width,
+        compact_out_height,
+        compact_out_width,
+        input_n_stride,
+        input_c_stride,
+        input_height_stride,
+        input_width_stride,
+        weight_n_stride,
+        weight_c_stride,
+        weight_height_stride,
+        weight_width_stride,
+        output_n_stride,
+        output_c_stride,
+        output_height_stride,
+        output_width_stride,
+        weight_c,
+        weight_height,
+        weight_width,
+        stride_height,
+        stride_width,
+        dilation_height,
+        dilation_width,
+        padding_height,
+        padding_width,
+        groups,
+        output_residue_height,
+        output_residue_width,
+        BLOCK_NI_HO_WO,
+        BLOCK_CI,
+        BLOCK_CO,
+    )
+
+
+@libentry()
+@triton.jit
+def conv_transpose2d_fill_kernel(
+    output_pointer,
+    bias_pointer,
+    total_elements,
+    out_c: tl.constexpr,
+    out_height: tl.constexpr,
+    out_width: tl.constexpr,
+    output_n_stride,
+    output_c_stride,
+    output_height_stride,
+    output_width_stride,
+    HAS_BIAS: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < total_elements
+    ow = offsets % out_width
+    oh = (offsets // out_width) % out_height
+    oc = (offsets // (out_height * out_width)) % out_c
+    n = offsets // (out_c * out_height * out_width)
+
+    output_offset = (
+        n * output_n_stride
+        + oc * output_c_stride
+        + oh * output_height_stride
+        + ow * output_width_stride
+    )
+    values = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+    if HAS_BIAS:
+        values = tl.load(bias_pointer + oc, mask=mask, other=0.0)
+    tl.store(output_pointer + output_offset, values, mask=mask)
+
+
+@libentry()
+@triton.autotune(
+    configs=_CONV_TRANSPOSE2D_SCATTER_CONFIGS,
+    key=_CONV_TRANSPOSE2D_SCATTER_KEYS,
+)
+@triton.jit
+def conv_transpose2d_forward_scatter_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    bias_pointer,
+    in_n,
+    input_height,
+    input_width,
+    out_c,
+    out_height,
+    out_width,
+    input_n_stride,
+    input_c_stride,
+    input_height_stride,
+    input_width_stride,
+    weight_n_stride,
+    weight_c_stride,
+    weight_height_stride,
+    weight_width_stride,
+    output_n_stride,
+    output_c_stride,
+    output_height_stride,
+    output_width_stride,
+    weight_c: tl.constexpr,
+    weight_height: tl.constexpr,
+    weight_width: tl.constexpr,
+    stride_height: tl.constexpr,
+    stride_width: tl.constexpr,
+    dilation_height: tl.constexpr,
+    dilation_width: tl.constexpr,
+    padding_height: tl.constexpr,
+    padding_width: tl.constexpr,
+    groups: tl.constexpr,
+    BLOCK_NI_HI_WI: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    pid_ni_hi_wi = tl.program_id(0)
+    pid_co = tl.program_id(1)
+    pid_group_tap = tl.program_id(2)
+
+    tap_count: tl.constexpr = weight_height * weight_width
+    input_plane: tl.constexpr = input_height * input_width
+    pid_group = pid_group_tap // tap_count
+    tap_id = pid_group_tap % tap_count
+    kh = tap_id // weight_width
+    kw = tap_id % weight_width
+
+    offsets = pid_ni_hi_wi * BLOCK_NI_HI_WI + tl.arange(0, BLOCK_NI_HI_WI)
+    iw = offsets % input_width
+    ih = (offsets // input_width) % input_height
+    n = offsets // input_plane
+
+    oh = ih * stride_height - padding_height + kh * dilation_height
+    ow = iw * stride_width - padding_width + kw * dilation_width
+
+    out_per_group_c = out_c // groups
+    output_c_offset = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
+
+    input_pointer += (input_n_stride * n + input_c_stride * pid_group * weight_c)[
+        :, None
+    ]
+    weight_pointer += weight_n_stride * pid_group * weight_c
+
+    accum = tl.zeros((BLOCK_NI_HI_WI, BLOCK_CO), dtype=tl.float32)
+    BLOCK_CI_COUNT: tl.constexpr = (weight_c + BLOCK_CI - 1) // BLOCK_CI
+    for c_iter in range(BLOCK_CI_COUNT):
+        input_c_offset = c_iter * BLOCK_CI + tl.arange(0, BLOCK_CI)
+        curr_input_pointer = (
+            input_pointer
+            + (input_c_stride * input_c_offset)[None, :]
+            + (input_height_stride * ih)[:, None]
+            + (input_width_stride * iw)[:, None]
+        )
+        curr_weight_pointer = (
+            weight_pointer
+            + (weight_n_stride * input_c_offset)[:, None]
+            + (weight_c_stride * output_c_offset)[None, :]
+            + (weight_height_stride * kh)
+            + (weight_width_stride * kw)
+        )
+
+        task_mask = (
+            (n < in_n) & (oh >= 0) & (oh < out_height) & (ow >= 0) & (ow < out_width)
+        )
+        input_mask = task_mask[:, None] & (input_c_offset < weight_c)[None, :]
+        weight_mask = (input_c_offset < weight_c)[:, None] & (
+            output_c_offset < out_per_group_c
+        )[None, :]
+
+        input_block = tl.load(curr_input_pointer, mask=input_mask, other=0.0)
+        weight_block = tl.load(curr_weight_pointer, mask=weight_mask, other=0.0)
+        accum += tl.dot(input_block, weight_block, input_precision="ieee")
+
+    bias_pointer += (pid_group[None] * out_per_group_c)[None, :] + output_c_offset[
+        None, :
+    ]
+    mask_bias = (output_c_offset < out_per_group_c)[None, :]
+    bias = tl.load(bias_pointer, mask=mask_bias, other=0.0).to(tl.float32)
+    accum += bias
+
+    output_pointer += (
+        (output_n_stride * n)[:, None]
+        + (output_c_stride * (pid_group * out_per_group_c + output_c_offset))[None, :]
+        + (output_height_stride * oh)[:, None]
+        + (output_width_stride * ow)[:, None]
+    )
+    output_mask = (
+        (n < in_n)[:, None]
+        & (output_c_offset < out_per_group_c)[None, :]
+        & (oh >= 0)[:, None]
+        & (oh < out_height)[:, None]
+        & (ow >= 0)[:, None]
+        & (ow < out_width)[:, None]
+    )
+    tl.store(output_pointer, accum, mask=output_mask)
+
+
+def conv_transpose2d(
+    input,
+    weight,
+    bias=None,
+    stride=1,
+    padding=0,
+    output_padding=0,
+    groups=1,
+    dilation=1,
+):
+    logger.debug("GEMS CONV_TRANSPOSE2D")
+    stride_height, stride_width = _to_pair(stride)
+    padding_height, padding_width = _to_pair(padding)
+    output_padding_height, output_padding_width = _to_pair(output_padding)
+    dilation_height, dilation_width = _to_pair(dilation)
+    _validate_conv_transpose2d_params(
+        stride_height,
+        stride_width,
+        padding_height,
+        padding_width,
+        output_padding_height,
+        output_padding_width,
+        dilation_height,
+        dilation_width,
+        groups,
+    )
+
+    if torch.is_grad_enabled():
+        return torch.ops.aten.conv_transpose2d.input.redispatch(
+            _FALLBACK_KEYSET,
+            input,
+            weight,
+            bias,
+            [stride_height, stride_width],
+            [padding_height, padding_width],
+            [output_padding_height, output_padding_width],
+            groups,
+            [dilation_height, dilation_width],
+        )
+
+    assert input.ndim == 4, f"Input must be 4D, received shape {input.shape}"
+    assert weight.ndim == 4, f"Weights must be 4D, received shape {weight.shape}"
+    assert (
+        bias is None or bias.ndim == 1
+    ), f"Bias must be 1D, received shape {bias.shape}"
+    assert (
+        input.shape[1] == weight.shape[0]
+    ), f"Incompatible input ({input.shape}) and weight ({weight.shape}) channels"
+    assert (
+        input.shape[1] % groups == 0
+    ), f"Input channels {input.shape[1]} must be divisible by groups {groups}"
+
+    in_n, input_channels, input_height, input_width = input.shape
+    _, out_channels_per_group, kernel_height, kernel_width = weight.shape
+    out_channels = groups * out_channels_per_group
+
+    assert (
+        bias is None or bias.shape[0] == out_channels
+    ), f"Incompatible weight ({weight.shape}) and bias ({bias.shape}) shape"
+
+    out_height = conv_transpose2d_output_size(
+        input_height,
+        kernel_height,
+        stride_height,
+        padding_height,
+        output_padding_height,
+        dilation_height,
+    )
+    out_width = conv_transpose2d_output_size(
+        input_width,
+        kernel_width,
+        stride_width,
+        padding_width,
+        output_padding_width,
+        dilation_width,
+    )
+
+    output = torch.empty(
+        (in_n, out_channels, out_height, out_width),
+        dtype=input.dtype,
+        device=input.device,
+    )
+
+    if bias is None:
+        bias_pointer = torch.zeros(out_channels, dtype=input.dtype, device=input.device)
+    else:
+        bias_pointer = bias
+
+    effective_kernel_height = dilation_height * (kernel_height - 1) + 1
+    effective_kernel_width = dilation_width * (kernel_width - 1) + 1
+    use_scatter_kernel = (
+        stride_height * stride_width > 4
+        and effective_kernel_height <= stride_height
+        and effective_kernel_width <= stride_width
+    )
+    if use_scatter_kernel:
+        total_elements = output.numel()
+        fill_grid = (triton.cdiv(total_elements, 1024),)
+        conv_transpose2d_fill_kernel[fill_grid](
+            output,
+            bias_pointer,
+            total_elements,
+            out_channels,
+            out_height,
+            out_width,
+            *output.stride(),
+            HAS_BIAS=bias is not None,
+            BLOCK_SIZE=1024,
+        )
+        scatter_grid = lambda meta: (
+            triton.cdiv(in_n * input_height * input_width, meta["BLOCK_NI_HI_WI"]),
+            triton.cdiv(int(out_channels // groups), meta["BLOCK_CO"]),
+            groups * kernel_height * kernel_width,
+        )
+        conv_transpose2d_forward_scatter_kernel[scatter_grid](
+            input,
+            weight,
+            output,
+            bias_pointer,
+            in_n,
+            input_height,
+            input_width,
+            out_channels,
+            out_height,
+            out_width,
+            *input.stride(),
+            *weight.stride(),
+            *output.stride(),
+            input_channels // groups,
+            kernel_height,
+            kernel_width,
+            stride_height,
+            stride_width,
+            dilation_height,
+            dilation_width,
+            padding_height,
+            padding_width,
+            groups=groups,
+        )
+        return output
+
+    stride_product = stride_height * stride_width
+    large_stride3_output = (
+        stride_height == 3
+        and stride_width == 3
+        and in_n * out_height * out_width >= 131072
+    )
+    use_residue_kernel = (stride_height > 1 or stride_width > 1) and (
+        stride_product <= 4 or large_stride3_output
+    )
+    if use_residue_kernel:
+        for output_residue_height in range(stride_height):
+            compact_out_height = (
+                out_height + stride_height - 1 - output_residue_height
+            ) // stride_height
+            for output_residue_width in range(stride_width):
+                compact_out_width = (
+                    out_width + stride_width - 1 - output_residue_width
+                ) // stride_width
+                grid = lambda meta: (
+                    triton.cdiv(
+                        in_n * compact_out_height * compact_out_width,
+                        meta["BLOCK_NI_HO_WO"],
+                    ),
+                    triton.cdiv(int(out_channels // groups), meta["BLOCK_CO"]),
+                    groups,
+                )
+                if input.dtype in (torch.float16, torch.bfloat16) and (
+                    kernel_height >= 5 or kernel_width >= 5
+                ):
+                    residue_kernel = (
+                        conv_transpose2d_forward_residue_low_precision_large_kernel
+                    )
+                elif input.dtype in (torch.float16, torch.bfloat16):
+                    residue_kernel = conv_transpose2d_forward_residue_fp16_kernel
+                elif kernel_height >= 5 or kernel_width >= 5:
+                    residue_kernel = conv_transpose2d_forward_residue_fp32_large_kernel
+                else:
+                    residue_kernel = conv_transpose2d_forward_residue_kernel
+                residue_kernel[grid](
+                    input,
+                    weight,
+                    output,
+                    bias_pointer,
+                    in_n,
+                    input_height,
+                    input_width,
+                    out_channels,
+                    out_height,
+                    out_width,
+                    compact_out_height,
+                    compact_out_width,
+                    *input.stride(),
+                    *weight.stride(),
+                    *output.stride(),
+                    input_channels // groups,
+                    kernel_height,
+                    kernel_width,
+                    stride_height,
+                    stride_width,
+                    dilation_height,
+                    dilation_width,
+                    padding_height,
+                    padding_width,
+                    groups=groups,
+                    output_residue_height=output_residue_height,
+                    output_residue_width=output_residue_width,
+                )
+        return output
+
+    grid = lambda meta: (
+        triton.cdiv(in_n * out_height * out_width, meta["BLOCK_NI_HO_WO"]),
+        triton.cdiv(int(out_channels // groups), meta["BLOCK_CO"]),
+        groups,
+    )
+    conv_transpose2d_forward_kernel[grid](
+        input,
+        weight,
+        output,
+        bias_pointer,
+        in_n,
+        input_height,
+        input_width,
+        out_channels,
+        out_height,
+        out_width,
+        *input.stride(),
+        *weight.stride(),
+        *output.stride(),
+        input_channels // groups,
+        kernel_height,
+        kernel_width,
+        stride_height,
+        stride_width,
+        padding_height,
+        padding_width,
+        dilation_height,
+        dilation_width,
+        groups=groups,
+    )
+    return output

--- a/tests/test_conv_transpose2d.py
+++ b/tests/test_conv_transpose2d.py
@@ -1,0 +1,351 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+SHAPE_CONV_TRANSPOSE2D = [
+    ((1, 2, 5, 5), (2, 3, 3, 3), 1),
+    ((2, 4, 7, 7), (4, 2, 3, 3), 2),
+    ((4, 8, 8, 8), (8, 4, 2, 2), 2),
+]
+
+CONV_TRANSPOSE2D_FORWARD_DTYPES = [torch.float16, torch.float32]
+if flag_gems.runtime.device.support_bf16:
+    CONV_TRANSPOSE2D_FORWARD_DTYPES.append(torch.bfloat16)
+
+
+def _disable_tf32():
+    torch.backends.cuda.matmul.allow_tf32 = False
+    torch.backends.cudnn.allow_tf32 = False
+
+
+def _skip_cpu_bf16_reference(dtype):
+    if utils.TO_CPU and dtype == torch.bfloat16:
+        pytest.skip(
+            "CPU bf16 conv_transpose2d uses a different accumulation path from CUDA"
+        )
+
+
+def _conv_transpose2d_forward_atol(dtype, reduce_dim):
+    if dtype == torch.bfloat16:
+        return 0.016 / reduce_dim
+    if dtype == torch.float16:
+        return 1e-3
+    return 1e-4
+
+
+@pytest.mark.conv_transpose2d
+@pytest.mark.parametrize("shape, kernel, groups", SHAPE_CONV_TRANSPOSE2D)
+@pytest.mark.parametrize(
+    "stride, padding, output_padding, dilation",
+    [
+        (1, 0, 0, 1),
+        (2, 1, 0, 1),
+        ((2, 2), (1, 1), (1, 1), 1),
+        ((2, 1), (1, 0), (1, 0), (2, 1)),
+    ],
+)
+@pytest.mark.parametrize("dtype", CONV_TRANSPOSE2D_FORWARD_DTYPES)
+@pytest.mark.parametrize("bias", [True, False])
+def test_accuracy_conv_transpose2d_forward(
+    shape, kernel, groups, stride, padding, output_padding, dilation, dtype, bias
+):
+    _skip_cpu_bf16_reference(dtype)
+    _disable_tf32()
+    reduce_dim = (shape[1] // groups) * kernel[2] * kernel[3]
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=False)
+    ref_inp = utils.to_reference(inp, False)
+    weight = torch.randn(
+        kernel, dtype=dtype, device=flag_gems.device, requires_grad=False
+    )
+    ref_weight = utils.to_reference(weight, False)
+
+    if bias:
+        bias_tensor = torch.randn(
+            [kernel[1] * groups],
+            dtype=dtype,
+            device=flag_gems.device,
+            requires_grad=False,
+        )
+        bias_ref = utils.to_reference(bias_tensor, False)
+    else:
+        bias_tensor = None
+        bias_ref = None
+
+    ref_out = torch.nn.functional.conv_transpose2d(
+        ref_inp,
+        ref_weight,
+        bias=bias_ref,
+        stride=stride,
+        padding=padding,
+        output_padding=output_padding,
+        groups=groups,
+        dilation=dilation,
+    ).to(dtype)
+
+    with torch.no_grad():
+        res_out = flag_gems.conv_transpose2d(
+            inp,
+            weight,
+            bias=bias_tensor,
+            stride=stride,
+            padding=padding,
+            output_padding=output_padding,
+            groups=groups,
+            dilation=dilation,
+        )
+
+    atol = _conv_transpose2d_forward_atol(dtype, reduce_dim)
+    utils.gems_assert_close(res_out, ref_out, dtype, reduce_dim=reduce_dim, atol=atol)
+
+
+CONV_TRANSPOSE2D_FORWARD_EDGE_CASES = [
+    ((1, 1, 1, 1), (1, 1, 1, 1), 1, 1, 0, 0, 1, False, False),
+    ((1, 2, 4, 4), (2, 3, 3, 3), 1, 4, 1, 0, 1, False, False),
+    ((1, 3, 4, 5), (3, 2, 2, 3), 1, (3, 2), (1, 0), (2, 1), 1, True, False),
+    ((2, 4, 5, 6), (4, 3, 5, 5), 1, 2, 2, 1, 1, True, True),
+    ((4, 4, 64, 64), (4, 4, 5, 5), 1, 3, 2, 0, 1, False, False),
+    ((1, 8, 4, 4), (8, 1, 3, 3), 4, 2, 1, 1, 1, False, False),
+    (
+        (1, 2, 5, 4),
+        (2, 3, 3, 2),
+        1,
+        (1, 2),
+        (0, 1),
+        (0, 1),
+        (2, 1),
+        False,
+        True,
+    ),
+]
+
+
+@pytest.mark.conv_transpose2d
+@pytest.mark.parametrize(
+    (
+        "shape, kernel, groups, stride, padding, output_padding, dilation, "
+        "noncontig_input, noncontig_weight"
+    ),
+    CONV_TRANSPOSE2D_FORWARD_EDGE_CASES,
+)
+@pytest.mark.parametrize("dtype", CONV_TRANSPOSE2D_FORWARD_DTYPES)
+def test_accuracy_conv_transpose2d_forward_edge_cases(
+    shape,
+    kernel,
+    groups,
+    stride,
+    padding,
+    output_padding,
+    dilation,
+    noncontig_input,
+    noncontig_weight,
+    dtype,
+):
+    _skip_cpu_bf16_reference(dtype)
+    _disable_tf32()
+    if noncontig_input:
+        inp_shape = (shape[0], shape[1], shape[3], shape[2])
+        inp = torch.randn(
+            inp_shape, dtype=dtype, device=flag_gems.device, requires_grad=False
+        ).transpose(2, 3)
+    else:
+        inp = torch.randn(
+            shape, dtype=dtype, device=flag_gems.device, requires_grad=False
+        )
+    ref_inp = utils.to_reference(inp, False)
+
+    if noncontig_weight:
+        weight_shape = (kernel[0], kernel[1], kernel[3], kernel[2])
+        weight = torch.randn(
+            weight_shape, dtype=dtype, device=flag_gems.device, requires_grad=False
+        ).transpose(2, 3)
+    else:
+        weight = torch.randn(
+            kernel, dtype=dtype, device=flag_gems.device, requires_grad=False
+        )
+    ref_weight = utils.to_reference(weight, False)
+
+    bias_tensor = torch.randn(
+        [kernel[1] * groups],
+        dtype=dtype,
+        device=flag_gems.device,
+        requires_grad=False,
+    )
+    bias_ref = utils.to_reference(bias_tensor, False)
+    reduce_dim = (shape[1] // groups) * kernel[2] * kernel[3]
+
+    ref_out = torch.nn.functional.conv_transpose2d(
+        ref_inp,
+        ref_weight,
+        bias=bias_ref,
+        stride=stride,
+        padding=padding,
+        output_padding=output_padding,
+        groups=groups,
+        dilation=dilation,
+    ).to(dtype)
+
+    with torch.no_grad():
+        res_out = flag_gems.conv_transpose2d(
+            inp,
+            weight,
+            bias=bias_tensor,
+            stride=stride,
+            padding=padding,
+            output_padding=output_padding,
+            groups=groups,
+            dilation=dilation,
+        )
+
+    atol = _conv_transpose2d_forward_atol(dtype, reduce_dim)
+    utils.gems_assert_close(res_out, ref_out, dtype, reduce_dim=reduce_dim, atol=atol)
+
+
+@pytest.mark.conv_transpose2d
+@pytest.mark.parametrize(
+    "case",
+    [
+        "input_ndim",
+        "weight_ndim",
+        "bias_ndim",
+        "channel_mismatch",
+        "groups_zero",
+        "channels_not_divisible",
+        "bias_size",
+        "bad_stride",
+        "bad_padding",
+        "bad_output_padding",
+        "bad_dilation",
+        "bad_pair_length",
+    ],
+)
+def test_accuracy_conv_transpose2d_invalid_inputs(case):
+    dtype = torch.float32
+    inp = torch.randn((1, 2, 4, 4), dtype=dtype, device=flag_gems.device)
+    weight = torch.randn((2, 3, 3, 3), dtype=dtype, device=flag_gems.device)
+    bias = torch.randn((3,), dtype=dtype, device=flag_gems.device)
+    kwargs = {
+        "stride": 1,
+        "padding": 0,
+        "output_padding": 0,
+        "groups": 1,
+        "dilation": 1,
+    }
+
+    if case == "input_ndim":
+        inp = inp.squeeze(0)
+    elif case == "weight_ndim":
+        weight = weight[0]
+    elif case == "bias_ndim":
+        bias = bias[None, :]
+    elif case == "channel_mismatch":
+        weight = torch.randn((3, 3, 3, 3), dtype=dtype, device=flag_gems.device)
+    elif case == "groups_zero":
+        kwargs["groups"] = 0
+    elif case == "channels_not_divisible":
+        kwargs["groups"] = 3
+    elif case == "bias_size":
+        bias = torch.randn((4,), dtype=dtype, device=flag_gems.device)
+    elif case == "bad_stride":
+        kwargs["stride"] = 0
+    elif case == "bad_padding":
+        kwargs["padding"] = -1
+    elif case == "bad_output_padding":
+        kwargs["stride"] = 2
+        kwargs["output_padding"] = 2
+    elif case == "bad_dilation":
+        kwargs["dilation"] = 0
+    elif case == "bad_pair_length":
+        kwargs["stride"] = (1, 1, 1)
+
+    with pytest.raises(AssertionError):
+        with torch.no_grad():
+            flag_gems.conv_transpose2d(inp, weight, bias=bias, **kwargs)
+
+
+@pytest.mark.conv_transpose2d
+@pytest.mark.parametrize("shape, kernel, groups", SHAPE_CONV_TRANSPOSE2D[:2])
+@pytest.mark.parametrize(
+    "stride, padding, output_padding, dilation",
+    [
+        (1, 0, 0, 1),
+        (2, 1, 0, 1),
+        ((2, 2), (1, 1), (1, 1), 1),
+    ],
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32])
+@pytest.mark.parametrize("bias", [True, False])
+def test_accuracy_conv_transpose2d_backward(
+    shape, kernel, groups, stride, padding, output_padding, dilation, dtype, bias
+):
+    _disable_tf32()
+    reduce_dim = (shape[1] // groups) * kernel[2] * kernel[3]
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    ref_inp = utils.to_reference(inp, True)
+    weight = torch.randn(
+        kernel, dtype=dtype, device=flag_gems.device, requires_grad=True
+    )
+    ref_weight = utils.to_reference(weight, True)
+
+    if bias:
+        bias_tensor = torch.randn(
+            [kernel[1] * groups],
+            dtype=dtype,
+            device=flag_gems.device,
+            requires_grad=True,
+        )
+        bias_ref = utils.to_reference(bias_tensor, True)
+    else:
+        bias_tensor = None
+        bias_ref = None
+
+    ref_out = torch.nn.functional.conv_transpose2d(
+        ref_inp,
+        ref_weight,
+        bias=bias_ref,
+        stride=stride,
+        padding=padding,
+        output_padding=output_padding,
+        groups=groups,
+        dilation=dilation,
+    ).to(dtype)
+
+    res_out = flag_gems.conv_transpose2d(
+        inp,
+        weight,
+        bias=bias_tensor,
+        stride=stride,
+        padding=padding,
+        output_padding=output_padding,
+        groups=groups,
+        dilation=dilation,
+    )
+
+    utils.gems_assert_close(res_out, ref_out, dtype, reduce_dim=reduce_dim)
+
+    out_grad = torch.randn_like(ref_out).to(flag_gems.device)
+    ref_grad = utils.to_reference(out_grad, True)
+
+    if bias:
+        ref_in_grad, ref_weight_grad, ref_bias_grad = torch.autograd.grad(
+            ref_out, (ref_inp, ref_weight, bias_ref), ref_grad
+        )
+        res_in_grad, res_weight_grad, res_bias_grad = torch.autograd.grad(
+            res_out, (inp, weight, bias_tensor), out_grad
+        )
+    else:
+        ref_in_grad, ref_weight_grad = torch.autograd.grad(
+            ref_out, (ref_inp, ref_weight), ref_grad
+        )
+        res_in_grad, res_weight_grad = torch.autograd.grad(
+            res_out, (inp, weight), out_grad
+        )
+
+    utils.gems_assert_close(res_in_grad, ref_in_grad, dtype, reduce_dim=kernel[2])
+    utils.gems_assert_close(
+        res_weight_grad, ref_weight_grad, dtype, reduce_dim=shape[1]
+    )
+    if bias:
+        utils.gems_assert_close(res_bias_grad, ref_bias_grad, dtype)


### PR DESCRIPTION
## Summary

This PR implements and optimizes the forward path of `torch.nn.functional.conv_transpose2d` in Triton.

Supported API:

```python
torch.nn.functional.conv_transpose2d(
    input,
    weight,
    bias=None,
    stride=1,
    padding=0,
    output_padding=0,
    groups=1,
    dilation=1,
) -> Tensor
```

Supported dtypes:

- `torch.float16`
- `torch.float32`
- `torch.bfloat16`

Autograd behavior:

- `torch.no_grad()` forward uses the optimized Triton implementation.
- When gradients are enabled, the operator redispatches to Aten for correctness.
- This PR focuses on forward acceleration, matching the competition schema for `conv_transpose2d`.

## Implementation

The implementation uses three main computation strategies:

| Path | Use Case | Notes |
| --- | --- | --- |
| direct gather | generic fallback, stride 1, small overlapping large-stride cases | single kernel launch, each output point gathers valid input/kernel contributions |
| residue gather | stride 2 style cases, plus large stride3 overlap outputs | multiple residue launches; compile-time residue constants remove invalid kernel taps |
| scatter sparse write | large stride with no spatial overlap, where `effective_kernel <= stride` | initializes output, then writes only non-zero transposed-convolution contributions |

There are several Triton wrapper entry points, but most of them share the same residue body. The split is intentional: it isolates autotune candidate pools by dtype and kernel-size bucket so one shape does not poison another shape's autotune result.

Residue autotune buckets:

- fp32 normal kernel
- fp32 large kernel
- fp16/bf16 normal kernel
- fp16/bf16 large kernel

Residue dispatch condition:

```python
stride_product = stride_h * stride_w
large_stride3_output = (
    stride_h == 3
    and stride_w == 3
    and N * out_h * out_w >= 131072
)
use_residue = stride_product <= 4 or large_stride3_output
```

The stride3 large-output case is included because direct gather wastes substantial work on the expanded output grid. Small stride3 cases stay on direct/scatter paths to avoid the launch overhead of 9 residue kernels.

Scatter path condition:

```python
stride_h * stride_w > 4
effective_kernel_h <= stride_h
effective_kernel_w <= stride_w
effective_kernel = dilation * (kernel - 1) + 1
```

This avoids atomics because neighboring input points do not overlap spatially under this condition.

## Accuracy Validation

Command:

```bash
export PATH="/usr/lib/wsl/lib:$PATH"
export GEMS_VENDOR=nvidia
export PYTHONPATH=src
python -m pytest tests/test_conv_transpose2d.py -q
```

Result:

```text
129 passed, 338 deselected, 37 warnings
```

## Test Coverage Checklist

| Category | Covered Cases |
| --- | --- |
| Input scale | 1x1 small case, 24x24 regular cases, 64x64 and 128x128 larger benchmark shapes |
| DType | float16, float32, bfloat16 forward |
| API parameters | stride 1, stride 2, stride 3, stride 4, stride 8, padding, output_padding, dilation, groups, bias/no-bias |
| Groups | groups 1, 2, 4 |
| Kernel sizes | 1x1, 2x2, 3x3, 3x2, 5x5 |
| Layout | contiguous and non-contiguous input/weight cases |
| Edge cases | 1x1 tensors, asymmetric stride/padding/output_padding, grouped/depthwise-like cases, stride3 overlapping large-output residue case |
| Invalid inputs | bad ndim, bad groups, channel mismatch, bad bias shape, invalid stride/padding/output_padding/dilation, bad pair length |
| Optimized branches | direct, stride2 residue, stride3 large-output residue, large-kernel residue, scatter sparse-write path |

## Benchmark

Command:

```bash
export PATH="/usr/lib/wsl/lib:$PATH"
export GEMS_VENDOR=nvidia
export PYTHONPATH=src
python -m pytest benchmark/test_conv_transpose2d.py -s --level core
```

Core benchmark shapes:

| ID | Input | Weight | Stride | Padding | Output Padding | Groups | Dilation | Main Path |
| --- | --- | --- | --- | --- | --- | --- | --- | --- |
| 1 | `[16, 32, 24, 24]` | `[32, 12, 3, 3]` | 1 | 1 | 0 | 2 | 1 | direct |
| 2 | `[16, 32, 24, 24]` | `[32, 12, 3, 3]` | 2 | 1 | 1 | 2 | 1 | residue |
| 3 | `[32, 64, 64, 64]` | `[64, 32, 3, 3]` | 2 | 1 | 1 | 1 | 1 | residue |
| 4 | `[32, 64, 128, 128]` | `[64, 32, 5, 5]` | 2 | 2 | 1 | 1 | 1 | large-kernel residue |
| 5 | `[4, 32, 128, 128]` | `[32, 32, 5, 5]` | 3 | 2 | 0 | 1 | 1 | stride3 large-output residue |
| 6 | `[16, 32, 24, 24]` | `[32, 12, 3, 3]` | 3 | 1 | 0 | 2 | 1 | scatter |
| 7 | `[16, 32, 24, 24]` | `[32, 12, 3, 3]` | 4 | 1 | 0 | 2 | 1 | scatter |
| 8 | `[8, 32, 32, 32]` | `[32, 32, 3, 3]` | 4 | 1 | 0 | 1 | 1 | scatter |
| 9 | `[4, 32, 32, 32]` | `[32, 32, 3, 3]` | 8 | 1 | 0 | 1 | 1 | scatter |

Benchmark result:

| DType | Input / Weight | Params | Main Path | PyTorch (ms) | FlagGems (ms) | Speedup |
| --- | --- | --- | --- | ---: | ---: | ---: |
| float16 | `16x32x24x24 / 32x12x3x3` | s1 p1 op0 g2 d1 | direct | 0.156240 | 0.017408 | 8.975x |
| float16 | `16x32x24x24 / 32x12x3x3` | s2 p1 op1 g2 d1 | residue | 0.163136 | 0.050144 | 3.253x |
| float16 | `32x64x64x64 / 64x32x3x3` | s2 p1 op1 g1 d1 | residue | 0.745984 | 0.529408 | 1.409x |
| float16 | `32x64x128x128 / 64x32x5x5` | s2 p2 op1 g1 d1 | large-kernel residue | 3.836928 | 4.241408 | 0.905x |
| float16 | `4x32x128x128 / 32x32x5x5` | s3 p2 op0 g1 d1 | stride3 residue | 0.673280 | 0.546816 | 1.231x |
| float16 | `16x32x24x24 / 32x12x3x3` | s3 p1 op0 g2 d1 | scatter | 0.179264 | 0.049152 | 3.647x |
| float16 | `16x32x24x24 / 32x12x3x3` | s4 p1 op0 g2 d1 | scatter | 0.364608 | 0.067584 | 5.395x |
| float16 | `8x32x32x32 / 32x32x3x3` | s4 p1 op0 g1 d1 | scatter | 0.134144 | 0.083968 | 1.598x |
| float16 | `4x32x32x32 / 32x32x3x3` | s8 p1 op0 g1 d1 | scatter | 0.223232 | 0.110080 | 2.028x |
| float32 | `16x32x24x24 / 32x12x3x3` | s1 p1 op0 g2 d1 | direct | 0.137216 | 0.034816 | 3.941x |
| float32 | `16x32x24x24 / 32x12x3x3` | s2 p1 op1 g2 d1 | residue | 0.163840 | 0.112640 | 1.455x |
| float32 | `32x64x64x64 / 64x32x3x3` | s2 p1 op1 g1 d1 | residue | 2.267136 | 2.153472 | 1.053x |
| float32 | `32x64x128x128 / 64x32x5x5` | s2 p2 op1 g1 d1 | large-kernel residue | 19.229696 | 12.160000 | 1.581x |
| float32 | `4x32x128x128 / 32x32x5x5` | s3 p2 op0 g1 d1 | stride3 residue | 2.868224 | 1.605632 | 1.786x |
| float32 | `16x32x24x24 / 32x12x3x3` | s3 p1 op0 g2 d1 | scatter | 0.215136 | 0.091136 | 2.361x |
| float32 | `16x32x24x24 / 32x12x3x3` | s4 p1 op0 g2 d1 | scatter | 0.439280 | 0.121888 | 3.604x |
| float32 | `8x32x32x32 / 32x32x3x3` | s4 p1 op0 g1 d1 | scatter | 0.207360 | 0.154624 | 1.341x |
| float32 | `4x32x32x32 / 32x32x3x3` | s8 p1 op0 g1 d1 | scatter | 1.360896 | 0.238592 | 5.704x |
| bfloat16 | `16x32x24x24 / 32x12x3x3` | s1 p1 op0 g2 d1 | direct | 0.111616 | 0.017408 | 6.412x |
| bfloat16 | `16x32x24x24 / 32x12x3x3` | s2 p1 op1 g2 d1 | residue | 0.294080 | 0.044032 | 6.679x |
| bfloat16 | `32x64x64x64 / 64x32x3x3` | s2 p1 op1 g1 d1 | residue | 0.734208 | 0.503808 | 1.457x |
| bfloat16 | `32x64x128x128 / 64x32x5x5` | s2 p2 op1 g1 d1 | large-kernel residue | 3.869632 | 4.144128 | 0.934x |
| bfloat16 | `4x32x128x128 / 32x32x5x5` | s3 p2 op0 g1 d1 | stride3 residue | 0.674816 | 0.565248 | 1.194x |
| bfloat16 | `16x32x24x24 / 32x12x3x3` | s3 p1 op0 g2 d1 | scatter | 0.872448 | 0.050080 | 17.421x |
| bfloat16 | `16x32x24x24 / 32x12x3x3` | s4 p1 op0 g2 d1 | scatter | 1.398784 | 0.066560 | 21.015x |
| bfloat16 | `8x32x32x32 / 32x32x3x3` | s4 p1 op0 g1 d1 | scatter | 0.134144 | 0.084544 | 1.587x |
| bfloat16 | `4x32x32x32 / 32x32x3x3` | s8 p1 op0 g1 d1 | scatter | 0.221696 | 0.110592 | 2.005x |

All core benchmark cases are above the competition threshold of `0.9x`.

## Notes

- The optimized forward path is active under `torch.no_grad()`.
- Gradient-enabled execution redispatches to Aten to preserve autograd correctness.
- The scatter path is intentionally limited to non-overlapping large-stride cases, avoiding atomic adds and reducing correctness risk.
- Overlapping large stride3 outputs use residue dispatch only above a size threshold. This keeps small cases on lower-overhead paths while fixing the large-output direct fallback weakness.
- The multiple Triton wrappers are mostly autotune buckets over shared compute bodies rather than separate algorithm implementations.
