### PR TITLE
Allow pytest to ignore the dataclass annotation

### DIFF
--- a/benchmark/base.py
+++ b/benchmark/base.py
@@ -5,7 +5,6 @@ import time
 from dataclasses import asdict
 from typing import Any, Generator, List, Optional, Tuple
 
-import consts
 import pytest
 import torch
 import triton
@@ -14,6 +13,7 @@ import yaml
 import flag_gems
 from flag_gems.utils import shape_utils
 
+from . import consts
 from .conftest import Config, emit_record_logger, update_result
 from .consts import (
     BenchmarkMetrics,

--- a/benchmark/test_flash_mla_sparse_fwd.py
+++ b/benchmark/test_flash_mla_sparse_fwd.py
@@ -21,6 +21,9 @@ except ImportError:
 
 @dataclasses.dataclass
 class TestParam:
+    # Instruct pytest to ignore this class
+    __test__ = False
+
     s_q: int
     s_kv: int
     topk: int


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Improvement

### Description

Allow the pytest to ignore an annotated dataclass found in benchmark tests.