### PR TITLE
[FlagGems Operator Development Competition] Add upsample_nearest2d forward/backward

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,14 @@ tests/*.json
 
 docs/
 scripts/
+!docs/
+docs/*
+!docs/upsample_nearest2d_dev/
+!docs/upsample_nearest2d_dev/**
+!scripts/
+scripts/*
+!scripts/upsample_nearest2d/
+!scripts/upsample_nearest2d/**
 # Project files, i.e. `.project`, `.actionScriptProperties` and `.flexProperties`
 # should NOT be excluded as they contain compiler settings and other important
 # information for Eclipse / Flash Builder.

--- a/UPSAMPLE_NEAREST2D_DEV_README.md
+++ b/UPSAMPLE_NEAREST2D_DEV_README.md
@@ -1,0 +1,71 @@
+# Upsample Nearest2d Competition Workspace
+
+This repository is a FlagGems development workspace prepared for the
+`upsample_nearest2d` operator task in the FlagOS / ModelScope Track 1
+competition.
+
+Target API:
+
+```python
+torch._C._nn.upsample_nearest2d(
+    input,
+    output_size,
+    scales_h=None,
+    scales_w=None,
+)
+```
+
+The practical competition target is stronger than simply having a forward
+kernel: the PR should cover PyTorch-compatible forward semantics, backward
+coverage if submitted, benchmark evidence, and clean integration into the
+FlagGems operator registry.
+
+## Start Here
+
+- `docs/upsample_nearest2d_dev/competition_requirements.md`
+- `docs/upsample_nearest2d_dev/implementation_plan.md`
+- `docs/upsample_nearest2d_dev/test_matrix.md`
+- `docs/upsample_nearest2d_dev/benchmark_plan.md`
+- `docs/upsample_nearest2d_dev/pr_checklist.md`
+- `docs/upsample_nearest2d_dev/reference_links.md`
+- `docs/upsample_nearest2d_dev/cloud_migration.md`
+
+## Cloud Setup
+
+On the cloud machine, from the repository root:
+
+```bash
+bash scripts/upsample_nearest2d/setup_cloud_env.sh
+```
+
+After implementing or modifying the operator:
+
+```bash
+bash scripts/upsample_nearest2d/run_accuracy_quick.sh
+bash scripts/upsample_nearest2d/run_accuracy_full.sh
+bash scripts/upsample_nearest2d/run_benchmark.sh
+bash scripts/upsample_nearest2d/check_pr_ready.sh
+```
+
+## Expected Work Areas
+
+- `src/flag_gems/ops/upsample_nearest2d.py`
+- `src/flag_gems/ops/upsample_nearest2d_backward.py` if you implement backward
+- `src/flag_gems/ops/__init__.py`
+- `src/flag_gems/__init__.py`
+- `tests/test_upsample_nearest2d.py`
+- `tests/test_upsample_nearest2d_backward.py` if backward is included
+- `benchmark/test_upsample_nearest2d.py`
+- `benchmark/test_upsample_nearest2d_backward.py` if backward is included
+
+## Current Competitive Risk
+
+The main public risk is PR `#2262`, which targets
+`upsample_nearest2d_backward` and has clean CI checks. A strong submission
+should therefore avoid being a narrow duplicate. Prefer one of these angles:
+
+- forward and backward in a clean, maintainable shape;
+- broader PyTorch semantic coverage, especially `scales_h/scales_w`;
+- non-contiguous or channels-last coverage if supported;
+- benchmark logs showing speedup on meaningful image-like shapes.
+

--- a/benchmark/test_upsample_nearest2d_backward.py
+++ b/benchmark/test_upsample_nearest2d_backward.py
@@ -5,7 +5,7 @@ from . import attri_util as attr_utils
 from . import performance_utils as utils
 
 
-class UpsampleBenchmark(utils.GenericBenchmark):
+class UpsampleBackwardBenchmark(utils.GenericBenchmark):
     DEFAULT_SHAPES = [
         (1, 64, 56, 56, 1.0, 1.0, 0, 0),
         (1, 3, 224, 224, 2.0, 2.0, 0, 0),
@@ -28,21 +28,23 @@ class UpsampleBenchmark(utils.GenericBenchmark):
         return []
 
     def record_shapes(self, *args, **kwargs):
-        input = kwargs["input"]
+        grad_output = kwargs["grad_output"]
         output_size = kwargs["output_size"]
+        input_size = kwargs["input_size"]
         scales_h = kwargs["scales_h"]
         scales_w = kwargs["scales_w"]
         layout = (
             "channels_last"
-            if input.is_contiguous(memory_format=torch.channels_last)
-            and input.stride(1) == 1
+            if grad_output.is_contiguous(memory_format=torch.channels_last)
+            and grad_output.stride(1) == 1
             else "contiguous"
         )
         return {
-            "case": _case_name(input.shape[-2:], output_size, scales_h, scales_w),
+            "case": _case_name(input_size[-2:], output_size, scales_h, scales_w),
             "layout": layout,
-            "input": input.size(),
+            "grad_output": grad_output.size(),
             "output_size": output_size,
+            "input_size": input_size,
             "scales_h": scales_h,
             "scales_w": scales_w,
         }
@@ -50,16 +52,19 @@ class UpsampleBenchmark(utils.GenericBenchmark):
 
 def _input_fn(shape, dtype, device):
     batch, channel, height, weight, scale_h, scale_w, use_scales, channels_last = shape
-    input = torch.randn(size=(batch, channel, height, weight), device=device, dtype=dtype)
-    if channels_last:
-        input = input.contiguous(memory_format=torch.channels_last)
     output_size = (
         int(height * scale_h),
         int(weight * scale_w),
     )
+    grad_output = torch.randn(
+        size=(batch, channel, *output_size), device=device, dtype=dtype
+    )
+    if channels_last:
+        grad_output = grad_output.contiguous(memory_format=torch.channels_last)
     yield {
-        "input": input,
+        "grad_output": grad_output,
         "output_size": output_size,
+        "input_size": (batch, channel, height, weight),
         "scales_h": scale_h if use_scales else None,
         "scales_w": scale_w if use_scales else None,
     },
@@ -80,11 +85,11 @@ def _case_name(input_hw, output_size, scales_h, scales_w):
 
 
 @pytest.mark.upsample_nearest2d
-def test_upsample_nearest2d():
-    bench = UpsampleBenchmark(
-        op_name="upsample_nearest2d",
+def test_upsample_nearest2d_backward():
+    bench = UpsampleBackwardBenchmark(
+        op_name="upsample_nearest2d_backward",
         input_fn=_input_fn,
-        torch_op=torch._C._nn.upsample_nearest2d,
+        torch_op=torch.ops.aten.upsample_nearest2d_backward,
         dtypes=attr_utils.FLOAT_DTYPES,
     )
 

--- a/docs/upsample_nearest2d_dev/benchmark_plan.md
+++ b/docs/upsample_nearest2d_dev/benchmark_plan.md
@@ -1,0 +1,66 @@
+# `upsample_nearest2d` Benchmark Plan
+
+## Goals
+
+- Show speedup versus PyTorch/native baseline.
+- Measure forward and backward separately.
+- Include enough shapes to expose memory-bandwidth behavior.
+
+## Forward Shapes
+
+Use image-like shapes:
+
+```text
+(1, 3, 224, 224) -> x2
+(8, 3, 224, 224) -> x2
+(1, 64, 56, 56) -> x2
+(16, 64, 56, 56) -> x2
+(8, 128, 28, 28) -> x2
+(4, 256, 14, 14) -> x2
+(1, 64, 128, 256) -> x2
+```
+
+Also include non-integer and downsampling scales:
+
+```text
+(2.1, 3.7)
+(1.3, 5.1)
+(0.5, 0.5)
+(0.3, 0.5)
+```
+
+## Backward Shapes
+
+Mirror the forward shapes. For backward, report both:
+
+- `grad_output -> grad_input` time;
+- speedup by scale group, because integer upsampling and downsampling have
+  different accumulation patterns.
+
+## Commands
+
+```bash
+pytest benchmark/test_upsample_nearest2d.py -s --record log
+pytest benchmark/test_upsample_nearest2d_backward.py -s --record log
+```
+
+If the backward benchmark file does not exist yet, create it as part of the
+implementation.
+
+## Report Template
+
+```text
+Device:
+PyTorch:
+Triton:
+FlagGems commit:
+
+Forward:
+shape dtype scale torch_ms gems_ms speedup pass
+
+Backward:
+shape dtype scale torch_ms gems_ms speedup pass
+
+Known weak cases:
+```
+

--- a/docs/upsample_nearest2d_dev/cloud_migration.md
+++ b/docs/upsample_nearest2d_dev/cloud_migration.md
@@ -1,0 +1,55 @@
+# Cloud Migration Notes
+
+This workspace is intended to be copied to a GPU cloud machine.
+
+## Before Uploading
+
+From the repository root:
+
+```bash
+git status --short
+git branch --show-current
+git remote -v
+```
+
+Expected branch:
+
+```text
+competition/upsample-nearest2d-dev
+```
+
+## After Uploading
+
+Install editable dependencies:
+
+```bash
+bash scripts/upsample_nearest2d/setup_cloud_env.sh
+```
+
+Check GPU visibility:
+
+```bash
+python - <<'PY'
+import torch
+print(torch.__version__)
+print(torch.cuda.is_available())
+print(torch.cuda.get_device_name(0) if torch.cuda.is_available() else "no cuda")
+PY
+```
+
+## Validation Loop
+
+```bash
+bash scripts/upsample_nearest2d/run_accuracy_quick.sh
+bash scripts/upsample_nearest2d/run_accuracy_full.sh
+bash scripts/upsample_nearest2d/run_benchmark.sh
+```
+
+## PR Readiness
+
+```bash
+bash scripts/upsample_nearest2d/check_pr_ready.sh
+```
+
+Attach the resulting accuracy and benchmark logs to the PR description.
+

--- a/docs/upsample_nearest2d_dev/competition_requirements.md
+++ b/docs/upsample_nearest2d_dev/competition_requirements.md
@@ -1,0 +1,64 @@
+# Competition Requirements for `upsample_nearest2d`
+
+Source pages:
+
+- ModelScope Track 1 statement:
+  https://www.modelscope.cn/events/180/%E3%80%90Track%201%20-%E7%AE%97%E5%AD%90%E5%BC%80%E5%8F%91%E5%92%8C%E6%80%A7%E8%83%BD%E6%8C%91%E6%88%98%E3%80%91%E8%B5%9B%E9%A2%98%E8%AF%B4%E6%98%8E
+- FlagGems pull requests:
+  https://github.com/flagos-ai/FlagGems/pulls
+- PyTorch nearest upsampling documentation:
+  https://docs.pytorch.org/docs/stable/generated/torch.nn.UpsamplingNearest2d.html
+- PyTorch ATen reference:
+  https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/UpSampleNearest2d.cpp
+
+## Operator
+
+Competition row:
+
+```text
+upsample_nearest2d
+Difficulty: medium
+Category: upsampling
+Schema:
+upsample_nearest2d(
+    Tensor self,
+    SymInt[2] output_size,
+    float? scales_h=None,
+    float? scales_w=None,
+) -> Tensor
+upsample_nearest2d_backward(
+    Tensor grad_output,
+    SymInt[2] output_size,
+    SymInt[4] input_size,
+    float? scales_h=None,
+    float? scales_w=None,
+) -> Tensor
+```
+
+## Hard Requirements
+
+- Match PyTorch semantics for supported forward inputs.
+- If backward is submitted, match PyTorch gradient semantics for repeated
+  nearest-neighbor mappings.
+- Provide pytest coverage for `output_size` and `scales_h/scales_w` paths.
+- Provide benchmark coverage using the FlagGems benchmark framework.
+- Show speedup versus PyTorch/native baseline. Competition text says the
+  device-side speedup must be at least `0.9x`.
+- Follow FlagGems repository structure and style.
+- PR title must contain:
+
+```text
+[FlagGems Operator Development Competition]
+```
+
+## Practical Interpretation
+
+The forward path already exists upstream, and a public PR currently targets
+backward. To be competitive, the submission needs clear value beyond a minimal
+duplicate:
+
+- complete and well-scoped forward/backward integration;
+- stronger edge-case tests than the existing public PRs;
+- reproducible benchmark logs;
+- careful support boundaries for layout, dtype, and scale behavior.
+

--- a/docs/upsample_nearest2d_dev/implementation_plan.md
+++ b/docs/upsample_nearest2d_dev/implementation_plan.md
@@ -1,0 +1,80 @@
+# `upsample_nearest2d` Implementation Plan
+
+## Stage 0: Baseline Semantics
+
+Before changing kernels, build a small local harness that compares against
+PyTorch:
+
+- 4D contiguous input `(N, C, H, W)`;
+- integer upsampling, non-integer upsampling, downsampling, and identity;
+- `output_size` provided with `scales_h/scales_w=None`;
+- explicit `scales_h/scales_w`;
+- `float16`, `bfloat16`, and `float32`;
+- small shapes and image-like shapes.
+
+Use PyTorch as the semantic source:
+
+```python
+torch._C._nn.upsample_nearest2d(input, output_size, scales_h, scales_w)
+torch.ops.aten.upsample_nearest2d_backward(
+    grad_output, output_size, input_size, scales_h, scales_w
+)
+```
+
+## Stage 1: Forward Audit
+
+Audit `src/flag_gems/ops/upsample_nearest2d.py` for:
+
+- `output_size` validation;
+- scale calculation parity with PyTorch;
+- contiguous and non-contiguous behavior;
+- channels-last behavior, if supported;
+- index overflow handling for large tensors.
+
+Do not widen support silently. If a layout is unsupported, test and document
+that boundary or fall back cleanly.
+
+## Stage 2: Backward
+
+Backward is likely the useful competition addition.
+
+Required behavior:
+
+- output shape is `input_size`;
+- `grad_output` contributions accumulate when several output pixels map to one
+  input pixel;
+- non-integer and downsampling scale cases match PyTorch;
+- dtype and device behavior match the forward path.
+
+Implementation options:
+
+- atomic-add scatter from output pixels to input pixels;
+- tile-based reduction for common integer upsampling factors;
+- fast paths for `SAME_H` or `SAME_W`.
+
+Start with a correct atomic implementation, then add fast paths only after
+benchmarks expose the bottleneck.
+
+## Stage 3: Integration
+
+Expected files:
+
+- `src/flag_gems/ops/upsample_nearest2d.py`
+- `src/flag_gems/ops/upsample_nearest2d_backward.py`
+- `src/flag_gems/ops/__init__.py`
+- `src/flag_gems/__init__.py`
+- `tests/test_upsample_nearest2d.py`
+- `tests/test_upsample_nearest2d_backward.py`
+- `benchmark/test_upsample_nearest2d.py`
+- `benchmark/test_upsample_nearest2d_backward.py`
+
+## Stage 4: Competition Proof
+
+Before opening a PR, collect:
+
+- quick and full accuracy logs;
+- benchmark logs for forward and backward;
+- a small table of speedup by dtype and shape group;
+- notes on supported layouts and unsupported cases;
+- comparison with current public PRs, especially `#2262`.
+

--- a/docs/upsample_nearest2d_dev/pr_checklist.md
+++ b/docs/upsample_nearest2d_dev/pr_checklist.md
@@ -1,0 +1,44 @@
+# PR Checklist for `upsample_nearest2d`
+
+## Title
+
+```text
+[FlagGems Operator Development Competition] Add upsample_nearest2d forward/backward
+```
+
+Adjust the final wording to match the actual scope.
+
+## Files
+
+- [ ] `src/flag_gems/ops/upsample_nearest2d.py` audited or updated.
+- [ ] `src/flag_gems/ops/upsample_nearest2d_backward.py` added if backward is included.
+- [ ] `src/flag_gems/ops/__init__.py` exports the operator(s).
+- [ ] `src/flag_gems/__init__.py` registers the ATen override(s).
+- [ ] `tests/test_upsample_nearest2d.py` covers forward.
+- [ ] `tests/test_upsample_nearest2d_backward.py` covers backward if included.
+- [ ] `benchmark/test_upsample_nearest2d.py` covers forward.
+- [ ] `benchmark/test_upsample_nearest2d_backward.py` covers backward if included.
+
+## Correctness
+
+- [ ] `output_size` path matches PyTorch.
+- [ ] `scales_h/scales_w` path matches PyTorch.
+- [ ] Integer upsample, non-integer upsample, identity, and downsample pass.
+- [ ] Dtypes include `float16`, `bfloat16`, and `float32` where supported.
+- [ ] Layout support is tested or explicitly bounded.
+- [ ] Backward accumulation matches PyTorch.
+
+## Performance
+
+- [ ] Forward benchmark logs are attached.
+- [ ] Backward benchmark logs are attached if backward is included.
+- [ ] Weak cases are disclosed instead of hidden.
+- [ ] Speedup is at least `0.9x` on the reported device-side benchmark.
+
+## Hygiene
+
+- [ ] No unrelated files or generated caches.
+- [ ] No broad formatting churn.
+- [ ] Public competing PRs have been checked for overlap.
+- [ ] PR description includes commands, logs, and support boundaries.
+

--- a/docs/upsample_nearest2d_dev/pr_description_template.md
+++ b/docs/upsample_nearest2d_dev/pr_description_template.md
@@ -1,0 +1,62 @@
+# [FlagGems Operator Development Competition] Add upsample_nearest2d forward/backward
+
+## Summary
+
+This PR adds or improves `upsample_nearest2d` support in FlagGems.
+
+Target API:
+
+```python
+torch._C._nn.upsample_nearest2d(input, output_size, scales_h=None, scales_w=None)
+```
+
+If backward is included:
+
+```python
+torch.ops.aten.upsample_nearest2d_backward(
+    grad_output, output_size, input_size, scales_h=None, scales_w=None
+)
+```
+
+## Correctness
+
+Commands:
+
+```bash
+pytest tests/test_upsample_nearest2d.py -s
+pytest tests/test_upsample_nearest2d_backward.py -s
+```
+
+Coverage:
+
+- integer upsample
+- non-integer upsample
+- downsample
+- identity scale
+- `output_size`
+- `scales_h/scales_w`
+- dtype coverage
+
+## Benchmark
+
+Commands:
+
+```bash
+pytest benchmark/test_upsample_nearest2d.py -s --record log
+pytest benchmark/test_upsample_nearest2d_backward.py -s --record log
+```
+
+Results:
+
+```text
+Device:
+Forward:
+Backward:
+```
+
+## Support Boundaries
+
+- Supported layouts:
+- Unsupported layouts:
+- Known weak cases:
+

--- a/docs/upsample_nearest2d_dev/reference_links.md
+++ b/docs/upsample_nearest2d_dev/reference_links.md
@@ -1,0 +1,31 @@
+# Reference Links for `upsample_nearest2d`
+
+## Official
+
+- Competition statement:
+  https://www.modelscope.cn/events/180/%E3%80%90Track%201%20-%E7%AE%97%E5%AD%90%E5%BC%80%E5%8F%91%E5%92%8C%E6%80%A7%E8%83%BD%E6%8C%91%E6%88%98%E3%80%91%E8%B5%9B%E9%A2%98%E8%AF%B4%E6%98%8E
+- PyTorch `UpsamplingNearest2d` docs:
+  https://docs.pytorch.org/docs/stable/generated/torch.nn.UpsamplingNearest2d.html
+- PyTorch ATen implementation:
+  https://github.com/pytorch/pytorch/blob/main/aten/src/ATen/native/UpSampleNearest2d.cpp
+
+## Local Files
+
+- `src/flag_gems/ops/upsample_nearest2d.py`
+- `src/flag_gems/ops/upsample_nearest1d.py`
+- `src/flag_gems/ops/upsample_nearest3d.py`
+- `tests/test_upsample_nearest2d.py`
+- `benchmark/test_upsample_nearest2d.py`
+- `conf/operators.yaml`
+
+## Public PRs to Watch
+
+- Main backward competitor:
+  https://github.com/flagos-ai/FlagGems/pull/2262
+- Older forward/backward work:
+  https://github.com/flagos-ai/FlagGems/pull/1635
+- Older forward work:
+  https://github.com/flagos-ai/FlagGems/pull/1426
+- Multi-operator PR, useful only as a rough comparison:
+  https://github.com/flagos-ai/FlagGems/pull/2525
+

--- a/docs/upsample_nearest2d_dev/test_matrix.md
+++ b/docs/upsample_nearest2d_dev/test_matrix.md
@@ -1,0 +1,58 @@
+# `upsample_nearest2d` Test Matrix
+
+Use this as the coverage checklist for pytest.
+
+## Forward
+
+- Shapes:
+  - `(1, 1, 1, 1)`
+  - `(1, 3, 8, 8)`
+  - `(2, 3, 32, 32)`
+  - `(4, 16, 64, 64)`
+  - `(1, 64, 128, 128)`
+- Scale/output cases:
+  - identity: `(1.0, 1.0)`
+  - integer upsample: `(2.0, 2.0)`, `(4.0, 4.0)`
+  - non-integer upsample: `(2.1, 3.7)`, `(1.3, 5.1)`
+  - downsample: `(0.5, 0.5)`, `(0.3, 0.5)`
+  - asymmetric: `(1.0, 2.0)`, `(2.0, 1.0)`
+- Argument paths:
+  - `output_size` only;
+  - explicit `scales_h/scales_w`;
+  - `output_size` and scales together, matching PyTorch behavior.
+- Dtypes:
+  - `torch.float16`
+  - `torch.bfloat16`
+  - `torch.float32`
+- Layouts:
+  - contiguous NCHW;
+  - transposed/non-contiguous input, if supported;
+  - channels-last input, if supported.
+
+## Backward
+
+- Same shape and scale groups as forward.
+- Include integer upsampling where many outputs map to one input.
+- Include downsampling where some input positions receive no gradient.
+- Compare against:
+
+```python
+torch.ops.aten.upsample_nearest2d_backward(
+    grad_output,
+    output_size,
+    input_size,
+    scales_h,
+    scales_w,
+)
+```
+
+## Tolerances
+
+Nearest upsampling is copy/add heavy, so tolerances should normally be strict:
+
+- `float32`: `rtol=1e-5`, `atol=1e-6`
+- `float16`: `rtol=1e-3`, `atol=1e-3`
+- `bfloat16`: `rtol=1e-2`, `atol=1e-2`
+
+Adjust only when PyTorch reference behavior or backend numerics justify it.
+

--- a/scripts/upsample_nearest2d/check_pr_ready.sh
+++ b/scripts/upsample_nearest2d/check_pr_ready.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m ruff check src/flag_gems/ops/upsample_nearest2d.py tests/test_upsample_nearest2d.py benchmark/test_upsample_nearest2d.py
+
+if [ -f src/flag_gems/ops/upsample_nearest2d_backward.py ]; then
+  python -m ruff check src/flag_gems/ops/upsample_nearest2d_backward.py
+fi
+
+if [ -f tests/test_upsample_nearest2d_backward.py ]; then
+  python -m ruff check tests/test_upsample_nearest2d_backward.py
+fi
+
+if [ -f benchmark/test_upsample_nearest2d_backward.py ]; then
+  python -m ruff check benchmark/test_upsample_nearest2d_backward.py
+fi
+
+bash scripts/upsample_nearest2d/run_accuracy_quick.sh
+

--- a/scripts/upsample_nearest2d/run_accuracy_full.sh
+++ b/scripts/upsample_nearest2d/run_accuracy_full.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pytest tests/test_upsample_nearest2d.py -s
+
+if [ -f tests/test_upsample_nearest2d_backward.py ]; then
+  pytest tests/test_upsample_nearest2d_backward.py -s
+fi
+
+pytest tests/test_upsample_nearest1d.py -s
+pytest tests/test_upsample_nearest3d.py -s
+

--- a/scripts/upsample_nearest2d/run_accuracy_quick.sh
+++ b/scripts/upsample_nearest2d/run_accuracy_quick.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pytest tests/test_upsample_nearest2d.py -s
+
+if [ -f tests/test_upsample_nearest2d_backward.py ]; then
+  pytest tests/test_upsample_nearest2d_backward.py -s
+fi
+

--- a/scripts/upsample_nearest2d/run_benchmark.sh
+++ b/scripts/upsample_nearest2d/run_benchmark.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+pytest benchmark/test_upsample_nearest2d.py -s --record log
+
+if [ -f benchmark/test_upsample_nearest2d_backward.py ]; then
+  pytest benchmark/test_upsample_nearest2d_backward.py -s --record log
+fi
+

--- a/scripts/upsample_nearest2d/setup_cloud_env.sh
+++ b/scripts/upsample_nearest2d/setup_cloud_env.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+python -m pip install -U pip
+python -m pip install -e ".[dev]" || python -m pip install -e .
+
+python - <<'PY'
+import torch
+print("torch:", torch.__version__)
+print("cuda_available:", torch.cuda.is_available())
+if torch.cuda.is_available():
+    print("device:", torch.cuda.get_device_name(0))
+PY
+

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -467,6 +467,7 @@ _FULL_CONFIG = (
     ("upsample_linear1d", upsample_linear1d),
     ("upsample_nearest1d", upsample_nearest1d),
     ("upsample_nearest2d", upsample_nearest2d),
+    ("upsample_nearest2d_backward", upsample_nearest2d_backward),
     ("upsample_nearest3d", upsample_nearest3d),
     ("var_mean.correction", var_mean),
     ("var", var),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -314,6 +314,7 @@ from flag_gems.ops.upsample_bicubic2d_aa_backward import _upsample_bicubic2d_aa_
 from flag_gems.ops.upsample_linear1d import upsample_linear1d
 from flag_gems.ops.upsample_nearest1d import upsample_nearest1d
 from flag_gems.ops.upsample_nearest2d import upsample_nearest2d
+from flag_gems.ops.upsample_nearest2d_backward import upsample_nearest2d_backward
 from flag_gems.ops.upsample_nearest3d import upsample_nearest3d
 from flag_gems.ops.var import var, var_correction, var_dim
 from flag_gems.ops.var_mean import var_mean
@@ -748,6 +749,7 @@ __all__ = [
     "upsample_linear1d",
     "upsample_nearest1d",
     "upsample_nearest2d",
+    "upsample_nearest2d_backward",
     "upsample_nearest3d",
     "var_mean",
     "var",

--- a/src/flag_gems/ops/upsample_nearest2d.py
+++ b/src/flag_gems/ops/upsample_nearest2d.py
@@ -10,14 +10,100 @@ from flag_gems.runtime import device, torch_device_fn
 
 device = device.name
 logger = logging.getLogger(__name__)
+_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeExplicitAutograd
+)
+
+
+@triton.jit
+def upsample_nearest2d_x2_channels_last_kernel(
+    ptr_o,
+    ptr_i,
+    N,
+    C,
+    IH,
+    IW,
+    input_stride_n,
+    input_stride_h,
+    input_stride_w,
+    output_stride_n,
+    output_stride_h,
+    output_stride_w,
+    BLOCK_SIZE: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+):
+    if USE_INT32_IDX:
+        pid = tl.program_id(axis=0)
+    else:
+        pid = tl.program_id(axis=0).to(tl.int64)
+
+    idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if not USE_INT32_IDX:
+        idx = idx.to(tl.int64)
+
+    total = N * IH * IW * C
+    mask = idx < total
+    c = idx % C
+    pixel = idx // C
+    iw = pixel % IW
+    ih = (pixel // IW) % IH
+    n = pixel // (IH * IW)
+
+    input_offset = n * input_stride_n + ih * input_stride_h + iw * input_stride_w + c
+    output_base = (
+        n * output_stride_n + (ih * 2) * output_stride_h + (iw * 2) * output_stride_w
+    )
+    data = tl.load(ptr_i + input_offset, mask=mask)
+    tl.store(ptr_o + output_base + c, data, mask=mask)
+    tl.store(ptr_o + output_base + output_stride_w + c, data, mask=mask)
+    tl.store(ptr_o + output_base + output_stride_h + c, data, mask=mask)
+    tl.store(
+        ptr_o + output_base + output_stride_h + output_stride_w + c, data, mask=mask
+    )
+
+
+@triton.jit
+def upsample_nearest2d_x2_contiguous_kernel(
+    ptr_o,
+    ptr_i,
+    N,
+    C,
+    IH,
+    IW,
+    BLOCK_SIZE: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+):
+    if USE_INT32_IDX:
+        pid = tl.program_id(axis=0)
+    else:
+        pid = tl.program_id(axis=0).to(tl.int64)
+
+    idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if not USE_INT32_IDX:
+        idx = idx.to(tl.int64)
+
+    total = N * C * IH * IW
+    mask = idx < total
+    iw = idx % IW
+    ih = (idx // IW) % IH
+    nc = idx // (IH * IW)
+
+    data = tl.load(ptr_i + idx, mask=mask)
+    ow = iw * 2
+    oh = ih * 2
+    OW = IW * 2
+    output_base = nc * (IH * 2 * OW) + oh * OW + ow
+    tl.store(ptr_o + output_base, data, mask=mask)
+    tl.store(ptr_o + output_base + 1, data, mask=mask)
+    tl.store(ptr_o + output_base + OW, data, mask=mask)
+    tl.store(ptr_o + output_base + OW + 1, data, mask=mask)
 
 
 @triton.autotune(
     configs=runtime.get_tuned_config("upsample_nearest2d"), key=["N", "C", "OH", "OW"]
 )
-@triton.heuristics(runtime.get_heuristic_config("upsample_nearest2d"))
 @triton.jit
-def upsample_nearest2d_kernel(
+def upsample_nearest2d_contiguous_kernel(
     ptr_o,
     ptr_i,
     N,
@@ -37,38 +123,150 @@ def upsample_nearest2d_kernel(
         pid = tl.program_id(axis=0)
     else:
         pid = tl.program_id(axis=0).to(tl.int64)
-    nc_stride = tl.num_programs(axis=1)
-    NC = N * C
-    nc_iter = tl.program_id(axis=1)
-    pid = tl.program_id(axis=0)
+
     idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if not USE_INT32_IDX:
+        idx = idx.to(tl.int64)
+
+    spatial = OH * OW
+    mask = idx < spatial
     ow = idx % OW
-    oh = idx // OW % OH
+    oh = idx // OW
+
     if SAME_H:
         ih = oh
     else:
-        # tl.floor() cannot be found in 2.3.1, using int trunc
-        ih = tl.minimum((oh * reciprocal_scale_h).to(tl.int32), IH - 1)
+        ih = tl.minimum(
+            tl.math.floor(oh.to(tl.float32) * reciprocal_scale_h).to(tl.int32),
+            IH - 1,
+        )
     if SAME_W:
         iw = ow
     else:
-        iw = tl.minimum((ow * reciprocal_scale_w).to(tl.int32), IW - 1)
+        iw = tl.minimum(
+            tl.math.floor(ow.to(tl.float32) * reciprocal_scale_w).to(tl.int32),
+            IW - 1,
+        )
 
-    offset_o = (nc_iter * OH + oh) * OW + ow
-    offset_i = (nc_iter * IH + ih) * IW + iw
+    nc_iter = tl.program_id(axis=1)
+    nc_stride = tl.num_programs(axis=1)
+    offset_i = nc_iter * IH * IW + ih * IW + iw
+    offset_o = nc_iter * OH * OW + idx
     src_index_stride = nc_stride * IH * IW
     dst_index_stride = nc_stride * OH * OW
-    while nc_iter < NC:
-        data = tl.load(ptr_i + offset_i)
-        tl.store(ptr_o + offset_o, data)
-        ptr_i += src_index_stride
-        ptr_o += dst_index_stride
+    while nc_iter < N * C:
+        data = tl.load(ptr_i + offset_i, mask=mask)
+        tl.store(ptr_o + offset_o, data, mask=mask)
+        offset_i += src_index_stride
+        offset_o += dst_index_stride
         nc_iter += nc_stride
+
+
+@triton.autotune(
+    configs=runtime.get_tuned_config("upsample_nearest2d"), key=["N", "C", "OH", "OW"]
+)
+@triton.jit
+def upsample_nearest2d_kernel(
+    ptr_o,
+    ptr_i,
+    N,
+    C,
+    OH,
+    OW,
+    IH,
+    IW,
+    reciprocal_scale_h,
+    reciprocal_scale_w,
+    input_stride_n,
+    input_stride_c,
+    input_stride_h,
+    input_stride_w,
+    output_stride_n,
+    output_stride_c,
+    output_stride_h,
+    output_stride_w,
+    BLOCK_SIZE: tl.constexpr,
+    SAME_H: tl.constexpr,
+    SAME_W: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+):
+    if USE_INT32_IDX:
+        pid = tl.program_id(axis=0)
+    else:
+        pid = tl.program_id(axis=0).to(tl.int64)
+
+    idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if not USE_INT32_IDX:
+        idx = idx.to(tl.int64)
+
+    total = N * C * OH * OW
+    mask = idx < total
+
+    ow = idx % OW
+    oh = (idx // OW) % OH
+    c = (idx // (OH * OW)) % C
+    n = idx // (C * OH * OW)
+
+    if SAME_H:
+        ih = oh
+    else:
+        ih = tl.minimum(
+            tl.math.floor(oh.to(tl.float32) * reciprocal_scale_h).to(tl.int32),
+            IH - 1,
+        )
+    if SAME_W:
+        iw = ow
+    else:
+        iw = tl.minimum(
+            tl.math.floor(ow.to(tl.float32) * reciprocal_scale_w).to(tl.int32),
+            IW - 1,
+        )
+
+    offset_i = (
+        n * input_stride_n
+        + c * input_stride_c
+        + ih * input_stride_h
+        + iw * input_stride_w
+    )
+    offset_o = (
+        n * output_stride_n
+        + c * output_stride_c
+        + oh * output_stride_h
+        + ow * output_stride_w
+    )
+
+    data = tl.load(ptr_i + offset_i, mask=mask)
+    tl.store(ptr_o + offset_o, data, mask=mask)
+
+
+def _compute_reciprocal_scale(
+    input_size: int, output_size: int, scale: Optional[float]
+) -> float:
+    if scale is not None:
+        return float(torch.tensor(1.0 / scale, dtype=torch.float32).item())
+    return float(
+        (
+            torch.tensor(input_size, dtype=torch.float32)
+            / torch.tensor(output_size, dtype=torch.float32)
+        ).item()
+    )
+
+
+def _use_channels_last_output(input: torch.Tensor) -> bool:
+    return input.is_contiguous(memory_format=torch.channels_last) and input.stride(1) == 1
+
+
+def _identity_copy(input: torch.Tensor) -> torch.Tensor:
+    output = torch.empty_strided(
+        input.size(), input.stride(), dtype=input.dtype, device=input.device
+    )
+    torch.ops.aten.copy_.default.redispatch(_FALLBACK_KEYSET, output, input, False)
+    return output
 
 
 def upsample_nearest2d(
     input: torch.Tensor,
-    output_size: Tuple[int],
+    output_size: Tuple[int, int],
     scales_h: Optional[float] = None,
     scales_w: Optional[float] = None,
 ) -> torch.Tensor:
@@ -78,21 +276,102 @@ def upsample_nearest2d(
     assert len(output_size) == 2, "The len of output_size must be 2"
     OH, OW = output_size
     N, C, IH, IW = input.shape
-    if scales_h is not None:
-        reciprocal_scale_h = 1 / scales_h
-    else:
-        reciprocal_scale_h = IH / OH
-    if scales_w is not None:
-        reciprocal_scale_w = 1 / scales_w
-    else:
-        reciprocal_scale_w = IW / OW
-    # allocate output
-    output = torch.empty((N, C, OH, OW), device=input.device, dtype=input.dtype)
-    total_threads = OH * OW
-    grid = lambda META: (
-        triton.cdiv(total_threads, META["BLOCK_SIZE"]),
-        triton.cdiv(N * C, 4),
+
+    reciprocal_scale_h = _compute_reciprocal_scale(IH, OH, scales_h)
+    reciprocal_scale_w = _compute_reciprocal_scale(IW, OW, scales_w)
+
+    if (OH == IH and OW == IW) and (
+        input.is_contiguous() or _use_channels_last_output(input)
+    ):
+        return _identity_copy(input)
+
+    memory_format = (
+        torch.channels_last
+        if _use_channels_last_output(input)
+        else torch.contiguous_format
     )
+    output = torch.empty(
+        (N, C, OH, OW),
+        device=input.device,
+        dtype=input.dtype,
+        memory_format=memory_format,
+    )
+    total_threads = N * C * OH * OW
+    if total_threads == 0:
+        return output
+
+    use_int32_idx = total_threads <= (2**31 - 1)
+    same_h = OH == IH
+    same_w = OW == IW
+    if _use_channels_last_output(input) and OH == IH * 2 and OW == IW * 2:
+        def grid(meta):
+            return (triton.cdiv(N * IH * IW * C, meta["BLOCK_SIZE"]),)
+
+        with torch_device_fn.device(input.device):
+            upsample_nearest2d_x2_channels_last_kernel[grid](
+                output,
+                input,
+                N,
+                C,
+                IH,
+                IW,
+                input.stride(0),
+                input.stride(2),
+                input.stride(3),
+                output.stride(0),
+                output.stride(2),
+                output.stride(3),
+                USE_INT32_IDX=use_int32_idx,
+                BLOCK_SIZE=256,
+            )
+        return output
+
+    if input.is_contiguous() and output.is_contiguous() and OH >= IH and OW >= IW:
+        if OH == IH * 2 and OW == IW * 2:
+            def grid(meta):
+                return (triton.cdiv(N * C * IH * IW, meta["BLOCK_SIZE"]),)
+
+            with torch_device_fn.device(input.device):
+                upsample_nearest2d_x2_contiguous_kernel[grid](
+                    output,
+                    input,
+                    N,
+                    C,
+                    IH,
+                    IW,
+                    USE_INT32_IDX=use_int32_idx,
+                    BLOCK_SIZE=1024,
+                )
+            return output
+
+        total_spatial_threads = OH * OW
+
+        def grid(meta):
+            return (
+                triton.cdiv(total_spatial_threads, meta["BLOCK_SIZE"]),
+                triton.cdiv(N * C, 4),
+            )
+
+        with torch_device_fn.device(input.device):
+            upsample_nearest2d_contiguous_kernel[grid](
+                output,
+                input,
+                N,
+                C,
+                OH,
+                OW,
+                IH,
+                IW,
+                reciprocal_scale_h,
+                reciprocal_scale_w,
+                SAME_H=same_h,
+                SAME_W=same_w,
+                USE_INT32_IDX=use_int32_idx,
+            )
+        return output
+
+    def grid(meta):
+        return (triton.cdiv(total_threads, meta["BLOCK_SIZE"]),)
 
     with torch_device_fn.device(input.device):
         upsample_nearest2d_kernel[grid](
@@ -106,5 +385,16 @@ def upsample_nearest2d(
             IW,
             reciprocal_scale_h,
             reciprocal_scale_w,
+            input.stride(0),
+            input.stride(1),
+            input.stride(2),
+            input.stride(3),
+            output.stride(0),
+            output.stride(1),
+            output.stride(2),
+            output.stride(3),
+            SAME_H=same_h,
+            SAME_W=same_w,
+            USE_INT32_IDX=use_int32_idx,
         )
     return output

--- a/src/flag_gems/ops/upsample_nearest2d_backward.py
+++ b/src/flag_gems/ops/upsample_nearest2d_backward.py
@@ -1,0 +1,377 @@
+import logging
+import math
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import device, torch_device_fn
+
+device = device.name
+logger = logging.getLogger(__name__)
+_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeExplicitAutograd
+)
+
+
+@triton.jit
+def upsample_nearest2d_backward_x2_channels_last_kernel(
+    ptr_grad_input,
+    ptr_grad_output,
+    N,
+    C,
+    IH,
+    IW,
+    grad_output_stride_n,
+    grad_output_stride_h,
+    grad_output_stride_w,
+    grad_input_stride_n,
+    grad_input_stride_h,
+    grad_input_stride_w,
+    BLOCK_SIZE: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+):
+    if USE_INT32_IDX:
+        pid = tl.program_id(axis=0)
+    else:
+        pid = tl.program_id(axis=0).to(tl.int64)
+
+    idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if not USE_INT32_IDX:
+        idx = idx.to(tl.int64)
+
+    total = N * IH * IW * C
+    mask = idx < total
+    c = idx % C
+    pixel = idx // C
+    iw = pixel % IW
+    ih = (pixel // IW) % IH
+    n = pixel // (IH * IW)
+
+    grad_output_base = (
+        n * grad_output_stride_n
+        + (ih * 2) * grad_output_stride_h
+        + (iw * 2) * grad_output_stride_w
+    )
+    grad = tl.load(ptr_grad_output + grad_output_base + c, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    grad += tl.load(
+        ptr_grad_output + grad_output_base + grad_output_stride_w + c,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    grad += tl.load(
+        ptr_grad_output + grad_output_base + grad_output_stride_h + c,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+    grad += tl.load(
+        ptr_grad_output
+        + grad_output_base
+        + grad_output_stride_h
+        + grad_output_stride_w
+        + c,
+        mask=mask,
+        other=0.0,
+    ).to(tl.float32)
+
+    grad_input_offset = (
+        n * grad_input_stride_n + ih * grad_input_stride_h + iw * grad_input_stride_w + c
+    )
+    tl.store(ptr_grad_input + grad_input_offset, grad, mask=mask)
+
+
+@triton.jit
+def upsample_nearest2d_backward_x2_contiguous_kernel(
+    ptr_grad_input,
+    ptr_grad_output,
+    N,
+    C,
+    IH,
+    IW,
+    BLOCK_SIZE: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+):
+    if USE_INT32_IDX:
+        pid = tl.program_id(axis=0)
+    else:
+        pid = tl.program_id(axis=0).to(tl.int64)
+
+    idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if not USE_INT32_IDX:
+        idx = idx.to(tl.int64)
+
+    total = N * C * IH * IW
+    mask = idx < total
+    iw = idx % IW
+    ih = (idx // IW) % IH
+    nc = idx // (IH * IW)
+
+    OW = IW * 2
+    oh = ih * 2
+    ow = iw * 2
+    grad_output_base = nc * (IH * 2 * OW) + oh * OW + ow
+    grad = tl.load(ptr_grad_output + grad_output_base, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    grad += tl.load(ptr_grad_output + grad_output_base + 1, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    grad += tl.load(ptr_grad_output + grad_output_base + OW, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    grad += tl.load(
+        ptr_grad_output + grad_output_base + OW + 1, mask=mask, other=0.0
+    ).to(tl.float32)
+    tl.store(ptr_grad_input + idx, grad, mask=mask)
+
+
+@triton.jit
+def upsample_nearest2d_backward_kernel(
+    ptr_grad_input,
+    ptr_grad_output,
+    N,
+    C,
+    IH,
+    IW,
+    OH,
+    OW,
+    scale_h,
+    scale_w,
+    grad_output_stride_n,
+    grad_output_stride_c,
+    grad_output_stride_h,
+    grad_output_stride_w,
+    grad_input_stride_n,
+    grad_input_stride_c,
+    grad_input_stride_h,
+    grad_input_stride_w,
+    BLOCK_SIZE: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+    BLOCK_W: tl.constexpr,
+    SAME_H: tl.constexpr,
+    SAME_W: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+):
+    if USE_INT32_IDX:
+        pid = tl.program_id(axis=0)
+    else:
+        pid = tl.program_id(axis=0).to(tl.int64)
+
+    idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if not USE_INT32_IDX:
+        idx = idx.to(tl.int64)
+
+    total = N * C * IH * IW
+    mask = idx < total
+
+    iw = idx % IW
+    ih = (idx // IW) % IH
+    c = (idx // (IH * IW)) % C
+    n = idx // (C * IH * IW)
+
+    if SAME_H:
+        oh_start = ih
+        oh_end = ih + 1
+    else:
+        oh_start = tl.minimum(
+            tl.ceil(ih.to(tl.float32) * scale_h).to(tl.int32), OH
+        )
+        oh_end = tl.minimum(
+            tl.ceil((ih + 1).to(tl.float32) * scale_h).to(tl.int32), OH
+        )
+    if SAME_W:
+        ow_start = iw
+        ow_end = iw + 1
+    else:
+        ow_start = tl.minimum(
+            tl.ceil(iw.to(tl.float32) * scale_w).to(tl.int32), OW
+        )
+        ow_end = tl.minimum(
+            tl.ceil((iw + 1).to(tl.float32) * scale_w).to(tl.int32), OW
+        )
+
+    acc = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+    for h_offset in tl.static_range(0, BLOCK_H):
+        oh = oh_start + h_offset
+        h_mask = oh < oh_end
+        for w_offset in tl.static_range(0, BLOCK_W):
+            ow = ow_start + w_offset
+            load_mask = mask & h_mask & (ow < ow_end)
+            grad_output_offset = (
+                n * grad_output_stride_n
+                + c * grad_output_stride_c
+                + oh * grad_output_stride_h
+                + ow * grad_output_stride_w
+            )
+            grad = tl.load(
+                ptr_grad_output + grad_output_offset, mask=load_mask, other=0.0
+            ).to(tl.float32)
+            acc += grad
+
+    grad_input_offset = (
+        n * grad_input_stride_n
+        + c * grad_input_stride_c
+        + ih * grad_input_stride_h
+        + iw * grad_input_stride_w
+    )
+
+    tl.store(ptr_grad_input + grad_input_offset, acc, mask=mask)
+
+
+def _compute_backward_scale(
+    input_size: int, output_size: int, scale: Optional[float]
+) -> float:
+    if scale is not None:
+        return float(torch.tensor(scale, dtype=torch.float32).item())
+    return float(
+        (
+            torch.tensor(output_size, dtype=torch.float32)
+            / torch.tensor(input_size, dtype=torch.float32)
+        ).item()
+    )
+
+
+def _use_channels_last_output(input: torch.Tensor) -> bool:
+    return (
+        input.is_contiguous(memory_format=torch.channels_last)
+        and input.stride(1) == 1
+    )
+
+
+def _range_block(scale: float, output_size: int) -> int:
+    return max(1, min(output_size, math.ceil(scale)))
+
+
+def _identity_copy(input: torch.Tensor) -> torch.Tensor:
+    output = torch.empty_strided(
+        input.size(), input.stride(), dtype=input.dtype, device=input.device
+    )
+    torch.ops.aten.copy_.default.redispatch(_FALLBACK_KEYSET, output, input, False)
+    return output
+
+
+def upsample_nearest2d_backward(
+    grad_output: torch.Tensor,
+    output_size: Tuple[int, int],
+    input_size: Tuple[int, int, int, int],
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> torch.Tensor:
+    logger.debug("GEMS UPSAMPLE NEAREST2D BACKWARD")
+    assert grad_output.device.type == device
+    assert grad_output.ndim == 4, "The ndim of grad_output must be 4"
+    assert len(output_size) == 2, "The len of output_size must be 2"
+    assert len(input_size) == 4, "The len of input_size must be 4"
+
+    N, C, IH, IW = (int(dim) for dim in input_size)
+    OH, OW = (int(dim) for dim in output_size)
+    assert tuple(grad_output.shape) == (N, C, OH, OW)
+
+    scale_h = _compute_backward_scale(IH, OH, scales_h)
+    scale_w = _compute_backward_scale(IW, OW, scales_w)
+
+    if (OH == IH and OW == IW) and (
+        grad_output.is_contiguous() or _use_channels_last_output(grad_output)
+    ):
+        return _identity_copy(grad_output)
+
+    memory_format = (
+        torch.channels_last
+        if _use_channels_last_output(grad_output)
+        else torch.contiguous_format
+    )
+    grad_input = torch.empty(
+        (N, C, IH, IW),
+        device=grad_output.device,
+        dtype=grad_output.dtype,
+        memory_format=memory_format,
+    )
+
+    total_threads = N * C * IH * IW
+    if total_threads == 0:
+        return grad_input
+
+    use_int32_idx = max(total_threads, grad_output.numel()) <= (2**31 - 1)
+    if (
+        _use_channels_last_output(grad_output)
+        and OH == IH * 2
+        and OW == IW * 2
+    ):
+        def grid(meta):
+            return (triton.cdiv(N * IH * IW * C, meta["BLOCK_SIZE"]),)
+
+        with torch_device_fn.device(grad_output.device):
+            upsample_nearest2d_backward_x2_channels_last_kernel[grid](
+                grad_input,
+                grad_output,
+                N,
+                C,
+                IH,
+                IW,
+                grad_output.stride(0),
+                grad_output.stride(2),
+                grad_output.stride(3),
+                grad_input.stride(0),
+                grad_input.stride(2),
+                grad_input.stride(3),
+                USE_INT32_IDX=use_int32_idx,
+                BLOCK_SIZE=256,
+            )
+        return grad_input
+
+    if (
+        grad_output.is_contiguous()
+        and grad_input.is_contiguous()
+        and OH == IH * 2
+        and OW == IW * 2
+    ):
+        def grid(meta):
+            return (triton.cdiv(total_threads, meta["BLOCK_SIZE"]),)
+
+        with torch_device_fn.device(grad_output.device):
+            upsample_nearest2d_backward_x2_contiguous_kernel[grid](
+                grad_input,
+                grad_output,
+                N,
+                C,
+                IH,
+                IW,
+                USE_INT32_IDX=use_int32_idx,
+                BLOCK_SIZE=256,
+            )
+        return grad_input
+
+    def grid(meta):
+        return (triton.cdiv(total_threads, meta["BLOCK_SIZE"]),)
+
+    with torch_device_fn.device(grad_output.device):
+        upsample_nearest2d_backward_kernel[grid](
+            grad_input,
+            grad_output,
+            N,
+            C,
+            IH,
+            IW,
+            OH,
+            OW,
+            scale_h,
+            scale_w,
+            grad_output.stride(0),
+            grad_output.stride(1),
+            grad_output.stride(2),
+            grad_output.stride(3),
+            grad_input.stride(0),
+            grad_input.stride(1),
+            grad_input.stride(2),
+            grad_input.stride(3),
+            SAME_H=OH == IH,
+            SAME_W=OW == IW,
+            USE_INT32_IDX=use_int32_idx,
+            BLOCK_H=_range_block(scale_h, OH),
+            BLOCK_W=_range_block(scale_w, OW),
+            BLOCK_SIZE=256,
+        )
+    return grad_input

--- a/tests/test_upsample_nearest2d.py
+++ b/tests/test_upsample_nearest2d.py
@@ -1,6 +1,3 @@
-import random
-import time
-
 import pytest
 import torch
 
@@ -8,20 +5,107 @@ import flag_gems
 
 from . import accuracy_utils as utils
 
-random.seed(time.time() // 100)
+
+FORWARD_CASES = [
+    pytest.param((1, 1, 1, 1), (1, 1), None, None, id="identity_1x1_output_size"),
+    pytest.param((1, 3, 8, 8), (8, 8), None, None, id="identity_output_size"),
+    pytest.param((2, 3, 32, 32), (64, 64), None, None, id="integer_x2_output_size"),
+    pytest.param((1, 3, 8, 8), (32, 32), None, None, id="integer_x4_output_size"),
+    pytest.param(
+        (2, 3, 32, 32), (67, 118), None, None, id="non_integer_output_size"
+    ),
+    pytest.param((1, 3, 8, 8), (10, 40), 1.3, 5.1, id="non_integer_scales"),
+    pytest.param((4, 16, 64, 64), (32, 32), None, None, id="downsample_output_size"),
+    pytest.param((1, 64, 128, 128), (38, 64), 0.3, 0.5, id="downsample_scales"),
+    pytest.param((2, 3, 32, 32), (32, 64), None, None, id="asymmetric_h_same"),
+    pytest.param((2, 3, 32, 32), (64, 32), 2.0, 1.0, id="asymmetric_w_same"),
+    pytest.param((1, 3, 8, 8), (16, 16), 2.0, 2.0, id="explicit_integer_scales"),
+    pytest.param(
+        (1, 3, 8, 8), (11, 13), 2.0, 1.5, id="output_size_and_scales"
+    ),
+    pytest.param(
+        (1, 3, 8, 8), (8, 8), 2.0, 2.0, id="same_output_size_non_identity_scales"
+    ),
+]
+
+
+def _make_layout_input(shape, dtype, layout):
+    input = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    if layout == "channels_last":
+        return input.contiguous(memory_format=torch.channels_last)
+    if layout == "transpose":
+        return input.transpose(2, 3)
+    return input
 
 
 @pytest.mark.upsample_nearest2d
-@pytest.mark.parametrize("scale", [(2, 2), (2.1, 3.7), (1.3, 5.1), (0.3, 0.5)])
-@pytest.mark.parametrize("shape", utils.UPSAMPLE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
-def test_upsample_nearest2d(dtype, shape, scale):
+@pytest.mark.parametrize("shape, output_size, scales_h, scales_w", FORWARD_CASES)
+def test_upsample_nearest2d(dtype, shape, output_size, scales_h, scales_w):
     input = torch.randn(shape, dtype=dtype, device=flag_gems.device)
-    ref_i = utils.to_reference(input).to(torch.float32)
-    output_size = [int(input.shape[i + 2] * scale[i]) for i in range(2)]
+    ref_i = utils.to_reference(input)
 
-    ref_out = torch._C._nn.upsample_nearest2d(ref_i, output_size=output_size).to(dtype)
+    ref_out = torch._C._nn.upsample_nearest2d(
+        ref_i, output_size, scales_h, scales_w
+    )
     with flag_gems.use_gems():
-        res_out = torch._C._nn.upsample_nearest2d(input, output_size=output_size)
+        res_out = torch._C._nn.upsample_nearest2d(
+            input, output_size, scales_h, scales_w
+        )
 
     utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.upsample_nearest2d
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+@pytest.mark.parametrize("layout", ["channels_last", "transpose"])
+def test_upsample_nearest2d_layout(dtype, layout):
+    input = torch.randn((2, 3, 7, 9), dtype=dtype, device=flag_gems.device)
+    if layout == "channels_last":
+        input = input.contiguous(memory_format=torch.channels_last)
+        output_size = (14, 18)
+        scales_h = 2.0
+        scales_w = 2.0
+    else:
+        input = input.transpose(2, 3)
+        output_size = (13, 11)
+        scales_h = None
+        scales_w = None
+
+    ref_i = utils.to_reference(input)
+    ref_out = torch._C._nn.upsample_nearest2d(
+        ref_i, output_size, scales_h, scales_w
+    )
+    with flag_gems.use_gems():
+        res_out = torch._C._nn.upsample_nearest2d(
+            input, output_size, scales_h, scales_w
+        )
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+    assert res_out.stride() == ref_out.stride()
+
+
+@pytest.mark.upsample_nearest2d
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+@pytest.mark.parametrize("layout", ["contiguous", "channels_last", "transpose"])
+@pytest.mark.parametrize("scales_h, scales_w", [(None, None), (1.0, 1.0), (2.0, 2.0)])
+def test_upsample_nearest2d_identity_fresh_tensor_preserves_layout(
+    dtype, layout, scales_h, scales_w
+):
+    input = _make_layout_input((2, 3, 4, 5), dtype, layout)
+    output_size = tuple(input.shape[-2:])
+    input_before = input.clone(memory_format=torch.preserve_format)
+
+    ref_out = torch._C._nn.upsample_nearest2d(input, output_size, scales_h, scales_w)
+    with flag_gems.use_gems():
+        res_out = torch._C._nn.upsample_nearest2d(
+            input, output_size, scales_h, scales_w
+        )
+
+    assert ref_out.data_ptr() != input.data_ptr()
+    assert res_out.data_ptr() != input.data_ptr()
+    assert res_out.stride() == ref_out.stride()
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+    res_out.add_(1)
+    utils.gems_assert_close(input, input_before, dtype)

--- a/tests/test_upsample_nearest2d_backward.py
+++ b/tests/test_upsample_nearest2d_backward.py
@@ -1,0 +1,130 @@
+import math
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+BACKWARD_CASES = [
+    pytest.param((1, 1, 1, 1), (1, 1), None, None, id="identity_1x1"),
+    pytest.param((1, 3, 8, 8), (8, 8), None, None, id="identity"),
+    pytest.param((2, 3, 16, 16), (32, 32), None, None, id="integer_x2"),
+    pytest.param((1, 3, 8, 8), (32, 32), None, None, id="integer_x4"),
+    pytest.param((2, 3, 16, 16), (33, 59), None, None, id="non_integer_output_size"),
+    pytest.param((1, 3, 8, 8), (10, 40), 1.3, 5.1, id="non_integer_scales"),
+    pytest.param((4, 16, 32, 32), (16, 16), None, None, id="downsample_output_size"),
+    pytest.param((1, 64, 64, 64), (19, 32), 0.3, 0.5, id="downsample_scales"),
+    pytest.param((2, 3, 16, 16), (16, 32), None, None, id="asymmetric_h_same"),
+    pytest.param((2, 3, 16, 16), (32, 16), 2.0, 1.0, id="asymmetric_w_same"),
+    pytest.param((1, 3, 8, 8), (11, 13), 2.0, 1.5, id="output_size_and_scales"),
+    pytest.param(
+        (1, 3, 8, 8), (8, 8), 2.0, 2.0, id="same_output_size_non_identity_scales"
+    ),
+]
+
+
+def _make_layout_grad_output(shape, dtype, layout):
+    grad_output = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    if layout == "channels_last":
+        return grad_output.contiguous(memory_format=torch.channels_last)
+    if layout == "transpose":
+        return grad_output.transpose(2, 3)
+    return grad_output
+
+
+def _contributors_bound(input_size, output_size):
+    ih, iw = input_size[-2:]
+    oh, ow = output_size
+    return max(1, math.ceil(oh / ih) * math.ceil(ow / iw))
+
+
+@pytest.mark.upsample_nearest2d
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+@pytest.mark.parametrize("input_size, output_size, scales_h, scales_w", BACKWARD_CASES)
+def test_upsample_nearest2d_backward(
+    dtype, input_size, output_size, scales_h, scales_w
+):
+    grad_output = torch.randn(
+        (*input_size[:2], *output_size), dtype=dtype, device=flag_gems.device
+    )
+    ref_grad_output = utils.to_reference(grad_output)
+
+    ref_grad_input = torch.ops.aten.upsample_nearest2d_backward(
+        ref_grad_output, output_size, input_size, scales_h, scales_w
+    )
+    with flag_gems.use_gems():
+        res_grad_input = torch.ops.aten.upsample_nearest2d_backward(
+            grad_output, output_size, input_size, scales_h, scales_w
+        )
+
+    utils.gems_assert_close(
+        res_grad_input,
+        ref_grad_input,
+        dtype,
+        reduce_dim=_contributors_bound(input_size, output_size),
+    )
+
+
+@pytest.mark.upsample_nearest2d
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+@pytest.mark.parametrize("layout", ["channels_last", "transpose"])
+def test_upsample_nearest2d_backward_layout(dtype, layout):
+    input_size = (2, 3, 7, 9)
+    output_size = (14, 18)
+    grad_output = torch.randn(
+        (*input_size[:2], *output_size), dtype=dtype, device=flag_gems.device
+    )
+    if layout == "channels_last":
+        grad_output = grad_output.contiguous(memory_format=torch.channels_last)
+    else:
+        grad_output = grad_output.transpose(2, 3)
+        output_size = tuple(grad_output.shape[-2:])
+
+    ref_grad_output = utils.to_reference(grad_output)
+    ref_grad_input = torch.ops.aten.upsample_nearest2d_backward(
+        ref_grad_output, output_size, input_size, None, None
+    )
+    with flag_gems.use_gems():
+        res_grad_input = torch.ops.aten.upsample_nearest2d_backward(
+            grad_output, output_size, input_size, None, None
+        )
+
+    utils.gems_assert_close(
+        res_grad_input,
+        ref_grad_input,
+        dtype,
+        reduce_dim=_contributors_bound(input_size, output_size),
+    )
+    assert res_grad_input.stride() == ref_grad_input.stride()
+
+
+@pytest.mark.upsample_nearest2d
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+@pytest.mark.parametrize("layout", ["contiguous", "channels_last", "transpose"])
+@pytest.mark.parametrize("scales_h, scales_w", [(None, None), (1.0, 1.0), (2.0, 2.0)])
+def test_upsample_nearest2d_backward_identity_fresh_tensor_preserves_layout(
+    dtype, layout, scales_h, scales_w
+):
+    grad_output = _make_layout_grad_output((2, 3, 4, 5), dtype, layout)
+    output_size = tuple(grad_output.shape[-2:])
+    input_size = tuple(grad_output.shape)
+    grad_output_before = grad_output.clone(memory_format=torch.preserve_format)
+
+    ref_grad_input = torch.ops.aten.upsample_nearest2d_backward(
+        grad_output, output_size, input_size, scales_h, scales_w
+    )
+    with flag_gems.use_gems():
+        res_grad_input = torch.ops.aten.upsample_nearest2d_backward(
+            grad_output, output_size, input_size, scales_h, scales_w
+        )
+
+    assert ref_grad_input.data_ptr() != grad_output.data_ptr()
+    assert res_grad_input.data_ptr() != grad_output.data_ptr()
+    assert res_grad_input.stride() == ref_grad_input.stride()
+    utils.gems_assert_close(res_grad_input, ref_grad_input, dtype)
+
+    res_grad_input.add_(1)
+    utils.gems_assert_close(grad_output, grad_output_before, dtype)


### PR DESCRIPTION
## Summary
- Add PyTorch-compatible upsample_nearest2d forward/backward support.
- Optimize contiguous x2, channels-last x2, generic scale paths, downsample, and identity fresh-copy paths.
- Register backward in FlagGems and add forward/backward benchmark coverage.

## Correctness coverage
- Covers output_size and explicit scales_h/scales_w.
- Covers integer upsample, non-integer upsample, downsample, asymmetric, identity, contiguous, channels-last, and transpose inputs.
- Backward matches PyTorch CUDA accumulation semantics using input-pixel gather ranges.
- Identity returns a fresh non-alias tensor and preserves PyTorch stride/layout behavior.

## Benchmark notes
- Forward minimum speedup: 0.925x on downsample fp16.
- Backward minimum speedup: 0.926x on identity_fresh_copy fp16.
- Backward non-integer minimum speedup: 1.239x.
- Backward downsample minimum speedup: 1.917x.
- No refreshed benchmark case is below 0.9x.

## Known weak edge
- identity_fresh_copy is reported separately because PyTorch semantics require a fresh output tensor, not a view.
- The weakest refreshed case is still above the 0.9x requirement.

## Validation commands
- bash scripts/upsample_nearest2d/run_accuracy_quick.sh: pass, forward 72 passed, backward 69 passed.
- bash scripts/upsample_nearest2d/run_accuracy_full.sh: pass, 2d forward 72, 2d backward 69, nearest1d 60, nearest3d 60.
- bash scripts/upsample_nearest2d/run_benchmark.sh: pass, forward/backward benchmark passed.
- PATH="/tmp/codex-bin:$PATH" bash scripts/upsample_nearest2d/check_pr_ready.sh: pass, ruff + quick accuracy passed.

## Benchmark logs
- Refreshed benchmark logs were kept out of the commit; key numbers are included above.