### PR TITLE
Fix two benchmarks

### DIFF
--- a/benchmark/test_dswiglu.py
+++ b/benchmark/test_dswiglu.py
@@ -12,25 +12,17 @@ try:
     from transformer_engine.pytorch import cpp_extensions as tex
 
     TE_OP = getattr(tex, "dswiglu")
-    TE_AVAILABLE = True
-    GEMS_OP = getattr(flag_gems, "dswiglu")
 except ImportError:
-    TE_AVAILABLE = False
     TE_OP = None
-    GEMS_OP = None
 
 
 @pytest.mark.dswiglu
-@pytest.mark.skipif(not TE_AVAILABLE, reason="TransformerEngine not installed")
-@pytest.mark.skipif(TE_OP is None, reason="'dswiglu' not found in TransformerEngine")
-@pytest.mark.skipif(GEMS_OP is None, reason="'dswiglu' not found in FlagGems")
+@pytest.mark.skipif(TE_OP is None, reason="TransformerEngine not installed")
 def test_dswiglu():
     bench = base.TexGluBackwardBenchmark(
         op_name="dswiglu",
         torch_op=TE_OP,
-        gems_op=GEMS_OP,
+        gems_op=flag_gems.dswiglu,
         dtypes=consts.FLOAT_DTYPES,
-        # TODO(Qiming): Is this flag correct?
-        is_backward=False,
     )
     bench.run()

--- a/benchmark/test_reglu.py
+++ b/benchmark/test_reglu.py
@@ -12,23 +12,17 @@ try:
     from transformer_engine.pytorch import cpp_extensions as tex
 
     TE_OP = getattr(tex, "reglu")
-    TE_AVAILABLE = True
-    GEMS_OP = getattr(flag_gems, "reglu")
 except ImportError:
-    TE_AVAILABLE = False
     TE_OP = None
-    GEMS_OP = None
 
 
 @pytest.mark.reglu
-@pytest.mark.skipif(not TE_AVAILABLE, reason="TransformerEngine not installed")
-@pytest.mark.skipif(TE_OP is None, reason="'reglu' not found in TransformerEngine")
-@pytest.mark.skipif(GEMS_OP is None, reason="'reglu' not found in FlagGems")
+@pytest.mark.skipif(TE_OP is None, reason="TransformerEngine not installed")
 def test_reglu():
     bench = base.TexGluForwardBenchmark(
         op_name="reglu",
         torch_op=TE_OP,
-        gems_op=GEMS_OP,
+        gems_op=flag_gems.reglu,
         dtypes=consts.FLOAT_DTYPES,
     )
     bench.run()


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

The benchmarks for the `reglu` and the `dswiglu` operators are doing redundant checks. These checks lead to inaccurate, confusing results from batch benchmark testing. This PR fixes the condition checking by making the skipping reason crystal clear.