### PR TITLE
[KMCompiler] Optimize fused MoE configurations and refactor dispatch logic

### DIFF
--- a/src/flag_gems/fused/fused_moe.py
+++ b/src/flag_gems/fused/fused_moe.py
@@ -209,22 +209,24 @@ def try_get_optimal_moe_config(
     ):
         # Use heuristic config like hpc-ops
         avg_tokens_per_expert = M * top_k // E
+        is_large_m = M >= 16384
         if avg_tokens_per_expert <= 16:
             block_size_m = 16
         elif avg_tokens_per_expert <= 32:
             block_size_m = 32
-        elif avg_tokens_per_expert <= 48:
-            block_size_m = 48
-        else:
+        elif avg_tokens_per_expert <= 64 or not is_large_m:
             block_size_m = 64
+        else:
+            block_size_m = 128
+
         config = {
             "BLOCK_SIZE_M": block_size_m,
             "BLOCK_SIZE_N": block_shape[0],
             "BLOCK_SIZE_K": block_shape[1],
-            "GROUP_SIZE_M": 1,
-            "num_warps": 4,
-            "num_stages": 3,
-            "SWAP_AB": True,
+            "GROUP_SIZE_M": 8 if (is_large_m and avg_tokens_per_expert > 16) else 1,
+            "num_warps": 8 if (is_large_m and block_size_m > 32) else 4,
+            "num_stages": 5 if is_large_m else 3,
+            "SWAP_AB": False,
         }
         override_config = config
 
@@ -964,12 +966,16 @@ def fused_moe_kernel(
     per_channel_quant: tl.constexpr,
     HAS_BIAS: tl.constexpr,
     SWAP_AB: tl.constexpr,
+    K_DIVISIBLE_BY_BLOCK_K: tl.constexpr,
+    FUSE_SILU: tl.constexpr,
 ):
-    """Fused MoE kernel: token × expert GEMM with quantization support."""
+    """Fused MoE kernel: token × expert GEMM with quantization support and optional SiLU fusion."""
     # Map pid to C block (grouped ordering for L2 reuse)
     pid = tl.program_id(axis=0)
+    # Adjust N for FUSE_SILU. If fused, the actual output dimension is N // 2
+    N_out = N // 2 if FUSE_SILU else N
     num_pid_m = tl.cdiv(EM, BLOCK_SIZE_M)
-    num_pid_n = tl.cdiv(N, BLOCK_SIZE_N)
+    num_pid_n = tl.cdiv(N_out, BLOCK_SIZE_N)
     num_pid_in_group = GROUP_SIZE_M * num_pid_n
     group_id = pid // num_pid_in_group
     first_pid_m = group_id * GROUP_SIZE_M
@@ -996,110 +1002,308 @@ def fused_moe_kernel(
     token_mask = offs_token < num_valid_tokens
 
     off_experts = tl.load(expert_ids_ptr + pid_m).to(tl.int64)
-    if off_experts == -1:
-        # Expert not in current EP rank, write zeros
-        write_zeros_to_output(
-            c_ptr,
-            stride_cm,
-            stride_cn,
-            pid_n,
-            N,
-            offs_token,
-            token_mask,
-            BLOCK_SIZE_M,
-            BLOCK_SIZE_N,
-            compute_type,
-        )
-        return
 
-    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N
+    offs_bn = (pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N).to(tl.int64)) % N_out
     offs_k = tl.arange(0, BLOCK_SIZE_K)
-    a_ptrs = a_ptr + (
-        offs_token[:, None] // top_k * stride_am + offs_k[None, :] * stride_ak
-    )
+    a_base = a_ptr + (offs_token[:, None] // top_k * stride_am)
 
-    b_ptrs = (
-        b_ptr
-        + off_experts * stride_be
-        + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
-    )
-    if use_int8_w8a16:
-        b_scale_ptrs = (
-            b_scale_ptr + off_experts * stride_bse + offs_bn[None, :] * stride_bsn
+    if FUSE_SILU:
+        offs_bn_gate = offs_bn
+        offs_bn_up = offs_bn + N_out
+
+        b_expert_base = b_ptr + off_experts * stride_be
+        b_ptrs_gate = b_expert_base + (
+            offs_k[:, None] * stride_bk + offs_bn_gate[None, :] * stride_bn
         )
-        b_scale = tl.load(b_scale_ptrs)
+        b_ptrs_up = b_expert_base + (
+            offs_k[:, None] * stride_bk + offs_bn_up[None, :] * stride_bn
+        )
 
-    if use_fp8_w8a8 or use_int8_w8a8:
-        if group_k > 0 and group_n > 0:  # block-wise
-            a_scale_ptrs = a_scale_ptr + (offs_token // top_k) * stride_asm
-            offs_bsn = offs_bn // group_n
-            b_scale_ptrs = (
-                b_scale_ptr + off_experts * stride_bse + offs_bsn * stride_bsn
+        if use_fp8_w8a8 or use_int8_w8a8:
+            if group_k > 0 and group_n > 0:  # block-wise
+                a_scale_ptrs = a_scale_ptr + (offs_token // top_k) * stride_asm
+                # Use scalar scale load for hardware broadcast when block size fits within quantization group.
+                if BLOCK_SIZE_N <= group_n:
+                    offs_bsn_gate_idx = (pid_n * BLOCK_SIZE_N) % N_out // group_n
+                    offs_bsn_up_idx = (
+                        (pid_n * BLOCK_SIZE_N) % N_out + N_out
+                    ) // group_n
+                else:
+                    offs_bsn_gate_idx = offs_bn_gate // group_n
+                    offs_bsn_up_idx = offs_bn_up // group_n
+                b_scale_gate_ptrs = (
+                    b_scale_ptr
+                    + off_experts * stride_bse
+                    + offs_bsn_gate_idx * stride_bsn
+                )
+                b_scale_up_ptrs = (
+                    b_scale_ptr
+                    + off_experts * stride_bse
+                    + offs_bsn_up_idx * stride_bsn
+                )
+            elif per_channel_quant:  # channel-wise
+                b_scale_gate_ptrs = (
+                    b_scale_ptr
+                    + off_experts * stride_bse
+                    + offs_bn_gate[None, :] * stride_bsn
+                )
+                b_scale_gate = tl.load(b_scale_gate_ptrs)
+                b_scale_up_ptrs = (
+                    b_scale_ptr
+                    + off_experts * stride_bse
+                    + offs_bn_up[None, :] * stride_bsn
+                )
+                b_scale_up = tl.load(b_scale_up_ptrs)
+                a_scale_ptrs = a_scale_ptr + (offs_token // top_k) * stride_asm
+                a_scale = tl.load(a_scale_ptrs, mask=token_mask, other=0.0)[:, None]
+            else:  # tensor-wise
+                a_scale = tl.load(a_scale_ptr)
+                b_scale_gate = tl.load(b_scale_ptr + off_experts)
+                b_scale_up = b_scale_gate
+
+        # Pass 1: Sequential execution of gate projection to minimize peak register pressure.
+        a_ptrs = a_base + offs_k[None, :] * stride_ak
+        acc_gate = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+        for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+            # Eliminate masking overhead when K is perfectly aligned with BLOCK_SIZE_K.
+            if K_DIVISIBLE_BY_BLOCK_K:
+                a = tl.load(a_ptrs, mask=token_mask[:, None], other=0.0)
+                b_gate = tl.load(b_ptrs_gate)
+            else:
+                k_remaining = K - k * BLOCK_SIZE_K
+                a = tl.load(
+                    a_ptrs,
+                    mask=token_mask[:, None] & (offs_k[None, :] < k_remaining),
+                    other=0.0,
+                )
+                b_gate = tl.load(
+                    b_ptrs_gate, mask=offs_k[:, None] < k_remaining, other=0.0
+                )
+
+            if use_fp8_w8a8 or use_int8_w8a8:
+                if group_k > 0 and group_n > 0:
+                    k_start = k * BLOCK_SIZE_K
+                    offs_ks = k_start // group_k
+                    a_scale = tl.load(
+                        a_scale_ptrs + offs_ks * stride_ask, mask=token_mask, other=0.0
+                    )
+                    b_scale_val = tl.load(b_scale_gate_ptrs + offs_ks * stride_bsk)
+
+                    # Pre-compute combined scale to reduce arithmetic overhead via the associative property.
+                    if BLOCK_SIZE_N <= group_n:
+                        combined_scale = a_scale[:, None] * b_scale_val
+                    else:
+                        combined_scale = a_scale[:, None] * b_scale_val[None, :]
+                    acc_gate += tl.dot(a, b_gate) * combined_scale
+                else:
+                    if use_fp8_w8a8:
+                        acc_gate = tl.dot(a, b_gate, acc=acc_gate)
+                    else:
+                        acc_gate += tl.dot(a, b_gate)
+            else:
+                acc_gate += tl.dot(a, b_gate)
+
+            a_ptrs += BLOCK_SIZE_K * stride_ak
+            b_ptrs_gate += BLOCK_SIZE_K * stride_bk
+
+        if use_fp8_w8a8 or use_int8_w8a8:
+            if group_k > 0 and group_n > 0:
+                pass
+            elif per_channel_quant:
+                acc_gate = acc_gate * a_scale * b_scale_gate
+            else:
+                acc_gate = acc_gate * a_scale * b_scale_gate
+
+        # Pass 2: Sequential up projection; operand A is reloaded with high L1 hit rate.
+        a_ptrs = a_base + offs_k[None, :] * stride_ak
+        acc_up = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+
+        for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+            # Apply mask elimination during the up projection stage.
+            if K_DIVISIBLE_BY_BLOCK_K:
+                a = tl.load(a_ptrs, mask=token_mask[:, None], other=0.0)
+                b_up = tl.load(b_ptrs_up)
+            else:
+                k_remaining = K - k * BLOCK_SIZE_K
+                a = tl.load(
+                    a_ptrs,
+                    mask=token_mask[:, None] & (offs_k[None, :] < k_remaining),
+                    other=0.0,
+                )
+                b_up = tl.load(b_ptrs_up, mask=offs_k[:, None] < k_remaining, other=0.0)
+
+            if use_fp8_w8a8 or use_int8_w8a8:
+                if group_k > 0 and group_n > 0:
+                    k_start = k * BLOCK_SIZE_K
+                    offs_ks = k_start // group_k
+                    a_scale = tl.load(
+                        a_scale_ptrs + offs_ks * stride_ask, mask=token_mask, other=0.0
+                    )
+                    b_scale_val = tl.load(b_scale_up_ptrs + offs_ks * stride_bsk)
+
+                    # Apply pre-computed scale merging to reduce multiplication overhead.
+                    if BLOCK_SIZE_N <= group_n:
+                        combined_scale = a_scale[:, None] * b_scale_val
+                    else:
+                        combined_scale = a_scale[:, None] * b_scale_val[None, :]
+                    acc_up += tl.dot(a, b_up) * combined_scale
+                else:
+                    if use_fp8_w8a8:
+                        acc_up = tl.dot(a, b_up, acc=acc_up)
+                    else:
+                        acc_up += tl.dot(a, b_up)
+            else:
+                acc_up += tl.dot(a, b_up)
+
+            a_ptrs += BLOCK_SIZE_K * stride_ak
+            b_ptrs_up += BLOCK_SIZE_K * stride_bk
+
+        if use_fp8_w8a8 or use_int8_w8a8:
+            if group_k > 0 and group_n > 0:
+                pass
+            elif per_channel_quant:
+                acc_up = acc_up * a_scale * b_scale_up
+            else:
+                acc_up = acc_up * a_scale * b_scale_up
+
+        # SiLU activation fusion
+        accumulator = tl.fdiv(acc_gate, (1.0 + tl.exp(-acc_gate))) * acc_up
+
+    else:
+        if off_experts == -1:
+            # Expert not in current EP rank, write zeros
+            write_zeros_to_output(
+                c_ptr,
+                stride_cm,
+                stride_cn,
+                pid_n,
+                N_out,
+                offs_token,
+                token_mask,
+                BLOCK_SIZE_M,
+                BLOCK_SIZE_N,
+                compute_type,
             )
-        elif per_channel_quant:  # channel-wise
+            return
+        a_ptrs = a_base + offs_k[None, :] * stride_ak
+        b_ptrs = (
+            b_ptr
+            + off_experts * stride_be
+            + (offs_k[:, None] * stride_bk + offs_bn[None, :] * stride_bn)
+        )
+
+        if use_int8_w8a16:
             b_scale_ptrs = (
                 b_scale_ptr + off_experts * stride_bse + offs_bn[None, :] * stride_bsn
             )
             b_scale = tl.load(b_scale_ptrs)
-            a_scale_ptrs = a_scale_ptr + (offs_token // top_k) * stride_asm
-            a_scale = tl.load(a_scale_ptrs, mask=token_mask, other=0.0)[:, None]
-        else:  # tensor-wise
-            a_scale = tl.load(a_scale_ptr)
-            b_scale = tl.load(b_scale_ptr + off_experts)
-    if HAS_BIAS:
-        bias_ptrs = b_bias_ptr + off_experts * stride_bbe + offs_bn * stride_bbn
-        bias = tl.load(bias_ptrs, mask=(offs_bn < N), other=0.0)
-    # Accumulate C block in fp32
-    accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
-    if SWAP_AB:
-        accumulator_nm = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
-    for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
-        a = tl.load(
-            a_ptrs,
-            mask=token_mask[:, None] & (offs_k[None, :] < K - k * BLOCK_SIZE_K),
-            other=0.0,
-        )
-        b = tl.load(b_ptrs, mask=offs_k[:, None] < K - k * BLOCK_SIZE_K, other=0.0)
-        if use_int8_w8a16:
-            accumulator = tl.dot(a, b.to(compute_type), acc=accumulator)
-        elif use_fp8_w8a8 or use_int8_w8a8:
-            if group_k > 0 and group_n > 0:
-                k_start = k * BLOCK_SIZE_K
-                offs_ks = k_start // group_k
-                a_scale = tl.load(
-                    a_scale_ptrs + offs_ks * stride_ask, mask=token_mask, other=0.0
-                )
-                if SWAP_AB:
-                    b_scale = tl.load(b_scale_ptrs + offs_ks * stride_bsk)
-                    accumulator_nm += (
-                        tl.dot(tl.trans(b), tl.trans(a))
-                        * b_scale[:, None]
-                        * a_scale[None, :]
-                    )
+
+        if use_fp8_w8a8 or use_int8_w8a8:
+            if group_k > 0 and group_n > 0:  # block-wise
+                a_scale_ptrs = a_scale_ptr + (offs_token // top_k) * stride_asm
+                # Use scalar scale load for hardware broadcast when block size fits within quantization group.
+                if BLOCK_SIZE_N <= group_n:
+                    offs_bsn = (pid_n * BLOCK_SIZE_N) % N_out // group_n
                 else:
-                    b_scale = tl.load(b_scale_ptrs + offs_ks * stride_bsk)
-                    accumulator += tl.dot(a, b) * a_scale[:, None] * b_scale[None, :]
+                    offs_bsn = offs_bn // group_n
+                b_scale_ptrs = (
+                    b_scale_ptr + off_experts * stride_bse + offs_bsn * stride_bsn
+                )
+            elif per_channel_quant:  # channel-wise
+                b_scale_ptrs = (
+                    b_scale_ptr
+                    + off_experts * stride_bse
+                    + offs_bn[None, :] * stride_bsn
+                )
+                b_scale = tl.load(b_scale_ptrs)
+                a_scale_ptrs = a_scale_ptr + (offs_token // top_k) * stride_asm
+                a_scale = tl.load(a_scale_ptrs, mask=token_mask, other=0.0)[:, None]
+            else:  # tensor-wise
+                a_scale = tl.load(a_scale_ptr)
+                b_scale = tl.load(b_scale_ptr + off_experts)
+
+        if HAS_BIAS:
+            bias_ptrs = b_bias_ptr + off_experts * stride_bbe + offs_bn * stride_bbn
+            bias = tl.load(bias_ptrs, mask=(offs_bn < N_out), other=0.0)
+
+        # Accumulate C block in fp32
+        accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
+        if SWAP_AB:
+            accumulator_nm = tl.zeros((BLOCK_SIZE_N, BLOCK_SIZE_M), dtype=tl.float32)
+
+        for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
+            # Eliminate masking overhead when K is perfectly aligned with BLOCK_SIZE_K.
+            if K_DIVISIBLE_BY_BLOCK_K:
+                a = tl.load(a_ptrs, mask=token_mask[:, None], other=0.0)
+                b = tl.load(b_ptrs)
             else:
-                if use_fp8_w8a8:
-                    accumulator = tl.dot(a, b, acc=accumulator)
+                k_remaining = K - k * BLOCK_SIZE_K
+                a = tl.load(
+                    a_ptrs,
+                    mask=token_mask[:, None] & (offs_k[None, :] < k_remaining),
+                    other=0.0,
+                )
+                b = tl.load(b_ptrs, mask=offs_k[:, None] < k_remaining, other=0.0)
+
+            if use_int8_w8a16:
+                accumulator = tl.dot(a, b.to(compute_type), acc=accumulator)
+            elif use_fp8_w8a8 or use_int8_w8a8:
+                if group_k > 0 and group_n > 0:
+                    k_start = k * BLOCK_SIZE_K
+                    offs_ks = k_start // group_k
+                    a_scale = tl.load(
+                        a_scale_ptrs + offs_ks * stride_ask, mask=token_mask, other=0.0
+                    )
+                    if SWAP_AB:
+                        b_scale_val = tl.load(b_scale_ptrs + offs_ks * stride_bsk)
+                        if BLOCK_SIZE_N <= group_n:
+                            combined_scale_nm = b_scale_val * a_scale[None, :]
+                        else:
+                            combined_scale_nm = b_scale_val[:, None] * a_scale[None, :]
+                        accumulator_nm += (
+                            tl.dot(tl.trans(b), tl.trans(a)) * combined_scale_nm
+                        )
+                    else:
+                        b_scale_val = tl.load(b_scale_ptrs + offs_ks * stride_bsk)
+                        # Pre-compute combined scale to reduce arithmetic overhead via the associative property.
+                        if BLOCK_SIZE_N <= group_n:
+                            combined_scale = a_scale[:, None] * b_scale_val
+                        else:
+                            combined_scale = a_scale[:, None] * b_scale_val[None, :]
+                        accumulator += tl.dot(a, b) * combined_scale
+                else:
+                    if use_fp8_w8a8:
+                        if SWAP_AB:
+                            accumulator_nm = tl.dot(
+                                tl.trans(b), tl.trans(a), acc=accumulator_nm
+                            )
+                        else:
+                            accumulator = tl.dot(a, b, acc=accumulator)
+                    else:
+                        if SWAP_AB:
+                            accumulator_nm += tl.dot(tl.trans(b), tl.trans(a))
+                        else:
+                            accumulator += tl.dot(a, b)
+            else:
+                if SWAP_AB:
+                    accumulator_nm += tl.dot(tl.trans(b), tl.trans(a))
                 else:
                     accumulator += tl.dot(a, b)
-        else:
-            accumulator += tl.dot(a, b)
-        a_ptrs += BLOCK_SIZE_K * stride_ak
-        b_ptrs += BLOCK_SIZE_K * stride_bk
+            a_ptrs += BLOCK_SIZE_K * stride_ak
+            b_ptrs += BLOCK_SIZE_K * stride_bk
 
-    if SWAP_AB:
-        accumulator = tl.trans(accumulator_nm)
+        if SWAP_AB:
+            accumulator = tl.trans(accumulator_nm)
 
-    # Dequantization
-    if use_int8_w8a16:
-        accumulator = accumulator * b_scale
-    elif (use_fp8_w8a8 or use_int8_w8a8) and not (group_k > 0 and group_n > 0):
-        accumulator = accumulator * a_scale * b_scale
+        # Dequantization
+        if use_int8_w8a16:
+            accumulator = accumulator * b_scale
+        elif (use_fp8_w8a8 or use_int8_w8a8) and not (group_k > 0 and group_n > 0):
+            accumulator = accumulator * a_scale * b_scale
 
-    if HAS_BIAS:
-        accumulator += bias[None, :]
+        if HAS_BIAS:
+            accumulator += bias[None, :]
 
     # Router weight multiplication (must be in fp32)
     if MUL_ROUTED_WEIGHT:
@@ -1115,7 +1319,7 @@ def fused_moe_kernel(
     # Write back output
     offs_cn = pid_n * BLOCK_SIZE_N + tl.arange(0, BLOCK_SIZE_N)
     c_ptrs = c_ptr + stride_cm * offs_token[:, None] + stride_cn * offs_cn[None, :]
-    c_mask = token_mask[:, None] & (offs_cn[None, :] < N)
+    c_mask = token_mask[:, None] & (offs_cn[None, :] < N_out)
     tl.store(c_ptrs, accumulator, mask=c_mask)
 
 
@@ -1230,6 +1434,7 @@ def invoke_fused_moe_triton_kernel(
     per_channel_quant: bool = False,
     block_shape: Optional[list[int]] = None,
     B_bias: torch.Tensor | None = None,
+    FUSE_SILU: bool = False,
 ) -> None:
     """Launch the fused_moe_kernel Triton kernel."""
     assert topk_weights is not None or not mul_routed_weight
@@ -1261,9 +1466,12 @@ def invoke_fused_moe_triton_kernel(
             )
     else:
         EM = num_tokens * config["BLOCK_SIZE_M"]
+
+    #  FUSE_SILU means B.size(1) contains both Gate and Up. N is halved.
+    actual_N = B.size(1) // 2 if FUSE_SILU else B.size(1)
     grid = lambda META: (
         triton.cdiv(EM, META["BLOCK_SIZE_M"])
-        * triton.cdiv(B.size(1), META["BLOCK_SIZE_N"]),
+        * triton.cdiv(actual_N, META["BLOCK_SIZE_N"]),
     )
     HAS_BIAS = B_bias is not None
 
@@ -1274,6 +1482,10 @@ def invoke_fused_moe_triton_kernel(
         BLOCK_SIZE_K = min(BLOCK_SIZE_K, min(block_shape[0], block_shape[1]))
 
     swap_AB = config.pop("SWAP_AB", False)
+    # Force disable SWAP_AB in fusion mode
+    if FUSE_SILU:
+        swap_AB = False
+
     fused_moe_kernel[grid](
         A,
         B,
@@ -1316,6 +1528,8 @@ def invoke_fused_moe_triton_kernel(
         HAS_BIAS=HAS_BIAS,
         BLOCK_SIZE_K=BLOCK_SIZE_K,
         SWAP_AB=swap_AB,
+        K_DIVISIBLE_BY_BLOCK_K=(B.size(2) % BLOCK_SIZE_K == 0),
+        FUSE_SILU=FUSE_SILU,
         **config,
     )
 
@@ -1342,6 +1556,7 @@ def dispatch_fused_moe_kernel(
     per_channel_quant: bool,
     block_shape: Optional[list[int]] = None,
     B_bias: Optional[torch.Tensor] = None,
+    FUSE_SILU: bool = False,
 ) -> None:
     """Dispatch to the appropriate fused MoE kernel based on quantization flags."""
     assert topk_weights is not None or not mul_routed_weight
@@ -1402,6 +1617,7 @@ def dispatch_fused_moe_kernel(
             per_channel_quant,
             block_shape,
             B_bias,
+            FUSE_SILU=FUSE_SILU,
         )
 
 
@@ -1472,7 +1688,7 @@ def fused_experts_impl(
         global_num_experts = E
     top_k_num = topk_ids.size(1)
 
-    CHUNK_SIZE: int = 16 * 1024
+    CHUNK_SIZE: int = 32 * 1024
     M = min(num_tokens, CHUNK_SIZE)
 
     config_dtype = _get_config_dtype_str(
@@ -1566,6 +1782,13 @@ def fused_experts_impl(
         use_int8_w8a16 = False
         use_int4_w4a16 = False
 
+    # Check if we can safely fuse the activation with the first GEMM pass
+    can_use_fused_silu = (
+        activation_enum in (MoEActivation.SILU, MoEActivation.SWIGLUOAI)
+        and w1_bias is None
+        and expert_map is None  # Fused kernel doesn't handle EP -1 experts
+    )
+
     for chunk in range((num_tokens // CHUNK_SIZE) + 1):
         begin_chunk_idx, end_chunk_idx = (
             chunk * CHUNK_SIZE,
@@ -1625,14 +1848,36 @@ def fused_experts_impl(
             num_tokens_post_padded.fill_(max_num_tokens_padded)
             sorted_token_ids = None
 
+        # 1. Extract a unified boolean flag for fusion
+        do_fuse_silu = can_use_fused_silu and not naive_block_assignment
+
+        # 2. Dynamically determine the differing parameters based on the fusion flag
+        if do_fuse_silu:
+            # Output goes directly to cache 2 with adjusted dimensions
+            out_cache = intermediate_cache2.view(
+                tokens_in_chunk, top_k_num, activation_out_dim
+            )
+
+            # Fused kernel weight handling depends on apply_router_weight_on_input
+            if apply_router_weight_on_input:
+                weights_arg = curr_topk_weights
+            else:
+                weights_arg = None
+        else:
+            # Standard path outputs to cache 1
+            out_cache = intermediate_cache1
+            # Standard path always passes the weights
+            weights_arg = curr_topk_weights
+
+        # 3. Unified dispatch call to eliminate redundant code blocks
         dispatch_fused_moe_kernel(
             qcurr_hidden_states,
             w1,
-            intermediate_cache1,
+            out_cache,  # Dynamically assigned output buffer
             a1q_scale,
             w1_scale,
             w1_zp,
-            curr_topk_weights,
+            weights_arg,  # Dynamically assigned weights argument
             sorted_token_ids,
             expert_ids,
             num_tokens_post_padded,
@@ -1647,11 +1892,14 @@ def fused_experts_impl(
             per_channel_quant=per_channel_quant,
             block_shape=block_shape,
             B_bias=w1_bias,
+            FUSE_SILU=do_fuse_silu,  # Master switch for the kernel
         )
 
-        apply_moe_activation(
-            activation_enum, intermediate_cache2, intermediate_cache1.view(-1, N)
-        )
+        # 4. Apply activation separately if the fused path was not taken
+        if not do_fuse_silu:
+            apply_moe_activation(
+                activation_enum, intermediate_cache2, intermediate_cache1.view(-1, N)
+            )
 
         qintermediate_cache2, a2q_scale = moe_kernel_quantize_input(
             A=intermediate_cache2,
@@ -1687,6 +1935,7 @@ def fused_experts_impl(
             per_channel_quant=per_channel_quant,
             block_shape=block_shape,
             B_bias=w2_bias,
+            FUSE_SILU=False,
         )
 
         moe_sum(


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Performance Optimization, Refactor

### Description
This PR introduces a highly optimized `fused_moe` kernel implementation. By combining structural operator fusion with low-level micro-architectural tuning, we achieved significant throughput gains and improved stability on Hopper architecture.

**Key Optimizations:**

1.  **SiLU-Mul Fusion & Two-Pass Architecture:** Fused the SiLU activation and element-wise multiplication into the GEMM epilogue. The Gate and Up projections are refactored into two sequential passes to effectively manage peak register pressure and maximize instruction-level parallelism (ILP).
2.  **Hardware Broadcast for Scales:** When `BLOCK_SIZE_N <= group_n`, the kernel is optimized to load a scalar `b_scale` instead of a tensor. This leverages hardware broadcast capabilities, reducing memory bandwidth requirements and SRAM footprint.
3.  **ALU Instruction Reduction via Scale Pre-computation:** Exploited the associative property to pre-calculate `combined_scale = a_scale * b_scale` before the point-wise accumulation. This significantly reduces the total count of floating-point multiplication instructions in the kernel's critical path.
4.  **Masking Overhead Elimination:** Optimized the inner loop logic to bypass boundary checks and mask computations (e.g., via `K_DIVISIBLE_BY_BLOCK_K`), reducing branch divergence and control-flow overhead.
5.  **Reduced Launch Overhead:** Increased the `CHUNK_SIZE` (e.g., from 16k to 32k) to decrease the number of Python-level loop iterations and cumulative kernel launch overhead for large token batches.
6.  **Hopper-Specific Heuristic Tuning:** Refined the selection logic for `BLOCK_SIZE_M`, `num_warps`, and `num_stages` to better align with Hopper's TMA (Tensor Memory Accelerator) and SRAM physical limits.
7.  **Stability-First Configuration (Disabled Swap):** Disabled `SWAP_AB` across all configurations. While `SWAP_AB` attempts to use transposed loading, profiling revealed it degrades performance and increases register pressure in this specific fused branch. Disabling it ensures higher throughput and avoids `cudaErrorIllegalAddress` under heavy workloads.

### Performance
Test configuration: FP8 W8A8 block-wise quantization
Demonstrated substantial speedups on H100:
**1. FP8 W8A8 Block-wise Quantization:**
- **Average Speedup:** 1.17x - 1.18x for token counts ranging from 512 to 64k.
- **Peak Speedup:** **1.36x** achieved at `num_tokens=32768`.

| `num_tokens` | `num_experts` | `hidden_size` | `inter_size` | `topk` | Base Latency (ms) | Opt Latency (ms) | Speedup |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 512 | 256 | 7168 | 2048 | 8 | 4.12 | 3.97 | **1.04x** |
| 1024 | 256 | 7168 | 2048 | 8 | 4.24 | 4.64 | **0.91x** |
| 2048 | 256 | 7168 | 2048 | 8 | 5.45 | 4.87 | **1.12x** |
| 4096 | 256 | 7168 | 2048 | 8 | 7.58 | 6.52 | **1.16x** |
| 8192 | 256 | 7168 | 2048 | 8 | 13.36 | 10.84 | **1.23x** |
| 16384 | 256 | 7168 | 2048 | 8 | 24.63 | 19.49 | **1.26x** |
| 32768 | 256 | 7168 | 2048 | 8 | 49.67 | 36.61 | **1.36x** |
| 65536 | 256 | 7168 | 2048 | 8 | 101.74 | 76.35 | **1.33x** |
| 512 | 512 | 4096 | 1024 | 10 | 2.25 | 2.25 | **1.00x** |
| 1024 | 512 | 4096 | 1024 | 10 | 2.36 | 2.35 | **1.01x** |
| 2048 | 512 | 4096 | 1024 | 10 | 2.64 | 2.52 | **1.05x** |
| 4096 | 512 | 4096 | 1024 | 10 | 4.08 | 3.43 | **1.19x** |
| 8192 | 512 | 4096 | 1024 | 10 | 6.14 | 4.99 | **1.23x** |
| 16384 | 512 | 4096 | 1024 | 10 | 11.04 | 8.91 | **1.24x** |
| 32768 | 512 | 4096 | 1024 | 10 | 21.72 | 16.18 | **1.34x** |
| 65536 | 512 | 4096 | 1024 | 10 | 43.36 | 32.56 | **1.33x** |

**2. BFloat16 (Unquantized):**
- **Average Speedup:** **1.03x** across the benchmark suite.
- **Peak Speedup:** **1.13x** achieved at `num_tokens=4096`.

| `num_tokens` | `num_experts` | `hidden_size` | `inter_size` | `topk` | Base Latency (ms) | Opt Latency (ms) | Speedup |
|---:|---:|---:|---:|---:|---:|---:|---:|
| 512 | 256 | 7168 | 2048 | 8 | 8.87 | 8.14 | **1.09x** |
| 1024 | 256 | 7168 | 2048 | 8 | 8.92 | 8.41 | **1.06x** |
| 2048 | 256 | 7168 | 2048 | 8 | 9.47 | 8.75 | **1.08x** |
| 4096 | 256 | 7168 | 2048 | 8 | 13.68 | 12.07 | **1.13x** |
| 8192 | 256 | 7168 | 2048 | 8 | 16.04 | 16.84 | **0.95x** |
| 16384 | 256 | 7168 | 2048 | 8 | 27.69 | 28.92 | **0.96x** |
| 32768 | 256 | 7168 | 2048 | 8 | 55.57 | 53.54 | **1.04x** |
| 65536 | 256 | 7168 | 2048 | 8 | 114.81 | 108.57 | **1.06x** |
| 512 | 512 | 4096 | 1024 | 10 | 4.33 | 4.29 | **1.01x** |
| 1024 | 512 | 4096 | 1024 | 10 | 4.94 | 4.58 | **1.08x** |
| 2048 | 512 | 4096 | 1024 | 10 | 5.13 | 5.44 | **0.94x** |
| 4096 | 512 | 4096 | 1024 | 10 | 5.63 | 5.63 | **1.00x** |
| 8192 | 512 | 4096 | 1024 | 10 | 7.70 | 7.40 | **1.04x** |
| 16384 | 512 | 4096 | 1024 | 10 | 11.24 | 11.79 | **0.95x** |
| 32768 | 512 | 4096 | 1024 | 10 | 22.32 | 21.08 | **1.06x** |
| 65536 | 512 | 4096 | 1024 | 10 | 44.64 | 43.47 | **1.03x** |

*(See the attached benchmark screenshot for full details)*
<img width="1366" height="604" alt="benchmark" src="https://github.com/user-attachments/assets/b21a7f83-4e29-450e-a140-995134e20677" />
<img width="1324" height="621" alt="image" src="https://github.com/user-attachments/assets/6aab6025-6b15-4f6d-8772-038e7da58e1e" />

### Test Command
```bash
pytest benchmark/test_fused_moe.py -v



