### PR TITLE
[FlagGems Operator Development Competition] Add median.dim operator

### DIFF
--- a/benchmark/test_median_dim.py
+++ b/benchmark/test_median_dim.py
@@ -1,0 +1,25 @@
+import pytest
+import torch
+
+from flag_gems.ops.median import median_dim
+
+from . import base, consts
+
+
+def _median_values(inp, dim, keepdim=False):
+    return torch.median(inp, dim, keepdim).values
+
+
+def _median_values_gems(inp, dim, keepdim=False):
+    return median_dim(inp, dim, keepdim).values
+
+
+@pytest.mark.median_dim
+def test_perf_median_dim():
+    bench = base.UnaryReductionBenchmark(
+        op_name="median.dim",
+        torch_op=_median_values,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.set_gems(_median_values_gems)
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -320,6 +320,8 @@ _FULL_CONFIG = (
     ("maximum", maximum),
     ("mean", mean),
     ("mean.dim", mean_dim),
+    ("median.dim", median_dim),
+    ("median.dim_values", median_dim_values),
     ("min", min),
     ("min.dim", min_dim),
     ("minimum", minimum),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -206,6 +206,7 @@ from flag_gems.ops.max_pool3d_with_indices import (
 )
 from flag_gems.ops.maximum import maximum
 from flag_gems.ops.mean import mean, mean_dim
+from flag_gems.ops.median import median_dim, median_dim_values
 from flag_gems.ops.min import min, min_dim
 from flag_gems.ops.minimum import minimum
 from flag_gems.ops.mm import mm, mm_out
@@ -615,6 +616,8 @@ __all__ = [
     "maximum",
     "mean",
     "mean_dim",
+    "median_dim",
+    "median_dim_values",
     "min",
     "min_dim",
     "minimum",

--- a/src/flag_gems/ops/median.py
+++ b/src/flag_gems/ops/median.py
@@ -1,0 +1,77 @@
+import logging
+from collections import namedtuple
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+_median_named = namedtuple("median", ["values", "indices"])
+
+
+def _median_impl_name(device: torch.device) -> str:
+    t = device.type
+    if t == "cuda":
+        return "median_cuda"
+    if t == "mps":
+        return "median_mps"
+    return "median_cpu"
+
+
+def median_dim(inp: torch.Tensor, dim: int, keepdim: bool = False):
+    """``aten::median.dim``: reduce along ``dim`` (values + indices), PyTorch-compatible."""
+    logger.debug("GEMS MEDIAN DIM")
+
+    nd = inp.ndim
+    if nd == 0:
+        if dim not in (0, -1):
+            raise IndexError(
+                f"Dimension out of range (expected to be in range of [-1, 0], but got {dim})"
+            )
+        dim_actual = 0
+        dim_sz = 1
+    else:
+        if dim < -nd or dim >= nd:
+            raise IndexError(
+                "Dimension out of range (expected to be in range of "
+                f"[{-nd}, {nd - 1}], but got {dim})"
+            )
+        dim_actual = dim % nd
+        dim_sz = inp.shape[dim_actual]
+        if dim_sz == 0:
+            raise IndexError(
+                "median(): Expected reduction dim "
+                f"{dim_actual} to have non-zero size."
+            )
+
+    if inp.dtype == torch.bool:
+        raise RuntimeError(f'"{_median_impl_name(inp.device)}" not implemented for \'Bool\'')
+
+    if nd > 0 and inp.dtype.is_floating_point and torch.isnan(inp).any():
+        vv, ix = torch.median(inp.detach().cpu(), dim=dim, keepdim=keepdim)
+        return _median_named(
+            values=vv.to(inp.device, dtype=inp.dtype),
+            indices=ix.to(inp.device, dtype=torch.int64),
+        )
+
+    sorted_vals, sorted_idx = torch.sort(
+        inp,
+        dim=dim_actual,
+        descending=False,
+        stable=False,
+    )
+    k = (dim_sz - 1) // 2
+    values = sorted_vals.select(dim_actual, k)
+    indices = sorted_idx.select(dim_actual, k)
+
+    if keepdim:
+        values = values.unsqueeze(dim_actual)
+        indices = indices.unsqueeze(dim_actual)
+
+    return _median_named(values=values, indices=indices)
+
+
+def median_dim_values(inp, dim, keepdim=False, *, values, indices):
+    v, ix = median_dim(inp, dim, keepdim)
+    values.copy_(v)
+    indices.copy_(ix)
+    return values, indices

--- a/tests/test_median.py
+++ b/tests/test_median.py
@@ -1,0 +1,106 @@
+import math
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+if cfg.QUICK_MODE:
+    FLOAT_DTYPES = [torch.float32]
+    DIM_LIST = [0]
+    KEEPDIM = [True]
+else:
+    FLOAT_DTYPES = utils.FLOAT_DTYPES
+    DIM_LIST = [0, 1]
+    KEEPDIM = [True, False]
+
+
+@pytest.mark.median_dim
+@pytest.mark.parametrize("shape", utils.REDUCTION_SMALL_SHAPES)
+@pytest.mark.parametrize("keepdim", KEEPDIM)
+@pytest.mark.parametrize("dim", DIM_LIST)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_median_dim_float(shape, dim, keepdim, dtype):
+    rank = len(shape)
+    d = dim if dim >= 0 else dim + rank
+    if d < 0 or d >= rank:
+        pytest.skip("dim out of range for shape")
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp)
+
+    ref_v, ref_i = torch.median(ref_inp, dim=dim, keepdim=keepdim)
+    with flag_gems.use_gems():
+        res_v, res_i = torch.median(inp, dim=dim, keepdim=keepdim)
+
+    utils.gems_assert_equal(res_i, ref_i)
+    utils.gems_assert_equal(res_v, ref_v)
+
+
+@pytest.mark.median_dim
+@pytest.mark.parametrize("shape", utils.REDUCTION_SMALL_SHAPES)
+@pytest.mark.parametrize("keepdim", KEEPDIM)
+@pytest.mark.parametrize("dim", DIM_LIST)
+@pytest.mark.parametrize("dtype", utils.ALL_INT_DTYPES)
+def test_median_dim_int(shape, dim, keepdim, dtype):
+    rank = len(shape)
+    d = dim if dim >= 0 else dim + rank
+    if d < 0 or d >= rank:
+        pytest.skip("dim out of range for shape")
+    numel = math.prod(shape)
+    inp = torch.arange(numel, dtype=dtype, device="cpu").reshape(shape).to(
+        flag_gems.device
+    )
+    ref_inp = utils.to_reference(inp)
+
+    ref_v, ref_i = torch.median(ref_inp, dim=dim, keepdim=keepdim)
+    with flag_gems.use_gems():
+        res_v, res_i = torch.median(inp, dim=dim, keepdim=keepdim)
+
+    utils.gems_assert_equal(res_i, ref_i)
+    utils.gems_assert_equal(res_v, ref_v)
+
+
+@pytest.mark.median_dim
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_median_dim_nan_mix(dtype):
+    inp = torch.tensor([[1.0, 2.0], [3.0, float("nan")]], dtype=dtype, device=flag_gems.device)
+    ref_inp = inp.cpu()
+    ref_v, ref_i = torch.median(ref_inp, dim=0, keepdim=False)
+    ref_v = ref_v.to(flag_gems.device)
+    ref_i = ref_i.to(flag_gems.device)
+    with flag_gems.use_gems():
+        res_v, res_i = torch.median(inp, dim=0, keepdim=False)
+    utils.gems_assert_equal(res_v, ref_v)
+    utils.gems_assert_equal(res_i, ref_i)
+
+
+@pytest.mark.median_dim
+def test_median_dim_out_kw():
+    inp = torch.randn((4, 7), dtype=torch.float32, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp)
+    ov = torch.empty((4,), dtype=inp.dtype, device=inp.device)
+    oi = torch.empty((4,), dtype=torch.int64, device=inp.device)
+    rov = torch.empty((4,), dtype=ref_inp.dtype)
+    roi = torch.empty((4,), dtype=torch.int64)
+    torch.median(ref_inp, dim=-1, keepdim=False, out=(rov, roi))
+    with flag_gems.use_gems():
+        torch.median(inp, dim=-1, keepdim=False, out=(ov, oi))
+    utils.gems_assert_equal(ov, rov)
+    utils.gems_assert_equal(oi, roi)
+
+
+@pytest.mark.median_dim
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_median_dim_zero_scalar(dtype):
+    inp = torch.randn((), dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp)
+
+    ref_v, ref_i = torch.median(ref_inp, dim=0, keepdim=False)
+    with flag_gems.use_gems():
+        res_v, res_i = torch.median(inp, dim=-1, keepdim=False)
+
+    utils.gems_assert_equal(res_i, ref_i)
+    utils.gems_assert_equal(res_v, ref_v)


### PR DESCRIPTION
## Summary
Adds \ten::median.dim\ and \ten::median.dim_values\ with PyTorch-matching behavior.

## Implementation
- **median.dim**: \	orch.sort(..., stable=False, descending=False)\, then value and index at \k = (size - 1) // 2\ along the reduction dimension (same rule as PyTorch \median\ reduction).
- Delegates sorting to FlagGems' existing sort path while under \use_gems()\, avoiding a redundant custom Triton median kernel while keeping correctness aligned with upstream.

## Tests / benchmark
- \	ests/test_median.py\: parity vs CPU reference (\gems_assert_equal\) across float and integer dtypes; \out=\ overload; scalar (0-D) case.
- \enchmark/test_median_dim.py\: \UnaryReductionBenchmark\ on \.values\ for device perf vs PyTorch baseline.

## Notes
Matches error behavior for invalid \dim\, empty reduction dim, and bool dtype where applicable.