### PR TITLE
[FlagGems Operator Development Competition] Add upsample_nearest2d operator

### DIFF
--- a/benchmark/test_upsample_nearest2d.py
+++ b/benchmark/test_upsample_nearest2d.py
@@ -4,34 +4,39 @@ import torch
 from . import base, consts
 
 
-class UpsampleBenchmark(base.GenericBenchmark):
-    def set_more_shapes(self):
-        # self.shapes is a list of tuples, each containing three elements:
-        # (N, C, H, W).
-        return []
+class UpsampleBenchmark(base.Benchmark):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._cfgs = [
+            (1, 3, 512, 512, 1024, 1024, "contiguous", None, None, "x2 nchw"),
+            (8, 16, 128, 128, 256, 256, "contiguous", None, None, "x2 nchw C16"),
+            (2, 3, 1024, 1024, 2048, 2048, "contiguous", None, None, "x2 nchw big"),
+            (16, 16, 512, 512, 1024, 1024, "contiguous", None, None, "x2 nchw large"),
+            (16, 16, 1024, 1024, 2048, 2048, "contiguous", None, None, "x2 nchw huge"),
+            (1, 3, 127, 127, 255, 255, "contiguous", None, None, "near2 nchw"),
+            (1, 16, 64, 64, 135, 147, "contiguous", 2.1, 2.3, "explicit nchw"),
+            (1, 64, 64, 64, 135, 147, "channels_last", 2.1, 2.3, "explicit nhwc C64"),
+            (1, 128, 64, 64, 135, 147, "channels_last", 2.1, 2.3, "explicit nhwc C128"),
+            (1, 17, 64, 64, 129, 131, "channels_last", None, None, "near2 nhwc C17"),
+        ]
 
-
-def _input_fn(shape, dtype, device):
-    batch, channel, height, weight = shape
-    input = torch.randn(size=shape, device=device, dtype=dtype)
-    scale_factors = (2, 2)
-    output_size = (
-        int(height * scale_factors[0]),
-        int(weight * scale_factors[1]),
-    )
-    yield {
-        "input": input,
-        "output_size": output_size,
-        "scales_h": None,
-        "scales_w": None,
-    },
+    def get_input_iter(self, dtype):
+        for N, C, Hi, Wi, Ho, Wo, layout, scales_h, scales_w, label in self._cfgs:
+            input = torch.randn([N, C, Hi, Wi], device=self.device, dtype=dtype)
+            if layout == "channels_last":
+                input = input.contiguous(memory_format=torch.channels_last)
+            yield {
+                "input": input,
+                "output_size": [Ho, Wo],
+                "scales_h": scales_h,
+                "scales_w": scales_w,
+            }, label
 
 
 @pytest.mark.upsample_nearest2d
 def test_upsample_nearest2d():
     bench = UpsampleBenchmark(
         op_name="upsample_nearest2d",
-        input_fn=_input_fn,
         torch_op=torch._C._nn.upsample_nearest2d,
         dtypes=consts.FLOAT_DTYPES,
     )

--- a/benchmark/test_upsample_nearest2d_backward.py
+++ b/benchmark/test_upsample_nearest2d_backward.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+
+from . import base, consts
+
+
+class UpsampleNearest2dBackwardBenchmark(base.Benchmark):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._cfgs = [
+            (4, 16, 64, 64, 128, 128, "contiguous", None, None, "x2 nchw"),
+            (1, 3, 127, 127, 255, 255, "contiguous", None, None, "non-integer"),
+            (4, 32, 128, 128, 64, 64, "contiguous", None, None, "downsample"),
+            (4, 16, 64, 64, 128, 128, "channels_last", None, None, "x2 nhwc"),
+            (1, 64, 64, 64, 128, 128, "channels_last", None, None, "x2 nhwc C64"),
+            (1, 3, 64, 64, 135, 147, "contiguous", 2.1, 2.3, "explicit scales"),
+        ]
+
+    def get_input_iter(self, dtype):
+        for N, C, Hi, Wi, Ho, Wo, layout, scales_h, scales_w, label in self._cfgs:
+            grad = torch.randn([N, C, Ho, Wo], device=self.device, dtype=dtype)
+            if layout == "channels_last":
+                grad = grad.contiguous(memory_format=torch.channels_last)
+            yield grad, [Ho, Wo], [N, C, Hi, Wi], scales_h, scales_w, label
+
+    def get_tflops(self, op, *args, **kwargs):
+        grad = args[0]
+        return grad.numel()
+
+
+@pytest.mark.upsample_nearest2d_backward
+def test_upsample_nearest2d_backward():
+    bench = UpsampleNearest2dBackwardBenchmark(
+        op_name="upsample_nearest2d_backward",
+        torch_op=torch.ops.aten.upsample_nearest2d_backward,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+
+    bench.run()

--- a/benchmark/test_upsample_nearest2d_backward.py
+++ b/benchmark/test_upsample_nearest2d_backward.py
@@ -10,9 +10,13 @@ class UpsampleNearest2dBackwardBenchmark(base.Benchmark):
         self._cfgs = [
             (4, 16, 64, 64, 128, 128, "contiguous", None, None, "x2 nchw"),
             (1, 3, 127, 127, 255, 255, "contiguous", None, None, "non-integer"),
+            (4, 16, 64, 64, 256, 256, "contiguous", None, None, "x4 nchw"),
+            (4, 32, 256, 256, 128, 128, "contiguous", None, None, "downsample x2"),
             (4, 32, 128, 128, 64, 64, "contiguous", None, None, "downsample"),
+            (1, 8, 64, 64, 128, 192, "contiguous", None, None, "asymmetric"),
             (4, 16, 64, 64, 128, 128, "channels_last", None, None, "x2 nhwc"),
             (1, 64, 64, 64, 128, 128, "channels_last", None, None, "x2 nhwc C64"),
+            (1, 128, 64, 64, 135, 147, "channels_last", 2.1, 2.3, "generic nhwc C128"),
             (1, 3, 64, 64, 135, 147, "contiguous", 2.1, 2.3, "explicit scales"),
         ]
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,6 @@
 testpaths = tests
 pythonpath = src
 filterwarnings = ignore::pytest.PytestUnknownMarkWarning
+markers =
+    upsample_nearest2d: tests for aten::upsample_nearest2d
+    upsample_nearest2d_backward: tests for aten::upsample_nearest2d_backward

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -1,3 +1,4 @@
+# ruff: noqa: F405
 import warnings
 
 import torch
@@ -481,6 +482,7 @@ _FULL_CONFIG = (
     ("upsample_linear1d", upsample_linear1d),
     ("upsample_nearest1d", upsample_nearest1d),
     ("upsample_nearest2d", upsample_nearest2d),
+    ("upsample_nearest2d_backward", upsample_nearest2d_backward),
     ("upsample_nearest3d", upsample_nearest3d),
     ("var_mean.correction", var_mean),
     ("var", var),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -330,6 +330,7 @@ from flag_gems.ops.upsample_bicubic2d_aa_backward import _upsample_bicubic2d_aa_
 from flag_gems.ops.upsample_linear1d import upsample_linear1d
 from flag_gems.ops.upsample_nearest1d import upsample_nearest1d
 from flag_gems.ops.upsample_nearest2d import upsample_nearest2d
+from flag_gems.ops.upsample_nearest2d_backward import upsample_nearest2d_backward
 from flag_gems.ops.upsample_nearest3d import upsample_nearest3d
 from flag_gems.ops.var import var, var_correction, var_dim
 from flag_gems.ops.var_mean import var_mean
@@ -779,6 +780,7 @@ __all__ = [
     "upsample_linear1d",
     "upsample_nearest1d",
     "upsample_nearest2d",
+    "upsample_nearest2d_backward",
     "upsample_nearest3d",
     "var_mean",
     "var",

--- a/src/flag_gems/ops/upsample_nearest2d.py
+++ b/src/flag_gems/ops/upsample_nearest2d.py
@@ -254,6 +254,74 @@ def nearest2d_2x_nhwc_source_kernel(
 
 
 @triton.jit
+def nearest2d_nhwc_channel_block_kernel(
+    out_ptr,
+    in_ptr,
+    N: tl.constexpr,
+    C: tl.constexpr,
+    OH: tl.constexpr,
+    OW: tl.constexpr,
+    IH: tl.constexpr,
+    IW: tl.constexpr,
+    reciprocal_scale_h,
+    reciprocal_scale_w,
+    input_stride_n,
+    input_stride_h,
+    input_stride_w,
+    output_stride_n,
+    output_stride_h,
+    output_stride_w,
+    BLOCK_HW: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+    SAME_H: tl.constexpr,
+    SAME_W: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+):
+    hw_offsets = tl.program_id(axis=0) * BLOCK_HW + tl.arange(0, BLOCK_HW)
+    if not USE_INT32_IDX:
+        hw_offsets = hw_offsets.to(tl.int64)
+    c_offsets = tl.program_id(axis=1) * BLOCK_C + tl.arange(0, BLOCK_C)
+
+    hw_total: tl.constexpr = N * OH * OW
+    hw_mask = hw_offsets < hw_total
+    c_mask = c_offsets < C
+    mask = hw_mask[:, None] & c_mask[None, :]
+
+    out_w = hw_offsets % OW
+    out_h = (hw_offsets // OW) % OH
+    batch = hw_offsets // (OH * OW)
+
+    if SAME_H:
+        source_h = out_h
+    else:
+        source_h = tl.minimum(
+            (out_h.to(tl.float32) * reciprocal_scale_h).to(tl.int32), IH - 1
+        )
+    if SAME_W:
+        source_w = out_w
+    else:
+        source_w = tl.minimum(
+            (out_w.to(tl.float32) * reciprocal_scale_w).to(tl.int32), IW - 1
+        )
+
+    channel = c_offsets[None, :]
+    input_offset = (
+        batch[:, None].to(tl.int64) * input_stride_n
+        + source_h[:, None].to(tl.int64) * input_stride_h
+        + source_w[:, None].to(tl.int64) * input_stride_w
+        + channel
+    )
+    output_offset = (
+        batch[:, None].to(tl.int64) * output_stride_n
+        + out_h[:, None].to(tl.int64) * output_stride_h
+        + out_w[:, None].to(tl.int64) * output_stride_w
+        + channel
+    )
+    data = tl.load(in_ptr + input_offset, mask=mask)
+    tl.store(out_ptr + output_offset, data, mask=mask)
+
+
+@triton.jit
 def upsample_nearest2d_spatial_strided_kernel(
     ptr_o,
     ptr_i,
@@ -441,6 +509,18 @@ def _nhwc_2x_source_config(dtype: torch.dtype) -> tuple[int, int]:
     return 512, 4
 
 
+def _nhwc_channel_block_config(
+    dtype: torch.dtype, channel_count: int
+) -> Optional[tuple[int, int, int]]:
+    if channel_count < 16:
+        return None
+    if dtype is torch.float32:
+        return 32, 32, 4
+    if channel_count >= 64:
+        return 32, 64, 4
+    return 32, 32, 4
+
+
 def _nchw_2x_output_config(
     dtype: torch.dtype, channel_count: int, input_total: int
 ) -> Optional[tuple[int, int]]:
@@ -540,6 +620,45 @@ def upsample_nearest2d(
                 output.stride(3),
                 USE_INT32_IDX=use_int32_idx,
                 BLOCK_SIZE=block_size,
+                num_warps=num_warps,
+            )
+        return output
+
+    nhwc_channel_block_config = (
+        _nhwc_channel_block_config(input.dtype, C) if channels_last else None
+    )
+    if nhwc_channel_block_config is not None:
+        block_hw, block_c, num_warps = nhwc_channel_block_config
+
+        def grid(meta):
+            return (
+                triton.cdiv(N * OH * OW, meta["BLOCK_HW"]),
+                triton.cdiv(C, meta["BLOCK_C"]),
+            )
+
+        with torch_device_fn.device(input.device):
+            nearest2d_nhwc_channel_block_kernel[grid](
+                output,
+                input,
+                N,
+                C,
+                OH,
+                OW,
+                IH,
+                IW,
+                reciprocal_scale_h,
+                reciprocal_scale_w,
+                input.stride(0),
+                input.stride(2),
+                input.stride(3),
+                output.stride(0),
+                output.stride(2),
+                output.stride(3),
+                SAME_H=same_h,
+                SAME_W=same_w,
+                USE_INT32_IDX=use_int32_idx,
+                BLOCK_HW=block_hw,
+                BLOCK_C=block_c,
                 num_warps=num_warps,
             )
         return output

--- a/src/flag_gems/ops/upsample_nearest2d.py
+++ b/src/flag_gems/ops/upsample_nearest2d.py
@@ -1,23 +1,22 @@
 import logging
+import struct
 from typing import Optional, Tuple
 
 import torch
 import triton
 import triton.language as tl
 
-from flag_gems import runtime
 from flag_gems.runtime import device, torch_device_fn
 
 device = device.name
 logger = logging.getLogger(__name__)
-
-
-@triton.autotune(
-    configs=runtime.get_tuned_config("upsample_nearest2d"), key=["N", "C", "OH", "OW"]
+_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeExplicitAutograd
 )
-@triton.heuristics(runtime.get_heuristic_config("upsample_nearest2d"))
+
+
 @triton.jit
-def upsample_nearest2d_kernel(
+def upsample_nearest2d_contiguous_flat_kernel(
     ptr_o,
     ptr_i,
     N,
@@ -37,38 +36,454 @@ def upsample_nearest2d_kernel(
         pid = tl.program_id(axis=0)
     else:
         pid = tl.program_id(axis=0).to(tl.int64)
-    nc_stride = tl.num_programs(axis=1)
-    NC = N * C
-    nc_iter = tl.program_id(axis=1)
-    pid = tl.program_id(axis=0)
+
     idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if not USE_INT32_IDX:
+        idx = idx.to(tl.int64)
+
+    total = N * C * OH * OW
+    mask = idx < total
     ow = idx % OW
-    oh = idx // OW % OH
+    oh = (idx // OW) % OH
+    nc = idx // (OH * OW)
+
     if SAME_H:
         ih = oh
     else:
-        # tl.floor() cannot be found in 2.3.1, using int trunc
-        ih = tl.minimum((oh * reciprocal_scale_h).to(tl.int32), IH - 1)
+        ih = tl.minimum((oh.to(tl.float32) * reciprocal_scale_h).to(tl.int32), IH - 1)
     if SAME_W:
         iw = ow
     else:
-        iw = tl.minimum((ow * reciprocal_scale_w).to(tl.int32), IW - 1)
+        iw = tl.minimum((ow.to(tl.float32) * reciprocal_scale_w).to(tl.int32), IW - 1)
 
-    offset_o = (nc_iter * OH + oh) * OW + ow
-    offset_i = (nc_iter * IH + ih) * IW + iw
-    src_index_stride = nc_stride * IH * IW
-    dst_index_stride = nc_stride * OH * OW
-    while nc_iter < NC:
-        data = tl.load(ptr_i + offset_i)
-        tl.store(ptr_o + offset_o, data)
-        ptr_i += src_index_stride
-        ptr_o += dst_index_stride
-        nc_iter += nc_stride
+    offset_i = nc * IH * IW + ih * IW + iw
+    data = tl.load(ptr_i + offset_i, mask=mask)
+    tl.store(ptr_o + idx, data, mask=mask)
+
+
+@triton.jit
+def nearest2d_contiguous_spatial_tiles_kernel(
+    out_ptr,
+    in_ptr,
+    N,
+    C,
+    OH,
+    OW,
+    IH,
+    IW,
+    reciprocal_scale_h,
+    reciprocal_scale_w,
+    BLOCK_SIZE: tl.constexpr,
+    SAME_H: tl.constexpr,
+    SAME_W: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+):
+    if USE_INT32_IDX:
+        tile = tl.program_id(axis=0)
+    else:
+        tile = tl.program_id(axis=0).to(tl.int64)
+
+    offsets = tile * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if not USE_INT32_IDX:
+        offsets = offsets.to(tl.int64)
+
+    output_plane = OH * OW
+    inside_plane = offsets < output_plane
+    out_w = offsets % OW
+    out_h = offsets // OW
+
+    if SAME_H:
+        source_h = out_h
+    else:
+        source_h = tl.minimum(
+            (out_h.to(tl.float32) * reciprocal_scale_h).to(tl.int32), IH - 1
+        )
+    if SAME_W:
+        source_w = out_w
+    else:
+        source_w = tl.minimum(
+            (out_w.to(tl.float32) * reciprocal_scale_w).to(tl.int32), IW - 1
+        )
+
+    plane_owner = tl.program_id(axis=1)
+    owner_step = tl.num_programs(axis=1)
+    input_offset = plane_owner * IH * IW + source_h * IW + source_w
+    output_offset = plane_owner * output_plane + offsets
+    input_plane_step = owner_step * IH * IW
+    output_plane_step = owner_step * output_plane
+    while plane_owner < N * C:
+        data = tl.load(in_ptr + input_offset, mask=inside_plane)
+        tl.store(out_ptr + output_offset, data, mask=inside_plane)
+        input_offset += input_plane_step
+        output_offset += output_plane_step
+        plane_owner += owner_step
+
+
+@triton.jit
+def nearest2d_2x_nchw_source_kernel(
+    out_ptr,
+    in_ptr,
+    batch_count,
+    channel_count,
+    input_h,
+    input_w,
+    BLOCK_SIZE: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+):
+    if USE_INT32_IDX:
+        tile_id = tl.program_id(axis=0)
+    else:
+        tile_id = tl.program_id(axis=0).to(tl.int64)
+
+    source_offset = tile_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if not USE_INT32_IDX:
+        source_offset = source_offset.to(tl.int64)
+
+    input_plane = input_h * input_w
+    element_count = batch_count * channel_count * input_plane
+    valid = source_offset < element_count
+    source_pixel = source_offset % input_plane
+    source_x = source_pixel % input_w
+    source_y = source_pixel // input_w
+    batch_channel = source_offset // input_plane
+
+    value = tl.load(in_ptr + source_offset, mask=valid)
+    output_w = input_w + input_w
+    output_plane = (input_h + input_h) * output_w
+    output_row = source_y + source_y
+    output_col = source_x + source_x
+    top_left = batch_channel * output_plane + output_row * output_w + output_col
+    next_row = top_left + output_w
+    tl.store(out_ptr + top_left, value, mask=valid)
+    tl.store(out_ptr + top_left + 1, value, mask=valid)
+    tl.store(out_ptr + next_row, value, mask=valid)
+    tl.store(out_ptr + next_row + 1, value, mask=valid)
+
+
+@triton.jit
+def nearest2d_2x_nchw_output_kernel(
+    out_ptr,
+    in_ptr,
+    batch_count,
+    channel_count,
+    input_h,
+    input_w,
+    BLOCK_SIZE: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+):
+    if USE_INT32_IDX:
+        tile_id = tl.program_id(axis=0)
+    else:
+        tile_id = tl.program_id(axis=0).to(tl.int64)
+
+    output_offset = tile_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if not USE_INT32_IDX:
+        output_offset = output_offset.to(tl.int64)
+
+    output_h = input_h + input_h
+    output_w = input_w + input_w
+    output_plane = output_h * output_w
+    valid = output_offset < batch_count * channel_count * output_plane
+    output_x = output_offset % output_w
+    output_y = (output_offset // output_w) % output_h
+    batch_channel = output_offset // output_plane
+    source_y = output_y // 2
+    source_x = output_x // 2
+
+    input_offset = batch_channel * input_h * input_w + source_y * input_w + source_x
+    value = tl.load(in_ptr + input_offset, mask=valid)
+    tl.store(out_ptr + output_offset, value, mask=valid)
+
+
+@triton.jit
+def nearest2d_2x_nhwc_source_kernel(
+    out_ptr,
+    in_ptr,
+    batch_count,
+    channel_count,
+    input_h,
+    input_w,
+    input_stride_n,
+    input_stride_h,
+    input_stride_w,
+    output_stride_n,
+    output_stride_h,
+    output_stride_w,
+    BLOCK_SIZE: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+):
+    if USE_INT32_IDX:
+        tile_id = tl.program_id(axis=0)
+    else:
+        tile_id = tl.program_id(axis=0).to(tl.int64)
+
+    lane = tile_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if not USE_INT32_IDX:
+        lane = lane.to(tl.int64)
+
+    input_pixels = input_h * input_w
+    lane_count = batch_count * input_pixels * channel_count
+    valid = lane < lane_count
+    channel = lane % channel_count
+    pixel_id = lane // channel_count
+    source_x = pixel_id % input_w
+    source_y = (pixel_id // input_w) % input_h
+    batch = pixel_id // input_pixels
+
+    source_addr = (
+        batch * input_stride_n
+        + source_y * input_stride_h
+        + source_x * input_stride_w
+        + channel
+    )
+    output_y = source_y + source_y
+    output_x = source_x + source_x
+    dest_pixel = (
+        batch * output_stride_n
+        + output_y * output_stride_h
+        + output_x * output_stride_w
+    )
+    dest_left = dest_pixel + channel
+    dest_right = dest_left + output_stride_w
+    dest_bottom = dest_left + output_stride_h
+    value = tl.load(in_ptr + source_addr, mask=valid)
+    tl.store(out_ptr + dest_left, value, mask=valid)
+    tl.store(out_ptr + dest_right, value, mask=valid)
+    tl.store(out_ptr + dest_bottom, value, mask=valid)
+    tl.store(out_ptr + dest_bottom + output_stride_w, value, mask=valid)
+
+
+@triton.jit
+def upsample_nearest2d_spatial_strided_kernel(
+    ptr_o,
+    ptr_i,
+    N,
+    C,
+    OH,
+    OW,
+    IH,
+    IW,
+    reciprocal_scale_h,
+    reciprocal_scale_w,
+    input_stride_n,
+    input_stride_c,
+    input_stride_h,
+    input_stride_w,
+    BLOCK_SIZE: tl.constexpr,
+    SAME_H: tl.constexpr,
+    SAME_W: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+):
+    if USE_INT32_IDX:
+        pid = tl.program_id(axis=0)
+    else:
+        pid = tl.program_id(axis=0).to(tl.int64)
+
+    idx = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if not USE_INT32_IDX:
+        idx = idx.to(tl.int64)
+
+    spatial = OH * OW
+    mask = idx < spatial
+    ow = idx % OW
+    oh = idx // OW
+    nc = tl.program_id(axis=1)
+    c = nc % C
+    n = nc // C
+
+    if SAME_H:
+        ih = oh
+    else:
+        ih = tl.minimum((oh.to(tl.float32) * reciprocal_scale_h).to(tl.int32), IH - 1)
+    if SAME_W:
+        iw = ow
+    else:
+        iw = tl.minimum((ow.to(tl.float32) * reciprocal_scale_w).to(tl.int32), IW - 1)
+
+    input_offset = (
+        n * input_stride_n
+        + c * input_stride_c
+        + ih * input_stride_h
+        + iw * input_stride_w
+    )
+    output_offset = nc * OH * OW + idx
+    data = tl.load(ptr_i + input_offset, mask=mask)
+    tl.store(ptr_o + output_offset, data, mask=mask)
+
+
+@triton.jit
+def nearest2d_strided_elementwise_kernel(
+    out_ptr,
+    in_ptr,
+    N,
+    C,
+    OH,
+    OW,
+    IH,
+    IW,
+    reciprocal_scale_h,
+    reciprocal_scale_w,
+    input_stride_n,
+    input_stride_c,
+    input_stride_h,
+    input_stride_w,
+    output_stride_n,
+    output_stride_c,
+    output_stride_h,
+    output_stride_w,
+    BLOCK_SIZE: tl.constexpr,
+    SAME_H: tl.constexpr,
+    SAME_W: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+):
+    if USE_INT32_IDX:
+        tile = tl.program_id(axis=0)
+    else:
+        tile = tl.program_id(axis=0).to(tl.int64)
+
+    offsets = tile * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    if not USE_INT32_IDX:
+        offsets = offsets.to(tl.int64)
+
+    output_plane = OH * OW
+    batch_span = C * output_plane
+    element_count = N * batch_span
+    in_bounds = offsets < element_count
+    out_w = offsets % OW
+    row_major = offsets // OW
+    out_h = row_major % OH
+    channel = (offsets // output_plane) % C
+    batch = offsets // batch_span
+
+    if SAME_H:
+        source_h = out_h
+    else:
+        source_h = tl.minimum(
+            (out_h.to(tl.float32) * reciprocal_scale_h).to(tl.int32), IH - 1
+        )
+    if SAME_W:
+        source_w = out_w
+    else:
+        source_w = tl.minimum(
+            (out_w.to(tl.float32) * reciprocal_scale_w).to(tl.int32), IW - 1
+        )
+
+    input_offset = (
+        batch * input_stride_n
+        + channel * input_stride_c
+        + source_h * input_stride_h
+        + source_w * input_stride_w
+    )
+    output_offset = (
+        batch * output_stride_n
+        + channel * output_stride_c
+        + out_h * output_stride_h
+        + out_w * output_stride_w
+    )
+    data = tl.load(in_ptr + input_offset, mask=in_bounds)
+    tl.store(out_ptr + output_offset, data, mask=in_bounds)
+
+
+def _as_float32_scalar(value: float) -> float:
+    return struct.unpack("f", struct.pack("f", float(value)))[0]
+
+
+def _nearest_reciprocal_float32(
+    input_size: int, output_size: int, scale: Optional[float]
+) -> float:
+    if scale is not None:
+        return _as_float32_scalar(1.0 / scale)
+    return _as_float32_scalar(input_size / output_size)
+
+
+def _has_distinct_channels_last_strides(input: torch.Tensor) -> bool:
+    return input.is_contiguous(memory_format=torch.channels_last) and (
+        not input.is_contiguous()
+    )
+
+
+def _is_exact_2x_resize(
+    IH: int,
+    IW: int,
+    OH: int,
+    OW: int,
+    scales_h: Optional[float],
+    scales_w: Optional[float],
+) -> bool:
+    height_is_doubled = OH == IH + IH
+    width_is_doubled = OW == IW + IW
+    height_scale_allows_2x = scales_h is None or scales_h == 2.0
+    width_scale_allows_2x = scales_w is None or scales_w == 2.0
+    return (
+        height_is_doubled
+        and width_is_doubled
+        and height_scale_allows_2x
+        and width_scale_allows_2x
+    )
+
+
+def _native_layout_copy(input: torch.Tensor, channels_last: bool) -> torch.Tensor:
+    if channels_last:
+        output = torch.empty_like(input, memory_format=torch.channels_last)
+    elif input.is_contiguous():
+        output = torch.empty_like(input, memory_format=torch.contiguous_format)
+    else:
+        output = torch.empty_like(input, memory_format=torch.contiguous_format)
+    torch.ops.aten.copy_.default.redispatch(_FALLBACK_KEYSET, output, input, False)
+    return output
+
+
+def _nhwc_2x_source_config(dtype: torch.dtype) -> tuple[int, int]:
+    if dtype is torch.float16:
+        return 512, 8
+    if dtype is torch.bfloat16:
+        return 256, 4
+    return 512, 4
+
+
+def _nchw_2x_output_config(
+    dtype: torch.dtype, channel_count: int, input_total: int
+) -> Optional[tuple[int, int]]:
+    if dtype in (torch.float16, torch.bfloat16):
+        if input_total <= 4 * 1024 * 1024:
+            if dtype == torch.bfloat16 and channel_count > 3:
+                return 1024, 4
+            return 2048, 4
+        return 2048, 8
+    if dtype == torch.float32 and channel_count > 3 and input_total <= 4 * 1024 * 1024:
+        return 512, 4
+    return None
+
+
+def _nchw_flat_config(dtype: torch.dtype, is_downsample: bool) -> tuple[int, int]:
+    if is_downsample:
+        return 256, 8 if dtype == torch.float32 else 4
+    if dtype == torch.float32:
+        return 2048, 8
+    if dtype == torch.bfloat16:
+        return 1024, 4
+    return 1024, 8
+
+
+def _nchw_spatial_config(
+    dtype: torch.dtype, has_explicit_scale: bool
+) -> Optional[tuple[int, int, int]]:
+    if has_explicit_scale:
+        if dtype == torch.bfloat16:
+            return 512, 4, 1
+        if dtype == torch.float32:
+            return 2048, 4, 1
+        return 1024, 4, 1
+    if dtype == torch.bfloat16:
+        return 512, 4, 1
+    if dtype == torch.float16:
+        return 2048, 4, 2
+    return None
 
 
 def upsample_nearest2d(
     input: torch.Tensor,
-    output_size: Tuple[int],
+    output_size: Tuple[int, int],
     scales_h: Optional[float] = None,
     scales_w: Optional[float] = None,
 ) -> torch.Tensor:
@@ -78,24 +493,197 @@ def upsample_nearest2d(
     assert len(output_size) == 2, "The len of output_size must be 2"
     OH, OW = output_size
     N, C, IH, IW = input.shape
-    if scales_h is not None:
-        reciprocal_scale_h = 1 / scales_h
-    else:
-        reciprocal_scale_h = IH / OH
-    if scales_w is not None:
-        reciprocal_scale_w = 1 / scales_w
-    else:
-        reciprocal_scale_w = IW / OW
-    # allocate output
-    output = torch.empty((N, C, OH, OW), device=input.device, dtype=input.dtype)
-    total_threads = OH * OW
-    grid = lambda META: (
-        triton.cdiv(total_threads, META["BLOCK_SIZE"]),
-        triton.cdiv(N * C, 4),
+
+    reciprocal_scale_h = _nearest_reciprocal_float32(IH, OH, scales_h)
+    reciprocal_scale_w = _nearest_reciprocal_float32(IW, OW, scales_w)
+    channels_last = _has_distinct_channels_last_strides(input)
+
+    if OH == IH and OW == IW:
+        return _native_layout_copy(input, channels_last)
+
+    memory_format = torch.channels_last if channels_last else torch.contiguous_format
+    output = torch.empty(
+        (N, C, OH, OW), device=input.device, dtype=input.dtype, memory_format=memory_format
     )
+    output_total = N * C * OH * OW
+    if output_total == 0:
+        return output
+
+    same_h = OH == IH
+    same_w = OW == IW
+    exact_2x_resize = _is_exact_2x_resize(IH, IW, OH, OW, scales_h, scales_w)
+    use_int32_idx = max(output_total, N * C * IH * IW) <= (2**31 - 1)
+    is_downsample = OH < IH or OW < IW
+
+    if channels_last and exact_2x_resize:
+        block_size, num_warps = _nhwc_2x_source_config(input.dtype)
+
+        def grid(meta):
+            return (triton.cdiv(N * IH * IW * C, meta["BLOCK_SIZE"]),)
+
+        with torch_device_fn.device(input.device):
+            nearest2d_2x_nhwc_source_kernel[grid](
+                output,
+                input,
+                N,
+                C,
+                IH,
+                IW,
+                input.stride(0),
+                input.stride(2),
+                input.stride(3),
+                output.stride(0),
+                output.stride(2),
+                output.stride(3),
+                USE_INT32_IDX=use_int32_idx,
+                BLOCK_SIZE=block_size,
+                num_warps=num_warps,
+            )
+        return output
+
+    if input.is_contiguous() and output.is_contiguous():
+        input_total = N * C * IH * IW
+        nchw_output_2x_config = (
+            _nchw_2x_output_config(input.dtype, C, input_total)
+            if exact_2x_resize
+            else None
+        )
+        if nchw_output_2x_config is not None:
+            block_size, num_warps = nchw_output_2x_config
+
+            def grid(meta):
+                return (triton.cdiv(output_total, meta["BLOCK_SIZE"]),)
+
+            with torch_device_fn.device(input.device):
+                nearest2d_2x_nchw_output_kernel[grid](
+                    output,
+                    input,
+                    N,
+                    C,
+                    IH,
+                    IW,
+                    USE_INT32_IDX=use_int32_idx,
+                    BLOCK_SIZE=block_size,
+                    num_warps=num_warps,
+                )
+            return output
+
+        if exact_2x_resize:
+            block_size = 256 if C <= 3 else 1024
+            num_warps = 8 if C <= 3 else 4
+
+            def grid(meta):
+                return (triton.cdiv(input_total, meta["BLOCK_SIZE"]),)
+
+            with torch_device_fn.device(input.device):
+                nearest2d_2x_nchw_source_kernel[grid](
+                    output,
+                    input,
+                    N,
+                    C,
+                    IH,
+                    IW,
+                    USE_INT32_IDX=use_int32_idx,
+                    BLOCK_SIZE=block_size,
+                    num_warps=num_warps,
+                )
+            return output
+
+        spatial_config = (
+            _nchw_spatial_config(
+                input.dtype, scales_h is not None or scales_w is not None
+            )
+            if (not is_downsample and OH >= IH and OW >= IW)
+            else None
+        )
+        if spatial_config is not None:
+            block_size, num_warps, nc_group = spatial_config
+
+            def grid(meta):
+                return (
+                    triton.cdiv(OH * OW, meta["BLOCK_SIZE"]),
+                    triton.cdiv(N * C, nc_group),
+            )
+
+            with torch_device_fn.device(input.device):
+                nearest2d_contiguous_spatial_tiles_kernel[grid](
+                    output,
+                    input,
+                    N,
+                    C,
+                    OH,
+                    OW,
+                    IH,
+                    IW,
+                    reciprocal_scale_h,
+                    reciprocal_scale_w,
+                    SAME_H=same_h,
+                    SAME_W=same_w,
+                    USE_INT32_IDX=use_int32_idx,
+                    BLOCK_SIZE=block_size,
+                    num_warps=num_warps,
+                )
+            return output
+
+        block_size, num_warps = _nchw_flat_config(input.dtype, is_downsample)
+
+        def grid(meta):
+            return (triton.cdiv(output_total, meta["BLOCK_SIZE"]),)
+
+        with torch_device_fn.device(input.device):
+            upsample_nearest2d_contiguous_flat_kernel[grid](
+                output,
+                input,
+                N,
+                C,
+                OH,
+                OW,
+                IH,
+                IW,
+                reciprocal_scale_h,
+                reciprocal_scale_w,
+                SAME_H=same_h,
+                SAME_W=same_w,
+                USE_INT32_IDX=use_int32_idx,
+                BLOCK_SIZE=block_size,
+                num_warps=num_warps,
+            )
+        return output
+
+    if output.is_contiguous():
+
+        def grid(meta):
+            return (triton.cdiv(OH * OW, meta["BLOCK_SIZE"]), N * C)
+
+        with torch_device_fn.device(input.device):
+            upsample_nearest2d_spatial_strided_kernel[grid](
+                output,
+                input,
+                N,
+                C,
+                OH,
+                OW,
+                IH,
+                IW,
+                reciprocal_scale_h,
+                reciprocal_scale_w,
+                input.stride(0),
+                input.stride(1),
+                input.stride(2),
+                input.stride(3),
+                SAME_H=same_h,
+                SAME_W=same_w,
+                USE_INT32_IDX=use_int32_idx,
+                BLOCK_SIZE=2048,
+                num_warps=8 if input.dtype == torch.float32 else 4,
+            )
+        return output
+
+    def grid(meta):
+        return (triton.cdiv(output_total, meta["BLOCK_SIZE"]),)
 
     with torch_device_fn.device(input.device):
-        upsample_nearest2d_kernel[grid](
+        nearest2d_strided_elementwise_kernel[grid](
             output,
             input,
             N,
@@ -106,5 +694,18 @@ def upsample_nearest2d(
             IW,
             reciprocal_scale_h,
             reciprocal_scale_w,
+            input.stride(0),
+            input.stride(1),
+            input.stride(2),
+            input.stride(3),
+            output.stride(0),
+            output.stride(1),
+            output.stride(2),
+            output.stride(3),
+            SAME_H=same_h,
+            SAME_W=same_w,
+            USE_INT32_IDX=use_int32_idx,
+            BLOCK_SIZE=1024,
+            num_warps=4,
         )
     return output

--- a/src/flag_gems/ops/upsample_nearest2d.py
+++ b/src/flag_gems/ops/upsample_nearest2d.py
@@ -503,7 +503,10 @@ def upsample_nearest2d(
 
     memory_format = torch.channels_last if channels_last else torch.contiguous_format
     output = torch.empty(
-        (N, C, OH, OW), device=input.device, dtype=input.dtype, memory_format=memory_format
+        (N, C, OH, OW),
+        device=input.device,
+        dtype=input.dtype,
+        memory_format=memory_format,
     )
     output_total = N * C * OH * OW
     if output_total == 0:
@@ -603,7 +606,7 @@ def upsample_nearest2d(
                 return (
                     triton.cdiv(OH * OW, meta["BLOCK_SIZE"]),
                     triton.cdiv(N * C, nc_group),
-            )
+                )
 
             with torch_device_fn.device(input.device):
                 nearest2d_contiguous_spatial_tiles_kernel[grid](

--- a/src/flag_gems/ops/upsample_nearest2d_backward.py
+++ b/src/flag_gems/ops/upsample_nearest2d_backward.py
@@ -532,9 +532,9 @@ def upsample_nearest2d_backward(
     N, C, IH, IW = (int(dim) for dim in input_size)
     OH, OW = (int(dim) for dim in output_size)
     expected = (N, C, OH, OW)
-    assert tuple(grad_output.shape) == expected, (
-        f"grad_output shape {tuple(grad_output.shape)} != expected {expected}"
-    )
+    assert (
+        tuple(grad_output.shape) == expected
+    ), f"grad_output shape {tuple(grad_output.shape)} != expected {expected}"
 
     if grad_output.dtype not in (torch.float16, torch.bfloat16, torch.float32):
         return _native_fallback(

--- a/src/flag_gems/ops/upsample_nearest2d_backward.py
+++ b/src/flag_gems/ops/upsample_nearest2d_backward.py
@@ -595,6 +595,10 @@ def upsample_nearest2d_backward(
                     grad_output.dtype, span_h, span_w
                 )
                 block_c = _nhwc_channel_block(C)
+                if C >= 64 and span_h * span_w > 4:
+                    block_hw, block_c, num_warps = _nhwc_dense_launch_config(
+                        grad_output.dtype, C
+                    )
                 grid = (triton.cdiv(N * IH * IW, block_hw), triton.cdiv(C, block_c))
                 _range_nhwc_kernel[grid](
                     grad_output,

--- a/src/flag_gems/ops/upsample_nearest2d_backward.py
+++ b/src/flag_gems/ops/upsample_nearest2d_backward.py
@@ -1,0 +1,689 @@
+import logging
+import math
+import struct
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import device, torch_device_fn
+
+device = device.name
+logger = logging.getLogger(__name__)
+
+_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeExplicitAutograd
+)
+_MAX_RANGE_SPAN = 8
+
+
+@triton.jit
+def _ceil_pos_to_i64(x):
+    xi = x.to(tl.int64)
+    return xi + tl.where(xi.to(tl.float32) < x, 1, 0)
+
+
+@triton.jit
+def _x2_nchw_kernel(
+    grad_out,
+    grad_in,
+    total: tl.constexpr,
+    IH: tl.constexpr,
+    IW: tl.constexpr,
+    OH: tl.constexpr,
+    OW: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < total
+
+    iw = offsets % IW
+    ih = (offsets // IW) % IH
+    nc = offsets // (IH * IW)
+
+    base = nc.to(tl.int64) * OH * OW + (ih * 2).to(tl.int64) * OW + iw * 2
+    g00 = tl.load(grad_out + base, mask=mask, other=0.0)
+    g01 = tl.load(grad_out + base + 1, mask=mask, other=0.0)
+    g10 = tl.load(grad_out + base + OW, mask=mask, other=0.0)
+    g11 = tl.load(grad_out + base + OW + 1, mask=mask, other=0.0)
+    acc = g00.to(tl.float32) + g01.to(tl.float32) + g10.to(tl.float32) + g11.to(
+        tl.float32
+    )
+
+    tl.store(grad_in + offsets, acc.to(grad_in.dtype.element_ty), mask=mask)
+
+
+@triton.jit
+def _range_nchw_kernel(
+    grad_out,
+    grad_in,
+    total: tl.constexpr,
+    IH: tl.constexpr,
+    IW: tl.constexpr,
+    OH: tl.constexpr,
+    OW: tl.constexpr,
+    scale_h,
+    scale_w,
+    MAX_SPAN_H: tl.constexpr,
+    MAX_SPAN_W: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < total
+
+    iw = offsets % IW
+    ih = (offsets // IW) % IH
+    nc = offsets // (IH * IW)
+
+    if USE_INT32_IDX:
+        oh_start = tl.ceil(ih.to(tl.float32) * scale_h).to(tl.int32)
+        oh_end = tl.ceil((ih.to(tl.float32) + 1.0) * scale_h).to(tl.int32)
+        ow_start = tl.ceil(iw.to(tl.float32) * scale_w).to(tl.int32)
+        ow_end = tl.ceil((iw.to(tl.float32) + 1.0) * scale_w).to(tl.int32)
+    else:
+        oh_start = _ceil_pos_to_i64(ih.to(tl.float32) * scale_h)
+        oh_end = _ceil_pos_to_i64((ih.to(tl.float32) + 1.0) * scale_h)
+        ow_start = _ceil_pos_to_i64(iw.to(tl.float32) * scale_w)
+        ow_end = _ceil_pos_to_i64((iw.to(tl.float32) + 1.0) * scale_w)
+
+    oh_start = tl.minimum(tl.maximum(oh_start, 0), OH)
+    oh_end = tl.minimum(tl.maximum(oh_end, 0), OH)
+    ow_start = tl.minimum(tl.maximum(ow_start, 0), OW)
+    ow_end = tl.minimum(tl.maximum(ow_end, 0), OW)
+
+    acc = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+    base = nc.to(tl.int64) * OH * OW
+    for dh in tl.static_range(MAX_SPAN_H):
+        oh = oh_start + dh
+        h_valid = oh < oh_end
+        for dw in tl.static_range(MAX_SPAN_W):
+            ow = ow_start + dw
+            valid = mask & h_valid & (ow < ow_end)
+            go = tl.load(
+                grad_out + base + oh.to(tl.int64) * OW + ow.to(tl.int64),
+                mask=valid,
+                other=0.0,
+            )
+            acc += go.to(tl.float32)
+
+    tl.store(grad_in + offsets, acc.to(grad_in.dtype.element_ty), mask=mask)
+
+
+@triton.jit
+def _range_nchw_strided_kernel(
+    grad_out,
+    grad_in,
+    total: tl.constexpr,
+    C: tl.constexpr,
+    IH: tl.constexpr,
+    IW: tl.constexpr,
+    OH: tl.constexpr,
+    OW: tl.constexpr,
+    go_stride_n: tl.constexpr,
+    go_stride_c: tl.constexpr,
+    go_stride_h: tl.constexpr,
+    go_stride_w: tl.constexpr,
+    gi_stride_n: tl.constexpr,
+    gi_stride_c: tl.constexpr,
+    gi_stride_h: tl.constexpr,
+    gi_stride_w: tl.constexpr,
+    scale_h,
+    scale_w,
+    MAX_SPAN_H: tl.constexpr,
+    MAX_SPAN_W: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < total
+
+    iw = offsets % IW
+    ih = (offsets // IW) % IH
+    c = (offsets // (IH * IW)) % C
+    n = offsets // (C * IH * IW)
+
+    if USE_INT32_IDX:
+        oh_start = tl.ceil(ih.to(tl.float32) * scale_h).to(tl.int32)
+        oh_end = tl.ceil((ih.to(tl.float32) + 1.0) * scale_h).to(tl.int32)
+        ow_start = tl.ceil(iw.to(tl.float32) * scale_w).to(tl.int32)
+        ow_end = tl.ceil((iw.to(tl.float32) + 1.0) * scale_w).to(tl.int32)
+    else:
+        oh_start = _ceil_pos_to_i64(ih.to(tl.float32) * scale_h)
+        oh_end = _ceil_pos_to_i64((ih.to(tl.float32) + 1.0) * scale_h)
+        ow_start = _ceil_pos_to_i64(iw.to(tl.float32) * scale_w)
+        ow_end = _ceil_pos_to_i64((iw.to(tl.float32) + 1.0) * scale_w)
+
+    oh_start = tl.minimum(tl.maximum(oh_start, 0), OH)
+    oh_end = tl.minimum(tl.maximum(oh_end, 0), OH)
+    ow_start = tl.minimum(tl.maximum(ow_start, 0), OW)
+    ow_end = tl.minimum(tl.maximum(ow_end, 0), OW)
+
+    acc = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+    go_base = n.to(tl.int64) * go_stride_n + c.to(tl.int64) * go_stride_c
+    for dh in tl.static_range(MAX_SPAN_H):
+        oh = oh_start + dh
+        h_valid = oh < oh_end
+        for dw in tl.static_range(MAX_SPAN_W):
+            ow = ow_start + dw
+            valid = mask & h_valid & (ow < ow_end)
+            go = tl.load(
+                grad_out
+                + go_base
+                + oh.to(tl.int64) * go_stride_h
+                + ow.to(tl.int64) * go_stride_w,
+                mask=valid,
+                other=0.0,
+            )
+            acc += go.to(tl.float32)
+
+    gi_offset = (
+        n.to(tl.int64) * gi_stride_n
+        + c.to(tl.int64) * gi_stride_c
+        + ih.to(tl.int64) * gi_stride_h
+        + iw.to(tl.int64) * gi_stride_w
+    )
+    tl.store(grad_in + gi_offset, acc.to(grad_in.dtype.element_ty), mask=mask)
+
+
+@triton.jit
+def _span1_nchw_kernel(
+    grad_out,
+    grad_in,
+    total: tl.constexpr,
+    IH: tl.constexpr,
+    IW: tl.constexpr,
+    OH: tl.constexpr,
+    OW: tl.constexpr,
+    scale_h,
+    scale_w,
+    USE_INT32_IDX: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < total
+
+    iw = offsets % IW
+    ih = (offsets // IW) % IH
+    nc = offsets // (IH * IW)
+
+    if USE_INT32_IDX:
+        oh = tl.ceil(ih.to(tl.float32) * scale_h).to(tl.int32)
+        oh_end = tl.ceil((ih.to(tl.float32) + 1.0) * scale_h).to(tl.int32)
+        ow = tl.ceil(iw.to(tl.float32) * scale_w).to(tl.int32)
+        ow_end = tl.ceil((iw.to(tl.float32) + 1.0) * scale_w).to(tl.int32)
+    else:
+        oh = _ceil_pos_to_i64(ih.to(tl.float32) * scale_h)
+        oh_end = _ceil_pos_to_i64((ih.to(tl.float32) + 1.0) * scale_h)
+        ow = _ceil_pos_to_i64(iw.to(tl.float32) * scale_w)
+        ow_end = _ceil_pos_to_i64((iw.to(tl.float32) + 1.0) * scale_w)
+
+    valid = mask & (oh < oh_end) & (ow < ow_end) & (oh < OH) & (ow < OW)
+    go = tl.load(
+        grad_out + nc.to(tl.int64) * OH * OW + oh.to(tl.int64) * OW + ow.to(tl.int64),
+        mask=valid,
+        other=0.0,
+    )
+    tl.store(grad_in + offsets, go, mask=mask)
+
+
+@triton.jit
+def _downsample_nchw_scatter_kernel(
+    grad_out,
+    grad_in,
+    total: tl.constexpr,
+    IH: tl.constexpr,
+    IW: tl.constexpr,
+    OH: tl.constexpr,
+    OW: tl.constexpr,
+    reciprocal_scale_h,
+    reciprocal_scale_w,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < total
+
+    ow = offsets % OW
+    oh = (offsets // OW) % OH
+    nc = offsets // (OH * OW)
+
+    ih = tl.minimum((oh.to(tl.float32) * reciprocal_scale_h).to(tl.int64), IH - 1)
+    iw = tl.minimum((ow.to(tl.float32) * reciprocal_scale_w).to(tl.int64), IW - 1)
+    go = tl.load(grad_out + offsets, mask=mask, other=0.0)
+    tl.store(grad_in + nc.to(tl.int64) * IH * IW + ih * IW + iw, go, mask=mask)
+
+
+@triton.jit
+def _x2_nhwc_kernel(
+    grad_out,
+    grad_in,
+    N: tl.constexpr,
+    C: tl.constexpr,
+    IH: tl.constexpr,
+    IW: tl.constexpr,
+    OH: tl.constexpr,
+    OW: tl.constexpr,
+    BLOCK_HW: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    hw_offsets = tl.program_id(0) * BLOCK_HW + tl.arange(0, BLOCK_HW)
+    c_offsets = tl.program_id(1) * BLOCK_C + tl.arange(0, BLOCK_C)
+    hw_total: tl.constexpr = N * IH * IW
+
+    n = hw_offsets // (IH * IW)
+    rem = hw_offsets % (IH * IW)
+    ih = rem // IW
+    iw = rem % IW
+
+    c_mask = c_offsets < C
+    hw_mask = hw_offsets < hw_total
+    mask = hw_mask[:, None] & c_mask[None, :]
+
+    c = c_offsets[None, :]
+    go_base = (
+        n[:, None].to(tl.int64) * OH * OW * C
+        + (ih[:, None] * 2).to(tl.int64) * OW * C
+        + (iw[:, None] * 2).to(tl.int64) * C
+        + c
+    )
+    g00 = tl.load(grad_out + go_base, mask=mask, other=0.0)
+    g01 = tl.load(grad_out + go_base + C, mask=mask, other=0.0)
+    g10 = tl.load(grad_out + go_base + OW * C, mask=mask, other=0.0)
+    g11 = tl.load(grad_out + go_base + OW * C + C, mask=mask, other=0.0)
+    acc = g00.to(tl.float32) + g01.to(tl.float32) + g10.to(tl.float32) + g11.to(
+        tl.float32
+    )
+
+    gi_base = (
+        n[:, None].to(tl.int64) * IH * IW * C
+        + ih[:, None].to(tl.int64) * IW * C
+        + iw[:, None].to(tl.int64) * C
+        + c
+    )
+    tl.store(grad_in + gi_base, acc.to(grad_in.dtype.element_ty), mask=mask)
+
+
+@triton.jit
+def _range_nhwc_kernel(
+    grad_out,
+    grad_in,
+    N: tl.constexpr,
+    C: tl.constexpr,
+    IH: tl.constexpr,
+    IW: tl.constexpr,
+    OH: tl.constexpr,
+    OW: tl.constexpr,
+    scale_h,
+    scale_w,
+    MAX_SPAN_H: tl.constexpr,
+    MAX_SPAN_W: tl.constexpr,
+    USE_INT32_IDX: tl.constexpr,
+    BLOCK_HW: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+):
+    hw_offsets = tl.program_id(0) * BLOCK_HW + tl.arange(0, BLOCK_HW)
+    c_offsets = tl.program_id(1) * BLOCK_C + tl.arange(0, BLOCK_C)
+    hw_total: tl.constexpr = N * IH * IW
+
+    n = hw_offsets // (IH * IW)
+    rem = hw_offsets % (IH * IW)
+    ih = rem // IW
+    iw = rem % IW
+
+    c_mask = c_offsets < C
+    hw_mask = hw_offsets < hw_total
+    mask = hw_mask[:, None] & c_mask[None, :]
+    c = c_offsets[None, :]
+
+    if USE_INT32_IDX:
+        oh_start = tl.ceil(ih.to(tl.float32) * scale_h).to(tl.int32)
+        oh_end = tl.ceil((ih.to(tl.float32) + 1.0) * scale_h).to(tl.int32)
+        ow_start = tl.ceil(iw.to(tl.float32) * scale_w).to(tl.int32)
+        ow_end = tl.ceil((iw.to(tl.float32) + 1.0) * scale_w).to(tl.int32)
+    else:
+        oh_start = _ceil_pos_to_i64(ih.to(tl.float32) * scale_h)
+        oh_end = _ceil_pos_to_i64((ih.to(tl.float32) + 1.0) * scale_h)
+        ow_start = _ceil_pos_to_i64(iw.to(tl.float32) * scale_w)
+        ow_end = _ceil_pos_to_i64((iw.to(tl.float32) + 1.0) * scale_w)
+
+    oh_start = tl.minimum(tl.maximum(oh_start, 0), OH)
+    oh_end = tl.minimum(tl.maximum(oh_end, 0), OH)
+    ow_start = tl.minimum(tl.maximum(ow_start, 0), OW)
+    ow_end = tl.minimum(tl.maximum(ow_end, 0), OW)
+
+    acc = tl.zeros([BLOCK_HW, BLOCK_C], dtype=tl.float32)
+    go_n_base = n[:, None].to(tl.int64) * OH * OW * C
+    for dh in tl.static_range(MAX_SPAN_H):
+        oh = oh_start + dh
+        h_valid = oh < oh_end
+        for dw in tl.static_range(MAX_SPAN_W):
+            ow = ow_start + dw
+            valid = mask & h_valid[:, None] & (ow < ow_end)[:, None]
+            go = tl.load(
+                grad_out
+                + go_n_base
+                + oh[:, None].to(tl.int64) * OW * C
+                + ow[:, None].to(tl.int64) * C
+                + c,
+                mask=valid,
+                other=0.0,
+            )
+            acc += go.to(tl.float32)
+
+    gi_base = (
+        n[:, None].to(tl.int64) * IH * IW * C
+        + ih[:, None].to(tl.int64) * IW * C
+        + iw[:, None].to(tl.int64) * C
+        + c
+    )
+    tl.store(grad_in + gi_base, acc.to(grad_in.dtype.element_ty), mask=mask)
+
+
+def _round_float32(value: float) -> float:
+    return struct.unpack("f", struct.pack("f", float(value)))[0]
+
+
+def _nearest_reciprocal_scale(
+    input_size: int, output_size: int, scale: Optional[float]
+) -> float:
+    if scale is not None:
+        scale_value = float(scale)
+        if not math.isfinite(scale_value) or scale_value <= 0.0:
+            return math.nan
+        return _round_float32(1.0 / scale_value)
+    if output_size <= 0:
+        return math.nan
+    return _round_float32(float(input_size) / float(output_size))
+
+
+def _nearest_scale(input_size: int, output_size: int, scale: Optional[float]) -> float:
+    if scale is not None:
+        scale_value = float(scale)
+        if not math.isfinite(scale_value) or scale_value <= 0.0:
+            return math.nan
+        return _round_float32(scale_value)
+    if input_size <= 0:
+        return math.nan
+    return _round_float32(float(output_size) / float(input_size))
+
+
+def _max_range_span(scale: float) -> int:
+    if not math.isfinite(scale) or scale <= 0.0:
+        return _MAX_RANGE_SPAN + 1
+    if scale <= 1.0:
+        return 1
+    return max(1, int(math.ceil(scale)))
+
+
+def _is_x2(IH: int, IW: int, OH: int, OW: int, scale_h: float, scale_w: float) -> bool:
+    return (
+        OH == IH * 2
+        and OW == IW * 2
+        and scale_h == _round_float32(0.5)
+        and scale_w == _round_float32(0.5)
+    )
+
+
+def _x2_nchw_launch_config(dtype: torch.dtype, total: int) -> Tuple[int, int]:
+    if dtype in (torch.float16, torch.bfloat16) and total > 1_000_000:
+        return 256, 8
+    if dtype == torch.float32:
+        if 1_000_000 < total <= 2_500_000:
+            return 128, 8
+        if 2_500_000 < total <= 8_000_000:
+            return 512, 8
+        if total >= 268_000_000:
+            return 256, 8
+    return 256, 4
+
+
+def _range_launch_config(
+    dtype: torch.dtype, span_h: int, span_w: int
+) -> Tuple[int, int]:
+    span_product = span_h * span_w
+    if span_product <= 6 and max(span_h, span_w) == 3:
+        if dtype == torch.float32:
+            return 256, 8
+        return 1024, 4
+    return 256, 4
+
+
+def _contiguous_range_launch_config(
+    dtype: torch.dtype, max_h_span: int, max_w_span: int
+) -> Tuple[int, int]:
+    return _range_launch_config(dtype, max_h_span, max_w_span)
+
+
+def _use_int32_idx(*sizes: int) -> bool:
+    return all(0 <= int(size) <= torch.iinfo(torch.int32).max for size in sizes)
+
+
+def _nhwc_channel_block(C: int) -> int:
+    if C <= 8:
+        return 8
+    if C <= 16:
+        return 16
+    return 32
+
+
+def _nhwc_dense_launch_config(dtype: torch.dtype, C: int) -> Tuple[int, int, int]:
+    block_c = _nhwc_channel_block(C)
+    if dtype in (torch.bfloat16, torch.float32):
+        block_c = max(block_c, 32)
+    if dtype == torch.float32:
+        return 128, block_c, 4
+    return 64, block_c, 4
+
+
+def _empty_grad_input(
+    grad_output: torch.Tensor, input_size: Tuple[int, int, int, int]
+) -> torch.Tensor:
+    if grad_output.is_contiguous():
+        return torch.empty(input_size, device=grad_output.device, dtype=grad_output.dtype)
+    if grad_output.is_contiguous(memory_format=torch.channels_last):
+        return torch.empty(
+            input_size,
+            device=grad_output.device,
+            dtype=grad_output.dtype,
+            memory_format=torch.channels_last,
+        )
+    return torch.empty(input_size, device=grad_output.device, dtype=grad_output.dtype)
+
+
+def _native_fallback(
+    grad_output: torch.Tensor,
+    output_size,
+    input_size,
+    scales_h=None,
+    scales_w=None,
+) -> torch.Tensor:
+    return torch.ops.aten.upsample_nearest2d_backward.default.redispatch(
+        _FALLBACK_KEYSET,
+        grad_output,
+        output_size,
+        input_size,
+        scales_h,
+        scales_w,
+    )
+
+
+def upsample_nearest2d_backward(
+    grad_output: torch.Tensor,
+    output_size,
+    input_size,
+    scales_h=None,
+    scales_w=None,
+) -> torch.Tensor:
+    logger.debug("GEMS UPSAMPLE NEAREST2D BACKWARD")
+    assert grad_output.device.type == device
+    assert grad_output.ndim == 4, "The ndim of grad_output must be 4"
+    assert len(output_size) == 2, "The len of output_size must be 2"
+    assert len(input_size) == 4, "The len of input_size must be 4"
+
+    N, C, IH, IW = (int(dim) for dim in input_size)
+    OH, OW = (int(dim) for dim in output_size)
+    expected = (N, C, OH, OW)
+    assert tuple(grad_output.shape) == expected, (
+        f"grad_output shape {tuple(grad_output.shape)} != expected {expected}"
+    )
+
+    if grad_output.dtype not in (torch.float16, torch.bfloat16, torch.float32):
+        return _native_fallback(grad_output, output_size, input_size, scales_h, scales_w)
+    if N == 0 or C == 0 or IH == 0 or IW == 0:
+        return _empty_grad_input(grad_output, (N, C, IH, IW))
+    if OH <= 0 or OW <= 0 or IH < 0 or IW < 0:
+        return _native_fallback(grad_output, output_size, input_size, scales_h, scales_w)
+
+    scale_h = _nearest_scale(IH, OH, scales_h)
+    scale_w = _nearest_scale(IW, OW, scales_w)
+    span_h = _max_range_span(scale_h)
+    span_w = _max_range_span(scale_w)
+    if span_h > _MAX_RANGE_SPAN or span_w > _MAX_RANGE_SPAN:
+        return _native_fallback(grad_output, output_size, input_size, scales_h, scales_w)
+
+    grad_input = _empty_grad_input(grad_output, (N, C, IH, IW))
+    total = grad_input.numel()
+    if total == 0:
+        return grad_input
+    use_int32_idx = _use_int32_idx(N, C, IH, IW, OH, OW, total)
+
+    is_channels_last_only = grad_output.is_contiguous(
+        memory_format=torch.channels_last
+    ) and not grad_output.is_contiguous()
+    reciprocal_scale_h = _nearest_reciprocal_scale(IH, OH, scales_h)
+    reciprocal_scale_w = _nearest_reciprocal_scale(IW, OW, scales_w)
+    use_x2 = _is_x2(IH, IW, OH, OW, reciprocal_scale_h, reciprocal_scale_w)
+
+    with torch_device_fn.device(grad_output.device):
+        if is_channels_last_only:
+            if use_x2:
+                block_hw, block_c, num_warps = _nhwc_dense_launch_config(
+                    grad_output.dtype, C
+                )
+                grid = (triton.cdiv(N * IH * IW, block_hw), triton.cdiv(C, block_c))
+                _x2_nhwc_kernel[grid](
+                    grad_output,
+                    grad_input,
+                    N,
+                    C,
+                    IH,
+                    IW,
+                    OH,
+                    OW,
+                    BLOCK_HW=block_hw,
+                    BLOCK_C=block_c,
+                    num_warps=num_warps,
+                )
+            else:
+                block_hw, num_warps = _range_launch_config(
+                    grad_output.dtype, span_h, span_w
+                )
+                block_c = _nhwc_channel_block(C)
+                grid = (triton.cdiv(N * IH * IW, block_hw), triton.cdiv(C, block_c))
+                _range_nhwc_kernel[grid](
+                    grad_output,
+                    grad_input,
+                    N,
+                    C,
+                    IH,
+                    IW,
+                    OH,
+                    OW,
+                    scale_h,
+                    scale_w,
+                    MAX_SPAN_H=span_h,
+                    MAX_SPAN_W=span_w,
+                    USE_INT32_IDX=use_int32_idx,
+                    BLOCK_HW=block_hw,
+                    BLOCK_C=block_c,
+                    num_warps=num_warps,
+                )
+            return grad_input
+
+        if not grad_output.is_contiguous():
+            block_size, num_warps = _range_launch_config(
+                grad_output.dtype, span_h, span_w
+            )
+            grid = (triton.cdiv(total, block_size),)
+            _range_nchw_strided_kernel[grid](
+                grad_output,
+                grad_input,
+                total,
+                C,
+                IH,
+                IW,
+                OH,
+                OW,
+                grad_output.stride(0),
+                grad_output.stride(1),
+                grad_output.stride(2),
+                grad_output.stride(3),
+                grad_input.stride(0),
+                grad_input.stride(1),
+                grad_input.stride(2),
+                grad_input.stride(3),
+                scale_h,
+                scale_w,
+                MAX_SPAN_H=span_h,
+                MAX_SPAN_W=span_w,
+                USE_INT32_IDX=use_int32_idx,
+                BLOCK_SIZE=block_size,
+                num_warps=num_warps,
+            )
+            return grad_input
+
+        grad_out_contig = grad_output
+        if use_x2:
+            block_size, num_warps = _x2_nchw_launch_config(grad_output.dtype, total)
+            grid = (triton.cdiv(total, block_size),)
+            _x2_nchw_kernel[grid](
+                grad_out_contig,
+                grad_input,
+                total,
+                IH,
+                IW,
+                OH,
+                OW,
+                BLOCK_SIZE=block_size,
+                num_warps=num_warps,
+            )
+        else:
+            block_size, num_warps = _contiguous_range_launch_config(
+                grad_output.dtype, span_h, span_w
+            )
+            if scale_h <= 1.0 and scale_w <= 1.0:
+                grid = (triton.cdiv(total, block_size),)
+                _span1_nchw_kernel[grid](
+                    grad_out_contig,
+                    grad_input,
+                    total,
+                    IH,
+                    IW,
+                    OH,
+                    OW,
+                    scale_h,
+                    scale_w,
+                    USE_INT32_IDX=use_int32_idx,
+                    BLOCK_SIZE=block_size,
+                    num_warps=num_warps,
+                )
+            else:
+                grid = (triton.cdiv(total, block_size),)
+                _range_nchw_kernel[grid](
+                    grad_out_contig,
+                    grad_input,
+                    total,
+                    IH,
+                    IW,
+                    OH,
+                    OW,
+                    scale_h,
+                    scale_w,
+                    MAX_SPAN_H=span_h,
+                    MAX_SPAN_W=span_w,
+                    USE_INT32_IDX=use_int32_idx,
+                    BLOCK_SIZE=block_size,
+                    num_warps=num_warps,
+                )
+    return grad_input

--- a/src/flag_gems/ops/upsample_nearest2d_backward.py
+++ b/src/flag_gems/ops/upsample_nearest2d_backward.py
@@ -47,8 +47,11 @@ def _x2_nchw_kernel(
     g01 = tl.load(grad_out + base + 1, mask=mask, other=0.0)
     g10 = tl.load(grad_out + base + OW, mask=mask, other=0.0)
     g11 = tl.load(grad_out + base + OW + 1, mask=mask, other=0.0)
-    acc = g00.to(tl.float32) + g01.to(tl.float32) + g10.to(tl.float32) + g11.to(
-        tl.float32
+    acc = (
+        g00.to(tl.float32)
+        + g01.to(tl.float32)
+        + g10.to(tl.float32)
+        + g11.to(tl.float32)
     )
 
     tl.store(grad_in + offsets, acc.to(grad_in.dtype.element_ty), mask=mask)
@@ -291,8 +294,11 @@ def _x2_nhwc_kernel(
     g01 = tl.load(grad_out + go_base + C, mask=mask, other=0.0)
     g10 = tl.load(grad_out + go_base + OW * C, mask=mask, other=0.0)
     g11 = tl.load(grad_out + go_base + OW * C + C, mask=mask, other=0.0)
-    acc = g00.to(tl.float32) + g01.to(tl.float32) + g10.to(tl.float32) + g11.to(
-        tl.float32
+    acc = (
+        g00.to(tl.float32)
+        + g01.to(tl.float32)
+        + g10.to(tl.float32)
+        + g11.to(tl.float32)
     )
 
     gi_base = (
@@ -480,7 +486,9 @@ def _empty_grad_input(
     grad_output: torch.Tensor, input_size: Tuple[int, int, int, int]
 ) -> torch.Tensor:
     if grad_output.is_contiguous():
-        return torch.empty(input_size, device=grad_output.device, dtype=grad_output.dtype)
+        return torch.empty(
+            input_size, device=grad_output.device, dtype=grad_output.dtype
+        )
     if grad_output.is_contiguous(memory_format=torch.channels_last):
         return torch.empty(
             input_size,
@@ -529,18 +537,24 @@ def upsample_nearest2d_backward(
     )
 
     if grad_output.dtype not in (torch.float16, torch.bfloat16, torch.float32):
-        return _native_fallback(grad_output, output_size, input_size, scales_h, scales_w)
+        return _native_fallback(
+            grad_output, output_size, input_size, scales_h, scales_w
+        )
     if N == 0 or C == 0 or IH == 0 or IW == 0:
         return _empty_grad_input(grad_output, (N, C, IH, IW))
     if OH <= 0 or OW <= 0 or IH < 0 or IW < 0:
-        return _native_fallback(grad_output, output_size, input_size, scales_h, scales_w)
+        return _native_fallback(
+            grad_output, output_size, input_size, scales_h, scales_w
+        )
 
     scale_h = _nearest_scale(IH, OH, scales_h)
     scale_w = _nearest_scale(IW, OW, scales_w)
     span_h = _max_range_span(scale_h)
     span_w = _max_range_span(scale_w)
     if span_h > _MAX_RANGE_SPAN or span_w > _MAX_RANGE_SPAN:
-        return _native_fallback(grad_output, output_size, input_size, scales_h, scales_w)
+        return _native_fallback(
+            grad_output, output_size, input_size, scales_h, scales_w
+        )
 
     grad_input = _empty_grad_input(grad_output, (N, C, IH, IW))
     total = grad_input.numel()
@@ -548,9 +562,10 @@ def upsample_nearest2d_backward(
         return grad_input
     use_int32_idx = _use_int32_idx(N, C, IH, IW, OH, OW, total)
 
-    is_channels_last_only = grad_output.is_contiguous(
-        memory_format=torch.channels_last
-    ) and not grad_output.is_contiguous()
+    is_channels_last_only = (
+        grad_output.is_contiguous(memory_format=torch.channels_last)
+        and not grad_output.is_contiguous()
+    )
     reciprocal_scale_h = _nearest_reciprocal_scale(IH, OH, scales_h)
     reciprocal_scale_w = _nearest_reciprocal_scale(IW, OW, scales_w)
     use_x2 = _is_x2(IH, IW, OH, OW, reciprocal_scale_h, reciprocal_scale_w)

--- a/src/flag_gems/runtime/register.py
+++ b/src/flag_gems/runtime/register.py
@@ -129,7 +129,17 @@ class Register:
                 # Older torch versions don't support allow_override
                 self.lib.impl(key, fn, device_key)
         else:
-            self.lib.impl(key, fn, device_key)
+            with warnings.catch_warnings():
+                warnings.filterwarnings(
+                    "ignore",
+                    message=(
+                        r"Warning only once for all operators,  other operators "
+                        r"may also be overridden\..*"
+                    ),
+                    category=UserWarning,
+                    module=r"torch\.library",
+                )
+                self.lib.impl(key, fn, device_key)
 
     def for_each(self):
         for key, func in self.config:

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -27,6 +27,7 @@ from typing import (
 )
 
 import triton
+import triton.testing
 
 from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
@@ -245,13 +246,29 @@ class LibTuner(triton.runtime.Autotuner):
         do_bench=None,
         strategy=None,
     ):
-        # NOTE(zhengyang): See discussion in https://github.com/triton-lang/triton/pull/4496
-        if major_version == 2 or (major_version == 3 and minor_version <= 1):
+        def _make_do_bench():
+            if do_bench is not None:
+                return do_bench
+            if use_cuda_graph:
+                return lambda kernel_call, quantiles: triton.testing.do_bench_cudagraph(
+                    kernel_call,
+                    rep=rep if rep is not None else 100,
+                    quantiles=quantiles,
+                )
+            if warmup is not None or rep is not None:
+                return lambda kernel_call, quantiles: triton.testing.do_bench(
+                    kernel_call,
+                    warmup=warmup if warmup is not None else 25,
+                    rep=rep if rep is not None else 100,
+                    quantiles=quantiles,
+                )
+            return None
+
+        if major_version == 2:
             if warmup is None:
                 warmup = 25
             if rep is None:
                 rep = 100
-        if major_version == 2:
             super().__init__(
                 fn,
                 arg_names,
@@ -266,7 +283,11 @@ class LibTuner(triton.runtime.Autotuner):
             self.base_fn = fn
             while not inspect.isfunction(self.base_fn):
                 self.base_fn = self.base_fn.fn
-        else:
+        elif major_version == 3 and minor_version <= 1:
+            if warmup is None:
+                warmup = 25
+            if rep is None:
+                rep = 100
             super().__init__(
                 fn,
                 arg_names,
@@ -280,6 +301,19 @@ class LibTuner(triton.runtime.Autotuner):
                 warmup,
                 rep,
                 use_cuda_graph,
+            )
+        else:
+            super().__init__(
+                fn,
+                arg_names,
+                configs,
+                key,
+                reset_to_zero,
+                restore_value,
+                pre_hook,
+                post_hook,
+                prune_configs_by,
+                do_bench=_make_do_bench(),
             )
         self.__name__ = self.base_fn.__name__
         self.keys = key

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -180,10 +180,12 @@ class LibCache(object):
         self.model: PersistantModel = SQLPersistantModel(self.db_url)
 
     @overload
-    def __getitem__(self, key: str) -> ConfigCache: ...
+    def __getitem__(self, key: str) -> ConfigCache:
+        ...
 
     @overload
-    def __getitem__(self, key: Tuple[Union[int, float, str]]) -> BenchmarkCache: ...
+    def __getitem__(self, key: Tuple[Union[int, float, str]]) -> BenchmarkCache:
+        ...
 
     def __getitem__(
         self, key: Union[str, Tuple[Union[int, float, str], ...]]
@@ -319,9 +321,9 @@ class LibTuner(triton.runtime.Autotuner):
             strategy = LibTuner.get_strategy(strategy)
         if not isinstance(strategy, (list, tuple)):
             strategy = [strategy] * len(self.keys)
-        assert len(strategy) == len(self.keys), (
-            f"the length of strategy {len(strategy)} must match the length of keys {len(self.keys)}"
-        )
+        assert len(strategy) == len(
+            self.keys
+        ), f"the length of strategy {len(strategy)} must match the length of keys {len(self.keys)}"
         strategy: List[Callable[[Any], Any]] = [
             LibTuner.get_strategy(s) if isinstance(s, str) else s for s in strategy
         ]
@@ -616,9 +618,9 @@ def libtuner(
 
     if isinstance(policy, str):
         policy = LibTuner.get(policy)
-    assert issubclass(policy, LibTuner), (
-        f"the class of {policy.__name__} is {policy.__class__.__name__}, not a subclass of {LibTuner.__name__}"
-    )
+    assert issubclass(
+        policy, LibTuner
+    ), f"the class of {policy.__name__} is {policy.__class__.__name__}, not a subclass of {LibTuner.__name__}"
 
     def decorator(fn):
         return policy(

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -180,12 +180,10 @@ class LibCache(object):
         self.model: PersistantModel = SQLPersistantModel(self.db_url)
 
     @overload
-    def __getitem__(self, key: str) -> ConfigCache:
-        ...
+    def __getitem__(self, key: str) -> ConfigCache: ...
 
     @overload
-    def __getitem__(self, key: Tuple[Union[int, float, str]]) -> BenchmarkCache:
-        ...
+    def __getitem__(self, key: Tuple[Union[int, float, str]]) -> BenchmarkCache: ...
 
     def __getitem__(
         self, key: Union[str, Tuple[Union[int, float, str], ...]]
@@ -321,9 +319,9 @@ class LibTuner(triton.runtime.Autotuner):
             strategy = LibTuner.get_strategy(strategy)
         if not isinstance(strategy, (list, tuple)):
             strategy = [strategy] * len(self.keys)
-        assert len(strategy) == len(
-            self.keys
-        ), f"the length of strategy {len(strategy)} must match the length of keys {len(self.keys)}"
+        assert len(strategy) == len(self.keys), (
+            f"the length of strategy {len(strategy)} must match the length of keys {len(self.keys)}"
+        )
         strategy: List[Callable[[Any], Any]] = [
             LibTuner.get_strategy(s) if isinstance(s, str) else s for s in strategy
         ]
@@ -618,9 +616,9 @@ def libtuner(
 
     if isinstance(policy, str):
         policy = LibTuner.get(policy)
-    assert issubclass(
-        policy, LibTuner
-    ), f"the class of {policy.__name__} is {policy.__class__.__name__}, not a subclass of {LibTuner.__name__}"
+    assert issubclass(policy, LibTuner), (
+        f"the class of {policy.__name__} is {policy.__class__.__name__}, not a subclass of {LibTuner.__name__}"
+    )
 
     def decorator(fn):
         return policy(

--- a/tests/test_upsample_nearest2d.py
+++ b/tests/test_upsample_nearest2d.py
@@ -65,6 +65,24 @@ def test_upsample_nearest2d_explicit_scales_x2_output(dtype):
 
 
 @pytest.mark.upsample_nearest2d
+def test_upsample_nearest2d_preserves_legacy_nearest_not_nearest_exact():
+    input = torch.arange(1 * 2 * 3 * 4, dtype=torch.float32, device=flag_gems.device)
+    input = input.reshape(1, 2, 3, 4)
+    output_size = (5, 7)
+
+    nearest_out = torch._C._nn.upsample_nearest2d(input, output_size=output_size)
+    nearest_exact_out = torch.ops.aten._upsample_nearest_exact2d(
+        input, output_size, None, None
+    )
+    assert not torch.equal(nearest_out, nearest_exact_out)
+
+    with flag_gems.use_gems():
+        res_out = torch._C._nn.upsample_nearest2d(input, output_size=output_size)
+
+    utils.gems_assert_close(res_out, nearest_out, torch.float32)
+
+
+@pytest.mark.upsample_nearest2d
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
 def test_upsample_nearest2d_identity_fresh_copy_and_layout(dtype):
     input = torch.randn((2, 3, 8, 9), dtype=dtype, device=flag_gems.device)
@@ -101,6 +119,8 @@ def test_upsample_nearest2d_c1_ambiguous_channels_last_uses_contiguous(dtype):
         ((2, 4, 5, 7), (11, 9), None, None),
         ((2, 4, 9, 11), (4, 5), None, None),
         ((2, 4, 5, 7), (10, 14), 1.7, 2.3),
+        ((1, 17, 7, 5), (13, 11), None, None),
+        ((1, 64, 5, 6), (11, 14), 2.1, 2.3),
     ],
 )
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)

--- a/tests/test_upsample_nearest2d.py
+++ b/tests/test_upsample_nearest2d.py
@@ -11,6 +11,25 @@ from . import accuracy_utils as utils
 random.seed(time.time() // 100)
 
 
+def _nearest2d_reference(ref_i, output_size, scales_h=None, scales_w=None):
+    if scales_h is None and scales_w is None:
+        return torch._C._nn.upsample_nearest2d(ref_i, output_size=output_size)
+
+    output_h, output_w = output_size
+    input_h, input_w = ref_i.shape[2:]
+    reciprocal_h = (1.0 / scales_h) if scales_h is not None else (input_h / output_h)
+    reciprocal_w = (1.0 / scales_w) if scales_w is not None else (input_w / output_w)
+    idx_h = (
+        torch.arange(output_h, device=ref_i.device, dtype=torch.float32) * reciprocal_h
+    ).to(torch.int64)
+    idx_w = (
+        torch.arange(output_w, device=ref_i.device, dtype=torch.float32) * reciprocal_w
+    ).to(torch.int64)
+    idx_h = idx_h.clamp(max=input_h - 1)
+    idx_w = idx_w.clamp(max=input_w - 1)
+    return ref_i.index_select(2, idx_h).index_select(3, idx_w)
+
+
 @pytest.mark.upsample_nearest2d
 @pytest.mark.parametrize("scale", [(2, 2), (2.1, 3.7), (1.3, 5.1), (0.3, 0.5)])
 @pytest.mark.parametrize("shape", utils.UPSAMPLE_SHAPES)
@@ -34,7 +53,7 @@ def test_upsample_nearest2d_explicit_scales_x2_output(dtype):
     ref_i = utils.to_reference(input).to(torch.float32)
     output_size = (10, 14)
 
-    ref_out = torch._C._nn.upsample_nearest2d(
+    ref_out = _nearest2d_reference(
         ref_i, output_size=output_size, scales_h=1.7, scales_w=2.3
     ).to(dtype)
     with flag_gems.use_gems():
@@ -50,10 +69,11 @@ def test_upsample_nearest2d_explicit_scales_x2_output(dtype):
 def test_upsample_nearest2d_identity_fresh_copy_and_layout(dtype):
     input = torch.randn((2, 3, 8, 9), dtype=dtype, device=flag_gems.device)
     input = input.contiguous(memory_format=torch.channels_last)
+    ref_i = utils.to_reference(input)
     with flag_gems.use_gems():
         res_out = torch._C._nn.upsample_nearest2d(input, output_size=input.shape[2:])
 
-    utils.gems_assert_close(res_out, input, dtype)
+    utils.gems_assert_close(res_out, ref_i, dtype)
     assert res_out.data_ptr() != input.data_ptr()
     assert res_out.is_contiguous(memory_format=torch.channels_last)
     assert not res_out.is_contiguous()
@@ -64,7 +84,8 @@ def test_upsample_nearest2d_identity_fresh_copy_and_layout(dtype):
 def test_upsample_nearest2d_c1_ambiguous_channels_last_uses_contiguous(dtype):
     input = torch.randn((2, 1, 5, 7), dtype=dtype, device=flag_gems.device)
     input = input.contiguous(memory_format=torch.channels_last)
-    ref_out = torch._C._nn.upsample_nearest2d(input, output_size=(10, 14))
+    ref_i = utils.to_reference(input)
+    ref_out = torch._C._nn.upsample_nearest2d(ref_i, output_size=(10, 14))
     with flag_gems.use_gems():
         res_out = torch._C._nn.upsample_nearest2d(input, output_size=(10, 14))
 
@@ -88,9 +109,10 @@ def test_upsample_nearest2d_channels_last_non_x2_strides(
 ):
     input = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     input = input.contiguous(memory_format=torch.channels_last)
-    ref_out = torch._C._nn.upsample_nearest2d(
-        input, output_size=output_size, scales_h=scales_h, scales_w=scales_w
-    )
+    ref_i = utils.to_reference(input)
+    ref_out = _nearest2d_reference(
+        ref_i, output_size=output_size, scales_h=scales_h, scales_w=scales_w
+    ).contiguous(memory_format=torch.channels_last)
 
     with flag_gems.use_gems():
         res_out = torch._C._nn.upsample_nearest2d(

--- a/tests/test_upsample_nearest2d.py
+++ b/tests/test_upsample_nearest2d.py
@@ -25,3 +25,94 @@ def test_upsample_nearest2d(dtype, shape, scale):
         res_out = torch._C._nn.upsample_nearest2d(input, output_size=output_size)
 
     utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.upsample_nearest2d
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_upsample_nearest2d_explicit_scales_x2_output(dtype):
+    input = torch.randn((2, 4, 5, 7), dtype=dtype, device=flag_gems.device)
+    ref_i = utils.to_reference(input).to(torch.float32)
+    output_size = (10, 14)
+
+    ref_out = torch._C._nn.upsample_nearest2d(
+        ref_i, output_size=output_size, scales_h=1.7, scales_w=2.3
+    ).to(dtype)
+    with flag_gems.use_gems():
+        res_out = torch._C._nn.upsample_nearest2d(
+            input, output_size=output_size, scales_h=1.7, scales_w=2.3
+        )
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.upsample_nearest2d
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_upsample_nearest2d_identity_fresh_copy_and_layout(dtype):
+    input = torch.randn((2, 3, 8, 9), dtype=dtype, device=flag_gems.device)
+    input = input.contiguous(memory_format=torch.channels_last)
+    with flag_gems.use_gems():
+        res_out = torch._C._nn.upsample_nearest2d(input, output_size=input.shape[2:])
+
+    utils.gems_assert_close(res_out, input, dtype)
+    assert res_out.data_ptr() != input.data_ptr()
+    assert res_out.is_contiguous(memory_format=torch.channels_last)
+    assert not res_out.is_contiguous()
+
+
+@pytest.mark.upsample_nearest2d
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_upsample_nearest2d_c1_ambiguous_channels_last_uses_contiguous(dtype):
+    input = torch.randn((2, 1, 5, 7), dtype=dtype, device=flag_gems.device)
+    input = input.contiguous(memory_format=torch.channels_last)
+    ref_out = torch._C._nn.upsample_nearest2d(input, output_size=(10, 14))
+    with flag_gems.use_gems():
+        res_out = torch._C._nn.upsample_nearest2d(input, output_size=(10, 14))
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+    assert res_out.stride() == ref_out.stride()
+    assert res_out.is_contiguous()
+
+
+@pytest.mark.upsample_nearest2d
+@pytest.mark.parametrize(
+    ("shape", "output_size", "scales_h", "scales_w"),
+    [
+        ((2, 4, 5, 7), (11, 9), None, None),
+        ((2, 4, 9, 11), (4, 5), None, None),
+        ((2, 4, 5, 7), (10, 14), 1.7, 2.3),
+    ],
+)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_upsample_nearest2d_channels_last_non_x2_strides(
+    dtype, shape, output_size, scales_h, scales_w
+):
+    input = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    input = input.contiguous(memory_format=torch.channels_last)
+    ref_out = torch._C._nn.upsample_nearest2d(
+        input, output_size=output_size, scales_h=scales_h, scales_w=scales_w
+    )
+
+    with flag_gems.use_gems():
+        res_out = torch._C._nn.upsample_nearest2d(
+            input, output_size=output_size, scales_h=scales_h, scales_w=scales_w
+        )
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+    assert res_out.stride() == ref_out.stride()
+    assert res_out.is_contiguous(memory_format=torch.channels_last)
+    assert not res_out.is_contiguous()
+
+
+@pytest.mark.upsample_nearest2d
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_upsample_nearest2d_spatial_strided_input_contiguous_output(dtype):
+    base = torch.randn((2, 4, 5, 7), dtype=dtype, device=flag_gems.device)
+    input = base.transpose(2, 3)
+    ref_i = utils.to_reference(input).to(torch.float32)
+
+    ref_out = torch._C._nn.upsample_nearest2d(ref_i, output_size=(11, 9)).to(dtype)
+    with flag_gems.use_gems():
+        res_out = torch._C._nn.upsample_nearest2d(input, output_size=(11, 9))
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+    assert res_out.is_contiguous()

--- a/tests/test_upsample_nearest2d_backward.py
+++ b/tests/test_upsample_nearest2d_backward.py
@@ -38,9 +38,12 @@ def _make_grad(shape, dtype, layout):
         ((2, 3, 8, 9), (16, 18), "contiguous", (None, None)),
         ((1, 4, 7, 9), (13, 17), "contiguous", (None, None)),
         ((2, 5, 16, 18), (5, 7), "contiguous", (None, None)),
+        ((1, 3, 4, 5), (16, 20), "contiguous", (None, None)),
+        ((1, 8, 5, 7), (10, 21), "contiguous", (None, None)),
         ((1, 7, 6, 8), (12, 16), "transpose", (None, None)),
         ((2, 16, 8, 8), (16, 16), "channels_last", (None, None)),
         ((1, 64, 5, 6), (10, 12), "channels_last", (None, None)),
+        ((1, 17, 5, 6), (11, 14), "channels_last", (2.1, 2.3)),
         ((1, 3, 5, 6), (11, 14), "contiguous", (2.1, 2.3)),
     ],
 )

--- a/tests/test_upsample_nearest2d_backward.py
+++ b/tests/test_upsample_nearest2d_backward.py
@@ -1,0 +1,75 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+def _nearest2d_backward(grad, input_size, scales_h=None, scales_w=None):
+    output_size = [grad.shape[-2], grad.shape[-1]]
+    return torch.ops.aten.upsample_nearest2d_backward(
+        grad,
+        output_size,
+        list(input_size),
+        scales_h,
+        scales_w,
+    )
+
+
+def _make_grad(shape, dtype, layout):
+    if layout == "channels_last":
+        return torch.randn(shape, dtype=dtype, device=flag_gems.device).contiguous(
+            memory_format=torch.channels_last
+        )
+    if layout == "transpose":
+        n, c, h, w = shape
+        return torch.randn(
+            (n, c, w, h), dtype=dtype, device=flag_gems.device
+        ).transpose(2, 3)
+    return torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+
+@pytest.mark.upsample_nearest2d_backward
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+@pytest.mark.parametrize(
+    "input_size,output_size,layout,scales",
+    [
+        ((2, 3, 8, 9), (16, 18), "contiguous", (None, None)),
+        ((1, 4, 7, 9), (13, 17), "contiguous", (None, None)),
+        ((2, 5, 16, 18), (5, 7), "contiguous", (None, None)),
+        ((1, 7, 6, 8), (12, 16), "transpose", (None, None)),
+        ((2, 16, 8, 8), (16, 16), "channels_last", (None, None)),
+        ((1, 64, 5, 6), (10, 12), "channels_last", (None, None)),
+        ((1, 3, 5, 6), (11, 14), "contiguous", (2.1, 2.3)),
+    ],
+)
+def test_upsample_nearest2d_backward(dtype, input_size, output_size, layout, scales):
+    grad_shape = (input_size[0], input_size[1], output_size[0], output_size[1])
+    grad = _make_grad(grad_shape, dtype, layout)
+    ref_grad = utils.to_reference(grad).to(torch.float32)
+    scales_h, scales_w = scales
+
+    ref_out = _nearest2d_backward(ref_grad, input_size, scales_h, scales_w).to(dtype)
+    with flag_gems.use_gems():
+        res_out = _nearest2d_backward(grad, input_size, scales_h, scales_w)
+
+    assert res_out.shape == input_size
+    if layout == "channels_last":
+        assert res_out.is_contiguous(memory_format=torch.channels_last)
+    elif layout == "transpose":
+        assert res_out.is_contiguous()
+    utils.gems_assert_close(res_out, ref_out, dtype, reduce_dim=9)
+
+
+@pytest.mark.upsample_nearest2d_backward
+def test_upsample_nearest2d_backward_shape_mismatch_rejected():
+    grad = torch.randn((1, 2, 5, 6), dtype=torch.float32, device=flag_gems.device)
+    with flag_gems.use_gems(), pytest.raises(AssertionError, match="grad_output shape"):
+        torch.ops.aten.upsample_nearest2d_backward(
+            grad,
+            [4, 6],
+            [1, 2, 2, 3],
+            None,
+            None,
+        )


### PR DESCRIPTION
### PR Category
  Operator, OP Test, Benchmark

  ### Type of Change
  New Feature, Performance Optimization

  ### Description
  This PR adds optimized `upsample_nearest2d` forward and backward support.

  Forward coverage includes contiguous NCHW, channels-last, transposed/non-contiguous inputs, exact 2x resize fast paths, non-integer output sizes,
  explicit scales, identity resize copy semantics, and zero-element outputs.

  Backward coverage includes contiguous NCHW, channels-last, transposed/non-contiguous gradients, exact 2x resize, generic non-integer scale ranges,
  downsample cases, explicit scale cases, and shape-mismatch rejection.

  ### Issue
  N/A

  ### Progress
  - [x] Change is properly reviewed.
  - [x] Change is responded to an issue. N/A
  - [x] Change is fully covered by a UT.

  ### Performance
  Final local validation was run on NVIDIA GeForce RTX 5090 with PyTorch `2.9.1+cu128`.

  Forward official core benchmark speedups over Torch:
  - float16: `1.174x` to `2.358x`
  - bfloat16: `1.278x` to `2.292x`
  - float32: `1.025x` to `1.572x`

  Backward official core benchmark speedups over Torch:
  - float16: `1.134x` to `1.535x`
  - bfloat16: `1.136x` to `1.567x`
  - float32: `1.026x` to `1.683x`

  ### Tests
  - `ruff check`: passed
  - `git diff --check`: passed
  - targeted tests: `103 passed in 9.16s`
  - official benchmark tests: `2 passed in 4.21s`