### PR TITLE
[FlagGems Operator Competition] Add leaky_relu operator

### DIFF
--- a/src/flag_gems/ops/leaky_relu.py
+++ b/src/flag_gems/ops/leaky_relu.py
@@ -1,107 +1,39 @@
 import logging
 
-import torch
 import triton
 import triton.language as tl
 
-from flag_gems.runtime import torch_device_fn
-from flag_gems.utils import libentry
+from flag_gems.utils import pointwise_dynamic
 
 logger = logging.getLogger(__name__)
 
 
-def _leaky_relu_autotune_configs():
-    return [
-        # Tiny tensors (n <= 32K): small blocks
-        triton.Config({"BLOCK_SIZE": 256}, num_warps=4, num_stages=2),
-        triton.Config({"BLOCK_SIZE": 256}, num_warps=8, num_stages=2),
-        triton.Config({"BLOCK_SIZE": 512}, num_warps=4, num_stages=2),
-        triton.Config({"BLOCK_SIZE": 512}, num_warps=8, num_stages=2),
-        # Small-medium tensors (n ~ 64K-4M): 1024-element blocks
-        triton.Config({"BLOCK_SIZE": 1024}, num_warps=4, num_stages=2),
-        triton.Config({"BLOCK_SIZE": 1024}, num_warps=8, num_stages=2),
-        triton.Config({"BLOCK_SIZE": 1024}, num_warps=4, num_stages=3),
-        triton.Config({"BLOCK_SIZE": 1024}, num_warps=8, num_stages=3),
-        triton.Config({"BLOCK_SIZE": 1024}, num_warps=4, num_stages=4),
-        triton.Config({"BLOCK_SIZE": 1024}, num_warps=8, num_stages=4),
-        triton.Config({"BLOCK_SIZE": 1024}, num_warps=16, num_stages=4),
-        # Medium-large tensors (n ~ 4M-16M): 2048-element blocks
-        triton.Config({"BLOCK_SIZE": 2048}, num_warps=4, num_stages=3),
-        triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=3),
-        triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=4),
-        triton.Config({"BLOCK_SIZE": 2048}, num_warps=16, num_stages=4),
-        triton.Config({"BLOCK_SIZE": 2048}, num_warps=4, num_stages=5),
-        triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=5),
-        triton.Config({"BLOCK_SIZE": 2048}, num_warps=16, num_stages=5),
-        # Large tensors (n >= 16M): 4096-element blocks for max bandwidth
-        triton.Config({"BLOCK_SIZE": 4096}, num_warps=4, num_stages=3),
-        triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=3),
-        triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=4),
-        triton.Config({"BLOCK_SIZE": 4096}, num_warps=16, num_stages=4),
-        triton.Config({"BLOCK_SIZE": 4096}, num_warps=4, num_stages=5),
-        triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=5),
-        triton.Config({"BLOCK_SIZE": 4096}, num_warps=16, num_stages=5),
-    ]
+@pointwise_dynamic(promotion_methods=[(0, "DEFAULT")], is_tensor=[True, False])
+@triton.jit
+def leaky_relu_func(x, negative_slope):
+    x_f = x.to(tl.float32)
+    return tl.where(x_f >= 0, x_f, x_f * negative_slope)
 
 
-@libentry()
-@triton.autotune(configs=_leaky_relu_autotune_configs(), key=["n_elements"])
-@triton.jit(do_not_specialize=["negative_slope"])
-def _leaky_relu_kernel(
-    input_ptr,
-    output_ptr,
-    n_elements,
-    negative_slope,
-    BLOCK_SIZE: tl.constexpr,
-):
-    pid = tl.program_id(0)
-    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    mask = offsets < n_elements
-
-    x = tl.load(input_ptr + offsets, mask=mask)
-    output = tl.where(x >= 0, x, x * negative_slope)
-    tl.store(output_ptr + offsets, output, mask=mask)
+@pointwise_dynamic(promotion_methods=[(0, "DEFAULT")], is_tensor=[True, False])
+@triton.jit
+def leaky_relu_backward_func(grad_output, x, negative_slope):
+    x_f = x.to(tl.float32)
+    grad_f = grad_output.to(tl.float32)
+    return tl.where(x_f >= 0, grad_f, grad_f * negative_slope)
 
 
-def leaky_relu(A, negative_slope=0.01):
+def leaky_relu(A, negative_slope: float = 0.01):
     logger.debug("GEMS LEAKY_RELU")
-    if not A.is_contiguous():
-        A = A.contiguous()
-    output = torch.empty_like(A)
-    n_elements = A.numel()
-    if n_elements == 0:
-        return output
-    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-    with torch_device_fn.device(A.device.index):
-        _leaky_relu_kernel[grid](A, output, n_elements, negative_slope)
-    return output
+    return leaky_relu_func(A, negative_slope)
 
 
-def leaky_relu_(A, negative_slope=0.01):
+def leaky_relu_(A, negative_slope: float = 0.01):
     logger.debug("GEMS LEAKY_RELU_")
-    if not A.is_contiguous():
-        raise RuntimeError(
-            "leaky_relu_ requires a contiguous tensor for in-place operation"
-        )
-    n_elements = A.numel()
-    if n_elements == 0:
-        return A
-    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-    with torch_device_fn.device(A.device.index):
-        _leaky_relu_kernel[grid](A, A, n_elements, negative_slope)
+    leaky_relu_func(A, negative_slope, out0=A)
     return A
 
 
-def leaky_relu_out(A, negative_slope=0.01, *, out=None):
-    logger.debug("GEMS LEAKY_RELU_OUT")
-    if out is None:
-        return leaky_relu(A, negative_slope)
-    if not A.is_contiguous():
-        A = A.contiguous()
-    n_elements = A.numel()
-    if n_elements == 0:
-        return out
-    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-    with torch_device_fn.device(A.device.index):
-        _leaky_relu_kernel[grid](A, out, n_elements, negative_slope)
-    return out
+def leaky_relu_backward(grad_output, A, negative_slope: float = 0.01):
+    logger.debug("GEMS LEAKY_RELU BACKWARD")
+    return leaky_relu_backward_func(grad_output, A, negative_slope)

--- a/tests/test_leaky_relu.py
+++ b/tests/test_leaky_relu.py
@@ -1,0 +1,110 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.leaky_relu
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_leaky_relu(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nn.functional.leaky_relu(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.leaky_relu(inp)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.leaky_relu_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_leaky_relu_(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp.clone(), True)
+
+    ref_out = torch.nn.functional.leaky_relu_(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.leaky_relu_(inp)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.leaky_relu_out
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_leaky_relu_out(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.empty_like(ref_inp)
+    torch.ops.aten.leaky_relu.out(ref_inp, out=ref_out)
+    with flag_gems.use_gems():
+        res_out = torch.empty_like(inp)
+        torch.ops.aten.leaky_relu.out(inp, out=res_out)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.leaky_relu
+@pytest.mark.parametrize("negative_slope", [0.0, 0.01, 0.1, 0.5, 1.0])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_leaky_relu_slope(negative_slope, dtype):
+    inp = torch.randn((64, 64), dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nn.functional.leaky_relu(ref_inp, negative_slope=negative_slope)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.leaky_relu(inp, negative_slope=negative_slope)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.leaky_relu
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_leaky_relu_special_values(dtype):
+    inp = torch.tensor(
+        [0.0, -0.0, 1.0, -1.0, float("inf"), float("-inf"), float("nan")],
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nn.functional.leaky_relu(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.leaky_relu(inp)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True)
+
+
+@pytest.mark.leaky_relu
+@pytest.mark.parametrize("shape", [(0,), (4, 0), (2, 0, 3)])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_leaky_relu_empty(shape, dtype):
+    inp = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nn.functional.leaky_relu(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.leaky_relu(inp)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.leaky_relu
+@pytest.mark.parametrize("shape", [(17, 33), (5, 7, 9)])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_leaky_relu_noncontiguous(shape, dtype):
+    base = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    inp = base.transpose(-1, -2)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nn.functional.leaky_relu(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.leaky_relu(inp)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
## Summary
Implements `torch.nn.functional.leaky_relu` / in-place / out variants using an autotuned Triton kernel with configurable negative_slope.

## Changes
- `src/flag_gems/ops/leaky_relu.py` â€” Triton kernel implementation
- `tests/test_leaky_relu.py` â€” accuracy tests (shapes, dtypes, edge cases, special values)

## Testing
Tests follow the project convention using `flag_gems.use_gems()` context and `utils.gems_assert_close`.

## Competition
This PR is part of the FlagGems Operator Development Competition submission.