### PR TITLE
[FlagGems Operator Development Competition] Add logaddexp operator

### DIFF
--- a/src/flag_gems/ops/logaddexp.py
+++ b/src/flag_gems/ops/logaddexp.py
@@ -8,15 +8,18 @@ from flag_gems.utils import pointwise_dynamic
 logger = logging.getLogger(__name__)
 
 
+# logaddexp(a, b) = max(a, b) + log(1 + exp(-|a - b|))
+# The shifted form keeps the argument of exp in (-inf, 0] which avoids
+# overflow when both inputs are large. fp32 accumulation gives stable
+# results for fp16/bf16 inputs.
 @pointwise_dynamic(is_tensor=[True, True], promotion_methods=[(0, 1, "DEFAULT")])
 @triton.jit
 def logaddexp_func(x, y):
-    # log(exp(x) + exp(y)) = m + log(1 + exp(-|x - y|)), m = max(x, y)
-    x_f32 = x.to(tl.float32)
-    y_f32 = y.to(tl.float32)
-    m = tl.maximum(x_f32, y_f32)
-    delta = x_f32 - y_f32
-    return m + tl.log(1.0 + tl.exp(-tl.abs(delta)))
+    x_fp32 = x.to(tl.float32)
+    y_fp32 = y.to(tl.float32)
+    m = tl.maximum(x_fp32, y_fp32)
+    delta = tl.abs(x_fp32 - y_fp32)
+    return m + tl.log(1.0 + tl.exp(-delta))
 
 
 def logaddexp(self, other):

--- a/src/flag_gems/ops/logaddexp.py
+++ b/src/flag_gems/ops/logaddexp.py
@@ -9,9 +9,18 @@ logger = logging.getLogger(__name__)
 
 
 # logaddexp(a, b) = max(a, b) + log(1 + exp(-|a - b|))
+#
 # The shifted form keeps the argument of exp in (-inf, 0] which avoids
-# overflow when both inputs are large. fp32 accumulation gives stable
+# overflow when both inputs are large.  fp32 accumulation gives stable
 # results for fp16/bf16 inputs.
+#
+# Edge cases:
+#   * a == b == +inf  -> diff = NaN, but result must be +inf
+#   * a == b == -inf  -> diff = NaN, but result must be -inf
+#   * one input +inf  -> diff = +inf, exp(-diff) = 0, correction = 0 -> max
+# We mask out the NaN-from-inf-minus-inf case by selecting on
+# ``delta == delta`` (False only when delta is NaN) and falling back to
+# the max, which is the correct limit for both ``+inf`` cases.
 @pointwise_dynamic(is_tensor=[True, True], promotion_methods=[(0, 1, "DEFAULT")])
 @triton.jit
 def logaddexp_func(x, y):
@@ -19,7 +28,8 @@ def logaddexp_func(x, y):
     y_fp32 = y.to(tl.float32)
     m = tl.maximum(x_fp32, y_fp32)
     delta = tl.abs(x_fp32 - y_fp32)
-    return m + tl.log(1.0 + tl.exp(-delta))
+    correction = tl.log(1.0 + tl.exp(-delta))
+    return tl.where(delta == delta, m + correction, m)
 
 
 def logaddexp(self, other):

--- a/src/flag_gems/ops/logaddexp.py
+++ b/src/flag_gems/ops/logaddexp.py
@@ -29,7 +29,15 @@ def logaddexp_func(x, y):
     m = tl.maximum(x_fp32, y_fp32)
     delta = tl.abs(x_fp32 - y_fp32)
     correction = tl.log(1.0 + tl.exp(-delta))
-    return tl.where(delta == delta, m + correction, m)
+    # Inf - Inf (same sign) makes ``delta`` NaN; the limit is the signed
+    # infinity itself, which equals ``m``.
+    base = tl.where(delta == delta, m + correction, m)
+    # ``tl.maximum`` follows IEEE 754 fmax semantics and does NOT propagate
+    # NaN — a NaN input would silently return the other operand here, but
+    # torch.logaddexp returns NaN.  Force NaN propagation explicitly:
+    # ``x + y`` is NaN whenever either input is NaN.
+    nan_mask = (x_fp32 != x_fp32) | (y_fp32 != y_fp32)
+    return tl.where(nan_mask, x_fp32 + y_fp32, base)
 
 
 def logaddexp(self, other):

--- a/tests/test_logaddexp.py
+++ b/tests/test_logaddexp.py
@@ -23,6 +23,70 @@ def test_logaddexp(shape, dtype):
     utils.gems_assert_close(res_out, ref_out, dtype)
 
 
+@pytest.mark.logaddexp
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_logaddexp_broadcast(dtype):
+    x = torch.randn((4, 1, 8), dtype=dtype, device=flag_gems.device)
+    y = torch.randn((1, 6, 8), dtype=dtype, device=flag_gems.device)
+
+    ref_x = utils.to_reference(x, True)
+    ref_y = utils.to_reference(y, True)
+    ref_out = torch.logaddexp(ref_x, ref_y)
+    with flag_gems.use_gems():
+        res_out = torch.logaddexp(x, y)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.logaddexp
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_logaddexp_large_values(dtype):
+    # exp(50) overflows fp16/bf16 — the shifted form must keep results finite.
+    x = torch.tensor([50.0, -50.0, 30.0, -30.0], dtype=dtype, device=flag_gems.device)
+    y = torch.tensor([49.0, -49.0, 35.0, -25.0], dtype=dtype, device=flag_gems.device)
+
+    ref_x = utils.to_reference(x, True)
+    ref_y = utils.to_reference(y, True)
+    ref_out = torch.logaddexp(ref_x, ref_y)
+    with flag_gems.use_gems():
+        res_out = torch.logaddexp(x, y)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.logaddexp
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_logaddexp_edge_cases(dtype):
+    x = torch.tensor(
+        [0.0, -0.0, 1.0, -1.0, float("inf"), float("-inf"), float("nan")],
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+    y = torch.tensor(
+        [0.0, 0.0, -1.0, 1.0, float("inf"), 1.0, 1.0],
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+
+    ref_x = utils.to_reference(x, True)
+    ref_y = utils.to_reference(y, True)
+    ref_out = torch.logaddexp(ref_x, ref_y)
+    with flag_gems.use_gems():
+        res_out = torch.logaddexp(x, y)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True)
+
+
+@pytest.mark.logaddexp
+def test_logaddexp_empty_tensor():
+    x = torch.empty(0, dtype=torch.float32, device=flag_gems.device)
+    y = torch.empty(0, dtype=torch.float32, device=flag_gems.device)
+    ref_out = torch.logaddexp(x, y)
+    with flag_gems.use_gems():
+        res_out = torch.logaddexp(x, y)
+    utils.gems_assert_equal(res_out, ref_out)
+
+
 @pytest.mark.logaddexp_out
 @pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)

--- a/tests/test_logaddexp.py
+++ b/tests/test_logaddexp.py
@@ -81,8 +81,8 @@ def test_logaddexp_edge_cases(dtype):
 def test_logaddexp_empty_tensor():
     x = torch.empty(0, dtype=torch.float32, device=flag_gems.device)
     y = torch.empty(0, dtype=torch.float32, device=flag_gems.device)
-    ref_x = utils.to_reference(x, True)
-    ref_y = utils.to_reference(y, True)
+    ref_x = utils.to_reference(x)
+    ref_y = utils.to_reference(y)
     ref_out = torch.logaddexp(ref_x, ref_y)
     with flag_gems.use_gems():
         res_out = torch.logaddexp(x, y)

--- a/tests/test_logaddexp.py
+++ b/tests/test_logaddexp.py
@@ -81,7 +81,9 @@ def test_logaddexp_edge_cases(dtype):
 def test_logaddexp_empty_tensor():
     x = torch.empty(0, dtype=torch.float32, device=flag_gems.device)
     y = torch.empty(0, dtype=torch.float32, device=flag_gems.device)
-    ref_out = torch.logaddexp(x, y)
+    ref_x = utils.to_reference(x, True)
+    ref_y = utils.to_reference(y, True)
+    ref_out = torch.logaddexp(ref_x, ref_y)
     with flag_gems.use_gems():
         res_out = torch.logaddexp(x, y)
     utils.gems_assert_equal(res_out, ref_out)


### PR DESCRIPTION
## Summary

Replace the existing KernelGen-migrated `logaddexp` with a hand-written Triton implementation, plus comprehensive accuracy tests.

## Implementation

Numerically stable shifted form:
```
logaddexp(x, y) = m + log(1 + exp(-|x - y|))
```
where `m = max(x, y)`. The argument of `exp` is always in `(-inf, 0]`, so the formula stays finite even when `x` or `y` are large enough that `exp(x)` would overflow. fp32 accumulation is used for fp16/bf16 inputs.

## Tests added (`tests/test_logaddexp.py`)

- Shape coverage from `POINTWISE_SHAPES` across all FLOAT_DTYPES
- Broadcast shapes `(4, 1, 8)` x `(1, 6, 8)`
- Large values (e.g. 50, -50) that would overflow `exp` in fp16/bf16 if computed naively
- Edge cases: 0, -0, +/- inf, NaN combinations
- Empty tensor
- `.out` variant via `torch.ops.aten.logaddexp.out`