### PR TITLE
Optimize accuracy tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,13 +26,14 @@ REGISTERED_MARKS = []
 TEST_RESULTS = {}
 RUNTEST_INFO = {}
 RECORD_LOG = False
+RECORD_JSON = False
 TO_CPU = False
 QUICK_MODE = False
 
 device = flag_gems.device
 
 TIMESTAMP = datetime.now().strftime("%Y%m%d_%H%M%S")
-REPORT_FILE = f"report_{TIMESTAMP}.json"
+REPORT_FILE = "accuracy_result.json"
 
 
 def pytest_addoption(parser):
@@ -57,9 +58,14 @@ def pytest_addoption(parser):
             action="store",
             default="none",
             required=False,
-            choices=["none", "log"],
-            help="tests function param recorded in log files or not",
+            choices=["none", "log", "json"],
+            help="record test results in log/json files or not",
         )
+        parser.addoption(
+            "--output",
+            help="path to the result file",
+        )
+
     except ValueError:
         # Mixed test+benchmark pytest runs may already register --record in
         # benchmark/conftest.py. Reuse the existing option in that case.
@@ -79,6 +85,8 @@ def pytest_addoption(parser):
 
 def pytest_configure(config):
     global RECORD_LOG
+    global RECORD_JSON
+    global REPORT_FILE
     global REGISTERED_MARKS
     global RUNTEST_INFO
     global TO_CPU
@@ -89,8 +97,14 @@ def pytest_configure(config):
     }
 
     RECORD_LOG = config.getoption("--record") == "log"
+    RECORD_JSON = config.getoption("--record") == "json"
     TO_CPU = config.getoption("--ref") == "cpu"
     QUICK_MODE = config.getoption("--quick") is True
+
+    if RECORD_JSON:
+        report_file = config.getoption("--output")
+        if report_file:
+            REPORT_FILE = report_file
 
     if RECORD_LOG:
         RUNTEST_INFO = {}
@@ -183,7 +197,7 @@ def pytest_terminal_summary(terminalreporter):
         existing_data.update(TEST_RESULTS)
         data = existing_data
 
-    with open(f"result_{TIMESTAMP}.json", "w") as json_file:
+    with open(REPORT_FILE, "w") as json_file:
         json.dump(data, json_file, indent=2, default=str)
 
 

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -222,36 +222,58 @@ def run_cmd_capture(cmd, cwd=None, env=None):
     return out or "", err or "", p.returncode
 
 
-def parse_accuracy_log(text):
-    record = {
-        "status": "",
-        "total": 0,
-        "passed": 0,
-        "failed": 0,
-        "skipped": 0,
-        "errors": 0,
+def parse_accuracy_data(op, result_file):
+    raw_data = {}
+    with result_file.open("r") as f:
+        raw_data = json.load(f)
+
+    passed = []
+    skipped = {}
+    failed = {}
+    for test_case, item in raw_data.items():
+        case_str = test_case[: test_case.find("[")]
+        result = item.get("result", "")
+        params = [case_str]
+        for k, v in item.get("params", {}).items():
+            params.append(str(v).replace(" ", ""))
+        param_str = ":".join(params)
+
+        if result == "passed":
+            passed.append(param_str)
+        elif result == "skipped":
+            reason = item.get("reason", "Unknown")
+            skipped.setdefault(reason, set())
+            skipped[reason].add(param_str)
+        else:
+            reason = item.get("reason", "Unknown")
+            failed.setdefault(reason, set())
+            failed[reason].add(param_str)
+
+    # TODO: Add errors
+    result = {
+        "total": len(skipped) + len(failed) + len(passed),
+        "skipped": len(skipped),
+        "failed": len(failed),
+        "passed": len(passed),
+        "details": {},
     }
-
-    clean = ANSI_RE.sub("", text)
-    for m in re.finditer(r"(\d+)\s+([A-Za-z_]+)", clean):
-        num = int(m.group(1))
-        key = m.group(2).lower()
-        if key in record:
-            record[key] = num
-
-    total = record["failed"] + record["passed"] + record["skipped"]
-    record["total"] = total
-
-    if record["failed"] > 0:
-        record["status"] = "FAIL"
-    elif record["errors"] > 0 and total == 0:
-        record["status"] = "FAIL"  # pytest failed to start
-    elif record["passed"] == 0:
-        record["status"] = "FAIL"
+    if len(skipped) == 0 and len(failed) == 0:
+        if len(passed) == 0:
+            result["status"] = "NotFound"
+        else:
+            result["status"] = "Passed"
     else:
-        record["status"] = "PASS"
+        result["status"] = "Failed"
+        if len(skipped):
+            for k, v in skipped.items():
+                skipped[k] = list(v)
+            result["details"]["skipped"] = skipped
+        if len(failed):
+            for k, v in failed.items():
+                failed[k] = list(v)
+            result["details"]["failed"] = failed
 
-    return record
+    return result
 
 
 def get_env(gpu_ids):
@@ -306,12 +328,19 @@ def run_accuracy(gpu_id, start, index, count):
     env = get_env(str(gpu_id))
 
     if op in NO_CPU_LIST:
-        cmd = f'pytest -m "{op}" -vs'
+        cmd = f'pytest -m "{op}" --record json --output accuracy_{op}.json -vs'
     else:
-        cmd = f'pytest -m "{op}" --ref cpu -vs'
+        cmd = (
+            f'pytest -m "{op}" --record json --output accuracy_{op}.json --ref cpu -vs'
+        )
+
+    accuracy_dir = ROOT.joinpath("tests")
+    result_file = accuracy_dir / f"accuracy_{op}.json"
+    if result_file.exists():
+        result_file.unlink()
 
     start = time.time()
-    stdout, stderr, code = run_cmd_capture(cmd, cwd=ROOT.joinpath("tests"), env=env)
+    stdout, stderr, code = run_cmd_capture(cmd, cwd=accuracy_dir, env=env)
     end = time.time()
 
     if code == TIMEOUT:  # Timeout
@@ -326,22 +355,20 @@ def run_accuracy(gpu_id, start, index, count):
             "duration": end - start,
         }
 
-    combined = stdout + "\n---\n" + stderr
     op_dir = OUTPUT_DIR.joinpath(op)
-    log_file = op_dir.joinpath("accuracy.log")
-    with open(log_file, "w") as f:
-        f.write(combined)
+    dest = op_dir / "accuracy_result.json"
+    shutil.move(result_file, str(dest))
+    result_file = dest
 
-    result = parse_accuracy_log(combined)
+    result = parse_accuracy_data(op, result_file)
     result["exit_code"] = code
     result["duration"] = end - start
-    result["log_file"] = str(log_file.relative_to(OUTPUT_DIR))
+    result["data_file"] = str(result_file.relative_to(OUTPUT_DIR))
 
     return result
 
 
-def parse_perf_data(op, op_dir):
-    result_file = op_dir / "performance_result.json"
+def parse_perf_data(op, result_file):
     raw_data = {}
     with result_file.open("r") as f:
         raw_data = json.load(f)
@@ -441,10 +468,10 @@ def run_benchmark(gpu_id, start, index, count):
     record = {
         "duration": end - start,
         "exit_code": code,
-        "result_file": str(result_file.relative_to(OUTPUT_DIR)),
+        "data_file": str(result_file.relative_to(OUTPUT_DIR)),
         "data": [],
     }
-    record.update(parse_perf_data(op, op_dir))
+    record.update(parse_perf_data(op, result_file))
 
     return record
 


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Optimization

### Description

This PR tweaks the accuracy test workflow and hooks so that we don't depend on the log output from tests. Be eliminating the dependency on logs, we can later remove the pipes with the sub-process which has been reported as buggy when timeout is set.

The JSON output from the accuracy test can be further improved (simplified) in a future PR.