### PR TITLE
[KMCompiler] Optimize flashmla_sparse

### DIFF
--- a/src/flag_gems/fused/flashmla_sparse.py
+++ b/src/flag_gems/fused/flashmla_sparse.py
@@ -4,15 +4,13 @@ import torch
 import triton
 import triton.language as tl
 
-flash_mla_sparse_fwd_configs = [
-    triton.Config({"num_stages": 4, "num_warps": 8}),
-    triton.Config({"num_stages": 2, "num_warps": 4}),
-]
 
-
-@triton.autotune(  # Decorate the kernel
-    configs=flash_mla_sparse_fwd_configs,
-    key=["K", "is_causal"],
+@triton.autotune(
+    configs=[
+        triton.Config({"BK": 64, "BH": 64}, num_warps=8, num_stages=2),
+        triton.Config({"BK": 64, "BH": 64}, num_warps=8, num_stages=4),
+    ],
+    key=["SQ", "HQ", "DQK", "SKV", "TOPK", "HAVE_ATTN_SINK", "HAVE_TOPK_LENGTH"],
 )
 @triton.jit
 def triton_flash_mla_sparse_fwd(
@@ -27,186 +25,137 @@ def triton_flash_mla_sparse_fwd(
     lse,
     stride_qh,
     stride_qm,
-    stride_qd,
     stride_kvg,
     stride_kvn,
-    stride_kvd,
     stride_tg,
     stride_tm,
-    stride_tt,  # indices dim
-    stride_attn_sink_h,
-    stride_topk_length_s,
     stride_oh,
     stride_om,
-    stride_od,
-    stride_mh,
     stride_mm,
-    stride_lh,
     stride_lm,
-    SQ: tl.constexpr,  # seqlen
-    SKV: tl.constexpr,  # seqlen_kv
-    K: tl.constexpr,  # topk
-    D: tl.constexpr,  # QKV dim
-    TD: tl.constexpr,  # tail dim
-    DP: tl.constexpr,
-    TDP: tl.constexpr,
-    G: tl.constexpr,  # group_size
-    BK: tl.constexpr,
-    BH: tl.constexpr,
-    is_causal: tl.constexpr,
-    q_idx_i64: tl.constexpr,
-    output_idx_i64: tl.constexpr,
+    SQ,  # s_q
+    HQ: tl.constexpr,  # h_q=64 or 128
+    DQK: tl.constexpr,  # d_qk=512 or 576
+    SKV,  # s_kv
+    TOPK: tl.constexpr,  # topk
     HAVE_ATTN_SINK: tl.constexpr,
     HAVE_TOPK_LENGTH: tl.constexpr,
+    BK: tl.constexpr,
+    BH: tl.constexpr,
 ):
-    i_sq, i_gbh = tl.program_id(0), tl.program_id(1)
-    i_g, i_bh = i_gbh // G, i_gbh % G
-    if not q_idx_i64:
-        q_base = q + i_sq * stride_qm + i_gbh * (BH * stride_qh)
-    else:
-        q_base = q + i_sq * tl.cast(stride_qm, tl.int64) + i_gbh * (BH * stride_qh)
-    tq_base = q_base + D * stride_qd
-    kv_base = kv + i_g * stride_kvg
-    tkv_base = kv_base + D * stride_kvd
-    t_base = indices + i_sq * stride_tm + i_g * stride_tg
-    attn_sink_ptr = (
-        attn_sink + i_gbh * (BH * stride_attn_sink_h) if HAVE_ATTN_SINK else 0
-    )
-    topk_length_ptr = (
-        topk_length + i_sq * stride_topk_length_s if HAVE_TOPK_LENGTH else 0
-    )
-    if not output_idx_i64:
-        o_base = output + i_sq * stride_om + i_gbh * (BH * stride_oh)
-    else:
-        o_base = output + i_sq * tl.cast(stride_om, tl.int64) + i_gbh * (BH * stride_oh)
-    max_log_base = max_logits + i_sq * stride_mm + i_gbh * (BH * stride_mh)
-    l_base = lse + i_sq * stride_lm + i_gbh * (BH * stride_lh)
+    num_head_blocks: tl.constexpr = (HQ + BH - 1) // BH
+    pid = tl.program_id(0)
+    i_sq = pid // num_head_blocks
+    i_sq = i_sq.to(tl.int64)  # prevent mul overflow
+    i_gbh = pid % num_head_blocks
+    gbh_base = i_gbh * BH
+    DP: tl.constexpr = 512
+    BDP: tl.constexpr = 256
+
+    q_base = q + i_sq * stride_qm + gbh_base * stride_qh
+    kv_base = kv
+    tkv_base = kv + DP
+    t_base = indices + i_sq * stride_tm
+    attn_sink_ptr = attn_sink + gbh_base if HAVE_ATTN_SINK else 0
+    topk_length_ptr = topk_length + i_sq if HAVE_TOPK_LENGTH else 0
+    o_base = output + i_sq * stride_om + gbh_base * stride_oh
+    max_log_base = max_logits + i_sq * stride_mm + gbh_base
+    l_base = lse + i_sq * stride_lm + gbh_base
 
     offs_h = tl.arange(0, BH)
-    offs_d = tl.arange(0, DP)
-    offs_td = tl.arange(0, TDP) if TDP > 0 else None
-    offs_od = tl.arange(0, DP)
+    offs_d = tl.arange(0, BDP)
+    if DQK == 576:
+        offs_td = tl.arange(0, 64)
     offs_t = tl.arange(0, BK)
-    mask_h = i_bh * BH + offs_h < G
-    mask_d = offs_d < D
-    mask_td = offs_td < TD if TDP > 0 else None
-    mask_od = mask_d
 
-    q_ptr = q_base + offs_h[:, None] * stride_qh + offs_d[None, :] * stride_qd
-    q_msk = mask_h[:, None] & mask_d[None, :]
-    q_blk = tl.load(q_ptr, q_msk, other=0.0).to(tl.float32)
-
-    tq_blk = None
-    if TDP > 0:
-        tq_ptr = tq_base + offs_h[:, None] * stride_qh + offs_td[None, :] * stride_qd
-        tq_msk = mask_h[:, None] & mask_td[None, :]
-        tq_blk = tl.load(tq_ptr, tq_msk, other=0.0).to(tl.float32)
+    # `[BH, 256] x 2` delivers better performance than `[BH, 512]` when BH=64
+    q_ptr = q_base + offs_h[:, None] * stride_qh + offs_d[None, :]
+    q_blk0 = tl.load(q_ptr, eviction_policy="evict_first")
+    q_blk1 = tl.load(q_ptr + BDP, eviction_policy="evict_first")
+    if DQK == 576:
+        tq_ptr = q_base + DP + offs_h[:, None] * stride_qh + offs_td[None, :]
+        tq_blk = tl.load(tq_ptr, eviction_policy="evict_first")
 
     max_log = tl.full([BH], float("-inf"), dtype=tl.float32)
     sum_exp = tl.full([BH], 0.0, dtype=tl.float32)
-    acc = tl.zeros([BH, DP], dtype=tl.float32)
-    qk = tl.zeros([BH, BK], dtype=tl.float32)
+    acc0 = tl.zeros([BH, BDP], dtype=tl.float32)
+    acc1 = tl.zeros([BH, BDP], dtype=tl.float32)
 
-    max_col = i_sq if is_causal else SKV - 1
-    topk_len = tl.load(topk_length_ptr).to(tl.int32) if HAVE_TOPK_LENGTH else K
-
-    NK = tl.cdiv(K, BK)
+    topk_len = tl.load(topk_length_ptr) if HAVE_TOPK_LENGTH else TOPK
+    NK = tl.cdiv(topk_len, BK)
     for ck in range(NK):
         # step1: load indices
-        t_ptr = (BK * ck + offs_t) * stride_tt
+        t_ptr = BK * ck + offs_t  # [BK]
         t_msk = t_ptr < topk_len
         t_ptr += t_base
         kv_ids = tl.load(t_ptr, t_msk, other=-1)
-        mask_ids = (kv_ids <= max_col) & (kv_ids >= 0)
+        mask_ids = (kv_ids < SKV) & (kv_ids >= 0)
         # filter invalid index that may cause overflow in mul
         kv_ids = tl.where(mask_ids, kv_ids, 0)
 
-        # if mask_ids.max(0) > 0:
-        if ck * BK <= max_col:
-            # step2: gather kv with indices
-            kv_ptr = (
-                kv_base + offs_d[:, None] * stride_kvd + kv_ids[None, :] * stride_kvn
-            )
-            kv_msk = mask_d[:, None] & mask_ids[None, :]
-            kv_blk = tl.load(kv_ptr, kv_msk, other=0.0).to(tl.float32)  # [DP, BK]
+        # step2: gather kv with indices
+        kv_ptr = kv_base + offs_d[:, None] + kv_ids[None, :] * stride_kvn
+        kv_blk0 = tl.load(kv_ptr, cache_modifier=".cg")  # [BDP, BK]
+        kv_blk1 = tl.load(kv_ptr + BDP, cache_modifier=".cg")  # [BDP, BK]
+        # step3: (q @ kv) * sm_scale
+        qk = tl.dot(
+            q_blk0, kv_blk0, out_dtype=tl.float32
+        )  # [BH, BDP]@[BDP, BK] -> [BH, BK]
+        qk = tl.dot(q_blk1, kv_blk1, qk, out_dtype=tl.float32)
+        if DQK == 576:
+            tkv_ptr = tkv_base + offs_td[:, None] + kv_ids[None, :] * stride_kvn
+            tkv_blk = tl.load(tkv_ptr, cache_modifier=".cg")  # [TDP, BK]
+            qk = tl.dot(tq_blk, tkv_blk, qk, out_dtype=tl.float32)
+        qk *= sm_scale
 
-            # step3: (q @ kv) * sm_scale
-            qk = tl.dot(q_blk, kv_blk)
-            if TDP > 0:
-                tkv_ptr = (
-                    tkv_base
-                    + offs_td[:, None] * stride_kvd
-                    + kv_ids[None, :] * stride_kvn
-                )
-                tkv_msk = mask_td[:, None] & mask_ids[None, :]
-                tkv_blk = tl.load(tkv_ptr, tkv_msk, other=0.0).to(
-                    tl.float32
-                )  # [TDP, BK]
-                qk = tl.dot(tq_blk, tkv_blk, qk) * sm_scale
-            else:
-                qk = qk * sm_scale
-
-            # step4: preprocess for logsumexp
-            qk = tl.where(mask_ids[None, :], qk, float("-inf"))  # [BH, BK]
-            # step5: lse=log2sumexp2(qk), loop part
-            new_max = tl.maximum(max_log, tl.max(qk, axis=1))  # [BH]
-            # avoid nan generated by ((-inf) - (-inf))
-            tmp = qk - new_max[:, None]
-            tmp = tl.where(
-                (~mask_ids[None, :]) & (new_max[:, None] == float("-inf")),
-                float("-inf"),
-                tmp,
-            )
-            exp_qk = tl.math.exp(tmp)  # [BH, BK]
-            sum_qk = tl.sum(exp_qk, axis=1)  # [BH]
-            # avoid nan generated by ((-inf) - (-inf))
-            tmp2 = max_log - new_max
-            tmp2 = tl.where(
-                (max_log == float("-inf")) & (new_max == float("-inf")),
-                float("-inf"),
-                tmp2,
-            )
-            alpha = tl.math.exp(tmp2)  # [BH]
-            sum_exp = tl.fma(sum_exp, alpha, sum_qk)  # [BH]
-            acc = acc * alpha[:, None]  # [BH, DP]
-            # step6: exp2(qk-lse) @ gathered_kv.trans(), loop part
-            acc = tl.dot(exp_qk, kv_blk.trans(), acc)  # [BH, DP]
-            max_log = new_max
+        # step4: preprocess for logsumexp
+        qk = tl.where(mask_ids[None, :], qk, float("-inf"))  # [BH, BK]
+        # step5: lse=logsumexp(qk), loop part
+        new_max = tl.maximum(max_log, tl.max(qk, axis=1))  # [BH]
+        exp_qk = tl.math.exp(qk - new_max[:, None])  # [BH, BK]
+        sum_qk = tl.sum(exp_qk, axis=1)  # [BH]
+        alpha = tl.math.exp(max_log - new_max)  # [BH]
+        sum_exp = sum_exp * alpha + sum_qk  # [BH]
+        # step6: exp(qk-lse) @ gathered_kv.trans(), loop part
+        acc0 = tl.dot(
+            exp_qk.to(tl.bfloat16),
+            kv_blk0.trans(),
+            acc0 * alpha[:, None],
+            out_dtype=tl.float32,
+        )  # [BH, BK]@[BK, BDP]->[BH, BDP]
+        acc1 = tl.dot(
+            exp_qk.to(tl.bfloat16),
+            kv_blk1.trans(),
+            acc1 * alpha[:, None],
+            out_dtype=tl.float32,
+        )  # [BH, BK]@[BK, BDP]->[BH, BDP]
+        max_log = new_max
 
     # step7: store max_logits
-    max_log_ptr = max_log_base + offs_h * stride_lh
-    tl.store(max_log_ptr, max_log, mask_h)  # [BH], float32
+    valid_mask = max_log != float("-inf")
+    max_log = tl.where(valid_mask, max_log, float("-inf"))
+    tl.store(max_log_base + offs_h, max_log)  # [BH], float32
 
-    # step8: lse=log2sumexp2(qk) final part, store lse
+    # step8: lse=logsumexp(qk) final part, store lse
     orig_lse = max_log + tl.math.log(sum_exp)
-    lse_out = tl.where(orig_lse == float("-inf"), float("inf"), orig_lse)
-    l_ptr = l_base + offs_h * stride_lh
-    l_msk = mask_h
-    tl.store(l_ptr, lse_out, l_msk)  # [BH], float32
+    lse_out = tl.where(valid_mask, orig_lse, float("inf"))
+    tl.store(l_base + offs_h, lse_out)  # [BH], float32
 
-    # step9: exp2(qk-lse) @ gathered_kv.trans(), final part
+    # step9: exp(qk-lse) @ gathered_kv.trans(), final part
     if HAVE_ATTN_SINK:
         # step10: attn_sink
-        exp_max_qk = tl.math.exp(max_log)  # [BH]
-        exp_orig_lse = tl.math.exp(orig_lse)
-        sink = tl.load(attn_sink_ptr + offs_h).to(tl.float32)  # [BH]
-        exp_sink = tl.math.exp(sink)
-        sum_exp_new_lse = exp_orig_lse + exp_sink
-        # avoid divide 0
-        sum_exp_new_lse = tl.where(sum_exp_new_lse == 0.0, 1.0, sum_exp_new_lse)
-        factor = exp_max_qk / sum_exp_new_lse
-        out_vals = acc * factor[:, None]
+        sink = tl.load(attn_sink_ptr + offs_h)  # [BH]
+        sum_exp_new_lse = tl.math.exp(orig_lse) + tl.math.exp(sink)
+        factor = tl.math.exp(max_log) / sum_exp_new_lse
     else:
-        # avoid divide 0
-        sum_exp = tl.where(sum_exp == 0, 1.0, sum_exp)
-        out_vals = acc / sum_exp[:, None]
+        factor = 1.0 / sum_exp
 
+    out_vals0 = tl.where(valid_mask[:, None], acc0 * factor[:, None], 0.0)
+    out_vals1 = tl.where(valid_mask[:, None], acc1 * factor[:, None], 0.0)
     # step11: store output
-    o_ptr = (
-        o_base + offs_h[:, None] * stride_oh + offs_od[None, :] * stride_od
-    )  # [BH, DP]
-    o_msk = mask_h[:, None] & mask_od[None, :]
-    tl.store(o_ptr, out_vals.to(q_blk.dtype), o_msk)
+    o_ptr = o_base + offs_h[:, None] * stride_oh + offs_d[None, :]  # [BH, BDP]
+    tl.store(o_ptr, out_vals0.to(tl.bfloat16))
+    tl.store(o_ptr + BDP, out_vals1.to(tl.bfloat16))
 
 
 def flash_mla_sparse_fwd(
@@ -245,43 +194,42 @@ def flash_mla_sparse_fwd(
         - max_logits:  [s_q, h_q], float
         - lse: [s_q, h_q], float, log-sum-exp of attention scores
     """
-    is_causal = False  # turn off opt for causal sparse attention
     assert q.is_contiguous() and kv.is_contiguous() and indices.is_contiguous()
-    SQ, H, DT = q.shape
-    SKV, VG, _ = kv.shape
+    assert (
+        q.dtype == torch.bfloat16
+        and kv.dtype == torch.bfloat16
+        and indices.dtype == torch.int32
+    )
+    SQ, HQ, DQK = q.shape
+    SKV, HKV, _ = kv.shape
 
     assert d_v == 512, "Unsupported d_v"
-    D = d_v
+    DV = d_v
 
-    assert kv.shape[-1] == DT
-    TD = DT - D
-    DP = triton.next_power_of_2(D)
-    TDP = triton.next_power_of_2(TD)
-    _, _, K = indices.shape
-    assert indices.shape == (SQ, VG, K)
+    assert kv.shape[-1] == DQK
+    _, _, TOPK = indices.shape
+    assert indices.shape == (SQ, HKV, TOPK)
     if attn_sink is not None:
-        assert attn_sink.shape == (H,), "attn_sink error shape"
+        assert attn_sink.is_contiguous()
+        assert attn_sink.dtype == torch.float32
+        assert attn_sink.shape == (HQ,), "attn_sink error shape"
     if topk_length is not None:
+        assert topk_length.is_contiguous()
+        assert topk_length.dtype == torch.int32
         assert topk_length.shape == (SQ,), "topk_length error shape"
 
     # check from FlashMLA
-    assert VG == 1, "h_kv is expected to be 1"
-    assert H == 64 or H == 128, "Unsupported h_q"
-    assert DT == 576 or DT == 512, "Unsupported d_qk"
+    assert HKV == 1, "h_kv is expected to be 1"
+    assert HQ == 64 or HQ == 128, "Unsupported h_q"
+    assert DQK == 576 or DQK == 512, "Unsupported d_qk"
 
-    G = H // VG
-    BH = max(16, min(32, triton.next_power_of_2(G)))
-    NH = triton.cdiv(G, BH)
-    BK = 16  # used to be out of memory for 32
-    output = torch.zeros((SQ, H, D), device=q.device, dtype=q.dtype)
-    max_logits = torch.full(
-        (SQ, H), float("-inf"), device=q.device, dtype=torch.float32
-    )
-    lse = torch.full((SQ, H), float("-inf"), device=q.device, dtype=torch.float32)
-    INT32_MAX = 2147483647
-    q_idx_i64 = q.numel() > INT32_MAX
-    output_idx_i64 = output.numel() > INT32_MAX
-    grid = (SQ, VG * NH, 1)
+    output = torch.empty((SQ, HQ, DV), device=q.device, dtype=q.dtype)
+    max_logits = torch.empty((SQ, HQ), device=q.device, dtype=torch.float32)
+    lse = torch.empty((SQ, HQ), device=q.device, dtype=torch.float32)
+
+    def grid(META):
+        return (triton.cdiv(HQ, META["BH"]) * SQ,)
+
     triton_flash_mla_sparse_fwd[grid](
         q,
         kv,
@@ -294,35 +242,19 @@ def flash_mla_sparse_fwd(
         lse,
         q.stride(1),
         q.stride(0),
-        q.stride(2),
         kv.stride(1),
         kv.stride(0),
-        kv.stride(2),
         indices.stride(1),
         indices.stride(0),
-        indices.stride(2),
-        attn_sink.stride(0) if attn_sink is not None else 0,
-        topk_length.stride(0) if topk_length is not None else 0,
         output.stride(1),
         output.stride(0),
-        output.stride(2),
-        max_logits.stride(1),
         max_logits.stride(0),
-        lse.stride(1),
         lse.stride(0),
         SQ,
+        HQ,
+        DQK,
         SKV,
-        K,
-        D,
-        TD,
-        DP,
-        TDP,
-        G,
-        BK,
-        BH,
-        is_causal,
-        q_idx_i64,
-        output_idx_i64,
+        TOPK,
         attn_sink is not None,
         topk_length is not None,
     )


### PR DESCRIPTION
### Summary
1. use bfloat16 for mul part and float32 for acc part in dot
2. apply autotune result {BH=64, BK=64, num_wraps=8, num_stages=2} and {BH=64, BK=64, num_wraps=8, num_stages=4}
3. use topk_length to determine the num of BK slices, and remove branch in the loop
4. remove unnecessary mask in load/store
5. split the slice size of 'q', 'kv' and 'output' from '[64, 512]' into two '[64, 256]'
6. init with 'torch.empty' instead of 'torch.full'
7. use cache policy in load of 'q' and 'kv'

### Interface declaration review
```
def flash_mla_sparse_fwd(
    q: torch.Tensor,
    kv: torch.Tensor,
    indices: torch.Tensor,
    sm_scale: float,
    d_v: int = 512,
    attn_sink: Optional[torch.Tensor] = None,
    topk_length: Optional[torch.Tensor] = None,
) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
    """
    Sparse attention prefill kernel

    Args:
        q: [s_q, h_q, d_qk], bfloat16
        kv: [s_kv, h_kv, d_qk], bfloat16
        indices: [s_q, h_kv, topk], int32. Invalid indices should be set to -1 or numbers >= s_kv
        sm_scale: float
        d_v: The dimension of value vectors. Can only be 512
        attn_sink: optional, [h_q], float32.
            If attn_sink is provided, when computing output, output will be additionally multiplied by
            exp(lse) / (exp(lse) + exp(attn_sink)). +-inf in attn_sink will be handled normally (i.e., -inf has no
            effect, +inf will make corresponding output all zeros).
            This argument has no effect on lse and max_logits.
        topk_length: optional, [s_q], int32.
            If provided, the i-th q token will only attend to k tokens specified by indices[i, :, :topk_length[i]],
            ignoring later k/v tokens (even if provided in indices). In extremely rare cases (topk_length provided,
            there is a valid topk index between topk_length[i] ~ s_kv, and that topk index points to a k token
            containing NaN), operator output will contain NaN, so please avoid this situation.

    Returns:
        (output, max_logits, lse)
        Please refer to tests/ref.py for the precise definitions of these parameters.
        - output: [s_q, h_q, d_v], bfloat16
        - max_logits:  [s_q, h_q], float
        - lse: [s_q, h_q], float, log-sum-exp of attention scores
    """
```

### Performance test
- GPU: NVIDIA H100
`CUDA_VISIBLE_DEVICES=7 pytest -m flash_mla_sparse_fwd --record log --level core  benchmark/test_flash_mla_sparse_fwd.py`

### Performance vs vllm
- h_kv : 1
- d_v : 512
- sm_scale : 0.5
- attn_sink: provided
- topk_length : None

| s_q | s_kv | topk | h_q | d_qk | latency_base(ms) | latency(ms) | speed_up |
| --- | --- | --- | --- | --- | --- | --- | --- | 
| 4096 | 8192 | 2048 | 128 | 576 | 4.85145616531372 | 7.75203204154968 | 0.625830251901781 |
| 4096 | 32768 | 2048 | 128 | 576 | 4.4177918434143 | 8.34879970550537 | 0.529152932067722 |
| 4096 | 65536 | 2048 | 128 | 576 | 4.59945583343505 | 8.67833614349365 | 0.529992818598456 |
| 4096 | 98304 | 2048 | 128 | 576 | 4.70308804512023 | 9.19356822967529 | 0.511562858688475 |
| 4096 | 131072 | 2048 | 128 | 576 | 4.75680017471313 | 9.04652786254882 | 0.525815014001728 |
| 4096 | 8192 | 512 | 64 | 512 | 0.668416023254394 | 1.05564796924591 | 0.633180797697048 |
| 4096 | 32768 | 512 | 64 | 512 | 0.716575980186462 | 1.15289598703384 | 0.621544344195402 |
| 4096 | 49152 | 512 | 64 | 512 | 0.752192020416259 | 1.1825920343399 | 0.636053684258169 |
| 4096 | 65536 | 512 | 64 | 512 | 0.818240016698837 | 1.20350402593612 | 0.679881412164269 |
| 4096 | 8192 | 1024 | 128 | 512 | 2.10663998126983 | 3.76558399200439 | 0.559445755490501 |
| 4096 | 32768 | 1024 | 128 | 512 | 2.25587201118469 | 4.08828783035278 | 0.55178894069942 |
| 4096 | 49152 | 1024 | 128 | 512 | 2.34737598896026 | 4.15392017364501 | 0.565098964552433 |
| 4096 | 65536 | 1024 | 128 | 512 | 2.36156797409057 | 4.17823982238769 | 0.565206420521126 |

### Performance vs sparse mla(`src/flag_gems/fused/DSA/sparse_mla.py`)
- h_kv : 1
- d_qk : 576 (sparse mla does not support d_qk=512)
- d_v : 512
- sm_scale : 0.5
- attn_sink: None (sparse mla does not support attn_sink)
- topk_length : None

| s_q | s_kv | topk | h_q  | latency_base(ms) | latency(ms) | speed_up |
| --- | --- | --- | --- | --- | --- | --- |
| 4096 | 8192 | 2048 | 128 | 11.5872960090637 | 7.78387188911438 | 1.48862881791109 |
| 4096 | 32768 | 2048 | 128 | 9.69889593124389 | 8.43542385101318 | 1.14978169473712 |
| 4096 | 65536 | 2048 | 128 | 7.81118416786193 | 8.66003227233886 | 0.901980953675167 |
| 4096 | 98304 | 2048 | 128 | 6.60976004600524 | 8.88108825683593 | 0.744251138470287 |
| 4096 | 131072 | 2048 | 128 | 5.81571221351623 | 8.77497577667236 | 0.66276105615891 |

### Performance vs sparse mla(global attention version by set `is_causal=False` in `src/flag_gems/fused/DSA/sparse_mla.py`)
- h_kv : 1
- d_qk : 576 (sparse mla does not support d_qk=512)
- d_v : 512
- sm_scale : 0.5
- attn_sink: None (sparse mla does not support attn_sink)
- topk_length : None

| s_q | s_kv | topk | h_q  | latency_base(ms) | latency(ms) | speed_up |
| --- | --- | --- | --- | --- | --- | --- |
| 4096 | 8192 | 2048 | 128 | 12.5730562210083 | 7.77233600616455 | 1.61766761126077 |
| 4096 | 32768 | 2048 | 128 | 12.1415200233459 | 8.43052768707275 | 1.44018506006018 |
| 4096 | 65536 | 2048 | 128 | 10.8630399703979 | 8.66662406921386 | 1.25343384963313 |
| 4096 | 98304 | 2048 | 128 | 9.53264045715332 | 8.895263671875 | 1.07165350109784 |
| 4096 | 131072 | 2048 | 128 | 8.44246387481689 | 8.88611221313476 | 0.950073966243403 |


