### PR TITLE
[kunlunxin]: fix kunlunxin round_ test bug

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/__init__.py
@@ -184,6 +184,7 @@ from .repeat_interleave import (
 from .resolve_conj import resolve_conj
 from .resolve_neg import resolve_neg
 from .rms_norm import rms_norm, rms_norm_backward, rms_norm_forward
+from .round import round, round_, round_out
 from .rsqrt import rsqrt, rsqrt_
 from .rsub import rsub
 from .scaled_softmax import scaled_softmax_backward, scaled_softmax_forward
@@ -467,6 +468,9 @@ __all__ = [
     "repeat_interleave_tensor",
     "resolve_conj",
     "resolve_neg",
+    "round",
+    "round_",
+    "round_out",
     "rms_norm",
     "rms_norm_backward",
     "rms_norm_forward",

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/round.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/round.py
@@ -1,0 +1,76 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+from triton.language.extra.xpu.libdevice import rint as _rint
+
+from ..utils.pointwise_dynamic import pointwise_dynamic
+
+logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
+
+
+# rint(fp32) implements round-half-to-even, matching torch.round semantics.
+# XPU libdevice rint only supports fp32, so always cast to fp32 for computation.
+# The scale trick handles non-zero decimals: round(x, d) = rint(x * 10^d) / 10^d.
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, "DEFAULT")])
+@triton.jit
+def round_func(x, scale):
+    x_fp32 = x.to(tl.float32)
+    return _rint(x_fp32 * scale) / scale
+
+
+def _scale(decimals):
+    return 10.0**decimals
+
+
+def round(input, decimals=0):
+    logger.debug("GEMS_KUNLUNXIN ROUND")
+    if not isinstance(input, torch.Tensor):
+        raise TypeError("round expects a torch.Tensor.")
+    if input.is_complex():
+        raise TypeError("round is not supported for complex tensors.")
+    if input.dtype in [torch.int32, torch.int64, torch.int16, torch.int8]:
+        return input.clone()
+    if input.numel() == 0:
+        return torch.empty_like(input)
+    if not input.is_contiguous():
+        input = input.contiguous()
+    return round_func(input, _scale(decimals))
+
+
+def round_out(input, *, decimals=0, out=None):
+    logger.debug("GEMS_KUNLUNXIN ROUND_OUT")
+    if out is None:
+        return round(input, decimals=decimals)
+    if not isinstance(input, torch.Tensor):
+        raise TypeError("round expects a torch.Tensor.")
+    if input.is_complex():
+        raise TypeError("round is not supported for complex tensors.")
+    if input.dtype in [torch.int32, torch.int64, torch.int16, torch.int8]:
+        out.copy_(input)
+        return out
+    if input.numel() == 0:
+        return out
+    if not input.is_contiguous():
+        input = input.contiguous()
+    round_func(input, _scale(decimals), out0=out)
+    return out
+
+
+def round_(input, *, decimals=0):
+    logger.debug("GEMS_KUNLUNXIN ROUND_")
+    if not isinstance(input, torch.Tensor):
+        raise TypeError("round expects a torch.Tensor.")
+    if input.is_complex():
+        raise TypeError("round is not supported for complex tensors.")
+    if input.dtype in [torch.int32, torch.int64, torch.int16, torch.int8]:
+        return input
+    if input.numel() == 0:
+        return input
+    if not input.is_contiguous():
+        raise ValueError(
+            "round Triton kernel currently supports only contiguous tensors."
+        )
+    round_func(input, _scale(decimals), out0=input)
+    return input


### PR DESCRIPTION


The generic implementation in `src/flag_gems/ops/round.py` uses a hand-written
`@triton.jit` kernel (`round_kernel`) that calls a nested `@triton.jit` helper
(`round_half_to_even_impl`). The XPU Triton compiler's `make_ttxir` stage
crashes when processing this IR pattern (nested JIT calls + multi-level
`constexpr` if/elif branching).

### Root Cause

The generic `round_kernel` contains constructs that the XPU backend compiler
cannot handle:

- **Nested `@triton.jit` function call**: `round_half_to_even_impl` is called
  from within `round_kernel`, producing nested JIT IR
- **Multi-level `constexpr` if/elif branching**: separate branches for
  `IS_FP32`, `IS_FP16`, `IS_BF16`
- **Complex boolean expression**: `(d > 0.5) | ((tl.abs(d - 0.5) < 1e-10) & is_odd)`

### Solution

Add a KunlunXin-specific implementation of `round`, `round_`, and `round_out`
under `src/flag_gems/runtime/backend/_kunlunxin/ops/round.py`.

The backend implementation:

- Uses `@pointwise_dynamic` + `@triton.jit` (the standard pattern for KunlunXin
  backend operators), which avoids the problematic IR structures
- Replaces the manual round-half-to-even algorithm with
  `triton.language.extra.xpu.libdevice.rint` — the native XPU hardware
  instruction that implements IEEE round-to-nearest-even for fp32
- Handles fp16/bf16 by casting to fp32 before calling `rint`, then casting
  back via `promotion_methods`
- Supports non-zero `decimals` via the scaling approach:
  `rint(x * 10^d) / 10^d`, passed as a scalar through
  `is_tensor=[True, False]`

### Changes

- **New**: `src/flag_gems/runtime/backend/_kunlunxin/ops/round.py`
  — KunlunXin-specific implementation of `round`, `round_`, `round_out`
- **Modified**: `src/flag_gems/runtime/backend/_kunlunxin/ops/__init__.py`
  — Register `round`, `round_`, `round_out` in the backend op registry

### Testing

```bash
pytest -m round_ --ref cpu -sv
pytest -m round --ref cpu -sv