### PR TITLE
Fix sparse MLA reference device mismatch

### DIFF
--- a/tests/test_DSA/test_sparse_mla_ops.py
+++ b/tests/test_DSA/test_sparse_mla_ops.py
@@ -106,7 +106,6 @@ def reference_sparse_mla_implementation(q, kv, indices, sm_scale=None, d_v=512):
 
 
 @pytest.mark.sparse_mla_fwd_interface
-@pytest.mark.skip("#2872: RuntimeError")
 @pytest.mark.parametrize("batch_size", [1])
 @pytest.mark.parametrize("seq_len_q", [64, 128, 512])
 @pytest.mark.parametrize("seq_len_kv", [1024, 2048, 4096])
@@ -165,7 +164,6 @@ def test_sparse_mla_forward(
 
 
 @pytest.mark.sparse_mla_fwd_interface
-@pytest.mark.skip("#2872: RuntimeError")
 @pytest.mark.parametrize(
     "config",
     [
@@ -226,7 +224,6 @@ def test_sparse_mla_forward_edge_cases(config):
 
 
 # Device compatibility test
-@pytest.mark.skip("#2872: RuntimeError")
 @pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA device required")
 @pytest.mark.sparse_mla_fwd_interface
 def test_sparse_mla_device_compatibility():

--- a/tests/test_DSA/torch_src/sparse_mla_fwd.py
+++ b/tests/test_DSA/torch_src/sparse_mla_fwd.py
@@ -19,9 +19,12 @@ def ref_sparse_mla_fwd_interface(
     b, _, _, dim_v = v.shape
     g_index = g
     h_index = h // g
-    compressed_casual_mask = (
-        torch.arange(0, sq, dtype=torch.int32, device=q.device).view(-1, 1)
-        >= torch.arange(1 - 1, sk * 1, 1, dtype=torch.int32, device=q.device).view(1, -1)
+    compressed_casual_mask = torch.arange(
+        0, sq, dtype=torch.int32, device=q.device
+    ).view(-1, 1) >= torch.arange(
+        1 - 1, sk * 1, 1, dtype=torch.int32, device=q.device
+    ).view(
+        1, -1
     )
 
     mask = q.new_zeros(b, g_index, sq, sk + 1, dtype=torch.bool).scatter(

--- a/tests/test_DSA/torch_src/sparse_mla_fwd.py
+++ b/tests/test_DSA/torch_src/sparse_mla_fwd.py
@@ -19,9 +19,9 @@ def ref_sparse_mla_fwd_interface(
     b, _, _, dim_v = v.shape
     g_index = g
     h_index = h // g
-    compressed_casual_mask = torch.arange(0, sq, dtype=torch.int32, device="cuda").view(
+    compressed_casual_mask = torch.arange(0, sq, dtype=torch.int32, device=q.device).view(
         -1, 1
-    ) >= torch.arange(1 - 1, sk * 1, 1, dtype=torch.int32, device="cuda").view(1, -1)
+    ) >= torch.arange(1 - 1, sk * 1, 1, dtype=torch.int32, device=q.device).view(1, -1)
 
     mask = q.new_zeros(b, g_index, sq, sk + 1, dtype=torch.bool).scatter(
         3, indices.long(), 1

--- a/tests/test_DSA/torch_src/sparse_mla_fwd.py
+++ b/tests/test_DSA/torch_src/sparse_mla_fwd.py
@@ -19,9 +19,10 @@ def ref_sparse_mla_fwd_interface(
     b, _, _, dim_v = v.shape
     g_index = g
     h_index = h // g
-    compressed_casual_mask = torch.arange(0, sq, dtype=torch.int32, device=q.device).view(
-        -1, 1
-    ) >= torch.arange(1 - 1, sk * 1, 1, dtype=torch.int32, device=q.device).view(1, -1)
+    compressed_casual_mask = (
+        torch.arange(0, sq, dtype=torch.int32, device=q.device).view(-1, 1)
+        >= torch.arange(1 - 1, sk * 1, 1, dtype=torch.int32, device=q.device).view(1, -1)
+    )
 
     mask = q.new_zeros(b, g_index, sq, sk + 1, dtype=torch.bool).scatter(
         3, indices.long(), 1

--- a/tools/test-op.sh
+++ b/tools/test-op.sh
@@ -40,12 +40,15 @@ TEST_CASES=()
 PERF_TEST_CASES=()
 TEST_CASES_CPU=()
 for item in $CHANGED_FILES; do
+  file_name=$(basename "$item")
   case $item in
     tests/test_quant.py)
       # skip because it always fail
       ;;
-    tests/test*)
-      TEST_CASES+=($item)
+    tests/*.py)
+      if [[ "$file_name" == test*.py ]]; then
+        TEST_CASES+=($item)
+      fi
       ;;
     benchmark/test*)
       PERF_TEST_CASES+=($item)
@@ -62,7 +65,11 @@ for item in $CHANGED_FILES; do
   done
   if (( $found == 0 )); then
     case $item in
-      tests/*) TEST_CASES_CPU+=($item) ;;
+      tests/*.py)
+        if [[ "$file_name" == test*.py ]]; then
+          TEST_CASES_CPU+=($item)
+        fi
+        ;;
     esac
   fi
 done


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
Bug Fix

### Description
1. Fix the reference implementation of `sparse_mla_fwd_interface` by creating `compressed_casual_mask` on `q.device` instead of hardcoding CUDA. This avoids device mismatch when running accuracy tests with `--ref cpu`.

Also re-enable the sparse MLA accuracy tests skipped for #2872.

2. Modified test file discovery logic to find Python files starting with 'test' in tests directory and all subdirectories at any depth.

### Issue
- Resolves #2872

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
No performance changes. Test/reference-only change.

### Validation
- `pytest tests/test_DSA/test_sparse_mla_ops.py -s --ref cpu`
  - 166 passed, 38 warnings in 163.22s
- `pytest tests/test_DSA/test_sparse_mla_ops.py -s`
  - 166 passed, 38 warnings in 6.30s