### PR TITLE
fix stack OP benchmark

### DIFF
--- a/benchmark/test_stack.py
+++ b/benchmark/test_stack.py
@@ -32,7 +32,7 @@ def _input_fn(shape, dtype, device):
         yield [inp1, inp2, inp3], {"dim": -1},
 
 
-@pytest.mark.skip(reason="CUDA error - illegal memory access: issue #2675")
+# @pytest.mark.skip(reason="CUDA error - illegal memory access: issue #2675")
 @pytest.mark.stack
 def test_stack():
     bench = StackBenchmark(

--- a/benchmark/test_stack.py
+++ b/benchmark/test_stack.py
@@ -32,7 +32,6 @@ def _input_fn(shape, dtype, device):
         yield [inp1, inp2, inp3], {"dim": -1},
 
 
-# @pytest.mark.skip(reason="CUDA error - illegal memory access: issue #2675")
 @pytest.mark.stack
 def test_stack():
     bench = StackBenchmark(

--- a/src/flag_gems/ops/stack.py
+++ b/src/flag_gems/ops/stack.py
@@ -47,11 +47,17 @@ def stack_copy_func_kernel_4(
         dim_offset = dim_offset_d
         total_elements = total_elements_d
 
-    block_start = pid_x * BLOCK_X
-    offsets = tl.arange(0, BLOCK_X)
-    mask = block_start + offsets < total_elements
-
+    block_start = pid_x.to(tl.int64) * BLOCK_X
+    offsets = tl.arange(0, BLOCK_X).to(tl.int64)
     idx = block_start + offsets
+    scalar_zero = offsets * 0
+
+    dim_size_out = dim_size_out + scalar_zero
+    dim_prod_post = dim_prod_post + scalar_zero
+    dim_offset = dim_offset + scalar_zero
+    total_elements = total_elements + scalar_zero
+
+    mask = idx < total_elements
 
     pre_idx = idx // dim_prod_post
     post_idx = idx % dim_prod_post


### PR DESCRIPTION
### PR Category
Benchmark

### Type of Change
Bug Fix

### Description
fix stack OP benchmark.

### Issue
https://github.com/flagos-ai/FlagGems/issues/2675

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
benchmark on H20 HBM3
`pytest -s benchmark/test_stack.py::test_stack`

```
test_stack.py 
Operator: stack  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               3.835392            4.303392               0.891          ([[torch.Size([1073741824]), torch.Size([1073741824]), torch.Size([1073741824])]], {'dim': 0})
SUCCESS              14.935408           12.880000               1.160          ([[torch.Size([1073741824]), torch.Size([1073741824]), torch.Size([1073741824])]], {'dim': -1})
SUCCESS               0.006240            0.005664               1.102          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': 0})
SUCCESS               0.006304            0.005728               1.101          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': -1})
SUCCESS               0.081696            0.066816               1.223          ([[torch.Size([4096, 4096]), torch.Size([4096, 4096]), torch.Size([4096, 4096])]], {'dim': 0})
SUCCESS               0.412512            0.211680               1.949          ([[torch.Size([4096, 4096]), torch.Size([4096, 4096]), torch.Size([4096, 4096])]], {'dim': -1})
SUCCESS               0.142048            0.066816               2.126          ([[torch.Size([64, 512, 512]), torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]], {'dim': 0})
SUCCESS               0.409760            0.211584               1.937          ([[torch.Size([64, 512, 512]), torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]], {'dim': -1})
SUCCESS               3.885536            3.844704               1.011          ([[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]], {'dim': 0})
SUCCESS              14.936912           12.885344               1.159          ([[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]], {'dim': -1})
SUCCESS               0.006176            0.005600               1.103          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': 0})
SUCCESS               0.006400            0.005728               1.117          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': -1})
SUCCESS               0.006592            0.005824               1.132          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': 0})
SUCCESS               0.006720            0.005920               1.135          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': -1})
SUCCESS               0.009664            0.008032               1.203          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': 0})
SUCCESS               0.016256            0.009344               1.740          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': -1})
SUCCESS               0.006368            0.005664               1.124          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': 0})
SUCCESS               0.006592            0.005728               1.151          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': -1})
SUCCESS               0.006784            0.006048               1.122          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': 0})
SUCCESS               0.007744            0.006176               1.254          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': -1})


Operator: stack  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               7.707440            7.017904               1.098          ([[torch.Size([1073741824]), torch.Size([1073741824]), torch.Size([1073741824])]], {'dim': 0})
SUCCESS              24.714576           24.734480               0.999          ([[torch.Size([1073741824]), torch.Size([1073741824]), torch.Size([1073741824])]], {'dim': -1})
SUCCESS               0.006464            0.005760               1.122          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': 0})
SUCCESS               0.006624            0.005856               1.131          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': -1})
SUCCESS               0.124128            0.115968               1.070          ([[torch.Size([4096, 4096]), torch.Size([4096, 4096]), torch.Size([4096, 4096])]], {'dim': 0})
SUCCESS               0.747840            0.392352               1.906          ([[torch.Size([4096, 4096]), torch.Size([4096, 4096]), torch.Size([4096, 4096])]], {'dim': -1})
SUCCESS               0.145136            0.116864               1.242          ([[torch.Size([64, 512, 512]), torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]], {'dim': 0})
SUCCESS               0.743872            0.392352               1.896          ([[torch.Size([64, 512, 512]), torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]], {'dim': -1})
SUCCESS               7.694736            7.015488               1.097          ([[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]], {'dim': 0})
SUCCESS              24.703264           24.737200               0.999          ([[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]], {'dim': -1})
SUCCESS               0.006368            0.005728               1.112          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': 0})
SUCCESS               0.006432            0.005760               1.117          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': -1})
SUCCESS               0.006656            0.006080               1.095          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': 0})
SUCCESS               0.007136            0.006240               1.144          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': -1})
SUCCESS               0.010720            0.009824               1.091          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': 0})
SUCCESS               0.020928            0.013504               1.550          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': -1})
SUCCESS               0.006560            0.005760               1.139          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': 0})
SUCCESS               0.006720            0.005824               1.154          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': -1})
SUCCESS               0.007328            0.006240               1.174          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': 0})
SUCCESS               0.007680            0.006560               1.171          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': -1})


Operator: stack  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               3.852704            3.840896               1.003          ([[torch.Size([1073741824]), torch.Size([1073741824]), torch.Size([1073741824])]], {'dim': 0})
SUCCESS              14.936016           12.874592               1.160          ([[torch.Size([1073741824]), torch.Size([1073741824]), torch.Size([1073741824])]], {'dim': -1})
SUCCESS               0.006400            0.005664               1.130          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': 0})
SUCCESS               0.006432            0.005728               1.123          ([[torch.Size([64, 64]), torch.Size([64, 64]), torch.Size([64, 64])]], {'dim': -1})
SUCCESS               0.081232            0.066400               1.223          ([[torch.Size([4096, 4096]), torch.Size([4096, 4096]), torch.Size([4096, 4096])]], {'dim': 0})
SUCCESS               0.412192            0.211296               1.951          ([[torch.Size([4096, 4096]), torch.Size([4096, 4096]), torch.Size([4096, 4096])]], {'dim': -1})
SUCCESS               0.141824            0.066464               2.134          ([[torch.Size([64, 512, 512]), torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]], {'dim': 0})
SUCCESS               0.409568            0.211264               1.939          ([[torch.Size([64, 512, 512]), torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]], {'dim': -1})
SUCCESS               3.844896            3.822752               1.006          ([[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]], {'dim': 0})
SUCCESS              14.936208           12.871200               1.160          ([[torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]], {'dim': -1})
SUCCESS               0.006336            0.005600               1.131          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': 0})
SUCCESS               0.006432            0.005664               1.136          ([[torch.Size([1024, 2]), torch.Size([1024, 2]), torch.Size([1024, 2])]], {'dim': -1})
SUCCESS               0.006464            0.005856               1.104          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': 0})
SUCCESS               0.006880            0.005920               1.162          ([[torch.Size([1024, 32]), torch.Size([1024, 32]), torch.Size([1024, 32])]], {'dim': -1})
SUCCESS               0.009664            0.008000               1.208          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': 0})
SUCCESS               0.016288            0.009376               1.737          ([[torch.Size([1024, 512]), torch.Size([1024, 512]), torch.Size([1024, 512])]], {'dim': -1})
SUCCESS               0.006208            0.005696               1.090          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': 0})
SUCCESS               0.006720            0.005728               1.173          ([[torch.Size([64, 64, 1]), torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]], {'dim': -1})
SUCCESS               0.006784            0.006048               1.122          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': 0})
SUCCESS               0.007744            0.006208               1.247          ([[torch.Size([64, 64, 16]), torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]], {'dim': -1})
```