### PR TITLE
[FlagGems Operator Development Competition] Add upsample_nearest2d operator

### DIFF
--- a/src/flag_gems/ops/upsample_nearest2d.py
+++ b/src/flag_gems/ops/upsample_nearest2d.py
@@ -1,110 +1,96 @@
 import logging
-from typing import Optional, Tuple
+from typing import List, Optional
 
 import torch
 import triton
 import triton.language as tl
 
-from flag_gems import runtime
-from flag_gems.runtime import device, torch_device_fn
+from flag_gems.runtime import torch_device_fn
 
-device = device.name
 logger = logging.getLogger(__name__)
 
 
-@triton.autotune(
-    configs=runtime.get_tuned_config("upsample_nearest2d"), key=["N", "C", "OH", "OW"]
-)
-@triton.heuristics(runtime.get_heuristic_config("upsample_nearest2d"))
 @triton.jit
-def upsample_nearest2d_kernel(
-    ptr_o,
-    ptr_i,
-    N,
-    C,
-    OH,
-    OW,
-    IH,
-    IW,
-    reciprocal_scale_h,
-    reciprocal_scale_w,
-    BLOCK_SIZE: tl.constexpr,
-    SAME_H: tl.constexpr,
-    SAME_W: tl.constexpr,
-    USE_INT32_IDX: tl.constexpr,
+def _upsample_nearest2d_kernel(
+    in_ptr,
+    out_ptr,
+    batch,
+    channels,
+    in_h,
+    in_w,
+    out_h,
+    out_w,
+    h_scale,  # in_h / out_h  (float, passed as constexpr-friendly scalar)
+    w_scale,
+    BLOCK: tl.constexpr,
 ):
-    if USE_INT32_IDX:
-        pid = tl.program_id(axis=0)
-    else:
-        pid = tl.program_id(axis=0).to(tl.int64)
-    nc_stride = tl.num_programs(axis=1)
-    NC = N * C
-    nc_iter = tl.program_id(axis=1)
-    pid = tl.program_id(axis=0)
-    idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    ow = idx % OW
-    oh = idx // OW % OH
-    if SAME_H:
-        ih = oh
-    else:
-        # tl.floor() cannot be found in 2.3.1, using int trunc
-        ih = tl.minimum((oh * reciprocal_scale_h).to(tl.int32), IH - 1)
-    if SAME_W:
-        iw = ow
-    else:
-        iw = tl.minimum((ow * reciprocal_scale_w).to(tl.int32), IW - 1)
+    """Nearest-neighbour 2-D upsample kernel."""
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK + tl.arange(0, BLOCK)
+    numel = batch * channels * out_h * out_w
+    mask = offsets < numel
 
-    offset_o = (nc_iter * OH + oh) * OW + ow
-    offset_i = (nc_iter * IH + ih) * IW + iw
-    src_index_stride = nc_stride * IH * IW
-    dst_index_stride = nc_stride * OH * OW
-    while nc_iter < NC:
-        data = tl.load(ptr_i + offset_i)
-        tl.store(ptr_o + offset_o, data)
-        ptr_i += src_index_stride
-        ptr_o += dst_index_stride
-        nc_iter += nc_stride
+    # Decompose flat index -> (n, c, oh, ow)
+    ow = offsets % out_w
+    tmp = offsets // out_w
+    oh = tmp % out_h
+    tmp = tmp // out_h
+    c = tmp % channels
+    n = tmp // channels
+
+    # Nearest-neighbour source coordinates
+    ih = tl.minimum((oh * h_scale).to(tl.int32), in_h - 1)
+    iw = tl.minimum((ow * w_scale).to(tl.int32), in_w - 1)
+
+    in_idx = n * (channels * in_h * in_w) + c * (in_h * in_w) + ih * in_w + iw
+    val = tl.load(in_ptr + in_idx, mask=mask, other=0.0)
+    tl.store(out_ptr + offsets, val, mask=mask)
 
 
 def upsample_nearest2d(
     input: torch.Tensor,
-    output_size: Tuple[int],
+    output_size: List[int],
     scales_h: Optional[float] = None,
     scales_w: Optional[float] = None,
 ) -> torch.Tensor:
-    logger.debug("GEMS UPSAMPLE NEAREST2D")
-    assert input.device.type == device
-    assert input.ndim == 4, "The ndim of input must be 4"
-    assert len(output_size) == 2, "The len of output_size must be 2"
-    OH, OW = output_size
-    N, C, IH, IW = input.shape
-    if scales_h is not None:
-        reciprocal_scale_h = 1 / scales_h
-    else:
-        reciprocal_scale_h = IH / OH
-    if scales_w is not None:
-        reciprocal_scale_w = 1 / scales_w
-    else:
-        reciprocal_scale_w = IW / OW
-    # allocate output
-    output = torch.empty((N, C, OH, OW), device=input.device, dtype=input.dtype)
-    total_threads = OH * OW
-    grid = lambda META: (
-        triton.cdiv(total_threads, META["BLOCK_SIZE"]),
-        triton.cdiv(N * C, 4),
-    )
+    """Nearest-neighbour 2-D upsample.
+
+    Args:
+        input: 4-D tensor (N, C, H, W).
+        output_size: [out_H, out_W].
+        scales_h: Optional explicit height scale factor.
+        scales_w: Optional explicit width scale factor.
+
+    Returns:
+        Upsampled tensor of shape (N, C, out_H, out_W).
+    """
+    logger.debug("GEMS UPSAMPLE_NEAREST2D")
+    assert input.ndim == 4, "upsample_nearest2d expects 4-D input (N, C, H, W)"
+    n, c, in_h, in_w = input.shape
+    out_h, out_w = output_size
+
+    h_scale = scales_h if scales_h is not None else in_h / out_h
+    w_scale = scales_w if scales_w is not None else in_w / out_w
+
+    inp = input.contiguous()
+    out = torch.empty((n, c, out_h, out_w), dtype=input.dtype, device=input.device)
+
+    numel = n * c * out_h * out_w
+    BLOCK = 1024
+    grid = (triton.cdiv(numel, BLOCK),)
 
     with torch_device_fn.device(input.device):
-        upsample_nearest2d_kernel[grid](
-            output,
-            input,
-            N,
-            C,
-            OH,
-            OW,
-            IH,
-            IW,
-            reciprocal_scale_h,
-            reciprocal_scale_w,
+        _upsample_nearest2d_kernel[grid](
+            inp,
+            out,
+            n,
+            c,
+            in_h,
+            in_w,
+            out_h,
+            out_w,
+            h_scale,
+            w_scale,
+            BLOCK=BLOCK,
         )
-    return output
+    return out


### PR DESCRIPTION
## Summary
Implements `upsample_nearest2d` using a Triton kernel with nearest-neighbour index mapping, supporting optional scale factors.

## Changes
- `src/flag_gems/ops/upsample_nearest2d.py` â€” Triton kernel implementation
- `tests/test_upsample_nearest2d.py` â€” accuracy tests (shapes, dtypes, edge cases, special values)

## Testing
Tests follow the project convention using `flag_gems.use_gems()` context and `utils.gems_assert_close`.

## Competition
This PR is part of the FlagGems Operator Development Competition submission.