### PR TITLE
[SiliconFlow] Fix and optimize select_backward on Ascend NPU

### DIFF
--- a/benchmark/test_select_backward.py
+++ b/benchmark/test_select_backward.py
@@ -3,16 +3,6 @@ import torch
 
 from . import base, consts, utils
 
-_BASE_2D_SIZE = 1024
-_BASE_3D_SIZE = 64
-_MIN_EXPONENT = 0
-_MAX_2D_EXPONENT = 20
-_MAX_3D_EXPONENT = 15
-_EXPONENT_STEP = 4
-_FIRST_DIM = 0
-_DEFAULT_SELECT_DIM = 1
-_INDEX_DIVISOR = 2
-
 
 class SelectBackwardBenchmark(base.Benchmark):
     """
@@ -20,14 +10,8 @@ class SelectBackwardBenchmark(base.Benchmark):
     """
 
     def set_more_shapes(self):
-        special_shapes_2d = [
-            (_BASE_2D_SIZE, 2**exponent)
-            for exponent in range(_MIN_EXPONENT, _MAX_2D_EXPONENT, _EXPONENT_STEP)
-        ]
-        special_shapes_3d = [
-            (_BASE_3D_SIZE, _BASE_3D_SIZE, 2**exponent)
-            for exponent in range(_MIN_EXPONENT, _MAX_3D_EXPONENT, _EXPONENT_STEP)
-        ]
+        special_shapes_2d = [(1024, 2**exponent) for exponent in range(0, 20, 4)]
+        special_shapes_3d = [(64, 64, 2**exponent) for exponent in range(0, 15, 4)]
         return special_shapes_2d + special_shapes_3d
 
     def get_input_iter(self, cur_dtype):
@@ -35,9 +19,9 @@ class SelectBackwardBenchmark(base.Benchmark):
             x = utils.generate_tensor_input(shape, cur_dtype, self.device)
             ndim = len(shape)
 
-            dim = _DEFAULT_SELECT_DIM if ndim > _DEFAULT_SELECT_DIM else _FIRST_DIM
+            dim = 1 if ndim > 1 else 0
             actual_dim = dim if dim >= 0 else dim + ndim
-            index = shape[actual_dim] // _INDEX_DIVISOR
+            index = shape[actual_dim] // 2
 
             y = torch.select(x, actual_dim, index)
             grad = torch.randn_like(y)
@@ -50,15 +34,11 @@ class SelectBackwardBenchmark(base.Benchmark):
 
 
 @pytest.mark.select_backward
-@pytest.mark.parametrize(
-    "dtype",
-    consts.FLOAT_DTYPES,
-)
-def test_select_backward_perf(dtype):
+def test_select_backward():
     bench = SelectBackwardBenchmark(
         op_name="select_backward",
         torch_op=torch.ops.aten.select_backward,
-        dtypes=[dtype],
+        dtypes=consts.FLOAT_DTYPES,
     )
 
     bench.run()

--- a/benchmark/test_select_backward_perf.py
+++ b/benchmark/test_select_backward_perf.py
@@ -1,0 +1,65 @@
+import pytest
+import torch
+
+from . import attri_util as attr_utils
+from . import performance_utils as utils
+
+_BASE_2D_SIZE = 1024
+_BASE_3D_SIZE = 64
+_MIN_EXPONENT = 0
+_MAX_2D_EXPONENT = 20
+_MAX_3D_EXPONENT = 15
+_EXPONENT_STEP = 4
+_FIRST_DIM = 0
+_DEFAULT_SELECT_DIM = 1
+_INDEX_DIVISOR = 2
+
+
+class SelectBackwardBenchmark(utils.Benchmark):
+    """
+    Benchmark for select_backward operator.
+    """
+
+    def set_more_shapes(self):
+        special_shapes_2d = [
+            (_BASE_2D_SIZE, 2**exponent)
+            for exponent in range(_MIN_EXPONENT, _MAX_2D_EXPONENT, _EXPONENT_STEP)
+        ]
+        special_shapes_3d = [
+            (_BASE_3D_SIZE, _BASE_3D_SIZE, 2**exponent)
+            for exponent in range(_MIN_EXPONENT, _MAX_3D_EXPONENT, _EXPONENT_STEP)
+        ]
+        return special_shapes_2d + special_shapes_3d
+
+    def get_input_iter(self, cur_dtype):
+        for shape in self.shapes:
+            x = utils.generate_tensor_input(shape, cur_dtype, self.device)
+            ndim = len(shape)
+
+            dim = _DEFAULT_SELECT_DIM if ndim > _DEFAULT_SELECT_DIM else _FIRST_DIM
+            actual_dim = dim if dim >= 0 else dim + ndim
+            index = shape[actual_dim] // _INDEX_DIVISOR
+
+            y = torch.select(x, actual_dim, index)
+            grad = torch.randn_like(y)
+
+            yield grad, shape, actual_dim, index
+
+    def get_tflops(self, op, *args, **kwargs):
+        grad = args[0]
+        return grad.numel()
+
+
+@pytest.mark.select_backward
+@pytest.mark.parametrize(
+    "dtype",
+    attr_utils.FLOAT_DTYPES,
+)
+def test_select_backward_perf(dtype):
+    bench = SelectBackwardBenchmark(
+        op_name="select_backward",
+        torch_op=torch.ops.aten.select_backward,
+        dtypes=[dtype],
+    )
+
+    bench.run()

--- a/benchmark/test_select_backward_perf.py
+++ b/benchmark/test_select_backward_perf.py
@@ -1,8 +1,7 @@
 import pytest
 import torch
 
-from . import attri_util as attr_utils
-from . import performance_utils as utils
+from . import base, consts, utils
 
 _BASE_2D_SIZE = 1024
 _BASE_3D_SIZE = 64
@@ -15,7 +14,7 @@ _DEFAULT_SELECT_DIM = 1
 _INDEX_DIVISOR = 2
 
 
-class SelectBackwardBenchmark(utils.Benchmark):
+class SelectBackwardBenchmark(base.Benchmark):
     """
     Benchmark for select_backward operator.
     """
@@ -53,7 +52,7 @@ class SelectBackwardBenchmark(utils.Benchmark):
 @pytest.mark.select_backward
 @pytest.mark.parametrize(
     "dtype",
-    attr_utils.FLOAT_DTYPES,
+    consts.FLOAT_DTYPES,
 )
 def test_select_backward_perf(dtype):
     bench = SelectBackwardBenchmark(

--- a/src/flag_gems/ops/select_backward.py
+++ b/src/flag_gems/ops/select_backward.py
@@ -5,7 +5,6 @@ import triton
 import triton.language as tl
 
 _BLOCK_SIZE = 1024
-_SMALL_NUMEL_THRESHOLD = 4096
 
 
 @triton.jit
@@ -28,43 +27,6 @@ def _select_backward_kernel(
 
     vals = tl.load(grad_ptr + offs, mask=mask)
     out_offset = outer * dim_stride + index * inner_size + inner
-
-    tl.store(out_ptr + out_offset, vals, mask=mask)
-
-
-@triton.jit
-def _select_backward_dim0_kernel(
-    grad_ptr,
-    out_ptr,
-    total: tl.constexpr,
-    base: tl.constexpr,
-    BLOCK: tl.constexpr,
-):
-    pid = tl.program_id(0)
-
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
-    mask = offs < total
-
-    vals = tl.load(grad_ptr + offs, mask=mask)
-    tl.store(out_ptr + base + offs, vals, mask=mask)
-
-
-@triton.jit
-def _select_backward_lastdim_kernel(
-    grad_ptr,
-    out_ptr,
-    total: tl.constexpr,
-    dim_size: tl.constexpr,
-    index: tl.constexpr,
-    BLOCK: tl.constexpr,
-):
-    pid = tl.program_id(0)
-
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
-    mask = offs < total
-
-    vals = tl.load(grad_ptr + offs, mask=mask)
-    out_offset = offs * dim_size + index
 
     tl.store(out_ptr + out_offset, vals, mask=mask)
 
@@ -138,11 +100,9 @@ def _launch_select_backward(grad, input_sizes, dim, index, out=None):
 
     outer_size = math.prod(sizes[:dim]) if dim > 0 else 1
     inner_size = math.prod(sizes[dim + 1 :]) if dim < ndim - 1 else 1
-    out_numel = math.prod(sizes)
 
     outer_size = int(outer_size)
     inner_size = int(inner_size)
-    out_numel = int(out_numel)
 
     total = outer_size * inner_size
 
@@ -160,11 +120,6 @@ def _launch_select_backward(grad, input_sizes, dim, index, out=None):
         if out.device != grad.device:
             raise ValueError("device mismatch")
 
-    if out_numel <= _SMALL_NUMEL_THRESHOLD:
-        out.zero_()
-        out.select(dim, index).copy_(grad)
-        return out
-
     out.zero_()
 
     if total == 0:
@@ -174,33 +129,6 @@ def _launch_select_backward(grad, input_sizes, dim, index, out=None):
         grad = grad.contiguous()
 
     grad_view = grad.view(total)
-
-    if dim == 0:
-        grid = (triton.cdiv(total, _BLOCK_SIZE),)
-        base = index * inner_size
-
-        _select_backward_dim0_kernel[grid](
-            grad_view,
-            out,
-            total,
-            base,
-            BLOCK=_BLOCK_SIZE,
-        )
-        return out
-
-    # Last-dim select avoids division and modulo in the generic kernel.
-    if inner_size == 1:
-        grid = (triton.cdiv(total, _BLOCK_SIZE),)
-
-        _select_backward_lastdim_kernel[grid](
-            grad_view,
-            out,
-            total,
-            dim_size,
-            index,
-            BLOCK=_BLOCK_SIZE,
-        )
-        return out
 
     grid = (triton.cdiv(total, _BLOCK_SIZE),)
     dim_stride = dim_size * inner_size

--- a/src/flag_gems/ops/select_backward.py
+++ b/src/flag_gems/ops/select_backward.py
@@ -4,9 +4,12 @@ import torch
 import triton
 import triton.language as tl
 
+_BLOCK_SIZE = 1024
+_SMALL_NUMEL_THRESHOLD = 4096
+
 
 @triton.jit
-def _select_backward_kernel(
+def _cuda_select_backward_kernel(
     grad_ptr,
     out_ptr,
     outer_size,
@@ -32,20 +35,228 @@ def _select_backward_kernel(
     tl.store(out_ptr + out_offset, grad_vals, mask=mask)
 
 
-def _launch_select_backward(grad, input_sizes, dim, index, out=None):
-    if not grad.is_cuda:
-        raise ValueError("grad must be CUDA tensor")
+@triton.jit
+def _select_backward_kernel(
+    grad_ptr,
+    out_ptr,
+    total: tl.constexpr,
+    inner_size: tl.constexpr,
+    dim_stride: tl.constexpr,
+    index: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
 
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < total
+
+    outer = offs // inner_size
+    inner = offs % inner_size
+
+    vals = tl.load(grad_ptr + offs, mask=mask)
+    out_offset = outer * dim_stride + index * inner_size + inner
+
+    tl.store(out_ptr + out_offset, vals, mask=mask)
+
+
+@triton.jit
+def _select_backward_dim0_kernel(
+    grad_ptr,
+    out_ptr,
+    total: tl.constexpr,
+    base: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < total
+
+    vals = tl.load(grad_ptr + offs, mask=mask)
+    tl.store(out_ptr + base + offs, vals, mask=mask)
+
+
+@triton.jit
+def _select_backward_lastdim_kernel(
+    grad_ptr,
+    out_ptr,
+    total: tl.constexpr,
+    dim_size: tl.constexpr,
+    index: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0)
+
+    offs = pid * BLOCK + tl.arange(0, BLOCK)
+    mask = offs < total
+
+    vals = tl.load(grad_ptr + offs, mask=mask)
+    out_offset = offs * dim_size + index
+
+    tl.store(out_ptr + out_offset, vals, mask=mask)
+
+
+def _ascend_launch_select_backward(grad, input_sizes, dim, index, out=None):
     dim = int(dim)
     index = int(index)
 
-    sizes = list(input_sizes)
+    sizes = tuple(input_sizes)
     ndim = len(sizes)
 
     if dim < 0:
         dim += ndim
+        if dim < 0:
+            raise ValueError("invalid dim")
+    elif dim >= ndim:
+        raise ValueError("invalid dim")
 
-    if dim < 0 or dim >= ndim:
+    dim_size = int(sizes[dim])
+
+    if index < 0:
+        index += dim_size
+        if index < 0:
+            raise ValueError("index out of range")
+    elif index >= dim_size:
+        raise ValueError("index out of range")
+
+    if out is None:
+        out = torch.empty(
+            sizes,
+            dtype=grad.dtype,
+            device=grad.device,
+        )
+    else:
+        if out.shape != sizes:
+            raise ValueError("out shape mismatch")
+        if out.dtype != grad.dtype:
+            raise ValueError("dtype mismatch")
+        if out.device != grad.device:
+            raise ValueError("device mismatch")
+
+    # Ascend 910B: CANN's native zero + strided copy is faster than launching
+    # a Triton scatter kernel for this op.
+    out.zero_()
+    out.select(dim, index).copy_(grad)
+    return out
+
+
+def _launch_select_backward(grad, input_sizes, dim, index, out=None):
+    dim = int(dim)
+    index = int(index)
+
+    sizes = tuple(input_sizes)
+    ndim = len(sizes)
+
+    if dim < 0:
+        dim += ndim
+        if dim < 0:
+            raise ValueError("invalid dim")
+    elif dim >= ndim:
+        raise ValueError("invalid dim")
+
+    dim_size = int(sizes[dim])
+
+    if index < 0:
+        index += dim_size
+        if index < 0:
+            raise ValueError("index out of range")
+    elif index >= dim_size:
+        raise ValueError("index out of range")
+
+    outer_size = math.prod(sizes[:dim]) if dim > 0 else 1
+    inner_size = math.prod(sizes[dim + 1 :]) if dim < ndim - 1 else 1
+    out_numel = math.prod(sizes)
+
+    outer_size = int(outer_size)
+    inner_size = int(inner_size)
+    out_numel = int(out_numel)
+
+    total = outer_size * inner_size
+
+    if out is None:
+        out = torch.empty(
+            sizes,
+            dtype=grad.dtype,
+            device=grad.device,
+        )
+    else:
+        if out.shape != sizes:
+            raise ValueError("out shape mismatch")
+        if out.dtype != grad.dtype:
+            raise ValueError("dtype mismatch")
+        if out.device != grad.device:
+            raise ValueError("device mismatch")
+
+    if out_numel <= _SMALL_NUMEL_THRESHOLD:
+        out.zero_()
+        out.select(dim, index).copy_(grad)
+        return out
+
+    out.zero_()
+
+    if total == 0:
+        return out
+
+    if not grad.is_contiguous():
+        grad = grad.contiguous()
+
+    grad_view = grad.view(total)
+
+    if dim == 0:
+        grid = (triton.cdiv(total, _BLOCK_SIZE),)
+        base = index * inner_size
+
+        _select_backward_dim0_kernel[grid](
+            grad_view,
+            out,
+            total,
+            base,
+            BLOCK=_BLOCK_SIZE,
+        )
+        return out
+
+    # Last-dim select avoids division and modulo in the generic kernel.
+    if inner_size == 1:
+        grid = (triton.cdiv(total, _BLOCK_SIZE),)
+
+        _select_backward_lastdim_kernel[grid](
+            grad_view,
+            out,
+            total,
+            dim_size,
+            index,
+            BLOCK=_BLOCK_SIZE,
+        )
+        return out
+
+    grid = (triton.cdiv(total, _BLOCK_SIZE),)
+    dim_stride = dim_size * inner_size
+
+    _select_backward_kernel[grid](
+        grad_view,
+        out,
+        total,
+        inner_size,
+        dim_stride,
+        index,
+        BLOCK=_BLOCK_SIZE,
+    )
+
+    return out
+
+
+def _cuda_launch_select_backward(grad, input_sizes, dim, index, out=None):
+    dim = int(dim)
+    index = int(index)
+
+    sizes = tuple(input_sizes)
+    ndim = len(sizes)
+
+    if dim < 0:
+        dim += ndim
+        if dim < 0:
+            raise ValueError("invalid dim")
+    elif dim >= ndim:
         raise ValueError("invalid dim")
 
     dim_size = sizes[dim]
@@ -65,7 +276,7 @@ def _launch_select_backward(grad, input_sizes, dim, index, out=None):
             device=grad.device,
         )
     else:
-        if tuple(out.shape) != tuple(sizes):
+        if out.shape != sizes:
             raise ValueError("out shape mismatch")
         if out.dtype != grad.dtype:
             raise ValueError("dtype mismatch")
@@ -76,22 +287,25 @@ def _launch_select_backward(grad, input_sizes, dim, index, out=None):
 
     dim_stride = dim_size * inner_size
 
-    BLOCK = 1024
     n_elements = outer_size * inner_size
-    grid = (triton.cdiv(n_elements, BLOCK),)
+    grid = (triton.cdiv(n_elements, _BLOCK_SIZE),)
 
-    _select_backward_kernel[grid](
+    _cuda_select_backward_kernel[grid](
         grad_view,
         out,
         outer_size,
         inner_size,
         dim_stride,
         index,
-        BLOCK=BLOCK,
+        BLOCK=_BLOCK_SIZE,
     )
 
     return out
 
 
 def select_backward(grad, input_sizes, dim, index, out=None):
+    if grad.device.type == "npu":
+        return _ascend_launch_select_backward(grad, input_sizes, dim, index, out=out)
+    if grad.is_cuda:
+        return _cuda_launch_select_backward(grad, input_sizes, dim, index, out=out)
     return _launch_select_backward(grad, input_sizes, dim, index, out=out)

--- a/src/flag_gems/ops/select_backward.py
+++ b/src/flag_gems/ops/select_backward.py
@@ -4,7 +4,7 @@ import torch
 import triton
 import triton.language as tl
 
-_BLOCK_SIZE = 1024
+_BLOCK = 1024
 
 
 @triton.jit
@@ -79,59 +79,49 @@ def _launch_select_backward(grad, input_sizes, dim, index, out=None):
     dim = int(dim)
     index = int(index)
 
-    sizes = tuple(input_sizes)
+    sizes = list(input_sizes)
     ndim = len(sizes)
 
     if dim < 0:
         dim += ndim
-        if dim < 0:
-            raise ValueError("invalid dim")
-    elif dim >= ndim:
+
+    if dim < 0 or dim >= ndim:
         raise ValueError("invalid dim")
 
-    dim_size = int(sizes[dim])
+    dim_size = sizes[dim]
 
     if index < 0:
         index += dim_size
-        if index < 0:
-            raise ValueError("index out of range")
-    elif index >= dim_size:
+
+    if index < 0 or index >= dim_size:
         raise ValueError("index out of range")
 
     outer_size = math.prod(sizes[:dim]) if dim > 0 else 1
     inner_size = math.prod(sizes[dim + 1 :]) if dim < ndim - 1 else 1
-
-    outer_size = int(outer_size)
-    inner_size = int(inner_size)
-
     total = outer_size * inner_size
 
+    grad_view = grad.contiguous().view(outer_size, inner_size)
+
     if out is None:
-        out = torch.empty(
+        out = torch.zeros(
             sizes,
             dtype=grad.dtype,
             device=grad.device,
         )
     else:
-        if out.shape != sizes:
+        if tuple(out.shape) != tuple(sizes):
             raise ValueError("out shape mismatch")
         if out.dtype != grad.dtype:
             raise ValueError("dtype mismatch")
         if out.device != grad.device:
             raise ValueError("device mismatch")
 
-    out.zero_()
+        out.zero_()
 
-    if total == 0:
-        return out
-
-    if not grad.is_contiguous():
-        grad = grad.contiguous()
-
-    grad_view = grad.view(total)
-
-    grid = (triton.cdiv(total, _BLOCK_SIZE),)
     dim_stride = dim_size * inner_size
+
+    n_elements = outer_size * inner_size
+    grid = (triton.cdiv(n_elements, _BLOCK),)
 
     _select_backward_kernel[grid](
         grad_view,
@@ -140,7 +130,7 @@ def _launch_select_backward(grad, input_sizes, dim, index, out=None):
         inner_size,
         dim_stride,
         index,
-        BLOCK=_BLOCK_SIZE,
+        BLOCK=_BLOCK,
     )
 
     return out

--- a/src/flag_gems/ops/select_backward.py
+++ b/src/flag_gems/ops/select_backward.py
@@ -31,60 +31,14 @@ def _select_backward_kernel(
     tl.store(out_ptr + out_offset, vals, mask=mask)
 
 
-def _ascend_launch_select_backward(grad, input_sizes, dim, index, out=None):
+def select_backward(grad, input_sizes, dim, index, out=None):
     dim = int(dim)
     index = int(index)
-
-    sizes = tuple(input_sizes)
-    ndim = len(sizes)
-
-    if dim < 0:
-        dim += ndim
-        if dim < 0:
-            raise ValueError("invalid dim")
-    elif dim >= ndim:
-        raise ValueError("invalid dim")
-
-    dim_size = int(sizes[dim])
-
-    if index < 0:
-        index += dim_size
-        if index < 0:
-            raise ValueError("index out of range")
-    elif index >= dim_size:
-        raise ValueError("index out of range")
-
-    if out is None:
-        out = torch.empty(
-            sizes,
-            dtype=grad.dtype,
-            device=grad.device,
-        )
-    else:
-        if out.shape != sizes:
-            raise ValueError("out shape mismatch")
-        if out.dtype != grad.dtype:
-            raise ValueError("dtype mismatch")
-        if out.device != grad.device:
-            raise ValueError("device mismatch")
-
-    # Ascend 910B: CANN's native zero + strided copy is faster than launching
-    # a Triton scatter kernel for this op.
-    out.zero_()
-    out.select(dim, index).copy_(grad)
-    return out
-
-
-def _launch_select_backward(grad, input_sizes, dim, index, out=None):
-    dim = int(dim)
-    index = int(index)
-
     sizes = list(input_sizes)
     ndim = len(sizes)
 
     if dim < 0:
         dim += ndim
-
     if dim < 0 or dim >= ndim:
         raise ValueError("invalid dim")
 
@@ -92,15 +46,8 @@ def _launch_select_backward(grad, input_sizes, dim, index, out=None):
 
     if index < 0:
         index += dim_size
-
     if index < 0 or index >= dim_size:
         raise ValueError("index out of range")
-
-    outer_size = math.prod(sizes[:dim]) if dim > 0 else 1
-    inner_size = math.prod(sizes[dim + 1 :]) if dim < ndim - 1 else 1
-    total = outer_size * inner_size
-
-    grad_view = grad.contiguous().view(outer_size, inner_size)
 
     if out is None:
         out = torch.zeros(
@@ -118,6 +65,17 @@ def _launch_select_backward(grad, input_sizes, dim, index, out=None):
 
         out.zero_()
 
+    if grad.device.type == "npu":
+        # Ascend 910B: CANN's native zero + strided copy is faster than launching
+        # a Triton scatter kernel for this op.
+        out.select(dim, index).copy_(grad)
+        return out
+
+    outer_size = math.prod(sizes[:dim]) if dim > 0 else 1
+    inner_size = math.prod(sizes[dim + 1 :]) if dim < ndim - 1 else 1
+    total = outer_size * inner_size
+
+    grad_view = grad.contiguous().view(outer_size, inner_size)
     dim_stride = dim_size * inner_size
 
     n_elements = outer_size * inner_size
@@ -132,11 +90,4 @@ def _launch_select_backward(grad, input_sizes, dim, index, out=None):
         index,
         BLOCK=_BLOCK,
     )
-
     return out
-
-
-def select_backward(grad, input_sizes, dim, index, out=None):
-    if grad.device.type == "npu":
-        return _ascend_launch_select_backward(grad, input_sizes, dim, index, out=out)
-    return _launch_select_backward(grad, input_sizes, dim, index, out=out)

--- a/src/flag_gems/ops/select_backward.py
+++ b/src/flag_gems/ops/select_backward.py
@@ -1,3 +1,4 @@
+import logging
 import math
 
 import torch
@@ -5,6 +6,7 @@ import triton
 import triton.language as tl
 
 _BLOCK = 1024
+logger = logging.getLogger(__name__)
 
 
 @triton.jit
@@ -32,6 +34,7 @@ def _select_backward_kernel(
 
 
 def select_backward(grad, input_sizes, dim, index, out=None):
+    logger.debug("GEMS SELECT_BACKWARD")
     dim = int(dim)
     index = int(index)
     sizes = list(input_sizes)

--- a/src/flag_gems/ops/select_backward.py
+++ b/src/flag_gems/ops/select_backward.py
@@ -9,33 +9,6 @@ _SMALL_NUMEL_THRESHOLD = 4096
 
 
 @triton.jit
-def _cuda_select_backward_kernel(
-    grad_ptr,
-    out_ptr,
-    outer_size,
-    inner_size,
-    dim_stride,
-    index,
-    BLOCK: tl.constexpr,
-):
-    pid = tl.program_id(0)
-
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
-    total = outer_size * inner_size
-
-    mask = offs < total
-
-    outer = offs // inner_size
-    inner = offs % inner_size
-
-    grad_vals = tl.load(grad_ptr + outer * inner_size + inner, mask=mask)
-
-    out_offset = outer * dim_stride + index * inner_size + inner
-
-    tl.store(out_ptr + out_offset, grad_vals, mask=mask)
-
-
-@triton.jit
 def _select_backward_kernel(
     grad_ptr,
     out_ptr,
@@ -245,67 +218,7 @@ def _launch_select_backward(grad, input_sizes, dim, index, out=None):
     return out
 
 
-def _cuda_launch_select_backward(grad, input_sizes, dim, index, out=None):
-    dim = int(dim)
-    index = int(index)
-
-    sizes = tuple(input_sizes)
-    ndim = len(sizes)
-
-    if dim < 0:
-        dim += ndim
-        if dim < 0:
-            raise ValueError("invalid dim")
-    elif dim >= ndim:
-        raise ValueError("invalid dim")
-
-    dim_size = sizes[dim]
-
-    if index < 0 or index >= dim_size:
-        raise ValueError("index out of range")
-
-    outer_size = math.prod(sizes[:dim]) if dim > 0 else 1
-    inner_size = math.prod(sizes[dim + 1 :]) if dim < ndim - 1 else 1
-
-    grad_view = grad.contiguous().view(outer_size, inner_size)
-
-    if out is None:
-        out = torch.zeros(
-            sizes,
-            dtype=grad.dtype,
-            device=grad.device,
-        )
-    else:
-        if out.shape != sizes:
-            raise ValueError("out shape mismatch")
-        if out.dtype != grad.dtype:
-            raise ValueError("dtype mismatch")
-        if out.device != grad.device:
-            raise ValueError("device mismatch")
-
-        out.zero_()
-
-    dim_stride = dim_size * inner_size
-
-    n_elements = outer_size * inner_size
-    grid = (triton.cdiv(n_elements, _BLOCK_SIZE),)
-
-    _cuda_select_backward_kernel[grid](
-        grad_view,
-        out,
-        outer_size,
-        inner_size,
-        dim_stride,
-        index,
-        BLOCK=_BLOCK_SIZE,
-    )
-
-    return out
-
-
 def select_backward(grad, input_sizes, dim, index, out=None):
     if grad.device.type == "npu":
         return _ascend_launch_select_backward(grad, input_sizes, dim, index, out=out)
-    if grad.is_cuda:
-        return _cuda_launch_select_backward(grad, input_sizes, dim, index, out=out)
     return _launch_select_backward(grad, input_sizes, dim, index, out=out)

--- a/src/flag_gems/ops/select_backward.py
+++ b/src/flag_gems/ops/select_backward.py
@@ -65,12 +65,6 @@ def select_backward(grad, input_sizes, dim, index, out=None):
 
         out.zero_()
 
-    if grad.device.type == "npu":
-        # Ascend 910B: CANN's native zero + strided copy is faster than launching
-        # a Triton scatter kernel for this op.
-        out.select(dim, index).copy_(grad)
-        return out
-
     outer_size = math.prod(sizes[:dim]) if dim > 0 else 1
     inner_size = math.prod(sizes[dim + 1 :]) if dim < ndim - 1 else 1
     total = outer_size * inner_size

--- a/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/__init__.py
@@ -54,6 +54,7 @@ from .randperm import randperm
 from .repeat_interleave import repeat_interleave_self_int
 from .resolve_neg import resolve_neg
 from .rms_norm import rms_norm
+from .select_backward import select_backward
 from .select_scatter import select_scatter
 from .slice_scatter import slice_scatter
 from .softmax import softmax, softmax_backward
@@ -140,6 +141,7 @@ __all__ = [
     "repeat_interleave_self_int",
     "resolve_neg",
     "rms_norm",
+    "select_backward",
     "select_scatter",
     "slice_scatter",
     "softmax",

--- a/src/flag_gems/runtime/backend/_ascend/ops/select_backward.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/select_backward.py
@@ -1,0 +1,43 @@
+import logging
+
+import torch
+
+logger = logging.getLogger(__name__)
+
+
+def select_backward(grad, input_sizes, dim, index, out=None):
+    logger.debug("GEMS_ASCEND SELECT_BACKWARD")
+    dim = int(dim)
+    index = int(index)
+    sizes = list(input_sizes)
+    ndim = len(sizes)
+
+    if dim < 0:
+        dim += ndim
+    if dim < 0 or dim >= ndim:
+        raise ValueError("invalid dim")
+
+    dim_size = sizes[dim]
+
+    if index < 0:
+        index += dim_size
+    if index < 0 or index >= dim_size:
+        raise ValueError("index out of range")
+
+    if out is None:
+        out = torch.empty(
+            sizes,
+            dtype=grad.dtype,
+            device=grad.device,
+        )
+    else:
+        if tuple(out.shape) != tuple(sizes):
+            raise ValueError("out shape mismatch")
+        if out.dtype != grad.dtype:
+            raise ValueError("dtype mismatch")
+        if out.device != grad.device:
+            raise ValueError("device mismatch")
+
+    out.zero_()
+    out.select(dim, index).copy_(grad)
+    return out

--- a/src/flag_gems/runtime/backend/_ascend/ops/select_backward.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/select_backward.py
@@ -12,17 +12,13 @@ def select_backward(grad, input_sizes, dim, index, out=None):
     sizes = list(input_sizes)
     ndim = len(sizes)
 
-    if dim < 0:
-        dim += ndim
-    if dim < 0 or dim >= ndim:
-        raise ValueError("invalid dim")
+    assert dim >= -ndim and dim < ndim, "Invalid dim"
+    dim %= ndim
 
     dim_size = sizes[dim]
 
-    if index < 0:
-        index += dim_size
-    if index < 0 or index >= dim_size:
-        raise ValueError("index out of range")
+    assert index >= -dim_size and index < dim_size, "Invalid index"
+    index %= dim_size
 
     if out is None:
         out = torch.empty(
@@ -31,12 +27,9 @@ def select_backward(grad, input_sizes, dim, index, out=None):
             device=grad.device,
         )
     else:
-        if tuple(out.shape) != tuple(sizes):
-            raise ValueError("out shape mismatch")
-        if out.dtype != grad.dtype:
-            raise ValueError("dtype mismatch")
-        if out.device != grad.device:
-            raise ValueError("device mismatch")
+        assert tuple(out.shape) == tuple(sizes), "out shape mismatch"
+        assert out.dtype == grad.dtype, "dtype mismatch"
+        assert out.device == grad.device, "device mismatch"
 
     out.zero_()
     out.select(dim, index).copy_(grad)


### PR DESCRIPTION
### PR Category
Benchmark / Operator

### Type of Change
Bug Fix / Performance Optimization

### Description
* Removed `grad.is_cuda` assertions in `select_backward` impl. 
* Optimize `select_backward` for Ascend NPU and CUDA paths, pruning unused branches/kernels and reducing unnecessary dispatch overhead. 
* Optimize `select_backward` performance for Ascend NPU by falling back to CANN native impl.
* Restore the `select_backward` benchmark as an independent benchmark file following the split benchmark layout, instead of modifying the removed `benchmark/test_special_perf.py`. (Fix for [PR#2661](https://github.com/flagos-ai/FlagGems/pull/2661))

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
Same performance as [PR#2080](https://github.com/flagos-ai/FlagGems/pull/2080) on CUDA devices; on Ascend NPU, results are compared against the version that only removes assertions.
#### Benchmark on NVIDIA H20
```text
benchmark/test_select_backward_perf.py 
Operator: select_backward  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.638272            0.638304               1.000          [torch.Size([]), [1073741824], 0, 536870912]
SUCCESS               0.007616            0.007104               1.072          [torch.Size([64]), [64, 64], 1, 32]
SUCCESS               0.019936            0.018560               1.074          [torch.Size([4096]), [4096, 4096], 1, 2048]
SUCCESS               0.019744            0.017600               1.122          [torch.Size([64, 512]), [64, 512, 512], 1, 256]
SUCCESS               0.644192            0.640464               1.006          [torch.Size([1024, 1024]), [1024, 1024, 1024], 1, 512]
SUCCESS               0.007200            0.007072               1.018          [torch.Size([1024]), [1024, 1], 1, 0]
SUCCESS               0.009440            0.008032               1.175          [torch.Size([1024]), [1024, 16], 1, 8]
SUCCESS               0.009856            0.008576               1.149          [torch.Size([1024]), [1024, 256], 1, 128]
SUCCESS               0.012544            0.011168               1.123          [torch.Size([1024]), [1024, 4096], 1, 2048]
SUCCESS               0.049952            0.048224               1.036          [torch.Size([1024]), [1024, 65536], 1, 32768]
SUCCESS               0.007744            0.007264               1.066          [torch.Size([64, 1]), [64, 64, 1], 1, 32]
SUCCESS               0.009344            0.007392               1.264          [torch.Size([64, 16]), [64, 64, 16], 1, 32]
SUCCESS               0.010128            0.008096               1.251          [torch.Size([64, 256]), [64, 64, 256], 1, 32]
SUCCESS               0.020064            0.017856               1.124          [torch.Size([64, 4096]), [64, 64, 4096], 1, 32]

Operator: select_backward  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.092672            1.088944               1.003          [torch.Size([]), [1073741824], 0, 536870912]
SUCCESS               0.007744            0.007264               1.066          [torch.Size([64]), [64, 64], 1, 32]
SUCCESS               0.026208            0.025824               1.015          [torch.Size([4096]), [4096, 4096], 1, 2048]
SUCCESS               0.026240            0.024960               1.051          [torch.Size([64, 512]), [64, 512, 512], 1, 256]
SUCCESS               1.102560            1.092352               1.009          [torch.Size([1024, 1024]), [1024, 1024, 1024], 1, 512]
SUCCESS               0.007072            0.007008               1.009          [torch.Size([1024]), [1024, 1], 1, 0]
SUCCESS               0.008416            0.008192               1.027          [torch.Size([1024]), [1024, 16], 1, 8]
SUCCESS               0.008544            0.008576               0.996          [torch.Size([1024]), [1024, 256], 1, 128]
SUCCESS               0.012864            0.012672               1.015          [torch.Size([1024]), [1024, 4096], 1, 2048]
SUCCESS               0.077056            0.076352               1.009          [torch.Size([1024]), [1024, 65536], 1, 32768]
SUCCESS               0.007776            0.007296               1.066          [torch.Size([64, 1]), [64, 64, 1], 1, 32]
SUCCESS               0.008384            0.007424               1.129          [torch.Size([64, 16]), [64, 64, 16], 1, 32]
SUCCESS               0.009760            0.008736               1.117          [torch.Size([64, 256]), [64, 64, 256], 1, 32]
SUCCESS               0.026848            0.025376               1.058          [torch.Size([64, 4096]), [64, 64, 4096], 1, 32]

Operator: select_backward  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.638368            0.638560               1.000          [torch.Size([]), [1073741824], 0, 536870912]
SUCCESS               0.007680            0.007152               1.074          [torch.Size([64]), [64, 64], 1, 32]
SUCCESS               0.020032            0.018560               1.079          [torch.Size([4096]), [4096, 4096], 1, 2048]
SUCCESS               0.019744            0.017648               1.119          [torch.Size([64, 512]), [64, 512, 512], 1, 256]
SUCCESS               0.644224            0.640288               1.006          [torch.Size([1024, 1024]), [1024, 1024, 1024], 1, 512]
SUCCESS               0.007200            0.007168               1.004          [torch.Size([1024]), [1024, 1], 1, 0]
SUCCESS               0.009408            0.008032               1.171          [torch.Size([1024]), [1024, 16], 1, 8]
SUCCESS               0.010720            0.009344               1.147          [torch.Size([1024]), [1024, 256], 1, 128]
SUCCESS               0.012384            0.011040               1.122          [torch.Size([1024]), [1024, 4096], 1, 2048]
SUCCESS               0.049984            0.048320               1.034          [torch.Size([1024]), [1024, 65536], 1, 32768]
SUCCESS               0.007744            0.007328               1.057          [torch.Size([64, 1]), [64, 64, 1], 1, 32]
SUCCESS               0.009280            0.007456               1.245          [torch.Size([64, 16]), [64, 64, 16], 1, 32]
SUCCESS               0.010464            0.008272               1.265          [torch.Size([64, 256]), [64, 64, 256], 1, 32]
SUCCESS               0.020128            0.017952               1.121          [torch.Size([64, 4096]), [64, 64, 4096], 1, 32]
```

#### Performance on Ascend 910B
```text
benchmark/test_select_backward_perf.py 
Operator: select_backward  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.438280            1.438180               1.000          [torch.Size([]), [1073741824], 0, 536870912]
SUCCESS               0.122380            0.174280               0.702          [torch.Size([64]), [64, 64], 1, 32]
SUCCESS               0.087760            0.139880               0.627          [torch.Size([4096]), [4096, 4096], 1, 2048]
SUCCESS               0.088520            0.144920               0.611          [torch.Size([64, 512]), [64, 512, 512], 1, 256]
SUCCESS               1.464820            1.465200               1.000          [torch.Size([1024, 1024]), [1024, 1024, 1024], 1, 512]
SUCCESS               0.149840            0.220260               0.680          [torch.Size([1024]), [1024, 1], 1, 0]
SUCCESS               0.120040            0.174260               0.689          [torch.Size([1024]), [1024, 16], 1, 8]
SUCCESS               0.117760            0.180420               0.653          [torch.Size([1024]), [1024, 256], 1, 128]
SUCCESS               0.087920            0.148220               0.593          [torch.Size([1024]), [1024, 4096], 1, 2048]
SUCCESS               0.121560            0.121560               1.000          [torch.Size([1024]), [1024, 65536], 1, 32768]
SUCCESS               0.119280            0.179420               0.665          [torch.Size([64, 1]), [64, 64, 1], 1, 32]
SUCCESS               0.132860            0.179700               0.739          [torch.Size([64, 16]), [64, 64, 16], 1, 32]
SUCCESS               0.089800            0.140080               0.641          [torch.Size([64, 256]), [64, 64, 256], 1, 32]
SUCCESS               0.091640            0.144300               0.635          [torch.Size([64, 4096]), [64, 64, 4096], 1, 32]

Operator: select_backward  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.871260            2.871940               1.000          [torch.Size([]), [1073741824], 0, 536870912]
SUCCESS               0.116740            0.167020               0.699          [torch.Size([64]), [64, 64], 1, 32]
SUCCESS               0.071340            0.114640               0.622          [torch.Size([4096]), [4096, 4096], 1, 2048]
SUCCESS               0.061220            0.107840               0.568          [torch.Size([64, 512]), [64, 512, 512], 1, 256]
SUCCESS               2.894740            2.895020               1.000          [torch.Size([1024, 1024]), [1024, 1024, 1024], 1, 512]
SUCCESS               0.147720            0.196800               0.751          [torch.Size([1024]), [1024, 1], 1, 0]
SUCCESS               0.112560            0.164380               0.685          [torch.Size([1024]), [1024, 16], 1, 8]
SUCCESS               0.115240            0.166560               0.692          [torch.Size([1024]), [1024, 256], 1, 128]
SUCCESS               0.108140            0.159100               0.680          [torch.Size([1024]), [1024, 4096], 1, 2048]
SUCCESS               0.197960            0.197940               1.000          [torch.Size([1024]), [1024, 65536], 1, 32768]
SUCCESS               0.120440            0.167900               0.717          [torch.Size([64, 1]), [64, 64, 1], 1, 32]
SUCCESS               0.117960            0.164700               0.716          [torch.Size([64, 16]), [64, 64, 16], 1, 32]
SUCCESS               0.119140            0.168820               0.706          [torch.Size([64, 256]), [64, 64, 256], 1, 32]
SUCCESS               0.067120            0.115920               0.579          [torch.Size([64, 4096]), [64, 64, 4096], 1, 32]

Operator: select_backward  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.444400            1.444260               1.000          [torch.Size([]), [1073741824], 0, 536870912]
SUCCESS               0.122800            0.165160               0.744          [torch.Size([64]), [64, 64], 1, 32]
SUCCESS               0.086480            0.135620               0.638          [torch.Size([4096]), [4096, 4096], 1, 2048]
SUCCESS               0.083680            0.135400               0.618          [torch.Size([64, 512]), [64, 512, 512], 1, 256]
SUCCESS               1.471900            1.472080               1.000          [torch.Size([1024, 1024]), [1024, 1024, 1024], 1, 512]
SUCCESS               0.153100            0.203960               0.751          [torch.Size([1024]), [1024, 1], 1, 0]
SUCCESS               0.118920            0.166980               0.712          [torch.Size([1024]), [1024, 16], 1, 8]
SUCCESS               0.118860            0.166620               0.713          [torch.Size([1024]), [1024, 256], 1, 128]
SUCCESS               0.092520            0.143860               0.643          [torch.Size([1024]), [1024, 4096], 1, 2048]
SUCCESS               0.120800            0.120860               1.000          [torch.Size([1024]), [1024, 65536], 1, 32768]
SUCCESS               0.123420            0.174380               0.708          [torch.Size([64, 1]), [64, 64, 1], 1, 32]
SUCCESS               0.123380            0.173720               0.710          [torch.Size([64, 16]), [64, 64, 16], 1, 32]
SUCCESS               0.093320            0.141800               0.658          [torch.Size([64, 256]), [64, 64, 256], 1, 32]
SUCCESS               0.091400            0.141400               0.646          [torch.Size([64, 4096]), [64, 64, 4096], 1, 32]
```

Validation commands:
- `pytest tests/test_select_backward.py`
- `pytest -s benchmark/test_select_backward_perf.py::test_select_backward_perf`

The optimization was tested on Ascend 910B and CUDA H20 during development.



