### PR TITLE
[FlagGems Operator Development Competition] Add cosh operator

### DIFF
--- a/src/flag_gems/ops/cosh.py
+++ b/src/flag_gems/ops/cosh.py
@@ -8,11 +8,13 @@ from flag_gems.utils import pointwise_dynamic
 logger = logging.getLogger(__name__)
 
 
-@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
+@pointwise_dynamic(promotion_methods=[(0, "DEFAULT")])
 @triton.jit
 def cosh_func(x):
-    x = x.to(tl.float32)
-    return 0.5 * (tl.exp(x) + tl.exp(-x))
+    # cosh(x) = (exp(x) + exp(-x)) / 2
+    # Use float32 for intermediate computation to avoid overflow in fp16/bf16
+    x_f = x.to(tl.float32)
+    return (tl.exp(x_f) + tl.exp(-x_f)) * 0.5
 
 
 def cosh(A):
@@ -22,9 +24,10 @@ def cosh(A):
 
 def cosh_(A):
     logger.debug("GEMS COSH_")
-    return cosh_func(A, out0=A)
+    cosh_func(A, out0=A)
+    return A
 
 
-def cosh_out(A, out):
-    logger.debug("GEMS COSH_OUT")
+def cosh_out(A, *, out=None):
+    logger.debug("GEMS COSH OUT")
     return cosh_func(A, out0=out)


### PR DESCRIPTION
## Summary
Implements `torch.cosh` / `torch.cosh_` / `torch.cosh.out` using a Triton pointwise kernel with float32 intermediate for precision.

## Changes
- `src/flag_gems/ops/cosh.py` â€” Triton kernel implementation
- `tests/test_cosh.py` â€” accuracy tests (shapes, dtypes, edge cases, special values)

## Testing
Tests follow the project convention using `flag_gems.use_gems()` context and `utils.gems_assert_close`.

## Competition
This PR is part of the FlagGems Operator Development Competition submission.