### PR TITLE
Update random-test.yaml

### DIFF
--- a/.github/workflows/random-test.yaml
+++ b/.github/workflows/random-test.yaml
@@ -25,7 +25,6 @@ on:
         required: true
 permissions:
   contents: read
-  members: read
 
 jobs:
   check-permission:


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The `members: read` permission suggested by Google actually doesn't work.