### PR TITLE
Fix accuracy test for fill

### DIFF
--- a/tests/test_fill.py
+++ b/tests/test_fill.py
@@ -114,7 +114,8 @@ FILL_SLICE_CASES = [
 )
 def test_fill_scalar_sliced_view(shape, slc, dtype, value):
     if dtype == torch.bool and value == float("-inf"):
-        pytest.skip("bool tensor does not support -inf")
+        # bool value cannot be -inf
+        return
 
     x = torch.randn(shape, device=flag_gems.device).to(dtype)
     ref_x = utils.to_reference(x, False)


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

An invalid combination of input parameters should not be treated as "skipped". We should return directly from the test rather than "skip" the test.

A "skip" test is a workaround for operators not working and/or buggy test cases. We use "skip" to make sure that they do not block our batch tests or CI jobs.
