### PR TITLE
Bump flagtree version for iluvatar backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,7 @@ iluvatar = [
     "torch==2.7.1+corex.4.4.0",
     "torchaudio==2.7.1+corex.4.4.0",
     "torchvision==0.22.1+corex.4.4.0",
-    "flagtree==0.5.0+iluvatar3.1"
+    "flagtree==0.5.1+iluvatar3.1"
 ]
 
 kunlunxin = [

--- a/tools/setup_iluvatar.sh
+++ b/tools/setup_iluvatar.sh
@@ -10,7 +10,7 @@ uv pip install --index ${FLAGOS_PYPI} \
     "torch==2.7.1+corex.4.4.0" \
     "torchaudio==2.7.1+corex.4.4.0" \
     "torchvision==0.22.1+corex.4.4.0" \
-    "flagtree==0.5.0+iluvatar3.1"
+    "flagtree==0.5.1+iluvatar3.1"
 
 # Replace flagtree by Triton if requested
 if [ -n "${USE_TRITON}" ]; then


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Improvement

### Description

This PR bumps the FlagTree version from 0.5.0 to 0.5.1 on Iluvatar platforms.