### PR TITLE
Drop the `exposed` field from operator inventory

### DIFF
--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -1112,7 +1112,6 @@ ops:
   - id: contiguous
     description: |
       Returns a contiguous in memory tensor containing the same data as `self` tensor.
-      Introduced in v2.2 and removed from exposed list in v4.1.
     for:
       - contiguous
     labels:
@@ -1207,7 +1206,6 @@ ops:
       - Tensor
     stages:
       - beta: '4.2'
-    exposed: False
   - id: copy_
     description: Copies the elements from `src` into `self` tensor and returns `self`.
     for:
@@ -1598,7 +1596,6 @@ ops:
     description: |
       Rectified Gated Linear Unit is a variant of GLU that uses ReLU instead of
       the sigmoid function for gating. This is the backward case.
-      This operator was introduced in v4.2 but not exposed.
     for:
       - dreglu
     labels:
@@ -4294,7 +4291,6 @@ ops:
   - id: reglu
     description: |
       Rectified Gated Linear Unit is a variant of GLU that uses ReLU instead of the sigmoid function for gating.
-      This operator was introduced in v4.2 release but not exposed.
     for:
       - reglu
     labels:

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -604,9 +604,6 @@ def get_ops_to_test(ops_file, ops_list, stages):
         stage = next(iter(stages[-1].keys()), None)
         if stage not in effective_stages:
             continue
-        # Always skip operators not exposed.
-        if "exposed" in op and op["exposed"] is False:
-            continue
         ops.append(op["id"].lstrip("_"))
 
     return ops


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Refactor

### Description

Drop the `exposed` field which may cause confusion. Actually, it doesn't matter whether an operator is _exposed_ or not. We can always test them and even use them.