### PR TITLE
[kunlunxin]: Fix gather IndexError check before restride_dim

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/gather.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/gather.py
@@ -280,6 +280,11 @@ def gather(inp, dim, index, out=None, sparse_grad=False):
     logger.debug("GEMS GATHER")
     if dim < 0:
         dim += inp.ndim
+    if inp.ndim != index.ndim:
+        raise IndexError(
+            f"Index tensor must have the same number of dimensions as input tensor. "
+            f"Got {index.ndim} and {inp.ndim}."
+        )
     inp = inp.contiguous()
     index = index.contiguous()
     if out is None:


### PR DESCRIPTION

### Root Cause

In `src/flag_gems/runtime/backend/_kunlunxin/ops/gather.py:290`, the `restride_dim` function is called before checking if the input and index tensors have the same number of dimensions. This causes `as_strided` to fail when the shapes have different lengths.

### Solution

Add a dimension mismatch check before calling `restride_dim`. If dimensions don't match, raise `IndexError` with a clear message, which is the expected behavior per PyTorch's specification.

### Test

The fix correctly handles the test case that validates IndexError is raised for ndim mismatch:

```python
mismatch_inp = torch.randn((512, 128, 32), dtype=torch.float32, device=flag_gems.device)
mismatch_index = torch.zeros((512, 128), dtype=torch.long, device=flag_gems.device)
with pytest.raises(IndexError):
    torch.gather(mismatch_inp, 0, mismatch_index)