### PR TITLE
Fix some accuracy test cases

### DIFF
--- a/tests/test_angle.py
+++ b/tests/test_angle.py
@@ -4,6 +4,7 @@ import torch
 import flag_gems
 
 from . import accuracy_utils as utils
+from . import conftest as cfg
 
 
 @pytest.mark.angle
@@ -13,6 +14,14 @@ from . import accuracy_utils as utils
     utils.COMPLEX_DTYPES + utils.FLOAT_DTYPES + utils.ALL_INT_DTYPES + utils.BOOL_TYPES,
 )
 def test_angle(shape, dtype):
+    if cfg.TO_CPU and dtype == torch.complex32:
+        # Complex32 on CPU is not supported
+        return
+
+    if not cfg.TO_CPU and dtype in [torch.float16, torch.bfloat16]:
+        # Half is treated as an unsupported data type on GPU
+        return
+
     if flag_gems.vendor_name == "kunlunxin":
         torch.manual_seed(0)
         torch.cuda.manual_seed_all(0)
@@ -27,20 +36,8 @@ def test_angle(shape, dtype):
         inp = torch.randn(shape, dtype=dtype, device="cpu").to(flag_gems.device)
 
     ref_inp = utils.to_reference(inp)
-
-    try:
-        ref_out = torch.angle(ref_inp)
-    except RuntimeError as e:
-        if "angle_cpu" in str(e) and "ComplexHalf" in str(e):
-            pytest.skip("Skipping angle ComplexHalf for unsupported dtype on CPU")
-        elif "angle_cuda" in str(e) and "Half" in str(e):
-            pytest.skip("Skipping angle Half for unsupported dtype on GPU")
-        elif "angle_cuda" in str(e) and "BFloat16" in str(e):
-            pytest.skip("Skipping angle BFloat16 for unsupported dtype on GPU")
-        else:
-            raise
-
     ref_out = torch.angle(ref_inp)
+
     with flag_gems.use_gems():
         res_out = torch.angle(inp)
 

--- a/tests/test_argmax.py
+++ b/tests/test_argmax.py
@@ -28,19 +28,18 @@ def test_argmax(shape, dim, keepdim, dtype):
 
     if dim is not None:
         if rank == 0 or dim >= rank or dim < -rank:
-            pytest.skip(f"Dimension {dim} is out of bound for shape {shape}")
+            # Skip invalid input combination - dimension out of bound for shape
+            return
 
     if is_empty_tensor:
         if dim is None:
-            pytest.skip(
-                "PyTorch reference requires dim specification for empty tensor."
-            )
+            # The dim parameter must be specified for empty tensor for PyTorch
+            return
 
         dim_index = dim % rank
         if shape[dim_index] == 0:
-            pytest.skip(
-                f"PyTorch reference prohibits reduction on zero-sized dimension ({dim})."
-            )
+            # Zero-sized dimension is invalid input for PyTorch
+            return
 
     if is_empty_tensor:
         inp = torch.empty(shape, dtype=dtype, device=flag_gems.device)

--- a/tests/test_bmm.py
+++ b/tests/test_bmm.py
@@ -74,7 +74,8 @@ def test_bmm_non_contiguous(M, N, K, dtype):
     if N > 1 and K > 1:
         assert not mat2.is_contiguous()
     else:
-        pytest.skip("Skipping non-contiguous test for small N or K")
+        # Skipping non-contiguous test for small N or K
+        return
 
     ref_mat1 = utils.to_reference(mat1, True)
     ref_mat2 = utils.to_reference(mat2, True)

--- a/tests/test_flash_mla_sparse_fwd.py
+++ b/tests/test_flash_mla_sparse_fwd.py
@@ -295,19 +295,21 @@ class FlashmlaSparseTestKit:
 
 @pytest.mark.flash_mla_sparse_fwd
 @pytest.mark.parametrize("param", FlashmlaSparseTestKit.get_correctness_test_params())
-def test_flashmla_sparse(param: Flashmla_Sparse_Test_Param):
+def test_flashmla_sparse(param):
     """Sparse MLA forward propagation test"""
     # Skip FlashMLA unsupported cases
     if param.h_q != 64 and param.h_q != 128:
         # RuntimeError: Unsupported h_q: 256
         # FlashMLA csrc/api/sparse_fwd.h:197
-        pytest.skip("h_q unsupported by FlashMLA")
+        # FlashMLA requires that h_q is 64 or 128
+        return
 
     if param.topk % 128 != 0:
         # Assertion `params.topk % (2*B_TOPK) == 0` failed
         # FlashMLA csrc/sm90/prefill/sparse/phase1.cuh:577
         # FlashMLA csrc/sm90/prefill/sparse/config.h:27 "B_TOPK = 64"
-        pytest.skip("topk unsupported by FlashMLA")
+        # topk not divisible by 128, not supported by FlashMLA
+        return
 
     # Create input
     q, kv, indices = FlashmlaSparseTestKit.make_input(param)

--- a/tests/test_max.py
+++ b/tests/test_max.py
@@ -52,13 +52,14 @@ def test_max_all_neg_inf(shape, dtype):
 
 
 @pytest.mark.max
-@pytest.mark.skipif(
-    flag_gems.vendor_name not in ["cambricon", "metax"],
-    reason="#2829: Cambricon and Metax test only",
-)
 @pytest.mark.parametrize("shape", utils.REDUCTION_SHAPES + [[1]])
 @pytest.mark.parametrize("dtype", utils.ALL_INT_DTYPES)
 def test_max_int(shape, dtype):
+    if flag_gems.vendor_name not in ["cambricon", "metax"]:
+        # Issue #2829: This test is only for Cambricon and Metax
+        # We treat it a success for other platforms.
+        return
+
     inp = torch.randint(-1000, 1000, shape, dtype=dtype, device="cpu").to(
         flag_gems.device
     )

--- a/tests/test_pad.py
+++ b/tests/test_pad.py
@@ -24,7 +24,8 @@ device = flag_gems.device
 def test_pad(shape, dtype, pad_mode, contiguous):
     rank = len(shape)
     if pad_mode != "constant" and rank < 3:
-        pytest.skip("PyTorch non-constant padding requires 3D+ input tensors")
+        # Invalid combination: PyTorch non-constant padding requires 3D+ input tensors
+        return
 
     if flag_gems.vendor_name == "kunlunxin":
         torch.manual_seed(0)

--- a/tests/test_roll.py
+++ b/tests/test_roll.py
@@ -22,7 +22,8 @@ def test_roll_single_dim(shape, dtype, shifts_dims):
     ndim = len(shape)
     # Adjust dims if it's out of range for this shape
     if dims >= ndim or dims < -ndim:
-        pytest.skip(f"dims {dims} out of range for shape {shape}")
+        # Skip test if dims is out of range for the specified shape
+        return
 
     if dtype in utils.ALL_FLOAT_DTYPES:
         inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
@@ -54,7 +55,8 @@ def test_roll_multi_dims(shape, dtype, shifts_dims):
     # Check all dims are valid for this shape
     for d in dims:
         if d >= ndim or d < -ndim:
-            pytest.skip(f"dims {d} out of range for shape {shape}")
+            # Skip the case when dims is out of range for the shape
+            return
 
     inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     ref_inp = utils.to_reference(inp, False)
@@ -90,7 +92,8 @@ def test_roll_flatten(shape, dtype, shifts):
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
 def test_roll_with_non_dense_input(shape, dtype):
     if len(shape) < 2:
-        pytest.skip("Need at least 2D for non-dense test")
+        # Need at least 2D for non-dense test
+        return
 
     shape_dilated = tuple(item * 2 for item in shape)
     inp = torch.randn(shape_dilated, dtype=dtype, device=flag_gems.device)[::2, ::2]

--- a/tests/test_select_backward.py
+++ b/tests/test_select_backward.py
@@ -28,7 +28,8 @@ def test_select_backward(shape, dtype, dim):
     actual_dim = dim + ndim if dim < 0 else dim
 
     if actual_dim >= ndim:
-        pytest.skip(f"dim {dim} out of range for shape {shape}")
+        # Invalid input: dim out of range for shape
+        return
 
     dim_size = shape[actual_dim]
 

--- a/tests/test_std.py
+++ b/tests/test_std.py
@@ -40,7 +40,8 @@ def test_std(shape, dim, correction, keepdim, dtype):
         dims_to_check = dim
 
     if any(d >= len(shape) or d < -len(shape) for d in dims_to_check):
-        pytest.skip("Dimension out of range for the given shape.")
+        # skip the test if dimension is out of range for the given shape.
+        return
 
     if correction == 1:
         if dim is not None:
@@ -49,9 +50,11 @@ def test_std(shape, dim, correction, keepdim, dtype):
             for d in positive_dims:
                 reduction_size *= shape[d]
             if reduction_size < 2:
-                pytest.skip("Correction=1 requires reduction size of at least 2.")
+                # Invalid case: correction=1 requires reduction size of at least 2
+                return
         elif inp.numel() < 2:
-            pytest.skip("Correction=1 requires numel >= 2 for global reduction.")
+            # Invalid case: correction=1 requires numel >= 2 for global reduction.
+            return
 
     ref_inp = utils.to_reference(inp)
 

--- a/tests/test_upsample_linear1d.py
+++ b/tests/test_upsample_linear1d.py
@@ -51,14 +51,12 @@ def test_upsample_linear1d_boundaries(dtype, case):
             input_tensor = input_tensor.transpose(0, 2)
     ref_i = to_reference(input_tensor).to(torch.float32)
 
-    try:
-        ref_out = torch._C._nn.upsample_linear1d(
-            ref_i,
-            output_size=output_size,
-            align_corners=align_corners,
-        ).to(dtype)
-    except Exception as e:
-        pytest.skip(f"PyTorch reference raised error: {e}")
+    ref_out = torch._C._nn.upsample_linear1d(
+        ref_i,
+        output_size=output_size,
+        align_corners=align_corners,
+    ).to(dtype)
+
     with flag_gems.use_gems():
         res_out = torch._C._nn.upsample_linear1d(
             input_tensor,
@@ -80,7 +78,7 @@ def test_upsample_linear1d_boundaries(dtype, case):
 
 
 @pytest.mark.upsample_linear1d
-@pytest.mark.skipif(True, reason="Result not close.")
+@pytest.mark.skip(reason="Issue #2498: Result not close.")
 @pytest.mark.parametrize("align_corners", [False, True])
 @pytest.mark.parametrize("scale", [2, 2.5, 0.3, 0.7])
 @pytest.mark.parametrize("shape", UPSAMPLE_SHAPES_1D)

--- a/tests/test_var.py
+++ b/tests/test_var.py
@@ -40,7 +40,8 @@ def test_accuracy_var(shape, dim, correction, keepdim, dtype):
         dims_to_check = dim
 
     if any(d >= len(shape) or d < -len(shape) for d in dims_to_check):
-        pytest.skip("Dimension out of range for the given shape.")
+        # Invalid input: Dimension out of range for the given shape.
+        return
 
     if correction == 1:
         if dim is not None:
@@ -49,9 +50,11 @@ def test_accuracy_var(shape, dim, correction, keepdim, dtype):
             for d in positive_dims:
                 reduction_size *= shape[d]
             if reduction_size < 2:
-                pytest.skip("Correction=1 requires reduction size of at least 2.")
+                # Skip the test: correction=1 requires reduction size of at least 2.
+                return
         elif inp.numel() < 2:
-            pytest.skip("Correction=1 requires numel >= 2 for global reduction.")
+            # Skip the test: correction=1 requires numel >= 2 for global reduction.
+            return
 
     ref_inp = utils.to_reference(inp)
 


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

This PR fixes some test cases where the `pytest.skip` was abused.
We use `pytest.skip` and `pytest.mark.skip` as a workaround for buggy operators or test cases.
We don't use them to skip invalid input parameter combinations.