### PR TITLE
fix: fix dtype mismatch in floor_divide fmod call

### DIFF
--- a/src/flag_gems/ops/div.py
+++ b/src/flag_gems/ops/div.py
@@ -233,7 +233,7 @@ def _float_floordiv(x, y):
 @pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
 @triton.jit
 def floor_div_func(x, y):
-    if x.type.scalar.is_int() & x.type.scalar.is_int():
+    if x.type.scalar.is_int() & y.type.scalar.is_int():
         return _int_floordiv(x, y)
     else:
         return _float_floordiv(x, y)
@@ -242,7 +242,7 @@ def floor_div_func(x, y):
 @pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "DEFAULT")])
 @triton.jit
 def floor_div_func_tensor_scalar(x, y):
-    if x.type.scalar.is_int() & x.type.scalar.is_int():
+    if x.type.scalar.is_int() & y.type.scalar.is_int():
         return _int_floordiv(x, y)
     else:
         return _float_floordiv(x, y)
@@ -251,7 +251,7 @@ def floor_div_func_tensor_scalar(x, y):
 @pointwise_dynamic(is_tensor=[False, True], promotion_methods=[(0, 1, "DEFAULT")])
 @triton.jit
 def floor_div_func_scalar_tensor(x, y):
-    if x.type.scalar.is_int() & x.type.scalar.is_int():
+    if x.type.scalar.is_int() & y.type.scalar.is_int():
         return _int_floordiv(x, y)
     else:
         return _float_floordiv(x, y)

--- a/tests/test_floor_divide.py
+++ b/tests/test_floor_divide.py
@@ -13,6 +13,62 @@ from . import conftest as cfg
 def replace_zeros(inp):
     return torch.where(inp == 0, 1, inp)
 
+@pytest.mark.floor_divide_mixed_types
+@pytest.mark.parametrize("dtype1,dtype2", [
+    (torch.float32, torch.int32),
+    (torch.float32, torch.float32),
+    (torch.int32, torch.int32),
+])
+def test_floor_divide_mixed(dtype1, dtype2):
+
+    if dtype1.is_floating_point:
+        x = torch.randn(128, device="cuda", dtype=dtype1)
+    else:
+        x = torch.randint(-10, 10, (128,), device="cuda", dtype=dtype1)
+
+    if dtype2.is_floating_point:
+        y = torch.randn(128, device="cuda", dtype=dtype2) + 0.1
+    else:
+        y = torch.randint(1, 10, (128,), device="cuda", dtype=dtype2)
+
+    # reference
+    ref = torch.div(x, y, rounding_mode="floor")
+
+    out = flag_gems.ops.floor_divide(x, y)
+
+    torch.testing.assert_close(out, ref)
+# 测试 floor_div_func_scalar_tensor(x, y) - scalar // tensor 场景
+# 对应 div.py:253-257 的实现
+@pytest.mark.floor_divide_scalar_tensor
+@pytest.mark.parametrize("x_dtype,y_dtype", [
+    (torch.int32, torch.int32),
+    (torch.int32, torch.float32),
+    (torch.float32, torch.int32),
+    (torch.float32, torch.float32),
+])
+def test_floor_divide_scalar_tensor(x_dtype, y_dtype):
+    """测试 scalar // tensor 场景"""
+
+    def make_tensor(shape, dtype):
+        if dtype.is_floating_point:
+            return torch.randn(shape, device="cuda", dtype=dtype)
+        else:
+            return torch.randint(1, 10, (shape,), device="cuda", dtype=dtype)
+
+    # tensor y
+    y = make_tensor(128, y_dtype)
+
+    if x_dtype.is_floating_point:
+        x = torch.randn(1, device="cuda", dtype=x_dtype).squeeze(0)
+    else:
+        x = torch.randint(1, 10, (), device="cuda", dtype=x_dtype).item()
+
+    ref = torch.div(x, y, rounding_mode="floor")
+
+    # flaggems
+    out = flag_gems.ops.floor_divide(x, y)
+
+    torch.testing.assert_close(out, ref)
 
 # TODO: failed at large size, eg. (65536 * 2048,)
 @pytest.mark.floor_divide

--- a/tests/test_floor_divide.py
+++ b/tests/test_floor_divide.py
@@ -13,14 +13,17 @@ from . import conftest as cfg
 def replace_zeros(inp):
     return torch.where(inp == 0, 1, inp)
 
-@pytest.mark.floor_divide_mixed_types
-@pytest.mark.parametrize("dtype1,dtype2", [
-    (torch.float32, torch.int32),
-    (torch.float32, torch.float32),
-    (torch.int32, torch.int32),
-])
-def test_floor_divide_mixed(dtype1, dtype2):
 
+@pytest.mark.floor_divide
+@pytest.mark.parametrize(
+    "dtype1,dtype2",
+    [
+        (torch.float32, torch.int32),
+        (torch.float32, torch.float32),
+        (torch.int32, torch.int32),
+    ],
+)
+def test_floor_divide_mixed(dtype1, dtype2):
     if dtype1.is_floating_point:
         x = torch.randn(128, device="cuda", dtype=dtype1)
     else:
@@ -37,25 +40,25 @@ def test_floor_divide_mixed(dtype1, dtype2):
     out = flag_gems.ops.floor_divide(x, y)
 
     torch.testing.assert_close(out, ref)
-# 测试 floor_div_func_scalar_tensor(x, y) - scalar // tensor 场景
-# 对应 div.py:253-257 的实现
-@pytest.mark.floor_divide_scalar_tensor
-@pytest.mark.parametrize("x_dtype,y_dtype", [
-    (torch.int32, torch.int32),
-    (torch.int32, torch.float32),
-    (torch.float32, torch.int32),
-    (torch.float32, torch.float32),
-])
-def test_floor_divide_scalar_tensor(x_dtype, y_dtype):
-    """测试 scalar // tensor 场景"""
 
+
+@pytest.mark.floor_divide
+@pytest.mark.parametrize(
+    "x_dtype,y_dtype",
+    [
+        (torch.int32, torch.int32),
+        (torch.int32, torch.float32),
+        (torch.float32, torch.int32),
+        (torch.float32, torch.float32),
+    ],
+)
+def test_floor_divide_scalar_tensor(x_dtype, y_dtype):
     def make_tensor(shape, dtype):
         if dtype.is_floating_point:
             return torch.randn(shape, device="cuda", dtype=dtype)
         else:
             return torch.randint(1, 10, (shape,), device="cuda", dtype=dtype)
 
-    # tensor y
     y = make_tensor(128, y_dtype)
 
     if x_dtype.is_floating_point:
@@ -69,6 +72,7 @@ def test_floor_divide_scalar_tensor(x_dtype, y_dtype):
     out = flag_gems.ops.floor_divide(x, y)
 
     torch.testing.assert_close(out, ref)
+
 
 # TODO: failed at large size, eg. (65536 * 2048,)
 @pytest.mark.floor_divide


### PR DESCRIPTION
Fix #2612

## Problem
Incorrect dtype check in floor_divide functions:
Repeatedly checked `x.type.scalar.is_int()` twice, causing wrong dispatch for mixed dtype inputs (float tensor // int scalar), leading to Triton JIT compilation errors.

## Fix
Correct dtype condition to check both x and y:
`x.type.scalar.is_int() & y.type.scalar.is_int()`

Applied to:
- floor_div_func
- floor_div_func_tensor_scalar
- floor_div_func_scalar_tensor

## Testing
Added mixed dtype & scalar-tensor test cases in test_floor_divide.py.
All tests passed.