### PR TITLE
Fix benchmark opname used

### DIFF
--- a/benchmark/test_bitwise_and.py
+++ b/benchmark/test_bitwise_and.py
@@ -7,7 +7,7 @@ from . import base, consts
 @pytest.mark.bitwise_and_tensor
 def test_bitwise_and():
     bench = base.BinaryPointwiseBenchmark(
-        op_name="bitwise_and",
+        op_name="bitwise_and_tensor",
         torch_op=torch.bitwise_and,
         dtypes=consts.INT_DTYPES + consts.BOOL_DTYPES,
     )
@@ -17,7 +17,7 @@ def test_bitwise_and():
 @pytest.mark.bitwise_and_tensor_
 def test_bitwise_and_inplace():
     bench = base.BinaryPointwiseBenchmark(
-        op_name="bitwise_and_",
+        op_name="bitwise_and_tensor_",
         torch_op=lambda a, b: a.bitwise_and_(b),
         dtypes=consts.INT_DTYPES + consts.BOOL_DTYPES,
         is_inplace=True,

--- a/benchmark/test_bitwise_or.py
+++ b/benchmark/test_bitwise_or.py
@@ -5,9 +5,9 @@ from . import base, consts
 
 
 @pytest.mark.bitwise_or_tensor
-def test_bitwise_or():
+def test_bitwise_or_tensor():
     bench = base.BinaryPointwiseBenchmark(
-        op_name="bitwise_or",
+        op_name="bitwise_or_tensor",
         torch_op=torch.bitwise_or,
         dtypes=consts.INT_DTYPES + consts.BOOL_DTYPES,
     )
@@ -17,7 +17,7 @@ def test_bitwise_or():
 @pytest.mark.bitwise_or_tensor_
 def test_bitwise_or_inplace():
     bench = base.BinaryPointwiseBenchmark(
-        op_name="bitwise_or_",
+        op_name="bitwise_or_tensor_",
         torch_op=lambda a, b: a.bitwise_or_(b),
         dtypes=consts.INT_DTYPES + consts.BOOL_DTYPES,
         is_inplace=True,

--- a/benchmark/test_conv_depthwise2d.py
+++ b/benchmark/test_conv_depthwise2d.py
@@ -49,7 +49,7 @@ def test_conv_depthwise2d():
     torch.backends.cudnn.allow_tf32 = False
 
     bench = ConvDepthwise2DBenchmark(
-        op_name="_conv_depthwise2d",
+        op_name="conv_depthwise2d",
         input_fn=_input_fn,
         torch_op=torch.ops.aten._conv_depthwise2d,
         gems_op=flag_gems._conv_depthwise2d,

--- a/benchmark/test_div.py
+++ b/benchmark/test_div.py
@@ -8,7 +8,7 @@ from . import base, consts
 @pytest.mark.div_tensor
 def test_div():
     bench = base.BinaryPointwiseBenchmark(
-        op_name="div",
+        op_name="div_tensor",
         torch_op=torch.div,
         dtypes=consts.FLOAT_DTYPES,
     )
@@ -18,7 +18,7 @@ def test_div():
 @pytest.mark.div_tensor_
 def test_div_inplace():
     bench = base.BinaryPointwiseBenchmark(
-        op_name="div_",
+        op_name="div_tensor_",
         torch_op=lambda a, b: a.div_(b),
         dtypes=consts.FLOAT_DTYPES,
         is_inplace=True,

--- a/benchmark/test_dunder_ior.py
+++ b/benchmark/test_dunder_ior.py
@@ -6,7 +6,7 @@ from . import base, consts
 @pytest.mark.dunder_ior_tensor
 def test_dunder_ior_inplace():
     bench = base.BinaryPointwiseBenchmark(
-        op_name="dunder_ior",
+        op_name="dunder_ior_tensor",
         torch_op=lambda a, b: a.__ior__(b),
         dtypes=consts.INT_DTYPES + consts.BOOL_DTYPES,
         is_inplace=True,

--- a/benchmark/test_dunder_or.py
+++ b/benchmark/test_dunder_or.py
@@ -6,7 +6,7 @@ from . import base, consts
 @pytest.mark.dunder_or_tensor
 def test_dunder_or_tensor():
     bench = base.BinaryPointwiseBenchmark(
-        op_name="dunder_or",
+        op_name="dunder_or_tensor",
         torch_op=lambda a, b: a | b,
         dtypes=consts.INT_DTYPES + consts.BOOL_DTYPES,
     )

--- a/benchmark/test_fused_moe.py
+++ b/benchmark/test_fused_moe.py
@@ -111,7 +111,7 @@ def test_fused_moe_impl_gems_vs_vllm():
     Benchmark FlagGems fused_experts_impl vs vLLM fused_experts_impl (bf16/fp16).
     """
     bench = FusedMoEBenchmark(
-        op_name="fused_moe_gems_vs_vllm",
+        op_name="fused_experts_impl",
         torch_op=_vllm_fused_moe_wrapper,
         dtypes=[torch.bfloat16, torch.float16],
     )

--- a/benchmark/test_fused_moe_fp8.py
+++ b/benchmark/test_fused_moe_fp8.py
@@ -166,7 +166,7 @@ def _gems_fused_moe_fp8_wrapper(
     )
 
 
-@pytest.mark.fused_moe_impl
+@pytest.mark.fused_experts_impl
 @pytest.mark.skipif(
     not (HAS_VLLM_FUSED_MOE and CUDA_AVAILABLE),
     reason="requires vLLM and NVIDIA Hopper architecture for FP8",
@@ -176,7 +176,7 @@ def test_fused_moe_fp8():
     Benchmark FlagGems vs vLLM fused_experts_impl with FP8 W8A8 quantization.
     """
     bench = FusedMoEFP8Benchmark(
-        op_name="fused_moe_fp8_gems_vs_vllm",
+        op_name="fused_experts_impl",
         torch_op=_vllm_fused_moe_fp8_wrapper,
         dtypes=[torch.bfloat16],
     )

--- a/benchmark/test_fused_moe_fp8_blockwise.py
+++ b/benchmark/test_fused_moe_fp8_blockwise.py
@@ -189,7 +189,7 @@ def test_fused_moe_fp8_blockwise():
     Benchmark FlagGems vs vLLM fused_experts_impl with FP8 W8A8 block-wise quantization.
     """
     bench = FusedMoEFP8BlockwiseBenchmark(
-        op_name="fused_moe_fp8_blockwise_gems_vs_vllm",
+        op_name="fused_experts_impl",
         torch_op=_vllm_fused_moe_fp8_blockwise_wrapper,
         dtypes=[torch.bfloat16],
     )

--- a/benchmark/test_fused_moe_int4_w4a16.py
+++ b/benchmark/test_fused_moe_int4_w4a16.py
@@ -171,7 +171,7 @@ def test_fused_moe_int4_w4a16():
     specialised WNA16 CUDA kernel not available via the generic Triton path).
     """
     bench = FusedMoEINT4W4A16Benchmark(
-        op_name="fused_moe_int4_w4a16_gems_vs_bf16_deq",
+        op_name="fused_experts_impl",
         torch_op=_vllm_fused_moe_int4_w4a16_wrapper,
         dtypes=[torch.bfloat16],
     )

--- a/benchmark/test_fused_moe_int8.py
+++ b/benchmark/test_fused_moe_int8.py
@@ -168,7 +168,7 @@ def test_fused_experts_impl_int8():
     Benchmark FlagGems vs vLLM fused_experts_impl with INT8 W8A8 quantization.
     """
     bench = FusedMoEINT8Benchmark(
-        op_name="fused_moe_int8_gems_vs_vllm",
+        op_name="fused_experts_impl",
         torch_op=_vllm_fused_moe_int8_wrapper,
         dtypes=[torch.bfloat16],
     )

--- a/benchmark/test_index_put_impl.py
+++ b/benchmark/test_index_put_impl.py
@@ -96,7 +96,7 @@ def _input_fn(accumulate, unsafe=False):
 @pytest.mark.index_put_impl
 def test_index_put_impl_acc_false():
     bench = IndexPutAccFalseBenchmark(
-        op_name="_index_put_impl_",
+        op_name="index_put_impl",
         torch_op=torch._index_put_impl_,
         input_fn=_input_fn(False, unsafe=False),
         dtypes=consts.FLOAT_DTYPES,
@@ -124,7 +124,7 @@ class IndexPutAccTrueBenchmark(base.GenericBenchmark):
 @pytest.mark.index_put_impl
 def test_index_put_impl_acc_true():
     bench = IndexPutAccTrueBenchmark(
-        op_name="_index_put_impl_",
+        op_name="index_put_impl",
         torch_op=torch._index_put_impl_,
         input_fn=_input_fn(True, unsafe=False),
         dtypes=[torch.float16, torch.float32],

--- a/benchmark/test_mhc.py
+++ b/benchmark/test_mhc.py
@@ -154,11 +154,10 @@ class MHCSplitSinkhornBenchmark(base.Benchmark):
             yield mixes, hc_scale, hc_base, hc_mult, self.sinkhorn_iters, self.eps
 
 
-# TODO(Qiming): Find out where this is implemented
 @pytest.mark.hc_split_sinkhorn_forward
 def test_hc_split_sinkhorn_forward():
     bench = MHCSplitSinkhornBenchmark(
-        op_name="hc_split_sinkhorn",
+        op_name="hc_split_sinkhorn_forward",
         torch_op=mhc_split_sinkhorn_torch_ref,
         dtypes=[torch.float32],
     )

--- a/benchmark/test_nll_loss.py
+++ b/benchmark/test_nll_loss.py
@@ -19,7 +19,7 @@ def nll_loss_input_fn(shape, cur_dtype, device):
 @pytest.mark.nll_loss_forward
 def test_nll_loss_forward():
     bench = base.GenericBenchmark2DOnly(
-        op_name="nll_loss",
+        op_name="nll_loss_forward",
         input_fn=nll_loss_input_fn,
         torch_op=torch.nn.functional.nll_loss,
         dtypes=consts.FLOAT_DTYPES,

--- a/benchmark/test_nll_loss2d.py
+++ b/benchmark/test_nll_loss2d.py
@@ -20,7 +20,7 @@ def nll_loss_input_fn(shape, cur_dtype, device):
 def test_nll_loss2d_forward():
     bench = base.GenericBenchmark4DOnly(
         input_fn=nll_loss_input_fn,
-        op_name="nll_loss2d",
+        op_name="nll_loss2d_forward",
         torch_op=torch.nn.functional.nll_loss,
         dtypes=consts.FLOAT_DTYPES,
     )

--- a/benchmark/test_normal.py
+++ b/benchmark/test_normal.py
@@ -14,7 +14,7 @@ def normal_input_fn(shape, cur_dtype, device):
 def test_normal_tensor_tensor():
     bench = base.GenericBenchmark(
         input_fn=normal_input_fn,
-        op_name="normal",
+        op_name="normal_tensor_tensor",
         torch_op=torch.normal,
         dtypes=consts.FLOAT_DTYPES,
     )
@@ -32,7 +32,7 @@ def normal_inplace_input_fn(shape, dtype, device):
 def test_normal_inplace():
     bench = base.GenericBenchmark(
         input_fn=normal_inplace_input_fn,
-        op_name="normal_",
+        op_name="normal_float_float_",
         torch_op=torch.Tensor.normal_,
         dtypes=consts.FLOAT_DTYPES,
     )

--- a/benchmark/test_one_hot.py
+++ b/benchmark/test_one_hot.py
@@ -31,7 +31,7 @@ def _input_fn(shape, dtype, device):
 
 
 @pytest.mark.one_hot
-def test_perf_one_hot():
+def test_one_hot():
     bench = base.GenericBenchmark(
         op_name="one_hot",
         input_fn=_input_fn,

--- a/benchmark/test_pow.py
+++ b/benchmark/test_pow.py
@@ -7,7 +7,7 @@ from . import base, consts
 @pytest.mark.pow_tensor_tensor
 def test_pow_tensor_tensor():
     bench = base.ScalarBinaryPointwiseBenchmark(
-        op_name="pow",
+        op_name="pow_tensor_tensor",
         torch_op=torch.pow,
         dtypes=consts.FLOAT_DTYPES,
     )
@@ -17,7 +17,7 @@ def test_pow_tensor_tensor():
 @pytest.mark.pow_tensor_tensor_
 def test_pow_inplace():
     bench = base.BinaryPointwiseBenchmark(
-        op_name="pow_",
+        op_name="pow_tensor_tensor_",
         torch_op=lambda a, b: a.pow_(b),
         dtypes=consts.FLOAT_DTYPES,
         is_inplace=True,

--- a/benchmark/test_remainder.py
+++ b/benchmark/test_remainder.py
@@ -7,7 +7,7 @@ from . import base, consts
 @pytest.mark.remainder_tensor
 def test_remainder_tensor():
     bench = base.BinaryPointwiseBenchmark(
-        op_name="remainder",
+        op_name="remainder_tensor",
         torch_op=torch.remainder,
         dtypes=consts.INT_DTYPES,
         is_inplace=True,
@@ -18,7 +18,7 @@ def test_remainder_tensor():
 @pytest.mark.remainder_tensor_
 def test_remainder_tensor_inplace():
     bench = base.BinaryPointwiseBenchmark(
-        op_name="remainder_",
+        op_name="remainder_tensor_",
         torch_op=lambda a, b: a.remainder_(b),
         dtypes=consts.INT_DTYPES,
         is_inplace=True,

--- a/benchmark/test_repeat_interleave.py
+++ b/benchmark/test_repeat_interleave.py
@@ -34,7 +34,7 @@ def repeat_interleave_self_int_input_fn(shape, dtype, device):
 def test_repeat_interleave_self_int():
     bench = RepeatInterleaveBenchmark(
         input_fn=repeat_interleave_self_int_input_fn,
-        op_name="repeat_interleave.self_int",
+        op_name="repeat_interleave_self_int",
         torch_op=torch.repeat_interleave,
         dtypes=consts.FLOAT_DTYPES,
     )
@@ -60,7 +60,7 @@ def repeat_interleave_self_tensor_input_fn(shape, dtype, device):
 @pytest.mark.repeat_interleave_self_tensor
 def test_repeat_interleave_self_tensor():
     bench = RepeatInterleaveBenchmark(
-        op_name="repeat_interleave.self_tensor",
+        op_name="repeat_interleave_self_tensor",
         input_fn=repeat_interleave_self_tensor_input_fn,
         torch_op=torch.repeat_interleave,
         dtypes=[torch.int32],
@@ -85,7 +85,7 @@ def repeat_interleave_tensor_input_fn(shape, dtype, device):
 @pytest.mark.repeat_interleave_tensor
 def test_repeat_interleave_tensor():
     bench = RepeatInterleaveBenchmark(
-        op_name="repeat_interleave.tensor",
+        op_name="repeat_interleave_tensor",
         input_fn=repeat_interleave_tensor_input_fn,
         torch_op=torch.repeat_interleave,
         dtypes=[torch.int32],

--- a/benchmark/test_safe_softmax.py
+++ b/benchmark/test_safe_softmax.py
@@ -16,7 +16,7 @@ class SafeSoftmaxBenchmark(base.Benchmark):
 @pytest.mark.safe_softmax
 def test_safe_softmax():
     bench = SafeSoftmaxBenchmark(
-        op_name="_safe_softmax",
+        op_name="safe_softmax",
         torch_op=torch.ops.aten._safe_softmax,
         dtypes=consts.FLOAT_DTYPES,
     )

--- a/benchmark/test_scatter_reduce.py
+++ b/benchmark/test_scatter_reduce.py
@@ -80,7 +80,7 @@ def gather_scatter_gbps(bench_fn_args, latency):
 @pytest.mark.scatter_reduce
 def test_scatter_reduce_add():
     bench = TensorSelectBenchmark(
-        op_name="scatter.reduce",
+        op_name="scatter_reduce",
         torch_op=torch.scatter,
         input_fn=scatter_input_fn_factory("add"),
         get_gbps=gather_scatter_gbps,
@@ -92,7 +92,7 @@ def test_scatter_reduce_add():
 @pytest.mark.scatter_reduce
 def test_scatter_reduce_multiply():
     bench = TensorSelectBenchmark(
-        op_name="scatter.reduce",
+        op_name="scatter_reduce",
         torch_op=torch.scatter,
         input_fn=scatter_input_fn_factory("multiply"),
         get_gbps=gather_scatter_gbps,
@@ -104,7 +104,7 @@ def test_scatter_reduce_multiply():
 @pytest.mark.scatter_reduce_
 def test_scatter_reduce_add_inplace():
     bench = TensorSelectBenchmark(
-        op_name="scatter_.reduce",
+        op_name="scatter_reduce_",
         torch_op=torch.Tensor.scatter_,
         input_fn=scatter_inplace_input_fn_factory("add"),
         get_gbps=gather_scatter_gbps,
@@ -117,7 +117,7 @@ def test_scatter_reduce_add_inplace():
 @pytest.mark.scatter_reduce_
 def test_scatter_reduce_multiply_inplace():
     bench = TensorSelectBenchmark(
-        op_name="scatter_.reduce",
+        op_name="scatter_reduce_",
         torch_op=torch.Tensor.scatter_,
         input_fn=scatter_inplace_input_fn_factory("multiply"),
         get_gbps=gather_scatter_gbps,

--- a/benchmark/test_scatter_src.py
+++ b/benchmark/test_scatter_src.py
@@ -80,7 +80,7 @@ def scatter_input_fn_factory(reduce=None):
 @pytest.mark.scatter_src
 def test_scatter_src():
     bench = TensorSelectBenchmark(
-        op_name="scatter.src",
+        op_name="scatter_src",
         torch_op=torch.scatter,
         input_fn=scatter_input_fn_factory(),
         get_gbps=gather_scatter_gbps,
@@ -92,7 +92,7 @@ def test_scatter_src():
 @pytest.mark.scatter_src_
 def test_scatter_src_inplace():
     bench = TensorSelectBenchmark(
-        op_name="scatter_.src",
+        op_name="scatter_src_",
         torch_op=torch.Tensor.scatter_,
         input_fn=scatter_inplace_input_fn_factory(),
         get_gbps=gather_scatter_gbps,

--- a/benchmark/test_sgn.py
+++ b/benchmark/test_sgn.py
@@ -6,7 +6,7 @@ from . import base, consts
 @pytest.mark.sgn_
 def test_sgn_inplace():
     bench = base.UnaryPointwiseBenchmark(
-        op_name="atan_",
+        op_name="sgn_",
         torch_op=lambda a: a.sgn_(),
         dtypes=consts.FLOAT_DTYPES,
         is_inplace=True,

--- a/benchmark/test_skip_layer_norm.py
+++ b/benchmark/test_skip_layer_norm.py
@@ -24,7 +24,7 @@ def torch_op(inp, residual, layer_shape, weight, bias):
 def test_skip_layernorm():
     bench = base.GenericBenchmarkExcluse1D(
         input_fn=_input_fn,
-        op_name="skip_layernorm",
+        op_name="skip_layer_norm",
         gems_op=flag_gems.skip_layer_norm,
         torch_op=torch_op,
         dtypes=consts.FLOAT_DTYPES,

--- a/benchmark/test_upsample_linear1d.py
+++ b/benchmark/test_upsample_linear1d.py
@@ -29,7 +29,7 @@ def test_upsample_linear1d(align_corners):
 
     bench = UpsampleBenchmark(
         input_fn=upsample_linear1d_input_fn,
-        op_name=f"upsample_linear1d_align_{align_corners}",
+        op_name="upsample_linear1d",
         torch_op=torch._C._nn.upsample_linear1d,
         dtypes=consts.FLOAT_DTYPES,
     )

--- a/benchmark/test_upsample_nearest_exact1d.py
+++ b/benchmark/test_upsample_nearest_exact1d.py
@@ -21,7 +21,7 @@ class UpsampleNearestExact1dBenchmark(base.Benchmark):
 @pytest.mark.upsample_nearest_exact1d
 def test_upsample_nearest_exact1d():
     bench = UpsampleNearestExact1dBenchmark(
-        op_name="_upsample_nearest_exact1d",
+        op_name="upsample_nearest_exact1d",
         torch_op=torch.ops.aten._upsample_nearest_exact1d,
         dtypes=consts.FLOAT_DTYPES,
     )

--- a/benchmark/test_where.py
+++ b/benchmark/test_where.py
@@ -15,7 +15,7 @@ def _input_fn(shape, cur_dtype, device):
 @pytest.mark.where_self
 def test_where_self():
     bench = base.GenericBenchmark(
-        op_name="where",
+        op_name="where_self",
         input_fn=_input_fn,
         torch_op=torch.where,
         dtypes=consts.FLOAT_DTYPES,


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

This PR fixes the op_name used in benchmarks. We strictly require that the mark (ID) used for an operator to be the same as the op_name reported by a test case. Or else, we won't be able to extract the benchmark results reliably.