### PR TITLE
Make sure print outputs are unbuffered

### DIFF
--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -54,15 +54,15 @@ DTYPE_MAP = {
 
 
 def pinfo(str, **args):
-    print(f"\033[32m[INFO]\033[0m {str}", **args)
+    print(f"\033[32m[INFO]\033[0m {str}", flush=True, **args)
 
 
 def perror(str, **args):
-    print(f"\033[31m[ERROR]\033[0m {str}", **args)
+    print(f"\033[31m[ERROR]\033[0m {str}", flush=True, **args)
 
 
 def pwarn(str, **args):
-    print(f"\033[93m[WARN]\033[0m {str}", **args)
+    print(f"\033[93m[WARN]\033[0m {str}", flush=True, **args)
 
 
 def ensure_dir(p):
@@ -390,7 +390,7 @@ def parse_perf_data(op, result_file):
         count = 0
         # Iterate through shapes
         for res in item.get("result", []):
-            shape = str(res.get("shape_detail", "UNKNOWN")).replace(" ", "")
+            shape = str(res.get("shape_detail", "Unknown")).replace(" ", "")
             details.setdefault(shape, {})
             details[shape]["base"] = res.get("latency_base", 0.0)
             details[shape]["gems"] = res.get("latency", 0.0)
@@ -470,9 +470,6 @@ def run_benchmark(gpu_id, start, index, count):
 
 
 def worker_proc(gpu_id, start, count):
-    # Ensure python output are unbuffered
-    os.environ["PYTHONUNBUFFERED"] = "1"
-
     worker_result = {}
     for i in range(count):
         op = OP_LIST[start + i].strip()


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

Looks like chaning the `PYTHONUNBUFFERED` environment variable during runtime is not working as expected. The variable is supposed to be set before python process is launched. So the new tweak is to make sure that we flush all print calls so that (in hope) we can get a timely progress indicator when running test batches.