### PR TITLE
Revert "perf(softmax): fused Triton kernel with fp32 accumulation"

### DIFF
--- a/src/flag_gems/ops/softmax.py
+++ b/src/flag_gems/ops/softmax.py
@@ -1,105 +1,392 @@
+import logging
+
 import torch
 import triton
 import triton.language as tl
 
+from flag_gems import runtime
+from flag_gems.ops.zeros import zero_
+from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry
+from flag_gems.utils import triton_lang_extension as tle
 
-# Optimized softmax kernel for FlagGems
-# Supports fp16, bf16, fp32 via Python-level dtype casting
-# Uses triton.next_power_of_2 to ensure full row fits in one block
-
-
-@triton.jit
-def softmax_kernel(
-    out_ptr,
-    inp_ptr,
-    inp_row_stride,
-    out_row_stride,
-    N,
-    BLOCK_SIZE: tl.constexpr,
-):
-    # One program handles one row of the input tensor
-    row_idx = tl.program_id(axis=0)
-    row_inp = inp_ptr + row_idx * inp_row_stride
-    row_out = out_ptr + row_idx * out_row_stride
-
-    # Column offsets — BLOCK_SIZE always >= N so full row fits
-    cols = tl.arange(0, BLOCK_SIZE)
-    mask = cols < N
-
-    # Load row — pad out-of-bounds with -inf so they dont affect max
-    x = tl.load(row_inp + cols, mask=mask, other=-float("inf"))
-
-    # Subtract row max for numerical stability (prevents exp overflow)
-    x_max = tl.max(x, axis=0)
-    x = x - x_max
-
-    # Compute exp of shifted values
-    x_exp = tl.exp(x)
-
-    # Compute normalizing constant
-    x_sum = tl.sum(x_exp, axis=0)
-
-    # Normalize to get softmax probabilities
-    out = x_exp / x_sum
-
-    # Write result back to output row (coalesced store)
-    tl.store(row_out + cols, out, mask=mask)
+logger = logging.getLogger(__name__)
 
 
 @libentry()
-def softmax(x: torch.Tensor, dim: int = -1) -> torch.Tensor:
-    """
-    FlagGems optimized softmax.
-    Supports fp16, bf16, fp32 inputs via internal fp32 accumulation.
-    Fuses max-shift + exp + sum + normalize into single Triton kernel.
-    Cross-hardware compatible: NVIDIA A100, H100, AMD MI300X.
-    """
-    orig_dtype = x.dtype  # save dtype: float16 or bfloat16 or float32
-    orig_shape = x.shape
+@triton.heuristics(runtime.get_heuristic_config("softmax_non_inner"))
+@triton.jit
+def softmax_kernel_non_inner(
+    output_ptr,
+    input_ptr,
+    M,
+    N,
+    K,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    pid_k = tle.program_id(1)
+    pid_m = tle.program_id(0)
 
-    # Cast to fp32 for precision — fixes fp16 and bf16 numerical errors
-    x = x.contiguous().float()
+    k_offsets = pid_k * TILE_K + tl.arange(0, TILE_K)
 
-    # Move softmax dim to last axis for coalesced memory access
-    if dim not in (-1, len(orig_shape) - 1):
-        x = x.transpose(dim, -1).contiguous()
-
-    # Flatten to 2D: (num_rows, N)
-    x2d = x.reshape(-1, x.shape[-1])
-    num_rows, N = x2d.shape
-
-    # Allocate output buffer in fp32
-    out = torch.empty_like(x2d)
-
-    # BLOCK_SIZE must cover full row — use next power of 2 >= N
-    # This ensures mask covers all elements without partial blocks
-    BLOCK_SIZE = triton.next_power_of_2(N)
-
-    # Select num_warps based on block size for optimal occupancy
-    # float16 and bfloat16 inputs benefit from more warps at large N
-    if BLOCK_SIZE <= 256:
-        num_warps = 2  # small rows: 2 warps sufficient
-    elif BLOCK_SIZE <= 1024:
-        num_warps = 4  # medium rows: 4 warps
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)
+        offset = pid_m * N * K + n_offsets[:, None] * K + k_offsets
+        mask = (n_offsets[:, None] < N) & (k_offsets < K)
+        input_ptrs = input_ptr + offset
+        inp = tl.load(input_ptrs, mask=mask, other=-float("inf"))
+        m = tl.max(inp, 0)
+        e = tl.exp(inp - m[None, :])
+        z = tl.sum(e, 0)
+        out = e / z
+        output_ptrs = output_ptr + offset
+        tl.store(output_ptrs, out, mask=mask)
     else:
-        num_warps = 8  # large rows: 8 warps for fp16 bf16 workloads
+        m = tl.full([TILE_N, TILE_K], value=float("-inf"), dtype=tl.float32)
+        z = tl.full([TILE_N, TILE_K], value=0.0, dtype=tl.float32)
 
-    # Launch one program per row
-    softmax_kernel[(num_rows,)](
-        out,
-        x2d,
-        x2d.stride(0),
-        out.stride(0),
-        N,
-        BLOCK_SIZE=BLOCK_SIZE,
-        num_warps=num_warps,
+        # specialization does not improve performance inn this example, as tested
+        for start_n in range(0, N, TILE_N):
+            n_offsets = start_n + tl.arange(0, TILE_N)
+            offsets = pid_m * N * K + n_offsets[:, None] * K + k_offsets
+            mask = (n_offsets[:, None] < N) & (k_offsets < K)
+            inp = tl.load(input_ptr + offsets, mask=mask, other=-float("inf"))
+            m_new = tl.maximum(m, inp)
+            all_neg_inf = m_new == float("-inf")
+            z = tl.where(all_neg_inf, z, z * tl.exp(m - m_new) + tl.exp(inp - m_new))
+            m = m_new
+
+        m_reduced = tl.max(m, 0)  # (TILE_K,)
+        z = tl.sum(z * tl.exp(m - m_reduced[None, :]), 0)  # (TILE_K, )
+        m = m_reduced
+
+        # specialization does not improve performance inn this example, as tested
+        previous_multiple = prev_multiple_of(N, TILE_N)
+        for start_n in range(0, N, TILE_N):
+            n_offsets = (previous_multiple - start_n) + tl.arange(0, TILE_N)
+            offsets = pid_m * N * K + n_offsets[:, None] * K + k_offsets
+            mask = (n_offsets[:, None] < N) & (k_offsets[None, :] < K)
+            inp = tl.load(input_ptr + offsets, mask=mask, other=-float("inf"))
+            o = tl.exp(inp - m[None, :]) / z[None, :]
+            tl.store(output_ptr + offsets, o, mask=mask)
+
+
+@triton.jit
+def next_multiple_of(a, b):
+    # the smallest x>=a that x%b ==0
+    return tl.cidv(a, b) * b
+
+
+@triton.jit
+def prev_multiple_of(a, b):
+    # the largest x<a that x%b ==0
+    return tl.cdiv(a, b) * b - b
+
+
+@libentry()
+@triton.heuristics(runtime.get_heuristic_config("softmax_inner"))
+@triton.jit
+def softmax_kernel_inner(
+    output_ptr,
+    input_ptr,
+    M,
+    N,
+    TILE_N: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    pid_m = tle.program_id(0)
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)
+        offset = pid_m * N + n_offsets
+        input_ptrs = input_ptr + offset
+        mask = n_offsets < N
+        inp = tl.load(input_ptrs, mask=mask, other=-float("inf")).to(
+            output_ptr.dtype.element_ty
+        )
+        m = tl.max(inp, 0)
+        e = tl.exp(inp - m)
+        z = tl.sum(e, 0)
+        out = e / z
+        output_ptrs = output_ptr + offset
+        tl.store(output_ptrs, out, mask=mask)
+    else:
+        m = tl.full([TILE_N], value=float("-inf"), dtype=tl.float32)
+        z = tl.full([TILE_N], value=0.0, dtype=tl.float32)
+        input_ptr += pid_m * N
+        output_ptr += pid_m * N
+
+        previous_multiple = prev_multiple_of(N, TILE_N)
+        for start_n in range(0, previous_multiple, TILE_N):
+            n_offsets = start_n + tl.arange(0, TILE_N)
+            inp = tl.load(input_ptr + n_offsets)
+            m_new = tl.maximum(m, inp)
+            # it is possible that there are -inf's in the input
+            all_neg_inf = m_new == float("-inf")
+            z = tl.where(all_neg_inf, z, z * tl.exp(m - m_new) + tl.exp(inp - m_new))
+            m = m_new
+        # specialize the last iteration
+        for start_n in range(previous_multiple, N, TILE_N):
+            n_offsets = start_n + tl.arange(0, TILE_N)
+            mask = n_offsets < N
+            inp = tl.load(input_ptr + n_offsets, mask=mask, other=-float("inf"))
+            m_new = tl.maximum(m, inp)
+            all_neg_inf = m_new == float("-inf")
+            z = tl.where(all_neg_inf, z, z * tl.exp(m - m_new) + tl.exp(inp - m_new))
+            m = m_new
+
+        m_reduced = tl.max(m, 0)
+        z = tl.sum(z * tl.exp(m - m_reduced), 0)
+        m = m_reduced
+
+        previous_multiple = prev_multiple_of(N, TILE_N)
+        # specialize the first iteration
+        for start_n in range(0, TILE_N, TILE_N):
+            n_offsets = (previous_multiple - start_n) + tl.arange(0, TILE_N)
+            mask = n_offsets < N
+            inp = tl.load(
+                input_ptr + n_offsets,
+                mask=mask,
+                other=-float("inf"),
+                eviction_policy="evict_first",
+            )
+            o = tl.exp(inp - m) / z
+            tl.store(output_ptr + n_offsets, o, mask=mask)
+        for start_n in range(TILE_N, N, TILE_N):
+            n_offsets = (previous_multiple - start_n) + tl.arange(0, TILE_N)
+            inp = tl.load(input_ptr + n_offsets, eviction_policy="evict_first")
+            o = tl.exp(inp - m) / z
+            tl.store(output_ptr + n_offsets, o)
+
+
+# ------------------------  backward -------------------------------
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("softmax_non_inner"),
+    key=[
+        "M",
+        "N",
+        "K",
+    ],
+)
+@triton.heuristics(runtime.get_heuristic_config("softmax_backward_non_inner"))
+@triton.jit
+def softmax_backward_kernel_non_inner(
+    out_ptr,
+    out_grad_ptr,
+    in_grad_ptr,
+    M,
+    N,
+    K,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    pid_m = tle.program_id(0)
+    pid_k = tle.program_id(1)
+    offsets_k = pid_k * TILE_K + tl.arange(0, TILE_K)
+
+    if ONE_TILE_PER_CTA:
+        offsets_n = tl.arange(0, TILE_N)
+        offsets = pid_m * N * K + offsets_n[:, None] * K + offsets_k
+        mask = (offsets_n < N)[:, None] & (offsets_k < K)
+        out_tile = tl.load(out_ptr + offsets, mask=mask).to(tl.float32)
+        out_grad_tile = tl.load(out_grad_ptr + offsets, mask=mask).to(tl.float32)
+        scale = tl.sum(out_tile * out_grad_tile, axis=0)
+        in_grad_tile = out_tile * (out_grad_tile - scale[None, :])
+        tl.store(in_grad_ptr + offsets, in_grad_tile, mask=mask)
+    else:
+        offsets_n = tl.arange(0, TILE_N)
+        offsets = pid_m * N * K + offsets_n[:, None] * K + offsets_k
+        scale = tl.zeros([TILE_N, TILE_K], dtype=tl.float32)
+        for _ in range(0, N, TILE_N):
+            mask = (offsets_n < N)[:, None] & (offsets_k < K)
+            out_tile = tl.load(out_ptr + offsets, mask=mask).to(tl.float32)
+            out_grad_tile = tl.load(out_grad_ptr + offsets, mask=mask).to(tl.float32)
+            scale += out_tile * out_grad_tile
+            offsets_n += TILE_N
+            offsets += TILE_N * K
+        scale = tl.sum(scale, axis=0)  # (TILE_K)
+
+        offsets_n = tl.arange(0, TILE_N)
+        offsets = pid_m * N * K + offsets_n[:, None] * K + offsets_k
+        for _ in range(0, N, TILE_N):
+            mask = (offsets_n < N)[:, None] & (offsets_k < K)
+            out_tile = tl.load(out_ptr + offsets, mask=mask).to(tl.float32)
+            out_grad_tile = tl.load(out_grad_ptr + offsets, mask=mask).to(tl.float32)
+            in_grad_tile = out_tile * (out_grad_tile - scale[None, :])
+            tl.store(in_grad_ptr + offsets, in_grad_tile, mask=mask)
+            offsets_n += TILE_N
+            offsets += TILE_N * K
+
+
+@libentry()
+@triton.autotune(
+    configs=runtime.get_tuned_config("softmax_inner"),
+    key=["M", "N"],
+)
+@triton.heuristics(
+    values=runtime.get_heuristic_config("softmax_backward_inner"),
+)
+@triton.jit
+def softmax_backward_kernel_inner(
+    out_ptr,
+    out_grad_ptr,
+    in_grad_ptr,
+    M,
+    N,
+    TILE_M: tl.constexpr,
+    TILE_N: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    pid_m = tle.program_id(0)
+    m_offsets = pid_m * TILE_M + tl.arange(0, TILE_M)
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)
+        offsets = m_offsets[:, None] * N + n_offsets
+        mask = (m_offsets[:, None] < M) & (n_offsets < N)
+        out_tile = tl.load(out_ptr + offsets, mask=mask).to(tl.float32)
+        out_grad_tile = tl.load(out_grad_ptr + offsets, mask=mask).to(tl.float32)
+        scale = tl.sum(out_tile * out_grad_tile, 1)
+        in_grad_tile = out_tile * (out_grad_tile - scale[:, None])
+        tl.store(in_grad_ptr + offsets, in_grad_tile, mask=mask)
+    else:
+        scale = tl.zeros([TILE_M, TILE_N], dtype=tl.float32)
+
+        n_offsets = tl.arange(0, TILE_N)
+        offsets = m_offsets[:, None] * N + n_offsets
+        for _ in range(0, N, TILE_N):
+            mask = (m_offsets[:, None] < M) & (n_offsets < N)
+            out_tile = tl.load(
+                out_ptr + offsets, mask=mask, eviction_policy="evict_last"
+            ).to(tl.float32)
+            out_grad_tile = tl.load(out_grad_ptr + offsets, mask=mask).to(tl.float32)
+            scale += out_tile * out_grad_tile
+            n_offsets += TILE_N
+            offsets += TILE_N
+        scale = tl.sum(scale, 1)  # (TILE_M,)
+
+        n_offsets = tl.arange(0, TILE_N)
+        offsets = m_offsets[:, None] * N + n_offsets
+        for _ in range(0, N, TILE_N):
+            mask = (m_offsets[:, None] < M) & (n_offsets < N)
+            out_tile = tl.load(
+                out_ptr + offsets, mask=mask, eviction_policy="evict_first"
+            ).to(tl.float32)
+            out_grad_tile = tl.load(out_grad_ptr + offsets, mask=mask).to(tl.float32)
+            in_grad_tile = out_tile * (out_grad_tile - scale[:, None])
+            tl.store(in_grad_ptr + offsets, in_grad_tile, mask=mask)
+            n_offsets += TILE_N
+            offsets += TILE_N
+
+
+def softmax_out(self, dim, half_to_float=False, *, out):
+    logger.debug("GEMS SOFTMAX_OUT")
+
+    assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
+
+    if self.numel() == 0:
+        if tuple(out.shape) != tuple(self.shape):
+            out.resize_(self.shape)
+        zero_(out)
+        return out
+
+    dim = dim % self.ndim
+    M = 1
+    N = self.shape[dim]
+    for i in range(dim):
+        M *= self.shape[i]
+    self = self.contiguous()
+    dtype = torch.float32 if half_to_float else self.dtype
+    if tuple(out.shape) != tuple(self.shape):
+        out.resize_(self.shape)
+    if out.dtype != dtype:
+        raise RuntimeError(f"_softmax.out: expected out dtype {dtype}, got {out.dtype}")
+    K = self.numel() // M // N
+
+    with torch_device_fn.device(self.device):
+        if K > 1:
+            grid = lambda meta: (M, triton.cdiv(K, meta["TILE_K"]), 1)
+            softmax_kernel_non_inner[grid](
+                out,
+                self,
+                M,
+                N,
+                K,
+            )
+        else:
+            grid = (M, 1, 1)
+            softmax_kernel_inner[grid](
+                out,
+                self,
+                M,
+                N,
+            )
+    return out
+
+
+def softmax(self, dim, half_to_float=False):
+    logger.debug("GEMS SOFTMAX")
+
+    assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
+
+    if self.numel() == 0:
+        out_shape = list(self.shape)
+        out = torch.empty(out_shape, dtype=self.dtype, device=self.device)
+        zero_(out)
+        return out
+
+    dtype = torch.float32 if half_to_float else self.dtype
+    out = torch.empty_like(self, dtype=dtype)
+    return softmax_out(self, dim, half_to_float, out=out)
+
+
+def softmax_backward_out(grad_output, output, dim, input_dtype, *, grad_input):
+    logger.debug("GEMS SOFTMAX_BACKWARD_OUT")
+
+    assert dim >= -output.ndim and dim < output.ndim, "Invalid dim"
+    dim = dim % output.ndim
+    M = 1
+    N = output.shape[dim]
+    for i in range(dim):
+        M *= output.shape[i]
+
+    grad_output = grad_output.contiguous()
+    if tuple(grad_input.shape) != tuple(output.shape):
+        grad_input.resize_(output.shape)
+    if grad_input.dtype != input_dtype:
+        raise RuntimeError(
+            f"_softmax_backward_data.out: expected grad_input dtype {input_dtype}, got {grad_input.dtype}"
+        )
+    K = output.numel() // M // N
+
+    with torch_device_fn.device(grad_input.device):
+        if K > 1:
+            grid = lambda meta: (M, triton.cdiv(K, meta["TILE_K"]), 1)
+            softmax_backward_kernel_non_inner[grid](
+                output,
+                grad_output,
+                grad_input,
+                M,
+                N,
+                K,
+            )
+        else:
+            grid = lambda meta: (triton.cdiv(M, meta["TILE_M"]), 1, 1)
+            softmax_backward_kernel_inner[grid](
+                output,
+                grad_output,
+                grad_input,
+                M,
+                N,
+            )
+    return grad_input
+
+
+def softmax_backward(grad_output, output, dim, input_dtype):
+    logger.debug("GEMS SOFTMAX_BACKWARD")
+    in_grad = torch.empty_like(output, dtype=input_dtype)
+    return softmax_backward_out(
+        grad_output, output, dim, input_dtype, grad_input=in_grad
     )
-
-    # Restore original shape
-    out = out.view(x.shape)
-    if dim not in (-1, len(orig_shape) - 1):
-        out = out.transpose(dim, -1).contiguous()
-
-    # Cast back to original dtype: float16, bfloat16, or float32
-    return out.to(orig_dtype)


### PR DESCRIPTION
Reverts flagos-ai/FlagGems#2985

The optimization is good and it works on Nvidia and non-Nvidia backends.

However, it turned out that this PR introduced two flaws:

1. The `softmax_out`, `softmax_backward`, `softmax_backward_out` operators are all gone
2. The `libentry` annotation is causing CI jobs to fail.