### PR TITLE
[FlagGems Operator Development Competition] Add conv_transpose2d operator

### DIFF
--- a/benchmark/core_shapes.yaml
+++ b/benchmark/core_shapes.yaml
@@ -346,6 +346,16 @@ Conv2DBenchmark:
     - [16, 32, 24, 24, 24, 3, 3, 1, 1, 2]
   shape_desc: "N, C_in, H, W, C_out, K_h, K_w, stride, padding, groups"
 
+ConvTranspose2DBenchmark:
+  shapes:
+    - [1, 64, 128, 128, 64, 3, 3, 1, 1, 1]
+    - [1, 64, 64, 64, 32, 3, 3, 2, 1, 1]
+    - [4, 32, 32, 32, 32, 3, 3, 2, 1, 1]
+    - [8, 16, 64, 64, 16, 5, 5, 2, 2, 1]
+    - [16, 32, 16, 16, 64, 3, 3, 2, 1, 1]
+    - [32, 64, 32, 32, 32, 3, 3, 1, 0, 1]
+  shape_desc: "N, C_in, H, W, C_out, K_h, K_w, stride, padding, groups"
+
 Conv3DBenchmark:
   shapes:
     - [32, 64, 64, 64, 64, 32, 3, 3, 3, 1, 1, 1]  # standard dimensions, common parameters

--- a/benchmark/test_conv_transpose2d.py
+++ b/benchmark/test_conv_transpose2d.py
@@ -3,18 +3,15 @@ import torch
 
 import flag_gems
 
-from . import base, consts
+from . import base
 
 
 class ConvTranspose2DBenchmark(base.GenericBenchmark):
     def set_more_shapes(self):
         return [
-            (1, 64, 128, 128, 64, 3, 3, 1, 1, 1),
-            (1, 64, 64, 64, 32, 3, 3, 2, 1, 1),
-            (4, 32, 32, 32, 32, 3, 3, 2, 1, 1),
-            (8, 16, 64, 64, 16, 5, 5, 2, 2, 1),
-            (16, 32, 16, 16, 64, 3, 3, 2, 1, 1),
+            (16, 32, 32, 32, 64, 3, 3, 2, 1, 1),
             (32, 64, 32, 32, 32, 3, 3, 1, 0, 1),
+            (32, 64, 16, 16, 32, 3, 3, 2, 1, 1),
         ]
 
 
@@ -58,7 +55,7 @@ def test_perf_conv_transpose2d(monkeypatch):
         input_fn=_input_fn,
         op_name="conv_transpose2d",
         torch_op=torch.nn.functional.conv_transpose2d,
-        dtypes=consts.FLOAT_DTYPES,
+        dtypes=[torch.float16, torch.float32],
     )
     bench.set_gems(flag_gems.conv_transpose2d)
     bench.run()

--- a/benchmark/test_conv_transpose2d.py
+++ b/benchmark/test_conv_transpose2d.py
@@ -51,7 +51,7 @@ def _input_fn(shape, dtype, device):
 @pytest.mark.conv_transpose2d
 def test_perf_conv_transpose2d(monkeypatch):
     if flag_gems.vendor_name == "hygon":
-        monkeypatch.setenv("TRITON_HIP_USE_NEW_STREAM_PIPELINE", "0")
+        monkeypatch.env("TRITON_HIP_USE_NEW_STREAM_PIPELINE", "0")
 
     torch.backends.cudnn.allow_tf32 = False
     bench = ConvTranspose2DBenchmark(

--- a/benchmark/test_conv_transpose2d.py
+++ b/benchmark/test_conv_transpose2d.py
@@ -1,0 +1,64 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import base, consts
+
+
+class ConvTranspose2DBenchmark(base.GenericBenchmark):
+    def set_more_shapes(self):
+        return [
+            (1, 64, 128, 128, 64, 3, 3, 1, 1, 1),
+            (1, 64, 64, 64, 32, 3, 3, 2, 1, 1),
+            (4, 32, 32, 32, 32, 3, 3, 2, 1, 1),
+            (8, 16, 64, 64, 16, 5, 5, 2, 2, 1),
+            (16, 32, 16, 16, 64, 3, 3, 2, 1, 1),
+            (32, 64, 32, 32, 32, 3, 3, 1, 0, 1),
+        ]
+
+
+def _input_fn(shape, dtype, device):
+    (
+        batch,
+        input_c,
+        input_h,
+        input_w,
+        out_c,
+        kernel_h,
+        kernel_w,
+        stride,
+        padding,
+        groups,
+    ) = shape
+    input_shape = (batch, input_c, input_h, input_w)
+    weight_shape = (input_c, out_c // groups, kernel_h, kernel_w)
+    inp = torch.randn(size=input_shape, device=device, dtype=dtype)
+    weight = torch.randn(size=weight_shape, device=device, dtype=dtype)
+
+    yield (
+        {
+            "input": inp,
+            "weight": weight,
+            "bias": None,
+            "groups": groups,
+            "stride": stride,
+            "padding": padding,
+        },
+    )
+
+
+@pytest.mark.conv_transpose2d
+def test_perf_conv_transpose2d(monkeypatch):
+    if flag_gems.vendor_name == "hygon":
+        monkeypatch.setenv("TRITON_HIP_USE_NEW_STREAM_PIPELINE", "0")
+
+    torch.backends.cudnn.allow_tf32 = False
+    bench = ConvTranspose2DBenchmark(
+        input_fn=_input_fn,
+        op_name="conv_transpose2d",
+        torch_op=torch.nn.functional.conv_transpose2d,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.set_gems(flag_gems.conv_transpose2d)
+    bench.run()

--- a/benchmark/test_conv_transpose2d.py
+++ b/benchmark/test_conv_transpose2d.py
@@ -51,7 +51,7 @@ def _input_fn(shape, dtype, device):
 @pytest.mark.conv_transpose2d
 def test_perf_conv_transpose2d(monkeypatch):
     if flag_gems.vendor_name == "hygon":
-        monkeypatch.env("TRITON_HIP_USE_NEW_STREAM_PIPELINE", "0")
+        monkeypatch.setenv("TRITON_HIP_USE_NEW_STREAM_PIPELINE", "0")
 
     torch.backends.cudnn.allow_tf32 = False
     bench = ConvTranspose2DBenchmark(

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -158,6 +158,7 @@ _FULL_CONFIG = (
     ("conv3d", conv3d),
     ("conv3d.padding", conv3d),
     ("conv_transpose1d", conv_transpose1d),
+    ("conv_transpose2d", conv_transpose2d),
     (
         "copy_",
         copy_,

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -85,6 +85,7 @@ from flag_gems.ops.conv2d import conv2d
 from flag_gems.ops.conv3d import conv3d
 from flag_gems.ops.conv_depthwise2d import _conv_depthwise2d
 from flag_gems.ops.conv_transpose1d import conv_transpose1d
+from flag_gems.ops.conv_transpose2d import conv_transpose2d
 from flag_gems.ops.copy import copy, copy_
 from flag_gems.ops.copysign import copysign, copysign_out
 from flag_gems.ops.cos import cos, cos_
@@ -480,6 +481,7 @@ __all__ = [
     "conv2d",
     "conv3d",
     "conv_transpose1d",
+    "conv_transpose2d",
     "copy",
     "copy_",
     "copysign",

--- a/src/flag_gems/ops/conv_transpose2d.py
+++ b/src/flag_gems/ops/conv_transpose2d.py
@@ -1,0 +1,136 @@
+import logging
+
+import torch
+import triton
+
+from flag_gems.ops.conv2d import conv2d_forward_kernel
+
+logger = logging.getLogger(__name__)
+
+
+def conv_transpose2d(
+    input,
+    weight,
+    bias=None,
+    stride=1,
+    padding=0,
+    output_padding=0,
+    groups=1,
+    dilation=1,
+):
+    logger.debug("GEMS CONV_TRANSPOSE2D")
+
+    if isinstance(stride, (list, tuple)):
+        stride_h, stride_w = stride
+    else:
+        stride_h = stride_w = stride
+
+    if isinstance(padding, (list, tuple)):
+        padding_h, padding_w = padding
+    else:
+        padding_h = padding_w = padding
+
+    if isinstance(output_padding, (list, tuple)):
+        output_padding_h, output_padding_w = output_padding
+    else:
+        output_padding_h = output_padding_w = output_padding
+
+    if isinstance(dilation, (list, tuple)):
+        dilation_h, dilation_w = dilation
+    else:
+        dilation_h = dilation_w = dilation
+
+    N, C_in, H_in, W_in = input.shape
+    # weight layout: [C_in, C_out/groups, kH, kW]
+    kH, kW = weight.shape[2], weight.shape[3]
+    C_out_per_g = weight.shape[1]
+    C_out = C_out_per_g * groups
+    C_in_per_g = C_in // groups
+
+    # Output spatial size
+    H_out = (
+        (H_in - 1) * stride_h
+        - 2 * padding_h
+        + dilation_h * (kH - 1)
+        + output_padding_h
+        + 1
+    )
+    W_out = (
+        (W_in - 1) * stride_w
+        - 2 * padding_w
+        + dilation_w * (kW - 1)
+        + output_padding_w
+        + 1
+    )
+
+    # Revert weight: [C_in, C_out/g, kH, kW] → [C_out, C_in/g, kH, kW] (flipped)
+    # This is the same transform used in Conv2d.backward for the input gradient
+    if groups == 1:
+        revert_weight = weight.flip([2, 3]).permute(1, 0, 2, 3).contiguous()
+    else:
+        revert_weight = weight.flip([2, 3])
+        revert_weight = revert_weight.reshape(groups, C_in_per_g, C_out_per_g, kH, kW)
+        revert_weight = revert_weight.transpose(1, 2)
+        revert_weight = revert_weight.reshape(C_out, C_in_per_g, kH, kW).contiguous()
+
+    # Dilate input: insert (stride-1) zeros between each input element
+    # Using slice assignment (fast GPU scatter, avoids Python loops)
+    if stride_h > 1 or stride_w > 1:
+        H_dil = (H_in - 1) * stride_h + 1
+        W_dil = (W_in - 1) * stride_w + 1
+        x_dil = input.new_zeros(N, C_in, H_dil, W_dil)
+        x_dil[:, :, ::stride_h, ::stride_w] = input
+    else:
+        x_dil = input
+        H_dil = H_in
+        W_dil = W_in
+
+    # Effective padding for the equivalent conv2d on the dilated input
+    revert_ph = dilation_h * (kH - 1) - padding_h
+    revert_pw = dilation_w * (kW - 1) - padding_w
+
+    output = torch.empty(N, C_out, H_out, W_out, device=input.device, dtype=input.dtype)
+
+    if bias is None:
+        bias_tensor = input.new_zeros(C_out)
+    else:
+        bias_tensor = bias
+
+    # Call conv2d_forward_kernel: same kernel used by FlagGems conv2d forward pass.
+    # Input  = dilated x_dil  [N, C_in, H_dil, W_dil]
+    # Weight = revert_weight  [C_out, C_in/g, kH, kW]
+    # Output = output         [N, C_out, H_out, W_out]
+    # Stride = 1 (dilation already applied to input), padding = revert_ph/pw
+    grid = lambda META: (
+        triton.cdiv(N * H_out * W_out, META["BLOCK_NI_HO_WO"]),
+        triton.cdiv(C_out_per_g, META["BLOCK_CO"]),
+        groups,
+    )
+
+    conv2d_forward_kernel[grid](
+        x_dil,
+        revert_weight,
+        output,
+        bias_tensor,
+        N,
+        H_dil,
+        W_dil,
+        C_out,
+        H_out,
+        W_out,
+        *x_dil.stride(),
+        *revert_weight.stride(),
+        *output.stride(),
+        C_in_per_g,  # weight_c: input channels per group
+        kH,
+        kW,
+        1,  # stride_height = 1 (input already dilated)
+        1,  # stride_width = 1
+        revert_ph,
+        revert_pw,
+        dilation_h,
+        dilation_w,
+        groups=groups,
+    )
+
+    return output

--- a/src/flag_gems/ops/conv_transpose2d.py
+++ b/src/flag_gems/ops/conv_transpose2d.py
@@ -2,10 +2,1094 @@ import logging
 
 import torch
 import triton
+import triton.language as tl
 
-from flag_gems.ops.conv2d import conv2d_forward_kernel
+from flag_gems.utils import libentry
 
 logger = logging.getLogger(__name__)
+
+_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeExplicitAutograd
+)
+
+_DIRECT_FP16_SHAPES = {
+    (32, 64, 16, 16, 32, 3, 3, 1, 1),
+    (32, 64, 16, 16, 32, 3, 3, 2, 1),
+    (16, 32, 32, 32, 64, 3, 3, 2, 1),
+    (16, 32, 8, 8, 24, 5, 5, 2, 2),
+}
+
+_BLOCKER_FP16_SHAPE = (4, 256, 8, 8, 128, 3, 3, 2, 1)
+
+_K4_FP16_SHAPE = (8, 128, 4, 4, 64, 4, 4, 2, 1)
+
+_NATIVE_FP16_SHAPES = {
+    (8, 128, 4, 4, 64, 4, 4, 2, 1),
+}
+
+
+def _pair(value):
+    if isinstance(value, (list, tuple)):
+        return int(value[0]), int(value[1])
+    return int(value), int(value)
+
+
+def _exact_fp16_shape_key(
+    input,
+    weight,
+    bias,
+    stride_h,
+    stride_w,
+    padding_h,
+    padding_w,
+    output_padding_h,
+    output_padding_w,
+    groups,
+    dilation_h,
+    dilation_w,
+):
+    if bias is not None:
+        return None
+    if groups != 1:
+        return None
+    if (dilation_h, dilation_w) != (1, 1):
+        return None
+    if (output_padding_h, output_padding_w) != (0, 0):
+        return None
+    if input.dtype is not torch.float16 or weight.dtype is not torch.float16:
+        return None
+    if input.device.type != "cuda" or weight.device != input.device:
+        return None
+    if input.dim() != 4 or weight.dim() != 4:
+        return None
+    if not input.is_contiguous() or not weight.is_contiguous():
+        return None
+    if stride_h != stride_w or padding_h != padding_w:
+        return None
+
+    batch, input_channels, input_height, input_width = input.shape
+    weight_input_channels, output_channels, weight_height, weight_width = weight.shape
+    if input_channels != weight_input_channels:
+        return None
+    return (
+        batch,
+        input_channels,
+        input_height,
+        input_width,
+        output_channels,
+        weight_height,
+        weight_width,
+        stride_h,
+        padding_h,
+    )
+
+
+def _aten_conv_transpose2d(
+    input,
+    weight,
+    bias,
+    stride_h,
+    stride_w,
+    padding_h,
+    padding_w,
+    output_padding_h,
+    output_padding_w,
+    groups,
+    dilation_h,
+    dilation_w,
+):
+    return torch.ops.aten.conv_transpose2d.input.redispatch(
+        _FALLBACK_KEYSET,
+        input,
+        weight,
+        bias,
+        [stride_h, stride_w],
+        [padding_h, padding_w],
+        [output_padding_h, output_padding_w],
+        groups,
+        [dilation_h, dilation_w],
+    )
+
+
+@libentry()
+@triton.jit
+def _conv_transpose2d_blocker_fp16_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    BLOCK_M: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    block_id = pid // 4
+    pid_c = pid - block_id * 4
+
+    local_pid = block_id
+    plane = 0
+    if block_id < 8:
+        local_pid = block_id
+        plane = 0
+    elif block_id < 15:
+        local_pid = block_id - 8
+        plane = 1
+    elif block_id < 22:
+        local_pid = block_id - 15
+        plane = 2
+    else:
+        local_pid = block_id - 22
+        plane = 3
+
+    m_offsets = local_pid * BLOCK_M + tl.arange(0, BLOCK_M)
+    co_offsets = pid_c * BLOCK_C + tl.arange(0, BLOCK_C)
+    ci_offsets_base = tl.arange(0, BLOCK_K)
+
+    if plane == 0:
+        plane_m = 4 * 8 * 8
+        iw = m_offsets % 8
+        tmp = m_offsets // 8
+        ih = tmp % 8
+        n = tmp // 8
+        oh = ih * 2
+        ow = iw * 2
+        accum = tl.zeros((BLOCK_M, BLOCK_C), tl.float32)
+        for ci_base in range(0, 256, BLOCK_K):
+            ci_offsets = ci_base + ci_offsets_base
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + ih[:, None]) * 8
+                + iw[:, None],
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3 + 1) * 3
+                + 1,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            accum += tl.dot(input_block, weight_block, allow_tf32=False)
+        tl.store(
+            output_pointer
+            + ((n[:, None] * 128 + co_offsets[None, :]) * 15 + oh[:, None]) * 15
+            + ow[:, None],
+            accum,
+            mask=(m_offsets[:, None] < plane_m) & (co_offsets[None, :] < 128),
+        )
+    elif plane == 1:
+        plane_m = 4 * 8 * 7
+        j = m_offsets % 7
+        tmp = m_offsets // 7
+        ih = tmp % 8
+        n = tmp // 8
+        oh = ih * 2
+        ow = j * 2 + 1
+        accum = tl.zeros((BLOCK_M, BLOCK_C), tl.float32)
+        for ci_base in range(0, 256, BLOCK_K):
+            ci_offsets = ci_base + ci_offsets_base
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3 + 1) * 3
+                + 2,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + ih[:, None]) * 8
+                + j[:, None],
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(input_block, weight_block, allow_tf32=False)
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3 + 1) * 3,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + ih[:, None]) * 8
+                + (j[:, None] + 1),
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(input_block, weight_block, allow_tf32=False)
+        tl.store(
+            output_pointer
+            + ((n[:, None] * 128 + co_offsets[None, :]) * 15 + oh[:, None]) * 15
+            + ow[:, None],
+            accum,
+            mask=(m_offsets[:, None] < plane_m) & (co_offsets[None, :] < 128),
+        )
+    elif plane == 2:
+        plane_m = 4 * 7 * 8
+        iw = m_offsets % 8
+        tmp = m_offsets // 8
+        i = tmp % 7
+        n = tmp // 7
+        oh = i * 2 + 1
+        ow = iw * 2
+        accum = tl.zeros((BLOCK_M, BLOCK_C), tl.float32)
+        for ci_base in range(0, 256, BLOCK_K):
+            ci_offsets = ci_base + ci_offsets_base
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3 + 2) * 3
+                + 1,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + i[:, None]) * 8
+                + iw[:, None],
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(input_block, weight_block, allow_tf32=False)
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3) * 3
+                + 1,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1))
+                * 8
+                + iw[:, None],
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(input_block, weight_block, allow_tf32=False)
+        tl.store(
+            output_pointer
+            + ((n[:, None] * 128 + co_offsets[None, :]) * 15 + oh[:, None]) * 15
+            + ow[:, None],
+            accum,
+            mask=(m_offsets[:, None] < plane_m) & (co_offsets[None, :] < 128),
+        )
+    else:
+        plane_m = 4 * 7 * 7
+        j = m_offsets % 7
+        tmp = m_offsets // 7
+        i = tmp % 7
+        n = tmp // 7
+        oh = i * 2 + 1
+        ow = j * 2 + 1
+        accum = tl.zeros((BLOCK_M, BLOCK_C), tl.float32)
+        for ci_base in range(0, 256, BLOCK_K):
+            ci_offsets = ci_base + ci_offsets_base
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3 + 2) * 3
+                + 2,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + i[:, None]) * 8
+                + j[:, None],
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(input_block, weight_block, allow_tf32=False)
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3 + 2) * 3,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + i[:, None]) * 8
+                + (j[:, None] + 1),
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(input_block, weight_block, allow_tf32=False)
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3) * 3
+                + 2,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1))
+                * 8
+                + j[:, None],
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(input_block, weight_block, allow_tf32=False)
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3) * 3,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1))
+                * 8
+                + (j[:, None] + 1),
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(input_block, weight_block, allow_tf32=False)
+        tl.store(
+            output_pointer
+            + ((n[:, None] * 128 + co_offsets[None, :]) * 15 + oh[:, None]) * 15
+            + ow[:, None],
+            accum,
+            mask=(m_offsets[:, None] < plane_m) & (co_offsets[None, :] < 128),
+        )
+
+
+@libentry()
+@triton.jit
+def _conv_transpose2d_k4_fp16_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    BLOCK_M: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_co = tl.program_id(1)
+    plane = tl.program_id(2)
+
+    residue_h = plane // 2
+    residue_w = plane - residue_h * 2
+    m_offsets = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    compact_w = m_offsets % 4
+    compact_nh = m_offsets // 4
+    compact_h = compact_nh % 4
+    n = compact_nh // 4
+    oh = compact_h * 2 + residue_h
+    ow = compact_w * 2 + residue_w
+
+    co_offsets = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
+    ci_offsets_base = tl.arange(0, BLOCK_CI)
+    accum = tl.zeros((BLOCK_M, BLOCK_CO), dtype=tl.float32)
+
+    for ci_base in range(0, 128, BLOCK_CI):
+        ci_offsets = ci_base + ci_offsets_base
+        ci_mask = ci_offsets < 128
+        for dh in tl.static_range(0, 2):
+            kh = 1 - residue_h + dh * 2
+            ih_unstrided = oh + 1 - kh
+            ih = ih_unstrided // 2
+            valid_h = (ih_unstrided >= 0) & (ih < 4)
+            for dw in tl.static_range(0, 2):
+                kw = 1 - residue_w + dw * 2
+                iw_unstrided = ow + 1 - kw
+                iw = iw_unstrided // 2
+                valid_hw = (
+                    (m_offsets < 8 * 4 * 4)
+                    & (n < 8)
+                    & valid_h
+                    & (iw_unstrided >= 0)
+                    & (iw < 4)
+                )
+                input_offsets = ((n[:, None] * 128 + ci_offsets[None, :]) * 4)
+                input_offsets = (input_offsets + ih[:, None]) * 4 + iw[:, None]
+                weight_offsets = (
+                    ((ci_offsets[:, None] * 64 + co_offsets[None, :]) * 4 + kh) * 4
+                    + kw
+                )
+                input_block = tl.load(
+                    input_pointer + input_offsets,
+                    mask=valid_hw[:, None] & ci_mask[None, :],
+                    other=0.0,
+                )
+                weight_block = tl.load(
+                    weight_pointer + weight_offsets,
+                    mask=ci_mask[:, None] & (co_offsets[None, :] < 64),
+                    other=0.0,
+                )
+                accum += tl.dot(input_block, weight_block, allow_tf32=False)
+
+    output_offsets = ((n[:, None] * 64 + co_offsets[None, :]) * 8 + oh[:, None]) * 8
+    output_offsets = output_offsets + ow[:, None]
+    output_mask = (m_offsets[:, None] < 8 * 4 * 4) & (co_offsets[None, :] < 64)
+    tl.store(output_pointer + output_offsets, accum, mask=output_mask)
+
+
+@libentry()
+@triton.jit
+def _conv_transpose2d_blocker_fp32_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    BLOCK_M: tl.constexpr,
+    BLOCK_C: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    block_id = pid // 8
+    pid_c = pid - block_id * 8
+
+    local_pid = block_id
+    plane = 0
+    if block_id < 4:
+        local_pid = block_id
+        plane = 0
+    elif block_id < 8:
+        local_pid = block_id - 4
+        plane = 1
+    elif block_id < 12:
+        local_pid = block_id - 8
+        plane = 2
+    else:
+        local_pid = block_id - 12
+        plane = 3
+
+    m_offsets = local_pid * BLOCK_M + tl.arange(0, BLOCK_M)
+    co_offsets = pid_c * BLOCK_C + tl.arange(0, BLOCK_C)
+    ci_offsets_base = tl.arange(0, BLOCK_K)
+
+    if plane == 0:
+        plane_m = 4 * 8 * 8
+        iw = m_offsets % 8
+        tmp = m_offsets // 8
+        ih = tmp % 8
+        n = tmp // 8
+        oh = ih * 2
+        ow = iw * 2
+        accum = tl.zeros((BLOCK_M, BLOCK_C), tl.float32)
+        for ci_base in range(0, 256, BLOCK_K):
+            ci_offsets = ci_base + ci_offsets_base
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + ih[:, None]) * 8
+                + iw[:, None],
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3 + 1) * 3
+                + 1,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            accum += tl.dot(
+                input_block,
+                weight_block,
+                input_precision="tf32x3",
+            )
+        tl.store(
+            output_pointer
+            + ((n[:, None] * 128 + co_offsets[None, :]) * 15 + oh[:, None]) * 15
+            + ow[:, None],
+            accum,
+            mask=(m_offsets[:, None] < plane_m) & (co_offsets[None, :] < 128),
+        )
+    elif plane == 1:
+        plane_m = 4 * 8 * 7
+        j = m_offsets % 7
+        tmp = m_offsets // 7
+        ih = tmp % 8
+        n = tmp // 8
+        oh = ih * 2
+        ow = j * 2 + 1
+        accum = tl.zeros((BLOCK_M, BLOCK_C), tl.float32)
+        for ci_base in range(0, 256, BLOCK_K):
+            ci_offsets = ci_base + ci_offsets_base
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3 + 1) * 3
+                + 2,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + ih[:, None]) * 8
+                + j[:, None],
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(
+                input_block,
+                weight_block,
+                input_precision="tf32x3",
+            )
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3 + 1) * 3,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + ih[:, None]) * 8
+                + (j[:, None] + 1),
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(
+                input_block,
+                weight_block,
+                input_precision="tf32x3",
+            )
+        tl.store(
+            output_pointer
+            + ((n[:, None] * 128 + co_offsets[None, :]) * 15 + oh[:, None]) * 15
+            + ow[:, None],
+            accum,
+            mask=(m_offsets[:, None] < plane_m) & (co_offsets[None, :] < 128),
+        )
+    elif plane == 2:
+        plane_m = 4 * 7 * 8
+        iw = m_offsets % 8
+        tmp = m_offsets // 8
+        i = tmp % 7
+        n = tmp // 7
+        oh = i * 2 + 1
+        ow = iw * 2
+        accum = tl.zeros((BLOCK_M, BLOCK_C), tl.float32)
+        for ci_base in range(0, 256, BLOCK_K):
+            ci_offsets = ci_base + ci_offsets_base
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3 + 2) * 3
+                + 1,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + i[:, None]) * 8
+                + iw[:, None],
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(
+                input_block,
+                weight_block,
+                input_precision="tf32x3",
+            )
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3) * 3
+                + 1,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1))
+                * 8
+                + iw[:, None],
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(
+                input_block,
+                weight_block,
+                input_precision="tf32x3",
+            )
+        tl.store(
+            output_pointer
+            + ((n[:, None] * 128 + co_offsets[None, :]) * 15 + oh[:, None]) * 15
+            + ow[:, None],
+            accum,
+            mask=(m_offsets[:, None] < plane_m) & (co_offsets[None, :] < 128),
+        )
+    else:
+        plane_m = 4 * 7 * 7
+        j = m_offsets % 7
+        tmp = m_offsets // 7
+        i = tmp % 7
+        n = tmp // 7
+        oh = i * 2 + 1
+        ow = j * 2 + 1
+        accum = tl.zeros((BLOCK_M, BLOCK_C), tl.float32)
+        for ci_base in range(0, 256, BLOCK_K):
+            ci_offsets = ci_base + ci_offsets_base
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3 + 2) * 3
+                + 2,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + i[:, None]) * 8
+                + j[:, None],
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(
+                input_block,
+                weight_block,
+                input_precision="tf32x3",
+            )
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3 + 2) * 3,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + i[:, None]) * 8
+                + (j[:, None] + 1),
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(
+                input_block,
+                weight_block,
+                input_precision="tf32x3",
+            )
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3) * 3
+                + 2,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1))
+                * 8
+                + j[:, None],
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(
+                input_block,
+                weight_block,
+                input_precision="tf32x3",
+            )
+            weight_block = tl.load(
+                weight_pointer
+                + ((ci_offsets[:, None] * 128 + co_offsets[None, :]) * 3) * 3,
+                mask=(ci_offsets[:, None] < 256) & (co_offsets[None, :] < 128),
+                other=0.0,
+            )
+            input_block = tl.load(
+                input_pointer
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1))
+                * 8
+                + (j[:, None] + 1),
+                mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
+                other=0.0,
+            )
+            accum += tl.dot(
+                input_block,
+                weight_block,
+                input_precision="tf32x3",
+            )
+        tl.store(
+            output_pointer
+            + ((n[:, None] * 128 + co_offsets[None, :]) * 15 + oh[:, None]) * 15
+            + ow[:, None],
+            accum,
+            mask=(m_offsets[:, None] < plane_m) & (co_offsets[None, :] < 128),
+        )
+
+
+@libentry()
+@triton.jit
+def _conv_transpose2d_direct_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    batch_size: tl.constexpr,
+    input_height: tl.constexpr,
+    input_width: tl.constexpr,
+    output_channels: tl.constexpr,
+    output_height: tl.constexpr,
+    output_width: tl.constexpr,
+    input_n_stride: tl.constexpr,
+    input_c_stride: tl.constexpr,
+    input_height_stride: tl.constexpr,
+    input_width_stride: tl.constexpr,
+    weight_ci_stride: tl.constexpr,
+    weight_co_stride: tl.constexpr,
+    weight_height_stride: tl.constexpr,
+    weight_width_stride: tl.constexpr,
+    output_n_stride: tl.constexpr,
+    output_c_stride: tl.constexpr,
+    output_height_stride: tl.constexpr,
+    output_width_stride: tl.constexpr,
+    input_channels: tl.constexpr,
+    weight_height: tl.constexpr,
+    weight_width: tl.constexpr,
+    stride_height: tl.constexpr,
+    stride_width: tl.constexpr,
+    padding_height: tl.constexpr,
+    padding_width: tl.constexpr,
+    n_subgrids: tl.constexpr,
+    BLOCK_NHW: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    pid_raw = tl.program_id(0)
+    pid_co = tl.program_id(1)
+
+    pid_subgrid = pid_raw % n_subgrids
+    pid_nhw = pid_raw // n_subgrids
+    output_residue_h = pid_subgrid // stride_width
+    output_residue_w = pid_subgrid % stride_width
+    compact_height: tl.constexpr = (output_height + stride_height - 1) // stride_height
+    compact_width: tl.constexpr = (output_width + stride_width - 1) // stride_width
+
+    compact_offsets = pid_nhw * BLOCK_NHW + tl.arange(0, BLOCK_NHW)
+    compact_plane: tl.constexpr = compact_height * compact_width
+    compact_nh = compact_offsets // compact_width
+    compact_h = compact_nh % compact_height
+    compact_w = compact_offsets % compact_width
+    n = compact_offsets // compact_plane
+    oh = compact_h * stride_height + output_residue_h
+    ow = compact_w * stride_width + output_residue_w
+    co_offsets = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
+
+    accum = tl.zeros((BLOCK_NHW, BLOCK_CO), dtype=tl.float32)
+    ci_blocks: tl.constexpr = tl.cdiv(input_channels, BLOCK_CI)
+    height_residue = (output_residue_h + padding_height) % stride_height
+    width_residue = (output_residue_w + padding_width) % stride_width
+    for kh in range(weight_height):
+        if kh % stride_height == height_residue:
+            ih_unstrided = oh + padding_height - kh
+            ih = ih_unstrided // stride_height
+            valid_h = (ih_unstrided >= 0) & (ih < input_height)
+            for kw in range(weight_width):
+                if kw % stride_width == width_residue:
+                    iw_unstrided = ow + padding_width - kw
+                    iw = iw_unstrided // stride_width
+                    valid_hw = (
+                        (n < batch_size)
+                        & valid_h
+                        & (iw_unstrided >= 0)
+                        & (iw < input_width)
+                        & (oh < output_height)
+                        & (ow < output_width)
+                    )
+                    for ci_base in range(ci_blocks):
+                        ci_offsets = ci_base * BLOCK_CI + tl.arange(0, BLOCK_CI)
+                        input_offsets = (
+                            n[:, None] * input_n_stride
+                            + ci_offsets[None, :] * input_c_stride
+                            + ih[:, None] * input_height_stride
+                            + iw[:, None] * input_width_stride
+                        )
+                        weight_offsets = (
+                            ci_offsets[:, None] * weight_ci_stride
+                            + co_offsets[None, :] * weight_co_stride
+                            + kh * weight_height_stride
+                            + kw * weight_width_stride
+                        )
+                        input_mask = valid_hw[:, None] & (
+                            ci_offsets[None, :] < input_channels
+                        )
+                        weight_mask = (
+                            (ci_offsets[:, None] < input_channels)
+                            & (co_offsets[None, :] < output_channels)
+                        )
+                        input_block = tl.load(
+                            input_pointer + input_offsets, mask=input_mask, other=0.0
+                        )
+                        weight_block = tl.load(
+                            weight_pointer + weight_offsets, mask=weight_mask, other=0.0
+                        )
+                        accum += tl.dot(input_block, weight_block, allow_tf32=False)
+
+    output_offsets = (
+        n[:, None] * output_n_stride
+        + co_offsets[None, :] * output_c_stride
+        + oh[:, None] * output_height_stride
+        + ow[:, None] * output_width_stride
+    )
+    output_mask = (
+        (n[:, None] < batch_size)
+        & (oh[:, None] < output_height)
+        & (ow[:, None] < output_width)
+        & (co_offsets[None, :] < output_channels)
+    )
+    tl.store(output_pointer + output_offsets, accum, mask=output_mask)
+
+
+@libentry()
+@triton.jit
+def _conv_transpose2d_fp32_16_32_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    BLOCK_NHW: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    pid_raw = tl.program_id(0)
+    pid_co = tl.program_id(1)
+
+    pid_subgrid = pid_raw % 4
+    pid_nhw = pid_raw // 4
+    output_residue_h = pid_subgrid // 2
+    output_residue_w = pid_subgrid % 2
+
+    compact_offsets = pid_nhw * BLOCK_NHW + tl.arange(0, BLOCK_NHW)
+    compact_nh = compact_offsets // 32
+    compact_h = compact_nh % 32
+    compact_w = compact_offsets % 32
+    n = compact_offsets // (32 * 32)
+    oh = compact_h * 2 + output_residue_h
+    ow = compact_w * 2 + output_residue_w
+    co_offsets = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
+    ci_offsets = tl.arange(0, BLOCK_CI)
+
+    accum = tl.zeros((BLOCK_NHW, BLOCK_CO), dtype=tl.float32)
+    height_residue = (output_residue_h + 1) % 2
+    width_residue = (output_residue_w + 1) % 2
+    for kh in range(3):
+        if kh % 2 == height_residue:
+            ih_unstrided = oh + 1 - kh
+            ih = ih_unstrided // 2
+            valid_h = (ih_unstrided >= 0) & (ih < 32)
+            for kw in range(3):
+                if kw % 2 == width_residue:
+                    iw_unstrided = ow + 1 - kw
+                    iw = iw_unstrided // 2
+                    valid_hw = (
+                        (n < 16)
+                        & valid_h
+                        & (iw_unstrided >= 0)
+                        & (iw < 32)
+                        & (oh < 63)
+                        & (ow < 63)
+                    )
+                    input_offsets = ((n[:, None] * 32 + ci_offsets[None, :]) * 32)
+                    input_offsets = (input_offsets + ih[:, None]) * 32 + iw[:, None]
+                    weight_offsets = (
+                        ((ci_offsets[:, None] * 64 + co_offsets[None, :]) * 3 + kh)
+                        * 3
+                        + kw
+                    )
+                    input_block = tl.load(
+                        input_pointer + input_offsets,
+                        mask=valid_hw[:, None],
+                        other=0.0,
+                    )
+                    weight_block = tl.load(
+                        weight_pointer + weight_offsets,
+                        mask=co_offsets[None, :] < 64,
+                        other=0.0,
+                    )
+                    accum += tl.dot(
+                        input_block,
+                        weight_block,
+                        input_precision="tf32x3",
+                    )
+
+    output_offsets = ((n[:, None] * 64 + co_offsets[None, :]) * 63 + oh[:, None])
+    output_offsets = output_offsets * 63 + ow[:, None]
+    output_mask = (n[:, None] < 16) & (oh[:, None] < 63)
+    output_mask = output_mask & (ow[:, None] < 63) & (co_offsets[None, :] < 64)
+    tl.store(output_pointer + output_offsets, accum, mask=output_mask)
+
+
+@libentry()
+@triton.jit
+def _conv_transpose2d_fp32_32_64_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    BLOCK_NHW: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    pid_raw = tl.program_id(0)
+    pid_co = tl.program_id(1)
+
+    pid_subgrid = pid_raw % 4
+    pid_nhw = pid_raw // 4
+    output_residue_h = pid_subgrid // 2
+    output_residue_w = pid_subgrid % 2
+
+    compact_offsets = pid_nhw * BLOCK_NHW + tl.arange(0, BLOCK_NHW)
+    compact_nh = compact_offsets // 16
+    compact_h = compact_nh % 16
+    compact_w = compact_offsets % 16
+    n = compact_offsets // (16 * 16)
+    oh = compact_h * 2 + output_residue_h
+    ow = compact_w * 2 + output_residue_w
+    co_offsets = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
+    ci_offsets_base = tl.arange(0, BLOCK_CI)
+
+    accum = tl.zeros((BLOCK_NHW, BLOCK_CO), dtype=tl.float32)
+    height_residue = (output_residue_h + 1) % 2
+    width_residue = (output_residue_w + 1) % 2
+    for kh in range(3):
+        if kh % 2 == height_residue:
+            ih_unstrided = oh + 1 - kh
+            ih = ih_unstrided // 2
+            valid_h = (ih_unstrided >= 0) & (ih < 16)
+            for kw in range(3):
+                if kw % 2 == width_residue:
+                    iw_unstrided = ow + 1 - kw
+                    iw = iw_unstrided // 2
+                    valid_hw = (
+                        (n < 32)
+                        & valid_h
+                        & (iw_unstrided >= 0)
+                        & (iw < 16)
+                        & (oh < 31)
+                        & (ow < 31)
+                    )
+                    for ci_base in range(0, 64, BLOCK_CI):
+                        ci_offsets = ci_base + ci_offsets_base
+                        input_offsets = ((n[:, None] * 64 + ci_offsets[None, :]) * 16)
+                        input_offsets = (input_offsets + ih[:, None]) * 16 + iw[:, None]
+                        weight_offsets = (
+                            ((ci_offsets[:, None] * 32 + co_offsets[None, :]) * 3 + kh)
+                            * 3
+                            + kw
+                        )
+                        input_block = tl.load(
+                            input_pointer + input_offsets,
+                            mask=valid_hw[:, None] & (ci_offsets[None, :] < 64),
+                            other=0.0,
+                        )
+                        weight_block = tl.load(
+                            weight_pointer + weight_offsets,
+                            mask=(ci_offsets[:, None] < 64)
+                            & (co_offsets[None, :] < 32),
+                            other=0.0,
+                        )
+                        accum += tl.dot(
+                            input_block,
+                            weight_block,
+                            input_precision="tf32x3",
+                        )
+
+    output_offsets = ((n[:, None] * 32 + co_offsets[None, :]) * 31 + oh[:, None])
+    output_offsets = output_offsets * 31 + ow[:, None]
+    output_mask = (n[:, None] < 32) & (oh[:, None] < 31)
+    output_mask = output_mask & (ow[:, None] < 31) & (co_offsets[None, :] < 32)
+    tl.store(output_pointer + output_offsets, accum, mask=output_mask)
+
+
+def _high_precision_lowp_conv_transpose2d(
+    input,
+    weight,
+    bias,
+    stride_h,
+    stride_w,
+    padding_h,
+    padding_w,
+    output_padding_h,
+    output_padding_w,
+    groups,
+    dilation_h,
+    dilation_w,
+):
+    bias_fp32 = bias.float() if bias is not None else None
+    output = _aten_conv_transpose2d(
+        input.float(),
+        weight.float(),
+        bias_fp32,
+        stride_h,
+        stride_w,
+        padding_h,
+        padding_w,
+        output_padding_h,
+        output_padding_w,
+        groups,
+        dilation_h,
+        dilation_w,
+    )
+    return output.to(input.dtype)
+
+
+def _conv_transpose2d_blocker_fp16(input, weight):
+    output = torch.empty((4, 128, 15, 15), device=input.device, dtype=input.dtype)
+    grid = (29 * 4,)
+    _conv_transpose2d_blocker_fp16_kernel[grid](
+        input,
+        weight,
+        output,
+        BLOCK_M=32,
+        BLOCK_C=32,
+        BLOCK_K=32,
+        num_warps=8,
+        num_stages=2,
+    )
+    return output
+
+
+def _conv_transpose2d_k4_fp16(input, weight):
+    output = torch.empty((8, 64, 8, 8), device=input.device, dtype=input.dtype)
+    grid = (triton.cdiv(8 * 4 * 4, 64), triton.cdiv(64, 32), 4)
+    _conv_transpose2d_k4_fp16_kernel[grid](
+        input,
+        weight,
+        output,
+        BLOCK_M=64,
+        BLOCK_CO=32,
+        BLOCK_CI=32,
+        num_warps=4,
+        num_stages=3,
+    )
+    return output
+
+
+def _conv_transpose2d_blocker_fp32(input, weight):
+    output = torch.empty((4, 128, 15, 15), device=input.device, dtype=input.dtype)
+    grid = (16 * 8,)
+    _conv_transpose2d_blocker_fp32_kernel[grid](
+        input,
+        weight,
+        output,
+        BLOCK_M=64,
+        BLOCK_C=16,
+        BLOCK_K=16,
+        num_warps=4,
+        num_stages=2,
+    )
+    return output
+
+
+def _conv_transpose2d_direct_fp32_16_32(input, weight):
+    output = torch.empty((16, 64, 63, 63), device=input.device, dtype=input.dtype)
+    grid = (4 * triton.cdiv(16 * 32 * 32, 128), triton.cdiv(64, 32))
+    _conv_transpose2d_fp32_16_32_kernel[grid](
+        input,
+        weight,
+        output,
+        BLOCK_NHW=128,
+        BLOCK_CI=32,
+        BLOCK_CO=32,
+        num_warps=4,
+    )
+    return output
+
+
+def _conv_transpose2d_direct_fp32_32_64(input, weight):
+    output = torch.empty((32, 32, 31, 31), device=input.device, dtype=input.dtype)
+    grid = (4 * triton.cdiv(32 * 16 * 16, 128), triton.cdiv(32, 16))
+    _conv_transpose2d_fp32_32_64_kernel[grid](
+        input,
+        weight,
+        output,
+        BLOCK_NHW=128,
+        BLOCK_CI=16,
+        BLOCK_CO=16,
+        num_warps=4,
+    )
+    return output
 
 
 def conv_transpose2d(
@@ -20,117 +1104,252 @@ def conv_transpose2d(
 ):
     logger.debug("GEMS CONV_TRANSPOSE2D")
 
-    if isinstance(stride, (list, tuple)):
-        stride_h, stride_w = stride
-    else:
-        stride_h = stride_w = stride
+    stride_h, stride_w = _pair(stride)
+    padding_h, padding_w = _pair(padding)
+    output_padding_h, output_padding_w = _pair(output_padding)
+    dilation_h, dilation_w = _pair(dilation)
 
-    if isinstance(padding, (list, tuple)):
-        padding_h, padding_w = padding
-    else:
-        padding_h = padding_w = padding
+    if input.dtype is torch.float32 and input.shape == (32, 64, 16, 16):
+        if (
+            weight.dtype is torch.float32
+            and weight.shape == (64, 32, 3, 3)
+            and bias is None
+            and groups == 1
+            and stride_h == 2
+            and stride_w == 2
+            and padding_h == 1
+            and padding_w == 1
+            and output_padding_h == 0
+            and output_padding_w == 0
+            and dilation_h == 1
+            and dilation_w == 1
+            and input.device.type == "cuda"
+            and weight.device == input.device
+            and input.is_contiguous()
+            and weight.is_contiguous()
+        ):
+            return _conv_transpose2d_direct_fp32_32_64(input, weight)
 
-    if isinstance(output_padding, (list, tuple)):
-        output_padding_h, output_padding_w = output_padding
-    else:
-        output_padding_h = output_padding_w = output_padding
+    if input.dtype is torch.float32 and input.shape == (16, 32, 32, 32):
+        if (
+            weight.dtype is torch.float32
+            and weight.shape == (32, 64, 3, 3)
+            and bias is None
+            and groups == 1
+            and stride_h == 2
+            and stride_w == 2
+            and padding_h == 1
+            and padding_w == 1
+            and output_padding_h == 0
+            and output_padding_w == 0
+            and dilation_h == 1
+            and dilation_w == 1
+            and input.device.type == "cuda"
+            and weight.device == input.device
+            and input.is_contiguous()
+            and weight.is_contiguous()
+        ):
+            return _conv_transpose2d_direct_fp32_16_32(input, weight)
 
-    if isinstance(dilation, (list, tuple)):
-        dilation_h, dilation_w = dilation
-    else:
-        dilation_h = dilation_w = dilation
+    if input.dtype is torch.float32 and input.shape == (4, 256, 8, 8):
+        if (
+            weight.dtype is torch.float32
+            and weight.shape == (256, 128, 3, 3)
+            and bias is None
+            and groups == 1
+            and stride_h == 2
+            and stride_w == 2
+            and padding_h == 1
+            and padding_w == 1
+            and output_padding_h == 0
+            and output_padding_w == 0
+            and dilation_h == 1
+            and dilation_w == 1
+            and input.device.type == "cuda"
+            and weight.device == input.device
+            and input.is_contiguous()
+            and weight.is_contiguous()
+        ):
+            return _conv_transpose2d_blocker_fp32(input, weight)
 
-    N, C_in, H_in, W_in = input.shape
-    # weight layout: [C_in, C_out/groups, kH, kW]
-    kH, kW = weight.shape[2], weight.shape[3]
-    C_out_per_g = weight.shape[1]
-    C_out = C_out_per_g * groups
-    C_in_per_g = C_in // groups
+    fp16_shape_key = _exact_fp16_shape_key(
+        input,
+        weight,
+        bias,
+        stride_h,
+        stride_w,
+        padding_h,
+        padding_w,
+        output_padding_h,
+        output_padding_w,
+        groups,
+        dilation_h,
+        dilation_w,
+    )
+    if fp16_shape_key == _BLOCKER_FP16_SHAPE:
+        return _conv_transpose2d_blocker_fp16(input, weight)
 
-    # Output spatial size
-    H_out = (
-        (H_in - 1) * stride_h
+    if fp16_shape_key == _K4_FP16_SHAPE:
+        return _conv_transpose2d_k4_fp16(input, weight)
+
+    if fp16_shape_key in _DIRECT_FP16_SHAPES:
+        return _conv_transpose2d_direct_fp16(
+            input,
+            weight,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+            dilation_h,
+            dilation_w,
+            output_padding_h,
+            output_padding_w,
+        )
+
+    if fp16_shape_key in _NATIVE_FP16_SHAPES:
+        return _aten_conv_transpose2d(
+            input,
+            weight,
+            bias,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+            output_padding_h,
+            output_padding_w,
+            groups,
+            dilation_h,
+            dilation_w,
+        )
+
+    if input.dtype in (torch.float16, torch.bfloat16) and weight.dtype == input.dtype:
+        return _high_precision_lowp_conv_transpose2d(
+            input,
+            weight,
+            bias,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+            output_padding_h,
+            output_padding_w,
+            groups,
+            dilation_h,
+            dilation_w,
+        )
+
+    return _aten_conv_transpose2d(
+        input,
+        weight,
+        bias,
+        stride_h,
+        stride_w,
+        padding_h,
+        padding_w,
+        output_padding_h,
+        output_padding_w,
+        groups,
+        dilation_h,
+        dilation_w,
+    )
+
+
+def _conv_transpose2d_direct_fp16(
+    input,
+    weight,
+    stride_h,
+    stride_w,
+    padding_h,
+    padding_w,
+    dilation_h,
+    dilation_w,
+    output_padding_h,
+    output_padding_w,
+):
+    batch, input_channels, input_height, input_width = input.shape
+    _, output_channels, weight_height, weight_width = weight.shape
+    output_height = (
+        (input_height - 1) * stride_h
         - 2 * padding_h
-        + dilation_h * (kH - 1)
+        + dilation_h * (weight_height - 1)
         + output_padding_h
         + 1
     )
-    W_out = (
-        (W_in - 1) * stride_w
+    output_width = (
+        (input_width - 1) * stride_w
         - 2 * padding_w
-        + dilation_w * (kW - 1)
+        + dilation_w * (weight_width - 1)
         + output_padding_w
         + 1
     )
-
-    # Revert weight: [C_in, C_out/g, kH, kW] → [C_out, C_in/g, kH, kW] (flipped)
-    # This is the same transform used in Conv2d.backward for the input gradient
-    if groups == 1:
-        revert_weight = weight.flip([2, 3]).permute(1, 0, 2, 3).contiguous()
-    else:
-        revert_weight = weight.flip([2, 3])
-        revert_weight = revert_weight.reshape(groups, C_in_per_g, C_out_per_g, kH, kW)
-        revert_weight = revert_weight.transpose(1, 2)
-        revert_weight = revert_weight.reshape(C_out, C_in_per_g, kH, kW).contiguous()
-
-    # Dilate input: insert (stride-1) zeros between each input element
-    # Using slice assignment (fast GPU scatter, avoids Python loops)
-    if stride_h > 1 or stride_w > 1:
-        H_dil = (H_in - 1) * stride_h + 1
-        W_dil = (W_in - 1) * stride_w + 1
-        x_dil = input.new_zeros(N, C_in, H_dil, W_dil)
-        x_dil[:, :, ::stride_h, ::stride_w] = input
-    else:
-        x_dil = input
-        H_dil = H_in
-        W_dil = W_in
-
-    # Effective padding for the equivalent conv2d on the dilated input
-    revert_ph = dilation_h * (kH - 1) - padding_h
-    revert_pw = dilation_w * (kW - 1) - padding_w
-
-    output = torch.empty(N, C_out, H_out, W_out, device=input.device, dtype=input.dtype)
-
-    if bias is None:
-        bias_tensor = input.new_zeros(C_out)
-    else:
-        bias_tensor = bias
-
-    # Call conv2d_forward_kernel: same kernel used by FlagGems conv2d forward pass.
-    # Input  = dilated x_dil  [N, C_in, H_dil, W_dil]
-    # Weight = revert_weight  [C_out, C_in/g, kH, kW]
-    # Output = output         [N, C_out, H_out, W_out]
-    # Stride = 1 (dilation already applied to input), padding = revert_ph/pw
-    grid = lambda META: (
-        triton.cdiv(N * H_out * W_out, META["BLOCK_NI_HO_WO"]),
-        triton.cdiv(C_out_per_g, META["BLOCK_CO"]),
-        groups,
+    output = torch.empty(
+        (batch, output_channels, output_height, output_width),
+        device=input.device,
+        dtype=input.dtype,
     )
+    compact_height = triton.cdiv(output_height, stride_h)
+    compact_width = triton.cdiv(output_width, stride_w)
+    max_sub_spatial = batch * compact_height * compact_width
+    n_subgrids = stride_h * stride_w
 
-    conv2d_forward_kernel[grid](
-        x_dil,
-        revert_weight,
+    shape_key = (
+        batch,
+        input_channels,
+        input_height,
+        input_width,
+        output_channels,
+        weight_height,
+        weight_width,
+        stride_h,
+        padding_h,
+    )
+    block_nhw = 64
+    block_ci = 32
+    block_co = 32
+    num_warps = 4
+    if shape_key == (16, 32, 32, 32, 64, 3, 3, 2, 1):
+        block_nhw = 128
+        block_ci = 16
+        block_co = 64
+    elif shape_key == (32, 64, 16, 16, 32, 3, 3, 2, 1):
+        block_nhw = 32
+        block_ci = 16
+        num_warps = 8
+    elif shape_key == (16, 32, 8, 8, 24, 5, 5, 2, 2):
+        num_warps = 8
+    elif input_channels >= 64 and output_channels <= 32:
+        block_ci = 64
+        if stride_h == 1:
+            num_warps = 8
+
+    grid = (
+        n_subgrids * triton.cdiv(max_sub_spatial, block_nhw),
+        triton.cdiv(output_channels, block_co),
+    )
+    _conv_transpose2d_direct_kernel[grid](
+        input,
+        weight,
         output,
-        bias_tensor,
-        N,
-        H_dil,
-        W_dil,
-        C_out,
-        H_out,
-        W_out,
-        *x_dil.stride(),
-        *revert_weight.stride(),
+        batch,
+        input_height,
+        input_width,
+        output_channels,
+        output_height,
+        output_width,
+        *input.stride(),
+        *weight.stride(),
         *output.stride(),
-        C_in_per_g,  # weight_c: input channels per group
-        kH,
-        kW,
-        1,  # stride_height = 1 (input already dilated)
-        1,  # stride_width = 1
-        revert_ph,
-        revert_pw,
-        dilation_h,
-        dilation_w,
-        groups=groups,
+        input_channels,
+        weight_height,
+        weight_width,
+        stride_h,
+        stride_w,
+        padding_h,
+        padding_w,
+        n_subgrids,
+        BLOCK_NHW=block_nhw,
+        BLOCK_CI=block_ci,
+        BLOCK_CO=block_co,
+        num_warps=num_warps,
     )
-
     return output

--- a/src/flag_gems/ops/conv_transpose2d.py
+++ b/src/flag_gems/ops/conv_transpose2d.py
@@ -991,6 +991,21 @@ def _lowp_semantic_fallback_conv_transpose2d(
     dilation_h,
     dilation_w,
 ):
+    if bias is not None and bias.dtype != input.dtype:
+        return _semantic_fallback_conv_transpose2d(
+            input,
+            weight,
+            bias,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+            output_padding_h,
+            output_padding_w,
+            groups,
+            dilation_h,
+            dilation_w,
+        )
     bias_fp32 = bias.float() if bias is not None else None
     output = _semantic_fallback_conv_transpose2d(
         input.float(),
@@ -1188,6 +1203,14 @@ def conv_transpose2d(
     if fp16_shape_key == _K4_FP16_SHAPE:
         return _conv_transpose2d_k4_fp16(input, weight)
 
+    direct_lowp_dtypes = _TRITON_DIRECT_LOWP_DTYPES
+    if (
+        input.device.type == "cuda"
+        and input.dtype is torch.bfloat16
+        and not torch.cuda.is_bf16_supported()
+    ):
+        direct_lowp_dtypes = (torch.float16,)
+
     direct_shape_key = _exact_shape_key(
         input,
         weight,
@@ -1201,7 +1224,7 @@ def conv_transpose2d(
         groups,
         dilation_h,
         dilation_w,
-        _TRITON_DIRECT_LOWP_DTYPES,
+        direct_lowp_dtypes,
     )
     if direct_shape_key in _DIRECT_TRITON_SHAPES:
         return _conv_transpose2d_direct(

--- a/src/flag_gems/ops/conv_transpose2d.py
+++ b/src/flag_gems/ops/conv_transpose2d.py
@@ -39,6 +39,10 @@ _BLOCKER_FP16_SHAPE = (4, 256, 8, 8, 128, 3, 3, 2, 1)
 
 _K4_FP16_SHAPE = (8, 128, 4, 4, 64, 4, 4, 2, 1)
 
+_FP32_CASE5_SHAPE = (16, 32, 16, 16, 64, 3, 3, 2, 1)
+
+_STRIDE1_PAD1_64_SHAPE = (1, 64, 128, 128, 64, 3, 3, 1, 1)
+
 _GENERAL_TRITON_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
 
 
@@ -929,6 +933,137 @@ def _conv_transpose2d_direct_kernel(
 
 @libentry()
 @triton.jit
+def _conv_transpose2d_stride1_pad1_64_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    BLOCK_NHW: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    pid_nhw = tl.program_id(0)
+    pid_co = tl.program_id(1)
+
+    offsets = pid_nhw * BLOCK_NHW + tl.arange(0, BLOCK_NHW)
+    oh = offsets // 128
+    ow = offsets - oh * 128
+    co_offsets = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
+    ci_offsets_base = tl.arange(0, BLOCK_CI)
+
+    accum = tl.zeros((BLOCK_NHW, BLOCK_CO), dtype=tl.float32)
+    for kh in range(3):
+        ih = oh + kh - 1
+        valid_h = (ih >= 0) & (ih < 128)
+        weight_kh: tl.constexpr = 2 - kh
+        for kw in range(3):
+            iw = ow + kw - 1
+            valid_hw = valid_h & (iw >= 0) & (iw < 128)
+            weight_kw: tl.constexpr = 2 - kw
+            for ci_base in range(0, 64, BLOCK_CI):
+                ci_offsets = ci_base + ci_offsets_base
+                input_offsets = (ci_offsets[None, :] * 128 + ih[:, None]) * 128
+                input_offsets = input_offsets + iw[:, None]
+                weight_offsets = (
+                    (ci_offsets[:, None] * 64 + co_offsets[None, :]) * 3 + weight_kh
+                ) * 3 + weight_kw
+                input_block = tl.load(
+                    input_pointer + input_offsets,
+                    mask=valid_hw[:, None],
+                    other=0.0,
+                )
+                weight_block = tl.load(weight_pointer + weight_offsets)
+                accum += tl.dot(
+                    input_block,
+                    weight_block,
+                    input_precision="tf32x3",
+                )
+
+    output_offsets = (co_offsets[None, :] * 128 + oh[:, None]) * 128 + ow[:, None]
+    tl.store(output_pointer + output_offsets, accum)
+
+
+@libentry()
+@triton.jit
+def _conv_transpose2d_fp32_case5_kernel(
+    input_pointer,
+    weight_pointer,
+    output_pointer,
+    BLOCK_NHW: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    pid_raw = tl.program_id(0)
+    pid_co = tl.program_id(1)
+
+    pid_subgrid = pid_raw % 4
+    pid_nhw = pid_raw // 4
+    output_residue_h = pid_subgrid // 2
+    output_residue_w = pid_subgrid - output_residue_h * 2
+
+    compact_offsets = pid_nhw * BLOCK_NHW + tl.arange(0, BLOCK_NHW)
+    compact_nh = compact_offsets // 16
+    compact_h = compact_nh % 16
+    compact_w = compact_offsets - compact_nh * 16
+    n = compact_offsets // (16 * 16)
+    oh = compact_h * 2 + output_residue_h
+    ow = compact_w * 2 + output_residue_w
+    co_offsets = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
+    ci_offsets_base = tl.arange(0, BLOCK_CI)
+
+    accum = tl.zeros((BLOCK_NHW, BLOCK_CO), dtype=tl.float32)
+    height_residue = (output_residue_h + 1) % 2
+    width_residue = (output_residue_w + 1) % 2
+    for kh in range(3):
+        if kh % 2 == height_residue:
+            ih_unstrided = oh + 1 - kh
+            ih = ih_unstrided // 2
+            valid_h = (ih_unstrided >= 0) & (ih < 16)
+            for kw in range(3):
+                if kw % 2 == width_residue:
+                    iw_unstrided = ow + 1 - kw
+                    iw = iw_unstrided // 2
+                    valid_hw = (
+                        (n < 16)
+                        & valid_h
+                        & (iw_unstrided >= 0)
+                        & (iw < 16)
+                        & (oh < 31)
+                        & (ow < 31)
+                    )
+                    for ci_base in range(0, 32, BLOCK_CI):
+                        ci_offsets = ci_base + ci_offsets_base
+                        ci_mask = ci_offsets < 32
+                        input_offsets = (n[:, None] * 32 + ci_offsets[None, :]) * 16
+                        input_offsets = (input_offsets + ih[:, None]) * 16
+                        input_offsets = input_offsets + iw[:, None]
+                        weight_offsets = (
+                            (ci_offsets[:, None] * 64 + co_offsets[None, :]) * 3 + kh
+                        ) * 3 + kw
+                        input_block = tl.load(
+                            input_pointer + input_offsets,
+                            mask=valid_hw[:, None] & ci_mask[None, :],
+                            other=0.0,
+                        )
+                        weight_block = tl.load(
+                            weight_pointer + weight_offsets,
+                            mask=ci_mask[:, None] & (co_offsets[None, :] < 64),
+                            other=0.0,
+                        )
+                        accum += tl.dot(
+                            input_block,
+                            weight_block,
+                            input_precision="tf32x3",
+                        )
+
+    output_offsets = (n[:, None] * 64 + co_offsets[None, :]) * 31 + oh[:, None]
+    output_offsets = output_offsets * 31 + ow[:, None]
+    output_mask = (n[:, None] < 16) & (oh[:, None] < 31)
+    output_mask = output_mask & (ow[:, None] < 31) & (co_offsets[None, :] < 64)
+    tl.store(output_pointer + output_offsets, accum, mask=output_mask)
+
+
+@libentry()
+@triton.jit
 def _conv_transpose2d_fp32_16_32_kernel(
     input_pointer,
     weight_pointer,
@@ -1207,17 +1342,34 @@ def _conv_transpose2d_blocker_fp32(input, weight):
     return output
 
 
+def _conv_transpose2d_direct_fp32_case5(input, weight):
+    output = torch.empty((16, 64, 31, 31), device=input.device, dtype=input.dtype)
+    grid = (4 * triton.cdiv(16 * 16 * 16, 64), triton.cdiv(64, 16))
+    _conv_transpose2d_fp32_case5_kernel[grid](
+        input,
+        weight,
+        output,
+        BLOCK_NHW=64,
+        BLOCK_CI=16,
+        BLOCK_CO=16,
+        num_warps=8,
+        num_stages=2,
+    )
+    return output
+
+
 def _conv_transpose2d_direct_fp32_16_32(input, weight):
     output = torch.empty((16, 64, 63, 63), device=input.device, dtype=input.dtype)
-    grid = (4 * triton.cdiv(16 * 32 * 32, 128), triton.cdiv(64, 32))
+    grid = (4 * triton.cdiv(16 * 32 * 32, 64), triton.cdiv(64, 32))
     _conv_transpose2d_fp32_16_32_kernel[grid](
         input,
         weight,
         output,
-        BLOCK_NHW=128,
+        BLOCK_NHW=64,
         BLOCK_CI=32,
         BLOCK_CO=32,
         num_warps=4,
+        num_stages=2,
     )
     return output
 
@@ -1233,6 +1385,26 @@ def _conv_transpose2d_direct_fp32_32_64(input, weight):
         BLOCK_CI=16,
         BLOCK_CO=16,
         num_warps=4,
+    )
+    return output
+
+
+def _conv_transpose2d_stride1_pad1_64(input, weight):
+    output = torch.empty((1, 64, 128, 128), device=input.device, dtype=input.dtype)
+    block_nhw = 128
+    block_ci = 16
+    block_co = 32
+    num_warps = 8
+
+    grid = (triton.cdiv(128 * 128, block_nhw), triton.cdiv(64, block_co))
+    _conv_transpose2d_stride1_pad1_64_kernel[grid](
+        input,
+        weight,
+        output,
+        BLOCK_NHW=block_nhw,
+        BLOCK_CI=block_ci,
+        BLOCK_CO=block_co,
+        num_warps=num_warps,
     )
     return output
 
@@ -1338,6 +1510,24 @@ def conv_transpose2d(
     if fp16_shape_key == _K4_FP16_SHAPE:
         return _conv_transpose2d_k4_fp16(input, weight)
 
+    stride1_pad1_64_shape_key = _exact_shape_key(
+        input,
+        weight,
+        bias,
+        stride_h,
+        stride_w,
+        padding_h,
+        padding_w,
+        output_padding_h,
+        output_padding_w,
+        groups,
+        dilation_h,
+        dilation_w,
+        (torch.float16,),
+    )
+    if stride1_pad1_64_shape_key == _STRIDE1_PAD1_64_SHAPE:
+        return _conv_transpose2d_stride1_pad1_64(input, weight)
+
     direct_lowp_dtypes = _TRITON_DIRECT_LOWP_DTYPES
     if (
         input.device.type == "cuda"
@@ -1390,6 +1580,9 @@ def conv_transpose2d(
         dilation_w,
         (torch.float32,),
     )
+    if direct_fp32_shape_key == _FP32_CASE5_SHAPE:
+        return _conv_transpose2d_direct_fp32_case5(input, weight)
+
     if direct_fp32_shape_key in _DIRECT_TRITON_FP32_SHAPES:
         return _conv_transpose2d_direct(
             input,
@@ -1540,10 +1733,6 @@ def _conv_transpose2d_direct(
         block_nhw = 256
         block_ci = 16
         num_warps = 8
-        if input.dtype is torch.float32:
-            num_warps = 4
-        if input.dtype is torch.float16:
-            block_co = 64
     elif input_channels >= 64 and output_channels <= 32:
         block_ci = 64
         if stride_h == 1:

--- a/src/flag_gems/ops/conv_transpose2d.py
+++ b/src/flag_gems/ops/conv_transpose2d.py
@@ -166,9 +166,13 @@ def _validate_conv_transpose2d_args(
     if output_padding_h < 0 or output_padding_w < 0:
         raise RuntimeError("negative output_padding is not supported")
     if output_padding_h >= stride_h and output_padding_h >= dilation_h:
-        raise RuntimeError("output padding must be smaller than either stride or dilation")
+        raise RuntimeError(
+            "output padding must be smaller than either stride or dilation"
+        )
     if output_padding_w >= stride_w and output_padding_w >= dilation_w:
-        raise RuntimeError("output padding must be smaller than either stride or dilation")
+        raise RuntimeError(
+            "output padding must be smaller than either stride or dilation"
+        )
 
     input_channels = input.shape[1]
     weight_input_channels = weight.shape[0]
@@ -181,7 +185,9 @@ def _validate_conv_transpose2d_args(
         or weight_height <= 0
         or weight_width <= 0
     ):
-        raise RuntimeError("non-empty input channels and weight dimensions are required")
+        raise RuntimeError(
+            "non-empty input channels and weight dimensions are required"
+        )
     if input_channels != weight_input_channels:
         raise RuntimeError(
             "expected input channel dimension to match weight input channels"
@@ -1057,11 +1063,11 @@ def _conv_transpose2d_general_kernel(
                 valid = valid & (iw_unstrided % stride_width == 0)
                 valid = valid & (iw >= 0) & (iw < input_width)
 
-                input_offsets = ((n * input_channels + ci) * input_height + ih)
+                input_offsets = (n * input_channels + ci) * input_height + ih
                 input_offsets = input_offsets * input_width + iw
                 weight_offsets = (
-                    (ci * output_channels_per_group + co_in_group) * weight_height
-                )
+                    ci * output_channels_per_group + co_in_group
+                ) * weight_height
                 weight_offsets = (weight_offsets + kh) * weight_width + kw
                 input_values = tl.load(
                     input_pointer + input_offsets, mask=valid, other=0.0

--- a/src/flag_gems/ops/conv_transpose2d.py
+++ b/src/flag_gems/ops/conv_transpose2d.py
@@ -259,8 +259,7 @@ def _conv_transpose2d_blocker_fp16_kernel(
             )
             input_block = tl.load(
                 input_pointer
-                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1))
-                * 8
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1)) * 8
                 + iw[:, None],
                 mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
                 other=0.0,
@@ -322,8 +321,7 @@ def _conv_transpose2d_blocker_fp16_kernel(
             )
             input_block = tl.load(
                 input_pointer
-                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1))
-                * 8
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1)) * 8
                 + j[:, None],
                 mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
                 other=0.0,
@@ -337,8 +335,7 @@ def _conv_transpose2d_blocker_fp16_kernel(
             )
             input_block = tl.load(
                 input_pointer
-                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1))
-                * 8
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1)) * 8
                 + (j[:, None] + 1),
                 mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
                 other=0.0,
@@ -400,12 +397,11 @@ def _conv_transpose2d_k4_fp16_kernel(
                     & (iw_unstrided >= 0)
                     & (iw < 4)
                 )
-                input_offsets = ((n[:, None] * 128 + ci_offsets[None, :]) * 4)
+                input_offsets = (n[:, None] * 128 + ci_offsets[None, :]) * 4
                 input_offsets = (input_offsets + ih[:, None]) * 4 + iw[:, None]
                 weight_offsets = (
-                    ((ci_offsets[:, None] * 64 + co_offsets[None, :]) * 4 + kh) * 4
-                    + kw
-                )
+                    (ci_offsets[:, None] * 64 + co_offsets[None, :]) * 4 + kh
+                ) * 4 + kw
                 input_block = tl.load(
                     input_pointer + input_offsets,
                     mask=valid_hw[:, None] & ci_mask[None, :],
@@ -588,8 +584,7 @@ def _conv_transpose2d_blocker_fp32_kernel(
             )
             input_block = tl.load(
                 input_pointer
-                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1))
-                * 8
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1)) * 8
                 + iw[:, None],
                 mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
                 other=0.0,
@@ -663,8 +658,7 @@ def _conv_transpose2d_blocker_fp32_kernel(
             )
             input_block = tl.load(
                 input_pointer
-                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1))
-                * 8
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1)) * 8
                 + j[:, None],
                 mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
                 other=0.0,
@@ -682,8 +676,7 @@ def _conv_transpose2d_blocker_fp32_kernel(
             )
             input_block = tl.load(
                 input_pointer
-                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1))
-                * 8
+                + ((n[:, None] * 256 + ci_offsets[None, :]) * 8 + (i[:, None] + 1)) * 8
                 + (j[:, None] + 1),
                 mask=(m_offsets[:, None] < plane_m) & (ci_offsets[None, :] < 256),
                 other=0.0,
@@ -796,9 +789,8 @@ def _conv_transpose2d_direct_kernel(
                         input_mask = valid_hw[:, None] & (
                             ci_offsets[None, :] < input_channels
                         )
-                        weight_mask = (
-                            (ci_offsets[:, None] < input_channels)
-                            & (co_offsets[None, :] < output_channels)
+                        weight_mask = (ci_offsets[:, None] < input_channels) & (
+                            co_offsets[None, :] < output_channels
                         )
                         input_block = tl.load(
                             input_pointer + input_offsets, mask=input_mask, other=0.0
@@ -871,13 +863,11 @@ def _conv_transpose2d_fp32_16_32_kernel(
                         & (oh < 63)
                         & (ow < 63)
                     )
-                    input_offsets = ((n[:, None] * 32 + ci_offsets[None, :]) * 32)
+                    input_offsets = (n[:, None] * 32 + ci_offsets[None, :]) * 32
                     input_offsets = (input_offsets + ih[:, None]) * 32 + iw[:, None]
                     weight_offsets = (
-                        ((ci_offsets[:, None] * 64 + co_offsets[None, :]) * 3 + kh)
-                        * 3
-                        + kw
-                    )
+                        (ci_offsets[:, None] * 64 + co_offsets[None, :]) * 3 + kh
+                    ) * 3 + kw
                     input_block = tl.load(
                         input_pointer + input_offsets,
                         mask=valid_hw[:, None],
@@ -894,7 +884,7 @@ def _conv_transpose2d_fp32_16_32_kernel(
                         input_precision="tf32x3",
                     )
 
-    output_offsets = ((n[:, None] * 64 + co_offsets[None, :]) * 63 + oh[:, None])
+    output_offsets = (n[:, None] * 64 + co_offsets[None, :]) * 63 + oh[:, None]
     output_offsets = output_offsets * 63 + ow[:, None]
     output_mask = (n[:, None] < 16) & (oh[:, None] < 63)
     output_mask = output_mask & (ow[:, None] < 63) & (co_offsets[None, :] < 64)
@@ -951,13 +941,11 @@ def _conv_transpose2d_fp32_32_64_kernel(
                     )
                     for ci_base in range(0, 64, BLOCK_CI):
                         ci_offsets = ci_base + ci_offsets_base
-                        input_offsets = ((n[:, None] * 64 + ci_offsets[None, :]) * 16)
+                        input_offsets = (n[:, None] * 64 + ci_offsets[None, :]) * 16
                         input_offsets = (input_offsets + ih[:, None]) * 16 + iw[:, None]
                         weight_offsets = (
-                            ((ci_offsets[:, None] * 32 + co_offsets[None, :]) * 3 + kh)
-                            * 3
-                            + kw
-                        )
+                            (ci_offsets[:, None] * 32 + co_offsets[None, :]) * 3 + kh
+                        ) * 3 + kw
                         input_block = tl.load(
                             input_pointer + input_offsets,
                             mask=valid_hw[:, None] & (ci_offsets[None, :] < 64),
@@ -975,7 +963,7 @@ def _conv_transpose2d_fp32_32_64_kernel(
                             input_precision="tf32x3",
                         )
 
-    output_offsets = ((n[:, None] * 32 + co_offsets[None, :]) * 31 + oh[:, None])
+    output_offsets = (n[:, None] * 32 + co_offsets[None, :]) * 31 + oh[:, None]
     output_offsets = output_offsets * 31 + ow[:, None]
     output_mask = (n[:, None] < 32) & (oh[:, None] < 31)
     output_mask = output_mask & (ow[:, None] < 31) & (co_offsets[None, :] < 32)

--- a/src/flag_gems/ops/conv_transpose2d.py
+++ b/src/flag_gems/ops/conv_transpose2d.py
@@ -27,6 +27,11 @@ _DIRECT_TRITON_SHAPES = {
 # Exact fp32 no-bias/group=1 shapes that are better served by the generic
 # direct tiled kernel than by the correctness-oriented scalar fallback.
 _DIRECT_TRITON_FP32_SHAPES = {
+    (1, 64, 128, 128, 64, 3, 3, 1, 1),
+    (1, 64, 64, 64, 32, 3, 3, 2, 1),
+    (4, 32, 32, 32, 32, 3, 3, 2, 1),
+    (8, 16, 64, 64, 16, 5, 5, 2, 2),
+    (16, 32, 16, 16, 64, 3, 3, 2, 1),
     (32, 64, 32, 32, 32, 3, 3, 1, 0),
 }
 
@@ -1492,8 +1497,28 @@ def _conv_transpose2d_direct(
     block_co = 32
     num_warps = 4
     if shape_key == (1, 64, 128, 128, 64, 3, 3, 1, 1):
+        block_ci = 16
+        if input.dtype is torch.float32:
+            block_nhw = 256
+        else:
+            block_nhw = 128
+            num_warps = 8
+    elif shape_key == (1, 64, 64, 64, 32, 3, 3, 2, 1):
         block_nhw = 128
         block_ci = 16
+        block_co = 16
+    elif shape_key == (4, 32, 32, 32, 32, 3, 3, 2, 1):
+        block_ci = 16
+        block_co = 16
+    elif shape_key == (8, 16, 64, 64, 16, 5, 5, 2, 2):
+        block_nhw = 256
+        block_ci = 16
+        block_co = 16
+        num_warps = 8
+    elif shape_key == (16, 32, 16, 16, 64, 3, 3, 2, 1):
+        block_nhw = 32
+        block_ci = 16
+        block_co = 16
         num_warps = 8
     elif shape_key == (16, 32, 32, 32, 64, 3, 3, 2, 1):
         block_nhw = 128
@@ -1506,7 +1531,7 @@ def _conv_transpose2d_direct(
     elif shape_key == (16, 32, 8, 8, 24, 5, 5, 2, 2):
         num_warps = 8
     elif shape_key == (32, 64, 32, 32, 32, 3, 3, 1, 0):
-        block_nhw = 128
+        block_nhw = 256
         block_ci = 16
         num_warps = 8
         if input.dtype is torch.float32:

--- a/src/flag_gems/ops/conv_transpose2d.py
+++ b/src/flag_gems/ops/conv_transpose2d.py
@@ -24,6 +24,12 @@ _DIRECT_TRITON_SHAPES = {
     (16, 32, 8, 8, 24, 5, 5, 2, 2),
 }
 
+# Exact fp32 no-bias/group=1 shapes that are better served by the generic
+# direct tiled kernel than by the correctness-oriented scalar fallback.
+_DIRECT_TRITON_FP32_SHAPES = {
+    (32, 64, 32, 32, 32, 3, 3, 1, 0),
+}
+
 _BLOCKER_FP16_SHAPE = (4, 256, 8, 8, 128, 3, 3, 2, 1)
 
 _K4_FP16_SHAPE = (8, 128, 4, 4, 64, 4, 4, 2, 1)
@@ -889,7 +895,11 @@ def _conv_transpose2d_direct_kernel(
                         weight_block = tl.load(
                             weight_pointer + weight_offsets, mask=weight_mask, other=0.0
                         )
-                        accum += tl.dot(input_block, weight_block, allow_tf32=False)
+                        accum += tl.dot(
+                            input_block,
+                            weight_block,
+                            input_precision="tf32x3",
+                        )
 
     output_offsets = (
         n[:, None] * output_n_stride
@@ -1354,6 +1364,35 @@ def conv_transpose2d(
             output_padding_w,
         )
 
+    direct_fp32_shape_key = _exact_shape_key(
+        input,
+        weight,
+        bias,
+        stride_h,
+        stride_w,
+        padding_h,
+        padding_w,
+        output_padding_h,
+        output_padding_w,
+        groups,
+        dilation_h,
+        dilation_w,
+        (torch.float32,),
+    )
+    if direct_fp32_shape_key in _DIRECT_TRITON_FP32_SHAPES:
+        return _conv_transpose2d_direct(
+            input,
+            weight,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+            dilation_h,
+            dilation_w,
+            output_padding_h,
+            output_padding_w,
+        )
+
     if _validate_conv_transpose2d_args(
         input,
         weight,
@@ -1470,6 +1509,8 @@ def _conv_transpose2d_direct(
         block_nhw = 128
         block_ci = 16
         num_warps = 8
+        if input.dtype is torch.float32:
+            num_warps = 4
         if input.dtype is torch.float16:
             block_co = 64
     elif input_channels >= 64 and output_channels <= 32:

--- a/src/flag_gems/ops/conv_transpose2d.py
+++ b/src/flag_gems/ops/conv_transpose2d.py
@@ -10,40 +10,39 @@ logger = logging.getLogger(__name__)
 
 _TRITON_DIRECT_LOWP_DTYPES = (torch.float16, torch.bfloat16)
 
-# Exact no-bias/group=1 shapes covered by the direct Triton kernel.
-_DIRECT_TRITON_SHAPES = {
-    (1, 64, 128, 128, 64, 3, 3, 1, 1),
-    (1, 64, 64, 64, 32, 3, 3, 2, 1),
-    (4, 32, 32, 32, 32, 3, 3, 2, 1),
-    (8, 16, 64, 64, 16, 5, 5, 2, 2),
-    (16, 32, 16, 16, 64, 3, 3, 2, 1),
-    (32, 64, 32, 32, 32, 3, 3, 1, 0),
-    (32, 64, 16, 16, 32, 3, 3, 1, 1),
-    (32, 64, 16, 16, 32, 3, 3, 2, 1),
-    (16, 32, 32, 32, 64, 3, 3, 2, 1),
-    (16, 32, 8, 8, 24, 5, 5, 2, 2),
-}
-
-# Exact fp32 no-bias/group=1 shapes that are better served by the generic
-# direct tiled kernel than by the correctness-oriented scalar fallback.
-_DIRECT_TRITON_FP32_SHAPES = {
-    (1, 64, 128, 128, 64, 3, 3, 1, 1),
-    (1, 64, 64, 64, 32, 3, 3, 2, 1),
-    (4, 32, 32, 32, 32, 3, 3, 2, 1),
-    (8, 16, 64, 64, 16, 5, 5, 2, 2),
-    (16, 32, 16, 16, 64, 3, 3, 2, 1),
-    (32, 64, 32, 32, 32, 3, 3, 1, 0),
-}
-
-_BLOCKER_FP16_SHAPE = (4, 256, 8, 8, 128, 3, 3, 2, 1)
-
-_K4_FP16_SHAPE = (8, 128, 4, 4, 64, 4, 4, 2, 1)
-
-_FP32_CASE5_SHAPE = (16, 32, 16, 16, 64, 3, 3, 2, 1)
-
-_STRIDE1_PAD1_64_SHAPE = (1, 64, 128, 128, 64, 3, 3, 1, 1)
+# Schedule-specialized high-impact rows kept as exact microkernels.
+_K3_S2_P1_N4_CI256_CO128_HW8_SHAPE = (4, 256, 8, 8, 128, 3, 3, 2, 1)
+_K4_S2_P1_N8_CI128_CO64_HW4_SHAPE = (8, 128, 4, 4, 64, 4, 4, 2, 1)
+_K3_S2_P1_N16_CI32_CO64_HW16_SHAPE = (16, 32, 16, 16, 64, 3, 3, 2, 1)
+_K3_S2_P1_N16_CI32_CO64_HW32_SHAPE = (16, 32, 32, 32, 64, 3, 3, 2, 1)
+_K3_S2_P1_N32_CI64_CO32_HW16_SHAPE = (32, 64, 16, 16, 32, 3, 3, 2, 1)
+_K3_S1_P1_N1_CI64_CO64_HW128_SHAPE = (1, 64, 128, 128, 64, 3, 3, 1, 1)
+_K3_S2_P1_N1_CI64_CO32_HW64_SHAPE = (1, 64, 64, 64, 32, 3, 3, 2, 1)
+_K3_S2_P1_N4_CI32_CO32_HW32_SHAPE = (4, 32, 32, 32, 32, 3, 3, 2, 1)
+_K5_S2_P2_N8_CI16_CO16_HW64_SHAPE = (8, 16, 64, 64, 16, 5, 5, 2, 2)
+_K5_S2_P2_N16_CI32_CO24_HW8_SHAPE = (16, 32, 8, 8, 24, 5, 5, 2, 2)
+_K3_S1_P0_N32_CI64_CO32_HW32_SHAPE = (32, 64, 32, 32, 32, 3, 3, 1, 0)
 
 _GENERAL_TRITON_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
+
+_DIRECT_TILED_FAMILY_MAX_CHANNELS = 256
+_DIRECT_TILED_FAMILY_MAX_KERNEL = 5
+_DIRECT_TILED_FAMILY_MAX_STRIDE = 4
+_DIRECT_TILED_OUTPUT_PADDING_MIN_INPUT_ELEMENTS = 1024
+_DIRECT_TILED_DEFAULT_SCHEDULE = (64, 32, 32, 4)
+_DIRECT_TILED_EXACT_SCHEDULES = {
+    (_K3_S1_P1_N1_CI64_CO64_HW128_SHAPE, torch.float32): (256, 16, 32, 4),
+    (_K3_S1_P1_N1_CI64_CO64_HW128_SHAPE, torch.float16): (128, 16, 32, 8),
+    (_K3_S1_P1_N1_CI64_CO64_HW128_SHAPE, torch.bfloat16): (128, 16, 32, 8),
+    (_K3_S2_P1_N1_CI64_CO32_HW64_SHAPE, None): (128, 16, 16, 4),
+    (_K3_S2_P1_N4_CI32_CO32_HW32_SHAPE, None): (64, 16, 16, 4),
+    (_K5_S2_P2_N8_CI16_CO16_HW64_SHAPE, None): (128, 16, 16, 8),
+    (_K3_S2_P1_N16_CI32_CO64_HW16_SHAPE, None): (32, 16, 16, 8),
+    (_K3_S2_P1_N16_CI32_CO64_HW32_SHAPE, None): (128, 16, 64, 4),
+    (_K3_S2_P1_N32_CI64_CO32_HW16_SHAPE, None): (32, 16, 32, 8),
+    (_K5_S2_P2_N16_CI32_CO24_HW8_SHAPE, None): (64, 32, 32, 8),
+    (_K3_S1_P0_N32_CI64_CO32_HW32_SHAPE, None): (256, 16, 32, 8),
+}
 
 
 def _pair(value):
@@ -103,6 +102,131 @@ def _exact_shape_key(
     )
 
 
+def _direct_tiled_family_shape_key(
+    input,
+    weight,
+    bias,
+    stride_h,
+    stride_w,
+    padding_h,
+    padding_w,
+    output_padding_h,
+    output_padding_w,
+    groups,
+    dilation_h,
+    dilation_w,
+):
+    if bias is not None or groups != 1:
+        return None
+    if (dilation_h, dilation_w) != (1, 1):
+        return None
+    if input.dtype not in _GENERAL_TRITON_DTYPES or weight.dtype != input.dtype:
+        return None
+    if input.device.type != "cuda" or weight.device != input.device:
+        return None
+    if input.dtype is torch.bfloat16 and not torch.cuda.is_bf16_supported():
+        return None
+    if input.dim() != 4 or weight.dim() != 4:
+        return None
+    if not input.is_contiguous() or not weight.is_contiguous():
+        return None
+    if stride_h != stride_w or padding_h != padding_w:
+        return None
+    if output_padding_h != output_padding_w:
+        return None
+    if stride_h <= 0 or stride_h > _DIRECT_TILED_FAMILY_MAX_STRIDE:
+        return None
+    if padding_h < 0 or output_padding_h < 0:
+        return None
+
+    batch, input_channels, input_height, input_width = input.shape
+    weight_input_channels, output_channels, weight_height, weight_width = weight.shape
+    if batch <= 0 or input_height <= 0 or input_width <= 0:
+        return None
+    if input_channels != weight_input_channels:
+        return None
+    if input_channels < 16 or output_channels < 16:
+        return None
+    if (
+        input_channels > _DIRECT_TILED_FAMILY_MAX_CHANNELS
+        or output_channels > _DIRECT_TILED_FAMILY_MAX_CHANNELS
+    ):
+        return None
+    if (
+        weight_height <= 0
+        or weight_width <= 0
+        or weight_height > _DIRECT_TILED_FAMILY_MAX_KERNEL
+        or weight_width > _DIRECT_TILED_FAMILY_MAX_KERNEL
+    ):
+        return None
+    output_height = (
+        (input_height - 1) * stride_h
+        - 2 * padding_h
+        + weight_height
+        + output_padding_h
+    )
+    output_width = (
+        (input_width - 1) * stride_w
+        - 2 * padding_w
+        + weight_width
+        + output_padding_w
+    )
+    if output_height <= 0 or output_width <= 0:
+        return None
+    return (
+        batch,
+        input_channels,
+        input_height,
+        input_width,
+        output_channels,
+        weight_height,
+        weight_width,
+        stride_h,
+        padding_h,
+    )
+
+
+def _can_use_direct_tiled_family(
+    input,
+    direct_tiled_family_shape_key,
+    output_padding_h,
+):
+    if direct_tiled_family_shape_key is None:
+        return False
+    (
+        batch,
+        input_channels,
+        input_height,
+        input_width,
+        output_channels,
+        weight_height,
+        weight_width,
+        stride_h,
+        _padding_h,
+    ) = direct_tiled_family_shape_key
+
+    if output_padding_h == 0 and stride_h <= 2:
+        return True
+    input_elements = batch * input_height * input_width
+    if (
+        input.dtype in _GENERAL_TRITON_DTYPES
+        and stride_h == 2
+        and output_padding_h == 1
+        and weight_height == 3
+        and weight_width == 3
+        and input_channels >= 64
+        and output_channels <= 64
+        and input_elements >= _DIRECT_TILED_OUTPUT_PADDING_MIN_INPUT_ELEMENTS
+    ):
+        return True
+    if stride_h >= 3 and output_padding_h == 0:
+        if weight_height >= 5 or weight_width >= 5:
+            return True
+        if input.dtype in _TRITON_DIRECT_LOWP_DTYPES:
+            return True
+    return False
+
+
 def _unsupported_conv_transpose2d(
     input,
     weight,
@@ -119,8 +243,8 @@ def _unsupported_conv_transpose2d(
 ):
     bias_dtype = None if bias is None else bias.dtype
     raise NotImplementedError(
-        "flag_gems.conv_transpose2d supports 4D contiguous CUDA input/weight "
-        "tensors with float32, float16, or bfloat16 dtype; got "
+        "flag_gems.conv_transpose2d supports 3D or 4D CUDA input tensors "
+        "and 4D CUDA weight tensors with float32, float16, or bfloat16 dtype; got "
         f"input_shape={tuple(input.shape)}, weight_shape={tuple(weight.shape)}, "
         f"input_dtype={input.dtype}, weight_dtype={weight.dtype}, bias_dtype={bias_dtype}, "
         f"input_device={input.device}, weight_device={weight.device}, "
@@ -223,9 +347,36 @@ def _validate_conv_transpose2d_args(
     return True
 
 
+def _can_use_scatter_no_overlap(
+    input,
+    weight,
+    stride_h,
+    stride_w,
+    dilation_h,
+    dilation_w,
+    groups,
+):
+    batch, input_channels, input_height, input_width = input.shape
+    _, output_channels_per_group, weight_height, weight_width = weight.shape
+    if batch <= 0 or input_height <= 0 or input_width <= 0:
+        return False
+    if stride_h < 3 or stride_w < 3:
+        return False
+
+    effective_kernel_h = (weight_height - 1) * dilation_h + 1
+    effective_kernel_w = (weight_width - 1) * dilation_w + 1
+    if stride_h < effective_kernel_h or stride_w < effective_kernel_w:
+        return False
+
+    input_channels_per_group = input_channels // groups
+    if input_channels_per_group > 128 or output_channels_per_group > 128:
+        return False
+    return weight_height * weight_width <= 25
+
+
 @libentry()
 @triton.jit
-def _conv_transpose2d_blocker_fp16_kernel(
+def _conv_transpose2d_k3_s2_p1_n4_ci256_co128_hw8_lowp_kernel(
     input_pointer,
     weight_pointer,
     output_pointer,
@@ -464,7 +615,7 @@ def _conv_transpose2d_blocker_fp16_kernel(
 
 @libentry()
 @triton.jit
-def _conv_transpose2d_k4_fp16_kernel(
+def _conv_transpose2d_k4_s2_p1_n8_ci128_co64_hw4_lowp_kernel(
     input_pointer,
     weight_pointer,
     output_pointer,
@@ -534,7 +685,7 @@ def _conv_transpose2d_k4_fp16_kernel(
 
 @libentry()
 @triton.jit
-def _conv_transpose2d_blocker_fp32_kernel(
+def _conv_transpose2d_k3_s2_p1_n4_ci256_co128_hw8_fp32_kernel(
     input_pointer,
     weight_pointer,
     output_pointer,
@@ -933,7 +1084,7 @@ def _conv_transpose2d_direct_kernel(
 
 @libentry()
 @triton.jit
-def _conv_transpose2d_stride1_pad1_64_kernel(
+def _conv_transpose2d_k3_s1_p1_n1_ci64_co64_hw128_kernel(
     input_pointer,
     weight_pointer,
     output_pointer,
@@ -984,7 +1135,7 @@ def _conv_transpose2d_stride1_pad1_64_kernel(
 
 @libentry()
 @triton.jit
-def _conv_transpose2d_fp32_case5_kernel(
+def _conv_transpose2d_k3_s2_p1_n16_ci32_co64_hw16_fp32_kernel(
     input_pointer,
     weight_pointer,
     output_pointer,
@@ -1064,7 +1215,7 @@ def _conv_transpose2d_fp32_case5_kernel(
 
 @libentry()
 @triton.jit
-def _conv_transpose2d_fp32_16_32_kernel(
+def _conv_transpose2d_k3_s2_p1_n16_ci32_co64_hw32_fp32_kernel(
     input_pointer,
     weight_pointer,
     output_pointer,
@@ -1135,6 +1286,137 @@ def _conv_transpose2d_fp32_16_32_kernel(
     output_offsets = output_offsets * 63 + ow[:, None]
     output_mask = (n[:, None] < 16) & (oh[:, None] < 63)
     output_mask = output_mask & (ow[:, None] < 63) & (co_offsets[None, :] < 64)
+    tl.store(output_pointer + output_offsets, accum, mask=output_mask)
+
+
+@libentry()
+@triton.jit
+def _conv_transpose2d_residue_kernel(
+    input_pointer,
+    weight_pointer,
+    bias_pointer,
+    output_pointer,
+    batch_size: tl.constexpr,
+    input_channels: tl.constexpr,
+    input_height: tl.constexpr,
+    input_width: tl.constexpr,
+    output_channels: tl.constexpr,
+    output_height: tl.constexpr,
+    output_width: tl.constexpr,
+    weight_height: tl.constexpr,
+    weight_width: tl.constexpr,
+    output_channels_per_group: tl.constexpr,
+    input_channels_per_group: tl.constexpr,
+    stride_height: tl.constexpr,
+    stride_width: tl.constexpr,
+    padding_height: tl.constexpr,
+    padding_width: tl.constexpr,
+    dilation_height: tl.constexpr,
+    dilation_width: tl.constexpr,
+    has_bias: tl.constexpr,
+    n_subgrids: tl.constexpr,
+    co_blocks_per_group: tl.constexpr,
+    BLOCK_NHW: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    pid_raw = tl.program_id(0)
+    pid_gco = tl.program_id(1)
+
+    pid_subgrid = pid_raw % n_subgrids
+    pid_nhw = pid_raw // n_subgrids
+    output_residue_h = pid_subgrid // stride_width
+    output_residue_w = pid_subgrid % stride_width
+    compact_height: tl.constexpr = (output_height + stride_height - 1) // stride_height
+    compact_width: tl.constexpr = (output_width + stride_width - 1) // stride_width
+    compact_plane: tl.constexpr = compact_height * compact_width
+
+    compact_offsets = pid_nhw * BLOCK_NHW + tl.arange(0, BLOCK_NHW)
+    compact_nh = compact_offsets // compact_width
+    compact_h = compact_nh % compact_height
+    compact_w = compact_offsets % compact_width
+    n = compact_offsets // compact_plane
+    oh = compact_h * stride_height + output_residue_h
+    ow = compact_w * stride_width + output_residue_w
+
+    group = pid_gco // co_blocks_per_group
+    pid_co_in_group = pid_gco - group * co_blocks_per_group
+    co_in_offsets = pid_co_in_group * BLOCK_CO + tl.arange(0, BLOCK_CO)
+    co_offsets = group * output_channels_per_group + co_in_offsets
+
+    accum = tl.zeros((BLOCK_NHW, BLOCK_CO), dtype=tl.float32)
+    if has_bias:
+        bias_values = tl.load(
+            bias_pointer + co_offsets,
+            mask=co_in_offsets < output_channels_per_group,
+            other=0.0,
+        ).to(tl.float32)
+        accum += bias_values[None, :]
+
+    ci_blocks: tl.constexpr = tl.cdiv(input_channels_per_group, BLOCK_CI)
+    height_residue = (output_residue_h + padding_height) % stride_height
+    width_residue = (output_residue_w + padding_width) % stride_width
+    for kh in range(weight_height):
+        kh_residue: tl.constexpr = (kh * dilation_height) % stride_height
+        if kh_residue == height_residue:
+            ih_unstrided = oh + padding_height - kh * dilation_height
+            ih = ih_unstrided // stride_height
+            valid_h = (n < batch_size) & (ih_unstrided >= 0) & (ih < input_height)
+            for kw in range(weight_width):
+                kw_residue: tl.constexpr = (kw * dilation_width) % stride_width
+                if kw_residue == width_residue:
+                    iw_unstrided = ow + padding_width - kw * dilation_width
+                    iw = iw_unstrided // stride_width
+                    valid_hw = (
+                        valid_h
+                        & (iw_unstrided >= 0)
+                        & (iw < input_width)
+                        & (oh < output_height)
+                        & (ow < output_width)
+                    )
+                    for ci_base in range(ci_blocks):
+                        ci_in_offsets = ci_base * BLOCK_CI + tl.arange(0, BLOCK_CI)
+                        ci_offsets = group * input_channels_per_group + ci_in_offsets
+                        input_offsets = (
+                            n[:, None] * input_channels
+                            + ci_offsets[None, :]
+                        ) * input_height
+                        input_offsets = (
+                            input_offsets + ih[:, None]
+                        ) * input_width + iw[:, None]
+                        weight_offsets = (
+                            ci_offsets[:, None] * output_channels_per_group
+                            + co_in_offsets[None, :]
+                        ) * weight_height
+                        weight_offsets = (weight_offsets + kh) * weight_width + kw
+                        input_mask = valid_hw[:, None] & (
+                            ci_in_offsets[None, :] < input_channels_per_group
+                        )
+                        weight_mask = (
+                            ci_in_offsets[:, None] < input_channels_per_group
+                        ) & (co_in_offsets[None, :] < output_channels_per_group)
+                        input_block = tl.load(
+                            input_pointer + input_offsets, mask=input_mask, other=0.0
+                        )
+                        weight_block = tl.load(
+                            weight_pointer + weight_offsets, mask=weight_mask, other=0.0
+                        )
+                        accum += tl.dot(
+                            input_block,
+                            weight_block,
+                            input_precision="tf32x3",
+                        )
+
+    output_offsets = (n[:, None] * output_channels + co_offsets[None, :])
+    output_offsets = (output_offsets * output_height + oh[:, None]) * output_width
+    output_offsets = output_offsets + ow[:, None]
+    output_mask = (
+        (n[:, None] < batch_size)
+        & (oh[:, None] < output_height)
+        & (ow[:, None] < output_width)
+        & (co_in_offsets[None, :] < output_channels_per_group)
+        & (co_offsets[None, :] < output_channels)
+    )
     tl.store(output_pointer + output_offsets, accum, mask=output_mask)
 
 
@@ -1217,7 +1499,255 @@ def _conv_transpose2d_general_kernel(
 
 @libentry()
 @triton.jit
-def _conv_transpose2d_fp32_32_64_kernel(
+def _conv_transpose2d_residue_static_kernel(
+    input_pointer,
+    weight_pointer,
+    bias_pointer,
+    output_pointer,
+    batch_size: tl.constexpr,
+    input_channels: tl.constexpr,
+    input_height: tl.constexpr,
+    input_width: tl.constexpr,
+    output_channels: tl.constexpr,
+    output_height: tl.constexpr,
+    output_width: tl.constexpr,
+    compact_height: tl.constexpr,
+    compact_width: tl.constexpr,
+    weight_height: tl.constexpr,
+    weight_width: tl.constexpr,
+    output_channels_per_group: tl.constexpr,
+    input_channels_per_group: tl.constexpr,
+    stride_height: tl.constexpr,
+    stride_width: tl.constexpr,
+    padding_height: tl.constexpr,
+    padding_width: tl.constexpr,
+    dilation_height: tl.constexpr,
+    dilation_width: tl.constexpr,
+    has_bias: tl.constexpr,
+    output_residue_h: tl.constexpr,
+    output_residue_w: tl.constexpr,
+    co_blocks_per_group: tl.constexpr,
+    BLOCK_NHW: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    pid_nhw = tl.program_id(0)
+    pid_gco = tl.program_id(1)
+
+    compact_offsets = pid_nhw * BLOCK_NHW + tl.arange(0, BLOCK_NHW)
+    compact_plane: tl.constexpr = compact_height * compact_width
+    compact_nh = compact_offsets // compact_width
+    compact_h = compact_nh % compact_height
+    compact_w = compact_offsets % compact_width
+    n = compact_offsets // compact_plane
+    oh = compact_h * stride_height + output_residue_h
+    ow = compact_w * stride_width + output_residue_w
+
+    group = pid_gco // co_blocks_per_group
+    pid_co_in_group = pid_gco - group * co_blocks_per_group
+    co_in_offsets = pid_co_in_group * BLOCK_CO + tl.arange(0, BLOCK_CO)
+    co_offsets = group * output_channels_per_group + co_in_offsets
+
+    accum = tl.zeros((BLOCK_NHW, BLOCK_CO), dtype=tl.float32)
+    if has_bias:
+        bias_values = tl.load(
+            bias_pointer + co_offsets,
+            mask=co_in_offsets < output_channels_per_group,
+            other=0.0,
+        ).to(tl.float32)
+        accum += bias_values[None, :]
+
+    ci_blocks: tl.constexpr = tl.cdiv(input_channels_per_group, BLOCK_CI)
+    height_residue: tl.constexpr = (output_residue_h + padding_height) % stride_height
+    width_residue: tl.constexpr = (output_residue_w + padding_width) % stride_width
+    for kh in tl.static_range(0, weight_height):
+        if (kh * dilation_height) % stride_height == height_residue:
+            ih_unstrided = oh + padding_height - kh * dilation_height
+            ih = ih_unstrided // stride_height
+            valid_h = (n < batch_size) & (ih_unstrided >= 0) & (ih < input_height)
+            for kw in tl.static_range(0, weight_width):
+                if (kw * dilation_width) % stride_width == width_residue:
+                    iw_unstrided = ow + padding_width - kw * dilation_width
+                    iw = iw_unstrided // stride_width
+                    valid_hw = (
+                        valid_h
+                        & (iw_unstrided >= 0)
+                        & (iw < input_width)
+                        & (oh < output_height)
+                        & (ow < output_width)
+                    )
+                    for ci_base in range(ci_blocks):
+                        ci_in_offsets = ci_base * BLOCK_CI + tl.arange(0, BLOCK_CI)
+                        ci_offsets = group * input_channels_per_group + ci_in_offsets
+                        input_offsets = (
+                            n[:, None] * input_channels
+                            + ci_offsets[None, :]
+                        ) * input_height
+                        input_offsets = (
+                            input_offsets + ih[:, None]
+                        ) * input_width + iw[:, None]
+                        weight_offsets = (
+                            ci_offsets[:, None] * output_channels_per_group
+                            + co_in_offsets[None, :]
+                        ) * weight_height
+                        weight_offsets = (weight_offsets + kh) * weight_width + kw
+                        input_mask = valid_hw[:, None] & (
+                            ci_in_offsets[None, :] < input_channels_per_group
+                        )
+                        weight_mask = (
+                            ci_in_offsets[:, None] < input_channels_per_group
+                        ) & (co_in_offsets[None, :] < output_channels_per_group)
+                        input_block = tl.load(
+                            input_pointer + input_offsets, mask=input_mask, other=0.0
+                        )
+                        weight_block = tl.load(
+                            weight_pointer + weight_offsets, mask=weight_mask, other=0.0
+                        )
+                        accum += tl.dot(
+                            input_block,
+                            weight_block,
+                            input_precision="tf32x3",
+                        )
+
+    output_offsets = (n[:, None] * output_channels + co_offsets[None, :])
+    output_offsets = (output_offsets * output_height + oh[:, None]) * output_width
+    output_offsets = output_offsets + ow[:, None]
+    output_mask = (
+        (n[:, None] < batch_size)
+        & (oh[:, None] < output_height)
+        & (ow[:, None] < output_width)
+        & (co_in_offsets[None, :] < output_channels_per_group)
+        & (co_offsets[None, :] < output_channels)
+    )
+    tl.store(output_pointer + output_offsets, accum, mask=output_mask)
+
+
+@libentry()
+@triton.jit
+def _conv_transpose2d_scatter_init_kernel(
+    bias_pointer,
+    output_pointer,
+    total_elements: tl.constexpr,
+    output_channels: tl.constexpr,
+    output_height: tl.constexpr,
+    output_width: tl.constexpr,
+    has_bias: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < total_elements
+    values = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+    if has_bias:
+        spatial_size: tl.constexpr = output_height * output_width
+        co = (offsets // spatial_size) % output_channels
+        values = tl.load(bias_pointer + co, mask=mask, other=0.0).to(tl.float32)
+    tl.store(output_pointer + offsets, values, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _conv_transpose2d_scatter_no_overlap_kernel(
+    input_pointer,
+    weight_pointer,
+    bias_pointer,
+    output_pointer,
+    batch_size: tl.constexpr,
+    input_channels: tl.constexpr,
+    input_height: tl.constexpr,
+    input_width: tl.constexpr,
+    output_channels: tl.constexpr,
+    output_height: tl.constexpr,
+    output_width: tl.constexpr,
+    weight_height: tl.constexpr,
+    weight_width: tl.constexpr,
+    output_channels_per_group: tl.constexpr,
+    input_channels_per_group: tl.constexpr,
+    stride_height: tl.constexpr,
+    stride_width: tl.constexpr,
+    padding_height: tl.constexpr,
+    padding_width: tl.constexpr,
+    dilation_height: tl.constexpr,
+    dilation_width: tl.constexpr,
+    has_bias: tl.constexpr,
+    BLOCK_NHW: tl.constexpr,
+    BLOCK_CI: tl.constexpr,
+    BLOCK_CO: tl.constexpr,
+):
+    pid_nhw = tl.program_id(0)
+    pid_co = tl.program_id(1)
+    pid_gkk = tl.program_id(2)
+
+    kw = pid_gkk % weight_width
+    tmp = pid_gkk // weight_width
+    kh = tmp % weight_height
+    group = tmp // weight_height
+
+    nhw_offsets = pid_nhw * BLOCK_NHW + tl.arange(0, BLOCK_NHW)
+    iw = nhw_offsets % input_width
+    tmp = nhw_offsets // input_width
+    ih = tmp % input_height
+    n = tmp // input_height
+
+    oh = ih * stride_height - padding_height + kh * dilation_height
+    ow = iw * stride_width - padding_width + kw * dilation_width
+    valid_nhw = (nhw_offsets < batch_size * input_height * input_width) & (n < batch_size)
+    valid_nhw = valid_nhw & (oh >= 0) & (oh < output_height)
+    valid_nhw = valid_nhw & (ow >= 0) & (ow < output_width)
+
+    co_in_group = pid_co * BLOCK_CO + tl.arange(0, BLOCK_CO)
+    co = group * output_channels_per_group + co_in_group
+    ci_in_group_base = tl.arange(0, BLOCK_CI)
+
+    accum = tl.zeros((BLOCK_NHW, BLOCK_CO), dtype=tl.float32)
+    ci_blocks: tl.constexpr = tl.cdiv(input_channels_per_group, BLOCK_CI)
+    for ci_block in range(ci_blocks):
+        ci_in_group = ci_block * BLOCK_CI + ci_in_group_base
+        ci = group * input_channels_per_group + ci_in_group
+        input_offsets = (
+            n[:, None] * input_channels
+            + ci[None, :]
+        ) * input_height
+        input_offsets = (input_offsets + ih[:, None]) * input_width + iw[:, None]
+        weight_offsets = (
+            ci[:, None] * output_channels_per_group + co_in_group[None, :]
+        ) * weight_height
+        weight_offsets = (weight_offsets + kh) * weight_width + kw
+
+        ci_mask = ci_in_group < input_channels_per_group
+        co_mask = co_in_group < output_channels_per_group
+        input_block = tl.load(
+            input_pointer + input_offsets,
+            mask=valid_nhw[:, None] & ci_mask[None, :],
+            other=0.0,
+        )
+        weight_block = tl.load(
+            weight_pointer + weight_offsets,
+            mask=ci_mask[:, None] & co_mask[None, :],
+            other=0.0,
+        )
+        accum += tl.dot(
+            input_block,
+            weight_block,
+            input_precision="tf32x3",
+        )
+
+    if has_bias:
+        bias = tl.load(
+            bias_pointer + co,
+            mask=co_in_group < output_channels_per_group,
+            other=0.0,
+        ).to(tl.float32)
+        accum += bias[None, :]
+
+    output_offsets = (n[:, None] * output_channels + co[None, :]) * output_height
+    output_offsets = (output_offsets + oh[:, None]) * output_width + ow[:, None]
+    output_mask = valid_nhw[:, None] & (co_in_group[None, :] < output_channels_per_group)
+    tl.store(output_pointer + output_offsets, accum, mask=output_mask)
+
+
+@libentry()
+@triton.jit
+def _conv_transpose2d_k3_s2_p1_n32_ci64_co32_hw16_fp32_kernel(
     input_pointer,
     weight_pointer,
     output_pointer,
@@ -1294,10 +1824,10 @@ def _conv_transpose2d_fp32_32_64_kernel(
     tl.store(output_pointer + output_offsets, accum, mask=output_mask)
 
 
-def _conv_transpose2d_blocker_fp16(input, weight):
+def _conv_transpose2d_k3_s2_p1_n4_ci256_co128_hw8_lowp(input, weight):
     output = torch.empty((4, 128, 15, 15), device=input.device, dtype=input.dtype)
     grid = (29 * 4,)
-    _conv_transpose2d_blocker_fp16_kernel[grid](
+    _conv_transpose2d_k3_s2_p1_n4_ci256_co128_hw8_lowp_kernel[grid](
         input,
         weight,
         output,
@@ -1310,10 +1840,10 @@ def _conv_transpose2d_blocker_fp16(input, weight):
     return output
 
 
-def _conv_transpose2d_k4_fp16(input, weight):
+def _conv_transpose2d_k4_s2_p1_n8_ci128_co64_hw4_lowp(input, weight):
     output = torch.empty((8, 64, 8, 8), device=input.device, dtype=input.dtype)
     grid = (triton.cdiv(8 * 4 * 4, 64), triton.cdiv(64, 32), 4)
-    _conv_transpose2d_k4_fp16_kernel[grid](
+    _conv_transpose2d_k4_s2_p1_n8_ci128_co64_hw4_lowp_kernel[grid](
         input,
         weight,
         output,
@@ -1326,10 +1856,10 @@ def _conv_transpose2d_k4_fp16(input, weight):
     return output
 
 
-def _conv_transpose2d_blocker_fp32(input, weight):
+def _conv_transpose2d_k3_s2_p1_n4_ci256_co128_hw8_fp32(input, weight):
     output = torch.empty((4, 128, 15, 15), device=input.device, dtype=input.dtype)
     grid = (16 * 8,)
-    _conv_transpose2d_blocker_fp32_kernel[grid](
+    _conv_transpose2d_k3_s2_p1_n4_ci256_co128_hw8_fp32_kernel[grid](
         input,
         weight,
         output,
@@ -1342,10 +1872,10 @@ def _conv_transpose2d_blocker_fp32(input, weight):
     return output
 
 
-def _conv_transpose2d_direct_fp32_case5(input, weight):
+def _conv_transpose2d_direct_k3_s2_p1_n16_ci32_co64_hw16_fp32(input, weight):
     output = torch.empty((16, 64, 31, 31), device=input.device, dtype=input.dtype)
     grid = (4 * triton.cdiv(16 * 16 * 16, 64), triton.cdiv(64, 16))
-    _conv_transpose2d_fp32_case5_kernel[grid](
+    _conv_transpose2d_k3_s2_p1_n16_ci32_co64_hw16_fp32_kernel[grid](
         input,
         weight,
         output,
@@ -1358,10 +1888,10 @@ def _conv_transpose2d_direct_fp32_case5(input, weight):
     return output
 
 
-def _conv_transpose2d_direct_fp32_16_32(input, weight):
+def _conv_transpose2d_direct_k3_s2_p1_n16_ci32_co64_hw32_fp32(input, weight):
     output = torch.empty((16, 64, 63, 63), device=input.device, dtype=input.dtype)
     grid = (4 * triton.cdiv(16 * 32 * 32, 64), triton.cdiv(64, 32))
-    _conv_transpose2d_fp32_16_32_kernel[grid](
+    _conv_transpose2d_k3_s2_p1_n16_ci32_co64_hw32_fp32_kernel[grid](
         input,
         weight,
         output,
@@ -1374,10 +1904,10 @@ def _conv_transpose2d_direct_fp32_16_32(input, weight):
     return output
 
 
-def _conv_transpose2d_direct_fp32_32_64(input, weight):
+def _conv_transpose2d_direct_k3_s2_p1_n32_ci64_co32_hw16_fp32(input, weight):
     output = torch.empty((32, 32, 31, 31), device=input.device, dtype=input.dtype)
     grid = (4 * triton.cdiv(32 * 16 * 16, 128), triton.cdiv(32, 16))
-    _conv_transpose2d_fp32_32_64_kernel[grid](
+    _conv_transpose2d_k3_s2_p1_n32_ci64_co32_hw16_fp32_kernel[grid](
         input,
         weight,
         output,
@@ -1389,7 +1919,7 @@ def _conv_transpose2d_direct_fp32_32_64(input, weight):
     return output
 
 
-def _conv_transpose2d_stride1_pad1_64(input, weight):
+def _conv_transpose2d_k3_s1_p1_n1_ci64_co64_hw128(input, weight):
     output = torch.empty((1, 64, 128, 128), device=input.device, dtype=input.dtype)
     block_nhw = 128
     block_ci = 16
@@ -1397,7 +1927,7 @@ def _conv_transpose2d_stride1_pad1_64(input, weight):
     num_warps = 8
 
     grid = (triton.cdiv(128 * 128, block_nhw), triton.cdiv(64, block_co))
-    _conv_transpose2d_stride1_pad1_64_kernel[grid](
+    _conv_transpose2d_k3_s1_p1_n1_ci64_co64_hw128_kernel[grid](
         input,
         weight,
         output,
@@ -1405,6 +1935,110 @@ def _conv_transpose2d_stride1_pad1_64(input, weight):
         BLOCK_CI=block_ci,
         BLOCK_CO=block_co,
         num_warps=num_warps,
+    )
+    return output
+
+
+def _conv_transpose2d_scatter_no_overlap(
+    input,
+    weight,
+    bias,
+    stride_h,
+    stride_w,
+    padding_h,
+    padding_w,
+    dilation_h,
+    dilation_w,
+    output_padding_h,
+    output_padding_w,
+    groups,
+):
+    batch, input_channels, input_height, input_width = input.shape
+    _, output_channels_per_group, weight_height, weight_width = weight.shape
+    output_channels = output_channels_per_group * groups
+    output_height = (
+        (input_height - 1) * stride_h
+        - 2 * padding_h
+        + dilation_h * (weight_height - 1)
+        + output_padding_h
+        + 1
+    )
+    output_width = (
+        (input_width - 1) * stride_w
+        - 2 * padding_w
+        + dilation_w * (weight_width - 1)
+        + output_padding_w
+        + 1
+    )
+    output = torch.empty(
+        (batch, output_channels, output_height, output_width),
+        device=input.device,
+        dtype=input.dtype,
+    )
+    total_elements = output.numel()
+    if total_elements == 0:
+        return output
+
+    init_block = 1024
+    bias_pointer = bias if bias is not None else input
+    _conv_transpose2d_scatter_init_kernel[(triton.cdiv(total_elements, init_block),)](
+        bias_pointer,
+        output,
+        total_elements,
+        output_channels,
+        output_height,
+        output_width,
+        bias is not None,
+        BLOCK_SIZE=init_block,
+        num_warps=4,
+    )
+
+    input_channels_per_group = input_channels // groups
+    if input_channels_per_group <= 16:
+        block_ci = 16
+    elif input_channels_per_group <= 64:
+        block_ci = 64 if input.dtype is not torch.float32 else 32
+    else:
+        block_ci = 64
+    block_co = 16 if output_channels_per_group <= 16 else 32
+    block_nhw = 32 if input.dtype is torch.float32 else 64
+    if output_channels_per_group >= 64:
+        block_nhw = 32
+
+    input_nhw = batch * input_height * input_width
+    grid = (
+        triton.cdiv(input_nhw, block_nhw),
+        triton.cdiv(output_channels_per_group, block_co),
+        groups * weight_height * weight_width,
+    )
+    _conv_transpose2d_scatter_no_overlap_kernel[grid](
+        input,
+        weight,
+        bias_pointer,
+        output,
+        batch,
+        input_channels,
+        input_height,
+        input_width,
+        output_channels,
+        output_height,
+        output_width,
+        weight_height,
+        weight_width,
+        output_channels_per_group,
+        input_channels_per_group,
+        stride_h,
+        stride_w,
+        padding_h,
+        padding_w,
+        dilation_h,
+        dilation_w,
+        bias is not None,
+        BLOCK_NHW=block_nhw,
+        BLOCK_CI=block_ci,
+        BLOCK_CO=block_co,
+        num_warps=4,
+        num_stages=3,
     )
     return output
 
@@ -1426,70 +2060,18 @@ def conv_transpose2d(
     output_padding_h, output_padding_w = _pair(output_padding)
     dilation_h, dilation_w = _pair(dilation)
 
-    if input.dtype is torch.float32 and input.shape == (32, 64, 16, 16):
-        if (
-            weight.dtype is torch.float32
-            and weight.shape == (64, 32, 3, 3)
-            and bias is None
-            and groups == 1
-            and stride_h == 2
-            and stride_w == 2
-            and padding_h == 1
-            and padding_w == 1
-            and output_padding_h == 0
-            and output_padding_w == 0
-            and dilation_h == 1
-            and dilation_w == 1
-            and input.device.type == "cuda"
-            and weight.device == input.device
-            and input.is_contiguous()
-            and weight.is_contiguous()
-        ):
-            return _conv_transpose2d_direct_fp32_32_64(input, weight)
+    input_was_unbatched = input.dim() == 3
+    if input_was_unbatched:
+        input = input.unsqueeze(0)
 
-    if input.dtype is torch.float32 and input.shape == (16, 32, 32, 32):
-        if (
-            weight.dtype is torch.float32
-            and weight.shape == (32, 64, 3, 3)
-            and bias is None
-            and groups == 1
-            and stride_h == 2
-            and stride_w == 2
-            and padding_h == 1
-            and padding_w == 1
-            and output_padding_h == 0
-            and output_padding_w == 0
-            and dilation_h == 1
-            and dilation_w == 1
-            and input.device.type == "cuda"
-            and weight.device == input.device
-            and input.is_contiguous()
-            and weight.is_contiguous()
-        ):
-            return _conv_transpose2d_direct_fp32_16_32(input, weight)
+    if not input.is_contiguous():
+        input = input.contiguous()
+    if not weight.is_contiguous():
+        weight = weight.contiguous()
+    if bias is not None and not bias.is_contiguous():
+        bias = bias.contiguous()
 
-    if input.dtype is torch.float32 and input.shape == (4, 256, 8, 8):
-        if (
-            weight.dtype is torch.float32
-            and weight.shape == (256, 128, 3, 3)
-            and bias is None
-            and groups == 1
-            and stride_h == 2
-            and stride_w == 2
-            and padding_h == 1
-            and padding_w == 1
-            and output_padding_h == 0
-            and output_padding_w == 0
-            and dilation_h == 1
-            and dilation_w == 1
-            and input.device.type == "cuda"
-            and weight.device == input.device
-            and input.is_contiguous()
-            and weight.is_contiguous()
-        ):
-            return _conv_transpose2d_blocker_fp32(input, weight)
-
-    fp16_shape_key = _exact_shape_key(
+    output = _conv_transpose2d_4d_dispatch(
         input,
         weight,
         bias,
@@ -1502,70 +2084,27 @@ def conv_transpose2d(
         groups,
         dilation_h,
         dilation_w,
-        (torch.float16,),
     )
-    if fp16_shape_key == _BLOCKER_FP16_SHAPE:
-        return _conv_transpose2d_blocker_fp16(input, weight)
+    if input_was_unbatched:
+        return output.squeeze(0)
+    return output
 
-    if fp16_shape_key == _K4_FP16_SHAPE:
-        return _conv_transpose2d_k4_fp16(input, weight)
 
-    stride1_pad1_64_shape_key = _exact_shape_key(
-        input,
-        weight,
-        bias,
-        stride_h,
-        stride_w,
-        padding_h,
-        padding_w,
-        output_padding_h,
-        output_padding_w,
-        groups,
-        dilation_h,
-        dilation_w,
-        (torch.float16,),
-    )
-    if stride1_pad1_64_shape_key == _STRIDE1_PAD1_64_SHAPE:
-        return _conv_transpose2d_stride1_pad1_64(input, weight)
-
-    direct_lowp_dtypes = _TRITON_DIRECT_LOWP_DTYPES
-    if (
-        input.device.type == "cuda"
-        and input.dtype is torch.bfloat16
-        and not torch.cuda.is_bf16_supported()
-    ):
-        direct_lowp_dtypes = (torch.float16,)
-
-    direct_shape_key = _exact_shape_key(
-        input,
-        weight,
-        bias,
-        stride_h,
-        stride_w,
-        padding_h,
-        padding_w,
-        output_padding_h,
-        output_padding_w,
-        groups,
-        dilation_h,
-        dilation_w,
-        direct_lowp_dtypes,
-    )
-    if direct_shape_key in _DIRECT_TRITON_SHAPES:
-        return _conv_transpose2d_direct(
-            input,
-            weight,
-            stride_h,
-            stride_w,
-            padding_h,
-            padding_w,
-            dilation_h,
-            dilation_w,
-            output_padding_h,
-            output_padding_w,
-        )
-
-    direct_fp32_shape_key = _exact_shape_key(
+def _try_conv_transpose2d_specialized_schedule(
+    input,
+    weight,
+    bias,
+    stride_h,
+    stride_w,
+    padding_h,
+    padding_w,
+    output_padding_h,
+    output_padding_w,
+    groups,
+    dilation_h,
+    dilation_w,
+):
+    fp32_shape_key = _exact_shape_key(
         input,
         weight,
         bias,
@@ -1580,10 +2119,107 @@ def conv_transpose2d(
         dilation_w,
         (torch.float32,),
     )
-    if direct_fp32_shape_key == _FP32_CASE5_SHAPE:
-        return _conv_transpose2d_direct_fp32_case5(input, weight)
+    if fp32_shape_key == _K3_S2_P1_N32_CI64_CO32_HW16_SHAPE:
+        return _conv_transpose2d_direct_k3_s2_p1_n32_ci64_co32_hw16_fp32(
+            input, weight
+        )
+    if fp32_shape_key == _K3_S2_P1_N16_CI32_CO64_HW32_SHAPE:
+        return _conv_transpose2d_direct_k3_s2_p1_n16_ci32_co64_hw32_fp32(
+            input, weight
+        )
+    if fp32_shape_key == _K3_S2_P1_N4_CI256_CO128_HW8_SHAPE:
+        return _conv_transpose2d_k3_s2_p1_n4_ci256_co128_hw8_fp32(input, weight)
+    if fp32_shape_key == _K3_S2_P1_N16_CI32_CO64_HW16_SHAPE:
+        return _conv_transpose2d_direct_k3_s2_p1_n16_ci32_co64_hw16_fp32(
+            input, weight
+        )
 
-    if direct_fp32_shape_key in _DIRECT_TRITON_FP32_SHAPES:
+    lowp_dtypes = None
+    if input.dtype is torch.float16:
+        lowp_dtypes = (torch.float16,)
+    elif input.dtype is torch.bfloat16:
+        lowp_dtypes = _TRITON_DIRECT_LOWP_DTYPES
+        if input.device.type == "cuda" and not torch.cuda.is_bf16_supported():
+            lowp_dtypes = (torch.float16,)
+
+    if lowp_dtypes is not None:
+        lowp_shape_key = _exact_shape_key(
+            input,
+            weight,
+            bias,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+            output_padding_h,
+            output_padding_w,
+            groups,
+            dilation_h,
+            dilation_w,
+            lowp_dtypes,
+        )
+        if lowp_shape_key == _K3_S2_P1_N4_CI256_CO128_HW8_SHAPE:
+            return _conv_transpose2d_k3_s2_p1_n4_ci256_co128_hw8_lowp(
+                input, weight
+            )
+        if lowp_shape_key == _K4_S2_P1_N8_CI128_CO64_HW4_SHAPE:
+            return _conv_transpose2d_k4_s2_p1_n8_ci128_co64_hw4_lowp(
+                input, weight
+            )
+        if lowp_shape_key == _K3_S1_P1_N1_CI64_CO64_HW128_SHAPE:
+            return _conv_transpose2d_k3_s1_p1_n1_ci64_co64_hw128(input, weight)
+
+    return None
+
+
+def _conv_transpose2d_4d_dispatch(
+    input,
+    weight,
+    bias,
+    stride_h,
+    stride_w,
+    padding_h,
+    padding_w,
+    output_padding_h,
+    output_padding_w,
+    groups,
+    dilation_h,
+    dilation_w,
+):
+    specialized_output = _try_conv_transpose2d_specialized_schedule(
+        input,
+        weight,
+        bias,
+        stride_h,
+        stride_w,
+        padding_h,
+        padding_w,
+        output_padding_h,
+        output_padding_w,
+        groups,
+        dilation_h,
+        dilation_w,
+    )
+    if specialized_output is not None:
+        return specialized_output
+
+    direct_tiled_family_shape_key = _direct_tiled_family_shape_key(
+        input,
+        weight,
+        bias,
+        stride_h,
+        stride_w,
+        padding_h,
+        padding_w,
+        output_padding_h,
+        output_padding_w,
+        groups,
+        dilation_h,
+        dilation_w,
+    )
+    if _can_use_direct_tiled_family(
+        input, direct_tiled_family_shape_key, output_padding_h
+    ):
         return _conv_transpose2d_direct(
             input,
             weight,
@@ -1611,6 +2247,29 @@ def conv_transpose2d(
         dilation_h,
         dilation_w,
     ):
+        if _can_use_scatter_no_overlap(
+            input,
+            weight,
+            stride_h,
+            stride_w,
+            dilation_h,
+            dilation_w,
+            groups,
+        ):
+            return _conv_transpose2d_scatter_no_overlap(
+                input,
+                weight,
+                bias,
+                stride_h,
+                stride_w,
+                padding_h,
+                padding_w,
+                dilation_h,
+                dilation_w,
+                output_padding_h,
+                output_padding_w,
+                groups,
+            )
         return _conv_transpose2d_general(
             input,
             weight,
@@ -1640,6 +2299,68 @@ def conv_transpose2d(
         dilation_h,
         dilation_w,
     )
+
+
+def _select_conv_transpose2d_direct_schedule(input_dtype, shape_key):
+    exact_schedule = _DIRECT_TILED_EXACT_SCHEDULES.get((shape_key, input_dtype))
+    if exact_schedule is not None:
+        return exact_schedule
+    exact_schedule = _DIRECT_TILED_EXACT_SCHEDULES.get((shape_key, None))
+    if exact_schedule is not None:
+        return exact_schedule
+
+    (
+        _batch,
+        input_channels,
+        _input_height,
+        _input_width,
+        output_channels,
+        weight_height,
+        weight_width,
+        stride_h,
+        _padding_h,
+    ) = shape_key
+    block_nhw, block_ci, block_co, num_warps = _DIRECT_TILED_DEFAULT_SCHEDULE
+
+    if input_dtype is torch.bfloat16:
+        if stride_h >= 3:
+            block_nhw = 128
+            block_ci = 16
+            block_co = 16
+            num_warps = 8
+        elif input_channels >= 128:
+            block_nhw = 256
+            block_ci = 16
+            block_co = 16
+            num_warps = 8
+        elif weight_height >= 5 or weight_width >= 5:
+            block_nhw = 128
+            block_ci = 16
+        elif input_channels >= 64 and output_channels <= 32:
+            block_ci = 64
+            if stride_h == 1:
+                num_warps = 8
+    elif input_dtype is torch.float16:
+        if stride_h >= 3:
+            block_nhw = 128
+            block_ci = 16
+            block_co = 16
+            num_warps = 8
+        elif weight_height >= 5 or weight_width >= 5:
+            block_nhw = 128
+            block_ci = 16
+        elif input_channels >= 64 and output_channels <= 32:
+            block_ci = 64
+            if stride_h == 1:
+                num_warps = 8
+    elif input_dtype is torch.float32 and (weight_height >= 5 or weight_width >= 5):
+        block_ci = 16
+    elif input_channels >= 64 and output_channels <= 32:
+        block_ci = 64
+        if stride_h == 1:
+            num_warps = 8
+
+    return block_nhw, block_ci, block_co, num_warps
 
 
 def _conv_transpose2d_direct(
@@ -1691,52 +2412,9 @@ def _conv_transpose2d_direct(
         stride_h,
         padding_h,
     )
-    block_nhw = 64
-    block_ci = 32
-    block_co = 32
-    num_warps = 4
-    if shape_key == (1, 64, 128, 128, 64, 3, 3, 1, 1):
-        block_ci = 16
-        if input.dtype is torch.float32:
-            block_nhw = 256
-        else:
-            block_nhw = 128
-            num_warps = 8
-    elif shape_key == (1, 64, 64, 64, 32, 3, 3, 2, 1):
-        block_nhw = 128
-        block_ci = 16
-        block_co = 16
-    elif shape_key == (4, 32, 32, 32, 32, 3, 3, 2, 1):
-        block_ci = 16
-        block_co = 16
-    elif shape_key == (8, 16, 64, 64, 16, 5, 5, 2, 2):
-        block_nhw = 256
-        block_ci = 16
-        block_co = 16
-        num_warps = 8
-    elif shape_key == (16, 32, 16, 16, 64, 3, 3, 2, 1):
-        block_nhw = 32
-        block_ci = 16
-        block_co = 16
-        num_warps = 8
-    elif shape_key == (16, 32, 32, 32, 64, 3, 3, 2, 1):
-        block_nhw = 128
-        block_ci = 16
-        block_co = 64
-    elif shape_key == (32, 64, 16, 16, 32, 3, 3, 2, 1):
-        block_nhw = 32
-        block_ci = 16
-        num_warps = 8
-    elif shape_key == (16, 32, 8, 8, 24, 5, 5, 2, 2):
-        num_warps = 8
-    elif shape_key == (32, 64, 32, 32, 32, 3, 3, 1, 0):
-        block_nhw = 256
-        block_ci = 16
-        num_warps = 8
-    elif input_channels >= 64 and output_channels <= 32:
-        block_ci = 64
-        if stride_h == 1:
-            num_warps = 8
+    block_nhw, block_ci, block_co, num_warps = (
+        _select_conv_transpose2d_direct_schedule(input.dtype, shape_key)
+    )
 
     grid = (
         n_subgrids * triton.cdiv(max_sub_spatial, block_nhw),
@@ -1785,6 +2463,36 @@ def _conv_transpose2d_general(
     output_padding_w,
     groups,
 ):
+    return _conv_transpose2d_residue(
+        input,
+        weight,
+        bias,
+        stride_h,
+        stride_w,
+        padding_h,
+        padding_w,
+        dilation_h,
+        dilation_w,
+        output_padding_h,
+        output_padding_w,
+        groups,
+    )
+
+
+def _conv_transpose2d_residue(
+    input,
+    weight,
+    bias,
+    stride_h,
+    stride_w,
+    padding_h,
+    padding_w,
+    dilation_h,
+    dilation_w,
+    output_padding_h,
+    output_padding_w,
+    groups,
+):
     batch, input_channels, input_height, input_width = input.shape
     _, output_channels_per_group, weight_height, weight_width = weight.shape
     output_channels = output_channels_per_group * groups
@@ -1811,15 +2519,109 @@ def _conv_transpose2d_general(
     if total_elements == 0:
         return output
 
-    block_size = 256
-    grid = (triton.cdiv(total_elements, block_size),)
+    input_channels_per_group = input_channels // groups
+    if (
+        input.dtype in _TRITON_DIRECT_LOWP_DTYPES
+        and weight_height >= 5
+        and weight_width >= 5
+        and stride_h == 2
+        and stride_w == 2
+        and dilation_h == 1
+        and dilation_w == 1
+        and input_channels_per_group >= 64
+        and output_channels_per_group <= 32
+    ):
+        block_nhw = 256
+        block_ci = 16
+        block_co = 32
+        co_blocks_per_group = triton.cdiv(output_channels_per_group, block_co)
+        bias_pointer = bias if bias is not None else input
+        for residue_h in range(stride_h):
+            compact_height = (output_height + stride_h - 1 - residue_h) // stride_h
+            for residue_w in range(stride_w):
+                compact_width = (output_width + stride_w - 1 - residue_w) // stride_w
+                grid = (
+                    triton.cdiv(batch * compact_height * compact_width, block_nhw),
+                    groups * co_blocks_per_group,
+                )
+                _conv_transpose2d_residue_static_kernel[grid](
+                    input,
+                    weight,
+                    bias_pointer,
+                    output,
+                    batch,
+                    input_channels,
+                    input_height,
+                    input_width,
+                    output_channels,
+                    output_height,
+                    output_width,
+                    compact_height,
+                    compact_width,
+                    weight_height,
+                    weight_width,
+                    output_channels_per_group,
+                    input_channels_per_group,
+                    stride_h,
+                    stride_w,
+                    padding_h,
+                    padding_w,
+                    dilation_h,
+                    dilation_w,
+                    bias is not None,
+                    residue_h,
+                    residue_w,
+                    co_blocks_per_group,
+                    BLOCK_NHW=block_nhw,
+                    BLOCK_CI=block_ci,
+                    BLOCK_CO=block_co,
+                    num_warps=4,
+                    num_stages=2,
+                )
+        return output
+
+    block_nhw = 64
+    block_ci = 32
+    block_co = 32
+    num_warps = 4
+    if input.dtype is torch.float32:
+        block_ci = 16
+        block_co = 16
+    elif input_channels_per_group <= 16:
+        block_ci = 16
+    if output_channels_per_group <= 16:
+        block_co = 16
+    if (
+        weight_height >= 5
+        and weight_width >= 5
+        and stride_h == 2
+        and stride_w == 2
+        and input_channels_per_group >= 64
+        and output_channels_per_group <= 32
+    ):
+        block_nhw = 128
+        block_ci = 64 if input.dtype is not torch.float32 else 32
+        block_co = 16
+        num_warps = 8
+    if stride_h * stride_w >= 4 and input.dtype is not torch.float32:
+        block_nhw = 128
+        num_warps = 8
+
+    compact_height = triton.cdiv(output_height, stride_h)
+    compact_width = triton.cdiv(output_width, stride_w)
+    max_sub_spatial = batch * compact_height * compact_width
+    n_subgrids = stride_h * stride_w
+    co_blocks_per_group = triton.cdiv(output_channels_per_group, block_co)
+    grid = (
+        n_subgrids * triton.cdiv(max_sub_spatial, block_nhw),
+        groups * co_blocks_per_group,
+    )
     bias_pointer = bias if bias is not None else input
-    _conv_transpose2d_general_kernel[grid](
+    _conv_transpose2d_residue_kernel[grid](
         input,
         weight,
         bias_pointer,
         output,
-        total_elements,
         batch,
         input_channels,
         input_height,
@@ -1838,7 +2640,11 @@ def _conv_transpose2d_general(
         dilation_h,
         dilation_w,
         bias is not None,
-        BLOCK_SIZE=block_size,
-        num_warps=4,
+        n_subgrids,
+        co_blocks_per_group,
+        BLOCK_NHW=block_nhw,
+        BLOCK_CI=block_ci,
+        BLOCK_CO=block_co,
+        num_warps=num_warps,
     )
     return output

--- a/src/flag_gems/ops/conv_transpose2d.py
+++ b/src/flag_gems/ops/conv_transpose2d.py
@@ -28,6 +28,8 @@ _BLOCKER_FP16_SHAPE = (4, 256, 8, 8, 128, 3, 3, 2, 1)
 
 _K4_FP16_SHAPE = (8, 128, 4, 4, 64, 4, 4, 2, 1)
 
+_GENERAL_TRITON_DTYPES = (torch.float32, torch.float16, torch.bfloat16)
+
 
 def _pair(value):
     if isinstance(value, (list, tuple)):
@@ -102,10 +104,8 @@ def _unsupported_conv_transpose2d(
 ):
     bias_dtype = None if bias is None else bias.dtype
     raise NotImplementedError(
-        "flag_gems.conv_transpose2d supports only tuned Triton cases: "
-        "4D contiguous CUDA input/weight tensors, bias=None, groups=1, "
-        "dilation=(1, 1), output_padding=(0, 0), and one of the registered "
-        "shape/dtype combinations; got "
+        "flag_gems.conv_transpose2d supports 4D contiguous CUDA input/weight "
+        "tensors with float32, float16, or bfloat16 dtype; got "
         f"input_shape={tuple(input.shape)}, weight_shape={tuple(weight.shape)}, "
         f"input_dtype={input.dtype}, weight_dtype={weight.dtype}, bias_dtype={bias_dtype}, "
         f"input_device={input.device}, weight_device={weight.device}, "
@@ -113,6 +113,93 @@ def _unsupported_conv_transpose2d(
         f"output_padding=({output_padding_h}, {output_padding_w}), groups={groups}, "
         f"dilation=({dilation_h}, {dilation_w})"
     )
+
+
+def _validate_conv_transpose2d_args(
+    input,
+    weight,
+    bias,
+    stride_h,
+    stride_w,
+    padding_h,
+    padding_w,
+    output_padding_h,
+    output_padding_w,
+    groups,
+    dilation_h,
+    dilation_w,
+):
+    if input.device.type != "cuda" or weight.device != input.device:
+        return False
+    if input.dim() != 4 or weight.dim() != 4:
+        return False
+    if not input.is_contiguous() or not weight.is_contiguous():
+        return False
+    if input.dtype not in _GENERAL_TRITON_DTYPES or weight.dtype != input.dtype:
+        return False
+    if input.dtype is torch.bfloat16 and not torch.cuda.is_bf16_supported():
+        return False
+    if bias is not None:
+        if bias.device != input.device or bias.dtype != input.dtype:
+            return False
+        if bias.dim() != 1 or not bias.is_contiguous():
+            return False
+    if groups <= 0:
+        raise RuntimeError("groups must be a positive integer")
+    if stride_h <= 0 or stride_w <= 0:
+        raise RuntimeError("non-positive stride is not supported")
+    if dilation_h <= 0 or dilation_w <= 0:
+        raise RuntimeError("dilation should be greater than zero")
+    if padding_h < 0 or padding_w < 0:
+        raise RuntimeError("negative padding is not supported")
+    if output_padding_h < 0 or output_padding_w < 0:
+        raise RuntimeError("negative output_padding is not supported")
+    if output_padding_h >= stride_h and output_padding_h >= dilation_h:
+        raise RuntimeError("output padding must be smaller than either stride or dilation")
+    if output_padding_w >= stride_w and output_padding_w >= dilation_w:
+        raise RuntimeError("output padding must be smaller than either stride or dilation")
+
+    input_channels = input.shape[1]
+    weight_input_channels = weight.shape[0]
+    output_channels_per_group = weight.shape[1]
+    weight_height = weight.shape[2]
+    weight_width = weight.shape[3]
+    if (
+        input_channels <= 0
+        or output_channels_per_group <= 0
+        or weight_height <= 0
+        or weight_width <= 0
+    ):
+        raise RuntimeError("non-empty input channels and weight dimensions are required")
+    if input_channels != weight_input_channels:
+        raise RuntimeError(
+            "expected input channel dimension to match weight input channels"
+        )
+    if input_channels % groups != 0:
+        raise RuntimeError("input channels must be divisible by groups")
+    output_channels = output_channels_per_group * groups
+    if bias is not None and bias.numel() != output_channels:
+        raise RuntimeError("expected bias to have one element per output channel")
+
+    input_height = input.shape[2]
+    input_width = input.shape[3]
+    output_height = (
+        (input_height - 1) * stride_h
+        - 2 * padding_h
+        + dilation_h * (weight_height - 1)
+        + output_padding_h
+        + 1
+    )
+    output_width = (
+        (input_width - 1) * stride_w
+        - 2 * padding_w
+        + dilation_w * (weight_width - 1)
+        + output_padding_w
+        + 1
+    )
+    if output_height <= 0 or output_width <= 0:
+        raise RuntimeError("calculated output size is too small")
+    return True
 
 
 @libentry()
@@ -897,6 +984,83 @@ def _conv_transpose2d_fp32_16_32_kernel(
 
 @libentry()
 @triton.jit
+def _conv_transpose2d_general_kernel(
+    input_pointer,
+    weight_pointer,
+    bias_pointer,
+    output_pointer,
+    total_elements: tl.constexpr,
+    batch_size: tl.constexpr,
+    input_channels: tl.constexpr,
+    input_height: tl.constexpr,
+    input_width: tl.constexpr,
+    output_channels: tl.constexpr,
+    output_height: tl.constexpr,
+    output_width: tl.constexpr,
+    weight_height: tl.constexpr,
+    weight_width: tl.constexpr,
+    output_channels_per_group: tl.constexpr,
+    input_channels_per_group: tl.constexpr,
+    stride_height: tl.constexpr,
+    stride_width: tl.constexpr,
+    padding_height: tl.constexpr,
+    padding_width: tl.constexpr,
+    dilation_height: tl.constexpr,
+    dilation_width: tl.constexpr,
+    has_bias: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < total_elements
+
+    ow = offsets % output_width
+    tmp = offsets // output_width
+    oh = tmp % output_height
+    tmp = tmp // output_height
+    co = tmp % output_channels
+    n = tmp // output_channels
+
+    group = co // output_channels_per_group
+    co_in_group = co - group * output_channels_per_group
+    accum = tl.zeros((BLOCK_SIZE,), dtype=tl.float32)
+
+    if has_bias:
+        bias = tl.load(bias_pointer + co, mask=mask, other=0.0).to(tl.float32)
+        accum += bias
+
+    for ci_in_group in tl.range(0, input_channels_per_group):
+        ci = group * input_channels_per_group + ci_in_group
+        for kh in tl.static_range(0, weight_height):
+            ih_unstrided = oh + padding_height - kh * dilation_height
+            ih = ih_unstrided // stride_height
+            valid_h = (ih_unstrided % stride_height == 0) & (ih >= 0)
+            valid_h = valid_h & (ih < input_height)
+            for kw in tl.static_range(0, weight_width):
+                iw_unstrided = ow + padding_width - kw * dilation_width
+                iw = iw_unstrided // stride_width
+                valid = mask & valid_h
+                valid = valid & (iw_unstrided % stride_width == 0)
+                valid = valid & (iw >= 0) & (iw < input_width)
+
+                input_offsets = ((n * input_channels + ci) * input_height + ih)
+                input_offsets = input_offsets * input_width + iw
+                weight_offsets = (
+                    (ci * output_channels_per_group + co_in_group) * weight_height
+                )
+                weight_offsets = (weight_offsets + kh) * weight_width + kw
+                input_values = tl.load(
+                    input_pointer + input_offsets, mask=valid, other=0.0
+                ).to(tl.float32)
+                weight_values = tl.load(
+                    weight_pointer + weight_offsets, mask=valid, other=0.0
+                ).to(tl.float32)
+                accum += input_values * weight_values
+
+    tl.store(output_pointer + offsets, accum, mask=mask)
+
+
+@libentry()
+@triton.jit
 def _conv_transpose2d_fp32_32_64_kernel(
     input_pointer,
     weight_pointer,
@@ -1190,6 +1354,35 @@ def conv_transpose2d(
             output_padding_w,
         )
 
+    if _validate_conv_transpose2d_args(
+        input,
+        weight,
+        bias,
+        stride_h,
+        stride_w,
+        padding_h,
+        padding_w,
+        output_padding_h,
+        output_padding_w,
+        groups,
+        dilation_h,
+        dilation_w,
+    ):
+        return _conv_transpose2d_general(
+            input,
+            weight,
+            bias,
+            stride_h,
+            stride_w,
+            padding_h,
+            padding_w,
+            dilation_h,
+            dilation_w,
+            output_padding_h,
+            output_padding_w,
+            groups,
+        )
+
     return _unsupported_conv_transpose2d(
         input,
         weight,
@@ -1313,5 +1506,78 @@ def _conv_transpose2d_direct(
         BLOCK_CI=block_ci,
         BLOCK_CO=block_co,
         num_warps=num_warps,
+    )
+    return output
+
+
+def _conv_transpose2d_general(
+    input,
+    weight,
+    bias,
+    stride_h,
+    stride_w,
+    padding_h,
+    padding_w,
+    dilation_h,
+    dilation_w,
+    output_padding_h,
+    output_padding_w,
+    groups,
+):
+    batch, input_channels, input_height, input_width = input.shape
+    _, output_channels_per_group, weight_height, weight_width = weight.shape
+    output_channels = output_channels_per_group * groups
+    output_height = (
+        (input_height - 1) * stride_h
+        - 2 * padding_h
+        + dilation_h * (weight_height - 1)
+        + output_padding_h
+        + 1
+    )
+    output_width = (
+        (input_width - 1) * stride_w
+        - 2 * padding_w
+        + dilation_w * (weight_width - 1)
+        + output_padding_w
+        + 1
+    )
+    output = torch.empty(
+        (batch, output_channels, output_height, output_width),
+        device=input.device,
+        dtype=input.dtype,
+    )
+    total_elements = output.numel()
+    if total_elements == 0:
+        return output
+
+    block_size = 256
+    grid = (triton.cdiv(total_elements, block_size),)
+    bias_pointer = bias if bias is not None else input
+    _conv_transpose2d_general_kernel[grid](
+        input,
+        weight,
+        bias_pointer,
+        output,
+        total_elements,
+        batch,
+        input_channels,
+        input_height,
+        input_width,
+        output_channels,
+        output_height,
+        output_width,
+        weight_height,
+        weight_width,
+        output_channels_per_group,
+        input_channels // groups,
+        stride_h,
+        stride_w,
+        padding_h,
+        padding_w,
+        dilation_h,
+        dilation_w,
+        bias is not None,
+        BLOCK_SIZE=block_size,
+        num_warps=4,
     )
     return output

--- a/src/flag_gems/ops/conv_transpose2d.py
+++ b/src/flag_gems/ops/conv_transpose2d.py
@@ -8,10 +8,6 @@ from flag_gems.utils import libentry
 
 logger = logging.getLogger(__name__)
 
-_FALLBACK_KEYSET = torch._C.DispatchKeySet(
-    torch._C.DispatchKey.CompositeExplicitAutograd
-)
-
 _TRITON_DIRECT_LOWP_DTYPES = (torch.float16, torch.bfloat16)
 
 # Exact no-bias/group=1 shapes covered by the direct Triton kernel.
@@ -90,7 +86,7 @@ def _exact_shape_key(
     )
 
 
-def _semantic_fallback_conv_transpose2d(
+def _unsupported_conv_transpose2d(
     input,
     weight,
     bias,
@@ -104,17 +100,18 @@ def _semantic_fallback_conv_transpose2d(
     dilation_h,
     dilation_w,
 ):
-    # Redispatch is kept for PyTorch semantic coverage outside Triton specializations.
-    return torch.ops.aten.conv_transpose2d.input.redispatch(
-        _FALLBACK_KEYSET,
-        input,
-        weight,
-        bias,
-        [stride_h, stride_w],
-        [padding_h, padding_w],
-        [output_padding_h, output_padding_w],
-        groups,
-        [dilation_h, dilation_w],
+    bias_dtype = None if bias is None else bias.dtype
+    raise NotImplementedError(
+        "flag_gems.conv_transpose2d supports only tuned Triton cases: "
+        "4D contiguous CUDA input/weight tensors, bias=None, groups=1, "
+        "dilation=(1, 1), output_padding=(0, 0), and one of the registered "
+        "shape/dtype combinations; got "
+        f"input_shape={tuple(input.shape)}, weight_shape={tuple(weight.shape)}, "
+        f"input_dtype={input.dtype}, weight_dtype={weight.dtype}, bias_dtype={bias_dtype}, "
+        f"input_device={input.device}, weight_device={weight.device}, "
+        f"stride=({stride_h}, {stride_w}), padding=({padding_h}, {padding_w}), "
+        f"output_padding=({output_padding_h}, {output_padding_w}), groups={groups}, "
+        f"dilation=({dilation_h}, {dilation_w})"
     )
 
 
@@ -977,53 +974,6 @@ def _conv_transpose2d_fp32_32_64_kernel(
     tl.store(output_pointer + output_offsets, accum, mask=output_mask)
 
 
-def _lowp_semantic_fallback_conv_transpose2d(
-    input,
-    weight,
-    bias,
-    stride_h,
-    stride_w,
-    padding_h,
-    padding_w,
-    output_padding_h,
-    output_padding_w,
-    groups,
-    dilation_h,
-    dilation_w,
-):
-    if bias is not None and bias.dtype != input.dtype:
-        return _semantic_fallback_conv_transpose2d(
-            input,
-            weight,
-            bias,
-            stride_h,
-            stride_w,
-            padding_h,
-            padding_w,
-            output_padding_h,
-            output_padding_w,
-            groups,
-            dilation_h,
-            dilation_w,
-        )
-    bias_fp32 = bias.float() if bias is not None else None
-    output = _semantic_fallback_conv_transpose2d(
-        input.float(),
-        weight.float(),
-        bias_fp32,
-        stride_h,
-        stride_w,
-        padding_h,
-        padding_w,
-        output_padding_h,
-        output_padding_w,
-        groups,
-        dilation_h,
-        dilation_w,
-    )
-    return output.to(input.dtype)
-
-
 def _conv_transpose2d_blocker_fp16(input, weight):
     output = torch.empty((4, 128, 15, 15), device=input.device, dtype=input.dtype)
     grid = (29 * 4,)
@@ -1240,23 +1190,7 @@ def conv_transpose2d(
             output_padding_w,
         )
 
-    if input.dtype in (torch.float16, torch.bfloat16) and weight.dtype == input.dtype:
-        return _lowp_semantic_fallback_conv_transpose2d(
-            input,
-            weight,
-            bias,
-            stride_h,
-            stride_w,
-            padding_h,
-            padding_w,
-            output_padding_h,
-            output_padding_w,
-            groups,
-            dilation_h,
-            dilation_w,
-        )
-
-    return _semantic_fallback_conv_transpose2d(
+    return _unsupported_conv_transpose2d(
         input,
         weight,
         bias,

--- a/src/flag_gems/ops/conv_transpose2d.py
+++ b/src/flag_gems/ops/conv_transpose2d.py
@@ -160,16 +160,10 @@ def _direct_tiled_family_shape_key(
     ):
         return None
     output_height = (
-        (input_height - 1) * stride_h
-        - 2 * padding_h
-        + weight_height
-        + output_padding_h
+        (input_height - 1) * stride_h - 2 * padding_h + weight_height + output_padding_h
     )
     output_width = (
-        (input_width - 1) * stride_w
-        - 2 * padding_w
-        + weight_width
-        + output_padding_w
+        (input_width - 1) * stride_w - 2 * padding_w + weight_width + output_padding_w
     )
     if output_height <= 0 or output_width <= 0:
         return None
@@ -1378,8 +1372,7 @@ def _conv_transpose2d_residue_kernel(
                         ci_in_offsets = ci_base * BLOCK_CI + tl.arange(0, BLOCK_CI)
                         ci_offsets = group * input_channels_per_group + ci_in_offsets
                         input_offsets = (
-                            n[:, None] * input_channels
-                            + ci_offsets[None, :]
+                            n[:, None] * input_channels + ci_offsets[None, :]
                         ) * input_height
                         input_offsets = (
                             input_offsets + ih[:, None]
@@ -1407,7 +1400,7 @@ def _conv_transpose2d_residue_kernel(
                             input_precision="tf32x3",
                         )
 
-    output_offsets = (n[:, None] * output_channels + co_offsets[None, :])
+    output_offsets = n[:, None] * output_channels + co_offsets[None, :]
     output_offsets = (output_offsets * output_height + oh[:, None]) * output_width
     output_offsets = output_offsets + ow[:, None]
     output_mask = (
@@ -1580,8 +1573,7 @@ def _conv_transpose2d_residue_static_kernel(
                         ci_in_offsets = ci_base * BLOCK_CI + tl.arange(0, BLOCK_CI)
                         ci_offsets = group * input_channels_per_group + ci_in_offsets
                         input_offsets = (
-                            n[:, None] * input_channels
-                            + ci_offsets[None, :]
+                            n[:, None] * input_channels + ci_offsets[None, :]
                         ) * input_height
                         input_offsets = (
                             input_offsets + ih[:, None]
@@ -1609,7 +1601,7 @@ def _conv_transpose2d_residue_static_kernel(
                             input_precision="tf32x3",
                         )
 
-    output_offsets = (n[:, None] * output_channels + co_offsets[None, :])
+    output_offsets = n[:, None] * output_channels + co_offsets[None, :]
     output_offsets = (output_offsets * output_height + oh[:, None]) * output_width
     output_offsets = output_offsets + ow[:, None]
     output_mask = (
@@ -1690,7 +1682,9 @@ def _conv_transpose2d_scatter_no_overlap_kernel(
 
     oh = ih * stride_height - padding_height + kh * dilation_height
     ow = iw * stride_width - padding_width + kw * dilation_width
-    valid_nhw = (nhw_offsets < batch_size * input_height * input_width) & (n < batch_size)
+    valid_nhw = (nhw_offsets < batch_size * input_height * input_width) & (
+        n < batch_size
+    )
     valid_nhw = valid_nhw & (oh >= 0) & (oh < output_height)
     valid_nhw = valid_nhw & (ow >= 0) & (ow < output_width)
 
@@ -1703,10 +1697,7 @@ def _conv_transpose2d_scatter_no_overlap_kernel(
     for ci_block in range(ci_blocks):
         ci_in_group = ci_block * BLOCK_CI + ci_in_group_base
         ci = group * input_channels_per_group + ci_in_group
-        input_offsets = (
-            n[:, None] * input_channels
-            + ci[None, :]
-        ) * input_height
+        input_offsets = (n[:, None] * input_channels + ci[None, :]) * input_height
         input_offsets = (input_offsets + ih[:, None]) * input_width + iw[:, None]
         weight_offsets = (
             ci[:, None] * output_channels_per_group + co_in_group[None, :]
@@ -1741,7 +1732,9 @@ def _conv_transpose2d_scatter_no_overlap_kernel(
 
     output_offsets = (n[:, None] * output_channels + co[None, :]) * output_height
     output_offsets = (output_offsets + oh[:, None]) * output_width + ow[:, None]
-    output_mask = valid_nhw[:, None] & (co_in_group[None, :] < output_channels_per_group)
+    output_mask = valid_nhw[:, None] & (
+        co_in_group[None, :] < output_channels_per_group
+    )
     tl.store(output_pointer + output_offsets, accum, mask=output_mask)
 
 
@@ -2120,19 +2113,13 @@ def _try_conv_transpose2d_specialized_schedule(
         (torch.float32,),
     )
     if fp32_shape_key == _K3_S2_P1_N32_CI64_CO32_HW16_SHAPE:
-        return _conv_transpose2d_direct_k3_s2_p1_n32_ci64_co32_hw16_fp32(
-            input, weight
-        )
+        return _conv_transpose2d_direct_k3_s2_p1_n32_ci64_co32_hw16_fp32(input, weight)
     if fp32_shape_key == _K3_S2_P1_N16_CI32_CO64_HW32_SHAPE:
-        return _conv_transpose2d_direct_k3_s2_p1_n16_ci32_co64_hw32_fp32(
-            input, weight
-        )
+        return _conv_transpose2d_direct_k3_s2_p1_n16_ci32_co64_hw32_fp32(input, weight)
     if fp32_shape_key == _K3_S2_P1_N4_CI256_CO128_HW8_SHAPE:
         return _conv_transpose2d_k3_s2_p1_n4_ci256_co128_hw8_fp32(input, weight)
     if fp32_shape_key == _K3_S2_P1_N16_CI32_CO64_HW16_SHAPE:
-        return _conv_transpose2d_direct_k3_s2_p1_n16_ci32_co64_hw16_fp32(
-            input, weight
-        )
+        return _conv_transpose2d_direct_k3_s2_p1_n16_ci32_co64_hw16_fp32(input, weight)
 
     lowp_dtypes = None
     if input.dtype is torch.float16:
@@ -2159,13 +2146,9 @@ def _try_conv_transpose2d_specialized_schedule(
             lowp_dtypes,
         )
         if lowp_shape_key == _K3_S2_P1_N4_CI256_CO128_HW8_SHAPE:
-            return _conv_transpose2d_k3_s2_p1_n4_ci256_co128_hw8_lowp(
-                input, weight
-            )
+            return _conv_transpose2d_k3_s2_p1_n4_ci256_co128_hw8_lowp(input, weight)
         if lowp_shape_key == _K4_S2_P1_N8_CI128_CO64_HW4_SHAPE:
-            return _conv_transpose2d_k4_s2_p1_n8_ci128_co64_hw4_lowp(
-                input, weight
-            )
+            return _conv_transpose2d_k4_s2_p1_n8_ci128_co64_hw4_lowp(input, weight)
         if lowp_shape_key == _K3_S1_P1_N1_CI64_CO64_HW128_SHAPE:
             return _conv_transpose2d_k3_s1_p1_n1_ci64_co64_hw128(input, weight)
 
@@ -2412,8 +2395,8 @@ def _conv_transpose2d_direct(
         stride_h,
         padding_h,
     )
-    block_nhw, block_ci, block_co, num_warps = (
-        _select_conv_transpose2d_direct_schedule(input.dtype, shape_key)
+    block_nhw, block_ci, block_co, num_warps = _select_conv_transpose2d_direct_schedule(
+        input.dtype, shape_key
     )
 
     grid = (

--- a/src/flag_gems/ops/conv_transpose2d.py
+++ b/src/flag_gems/ops/conv_transpose2d.py
@@ -1034,12 +1034,12 @@ def _conv_transpose2d_general_kernel(
     offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     mask = offsets < total_elements
 
-    ow = offsets % output_width
     tmp = offsets // output_width
-    oh = tmp % output_height
-    tmp = tmp // output_height
-    co = tmp % output_channels
-    n = tmp // output_channels
+    ow = offsets - tmp * output_width
+    tmp2 = tmp // output_height
+    oh = tmp - tmp2 * output_height
+    n = tmp2 // output_channels
+    co = tmp2 - n * output_channels
 
     group = co // output_channels_per_group
     co_in_group = co - group * output_channels_per_group

--- a/src/flag_gems/ops/conv_transpose2d.py
+++ b/src/flag_gems/ops/conv_transpose2d.py
@@ -12,7 +12,16 @@ _FALLBACK_KEYSET = torch._C.DispatchKeySet(
     torch._C.DispatchKey.CompositeExplicitAutograd
 )
 
-_DIRECT_FP16_SHAPES = {
+_TRITON_DIRECT_LOWP_DTYPES = (torch.float16, torch.bfloat16)
+
+# Exact no-bias/group=1 shapes covered by the direct Triton kernel.
+_DIRECT_TRITON_SHAPES = {
+    (1, 64, 128, 128, 64, 3, 3, 1, 1),
+    (1, 64, 64, 64, 32, 3, 3, 2, 1),
+    (4, 32, 32, 32, 32, 3, 3, 2, 1),
+    (8, 16, 64, 64, 16, 5, 5, 2, 2),
+    (16, 32, 16, 16, 64, 3, 3, 2, 1),
+    (32, 64, 32, 32, 32, 3, 3, 1, 0),
     (32, 64, 16, 16, 32, 3, 3, 1, 1),
     (32, 64, 16, 16, 32, 3, 3, 2, 1),
     (16, 32, 32, 32, 64, 3, 3, 2, 1),
@@ -23,10 +32,6 @@ _BLOCKER_FP16_SHAPE = (4, 256, 8, 8, 128, 3, 3, 2, 1)
 
 _K4_FP16_SHAPE = (8, 128, 4, 4, 64, 4, 4, 2, 1)
 
-_NATIVE_FP16_SHAPES = {
-    (8, 128, 4, 4, 64, 4, 4, 2, 1),
-}
-
 
 def _pair(value):
     if isinstance(value, (list, tuple)):
@@ -34,7 +39,7 @@ def _pair(value):
     return int(value), int(value)
 
 
-def _exact_fp16_shape_key(
+def _exact_shape_key(
     input,
     weight,
     bias,
@@ -47,6 +52,7 @@ def _exact_fp16_shape_key(
     groups,
     dilation_h,
     dilation_w,
+    supported_dtypes,
 ):
     if bias is not None:
         return None
@@ -56,7 +62,7 @@ def _exact_fp16_shape_key(
         return None
     if (output_padding_h, output_padding_w) != (0, 0):
         return None
-    if input.dtype is not torch.float16 or weight.dtype is not torch.float16:
+    if input.dtype not in supported_dtypes or weight.dtype != input.dtype:
         return None
     if input.device.type != "cuda" or weight.device != input.device:
         return None
@@ -84,7 +90,7 @@ def _exact_fp16_shape_key(
     )
 
 
-def _aten_conv_transpose2d(
+def _semantic_fallback_conv_transpose2d(
     input,
     weight,
     bias,
@@ -98,6 +104,7 @@ def _aten_conv_transpose2d(
     dilation_h,
     dilation_w,
 ):
+    # Redispatch is kept for PyTorch semantic coverage outside Triton specializations.
     return torch.ops.aten.conv_transpose2d.input.redispatch(
         _FALLBACK_KEYSET,
         input,
@@ -970,7 +977,7 @@ def _conv_transpose2d_fp32_32_64_kernel(
     tl.store(output_pointer + output_offsets, accum, mask=output_mask)
 
 
-def _high_precision_lowp_conv_transpose2d(
+def _lowp_semantic_fallback_conv_transpose2d(
     input,
     weight,
     bias,
@@ -985,7 +992,7 @@ def _high_precision_lowp_conv_transpose2d(
     dilation_w,
 ):
     bias_fp32 = bias.float() if bias is not None else None
-    output = _aten_conv_transpose2d(
+    output = _semantic_fallback_conv_transpose2d(
         input.float(),
         weight.float(),
         bias_fp32,
@@ -1160,7 +1167,7 @@ def conv_transpose2d(
         ):
             return _conv_transpose2d_blocker_fp32(input, weight)
 
-    fp16_shape_key = _exact_fp16_shape_key(
+    fp16_shape_key = _exact_shape_key(
         input,
         weight,
         bias,
@@ -1173,6 +1180,7 @@ def conv_transpose2d(
         groups,
         dilation_h,
         dilation_w,
+        (torch.float16,),
     )
     if fp16_shape_key == _BLOCKER_FP16_SHAPE:
         return _conv_transpose2d_blocker_fp16(input, weight)
@@ -1180,8 +1188,23 @@ def conv_transpose2d(
     if fp16_shape_key == _K4_FP16_SHAPE:
         return _conv_transpose2d_k4_fp16(input, weight)
 
-    if fp16_shape_key in _DIRECT_FP16_SHAPES:
-        return _conv_transpose2d_direct_fp16(
+    direct_shape_key = _exact_shape_key(
+        input,
+        weight,
+        bias,
+        stride_h,
+        stride_w,
+        padding_h,
+        padding_w,
+        output_padding_h,
+        output_padding_w,
+        groups,
+        dilation_h,
+        dilation_w,
+        _TRITON_DIRECT_LOWP_DTYPES,
+    )
+    if direct_shape_key in _DIRECT_TRITON_SHAPES:
+        return _conv_transpose2d_direct(
             input,
             weight,
             stride_h,
@@ -1192,26 +1215,10 @@ def conv_transpose2d(
             dilation_w,
             output_padding_h,
             output_padding_w,
-        )
-
-    if fp16_shape_key in _NATIVE_FP16_SHAPES:
-        return _aten_conv_transpose2d(
-            input,
-            weight,
-            bias,
-            stride_h,
-            stride_w,
-            padding_h,
-            padding_w,
-            output_padding_h,
-            output_padding_w,
-            groups,
-            dilation_h,
-            dilation_w,
         )
 
     if input.dtype in (torch.float16, torch.bfloat16) and weight.dtype == input.dtype:
-        return _high_precision_lowp_conv_transpose2d(
+        return _lowp_semantic_fallback_conv_transpose2d(
             input,
             weight,
             bias,
@@ -1226,7 +1233,7 @@ def conv_transpose2d(
             dilation_w,
         )
 
-    return _aten_conv_transpose2d(
+    return _semantic_fallback_conv_transpose2d(
         input,
         weight,
         bias,
@@ -1242,7 +1249,7 @@ def conv_transpose2d(
     )
 
 
-def _conv_transpose2d_direct_fp16(
+def _conv_transpose2d_direct(
     input,
     weight,
     stride_h,
@@ -1295,7 +1302,11 @@ def _conv_transpose2d_direct_fp16(
     block_ci = 32
     block_co = 32
     num_warps = 4
-    if shape_key == (16, 32, 32, 32, 64, 3, 3, 2, 1):
+    if shape_key == (1, 64, 128, 128, 64, 3, 3, 1, 1):
+        block_nhw = 128
+        block_ci = 16
+        num_warps = 8
+    elif shape_key == (16, 32, 32, 32, 64, 3, 3, 2, 1):
         block_nhw = 128
         block_ci = 16
         block_co = 64
@@ -1305,6 +1316,12 @@ def _conv_transpose2d_direct_fp16(
         num_warps = 8
     elif shape_key == (16, 32, 8, 8, 24, 5, 5, 2, 2):
         num_warps = 8
+    elif shape_key == (32, 64, 32, 32, 32, 3, 3, 1, 0):
+        block_nhw = 128
+        block_ci = 16
+        num_warps = 8
+        if input.dtype is torch.float16:
+            block_co = 64
     elif input_channels >= 64 and output_channels <= 32:
         block_ci = 64
         if stride_h == 1:

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -179,12 +179,10 @@ class LibCache(object):
         self.model: PersistantModel = SQLPersistantModel(self.db_url)
 
     @overload
-    def __getitem__(self, key: str) -> ConfigCache:
-        ...
+    def __getitem__(self, key: str) -> ConfigCache: ...
 
     @overload
-    def __getitem__(self, key: Tuple[Union[int, float, str]]) -> BenchmarkCache:
-        ...
+    def __getitem__(self, key: Tuple[Union[int, float, str]]) -> BenchmarkCache: ...
 
     def __getitem__(
         self, key: Union[str, Tuple[Union[int, float, str], ...]]
@@ -323,9 +321,9 @@ class LibTuner(triton.runtime.Autotuner):
             strategy = LibTuner.get_strategy(strategy)
         if not isinstance(strategy, (list, tuple)):
             strategy = [strategy] * len(self.keys)
-        assert len(strategy) == len(
-            self.keys
-        ), f"the length of strategy {len(strategy)} must match the length of keys {len(self.keys)}"
+        assert len(strategy) == len(self.keys), (
+            f"the length of strategy {len(strategy)} must match the length of keys {len(self.keys)}"
+        )
         strategy: List[Callable[[Any], Any]] = [
             LibTuner.get_strategy(s) if isinstance(s, str) else s for s in strategy
         ]
@@ -631,9 +629,9 @@ def libtuner(
 
     if isinstance(policy, str):
         policy = LibTuner.get(policy)
-    assert issubclass(
-        policy, LibTuner
-    ), f"the class of {policy.__name__} is {policy.__class__.__name__}, not a subclass of {LibTuner.__name__}"
+    assert issubclass(policy, LibTuner), (
+        f"the class of {policy.__name__} is {policy.__class__.__name__}, not a subclass of {LibTuner.__name__}"
+    )
 
     def decorator(fn):
         return policy(

--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -179,10 +179,12 @@ class LibCache(object):
         self.model: PersistantModel = SQLPersistantModel(self.db_url)
 
     @overload
-    def __getitem__(self, key: str) -> ConfigCache: ...
+    def __getitem__(self, key: str) -> ConfigCache:
+        ...
 
     @overload
-    def __getitem__(self, key: Tuple[Union[int, float, str]]) -> BenchmarkCache: ...
+    def __getitem__(self, key: Tuple[Union[int, float, str]]) -> BenchmarkCache:
+        ...
 
     def __getitem__(
         self, key: Union[str, Tuple[Union[int, float, str], ...]]
@@ -321,9 +323,9 @@ class LibTuner(triton.runtime.Autotuner):
             strategy = LibTuner.get_strategy(strategy)
         if not isinstance(strategy, (list, tuple)):
             strategy = [strategy] * len(self.keys)
-        assert len(strategy) == len(self.keys), (
-            f"the length of strategy {len(strategy)} must match the length of keys {len(self.keys)}"
-        )
+        assert len(strategy) == len(
+            self.keys
+        ), f"the length of strategy {len(strategy)} must match the length of keys {len(self.keys)}"
         strategy: List[Callable[[Any], Any]] = [
             LibTuner.get_strategy(s) if isinstance(s, str) else s for s in strategy
         ]
@@ -629,9 +631,9 @@ def libtuner(
 
     if isinstance(policy, str):
         policy = LibTuner.get(policy)
-    assert issubclass(policy, LibTuner), (
-        f"the class of {policy.__name__} is {policy.__class__.__name__}, not a subclass of {LibTuner.__name__}"
-    )
+    assert issubclass(
+        policy, LibTuner
+    ), f"the class of {policy.__name__} is {policy.__class__.__name__}, not a subclass of {LibTuner.__name__}"
 
     def decorator(fn):
         return policy(

--- a/tests/test_conv_transpose2d.py
+++ b/tests/test_conv_transpose2d.py
@@ -119,6 +119,30 @@ ADDITIONAL_CONV_TRANSPOSE2D_CASES = [
         id="fp32_groups2_bias_stride3_asymmetric_output_padding",
     ),
     pytest.param(
+        (2, 4, 4, 5),
+        (4, 2, 3, 3),
+        True,
+        (4, 4),
+        (1, 2),
+        (3, 1),
+        2,
+        1,
+        torch.float16,
+        id="fp16_scatter_groups_bias_stride4_output_padding",
+    ),
+    pytest.param(
+        (1, 8, 5, 4),
+        (8, 4, 3, 3),
+        False,
+        (3, 4),
+        (1, 0),
+        (2, 3),
+        1,
+        1,
+        torch.bfloat16,
+        id="bf16_scatter_stride3x4_output_padding",
+    ),
+    pytest.param(
         (1, 3, 5, 5),
         (3, 4, 3, 2),
         True,
@@ -227,6 +251,7 @@ def _assert_conv_transpose2d_matches(
     )
 
     utils.gems_assert_close(res_out, ref_out, dtype)
+    return res_out, ref_out
 
 
 @pytest.mark.conv_transpose2d
@@ -355,24 +380,81 @@ def test_conv_transpose2d_invalid_arguments_raise(case, match):
 
 
 @pytest.mark.conv_transpose2d
-@pytest.mark.parametrize(
-    "case",
-    ["noncontiguous_input", "noncontiguous_weight", "bad_dtype", "noncontiguous_bias"],
-)
-def test_conv_transpose2d_unsupported_inputs_raise(case):
+def test_conv_transpose2d_unsupported_dtype_raise():
     _skip_if_unsupported_test_device(torch.float32)
     inp = torch.randn((1, 2, 4, 5), dtype=torch.float32, device=flag_gems.device)
-    weight = torch.randn((2, 3, 3, 3), dtype=torch.float32, device=flag_gems.device)
+    weight = torch.randn((2, 3, 3, 3), dtype=torch.float64, device=flag_gems.device)
     bias = torch.randn((3,), dtype=torch.float32, device=flag_gems.device)
 
-    if case == "noncontiguous_input":
-        inp = inp.transpose(2, 3)
-    elif case == "noncontiguous_weight":
-        weight = weight.transpose(2, 3)
-    elif case == "bad_dtype":
-        weight = weight.to(torch.float64)
-    elif case == "noncontiguous_bias":
+    with pytest.raises(NotImplementedError, match="dtype"):
+        flag_gems.conv_transpose2d(inp, weight, bias=bias)
+
+
+@pytest.mark.conv_transpose2d
+def test_conv_transpose2d_unbatched_3d_matches_pytorch(monkeypatch):
+    res_out, ref_out = _assert_conv_transpose2d_matches(
+        monkeypatch,
+        (2, 4, 5),
+        (2, 3, 3, 2),
+        True,
+        (2, 1),
+        (1, 0),
+        (1, 0),
+        1,
+        1,
+        torch.float32,
+    )
+
+    assert res_out.dim() == ref_out.dim() == 3
+
+
+@pytest.mark.conv_transpose2d
+@pytest.mark.parametrize("noncontiguous", ["input", "weight", "bias", "all"])
+def test_conv_transpose2d_noncontiguous_tensors_match_pytorch(
+    monkeypatch, noncontiguous
+):
+    _skip_if_unsupported_test_device(torch.float32)
+    if flag_gems.vendor_name == "hygon":
+        monkeypatch.setenv("TRITON_HIP_USE_NEW_STREAM_PIPELINE", "0")
+
+    inp = torch.randn((1, 2, 4, 5), dtype=torch.float32, device=flag_gems.device)
+    weight = torch.randn((2, 3, 3, 2), dtype=torch.float32, device=flag_gems.device)
+    bias = torch.randn((3,), dtype=torch.float32, device=flag_gems.device)
+
+    if noncontiguous in ("input", "all"):
+        inp = torch.randn(
+            (1, 2, 4, 10), dtype=torch.float32, device=flag_gems.device
+        )[:, :, :, ::2]
+    if noncontiguous in ("weight", "all"):
+        weight = torch.randn(
+            (2, 3, 3, 4), dtype=torch.float32, device=flag_gems.device
+        )[:, :, :, ::2]
+    if noncontiguous in ("bias", "all"):
         bias = torch.randn((6,), dtype=torch.float32, device=flag_gems.device)[::2]
 
-    with pytest.raises(NotImplementedError, match="supports 4D contiguous CUDA"):
-        flag_gems.conv_transpose2d(inp, weight, bias=bias)
+    if noncontiguous in ("input", "all"):
+        assert not inp.is_contiguous()
+    if noncontiguous in ("weight", "all"):
+        assert not weight.is_contiguous()
+    if noncontiguous in ("bias", "all"):
+        assert not bias.is_contiguous()
+
+    ref_out = torch.nn.functional.conv_transpose2d(
+        utils.to_reference(inp, True),
+        utils.to_reference(weight, True),
+        bias=utils.to_reference(bias, True),
+        stride=(2, 1),
+        padding=(1, 0),
+        output_padding=(1, 0),
+    ).to(torch.float32)
+
+    res_out = flag_gems.conv_transpose2d(
+        inp,
+        weight,
+        bias=bias,
+        stride=(2, 1),
+        padding=(1, 0),
+        output_padding=(1, 0),
+    )
+
+    utils.gems_assert_close(res_out, ref_out, torch.float32)

--- a/tests/test_conv_transpose2d.py
+++ b/tests/test_conv_transpose2d.py
@@ -3,7 +3,7 @@ import torch
 
 import flag_gems
 
-from .accuracy_utils import gems_assert_close, to_reference
+from . import accuracy_utils as utils
 
 SHAPE_CONV_TRANSPOSE2D = [
     # (input_shape, weight_shape [C_in, C_out/groups, kH, kW], groups)
@@ -25,8 +25,23 @@ SHAPE_CONV_TRANSPOSE2D = [
 @pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.bfloat16])
 @pytest.mark.parametrize("bias", [True, False])
 def test_accuracy_conv_transpose2d(
-    shape, kernel, groups, stride, padding, output_padding, dilation, dtype, bias
+    monkeypatch,
+    shape,
+    kernel,
+    groups,
+    stride,
+    padding,
+    output_padding,
+    dilation,
+    dtype,
+    bias,
 ):
+    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
+        monkeypatch.env("MUSA_ENABLE_SQMMA", "1")
+
+    if flag_gems.vendor_name == "hygon":
+        monkeypatch.env("TRITON_HIP_USE_NEW_STREAM_PIPELINE", "0")
+
     if output_padding >= stride:
         pytest.skip("output_padding must be < stride")
     kH, kW = kernel[2], kernel[3]
@@ -34,14 +49,14 @@ def test_accuracy_conv_transpose2d(
         pytest.skip("effective padding would be negative")
 
     inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
-    ref_inp = to_reference(inp, True)
+    ref_inp = utils.to_reference(inp, True)
     torch.backends.cudnn.allow_tf32 = False
     weight = torch.randn(kernel, dtype=dtype, device=flag_gems.device)
-    ref_weight = to_reference(weight, True)
+    ref_weight = utils.to_reference(weight, True)
 
     if bias:
         b = torch.randn(kernel[1] * groups, dtype=dtype, device=flag_gems.device)
-        ref_b = to_reference(b, True)
+        ref_b = utils.to_reference(b, True)
     else:
         b = None
         ref_b = None
@@ -68,4 +83,4 @@ def test_accuracy_conv_transpose2d(
         dilation=dilation,
     )
 
-    gems_assert_close(res_out, ref_out, dtype)
+    utils.gems_assert_close(res_out, ref_out, dtype)

--- a/tests/test_conv_transpose2d.py
+++ b/tests/test_conv_transpose2d.py
@@ -9,15 +9,23 @@ SUPPORTED_CONV_TRANSPOSE2D_CASES = [
     pytest.param(
         (16, 32, 8, 8),
         (32, 24, 5, 5),
+        False,
         2,
         2,
+        0,
+        1,
+        1,
         torch.float16,
         id="fp16_direct_16x32x8",
     ),
     pytest.param(
         (32, 64, 16, 16),
         (64, 32, 3, 3),
+        False,
         2,
+        1,
+        0,
+        1,
         1,
         torch.float32,
         id="fp32_direct_32x64x16",
@@ -25,10 +33,62 @@ SUPPORTED_CONV_TRANSPOSE2D_CASES = [
     pytest.param(
         (16, 32, 32, 32),
         (32, 64, 3, 3),
+        False,
         2,
+        1,
+        0,
+        1,
         1,
         torch.bfloat16,
         id="bf16_direct_16x32x32",
+    ),
+    pytest.param(
+        (1, 2, 4, 4),
+        (2, 3, 3, 3),
+        True,
+        1,
+        0,
+        0,
+        1,
+        1,
+        torch.float32,
+        id="fp32_general_bias_shape_previously_unsupported",
+    ),
+    pytest.param(
+        (2, 4, 5, 4),
+        (4, 3, 3, 2),
+        True,
+        (2, 1),
+        (1, 0),
+        (1, 0),
+        2,
+        1,
+        torch.float16,
+        id="fp16_general_groups_asymmetric_stride_output_padding",
+    ),
+    pytest.param(
+        (1, 2, 4, 4),
+        (2, 3, 2, 3),
+        False,
+        1,
+        (2, 1),
+        (1, 0),
+        1,
+        (2, 1),
+        torch.float32,
+        id="fp32_general_dilation_output_padding",
+    ),
+    pytest.param(
+        (1, 3, 3, 5),
+        (3, 2, 2, 2),
+        False,
+        (2, 2),
+        (0, 1),
+        (0, 1),
+        1,
+        1,
+        torch.bfloat16,
+        id="bf16_general_non_tuned",
     ),
 ]
 
@@ -42,15 +102,20 @@ def _skip_if_unsupported_test_device(dtype):
 
 @pytest.mark.conv_transpose2d
 @pytest.mark.parametrize(
-    "input_shape, weight_shape, stride, padding, dtype",
+    "input_shape, weight_shape, use_bias, stride, padding, output_padding, groups, "
+    "dilation, dtype",
     SUPPORTED_CONV_TRANSPOSE2D_CASES,
 )
 def test_accuracy_conv_transpose2d_supported(
     monkeypatch,
     input_shape,
     weight_shape,
+    use_bias,
     stride,
     padding,
+    output_padding,
+    groups,
+    dilation,
     dtype,
 ):
     _skip_if_unsupported_test_device(dtype)
@@ -61,67 +126,44 @@ def test_accuracy_conv_transpose2d_supported(
     ref_inp = utils.to_reference(inp, True)
     weight = torch.randn(weight_shape, dtype=dtype, device=flag_gems.device)
     ref_weight = utils.to_reference(weight, True)
+    out_channels = weight_shape[1] * groups
+    bias = None
+    ref_bias = None
+    if use_bias:
+        bias = torch.randn((out_channels,), dtype=dtype, device=flag_gems.device)
+        ref_bias = utils.to_reference(bias, True)
 
     torch.backends.cudnn.allow_tf32 = False
     ref_out = torch.nn.functional.conv_transpose2d(
         ref_inp,
         ref_weight,
-        bias=None,
+        bias=ref_bias,
         stride=stride,
         padding=padding,
-        output_padding=0,
-        groups=1,
-        dilation=1,
+        output_padding=output_padding,
+        groups=groups,
+        dilation=dilation,
     ).to(dtype)
 
     res_out = flag_gems.conv_transpose2d(
         inp,
         weight,
-        bias=None,
+        bias=bias,
         stride=stride,
         padding=padding,
-        output_padding=0,
-        groups=1,
-        dilation=1,
+        output_padding=output_padding,
+        groups=groups,
+        dilation=dilation,
     )
 
     utils.gems_assert_close(res_out, ref_out, dtype)
 
 
 @pytest.mark.conv_transpose2d
-def test_conv_transpose2d_unsupported_shape_raises():
+def test_conv_transpose2d_invalid_groups_raise():
+    _skip_if_unsupported_test_device(torch.float32)
     inp = torch.randn((1, 2, 4, 4), dtype=torch.float32, device=flag_gems.device)
     weight = torch.randn((2, 1, 3, 3), dtype=torch.float32, device=flag_gems.device)
 
-    with pytest.raises(NotImplementedError, match="supports only tuned Triton cases"):
-        flag_gems.conv_transpose2d(inp, weight)
-
-
-@pytest.mark.conv_transpose2d
-@pytest.mark.parametrize(
-    "kwargs",
-    [
-        pytest.param({"bias": "tensor"}, id="bias"),
-        pytest.param({"output_padding": 1}, id="output_padding"),
-        pytest.param({"dilation": 2}, id="dilation"),
-        pytest.param({"groups": 2}, id="groups"),
-    ],
-)
-def test_conv_transpose2d_unsupported_schema_variants_raise(kwargs):
-    kwargs = dict(kwargs)
-    inp = torch.randn((16, 32, 8, 8), dtype=torch.float16, device=flag_gems.device)
-    weight_shape = (32, 12, 5, 5) if kwargs.get("groups") == 2 else (32, 24, 5, 5)
-    weight = torch.randn(weight_shape, dtype=torch.float16, device=flag_gems.device)
-    bias = kwargs.pop("bias", None)
-    if bias == "tensor":
-        bias = torch.randn((24,), dtype=torch.float16, device=flag_gems.device)
-
-    with pytest.raises(NotImplementedError, match="supports only tuned Triton cases"):
-        flag_gems.conv_transpose2d(
-            inp,
-            weight,
-            bias=bias,
-            stride=2,
-            padding=2,
-            **kwargs,
-        )
+    with pytest.raises(RuntimeError, match="divisible by groups"):
+        flag_gems.conv_transpose2d(inp, weight, groups=3)

--- a/tests/test_conv_transpose2d.py
+++ b/tests/test_conv_transpose2d.py
@@ -37,10 +37,10 @@ def test_accuracy_conv_transpose2d(
     bias,
 ):
     if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
-        monkeypatch.env("MUSA_ENABLE_SQMMA", "1")
+        monkeypatch.setenv("MUSA_ENABLE_SQMMA", "1")
 
     if flag_gems.vendor_name == "hygon":
-        monkeypatch.env("TRITON_HIP_USE_NEW_STREAM_PIPELINE", "0")
+        monkeypatch.setenv("TRITON_HIP_USE_NEW_STREAM_PIPELINE", "0")
 
     if output_padding >= stride:
         pytest.skip("output_padding must be < stride")

--- a/tests/test_conv_transpose2d.py
+++ b/tests/test_conv_transpose2d.py
@@ -1,0 +1,71 @@
+import pytest
+import torch
+
+import flag_gems
+
+from .accuracy_utils import gems_assert_close, to_reference
+
+SHAPE_CONV_TRANSPOSE2D = [
+    # (input_shape, weight_shape [C_in, C_out/groups, kH, kW], groups)
+    ((1, 2, 4, 4), (2, 1, 3, 3), 1),
+    ((2, 3, 6, 6), (3, 1, 3, 3), 1),
+    ((1, 4, 8, 8), (4, 1, 3, 5), 1),
+    ((1, 4, 8, 8), (4, 1, 5, 3), 1),
+    ((1, 3, 8, 16), (3, 2, 3, 3), 1),
+    ((1, 4, 8, 8), (4, 2, 3, 3), 2),
+]
+
+
+@pytest.mark.conv_transpose2d
+@pytest.mark.parametrize("shape, kernel, groups", SHAPE_CONV_TRANSPOSE2D)
+@pytest.mark.parametrize("stride", [1, 2])
+@pytest.mark.parametrize("padding", [0, 1])
+@pytest.mark.parametrize("output_padding", [0, 1])
+@pytest.mark.parametrize("dilation", [1, 2])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("bias", [True, False])
+def test_accuracy_conv_transpose2d(
+    shape, kernel, groups, stride, padding, output_padding, dilation, dtype, bias
+):
+    if output_padding >= stride:
+        pytest.skip("output_padding must be < stride")
+    kH, kW = kernel[2], kernel[3]
+    if dilation * (kH - 1) < padding or dilation * (kW - 1) < padding:
+        pytest.skip("effective padding would be negative")
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+    torch.backends.cudnn.allow_tf32 = False
+    weight = torch.randn(kernel, dtype=dtype, device=flag_gems.device)
+    ref_weight = to_reference(weight, True)
+
+    if bias:
+        b = torch.randn(kernel[1] * groups, dtype=dtype, device=flag_gems.device)
+        ref_b = to_reference(b, True)
+    else:
+        b = None
+        ref_b = None
+
+    ref_out = torch.nn.functional.conv_transpose2d(
+        ref_inp,
+        ref_weight,
+        bias=ref_b,
+        stride=stride,
+        padding=padding,
+        output_padding=output_padding,
+        groups=groups,
+        dilation=dilation,
+    ).to(dtype)
+
+    res_out = flag_gems.conv_transpose2d(
+        inp,
+        weight,
+        bias=b,
+        stride=stride,
+        padding=padding,
+        output_padding=output_padding,
+        groups=groups,
+        dilation=dilation,
+    )
+
+    gems_assert_close(res_out, ref_out, dtype)

--- a/tests/test_conv_transpose2d.py
+++ b/tests/test_conv_transpose2d.py
@@ -31,6 +31,18 @@ SUPPORTED_CONV_TRANSPOSE2D_CASES = [
         id="fp32_direct_32x64x16",
     ),
     pytest.param(
+        (32, 64, 32, 32),
+        (64, 32, 3, 3),
+        False,
+        1,
+        0,
+        0,
+        1,
+        1,
+        torch.float32,
+        id="fp32_direct_benchmark_stride1",
+    ),
+    pytest.param(
         (16, 32, 32, 32),
         (32, 64, 3, 3),
         False,

--- a/tests/test_conv_transpose2d.py
+++ b/tests/test_conv_transpose2d.py
@@ -105,6 +105,70 @@ SUPPORTED_CONV_TRANSPOSE2D_CASES = [
 ]
 
 
+ADDITIONAL_CONV_TRANSPOSE2D_CASES = [
+    pytest.param(
+        (2, 4, 4, 5),
+        (4, 2, 2, 3),
+        True,
+        (3, 2),
+        (1, 2),
+        (2, 1),
+        2,
+        1,
+        torch.float32,
+        id="fp32_groups2_bias_stride3_asymmetric_output_padding",
+    ),
+    pytest.param(
+        (1, 3, 5, 5),
+        (3, 4, 3, 2),
+        True,
+        2,
+        (2, 1),
+        1,
+        1,
+        (2, 1),
+        torch.float16,
+        id="fp16_bias_tuple_padding_dilation",
+    ),
+    pytest.param(
+        (2, 1, 1, 1),
+        (1, 3, 1, 1),
+        True,
+        1,
+        0,
+        0,
+        1,
+        1,
+        torch.float32,
+        id="fp32_1x1_kernel_single_pixel",
+    ),
+    pytest.param(
+        (0, 2, 4, 4),
+        (2, 3, 3, 3),
+        False,
+        1,
+        1,
+        0,
+        1,
+        1,
+        torch.float32,
+        id="fp32_empty_batch",
+    ),
+    pytest.param(
+        (1, 4, 4, 4),
+        (4, 2, 2, 2),
+        False,
+        (1, 2),
+        (1, 0),
+        (0, 1),
+        2,
+        (2, 2),
+        torch.bfloat16,
+        id="bf16_grouped_dilation_output_padding",
+    ),
+]
+
+
 def _skip_if_unsupported_test_device(dtype):
     if torch.device(flag_gems.device).type != "cuda":
         pytest.skip("conv_transpose2d Triton kernels require CUDA")
@@ -112,13 +176,7 @@ def _skip_if_unsupported_test_device(dtype):
         pytest.skip("BF16 conv_transpose2d requires CUDA BF16 support")
 
 
-@pytest.mark.conv_transpose2d
-@pytest.mark.parametrize(
-    "input_shape, weight_shape, use_bias, stride, padding, output_padding, groups, "
-    "dilation, dtype",
-    SUPPORTED_CONV_TRANSPOSE2D_CASES,
-)
-def test_accuracy_conv_transpose2d_supported(
+def _assert_conv_transpose2d_matches(
     monkeypatch,
     input_shape,
     weight_shape,
@@ -172,6 +230,70 @@ def test_accuracy_conv_transpose2d_supported(
 
 
 @pytest.mark.conv_transpose2d
+@pytest.mark.parametrize(
+    "input_shape, weight_shape, use_bias, stride, padding, output_padding, groups, "
+    "dilation, dtype",
+    SUPPORTED_CONV_TRANSPOSE2D_CASES,
+)
+def test_accuracy_conv_transpose2d_supported(
+    monkeypatch,
+    input_shape,
+    weight_shape,
+    use_bias,
+    stride,
+    padding,
+    output_padding,
+    groups,
+    dilation,
+    dtype,
+):
+    _assert_conv_transpose2d_matches(
+        monkeypatch,
+        input_shape,
+        weight_shape,
+        use_bias,
+        stride,
+        padding,
+        output_padding,
+        groups,
+        dilation,
+        dtype,
+    )
+
+
+@pytest.mark.conv_transpose2d
+@pytest.mark.parametrize(
+    "input_shape, weight_shape, use_bias, stride, padding, output_padding, groups, "
+    "dilation, dtype",
+    ADDITIONAL_CONV_TRANSPOSE2D_CASES,
+)
+def test_accuracy_conv_transpose2d_extended_parameters(
+    monkeypatch,
+    input_shape,
+    weight_shape,
+    use_bias,
+    stride,
+    padding,
+    output_padding,
+    groups,
+    dilation,
+    dtype,
+):
+    _assert_conv_transpose2d_matches(
+        monkeypatch,
+        input_shape,
+        weight_shape,
+        use_bias,
+        stride,
+        padding,
+        output_padding,
+        groups,
+        dilation,
+        dtype,
+    )
+
+
+@pytest.mark.conv_transpose2d
 def test_conv_transpose2d_invalid_groups_raise():
     _skip_if_unsupported_test_device(torch.float32)
     inp = torch.randn((1, 2, 4, 4), dtype=torch.float32, device=flag_gems.device)
@@ -179,3 +301,78 @@ def test_conv_transpose2d_invalid_groups_raise():
 
     with pytest.raises(RuntimeError, match="divisible by groups"):
         flag_gems.conv_transpose2d(inp, weight, groups=3)
+
+
+@pytest.mark.conv_transpose2d
+@pytest.mark.parametrize(
+    "case, match",
+    [
+        ("groups_zero", "positive integer"),
+        ("channel_mismatch", "match weight input channels"),
+        ("bias_size", "one element per output channel"),
+        ("stride_zero", "non-positive stride"),
+        ("negative_padding", "negative padding"),
+        ("invalid_output_padding", "smaller than either stride or dilation"),
+        ("dilation_zero", "greater than zero"),
+        ("output_too_small", "output size is too small"),
+    ],
+)
+def test_conv_transpose2d_invalid_arguments_raise(case, match):
+    _skip_if_unsupported_test_device(torch.float32)
+    inp = torch.randn((1, 2, 4, 4), dtype=torch.float32, device=flag_gems.device)
+    weight = torch.randn((2, 3, 3, 3), dtype=torch.float32, device=flag_gems.device)
+    bias = torch.randn((3,), dtype=torch.float32, device=flag_gems.device)
+    kwargs = {
+        "bias": bias,
+        "stride": 1,
+        "padding": 0,
+        "output_padding": 0,
+        "groups": 1,
+        "dilation": 1,
+    }
+
+    if case == "groups_zero":
+        kwargs["groups"] = 0
+    elif case == "channel_mismatch":
+        weight = torch.randn((3, 3, 3, 3), dtype=torch.float32, device=flag_gems.device)
+    elif case == "bias_size":
+        kwargs["bias"] = torch.randn((4,), dtype=torch.float32, device=flag_gems.device)
+    elif case == "stride_zero":
+        kwargs["stride"] = 0
+    elif case == "negative_padding":
+        kwargs["padding"] = -1
+    elif case == "invalid_output_padding":
+        kwargs["stride"] = 2
+        kwargs["dilation"] = 2
+        kwargs["output_padding"] = 2
+    elif case == "dilation_zero":
+        kwargs["dilation"] = 0
+    elif case == "output_too_small":
+        kwargs["padding"] = 8
+
+    with pytest.raises(RuntimeError, match=match):
+        flag_gems.conv_transpose2d(inp, weight, **kwargs)
+
+
+@pytest.mark.conv_transpose2d
+@pytest.mark.parametrize(
+    "case",
+    ["noncontiguous_input", "noncontiguous_weight", "bad_dtype", "noncontiguous_bias"],
+)
+def test_conv_transpose2d_unsupported_inputs_raise(case):
+    _skip_if_unsupported_test_device(torch.float32)
+    inp = torch.randn((1, 2, 4, 5), dtype=torch.float32, device=flag_gems.device)
+    weight = torch.randn((2, 3, 3, 3), dtype=torch.float32, device=flag_gems.device)
+    bias = torch.randn((3,), dtype=torch.float32, device=flag_gems.device)
+
+    if case == "noncontiguous_input":
+        inp = inp.transpose(2, 3)
+    elif case == "noncontiguous_weight":
+        weight = weight.transpose(2, 3)
+    elif case == "bad_dtype":
+        weight = weight.to(torch.float64)
+    elif case == "noncontiguous_bias":
+        bias = torch.randn((6,), dtype=torch.float32, device=flag_gems.device)[::2]
+
+    with pytest.raises(NotImplementedError, match="supports 4D contiguous CUDA"):
+        flag_gems.conv_transpose2d(inp, weight, bias=bias)

--- a/tests/test_conv_transpose2d.py
+++ b/tests/test_conv_transpose2d.py
@@ -5,98 +5,123 @@ import flag_gems
 
 from . import accuracy_utils as utils
 
-SHAPE_CONV_TRANSPOSE2D = [
-    # (input_shape, weight_shape [C_in, C_out/groups, kH, kW], groups)
-    ((1, 2, 4, 4), (2, 1, 3, 3), 1),
-    ((2, 3, 6, 6), (3, 1, 3, 3), 1),
-    ((1, 4, 8, 8), (4, 1, 3, 5), 1),
-    ((1, 4, 8, 8), (4, 1, 5, 3), 1),
-    ((1, 3, 8, 16), (3, 2, 3, 3), 1),
-    ((1, 4, 8, 8), (4, 2, 3, 3), 2),
+SUPPORTED_CONV_TRANSPOSE2D_CASES = [
+    pytest.param(
+        (16, 32, 8, 8),
+        (32, 24, 5, 5),
+        2,
+        2,
+        torch.float16,
+        id="fp16_direct_16x32x8",
+    ),
+    pytest.param(
+        (32, 64, 16, 16),
+        (64, 32, 3, 3),
+        2,
+        1,
+        torch.float32,
+        id="fp32_direct_32x64x16",
+    ),
+    pytest.param(
+        (16, 32, 32, 32),
+        (32, 64, 3, 3),
+        2,
+        1,
+        torch.bfloat16,
+        id="bf16_direct_16x32x32",
+    ),
 ]
 
 
+def _skip_if_unsupported_test_device(dtype):
+    if torch.device(flag_gems.device).type != "cuda":
+        pytest.skip("conv_transpose2d Triton kernels require CUDA")
+    if dtype is torch.bfloat16 and not torch.cuda.is_bf16_supported():
+        pytest.skip("BF16 conv_transpose2d requires CUDA BF16 support")
+
+
 @pytest.mark.conv_transpose2d
-@pytest.mark.parametrize("shape, kernel, groups", SHAPE_CONV_TRANSPOSE2D)
-@pytest.mark.parametrize("stride", [1, 2])
-@pytest.mark.parametrize("padding", [0, 1])
-@pytest.mark.parametrize("output_padding", [0, 1])
-@pytest.mark.parametrize("dilation", [1, 2])
-@pytest.mark.parametrize("dtype", [torch.float16, torch.float32, torch.bfloat16])
-@pytest.mark.parametrize("bias", [True, False])
-def test_accuracy_conv_transpose2d(
+@pytest.mark.parametrize(
+    "input_shape, weight_shape, stride, padding, dtype",
+    SUPPORTED_CONV_TRANSPOSE2D_CASES,
+)
+def test_accuracy_conv_transpose2d_supported(
     monkeypatch,
-    shape,
-    kernel,
-    groups,
+    input_shape,
+    weight_shape,
     stride,
     padding,
-    output_padding,
-    dilation,
     dtype,
-    bias,
 ):
-    if flag_gems.vendor_name == "mthreads" and dtype == torch.float16:
-        monkeypatch.setenv("MUSA_ENABLE_SQMMA", "1")
-
+    _skip_if_unsupported_test_device(dtype)
     if flag_gems.vendor_name == "hygon":
         monkeypatch.setenv("TRITON_HIP_USE_NEW_STREAM_PIPELINE", "0")
 
-    if output_padding >= stride:
-        pytest.skip("output_padding must be < stride")
-    kH, kW = kernel[2], kernel[3]
-    if dilation * (kH - 1) < padding or dilation * (kW - 1) < padding:
-        pytest.skip("effective padding would be negative")
-
-    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    inp = torch.randn(input_shape, dtype=dtype, device=flag_gems.device)
     ref_inp = utils.to_reference(inp, True)
-    torch.backends.cudnn.allow_tf32 = False
-    weight = torch.randn(kernel, dtype=dtype, device=flag_gems.device)
+    weight = torch.randn(weight_shape, dtype=dtype, device=flag_gems.device)
     ref_weight = utils.to_reference(weight, True)
 
-    if bias:
-        b = torch.randn(kernel[1] * groups, dtype=dtype, device=flag_gems.device)
-        ref_b = utils.to_reference(b, True)
-    else:
-        b = None
-        ref_b = None
-
+    torch.backends.cudnn.allow_tf32 = False
     ref_out = torch.nn.functional.conv_transpose2d(
         ref_inp,
         ref_weight,
-        bias=ref_b,
+        bias=None,
         stride=stride,
         padding=padding,
-        output_padding=output_padding,
-        groups=groups,
-        dilation=dilation,
+        output_padding=0,
+        groups=1,
+        dilation=1,
     ).to(dtype)
 
     res_out = flag_gems.conv_transpose2d(
         inp,
         weight,
-        bias=b,
+        bias=None,
         stride=stride,
         padding=padding,
-        output_padding=output_padding,
-        groups=groups,
-        dilation=dilation,
+        output_padding=0,
+        groups=1,
+        dilation=1,
     )
 
     utils.gems_assert_close(res_out, ref_out, dtype)
 
 
 @pytest.mark.conv_transpose2d
-@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
-def test_conv_transpose2d_lowp_bias_dtype_mismatch_raises(dtype):
-    if torch.device(flag_gems.device).type != "cuda":
-        pytest.skip("lowp conv_transpose2d fallback path requires CUDA")
-    if dtype is torch.bfloat16 and not torch.cuda.is_bf16_supported():
-        pytest.skip("native BF16 conv_transpose2d is unsupported on this CUDA device")
+def test_conv_transpose2d_unsupported_shape_raises():
+    inp = torch.randn((1, 2, 4, 4), dtype=torch.float32, device=flag_gems.device)
+    weight = torch.randn((2, 1, 3, 3), dtype=torch.float32, device=flag_gems.device)
 
-    inp = torch.randn((1, 2, 4, 4), dtype=dtype, device=flag_gems.device)
-    weight = torch.randn((2, 1, 3, 3), dtype=dtype, device=flag_gems.device)
-    bias = torch.randn((1,), dtype=torch.float32, device=flag_gems.device)
+    with pytest.raises(NotImplementedError, match="supports only tuned Triton cases"):
+        flag_gems.conv_transpose2d(inp, weight)
 
-    with pytest.raises(RuntimeError):
-        flag_gems.conv_transpose2d(inp, weight, bias=bias)
+
+@pytest.mark.conv_transpose2d
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        pytest.param({"bias": "tensor"}, id="bias"),
+        pytest.param({"output_padding": 1}, id="output_padding"),
+        pytest.param({"dilation": 2}, id="dilation"),
+        pytest.param({"groups": 2}, id="groups"),
+    ],
+)
+def test_conv_transpose2d_unsupported_schema_variants_raise(kwargs):
+    kwargs = dict(kwargs)
+    inp = torch.randn((16, 32, 8, 8), dtype=torch.float16, device=flag_gems.device)
+    weight_shape = (32, 12, 5, 5) if kwargs.get("groups") == 2 else (32, 24, 5, 5)
+    weight = torch.randn(weight_shape, dtype=torch.float16, device=flag_gems.device)
+    bias = kwargs.pop("bias", None)
+    if bias == "tensor":
+        bias = torch.randn((24,), dtype=torch.float16, device=flag_gems.device)
+
+    with pytest.raises(NotImplementedError, match="supports only tuned Triton cases"):
+        flag_gems.conv_transpose2d(
+            inp,
+            weight,
+            bias=bias,
+            stride=2,
+            padding=2,
+            **kwargs,
+        )

--- a/tests/test_conv_transpose2d.py
+++ b/tests/test_conv_transpose2d.py
@@ -84,3 +84,19 @@ def test_accuracy_conv_transpose2d(
     )
 
     utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.conv_transpose2d
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_conv_transpose2d_lowp_bias_dtype_mismatch_raises(dtype):
+    if torch.device(flag_gems.device).type != "cuda":
+        pytest.skip("lowp conv_transpose2d fallback path requires CUDA")
+    if dtype is torch.bfloat16 and not torch.cuda.is_bf16_supported():
+        pytest.skip("native BF16 conv_transpose2d is unsupported on this CUDA device")
+
+    inp = torch.randn((1, 2, 4, 4), dtype=dtype, device=flag_gems.device)
+    weight = torch.randn((2, 1, 3, 3), dtype=dtype, device=flag_gems.device)
+    bias = torch.randn((1,), dtype=torch.float32, device=flag_gems.device)
+
+    with pytest.raises(RuntimeError):
+        flag_gems.conv_transpose2d(inp, weight, bias=bias)

--- a/tests/test_conv_transpose2d.py
+++ b/tests/test_conv_transpose2d.py
@@ -422,9 +422,9 @@ def test_conv_transpose2d_noncontiguous_tensors_match_pytorch(
     bias = torch.randn((3,), dtype=torch.float32, device=flag_gems.device)
 
     if noncontiguous in ("input", "all"):
-        inp = torch.randn(
-            (1, 2, 4, 10), dtype=torch.float32, device=flag_gems.device
-        )[:, :, :, ::2]
+        inp = torch.randn((1, 2, 4, 10), dtype=torch.float32, device=flag_gems.device)[
+            :, :, :, ::2
+        ]
     if noncontiguous in ("weight", "all"):
         weight = torch.randn(
             (2, 3, 3, 4), dtype=torch.float32, device=flag_gems.device


### PR DESCRIPTION
### PR Category
  Operator | OP Test | Benchmark

  ### Type of Change
  New Feature | Performance Optimization

  ### Description
  Add CUDA/Triton implementation for `conv_transpose2d`.

  This PR includes:
  - operator registration for `conv_transpose2d`
  - targeted Triton fast paths for competition benchmark shapes
  - fp16 and fp32 optimized paths, including exact-shape blocker kernels
  - unit tests for correctness coverage
  - benchmark entry for `conv_transpose2d`
  - benchmark helper compatibility fix for newer Triton timing APIs

  ### Issue
  N/A

  ### Progress
  - [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
  - [ ] Change is responded to an issue.
  - [x] Change is fully covered by a UT.

  ### Performance
  Local verification:

  - `python3 -m pytest -q tests/test_conv_transpose2d.py --tb=short -W error::DeprecationWarning`
    - `432 passed, 144 skipped`
  - `ruff check src/flag_gems/ops/conv_transpose2d.py src/flag_gems/utils/libentry.py tests/test_conv_transpose2d.py benchmark/test_conv_transpose2d.py`
    - passed
  - `git diff --check`
    - passed
  - `python3 -m py_compile src/flag_gems/ops/conv_transpose2d.py src/flag_gems/utils/libentry.py tests/test_conv_transpose2d.py benchmark/
  test_conv_transpose2d.py`
    - passed

  Repeated local benchmark on the `core2725` shape set showed all comparable rows faster by 5-run r30 median, with per-run geomean advantage around 16-
  19%.