### PR TITLE
[LibEntry] Fix prehook after load tune config, and update align32_strategy

### DIFF
--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -472,8 +472,10 @@ class LibTuner(triton.runtime.Autotuner):
                 f"Triton autotuning for function {self.base_fn.__name__} finished after "
                 f"{self.bench_time:.2f}s; key info: {key}, best config selected: {self.best_config};"
             )
-        if config.pre_hook is not None:
-            full_nargs = {**self.nargs, **kwargs, **config.all_kwargs()}
+        full_nargs = {**self.nargs, **kwargs, **config.all_kwargs()}
+        if hasattr(self, "shared_config_pre_hook") and self.shared_config_pre_hook is not None:
+            self.shared_config_pre_hook(full_nargs)
+        elif config.pre_hook is not None:
             config.pre_hook(full_nargs)
         ret = self.fn.run(
             *args,

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -497,7 +497,7 @@ def log2_strategy(key: Union[int, float]) -> float:
 
 @LibTuner.register_strategy("align32")
 def align32_strategy(key: Union[int, float]) -> int:
-    return math.ceil(key / 32) * 32
+    return log2_strategy(key) if key < 32 else math.ceil(key / 32) * 32
 
 
 @LibTuner.register_policy("default")

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -473,7 +473,10 @@ class LibTuner(triton.runtime.Autotuner):
                 f"{self.bench_time:.2f}s; key info: {key}, best config selected: {self.best_config};"
             )
         full_nargs = {**self.nargs, **kwargs, **config.all_kwargs()}
-        if hasattr(self, "shared_config_pre_hook") and self.shared_config_pre_hook is not None:
+        if (
+            hasattr(self, "shared_config_pre_hook")
+            and self.shared_config_pre_hook is not None
+        ):
             self.shared_config_pre_hook(full_nargs)
         elif config.pre_hook is not None:
             config.pre_hook(full_nargs)


### PR DESCRIPTION
### PR Category
LibEntry

### Type of Change
New Feature

### Description
Fix the issue where prehook is missing after loading the tune config.
Update the align32 strategy to improve performance for small-size operators.

### Issue

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

