### PR TITLE
[FlagGems Operator Development Competition] Add ctc_loss operator

### DIFF
--- a/benchmark/core_shapes.yaml
+++ b/benchmark/core_shapes.yaml
@@ -10,6 +10,22 @@ single_dim_shapes: &single_dim_shapes
 vdot:
   <<: *single_dim_shapes
 
+ctc_loss:
+  shapes:
+    - [64, 4, 32, 16]
+    - [256, 16, 64, 48]
+    - [512, 32, 64, 48]
+    - [1024, 32, 128, 96]
+  shape_desc: "T, N, C, S"
+
+ctc_loss_backward:
+  shapes:
+    - [64, 4, 32, 16]
+    - [256, 16, 64, 48]
+    - [512, 32, 64, 48]
+    - [1024, 32, 128, 96]
+  shape_desc: "T, N, C, S"
+
 randperm:
   <<: *single_dim_shapes
 

--- a/benchmark/test_ctc_loss.py
+++ b/benchmark/test_ctc_loss.py
@@ -1,0 +1,131 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+import flag_gems
+
+from . import base, consts
+
+CTC_DTYPES = [torch.float32, torch.float16]
+
+
+def _ctc_loss_reference(
+    log_probs,
+    targets,
+    input_lengths,
+    target_lengths,
+    blank=0,
+    reduction="mean",
+    zero_infinity=False,
+):
+    original_dtype = log_probs.dtype
+    work_log_probs = log_probs
+    if work_log_probs.dtype in (torch.float16, torch.bfloat16):
+        work_log_probs = work_log_probs.float()
+    out = F.ctc_loss(
+        work_log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        blank=blank,
+        reduction=reduction,
+        zero_infinity=zero_infinity,
+    )
+    return out.to(original_dtype) if out.dtype != original_dtype else out
+
+
+def _make_targets(batch, max_target, classes, device, target_layout):
+    target_lengths = torch.empty(batch, device=device, dtype=torch.long)
+    padded = torch.zeros(batch, max_target, device=device, dtype=torch.long)
+    pieces = []
+    for row in range(batch):
+        length = max(1, max_target - (row % 5))
+        target_lengths[row] = length
+        values = (torch.arange(length, device=device, dtype=torch.long) + row) % (
+            classes - 1
+        )
+        values = values + 1
+        padded[row, :length] = values
+        pieces.append(values)
+
+    if target_layout == "padded":
+        targets = padded
+    else:
+        targets = torch.cat(pieces)
+    return targets, target_lengths
+
+
+def ctc_loss_input_fn(shape, dtype, device):
+    t_steps, batch, classes, max_target = shape
+    raw = torch.randn(t_steps, batch, classes, dtype=torch.float32, device=device)
+    log_probs = raw.log_softmax(-1).to(dtype)
+    input_lengths = torch.full((batch,), t_steps, dtype=torch.long, device=device)
+
+    targets, target_lengths = _make_targets(
+        batch, max_target, classes, device, "padded"
+    )
+    yield (
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        {"blank": 0, "reduction": "mean", "zero_infinity": False},
+    )
+
+    targets, target_lengths = _make_targets(
+        batch, max_target, classes, device, "concatenated"
+    )
+    yield (
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        {"blank": 0, "reduction": "mean", "zero_infinity": False},
+    )
+
+    if base.Config.bench_level.value == consts.BenchLevel.COMPREHENSIVE.value:
+        yield (
+            log_probs,
+            targets,
+            input_lengths,
+            target_lengths,
+            {"blank": 0, "reduction": "sum", "zero_infinity": False},
+        )
+
+
+class CtcLossBenchmark(base.GenericBenchmark):
+    DEFAULT_SHAPES = [
+        (64, 4, 32, 16),
+        (256, 16, 64, 48),
+        (512, 32, 64, 48),
+        (1024, 32, 128, 96),
+    ]
+    DEFAULT_SHAPE_DESC = "T, N, C, S"
+
+    def set_more_shapes(self):
+        return []
+
+
+@pytest.mark.ctc_loss
+def test_ctc_loss():
+    bench = CtcLossBenchmark(
+        op_name="ctc_loss",
+        input_fn=ctc_loss_input_fn,
+        torch_op=_ctc_loss_reference,
+        dtypes=CTC_DTYPES,
+    )
+    bench.set_gems(flag_gems.ctc_loss)
+    bench.run()
+
+
+@pytest.mark.ctc_loss
+def test_ctc_loss_backward():
+    bench = CtcLossBenchmark(
+        op_name="ctc_loss",
+        input_fn=ctc_loss_input_fn,
+        torch_op=_ctc_loss_reference,
+        dtypes=CTC_DTYPES,
+        is_backward=True,
+    )
+    bench.set_gems(flag_gems.ctc_loss)
+    bench.run()

--- a/benchmark/test_trunc_divide.py
+++ b/benchmark/test_trunc_divide.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from . import base, consts, utils
+from . import base, utils
 
 
 def _binary_input_fn(shape, dtype, device):

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -22,6 +22,7 @@ aten_lib = torch.library.Library("aten", "IMPL")
 registrar = Register
 current_work_registrar = None
 runtime.replace_customized_ops(globals())
+AUTOGRAD_DISPATCH_KEY = torch._C.DispatchKey.Autograd.name
 
 
 def torch_ge(v):
@@ -184,6 +185,8 @@ _FULL_CONFIG = (
     ("copysign", copysign),
     ("copysign.out", copysign_out),
     ("count_nonzero", count_nonzero),
+    ("ctc_loss.IntList", ctc_loss, None, (AUTOGRAD_DISPATCH_KEY,)),
+    ("ctc_loss.Tensor", ctc_loss, None, (AUTOGRAD_DISPATCH_KEY,)),
     ("cudnn_convolution", cudnn_convolution),
     ("cummax", cummax),
     ("cummin", cummin),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -90,6 +90,7 @@ from flag_gems.ops.copysign import copysign, copysign_out
 from flag_gems.ops.cos import cos, cos_
 from flag_gems.ops.cosh import cosh, cosh_, cosh_out
 from flag_gems.ops.count_nonzero import count_nonzero
+from flag_gems.ops.ctc_loss import ctc_loss
 from flag_gems.ops.cudnn_convolution import cudnn_convolution
 from flag_gems.ops.cummax import cummax
 from flag_gems.ops.cummin import cummin
@@ -495,6 +496,7 @@ __all__ = [
     "cosh_",
     "cosh_out",
     "count_nonzero",
+    "ctc_loss",
     "cudnn_convolution",
     "cummax",
     "cummin",

--- a/src/flag_gems/ops/ctc_loss.py
+++ b/src/flag_gems/ops/ctc_loss.py
@@ -1,0 +1,1022 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+_REDUCTION_NONE = 0
+_REDUCTION_MEAN = 1
+_REDUCTION_SUM = 2
+_LENGTH_STATS_CACHE = {}
+_LENGTH_STATS_CACHE_LIMIT = 256
+
+
+if hasattr(tl, "debug_barrier"):
+    _debug_barrier = tl.debug_barrier
+else:
+
+    @triton.jit
+    def _debug_barrier():
+        return
+
+
+@triton.jit
+def _logaddexp(a, b):
+    max_ab = tl.maximum(a, b)
+    min_ab = tl.minimum(a, b)
+    return tl.where(
+        max_ab == -float("inf"),
+        -float("inf"),
+        max_ab + tl.log(1.0 + tl.exp(min_ab - max_ab)),
+    )
+
+
+@triton.jit
+def _logaddexp3(a, b, c, use_c):
+    c = tl.where(use_c, c, -float("inf"))
+    max_abc = tl.maximum(tl.maximum(a, b), c)
+    safe_max = tl.where(max_abc == -float("inf"), 0.0, max_abc)
+    exp_sum = tl.exp(a - safe_max) + tl.exp(b - safe_max) + tl.exp(c - safe_max)
+    return tl.where(
+        max_abc == -float("inf"),
+        -float("inf"),
+        max_abc + tl.log(exp_sum),
+    )
+
+
+@libentry()
+@triton.jit
+def _ctc_loss_forward_kernel(
+    log_probs,
+    targets,
+    input_lengths,
+    target_lengths,
+    target_offsets,
+    neg_log_likelihood,
+    log_alpha,
+    T: tl.constexpr,
+    N: tl.constexpr,
+    C: tl.constexpr,
+    MAX_TARGET: tl.constexpr,
+    STATE_COUNT_MAX: tl.constexpr,
+    BLANK: tl.constexpr,
+    TARGET_1D: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+):
+    batch = tl.program_id(0)
+    states = tl.arange(0, BLOCK_S)
+
+    input_len = tl.load(input_lengths + batch)
+    target_len = tl.load(target_lengths + batch)
+    state_count = target_len * 2 + 1
+    valid_state = states < state_count
+    stored_state = states < STATE_COUNT_MAX
+
+    is_blank_state = (states % 2) == 0
+    target_index = (states - 1) // 2
+    target_mask = (target_index >= 0) & (target_index < target_len)
+    target_safe_index = tl.where(target_mask, target_index, 0)
+
+    if TARGET_1D:
+        target_base = tl.full((), 0, tl.int64)
+        for prev_batch in tl.range(0, N):
+            target_base += tl.load(
+                target_lengths + prev_batch,
+                mask=prev_batch < batch,
+                other=0,
+            )
+        target_origin = target_base
+        target_ptrs = targets + target_origin + target_safe_index
+    else:
+        target_origin = batch * MAX_TARGET
+        target_ptrs = targets + target_origin + target_safe_index
+
+    target_value = tl.load(target_ptrs, mask=target_mask, other=BLANK)
+    labels = tl.where(is_blank_state, BLANK, target_value)
+
+    t0_active = input_len > 0
+    init_state = (states == 0) | ((states == 1) & (target_len > 0))
+    init_logp = tl.load(
+        log_probs + batch * C + labels,
+        mask=init_state & stored_state & t0_active,
+        other=0.0,
+    ).to(tl.float32)
+    alpha = tl.where(init_state & valid_state & t0_active, init_logp, -float("inf"))
+    tl.store(
+        log_alpha + batch * T * STATE_COUNT_MAX + states,
+        alpha,
+        mask=stored_state,
+    )
+    _debug_barrier()
+
+    for t in tl.range(1, T):
+        prev_base = log_alpha + batch * T * STATE_COUNT_MAX + (t - 1) * STATE_COUNT_MAX
+        prev0 = tl.load(prev_base + states, mask=stored_state, other=-float("inf")).to(
+            tl.float32
+        )
+        prev1 = tl.load(
+            prev_base + tl.where(states > 0, states - 1, 0),
+            mask=(states > 0) & stored_state,
+            other=-float("inf"),
+        ).to(tl.float32)
+        prev2 = tl.load(
+            prev_base + tl.where(states > 1, states - 2, 0),
+            mask=(states > 1) & stored_state,
+            other=-float("inf"),
+        ).to(tl.float32)
+
+        prev_target_index = tl.where(target_index > 0, target_index - 1, 0)
+        prev_target_value = tl.load(
+            targets + target_origin + prev_target_index,
+            mask=target_mask & (target_index > 0),
+            other=BLANK,
+        )
+        skip_allowed = (
+            (~is_blank_state) & (target_index > 0) & (target_value != prev_target_value)
+        )
+
+        acc = _logaddexp3(prev0, prev1, prev2, skip_allowed)
+
+        logp = tl.load(
+            log_probs + t * N * C + batch * C + labels,
+            mask=valid_state & (t < input_len),
+            other=0.0,
+        ).to(tl.float32)
+        alpha = tl.where(valid_state & (t < input_len), acc + logp, -float("inf"))
+        tl.store(
+            log_alpha + batch * T * STATE_COUNT_MAX + t * STATE_COUNT_MAX + states,
+            alpha,
+            mask=stored_state,
+        )
+        _debug_barrier()
+
+    if input_len <= 0:
+        loss = tl.where(target_len == 0, 0.0, float("inf"))
+    else:
+        _debug_barrier()
+        final_base = (
+            log_alpha + batch * T * STATE_COUNT_MAX + (input_len - 1) * STATE_COUNT_MAX
+        )
+        last = tl.load(final_base + state_count - 1).to(tl.float32)
+        prev_last = tl.load(
+            final_base + tl.where(target_len > 0, state_count - 2, 0),
+            mask=target_len > 0,
+            other=-float("inf"),
+        ).to(tl.float32)
+        log_likelihood = _logaddexp(last, prev_last)
+        loss = -log_likelihood
+
+    tl.store(neg_log_likelihood + batch, loss)
+
+
+@libentry()
+@triton.jit
+def _ctc_loss_forward_no_grad_kernel(
+    log_probs,
+    targets,
+    input_lengths,
+    target_lengths,
+    target_offsets,
+    neg_log_likelihood,
+    scratch_alpha,
+    T: tl.constexpr,
+    N: tl.constexpr,
+    C: tl.constexpr,
+    MAX_TARGET: tl.constexpr,
+    STATE_COUNT_MAX: tl.constexpr,
+    BLANK: tl.constexpr,
+    TARGET_1D: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+):
+    batch = tl.program_id(0)
+    states = tl.arange(0, BLOCK_S)
+
+    target_len = tl.load(target_lengths + batch)
+    state_count = target_len * 2 + 1
+    valid_state = states < state_count
+    stored_state = states < STATE_COUNT_MAX
+
+    is_blank_state = (states % 2) == 0
+    target_index = (states - 1) // 2
+    target_mask = (target_index >= 0) & (target_index < target_len)
+    target_safe_index = tl.where(target_mask, target_index, 0)
+
+    if TARGET_1D:
+        target_origin = tl.load(target_offsets + batch)
+        target_ptrs = targets + target_origin + target_safe_index
+    else:
+        target_origin = batch * MAX_TARGET
+        target_ptrs = targets + target_origin + target_safe_index
+
+    target_value = tl.load(target_ptrs, mask=target_mask, other=BLANK)
+    labels = tl.where(is_blank_state, BLANK, target_value)
+
+    input_len = tl.load(input_lengths + batch)
+    init_state = (states == 0) | ((states == 1) & (target_len > 0))
+    init_logp = tl.load(
+        log_probs + batch * C + labels,
+        mask=init_state & stored_state & (input_len > 0),
+        other=0.0,
+    ).to(tl.float32)
+    alpha = tl.where(
+        init_state & valid_state & (input_len > 0), init_logp, -float("inf")
+    )
+    scratch_batch = scratch_alpha + batch * 2 * STATE_COUNT_MAX
+    tl.store(scratch_batch + states, alpha, mask=stored_state)
+    _debug_barrier()
+
+    for t in tl.range(1, T):
+        prev_base = scratch_batch + ((t - 1) % 2) * STATE_COUNT_MAX
+        cur_base = scratch_batch + (t % 2) * STATE_COUNT_MAX
+        prev0 = tl.load(prev_base + states, mask=stored_state, other=-float("inf")).to(
+            tl.float32
+        )
+        prev1 = tl.load(
+            prev_base + tl.where(states > 0, states - 1, 0),
+            mask=(states > 0) & stored_state,
+            other=-float("inf"),
+        ).to(tl.float32)
+        prev2 = tl.load(
+            prev_base + tl.where(states > 1, states - 2, 0),
+            mask=(states > 1) & stored_state,
+            other=-float("inf"),
+        ).to(tl.float32)
+
+        prev_target_index = tl.where(target_index > 0, target_index - 1, 0)
+        prev_target_value = tl.load(
+            targets + target_origin + prev_target_index,
+            mask=target_mask & (target_index > 0),
+            other=BLANK,
+        )
+        skip_allowed = (
+            (~is_blank_state) & (target_index > 0) & (target_value != prev_target_value)
+        )
+
+        acc = _logaddexp3(prev0, prev1, prev2, skip_allowed)
+        logp = tl.load(
+            log_probs + t * N * C + batch * C + labels,
+            mask=valid_state & (t < input_len),
+            other=0.0,
+        ).to(tl.float32)
+        alpha = tl.where(valid_state & (t < input_len), acc + logp, -float("inf"))
+        tl.store(cur_base + states, alpha, mask=stored_state & (t < input_len))
+        _debug_barrier()
+
+    if input_len <= 0:
+        loss = tl.where(target_len == 0, 0.0, float("inf"))
+    else:
+        _debug_barrier()
+        final_base = scratch_batch + ((input_len - 1) % 2) * STATE_COUNT_MAX
+        last = tl.load(final_base + state_count - 1).to(tl.float32)
+        prev_last = tl.load(
+            final_base + tl.where(target_len > 0, state_count - 2, 0),
+            mask=target_len > 0,
+            other=-float("inf"),
+        ).to(tl.float32)
+        loss = -_logaddexp(last, prev_last)
+
+    tl.store(neg_log_likelihood + batch, loss)
+
+
+@libentry()
+@triton.jit
+def _ctc_loss_forward_full_length_reduce_kernel(
+    log_probs,
+    targets,
+    target_lengths,
+    target_offsets,
+    contrib,
+    scratch_alpha,
+    T: tl.constexpr,
+    N: tl.constexpr,
+    C: tl.constexpr,
+    MAX_TARGET: tl.constexpr,
+    STATE_COUNT_MAX: tl.constexpr,
+    BLANK: tl.constexpr,
+    TARGET_1D: tl.constexpr,
+    REDUCTION: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+):
+    batch = tl.program_id(0)
+    states = tl.arange(0, BLOCK_S)
+
+    target_len = tl.load(target_lengths + batch)
+    state_count = target_len * 2 + 1
+    valid_state = states < state_count
+    stored_state = states < STATE_COUNT_MAX
+
+    is_blank_state = (states % 2) == 0
+    target_index = (states - 1) // 2
+    target_mask = (target_index >= 0) & (target_index < target_len)
+    target_safe_index = tl.where(target_mask, target_index, 0)
+
+    if TARGET_1D:
+        target_origin = tl.load(target_offsets + batch)
+        target_ptrs = targets + target_origin + target_safe_index
+    else:
+        target_origin = batch * MAX_TARGET
+        target_ptrs = targets + target_origin + target_safe_index
+
+    target_value = tl.load(target_ptrs, mask=target_mask, other=BLANK)
+    labels = tl.where(is_blank_state, BLANK, target_value)
+
+    init_state = (states == 0) | ((states == 1) & (target_len > 0))
+    init_logp = tl.load(
+        log_probs + batch * C + labels,
+        mask=init_state & stored_state,
+        other=0.0,
+    ).to(tl.float32)
+    alpha = tl.where(init_state & valid_state, init_logp, -float("inf"))
+    scratch_batch = scratch_alpha + batch * 2 * STATE_COUNT_MAX
+    tl.store(scratch_batch + states, alpha, mask=stored_state)
+    _debug_barrier()
+
+    for t in tl.range(1, T):
+        prev_base = scratch_batch + ((t - 1) % 2) * STATE_COUNT_MAX
+        cur_base = scratch_batch + (t % 2) * STATE_COUNT_MAX
+        prev0 = tl.load(prev_base + states, mask=stored_state, other=-float("inf")).to(
+            tl.float32
+        )
+        prev1 = tl.load(
+            prev_base + tl.where(states > 0, states - 1, 0),
+            mask=(states > 0) & stored_state,
+            other=-float("inf"),
+        ).to(tl.float32)
+        prev2 = tl.load(
+            prev_base + tl.where(states > 1, states - 2, 0),
+            mask=(states > 1) & stored_state,
+            other=-float("inf"),
+        ).to(tl.float32)
+
+        prev_target_index = tl.where(target_index > 0, target_index - 1, 0)
+        prev_target_value = tl.load(
+            targets + target_origin + prev_target_index,
+            mask=target_mask & (target_index > 0),
+            other=BLANK,
+        )
+        skip_allowed = (
+            (~is_blank_state) & (target_index > 0) & (target_value != prev_target_value)
+        )
+
+        acc = _logaddexp3(prev0, prev1, prev2, skip_allowed)
+        logp = tl.load(
+            log_probs + t * N * C + batch * C + labels,
+            mask=valid_state,
+            other=0.0,
+        ).to(tl.float32)
+        alpha = tl.where(valid_state, acc + logp, -float("inf"))
+        tl.store(cur_base + states, alpha, mask=stored_state)
+        _debug_barrier()
+
+    if T <= 0:
+        loss = tl.where(target_len == 0, 0.0, float("inf"))
+    else:
+        _debug_barrier()
+        final_base = scratch_batch + ((T - 1) % 2) * STATE_COUNT_MAX
+        last = tl.load(final_base + state_count - 1).to(tl.float32)
+        prev_last = tl.load(
+            final_base + tl.where(target_len > 0, state_count - 2, 0),
+            mask=target_len > 0,
+            other=-float("inf"),
+        ).to(tl.float32)
+        loss = -_logaddexp(last, prev_last)
+
+    if REDUCTION == 1:
+        loss = loss / tl.maximum(target_len, 1).to(tl.float32) / N
+    tl.store(contrib + batch, loss)
+
+
+@libentry()
+@triton.jit
+def _ctc_loss_init_grad_kernel(
+    log_probs,
+    input_lengths,
+    target_lengths,
+    neg_log_likelihood,
+    grad_output,
+    grad_input,
+    total: tl.constexpr,
+    T: tl.constexpr,
+    N: tl.constexpr,
+    C: tl.constexpr,
+    REDUCTION: tl.constexpr,
+    ZERO_INFINITY: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = offsets < total
+    batch = (offsets // C) % N
+    t = offsets // (N * C)
+
+    input_len = tl.load(input_lengths + batch, mask=mask, other=0)
+    target_len = tl.load(target_lengths + batch, mask=mask, other=1)
+    nll = tl.load(neg_log_likelihood + batch, mask=mask, other=0.0).to(tl.float32)
+
+    if REDUCTION == 0:
+        scale = tl.load(grad_output + batch, mask=mask, other=0.0).to(tl.float32)
+    else:
+        scale = tl.load(grad_output).to(tl.float32)
+        if REDUCTION == 1:
+            denom = tl.maximum(target_len, 1).to(tl.float32) * N
+            scale = scale / denom
+
+    if ZERO_INFINITY:
+        scale = tl.where(nll == float("inf"), 0.0, scale)
+
+    logp = tl.load(log_probs + offsets, mask=mask, other=-float("inf")).to(tl.float32)
+    grad = tl.where((t < input_len) & mask, tl.exp(logp) * scale, 0.0)
+    nan_grad = float("nan")
+    grad = tl.where(
+        (t < input_len) & mask & (scale != 0.0) & (logp == -float("inf")),
+        nan_grad,
+        grad,
+    )
+    if not ZERO_INFINITY:
+        grad = tl.where((t < input_len) & mask & (nll == float("inf")), nan_grad, grad)
+    tl.store(grad_input + offsets, grad, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _ctc_loss_backward_kernel(
+    log_probs,
+    targets,
+    input_lengths,
+    target_lengths,
+    target_offsets,
+    neg_log_likelihood,
+    log_alpha,
+    grad_output,
+    grad_input,
+    scratch_beta,
+    T: tl.constexpr,
+    N: tl.constexpr,
+    C: tl.constexpr,
+    MAX_TARGET: tl.constexpr,
+    STATE_COUNT_MAX: tl.constexpr,
+    BLANK: tl.constexpr,
+    TARGET_1D: tl.constexpr,
+    REDUCTION: tl.constexpr,
+    ZERO_INFINITY: tl.constexpr,
+    BLOCK_S: tl.constexpr,
+):
+    batch = tl.program_id(0)
+    states = tl.arange(0, BLOCK_S)
+
+    input_len = tl.load(input_lengths + batch)
+    target_len = tl.load(target_lengths + batch)
+    nll = tl.load(neg_log_likelihood + batch).to(tl.float32)
+    state_count = target_len * 2 + 1
+    valid_state = states < state_count
+    stored_state = states < STATE_COUNT_MAX
+
+    is_blank_state = (states % 2) == 0
+    target_index = (states - 1) // 2
+    target_mask = (target_index >= 0) & (target_index < target_len)
+    target_safe_index = tl.where(target_mask, target_index, 0)
+
+    if TARGET_1D:
+        target_origin = tl.load(target_offsets + batch)
+        target_ptrs = targets + target_origin + target_safe_index
+    else:
+        target_origin = batch * MAX_TARGET
+        target_ptrs = targets + target_origin + target_safe_index
+
+    target_value = tl.load(target_ptrs, mask=target_mask, other=BLANK)
+    labels = tl.where(is_blank_state, BLANK, target_value)
+
+    state1 = states + 1
+    is_blank_state1 = (state1 % 2) == 0
+    target_index1 = (state1 - 1) // 2
+    target_mask1 = (target_index1 >= 0) & (target_index1 < target_len)
+    target_safe_index1 = tl.where(target_mask1, target_index1, 0)
+    target_ptrs1 = targets + target_origin + target_safe_index1
+    target_value1 = tl.load(target_ptrs1, mask=target_mask1, other=BLANK)
+    labels1 = tl.where(is_blank_state1, BLANK, target_value1)
+
+    state2 = states + 2
+    target_index2 = (state2 - 1) // 2
+    target_mask2 = (target_index2 >= 0) & (target_index2 < target_len)
+    target_safe_index2 = tl.where(target_mask2, target_index2, 0)
+    target_ptrs2 = targets + target_origin + target_safe_index2
+    target_value2 = tl.load(target_ptrs2, mask=target_mask2, other=BLANK)
+    labels2 = target_value2
+
+    if REDUCTION == 0:
+        scale = tl.load(grad_output + batch).to(tl.float32)
+    else:
+        scale = tl.load(grad_output).to(tl.float32)
+        if REDUCTION == 1:
+            denom = tl.maximum(target_len, 1).to(tl.float32) * N
+            scale = scale / denom
+
+    if ZERO_INFINITY:
+        scale = tl.where(nll == float("inf"), 0.0, scale)
+
+    beta_init = tl.where(
+        ((states == state_count - 1) | ((states == state_count - 2) & (target_len > 0)))
+        & valid_state
+        & (input_len > 0),
+        0.0,
+        -float("inf"),
+    )
+    scratch_batch = scratch_beta + batch * 2 * STATE_COUNT_MAX
+    tl.store(scratch_batch + states, beta_init, mask=stored_state)
+    _debug_barrier()
+    log_likelihood = tl.where(scale != 0.0, -nll, 0.0)
+
+    for step in tl.range(0, T):
+        t = input_len - 1 - step
+        active = t >= 0
+        safe_t = tl.where(active, t, 0)
+        beta_base = scratch_batch + (step % 2) * STATE_COUNT_MAX
+        next_beta_base = scratch_batch + ((step + 1) % 2) * STATE_COUNT_MAX
+        beta = tl.load(beta_base + states, mask=stored_state, other=-float("inf")).to(
+            tl.float32
+        )
+
+        alpha_t = tl.load(
+            log_alpha + batch * T * STATE_COUNT_MAX + safe_t * STATE_COUNT_MAX + states,
+            mask=active & stored_state,
+            other=-float("inf"),
+        ).to(tl.float32)
+        log_post = alpha_t + beta - log_likelihood
+        posterior = tl.where(
+            active & valid_state & (scale != 0.0),
+            tl.exp(log_post),
+            0.0,
+        )
+        tl.atomic_add(
+            grad_input + safe_t * N * C + batch * C + labels,
+            -scale * posterior,
+            sem="relaxed",
+            mask=active & valid_state & stored_state,
+        )
+
+        stay = beta + tl.load(
+            log_probs + safe_t * N * C + batch * C + labels,
+            mask=active & valid_state,
+            other=-float("inf"),
+        ).to(tl.float32)
+        next1 = tl.load(
+            beta_base + states + 1,
+            mask=(states + 1 < state_count) & stored_state,
+            other=-float("inf"),
+        ).to(tl.float32) + tl.load(
+            log_probs + safe_t * N * C + batch * C + labels1,
+            mask=active & (states + 1 < state_count) & stored_state,
+            other=-float("inf"),
+        ).to(
+            tl.float32
+        )
+        skip_allowed = (
+            (~is_blank_state)
+            & (states + 2 < state_count)
+            & (target_value != target_value2)
+        )
+        next2 = tl.load(
+            beta_base + states + 2,
+            mask=(states + 2 < state_count) & stored_state,
+            other=-float("inf"),
+        ).to(tl.float32) + tl.load(
+            log_probs + safe_t * N * C + batch * C + labels2,
+            mask=active & skip_allowed & stored_state,
+            other=-float("inf"),
+        ).to(
+            tl.float32
+        )
+
+        beta_next = _logaddexp3(stay, next1, next2, skip_allowed)
+        tl.store(
+            next_beta_base + states,
+            tl.where(active, beta_next, -float("inf")),
+            mask=stored_state,
+        )
+        _debug_barrier()
+
+
+def _reduction_enum(reduction):
+    if isinstance(reduction, str):
+        if reduction == "none":
+            return _REDUCTION_NONE
+        if reduction == "mean":
+            return _REDUCTION_MEAN
+        if reduction == "sum":
+            return _REDUCTION_SUM
+        raise ValueError(
+            "ctc_loss expected reduction to be one of 'none', 'mean', or 'sum', "
+            f"but got {reduction!r}"
+        )
+    return int(reduction)
+
+
+_INTEGRAL_DTYPES = {
+    torch.uint8,
+    torch.int8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+}
+
+
+def _is_integral_dtype(dtype):
+    return dtype in _INTEGRAL_DTYPES
+
+
+def _lengths_to_tensor(lengths, device, name):
+    if torch.is_tensor(lengths):
+        if not _is_integral_dtype(lengths.dtype):
+            raise RuntimeError(f"{name} must be integral")
+        out = lengths.to(device=device)
+    else:
+        out = torch.tensor(lengths, device=device)
+        if not _is_integral_dtype(out.dtype):
+            raise RuntimeError(f"{name} must be integral")
+    if out.dtype != torch.long:
+        out = out.to(dtype=torch.long)
+    return out.reshape(1) if out.ndim == 0 else out.reshape(-1).contiguous()
+
+
+def _length_stats(lengths):
+    key = None
+    if torch.is_tensor(lengths):
+        key = (
+            lengths.device.type,
+            lengths.device.index,
+            lengths.data_ptr(),
+            lengths.numel(),
+            lengths._version,
+        )
+        cached = _LENGTH_STATS_CACHE.get(key)
+        if cached is not None:
+            return cached[1]
+
+    stats_tensor = torch.stack((lengths.min(), lengths.max(), lengths.sum())).cpu()
+    stats = tuple(int(value) for value in stats_tensor.tolist())
+    if key is not None:
+        if len(_LENGTH_STATS_CACHE) >= _LENGTH_STATS_CACHE_LIMIT:
+            _LENGTH_STATS_CACHE.clear()
+        _LENGTH_STATS_CACHE[key] = (lengths, stats)
+    return stats
+
+
+def _compute_dtype(dtype):
+    if dtype in (torch.float16, torch.bfloat16):
+        return torch.float32
+    return dtype
+
+
+class CtcLossFunction(torch.autograd.Function):
+    @staticmethod
+    def forward(
+        ctx,
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        blank=0,
+        reduction="mean",
+        zero_infinity=False,
+    ):
+        reduction = _reduction_enum(reduction)
+        if reduction not in (_REDUCTION_NONE, _REDUCTION_MEAN, _REDUCTION_SUM):
+            raise ValueError(f"ctc_loss got invalid reduction enum {reduction}")
+
+        if log_probs.ndim not in (2, 3):
+            raise RuntimeError(
+                "ctc_loss expects log_probs to be a 2D or 3D tensor, "
+                f"but got {log_probs.ndim}D"
+            )
+        if not torch.is_floating_point(log_probs):
+            raise RuntimeError(f'"ctc_loss" not implemented for {log_probs.dtype}')
+        if blank < 0 or blank >= log_probs.shape[-1]:
+            raise RuntimeError("blank must be in label range")
+
+        original_dtype = log_probs.dtype
+        compute_dtype = _compute_dtype(original_dtype)
+        unbatched = log_probs.ndim == 2
+        batch_size = 1 if unbatched else log_probs.shape[1]
+
+        work_log_probs = log_probs.unsqueeze(1) if unbatched else log_probs
+        work_log_probs = work_log_probs.contiguous()
+        if work_log_probs.dtype != compute_dtype:
+            work_log_probs = work_log_probs.to(compute_dtype)
+
+        if torch.is_floating_point(targets):
+            work_targets = targets.to(dtype=torch.long).contiguous()
+        elif _is_integral_dtype(targets.dtype):
+            work_targets = targets.contiguous()
+        else:
+            raise RuntimeError("ctc_loss targets must be integral or floating point")
+        work_input_lengths = _lengths_to_tensor(
+            input_lengths, log_probs.device, "input_lengths"
+        )
+        work_target_lengths = _lengths_to_tensor(
+            target_lengths, log_probs.device, "target_lengths"
+        )
+        if work_input_lengths.numel() != batch_size:
+            raise RuntimeError(
+                f"ctc_loss expected input_lengths to have size {batch_size}, "
+                f"but got {work_input_lengths.numel()}"
+            )
+        if work_target_lengths.numel() != batch_size:
+            raise RuntimeError(
+                f"ctc_loss expected target_lengths to have size {batch_size}, "
+                f"but got {work_target_lengths.numel()}"
+            )
+        min_input_length, max_input_length, _ = _length_stats(work_input_lengths)
+        min_target_length, max_target, total_target_length = _length_stats(
+            work_target_lengths
+        )
+        if min_input_length < 0 or max_input_length > work_log_probs.shape[0]:
+            raise RuntimeError("ctc_loss input_lengths must be in [0, T]")
+        if min_target_length < 0:
+            raise RuntimeError("ctc_loss target_lengths must be non-negative")
+
+        state_count_max = 2 * max_target + 1
+        target_stride = max_target
+        if work_targets.ndim == 1:
+            target_1d = True
+            if total_target_length != work_targets.numel():
+                raise RuntimeError(
+                    "ctc_loss expected concatenated targets length to equal "
+                    "sum(target_lengths)"
+                )
+            work_target_offsets = (
+                work_target_lengths.cumsum(0) - work_target_lengths
+            ).contiguous()
+        elif work_targets.ndim == 2:
+            target_1d = False
+            if max_target > work_targets.shape[1]:
+                raise RuntimeError(
+                    "ctc_loss target_lengths cannot exceed padded target width"
+                )
+            target_stride = work_targets.shape[1]
+            work_target_offsets = work_target_lengths
+        else:
+            raise RuntimeError(
+                "ctc_loss expects targets to be a 1D concatenated tensor or a "
+                f"2D padded tensor, but got {work_targets.ndim}D"
+            )
+
+        needs_log_probs_grad = ctx.needs_input_grad[0]
+        block_s = triton.next_power_of_2(state_count_max)
+
+        if not needs_log_probs_grad:
+            if (
+                not unbatched
+                and not zero_infinity
+                and reduction in (_REDUCTION_MEAN, _REDUCTION_SUM)
+                and min_input_length == work_log_probs.shape[0]
+                and work_log_probs.shape[0] > 0
+            ):
+                contrib = torch.empty(
+                    (batch_size,), dtype=torch.float32, device=log_probs.device
+                )
+                scratch_alpha = torch.empty(
+                    (batch_size, 2, state_count_max),
+                    dtype=torch.float32,
+                    device=log_probs.device,
+                )
+                with torch_device_fn.device(log_probs.device):
+                    _ctc_loss_forward_full_length_reduce_kernel[(batch_size,)](
+                        work_log_probs,
+                        work_targets,
+                        work_target_lengths,
+                        work_target_offsets,
+                        contrib,
+                        scratch_alpha,
+                        work_log_probs.shape[0],
+                        batch_size,
+                        work_log_probs.shape[2],
+                        target_stride,
+                        state_count_max,
+                        blank,
+                        target_1d,
+                        reduction,
+                        block_s,
+                    )
+                output = contrib.sum()
+                if output.dtype != original_dtype:
+                    output = output.to(original_dtype)
+                return output
+
+            raw_neg_log_likelihood = torch.empty(
+                (batch_size,), dtype=torch.float32, device=log_probs.device
+            )
+            scratch_alpha = torch.empty(
+                (batch_size, 2, state_count_max),
+                dtype=torch.float32,
+                device=log_probs.device,
+            )
+            with torch_device_fn.device(log_probs.device):
+                _ctc_loss_forward_no_grad_kernel[(batch_size,)](
+                    work_log_probs,
+                    work_targets,
+                    work_input_lengths,
+                    work_target_lengths,
+                    work_target_offsets,
+                    raw_neg_log_likelihood,
+                    scratch_alpha,
+                    work_log_probs.shape[0],
+                    batch_size,
+                    work_log_probs.shape[2],
+                    target_stride,
+                    state_count_max,
+                    blank,
+                    target_1d,
+                    block_s,
+                )
+            neg_log_likelihood = raw_neg_log_likelihood
+            if zero_infinity:
+                neg_log_likelihood = torch.where(
+                    torch.isinf(neg_log_likelihood),
+                    torch.zeros(
+                        (), dtype=neg_log_likelihood.dtype, device=log_probs.device
+                    ),
+                    neg_log_likelihood,
+                )
+
+            if reduction == _REDUCTION_NONE:
+                output = neg_log_likelihood
+                if unbatched:
+                    output = output.squeeze(0)
+            elif reduction == _REDUCTION_SUM:
+                output = neg_log_likelihood.sum()
+            else:
+                denom = work_target_lengths.clamp_min(1)
+                output = (neg_log_likelihood / denom).mean()
+
+            if output.dtype != original_dtype:
+                output = output.to(original_dtype)
+            return output
+
+        raw_neg_log_likelihood = torch.empty(
+            (batch_size,), dtype=torch.float32, device=log_probs.device
+        )
+
+        log_alpha = torch.empty(
+            (batch_size, work_log_probs.shape[0], state_count_max),
+            dtype=torch.float32,
+            device=log_probs.device,
+        )
+        with torch_device_fn.device(log_probs.device):
+            _ctc_loss_forward_kernel[(batch_size,)](
+                work_log_probs,
+                work_targets,
+                work_input_lengths,
+                work_target_lengths,
+                work_target_offsets,
+                raw_neg_log_likelihood,
+                log_alpha,
+                work_log_probs.shape[0],
+                batch_size,
+                work_log_probs.shape[2],
+                target_stride,
+                state_count_max,
+                blank,
+                target_1d,
+                block_s,
+            )
+        neg_log_likelihood = raw_neg_log_likelihood
+        if zero_infinity:
+            neg_log_likelihood = torch.where(
+                torch.isinf(neg_log_likelihood),
+                torch.zeros(
+                    (), dtype=neg_log_likelihood.dtype, device=log_probs.device
+                ),
+                neg_log_likelihood,
+            )
+
+        if reduction == _REDUCTION_NONE:
+            output = neg_log_likelihood
+            if unbatched:
+                output = output.squeeze(0)
+            if output.dtype != original_dtype:
+                output = output.to(original_dtype)
+        elif reduction == _REDUCTION_SUM:
+            output = neg_log_likelihood.sum()
+        else:
+            denom = work_target_lengths.clamp_min(1)
+            output = (neg_log_likelihood / denom).mean()
+
+        if output.dtype != original_dtype:
+            output = output.to(original_dtype)
+
+        ctx.save_for_backward(
+            work_log_probs,
+            work_targets,
+            work_input_lengths,
+            work_target_lengths,
+            work_target_offsets,
+            raw_neg_log_likelihood,
+            log_alpha,
+        )
+        ctx.blank = blank
+        ctx.reduction = reduction
+        ctx.zero_infinity = zero_infinity
+        ctx.unbatched = unbatched
+        ctx.batch_size = batch_size
+        ctx.original_dtype = original_dtype
+        ctx.max_target = target_stride
+        ctx.state_count_max = state_count_max
+        ctx.target_1d = target_1d
+
+        return output
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        (
+            work_log_probs,
+            work_targets,
+            work_input_lengths,
+            work_target_lengths,
+            work_target_offsets,
+            neg_log_likelihood,
+            log_alpha,
+        ) = ctx.saved_tensors
+
+        grad_output = grad_output.contiguous()
+
+        grad_log_probs = torch.empty_like(work_log_probs)
+        total = work_log_probs.numel()
+        block = 256
+        with torch_device_fn.device(work_log_probs.device):
+            _ctc_loss_init_grad_kernel[(triton.cdiv(total, block),)](
+                work_log_probs,
+                work_input_lengths,
+                work_target_lengths,
+                neg_log_likelihood,
+                grad_output,
+                grad_log_probs,
+                total,
+                work_log_probs.shape[0],
+                ctx.batch_size,
+                work_log_probs.shape[2],
+                ctx.reduction,
+                ctx.zero_infinity,
+                block,
+            )
+
+            scratch_beta = torch.empty(
+                (ctx.batch_size, 2, ctx.state_count_max),
+                dtype=torch.float32,
+                device=work_log_probs.device,
+            )
+            block_s = triton.next_power_of_2(ctx.state_count_max)
+            _ctc_loss_backward_kernel[(ctx.batch_size,)](
+                work_log_probs,
+                work_targets,
+                work_input_lengths,
+                work_target_lengths,
+                work_target_offsets,
+                neg_log_likelihood,
+                log_alpha,
+                grad_output,
+                grad_log_probs,
+                scratch_beta,
+                work_log_probs.shape[0],
+                ctx.batch_size,
+                work_log_probs.shape[2],
+                ctx.max_target,
+                ctx.state_count_max,
+                ctx.blank,
+                ctx.target_1d,
+                ctx.reduction,
+                ctx.zero_infinity,
+                block_s,
+            )
+
+        if ctx.unbatched:
+            grad_log_probs = grad_log_probs.squeeze(1)
+        if grad_log_probs.dtype != ctx.original_dtype:
+            grad_log_probs = grad_log_probs.to(ctx.original_dtype)
+
+        return grad_log_probs, None, None, None, None, None, None
+
+
+def ctc_loss(
+    log_probs,
+    targets,
+    input_lengths,
+    target_lengths,
+    blank=0,
+    reduction="mean",
+    zero_infinity=False,
+):
+    logger.debug("GEMS CTC LOSS")
+    return CtcLossFunction.apply(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        blank,
+        reduction,
+        zero_infinity,
+    )

--- a/src/flag_gems/runtime/register.py
+++ b/src/flag_gems/runtime/register.py
@@ -60,13 +60,11 @@ class Register:
                 for config_item in self.full_config_by_func.get(name, []):
                     op_name, func = config_item[0], config_item[1]
                     # respect optional condition functions
-                    if len(config_item) > 2:
-                        condition_func = config_item[2]
-                        if not condition_func():
-                            continue
+                    if not self._config_enabled(config_item):
+                        continue
                     if op_name in self.cpp_patched_ops:
                         continue
-                    self.include_config.append((op_name, func))
+                    self.include_config.append(self._normalized_config(config_item))
         else:
             # fallback: scan provided config and match by func name or op name
             for config_item in self.config:
@@ -77,13 +75,11 @@ class Register:
                     and op_name not in self.include_ops
                 ):
                     continue
-                if len(config_item) > 2:
-                    condition_func = config_item[2]
-                    if not condition_func():
-                        continue
+                if not self._config_enabled(config_item):
+                    continue
                 if op_name in self.cpp_patched_ops:
                     continue
-                self.include_config.append((op_name, func))
+                self.include_config.append(self._normalized_config(config_item))
 
         if not self.include_config:
             warnings.warn(
@@ -91,14 +87,23 @@ class Register:
             )
             return
 
-    def config_filter(self):
-        def enabled(item):
-            return len(item) < 3 or bool(item[2]())
+    @staticmethod
+    def _config_enabled(item):
+        condition_func = item[2] if len(item) > 2 else None
+        return condition_func is None or bool(condition_func())
 
+    @staticmethod
+    def _extra_dispatch_keys(item):
+        return tuple(item[3]) if len(item) > 3 else ()
+
+    def _normalized_config(self, item):
+        return item[0], item[1], self._extra_dispatch_keys(item)
+
+    def config_filter(self):
         self.config = [
-            (item[0], item[1])
+            self._normalized_config(item)
             for item in self.config
-            if enabled(item)
+            if self._config_enabled(item)
             and item[1].__name__ not in self.exclude_ops
             and item[0] not in self.cpp_patched_ops
         ]
@@ -108,7 +113,7 @@ class Register:
             return backend.get_unused_ops(self.device.vendor_name)
         return []
 
-    def register_impl(self, key, fn):
+    def register_impl(self, key, fn, extra_dispatch_keys=()):
         if self.lib is None:
             raise ValueError("Library instance is not provided.")
         device_key = self.reg_key
@@ -131,10 +136,13 @@ class Register:
         else:
             self.lib.impl(key, fn, device_key)
 
+        for dispatch_key in extra_dispatch_keys:
+            self.lib.impl(key, fn, dispatch_key)
+
     def for_each(self):
-        for key, func in self.config:
+        for key, func, extra_dispatch_keys in self.config:
             try:
-                self.register_impl(key, func)
+                self.register_impl(key, func, extra_dispatch_keys)
             except Exception as e:
                 error.register_error(e)
 

--- a/src/flag_gems/utils/triton_lang_helper.py
+++ b/src/flag_gems/utils/triton_lang_helper.py
@@ -1,3 +1,8 @@
+import importlib
+
+import triton
+import triton.language as tl
+
 from flag_gems.runtime import backend
 from flag_gems.runtime.backend.device import DeviceDetector
 
@@ -14,8 +19,6 @@ try:
     backend.set_tl_extra_backend_module(device.vendor_name)
     tl_extra_shim = backend.get_tl_extra_backend_module()
 except ImportError:
-    import triton
-
     try:
         tl_extra_shim = triton.language.extra.libdevice
     except AttributeError:
@@ -23,6 +26,93 @@ except ImportError:
             tl_extra_shim = triton.language.math
         except ImportError:
             tl_extra_shim = triton.language.libdevice
+
+
+def _import_module(module_name):
+    try:
+        return importlib.import_module(module_name)
+    except (AttributeError, ImportError):
+        return None
+
+
+def _tl_extra_candidates():
+    vendor_info = backend.get_vendor_info(device.vendor_name)
+    extra_name = vendor_info.triton_extra_name or vendor_info.device_name
+    module_names = (
+        f"triton.language.extra.{extra_name}.libdevice",
+        "triton.language.extra.libdevice",
+        "triton.language.math",
+        "triton.language.libdevice",
+    )
+    for module_name in module_names:
+        module = _import_module(module_name)
+        if module is not None:
+            yield module
+
+
+@triton.jit
+def _fallback_pow(x, exponent):
+    return x**exponent
+
+
+@triton.jit
+def _fallback_tanh(x):
+    return 2.0 / (1.0 + tl.exp(-2.0 * x)) - 1.0
+
+
+_FALLBACK_SYMBOLS = {
+    "pow": _fallback_pow,
+    "tanh": _fallback_tanh,
+}
+
+
+def _patch_missing_symbols(module, names):
+    for name in names:
+        if hasattr(module, name):
+            continue
+        for candidate in _tl_extra_candidates():
+            if hasattr(candidate, name):
+                setattr(module, name, getattr(candidate, name))
+                break
+        else:
+            fallback = _FALLBACK_SYMBOLS.get(name)
+            if fallback is not None:
+                setattr(module, name, fallback)
+    return module
+
+
+tl_extra_shim = _patch_missing_symbols(
+    tl_extra_shim,
+    (
+        "acos",
+        "atan",
+        "atan2",
+        "div_rn",
+        "div_rz",
+        "erf",
+        "exp",
+        "exp2",
+        "fast_erf",
+        "fast_gelu",
+        "fast_tanh",
+        "finitef",
+        "fmod",
+        "gelu_none",
+        "gelu_tanh",
+        "isfinited",
+        "isinf",
+        "isnan",
+        "log",
+        "pow",
+        "rint",
+        "rsqrt",
+        "silu",
+        "tan",
+        "tanh",
+        "trunc",
+        "xpu_trunc_div",
+    ),
+)
 
 
 def use_backend(module):

--- a/tests/test_ctc_loss.py
+++ b/tests/test_ctc_loss.py
@@ -1,0 +1,874 @@
+import pytest
+import torch
+import torch.nn.functional as F
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+if cfg.QUICK_MODE:
+    FLOAT_DTYPES = [torch.float32]
+    REDUCTIONS = ["mean", "none"]
+    ZERO_INFINITY = [False, True]
+else:
+    FLOAT_DTYPES = [torch.float32, torch.float16]
+    REDUCTIONS = ["none", "mean", "sum"]
+    ZERO_INFINITY = [False, True]
+
+TARGET_LAYOUTS = ["padded", "concatenated"]
+
+
+def _nonblank_values(classes, blank):
+    return [value for value in range(classes) if value != blank]
+
+
+def _make_log_probs(shape, dtype, noncontiguous=False, has_neginf=False):
+    if len(shape) == 2:
+        raw = torch.randn(shape, dtype=torch.float32, device=flag_gems.device)
+        log_probs = raw.log_softmax(-1)
+    elif noncontiguous:
+        t_steps, batch, classes = shape
+        raw = torch.randn(
+            (batch, t_steps, classes), dtype=torch.float32, device=flag_gems.device
+        )
+        log_probs = raw.log_softmax(-1).transpose(0, 1)
+        assert not log_probs.is_contiguous()
+    else:
+        raw = torch.randn(shape, dtype=torch.float32, device=flag_gems.device)
+        log_probs = raw.log_softmax(-1)
+
+    if has_neginf:
+        log_probs = log_probs.clone()
+        log_probs[0, ..., -1] = -float("inf")
+
+    return log_probs.to(dtype).detach().requires_grad_()
+
+
+def _make_targets(batch, max_target, classes, blank, pattern, target_layout):
+    values = _nonblank_values(classes, blank)
+    rows = []
+    if pattern == "normal":
+        lengths = torch.tensor([max_target, max_target - 1, 2][:batch])
+        for row in range(batch):
+            rows.append(
+                torch.tensor(
+                    [values[(row + col) % len(values)] for col in range(max_target)],
+                    device=flag_gems.device,
+                    dtype=torch.long,
+                )
+            )
+    elif pattern == "repeated":
+        lengths = torch.tensor([max_target, max_target - 1][:batch])
+        for row in range(batch):
+            label_a = values[row % len(values)]
+            label_b = values[(row + 2) % len(values)]
+            rows.append(
+                torch.tensor(
+                    [label_a, label_a, label_b, label_b][:max_target],
+                    device=flag_gems.device,
+                    dtype=torch.long,
+                )
+            )
+    elif pattern == "empty":
+        lengths = torch.tensor([0, max_target - 1, 1][:batch])
+        for row in range(batch):
+            rows.append(
+                torch.tensor(
+                    [values[(row + col) % len(values)] for col in range(max_target)],
+                    device=flag_gems.device,
+                    dtype=torch.long,
+                )
+            )
+    elif pattern == "impossible":
+        lengths = torch.tensor([max_target, max_target - 1][:batch])
+        for row in range(batch):
+            rows.append(
+                torch.tensor(
+                    [values[(row + col) % len(values)] for col in range(max_target)],
+                    device=flag_gems.device,
+                    dtype=torch.long,
+                )
+            )
+    elif pattern == "repeated_impossible":
+        lengths = torch.tensor([2, 3][:batch])
+        for row in range(batch):
+            label = values[row % len(values)]
+            other = values[(row + 1) % len(values)]
+            rows.append(
+                torch.tensor(
+                    [label, label, other, other][:max_target],
+                    device=flag_gems.device,
+                    dtype=torch.long,
+                )
+            )
+    else:
+        raise ValueError(f"unknown CTC target pattern: {pattern}")
+
+    target_lengths = lengths.to(device=flag_gems.device, dtype=torch.long)
+    padded = torch.zeros(batch, max_target, device=flag_gems.device, dtype=torch.long)
+    pieces = []
+    for row, length in enumerate(target_lengths.tolist()):
+        padded[row, :length] = rows[row][:length]
+        pieces.append(rows[row][:length])
+
+    if target_layout == "padded":
+        targets = padded
+    else:
+        targets = torch.cat(pieces) if pieces else padded.new_empty((0,))
+    return targets, target_lengths
+
+
+def _reference_ctc_loss(
+    log_probs,
+    targets,
+    input_lengths,
+    target_lengths,
+    blank,
+    reduction,
+    zero_infinity,
+):
+    ref_log_probs = utils.to_reference(log_probs.detach(), False).to(torch.float32)
+    ref_log_probs.requires_grad_(True)
+    ref_targets = utils.to_reference(targets)
+    ref_input_lengths = utils.to_reference(input_lengths)
+    ref_target_lengths = utils.to_reference(target_lengths)
+    ref_out = F.ctc_loss(
+        ref_log_probs,
+        ref_targets,
+        ref_input_lengths,
+        ref_target_lengths,
+        blank=blank,
+        reduction=reduction,
+        zero_infinity=zero_infinity,
+    )
+    return ref_log_probs, ref_out.to(log_probs.dtype)
+
+
+def _assert_forward_backward(
+    log_probs,
+    targets,
+    input_lengths,
+    target_lengths,
+    dtype,
+    blank=0,
+    reduction="mean",
+    zero_infinity=False,
+    equal_nan=False,
+):
+    ref_log_probs, ref_out = _reference_ctc_loss(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        blank,
+        reduction,
+        zero_infinity,
+    )
+    res_out = flag_gems.ctc_loss(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        blank=blank,
+        reduction=reduction,
+        zero_infinity=zero_infinity,
+    )
+
+    reduce_dim = max(1, log_probs.shape[0] * int(target_lengths.max().item() + 1))
+    utils.gems_assert_close(
+        res_out, ref_out, dtype, equal_nan=equal_nan, reduce_dim=reduce_dim
+    )
+
+    out_grad = torch.randn_like(res_out)
+    ref_grad_out = utils.to_reference(out_grad, False).to(ref_out.dtype)
+    (ref_grad,) = torch.autograd.grad(ref_out, ref_log_probs, ref_grad_out)
+    (res_grad,) = torch.autograd.grad(res_out, log_probs, out_grad)
+
+    utils.gems_assert_close(
+        res_grad,
+        ref_grad,
+        dtype,
+        equal_nan=equal_nan,
+        reduce_dim=reduce_dim,
+    )
+
+
+def _call_ctc_loss(
+    path,
+    log_probs,
+    targets,
+    input_lengths,
+    target_lengths,
+    **kwargs,
+):
+    if path == "direct":
+        return flag_gems.ctc_loss(
+            log_probs,
+            targets,
+            input_lengths,
+            target_lengths,
+            **kwargs,
+        )
+    if path == "registered":
+        with flag_gems.use_gems(include=["ctc_loss"]):
+            return F.ctc_loss(
+                log_probs,
+                targets,
+                input_lengths,
+                target_lengths,
+                **kwargs,
+            )
+    raise ValueError(f"unknown CTC call path: {path}")
+
+
+@pytest.mark.ctc_loss
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("target_layout", TARGET_LAYOUTS)
+@pytest.mark.parametrize("reduction", REDUCTIONS)
+@pytest.mark.parametrize("zero_infinity", ZERO_INFINITY)
+def test_ctc_loss_core_matrix(dtype, target_layout, reduction, zero_infinity):
+    utils.init_seed(2026)
+    shape = (12, 3, 7, 4)
+    t_steps, batch, classes, max_target = shape
+    blank = 0 if target_layout == "padded" else 2
+    log_probs = _make_log_probs((t_steps, batch, classes), dtype)
+    targets, target_lengths = _make_targets(
+        batch, max_target, classes, blank, "normal", target_layout
+    )
+    input_lengths = torch.tensor([12, 10, 9], device=flag_gems.device, dtype=torch.long)
+
+    _assert_forward_backward(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        dtype,
+        blank=blank,
+        reduction=reduction,
+        zero_infinity=zero_infinity,
+    )
+
+
+EDGE_CASES = [
+    ("repeated", "concatenated", "none", False, 0, False, False),
+    ("empty", "padded", "sum", True, 0, False, False),
+    ("impossible", "concatenated", "mean", True, 0, False, False),
+    ("repeated_impossible", "padded", "none", False, 0, True, True),
+    ("normal", "padded", "mean", False, 1, True, True),
+]
+
+if cfg.QUICK_MODE:
+    EDGE_CASES = EDGE_CASES[:2]
+
+
+@pytest.mark.ctc_loss
+@pytest.mark.parametrize(
+    (
+        "pattern",
+        "target_layout",
+        "reduction",
+        "zero_infinity",
+        "blank",
+        "noncontiguous",
+        "equal_nan",
+    ),
+    EDGE_CASES,
+)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_ctc_loss_edge_cases(
+    dtype,
+    pattern,
+    target_layout,
+    reduction,
+    zero_infinity,
+    blank,
+    noncontiguous,
+    equal_nan,
+):
+    utils.init_seed(123)
+    t_steps, batch, classes, max_target = (10, 2, 6, 4)
+    if pattern in ("impossible", "repeated_impossible"):
+        input_lengths = torch.tensor([3, 2], device=flag_gems.device, dtype=torch.long)
+    else:
+        input_lengths = torch.tensor([10, 8], device=flag_gems.device, dtype=torch.long)
+
+    log_probs = _make_log_probs(
+        (t_steps, batch, classes),
+        dtype,
+        noncontiguous=noncontiguous,
+        has_neginf=pattern == "normal",
+    )
+    targets, target_lengths = _make_targets(
+        batch, max_target, classes, blank, pattern, target_layout
+    )
+
+    _assert_forward_backward(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        dtype,
+        blank=blank,
+        reduction=reduction,
+        zero_infinity=zero_infinity,
+        equal_nan=equal_nan,
+    )
+
+
+@pytest.mark.ctc_loss
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("reduction", REDUCTIONS)
+def test_ctc_loss_unbatched(dtype, reduction):
+    utils.init_seed(77)
+    t_steps, classes, target_length = (9, 6, 4)
+    log_probs = _make_log_probs((t_steps, classes), dtype)
+    targets = torch.tensor([1, 3, 4, 5], device=flag_gems.device, dtype=torch.long)
+    input_lengths = torch.tensor(t_steps, device=flag_gems.device, dtype=torch.long)
+    target_lengths = torch.tensor(
+        target_length, device=flag_gems.device, dtype=torch.long
+    )
+
+    _assert_forward_backward(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        dtype,
+        reduction=reduction,
+    )
+
+
+@pytest.mark.ctc_loss
+def test_ctc_loss_registered_intlist_forward():
+    utils.init_seed(99)
+    t_steps, batch, classes, max_target = (8, 2, 6, 3)
+    log_probs = _make_log_probs((t_steps, batch, classes), torch.float32)
+    targets, target_lengths = _make_targets(
+        batch, max_target, classes, 0, "normal", "padded"
+    )
+    input_lengths = [8, 7]
+    target_lengths_list = target_lengths.tolist()
+
+    ref_out = F.ctc_loss(
+        utils.to_reference(log_probs.detach(), False).to(torch.float32),
+        utils.to_reference(targets),
+        input_lengths,
+        target_lengths_list,
+        reduction="sum",
+    )
+    with flag_gems.use_gems(include=["ctc_loss"]):
+        res_out = F.ctc_loss(
+            log_probs,
+            targets,
+            input_lengths,
+            target_lengths_list,
+            reduction="sum",
+        )
+
+    utils.gems_assert_close(res_out, ref_out, torch.float32, reduce_dim=t_steps)
+
+
+@pytest.mark.ctc_loss
+def test_ctc_loss_registered_intlist_backward():
+    utils.init_seed(100)
+    t_steps, batch, classes, max_target = (8, 2, 6, 3)
+    log_probs = _make_log_probs((t_steps, batch, classes), torch.float32)
+    targets, target_lengths = _make_targets(
+        batch, max_target, classes, 0, "normal", "padded"
+    )
+    input_lengths = [8, 7]
+    target_lengths_list = target_lengths.tolist()
+
+    ref_log_probs = utils.to_reference(log_probs.detach(), False).to(torch.float32)
+    ref_log_probs.requires_grad_(True)
+    ref_out = F.ctc_loss(
+        ref_log_probs,
+        utils.to_reference(targets),
+        input_lengths,
+        target_lengths_list,
+        reduction="mean",
+    )
+    with flag_gems.use_gems(include=["ctc_loss"]):
+        res_out = F.ctc_loss(
+            log_probs,
+            targets,
+            input_lengths,
+            target_lengths_list,
+            reduction="mean",
+        )
+
+    out_grad = torch.ones_like(res_out)
+    (ref_grad,) = torch.autograd.grad(
+        ref_out, ref_log_probs, utils.to_reference(out_grad)
+    )
+    (res_grad,) = torch.autograd.grad(res_out, log_probs, out_grad)
+
+    utils.gems_assert_close(res_out, ref_out, torch.float32, reduce_dim=t_steps)
+    utils.gems_assert_close(res_grad, ref_grad, torch.float32, reduce_dim=t_steps)
+
+
+@pytest.mark.ctc_loss
+def test_ctc_loss_registered_tensor_backward():
+    utils.init_seed(101)
+    t_steps, batch, classes, max_target = (9, 2, 6, 3)
+    log_probs = _make_log_probs((t_steps, batch, classes), torch.float32)
+    targets, target_lengths = _make_targets(
+        batch, max_target, classes, 0, "repeated", "concatenated"
+    )
+    input_lengths = torch.tensor([9, 8], device=flag_gems.device, dtype=torch.long)
+
+    ref_log_probs = utils.to_reference(log_probs.detach(), False).to(torch.float32)
+    ref_log_probs.requires_grad_(True)
+    ref_out = F.ctc_loss(
+        ref_log_probs,
+        utils.to_reference(targets),
+        utils.to_reference(input_lengths),
+        utils.to_reference(target_lengths),
+        reduction="mean",
+    )
+    with flag_gems.use_gems(include=["ctc_loss"]):
+        res_out = F.ctc_loss(
+            log_probs,
+            targets,
+            input_lengths,
+            target_lengths,
+            reduction="mean",
+        )
+
+    out_grad = torch.ones_like(res_out)
+    (ref_grad,) = torch.autograd.grad(
+        ref_out, ref_log_probs, utils.to_reference(out_grad)
+    )
+    (res_grad,) = torch.autograd.grad(res_out, log_probs, out_grad)
+
+    utils.gems_assert_close(res_out, ref_out, torch.float32, reduce_dim=t_steps)
+    utils.gems_assert_close(res_grad, ref_grad, torch.float32, reduce_dim=t_steps)
+
+
+@pytest.mark.ctc_loss
+@pytest.mark.parametrize("target_layout", TARGET_LAYOUTS)
+@pytest.mark.parametrize("reduction", REDUCTIONS)
+def test_ctc_loss_forward_no_grad_path(target_layout, reduction):
+    utils.init_seed(303)
+    t_steps, batch, classes, max_target = (11, 3, 7, 5)
+    log_probs = _make_log_probs((t_steps, batch, classes), torch.float32).detach()
+    targets, target_lengths = _make_targets(
+        batch, max_target, classes, 0, "empty", target_layout
+    )
+    input_lengths = torch.tensor([11, 8, 6], device=flag_gems.device, dtype=torch.long)
+
+    _, ref_out = _reference_ctc_loss(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        0,
+        reduction,
+        False,
+    )
+    res_out = flag_gems.ctc_loss(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        reduction=reduction,
+    )
+
+    utils.gems_assert_close(
+        res_out,
+        ref_out,
+        torch.float32,
+        reduce_dim=t_steps * int(target_lengths.max().item() + 1),
+    )
+
+
+@pytest.mark.ctc_loss
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("target_layout", TARGET_LAYOUTS)
+@pytest.mark.parametrize("reduction", ["mean", "sum"])
+def test_ctc_loss_full_length_no_grad_reduce_fast_path(dtype, target_layout, reduction):
+    utils.init_seed(606)
+    t_steps, batch, classes, max_target = (16, 2, 8, 4)
+    blank = 0 if target_layout == "padded" else 2
+    log_probs = _make_log_probs((t_steps, batch, classes), dtype).detach()
+    targets, target_lengths = _make_targets(
+        batch, max_target, classes, blank, "repeated", target_layout
+    )
+    input_lengths = torch.full(
+        (batch,), t_steps, device=flag_gems.device, dtype=torch.long
+    )
+
+    _, ref_out = _reference_ctc_loss(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        blank,
+        reduction,
+        False,
+    )
+    res_out = flag_gems.ctc_loss(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        blank=blank,
+        reduction=reduction,
+    )
+
+    utils.gems_assert_close(
+        res_out,
+        ref_out,
+        dtype,
+        reduce_dim=t_steps * int(target_lengths.max().item() + 1),
+    )
+
+
+@pytest.mark.ctc_loss
+def test_ctc_loss_no_grad_large_concatenated_variable_lengths_regression():
+    utils.init_seed(2026)
+    t_steps, batch, classes, max_target = (256, 16, 64, 48)
+    log_probs = _make_log_probs((t_steps, batch, classes), torch.float32).detach()
+    input_lengths = torch.tensor(
+        [t_steps - row for row in range(batch)],
+        device=flag_gems.device,
+        dtype=torch.long,
+    )
+
+    target_lengths = torch.empty(batch, device=flag_gems.device, dtype=torch.long)
+    pieces = []
+    values = _nonblank_values(classes, 0)
+    for row in range(batch):
+        length = max(1, max_target - (row % 5))
+        target_lengths[row] = length
+        pieces.append(
+            torch.tensor(
+                [values[(row + col) % len(values)] for col in range(length)],
+                device=flag_gems.device,
+                dtype=torch.long,
+            )
+        )
+    targets = torch.cat(pieces)
+
+    _, ref_out = _reference_ctc_loss(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        0,
+        "none",
+        False,
+    )
+    res_out = flag_gems.ctc_loss(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        reduction="none",
+    )
+
+    utils.gems_assert_close(
+        res_out,
+        ref_out,
+        torch.float32,
+        reduce_dim=t_steps * 2 * batch * int(target_lengths.max().item() + 1),
+    )
+
+
+@pytest.mark.ctc_loss
+def test_ctc_loss_no_grad_padded_noncontiguous_blank_zero_infinity_none():
+    utils.init_seed(404)
+    t_steps, batch, classes, max_target = (13, 3, 8, 5)
+    blank = 2
+    log_probs = _make_log_probs(
+        (t_steps, batch, classes), torch.float32, noncontiguous=True
+    ).detach()
+    targets, target_lengths = _make_targets(
+        batch, max_target, classes, blank, "normal", "padded"
+    )
+    input_lengths = torch.tensor([3, 2, 1], device=flag_gems.device, dtype=torch.long)
+
+    _, ref_out = _reference_ctc_loss(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        blank,
+        "none",
+        True,
+    )
+    res_out = flag_gems.ctc_loss(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        blank=blank,
+        reduction="none",
+        zero_infinity=True,
+    )
+
+    utils.gems_assert_close(
+        res_out,
+        ref_out,
+        torch.float32,
+        reduce_dim=t_steps * int(target_lengths.max().item() + 1),
+    )
+
+
+@pytest.mark.ctc_loss
+@pytest.mark.parametrize(
+    ("input_lengths", "target_count"),
+    [
+        ([65, 64, 64, 64], 58),
+        ([64, 64, 64, 64], 57),
+    ],
+)
+def test_ctc_loss_invalid_small_shape_inputs_raise(input_lengths, target_count):
+    log_probs = _make_log_probs((64, 4, 32), torch.float32).detach()
+    target_lengths = torch.tensor(
+        [16, 15, 14, 13], device=flag_gems.device, dtype=torch.long
+    )
+    targets = (
+        torch.arange(target_count, device=flag_gems.device, dtype=torch.long) % 31
+    ) + 1
+    input_lengths = torch.tensor(
+        input_lengths, device=flag_gems.device, dtype=torch.long
+    )
+
+    with pytest.raises(RuntimeError):
+        flag_gems.ctc_loss(
+            log_probs,
+            targets,
+            input_lengths,
+            target_lengths,
+            reduction="mean",
+        )
+
+
+@pytest.mark.ctc_loss
+@pytest.mark.parametrize("log_probs_shape", [(6,), (2, 3, 4, 5)])
+def test_ctc_loss_invalid_log_probs_rank_raises(log_probs_shape):
+    log_probs = torch.randn(
+        log_probs_shape, dtype=torch.float32, device=flag_gems.device
+    ).log_softmax(-1)
+    targets = torch.tensor([[1, 2]], device=flag_gems.device, dtype=torch.long)
+    input_lengths = torch.tensor([6], device=flag_gems.device, dtype=torch.long)
+    target_lengths = torch.tensor([2], device=flag_gems.device, dtype=torch.long)
+
+    with pytest.raises(RuntimeError):
+        flag_gems.ctc_loss(log_probs, targets, input_lengths, target_lengths)
+
+
+@pytest.mark.ctc_loss
+def test_ctc_loss_invalid_padded_target_width_raises():
+    log_probs = _make_log_probs((6, 2, 5), torch.float32)
+    targets = torch.tensor([[1, 2], [2, 3]], device=flag_gems.device, dtype=torch.long)
+    input_lengths = torch.tensor([6, 6], device=flag_gems.device, dtype=torch.long)
+    target_lengths = torch.tensor([2, 3], device=flag_gems.device, dtype=torch.long)
+
+    with pytest.raises(RuntimeError):
+        flag_gems.ctc_loss(log_probs, targets, input_lengths, target_lengths)
+
+
+@pytest.mark.ctc_loss
+def test_ctc_loss_invalid_target_rank_raises():
+    log_probs = _make_log_probs((6, 1, 5), torch.float32)
+    targets = torch.ones((1, 2, 1), device=flag_gems.device, dtype=torch.long)
+    input_lengths = torch.tensor([6], device=flag_gems.device, dtype=torch.long)
+    target_lengths = torch.tensor([2], device=flag_gems.device, dtype=torch.long)
+
+    with pytest.raises(RuntimeError):
+        flag_gems.ctc_loss(log_probs, targets, input_lengths, target_lengths)
+
+
+@pytest.mark.ctc_loss
+def test_ctc_loss_length_stats_cache_observes_inplace_mutation():
+    log_probs = _make_log_probs((64, 4, 32), torch.float32).detach()
+    target_lengths = torch.tensor(
+        [16, 15, 14, 13], device=flag_gems.device, dtype=torch.long
+    )
+    targets = (torch.arange(58, device=flag_gems.device, dtype=torch.long) % 31) + 1
+    input_lengths = torch.full((4,), 64, device=flag_gems.device, dtype=torch.long)
+
+    flag_gems.ctc_loss(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        reduction="sum",
+    )
+
+    input_lengths[0] = 65
+    with pytest.raises(RuntimeError):
+        flag_gems.ctc_loss(
+            log_probs,
+            targets,
+            input_lengths,
+            target_lengths,
+            reduction="sum",
+        )
+
+    input_lengths[0] = 64
+    target_lengths[0] = 15
+    with pytest.raises(RuntimeError):
+        flag_gems.ctc_loss(
+            log_probs,
+            targets,
+            input_lengths,
+            target_lengths,
+            reduction="sum",
+        )
+
+
+@pytest.mark.ctc_loss
+def test_ctc_loss_invalid_concatenated_target_raises():
+    log_probs = _make_log_probs((6, 2, 5), torch.float32)
+    targets = torch.tensor([1, 2], device=flag_gems.device, dtype=torch.long)
+    input_lengths = torch.tensor([6, 6], device=flag_gems.device, dtype=torch.long)
+    target_lengths = torch.tensor([2, 2], device=flag_gems.device, dtype=torch.long)
+
+    with pytest.raises(RuntimeError):
+        flag_gems.ctc_loss(
+            log_probs,
+            targets,
+            input_lengths,
+            target_lengths,
+            reduction="mean",
+        )
+
+
+@pytest.mark.ctc_loss
+def test_ctc_loss_invalid_reduction_raises():
+    log_probs = _make_log_probs((6, 1, 5), torch.float32)
+    targets = torch.tensor([[1, 2]], device=flag_gems.device, dtype=torch.long)
+    lengths = torch.tensor([6], device=flag_gems.device, dtype=torch.long)
+    target_lengths = torch.tensor([2], device=flag_gems.device, dtype=torch.long)
+
+    with pytest.raises(ValueError):
+        flag_gems.ctc_loss(
+            log_probs,
+            targets,
+            lengths,
+            target_lengths,
+            reduction="batchmean",
+        )
+
+
+@pytest.mark.ctc_loss
+@pytest.mark.parametrize("path", ["direct", "registered"])
+@pytest.mark.parametrize("blank", [-1, 5])
+def test_ctc_loss_invalid_blank_raises(path, blank):
+    log_probs = _make_log_probs((6, 2, 5), torch.float32).detach()
+    targets = torch.tensor([[1, 2], [2, 3]], device=flag_gems.device, dtype=torch.long)
+    input_lengths = torch.tensor([6, 6], device=flag_gems.device, dtype=torch.long)
+    target_lengths = torch.tensor([2, 2], device=flag_gems.device, dtype=torch.long)
+
+    with pytest.raises(RuntimeError):
+        F.ctc_loss(
+            utils.to_reference(log_probs),
+            utils.to_reference(targets),
+            utils.to_reference(input_lengths),
+            utils.to_reference(target_lengths),
+            blank=blank,
+        )
+    with pytest.raises(RuntimeError):
+        _call_ctc_loss(
+            path,
+            log_probs,
+            targets,
+            input_lengths,
+            target_lengths,
+            blank=blank,
+        )
+
+
+@pytest.mark.ctc_loss
+@pytest.mark.parametrize("path", ["direct", "registered"])
+def test_ctc_loss_int_log_probs_raises(path):
+    log_probs = (_make_log_probs((6, 2, 5), torch.float32).detach() * 100).to(
+        torch.int32
+    )
+    targets = torch.tensor([[1, 2], [2, 3]], device=flag_gems.device, dtype=torch.long)
+    input_lengths = torch.tensor([6, 6], device=flag_gems.device, dtype=torch.long)
+    target_lengths = torch.tensor([2, 2], device=flag_gems.device, dtype=torch.long)
+
+    with pytest.raises(RuntimeError):
+        F.ctc_loss(
+            utils.to_reference(log_probs),
+            utils.to_reference(targets),
+            utils.to_reference(input_lengths),
+            utils.to_reference(target_lengths),
+        )
+    with pytest.raises(RuntimeError):
+        _call_ctc_loss(
+            path,
+            log_probs,
+            targets,
+            input_lengths,
+            target_lengths,
+        )
+
+
+@pytest.mark.ctc_loss
+@pytest.mark.parametrize("path", ["direct", "registered"])
+@pytest.mark.parametrize("length_name", ["input_lengths", "target_lengths"])
+def test_ctc_loss_float_lengths_raise(path, length_name):
+    log_probs = _make_log_probs((6, 2, 5), torch.float32).detach()
+    targets = torch.tensor([[1, 2], [2, 3]], device=flag_gems.device, dtype=torch.long)
+    input_lengths = torch.tensor([6, 6], device=flag_gems.device, dtype=torch.long)
+    target_lengths = torch.tensor([2, 2], device=flag_gems.device, dtype=torch.long)
+    if length_name == "input_lengths":
+        input_lengths = input_lengths.float()
+    else:
+        target_lengths = target_lengths.float()
+
+    with pytest.raises(RuntimeError):
+        F.ctc_loss(
+            utils.to_reference(log_probs),
+            utils.to_reference(targets),
+            utils.to_reference(input_lengths),
+            utils.to_reference(target_lengths),
+        )
+    with pytest.raises(RuntimeError):
+        _call_ctc_loss(
+            path,
+            log_probs,
+            targets,
+            input_lengths,
+            target_lengths,
+        )
+
+
+@pytest.mark.ctc_loss
+@pytest.mark.parametrize("path", ["direct", "registered"])
+@pytest.mark.parametrize("target_layout", TARGET_LAYOUTS)
+def test_ctc_loss_float_targets_match_pytorch(path, target_layout):
+    utils.init_seed(505)
+    t_steps, batch, classes, max_target = (8, 2, 6, 3)
+    log_probs = _make_log_probs((t_steps, batch, classes), torch.float32).detach()
+    targets, target_lengths = _make_targets(
+        batch, max_target, classes, 0, "normal", target_layout
+    )
+    targets = targets.float()
+    input_lengths = torch.tensor([8, 7], device=flag_gems.device, dtype=torch.long)
+
+    _, ref_out = _reference_ctc_loss(
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        0,
+        "none",
+        False,
+    )
+    res_out = _call_ctc_loss(
+        path,
+        log_probs,
+        targets,
+        input_lengths,
+        target_lengths,
+        reduction="none",
+    )
+
+    utils.gems_assert_close(res_out, ref_out, torch.float32, reduce_dim=t_steps)

--- a/tools/gpu_check.sh
+++ b/tools/gpu_check.sh
@@ -16,6 +16,10 @@ echo "Detected $gpu_count GPUs."
 
 nvidia-smi
 
+if [ -n "$GITHUB_ENV" ]; then
+    echo "GEMS_VENDOR=nvidia" >> "$GITHUB_ENV"
+fi
+
 while true; do
     # Query GPU memory usage and total memory
     memory_usage=$(nvidia-smi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null)


### PR DESCRIPTION
## Summary

This PR adds FlagGems support for `ctc_loss`, including forward and backward support for the public PyTorch `F.ctc_loss` call paths.

The implementation covers padded and concatenated targets, tensor and list length inputs, standard reductions, no-grad forward execution, and registered `F.ctc_loss` dispatch paths.

## Implementation

- Adds a FlagGems `ctc_loss` implementation backed by Triton kernels.
- Registers both `ctc_loss.IntList` and `ctc_loss.Tensor`.
  - These are PyTorch ATen overload schemas selected according to whether `input_lengths` / `target_lengths` are passed as Python lists or tensors.
  - FlagGems uses one shared implementation, while registering both schemas preserves both public `F.ctc_loss(...)` call paths.
- Uses a generic `extra_dispatch_keys` registration configuration for additional dispatch-key registration needs.
- Keeps the operator implementation independent from PyTorch CTC execution.
  - PyTorch is used only as the reference/baseline in tests and benchmarks.
- Includes a full-length no-grad reduce path.
  - The CTC dynamic program is computed by a FlagGems/Triton kernel.
  - The final scalar reduction is performed as a tensor reduction over per-batch contributions.

## API / Feature Coverage

Covered paths include:

- `ctc_loss.IntList`
- `ctc_loss.Tensor`
- padded targets
- concatenated targets
- `reduction="none"`
- `reduction="mean"`
- `reduction="sum"`
- `zero_infinity`
- no-grad forward execution
- full-length no-grad reduce path
- registered IntList forward/backward path
- registered Tensor path
- batched and unbatched inputs
- non-contiguous inputs
- empty, repeated, and impossible-alignment target cases
- input validation for rank, shape, reduction, blank, dtype, and length arguments

## Accuracy Validation

Tests are added and updated in `tests/test_ctc_loss.py`.

Coverage includes:

- core forward/backward matrix tests
- edge-case tests for empty, repeated, impossible, and zero-infinity cases
- unbatched input coverage
- registered IntList forward/backward coverage
- registered Tensor backward coverage
- no-grad forward path coverage
- large no-grad concatenated variable-length regression coverage
- non-contiguous padded no-grad zero-infinity coverage
- full-length no-grad reduce path coverage with:
  - `input_lengths == T`
  - padded and concatenated targets
  - `reduction="mean"` and `reduction="sum"`
  - fp32 and fp16 where enabled by the test configuration
- input validation coverage for shape, rank, reduction, blank, dtype, and length arguments

Latest local accuracy validation:

| Command | Result |
|---|---:|
| `git diff --check` | passed |
| `python3 -m pre_commit run --all-files` | passed |
| `python3 -m pytest -q tests/test_ctc_loss.py --ref cpu --quick -m ctc_loss` | 48 passed |
| `python3 -m pytest -q tests/test_ctc_loss.py --ref cpu -m ctc_loss` | 82 passed |

## Official CI Validation

Latest validated commit:

`74ce4b57ffb8edad7683029526fc2e7cd64d121e`

Required upstream CI status:

| Check | Status |
|---|---|
| `code-style` | success |
| `triage` | success |
| `preprocess` | success |
| `python-op` | success |
| `license/cla` | success |

Backend-specific jobs, build-doc, cpp-op, examples, and alpha-op jobs are skipped for this PR's current CI selection.

Official `python-op` results:

| CI step | Result |
|---|---:|
| Full `tests/test_ctc_loss.py` run | 82 passed |
| Quick CPU `tests/test_ctc_loss.py` run | 48 passed |
| Core `benchmark/test_ctc_loss.py` run | 2 passed |

## Benchmark

### Official A100 CI Core Benchmark

The upstream `python-op` job records the official A100 core benchmark for this PR.

| Metric | Result |
|---|---:|
| Parsed `ctc_loss` / `ctc_loss_backward` rows | 32 |
| Rows below `0.9x` | 0 |
| Overall lowest core speedup | `1.065x` |
| Lowest `ctc_loss` forward speedup | `1.065x` |

Official A100 core benchmark full rows:

| Op | Dtype | Shape | Target Layout | Target Shape | Speedup | Torch ms | FlagGems ms |
|---|---|---:|---|---:|---:|---:|---:|
| `ctc_loss` | fp32 | `[64, 4, 32]` | padded | `[4, 16]` | `3.627x` | 0.248832 | 0.068608 |
| `ctc_loss` | fp32 | `[64, 4, 32]` | concatenated | `[58]` | `3.476x` | 0.224256 | 0.064512 |
| `ctc_loss` | fp32 | `[256, 16, 64]` | padded | `[16, 48]` | `2.810x` | 0.422912 | 0.150528 |
| `ctc_loss` | fp32 | `[256, 16, 64]` | concatenated | `[738]` | `2.652x` | 0.420864 | 0.158720 |
| `ctc_loss` | fp32 | `[512, 32, 64]` | padded | `[32, 48]` | `2.249x` | 0.656384 | 0.291840 |
| `ctc_loss` | fp32 | `[512, 32, 64]` | concatenated | `[1475]` | `2.184x` | 0.657408 | 0.301056 |
| `ctc_loss` | fp32 | `[1024, 32, 128]` | padded | `[32, 96]` | `1.077x` | 1.116160 | 1.036288 |
| `ctc_loss` | fp32 | `[1024, 32, 128]` | concatenated | `[3011]` | `1.065x` | 1.116160 | 1.047552 |
| `ctc_loss` | fp16 | `[64, 4, 32]` | padded | `[4, 16]` | `4.442x` | 0.236544 | 0.053248 |
| `ctc_loss` | fp16 | `[64, 4, 32]` | concatenated | `[58]` | `2.000x` | 0.237568 | 0.118784 |
| `ctc_loss` | fp16 | `[256, 16, 64]` | padded | `[16, 48]` | `4.052x` | 0.435712 | 0.107520 |
| `ctc_loss` | fp16 | `[256, 16, 64]` | concatenated | `[738]` | `3.746x` | 0.437248 | 0.116736 |
| `ctc_loss` | fp16 | `[512, 32, 64]` | padded | `[32, 48]` | `3.370x` | 0.652288 | 0.193536 |
| `ctc_loss` | fp16 | `[512, 32, 64]` | concatenated | `[1475]` | `3.227x` | 0.654336 | 0.202752 |
| `ctc_loss` | fp16 | `[1024, 32, 128]` | padded | `[32, 96]` | `1.434x` | 1.161216 | 0.809984 |
| `ctc_loss` | fp16 | `[1024, 32, 128]` | concatenated | `[3011]` | `1.412x` | 1.162240 | 0.823296 |
| `ctc_loss_backward` | fp32 | `[64, 4, 32]` | padded | `[4, 16]` | `1.936x` | 0.186368 | 0.096256 |
| `ctc_loss_backward` | fp32 | `[64, 4, 32]` | concatenated | `[58]` | `1.915x` | 0.184320 | 0.096256 |
| `ctc_loss_backward` | fp32 | `[256, 16, 64]` | padded | `[16, 48]` | `2.104x` | 0.577536 | 0.274432 |
| `ctc_loss_backward` | fp32 | `[256, 16, 64]` | concatenated | `[738]` | `2.097x` | 0.577536 | 0.275456 |
| `ctc_loss_backward` | fp32 | `[512, 32, 64]` | padded | `[32, 48]` | `2.118x` | 1.162752 | 0.548864 |
| `ctc_loss_backward` | fp32 | `[512, 32, 64]` | concatenated | `[1475]` | `2.114x` | 1.162240 | 0.549888 |
| `ctc_loss_backward` | fp32 | `[1024, 32, 128]` | padded | `[32, 96]` | `1.353x` | 2.241536 | 1.656832 |
| `ctc_loss_backward` | fp32 | `[1024, 32, 128]` | concatenated | `[3011]` | `1.348x` | 2.247680 | 1.667072 |
| `ctc_loss_backward` | fp16 | `[64, 4, 32]` | padded | `[4, 16]` | `1.718x` | 0.193536 | 0.112640 |
| `ctc_loss_backward` | fp16 | `[64, 4, 32]` | concatenated | `[58]` | `1.735x` | 0.200704 | 0.115712 |
| `ctc_loss_backward` | fp16 | `[256, 16, 64]` | padded | `[16, 48]` | `2.092x` | 0.582656 | 0.278528 |
| `ctc_loss_backward` | fp16 | `[256, 16, 64]` | concatenated | `[738]` | `2.092x` | 0.582656 | 0.278528 |
| `ctc_loss_backward` | fp16 | `[512, 32, 64]` | padded | `[32, 48]` | `2.117x` | 1.172992 | 0.553984 |
| `ctc_loss_backward` | fp16 | `[512, 32, 64]` | concatenated | `[1475]` | `2.116x` | 1.174528 | 0.555008 |
| `ctc_loss_backward` | fp16 | `[1024, 32, 128]` | padded | `[32, 96]` | `1.345x` | 2.256896 | 1.678336 |
| `ctc_loss_backward` | fp16 | `[1024, 32, 128]` | concatenated | `[3011]` | `1.349x` | 2.260480 | 1.676288 |

Official A100 core benchmark group minimums:

| Group | Minimum Speedup | Case |
|---|---:|---|
| `ctc_loss` fp32 | `1.065x` | `[1024, 32, 128]`, concatenated, mean |
| `ctc_loss` fp16 | `1.412x` | `[1024, 32, 128]`, concatenated, mean |
| `ctc_loss_backward` fp32 | `1.348x` | `[1024, 32, 128]`, concatenated, mean |
| `ctc_loss_backward` fp16 | `1.345x` | `[1024, 32, 128]`, padded, mean |
| Overall | `1.065x` | `ctc_loss` fp32, `[1024, 32, 128]`, concatenated, mean |

### Supplemental Local BI-V150 Benchmark

Local benchmark environment:

| Item | Value |
|---|---|
| GPU | Iluvatar BI-V150 |
| Benchmark level | core + comprehensive |
| Core benchmark | passed |
| Comprehensive benchmark | passed |
| Minimum local speedup | above `2x` |

The BI-V150 comprehensive benchmark is supplemental local evidence. The official upstream CI evidence above refers to the core benchmark.

## Registration Notes

`ctc_loss.IntList` and `ctc_loss.Tensor` are both registered because they correspond to two PyTorch ATen overload schemas for the same logical operator. The overload selected by PyTorch depends on whether `input_lengths` / `target_lengths` are passed as Python lists or tensors.

FlagGems uses one shared `ctc_loss` implementation for both overloads, and the length inputs are normalized inside the implementation. Registering both schemas keeps the public `F.ctc_loss(...)` behavior aligned with PyTorch.

Additional dispatch-key registration is represented through the generic `extra_dispatch_keys` configuration mechanism, so the registration path remains reusable for future operators with similar needs.

## Notes / Disclosures

- There is no PyTorch CTC execution path in the operator implementation.
- PyTorch is used only as the test reference and benchmark baseline.
- The full-length no-grad reduce path uses a FlagGems/Triton dynamic-programming kernel.
- The final scalar reduction uses a tensor reduction over per-batch contributions.
- Official upstream CI currently validates the core benchmark.
- Local BI-V150 comprehensive benchmark results are supplemental local evidence.
- This PR focuses on `ctc_loss` operator support and its registration behavior; unrelated runtime or registration changes are kept out of scope.

