### PR TITLE
[FlagGems Operator Development Competition] add upsample_nearest2d_backward operator

### DIFF
--- a/benchmark/test_upsample_nearest2d.py
+++ b/benchmark/test_upsample_nearest2d.py
@@ -27,12 +27,41 @@ def _input_fn(shape, dtype, device):
     },
 
 
+def _backward_input_fn(shape, dtype, device):
+    batch, channel, height, width = shape
+    scale_factors = (2, 2)
+    OH = int(height * scale_factors[0])
+    OW = int(width * scale_factors[1])
+    grad_output = torch.randn(batch, channel, OH, OW, device=device, dtype=dtype)
+    output_size = (OH, OW)
+    input_size = (batch, channel, height, width)
+    yield {
+        "grad_output": grad_output,
+        "output_size": output_size,
+        "input_size": input_size,
+        "scales_h": None,
+        "scales_w": None,
+    },
+
+
 @pytest.mark.upsample_nearest2d
 def test_upsample_nearest2d():
     bench = UpsampleBenchmark(
         op_name="upsample_nearest2d",
         input_fn=_input_fn,
         torch_op=torch._C._nn.upsample_nearest2d,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+
+    bench.run()
+
+
+@pytest.mark.upsample_nearest2d_backward
+def test_upsample_nearest2d_backward():
+    bench = UpsampleBenchmark(
+        op_name="upsample_nearest2d_backward",
+        input_fn=_backward_input_fn,
+        torch_op=torch.ops.aten.upsample_nearest2d_backward.default,
         dtypes=consts.FLOAT_DTYPES,
     )
 

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -484,6 +484,7 @@ _FULL_CONFIG = (
     ("upsample_linear1d", upsample_linear1d),
     ("upsample_nearest1d", upsample_nearest1d),
     ("upsample_nearest2d", upsample_nearest2d),
+    ("upsample_nearest2d_backward", upsample_nearest2d_backward),
     ("upsample_nearest3d", upsample_nearest3d),
     ("var_mean.correction", var_mean),
     ("var", var),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -330,6 +330,7 @@ from flag_gems.ops.upsample_bicubic2d_aa_backward import _upsample_bicubic2d_aa_
 from flag_gems.ops.upsample_linear1d import upsample_linear1d
 from flag_gems.ops.upsample_nearest1d import upsample_nearest1d
 from flag_gems.ops.upsample_nearest2d import upsample_nearest2d
+from flag_gems.ops.upsample_nearest2d_backward import upsample_nearest2d_backward
 from flag_gems.ops.upsample_nearest3d import upsample_nearest3d
 from flag_gems.ops.var import var, var_correction, var_dim
 from flag_gems.ops.var_mean import var_mean
@@ -779,6 +780,7 @@ __all__ = [
     "upsample_linear1d",
     "upsample_nearest1d",
     "upsample_nearest2d",
+    "upsample_nearest2d_backward",
     "upsample_nearest3d",
     "var_mean",
     "var",

--- a/src/flag_gems/ops/upsample_nearest2d_backward.py
+++ b/src/flag_gems/ops/upsample_nearest2d_backward.py
@@ -1,0 +1,180 @@
+import logging
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.runtime import device, torch_device_fn
+
+device = device.name
+logger = logging.getLogger(__name__)
+
+
+def _build_range_lut(
+    output_size: int,
+    input_size: int,
+    scale: Optional[float],
+    device: torch.device,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    fwd_scale = scale if scale is not None else (output_size / input_size)
+    k = torch.arange(input_size, dtype=torch.float32, device=device)
+    starts = torch.ceil(k * fwd_scale).to(torch.int32).clamp(max=output_size)
+    ends = torch.ceil((k + 1) * fwd_scale).to(torch.int32).clamp(max=output_size)
+    return starts, ends
+
+
+def _is_integer_scale(
+    output_size: int, input_size: int, scale: Optional[float]
+) -> int:
+    if scale is not None:
+        s = int(scale)
+        return s if float(s) == scale else 0
+    return output_size // input_size if output_size % input_size == 0 else 0
+
+
+@triton.autotune(
+    configs=runtime.get_tuned_config("upsample_nearest2d_backward"),
+    key=["N", "C", "IH", "IW", "OH", "OW"],
+)
+@triton.jit
+def upsample_nearest2d_backward_kernel(
+    ptr_go,
+    ptr_gi,
+    ptr_h_start,
+    ptr_h_end,
+    ptr_w_start,
+    ptr_w_end,
+    N,
+    C,
+    OH,
+    OW,
+    IH,
+    IW,
+    SCALE_H_INT: tl.constexpr,
+    SCALE_W_INT: tl.constexpr,
+    MAX_RANGE_H: tl.constexpr,
+    MAX_RANGE_W: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    NC_PER_BLOCK: tl.constexpr,
+):
+    pid_spatial = tl.program_id(axis=0)
+    pid_nc_grp = tl.program_id(axis=1)
+
+    idx = pid_spatial * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    iw = idx % IW
+    ih = idx // IW % IH
+    mask = idx < IH * IW
+
+    NC = N * C
+    nc_grp_stride = tl.num_programs(axis=1)
+    nc_iter = pid_nc_grp * NC_PER_BLOCK
+
+    while nc_iter < NC:
+        for nc_off in range(NC_PER_BLOCK):
+            nc = nc_iter + nc_off
+            if nc < NC:
+                grad = tl.zeros([BLOCK_SIZE], dtype=tl.float32)
+
+                if SCALE_H_INT > 0:
+                    oh_base = SCALE_H_INT * ih
+                    ow_base = SCALE_W_INT * iw
+                    for dh in range(SCALE_H_INT):
+                        oh = oh_base + dh
+                        row_off = nc * OH * OW + oh * OW
+                        for dw in range(SCALE_W_INT):
+                            ow = ow_base + dw
+                            active = mask & (ow < OW)
+                            g = tl.load(
+                                ptr_go + row_off + ow, mask=active, other=0.0
+                            )
+                            grad += g.to(tl.float32)
+                else:
+                    oh_s = tl.load(ptr_h_start + ih, mask=mask, other=0)
+                    oh_e = tl.load(ptr_h_end + ih, mask=mask, other=0)
+                    ow_s = tl.load(ptr_w_start + iw, mask=mask, other=0)
+                    ow_e = tl.load(ptr_w_end + iw, mask=mask, other=0)
+                    for dh in range(MAX_RANGE_H):
+                        oh = oh_s + dh
+                        valid_h = dh < (oh_e - oh_s)
+                        for dw in range(MAX_RANGE_W):
+                            ow = ow_s + dw
+                            valid_w = dw < (ow_e - ow_s)
+                            active = valid_h & valid_w & mask
+                            g = tl.load(
+                                ptr_go + nc * OH * OW + oh * OW + ow,
+                                mask=active,
+                                other=0.0,
+                            )
+                            grad += g.to(tl.float32)
+
+                tl.store(ptr_gi + nc * IH * IW + ih * IW + iw, grad, mask=mask)
+
+        nc_iter += nc_grp_stride * NC_PER_BLOCK
+
+
+def upsample_nearest2d_backward(
+    grad_output: torch.Tensor,
+    output_size: Tuple[int, int],
+    input_size: Tuple[int, int, int, int],
+    scales_h: Optional[float] = None,
+    scales_w: Optional[float] = None,
+) -> torch.Tensor:
+    logger.debug("GEMS UPSAMPLE NEAREST2D BACKWARD")
+    assert grad_output.device.type == device
+    assert grad_output.ndim == 4, "grad_output must be 4-D"
+
+    OH, OW = output_size
+    N, C, IH, IW = input_size
+
+    if N * C * IH * IW == 0 or OH * OW == 0:
+        return torch.zeros(
+            (N, C, IH, IW), device=grad_output.device, dtype=grad_output.dtype
+        )
+
+    scale_h_int = _is_integer_scale(OH, IH, scales_h)
+    scale_w_int = _is_integer_scale(OW, IW, scales_w)
+
+    if scale_h_int > 0 and scale_w_int > 0:
+        max_range_h, max_range_w = scale_h_int, scale_w_int
+        h_start = h_end = w_start = w_end = grad_output
+    else:
+        with torch_device_fn.device(grad_output.device):
+            h_start, h_end = _build_range_lut(OH, IH, scales_h, grad_output.device)
+            w_start, w_end = _build_range_lut(OW, IW, scales_w, grad_output.device)
+        max_range_h = max(int((h_end - h_start).max().item()), 1)
+        max_range_w = max(int((w_end - w_start).max().item()), 1)
+
+    # allocate output
+    grad_input = torch.empty(
+        (N, C, IH, IW), device=grad_output.device, dtype=grad_output.dtype
+    )
+
+    total_elements = IH * IW
+    grid = lambda META: (
+        triton.cdiv(total_elements, META["BLOCK_SIZE"]),
+        triton.cdiv(N * C, META["NC_PER_BLOCK"]),
+    )
+
+    with torch_device_fn.device(grad_output.device):
+        upsample_nearest2d_backward_kernel[grid](
+            grad_output.contiguous(),
+            grad_input,
+            h_start,
+            h_end,
+            w_start,
+            w_end,
+            N,
+            C,
+            OH,
+            OW,
+            IH,
+            IW,
+            SCALE_H_INT=scale_h_int,
+            SCALE_W_INT=scale_w_int,
+            MAX_RANGE_H=max_range_h,
+            MAX_RANGE_W=max_range_w,
+        )
+
+    return grad_input

--- a/src/flag_gems/ops/upsample_nearest2d_backward.py
+++ b/src/flag_gems/ops/upsample_nearest2d_backward.py
@@ -25,9 +25,7 @@ def _build_range_lut(
     return starts, ends
 
 
-def _is_integer_scale(
-    output_size: int, input_size: int, scale: Optional[float]
-) -> int:
+def _is_integer_scale(output_size: int, input_size: int, scale: Optional[float]) -> int:
     if scale is not None:
         s = int(scale)
         return s if float(s) == scale else 0
@@ -86,9 +84,7 @@ def upsample_nearest2d_backward_kernel(
                         for dw in range(SCALE_W_INT):
                             ow = ow_base + dw
                             active = mask & (ow < OW)
-                            g = tl.load(
-                                ptr_go + row_off + ow, mask=active, other=0.0
-                            )
+                            g = tl.load(ptr_go + row_off + ow, mask=active, other=0.0)
                             grad += g.to(tl.float32)
                 else:
                     oh_s = tl.load(ptr_h_start + ih, mask=mask, other=0)

--- a/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
@@ -1065,6 +1065,17 @@ upsample_nearest2d:
     block_n: [1024, 2048]
     warps: [4, 8]
 
+upsample_nearest2d_backward:
+  - gen: true
+    param_map:
+      META:
+        BLOCK_SIZE: block_n
+        NC_PER_BLOCK: nc_per_block
+      num_warps: warps
+    block_n: [64, 256, 512, 1024]
+    nc_per_block: [4, 8, 16]
+    warps: [4, 8]
+
 upsample_nearest3d:
   - gen: true
     param_map:

--- a/tests/test_upsample_nearest2d.py
+++ b/tests/test_upsample_nearest2d.py
@@ -25,3 +25,70 @@ def test_upsample_nearest2d(dtype, shape, scale):
         res_out = torch._C._nn.upsample_nearest2d(input, output_size=output_size)
 
     utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.upsample_nearest2d_backward
+@pytest.mark.parametrize("scale", [(2, 2), (2.1, 3.7), (1.3, 5.1), (0.3, 0.5)])
+@pytest.mark.parametrize("shape", utils.UPSAMPLE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_upsample_nearest2d_backward(dtype, shape, scale):
+    output_size = [int(shape[i + 2] * scale[i]) for i in range(2)]
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+
+    ref_out = torch._C._nn.upsample_nearest2d(ref_inp, output_size=output_size)
+    out_grad = torch.randn_like(ref_out, dtype=dtype, device=flag_gems.device)
+    ref_out_grad = utils.to_reference(out_grad).to(torch.float32)
+
+    ref_grad_in = torch.ops.aten.upsample_nearest2d_backward.default(
+        ref_out_grad,
+        output_size,
+        list(shape),
+        None,
+        None,
+    )
+
+    with flag_gems.use_gems():
+        gem_grad_in = torch.ops.aten.upsample_nearest2d_backward.default(
+            out_grad,
+            output_size,
+            list(shape),
+            None,
+            None,
+        )
+
+    utils.gems_assert_close(gem_grad_in, ref_grad_in.to(dtype), dtype)
+
+
+@pytest.mark.upsample_nearest2d_backward
+@pytest.mark.parametrize(
+    "scales_h,scales_w", [(None, None), (2.0, 2.0), (1.5, 1.5), (0.5, 0.5)]
+)
+@pytest.mark.parametrize("shape", [(4, 8, 16, 16), (2, 3, 7, 5)])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_upsample_nearest2d_backward_with_scales(dtype, shape, scales_h, scales_w):
+    N, C, IH, IW = shape
+    if scales_h is None:
+        OH, OW = IH * 2, IW * 2
+    else:
+        OH, OW = int(IH * scales_h), int(IW * scales_w)
+    if OH == 0 or OW == 0:
+        pytest.skip("degenerate output size")
+
+    output_size = [OH, OW]
+    input_size = list(shape)
+
+    grad_out = torch.randn(N, C, OH, OW, dtype=dtype, device=flag_gems.device)
+    ref_grad_out = utils.to_reference(grad_out).to(torch.float32)
+
+    ref_grad_in = torch.ops.aten.upsample_nearest2d_backward.default(
+        ref_grad_out, output_size, input_size, scales_h, scales_w
+    )
+
+    with flag_gems.use_gems():
+        gem_grad_in = torch.ops.aten.upsample_nearest2d_backward.default(
+            grad_out, output_size, input_size, scales_h, scales_w
+        )
+
+    utils.gems_assert_close(gem_grad_in, ref_grad_in.to(dtype), dtype)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
 Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
 New Feature
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
 Add upsample_nearest2d_backward operator.
 Add accuracy tests for upsample_nearest2d_backward operator.
 Add benchmark for upsample_nearest2d_backward operator.

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
Run benchmark with: `pytest benchmark/test_upsample_nearest2d.py -m upsample_nearest2d_backward -s`
<img width="2076" height="830" alt="image" src="https://github.com/user-attachments/assets/ef696c9c-3c42-43a8-ac3e-385f978752c4" />

### Tests
Run tests with: `pytest tests/test_upsample_nearest2d.py -m upsample_nearest2d_backward`
<img width="2019" height="212" alt="image" src="https://github.com/user-attachments/assets/6a43d674-1ba8-431c-8e6a-930c3d5dad6e" />
