### PR TITLE
[MTHREADS] adapt 92 commits (a4c5466..78e846d)

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -14,7 +14,12 @@ from .index_add import index_add, index_add_
 from .index_put import index_put, index_put_
 from .index_select import index_select
 from .log import log
-from .log_softmax import log_softmax, log_softmax_backward
+from .log_softmax import (
+    log_softmax,
+    log_softmax_backward,
+    log_softmax_backward_out,
+    log_softmax_out,
+)
 from .max import max, max_dim
 from .min import min, min_dim
 from .normal import normal_
@@ -69,6 +74,8 @@ __all__ = [
     "log",
     "log_softmax",
     "log_softmax_backward",
+    "log_softmax_backward_out",
+    "log_softmax_out",
     "max",
     "max_dim",
     "min",
@@ -99,8 +106,9 @@ __all__ = [
     "zeros_like",
 ]
 
+
 if get_device_capability(current_device())[0] >= 3:
-    from .addmm import addmm  # noqa: F401
+    from .addmm import addmm, addmm_dtype, addmm_dtype_out  # noqa: F401
     from .bmm import bmm  # noqa: F401
     from .gelu import gelu  # noqa: F401
     from .mm import mm  # noqa: F401
@@ -109,6 +117,8 @@ if get_device_capability(current_device())[0] >= 3:
     __all__.extend(
         [
             "addmm",
+            "addmm_dtype",
+            "addmm_dtype_out",
             "bmm",
             "gelu",
             "mm",

--- a/src/flag_gems/runtime/backend/_mthreads/ops/addmm.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/addmm.py
@@ -351,3 +351,71 @@ def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
             os.environ.pop("MUSA_ENABLE_SQMMA", None)
         else:
             os.environ["MUSA_ENABLE_SQMMA"] = prev_sqmma
+
+
+def addmm_dtype(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1):
+    logger.debug("GEMS_MTHREADS ADDMM_DTYPE")
+    out = torch.empty(
+        (mat1.shape[0], mat2.shape[1]),
+        device=mat1.device,
+        dtype=out_dtype,
+    )
+    return addmm_dtype_out(bias, mat1, mat2, out_dtype, beta=beta, alpha=alpha, out=out)
+
+
+def addmm_dtype_out(bias, mat1, mat2, out_dtype, *, beta=1, alpha=1, out):
+    logger.debug("GEMS_MTHREADS ADDMM_DTYPE_OUT")
+    if mat1.dtype != mat2.dtype:
+        raise RuntimeError(
+            f"mat1 and mat2 must have the same dtype, but got {mat1.dtype} and {mat2.dtype}"
+        )
+    if out.dtype != out_dtype:
+        raise RuntimeError(
+            "out_dtype must be the same as the dtype of the provided out tensor"
+        )
+    if not (
+        out_dtype == mat1.dtype
+        or (
+            out_dtype == torch.float32 and mat1.dtype in (torch.float16, torch.bfloat16)
+        )
+    ):
+        raise RuntimeError(
+            "out_dtype must be the same as input dtype or fp32 for fp16/bf16 inputs"
+        )
+    if bias.dtype != out_dtype and bias.dtype != mat1.dtype:
+        raise RuntimeError("self dtype must match either out_dtype or mat1 dtype")
+
+    bias_c = bias.to(out_dtype)
+    M, K = mat1.shape
+    _, N = mat2.shape
+    a_dtype = mat1.dtype
+    b_dtype = mat2.dtype
+
+    need_sqmma = a_dtype != torch.float32 and b_dtype != torch.float32
+    prev_sqmma = os.environ.get("MUSA_ENABLE_SQMMA")
+    if need_sqmma:
+        os.environ["MUSA_ENABLE_SQMMA"] = "1"
+    else:
+        os.environ.pop("MUSA_ENABLE_SQMMA", None)
+    try:
+        if is_sqmma_compatible(mat1, mat2, N, K):
+            result = addmm_sqmma(
+                mat1,
+                mat2,
+                bias_c,
+                a_dtype,
+                alpha,
+                beta,
+                M,
+                N,
+                K,
+            )
+        else:
+            result = addmm_fma(bias_c, mat1, mat2, alpha=alpha, beta=beta)
+        out.copy_(result)
+        return out
+    finally:
+        if prev_sqmma is None:
+            os.environ.pop("MUSA_ENABLE_SQMMA", None)
+        else:
+            os.environ["MUSA_ENABLE_SQMMA"] = prev_sqmma

--- a/src/flag_gems/runtime/backend/_mthreads/ops/log_softmax.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/log_softmax.py
@@ -320,29 +320,34 @@ def log_softmax_backward_kernel_inner(
             offsets += TILE_N
 
 
-def log_softmax(self, dim, half_to_float=False):
-    logger.debug("GEMS_MTHREADS LOG_SOFTMAX")
+def log_softmax_out(self, dim, half_to_float=False, *, out):
+    logger.debug("GEMS_MTHREADS LOG_SOFTMAX_OUT")
 
     assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
     dim = dim % self.ndim
     M = 1
     N = self.shape[dim]
     for i in range(dim):
-        M *= self.shape[i]  # pre_dim
-    self = self.contiguous()
+        M *= self.shape[i]
+    inp = self.contiguous()
     if half_to_float:
         dtype = torch.float32
     else:
         dtype = self.dtype
-    out = torch.empty_like(self, dtype=dtype)
-    K = self.numel() // M // N  # post_dim
+    if tuple(out.shape) != tuple(inp.shape):
+        out.resize_(inp.shape)
+    if out.dtype != dtype:
+        raise RuntimeError(
+            f"_log_softmax.out: expected out dtype {dtype}, got {out.dtype}"
+        )
+    K = inp.numel() // M // N
 
-    with torch_device_fn.device(self.device):
+    with torch_device_fn.device(inp.device):
         if K > 1:
             grid = lambda meta: (M, triton.cdiv(K, meta["TILE_K"]), 1)
             log_softmax_kernel_non_inner[grid](
                 out,
-                self,
+                inp,
                 M,
                 N,
                 K,
@@ -351,15 +356,24 @@ def log_softmax(self, dim, half_to_float=False):
             grid = lambda meta: (triton.cdiv(M, meta["TILE_M"]), 1, 1)
             log_softmax_kernel_inner[grid](
                 out,
-                self,
+                inp,
                 M,
                 N,
             )
     return out
 
 
-def log_softmax_backward(grad_output, output, dim, input_dtype):
-    logger.debug("GEMS_MTHREADS LOG_SOFTMAX BACKWARD")
+def log_softmax(self, dim, half_to_float=False):
+    logger.debug("GEMS_MTHREADS LOG_SOFTMAX")
+    assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
+    dim = dim % self.ndim
+    dtype = torch.float32 if half_to_float else self.dtype
+    out = torch.empty_like(self.contiguous(), dtype=dtype)
+    return log_softmax_out(self, dim, half_to_float, out=out)
+
+
+def log_softmax_backward_out(grad_output, output, dim, input_dtype, *, out):
+    logger.debug("GEMS_MTHREADS LOG_SOFTMAX_BACKWARD_OUT")
 
     assert dim >= -output.ndim and dim < output.ndim, "Invalid dim"
     dim = dim % output.ndim
@@ -369,16 +383,21 @@ def log_softmax_backward(grad_output, output, dim, input_dtype):
         M *= output.shape[i]
 
     grad_output = grad_output.contiguous()
-    in_grad = torch.empty_like(output, dtype=input_dtype)
+    if tuple(out.shape) != tuple(output.shape):
+        out.resize_(output.shape)
+    if out.dtype != input_dtype:
+        raise RuntimeError(
+            f"_log_softmax_backward_data.out: expected out dtype {input_dtype}, got {out.dtype}"
+        )
     K = output.numel() // M // N
 
-    with torch_device_fn.device(in_grad.device):
+    with torch_device_fn.device(out.device):
         if K > 1:
             grid = lambda meta: (M, triton.cdiv(K, meta["TILE_K"]), 1)
             log_softmax_backward_kernel_non_inner[grid](
                 output,
                 grad_output,
-                in_grad,
+                out,
                 M,
                 N,
                 K,
@@ -388,8 +407,14 @@ def log_softmax_backward(grad_output, output, dim, input_dtype):
             log_softmax_backward_kernel_inner[grid](
                 output,
                 grad_output,
-                in_grad,
+                out,
                 M,
                 N,
             )
-    return in_grad
+    return out
+
+
+def log_softmax_backward(grad_output, output, dim, input_dtype):
+    logger.debug("GEMS_MTHREADS LOG_SOFTMAX_BACKWARD")
+    in_grad = torch.empty_like(output, dtype=input_dtype)
+    return log_softmax_backward_out(grad_output, output, dim, input_dtype, out=in_grad)

--- a/src/flag_gems/runtime/backend/_mthreads/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_mthreads/tune_configs.yaml
@@ -652,3 +652,318 @@ w8a8_block_fp8_matmul:
       GROUP_SIZE_M: 16
     num_warps: 4
     num_stages: 1
+# Shared memory tiling kernel for large tensors
+# Optimized for memory bandwidth by caching input tiles# Grid sample operator configurations
+grid_sample_2d_nearest:
+  - META:
+      BLOCK_SIZE: 256
+    num_warps: 4
+    num_stages: 3
+  - META:
+      BLOCK_SIZE: 512
+    num_warps: 8
+    num_stages: 4
+  - META:
+      BLOCK_SIZE: 1024
+    num_warps: 8
+    num_stages: 4
+grid_sample_2d_bilinear:
+  - META:
+      BLOCK_SIZE: 256
+    num_warps: 4
+    num_stages: 3
+  - META:
+      BLOCK_SIZE: 512
+    num_warps: 8
+    num_stages: 4
+  - META:
+      BLOCK_SIZE: 1024
+    num_warps: 8
+    num_stages: 4
+grid_sample_2d_bicubic:
+  - META:
+      BLOCK_SIZE: 256
+    num_warps: 4
+    num_stages: 3
+  - META:
+      BLOCK_SIZE: 512
+    num_warps: 8
+    num_stages: 4
+  - META:
+      BLOCK_SIZE: 1024
+    num_warps: 8
+    num_stages: 4
+grid_sample_3d_nearest:
+  - META:
+      BLOCK_SIZE: 256
+    num_warps: 4
+    num_stages: 3
+  - META:
+      BLOCK_SIZE: 512
+    num_warps: 8
+    num_stages: 4
+  - META:
+      BLOCK_SIZE: 1024
+    num_warps: 8
+    num_stages: 4
+  - META:
+      BLOCK_SIZE: 2048
+    num_warps: 8
+    num_stages: 3
+  - META:
+      BLOCK_SIZE: 4096
+    num_warps: 16
+    num_stages: 2
+grid_sample_3d_trilinear:
+  - META:
+      BLOCK_SIZE: 256
+    num_warps: 4
+    num_stages: 3
+  - META:
+      BLOCK_SIZE: 512
+    num_warps: 8
+    num_stages: 4
+  - META:
+      BLOCK_SIZE: 1024
+    num_warps: 8
+    num_stages: 4
+  - META:
+      BLOCK_SIZE: 2048
+    num_warps: 8
+    num_stages: 3
+  - META:
+      BLOCK_SIZE: 4096
+    num_warps: 16
+    num_stages: 2
+
+# Tiled grid sample kernels for medium-to-large inputs (multi-dimensional blocking)
+grid_sample_2d_nearest_tiled:
+  - META:
+      BLOCK_H: 8
+      BLOCK_W: 8
+    num_warps: 4
+    num_stages: 4
+  - META:
+      BLOCK_H: 16
+      BLOCK_W: 16
+    num_warps: 4
+    num_stages: 4
+  - META:
+      BLOCK_H: 32
+      BLOCK_W: 32
+    num_warps: 8
+    num_stages: 3
+  - META:
+      BLOCK_H: 16
+      BLOCK_W: 8
+    num_warps: 4
+    num_stages: 4
+  - META:
+      BLOCK_H: 8
+      BLOCK_W: 16
+    num_warps: 4
+    num_stages: 4
+grid_sample_2d_bilinear_tiled:
+  - META:
+      BLOCK_H: 4
+      BLOCK_W: 4
+    num_warps: 2
+    num_stages: 4
+  - META:
+      BLOCK_H: 8
+      BLOCK_W: 8
+    num_warps: 4
+    num_stages: 4
+  - META:
+      BLOCK_H: 16
+      BLOCK_W: 16
+    num_warps: 8
+    num_stages: 3
+  - META:
+      BLOCK_H: 8
+      BLOCK_W: 4
+    num_warps: 4
+    num_stages: 4
+  - META:
+      BLOCK_H: 4
+      BLOCK_W: 8
+    num_warps: 4
+    num_stages: 4
+  # Large tile configs for 128x128+ outputs
+  - META:
+      BLOCK_H: 32
+      BLOCK_W: 32
+    num_warps: 16
+    num_stages: 3
+  - META:
+      BLOCK_H: 64
+      BLOCK_W: 64
+    num_warps: 32
+    num_stages: 2
+  - META:
+      BLOCK_H: 32
+      BLOCK_W: 16
+    num_warps: 16
+    num_stages: 3
+  - META:
+      BLOCK_H: 16
+      BLOCK_W: 32
+    num_warps: 16
+    num_stages: 3
+
+grid_sample_3d_nearest_tiled:
+  # Small cubes - low register pressure
+  - META:
+      BLOCK_D: 4
+      BLOCK_H: 4
+      BLOCK_W: 4
+    num_warps: 4
+    num_stages: 4
+  - META:
+      BLOCK_D: 8
+      BLOCK_H: 8
+      BLOCK_W: 8
+    num_warps: 4
+    num_stages: 4
+  # Medium cubes - balanced
+  - META:
+      BLOCK_D: 16
+      BLOCK_H: 16
+      BLOCK_W: 16
+    num_warps: 8
+    num_stages: 3
+  # Rectangular blocks (D-dominant)
+  - META:
+      BLOCK_D: 16
+      BLOCK_H: 8
+      BLOCK_W: 8
+    num_warps: 8
+    num_stages: 3
+  - META:
+      BLOCK_D: 8
+      BLOCK_H: 4
+      BLOCK_W: 4
+    num_warps: 4
+    num_stages: 4
+  # Rectangular (H-dominant)
+  - META:
+      BLOCK_D: 8
+      BLOCK_H: 16
+      BLOCK_W: 8
+    num_warps: 8
+    num_stages: 3
+  # Rectangular (W-dominant)
+  - META:
+      BLOCK_D: 8
+      BLOCK_H: 8
+      BLOCK_W: 16
+    num_warps: 8
+    num_stages: 3
+  # Large cubes (for very large outputs)
+  - META:
+      BLOCK_D: 32
+      BLOCK_H: 32
+      BLOCK_W: 32
+    num_warps: 16
+    num_stages: 2
+  # Rectangular large tiles
+  - META:
+      BLOCK_D: 32
+      BLOCK_H: 16
+      BLOCK_W: 16
+    num_warps: 16
+    num_stages: 2
+  - META:
+      BLOCK_D: 16
+      BLOCK_H: 32
+      BLOCK_W: 16
+    num_warps: 16
+    num_stages: 2
+  - META:
+      BLOCK_D: 16
+      BLOCK_H: 16
+      BLOCK_W: 32
+    num_warps: 16
+    num_stages: 2
+
+grid_sample_3d_trilinear_tiled:
+  # Very small cubes - trilinear has 8x memory load
+  - META:
+      BLOCK_D: 2
+      BLOCK_H: 2
+      BLOCK_W: 2
+    num_warps: 2
+    num_stages: 4
+  - META:
+      BLOCK_D: 4
+      BLOCK_H: 4
+      BLOCK_W: 4
+    num_warps: 4
+    num_stages: 4
+  # Small cubes
+  - META:
+      BLOCK_D: 8
+      BLOCK_H: 8
+      BLOCK_W: 8
+    num_warps: 8
+    num_stages: 3
+  # Rectangular blocks (D-dominant)
+  - META:
+      BLOCK_D: 8
+      BLOCK_H: 4
+      BLOCK_W: 4
+    num_warps: 4
+    num_stages: 4
+  - META:
+      BLOCK_D: 4
+      BLOCK_H: 2
+      BLOCK_W: 2
+    num_warps: 2
+    num_stages: 4
+  # Rectangular (H-dominant)
+  - META:
+      BLOCK_D: 4
+      BLOCK_H: 8
+      BLOCK_W: 4
+    num_warps: 4
+    num_stages: 4
+  # Rectangular (W-dominant)
+  - META:
+      BLOCK_D: 4
+      BLOCK_H: 4
+      BLOCK_W: 8
+    num_warps: 4
+    num_stages: 4
+  # Medium cubes
+  - META:
+      BLOCK_D: 16
+      BLOCK_H: 16
+      BLOCK_W: 16
+    num_warps: 16
+    num_stages: 2
+  # Rectangular medium tiles
+  - META:
+      BLOCK_D: 16
+      BLOCK_H: 8
+      BLOCK_W: 8
+    num_warps: 8
+    num_stages: 3
+  - META:
+      BLOCK_D: 8
+      BLOCK_H: 16
+      BLOCK_W: 8
+    num_warps: 8
+    num_stages: 3
+  - META:
+      BLOCK_D: 8
+      BLOCK_H: 8
+      BLOCK_W: 16
+    num_warps: 8
+    num_stages: 3
+  # Large cubes (only for very large outputs)
+  - META:
+      BLOCK_D: 32
+      BLOCK_H: 32
+      BLOCK_W: 32
+    num_warps: 32
+    num_stages: 2


### PR DESCRIPTION
Adapted from upstream commits:
- 1 tune configuration (grid_sample with 9 configs, 315 lines)
- 2 custom operator updates (addmm dtype, log_softmax out)

Files modified: 4
Items skipped: 14 (heuristics:1, custom_ops:13)

Adapted content:
- tune_configs.yaml: Add grid_sample 2d/3d configurations
- addmm.py: Add addmm_dtype and addmm_dtype_out functions
- log_softmax.py: Add log_softmax_out and log_softmax_backward_out functions
- ops/__init__.py: Export new function variants
