### PR TITLE
[SiliconFlow] Add cumprod, cumprod_ operators

### DIFF
--- a/benchmark/test_cumprod.py
+++ b/benchmark/test_cumprod.py
@@ -1,0 +1,57 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import base, consts
+
+CUMPROD_DTYPES = consts.FLOAT_DTYPES + [
+    torch.int8,
+    torch.uint8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+]
+
+
+def _make_input(shape, dtype, device):
+    if dtype in consts.FLOAT_DTYPES:
+        return torch.empty(shape, dtype=dtype, device=device).uniform_(0.99, 1.01)
+    if dtype is torch.uint8:
+        return torch.randint(0, 4, shape, dtype=dtype, device="cpu").to(device)
+    return torch.randint(-3, 4, shape, dtype=dtype, device="cpu").to(device)
+
+
+def input_fn(shape, dtype, device):
+    inp = _make_input(shape, dtype, device)
+    yield inp, 1
+
+
+class CumprodBenchmark(base.GenericBenchmark2DOnly):
+    def set_more_shapes(self):
+        if flag_gems.vendor_name == "kunlunxin":
+            return []
+        return super().set_more_shapes()
+
+
+@pytest.mark.cumprod
+def test_cumprod_perf():
+    bench = CumprodBenchmark(
+        op_name="cumprod",
+        input_fn=input_fn,
+        torch_op=torch.cumprod,
+        dtypes=CUMPROD_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.cumprod_
+def test_cumprod_inplace_perf():
+    bench = CumprodBenchmark(
+        op_name="cumprod_",
+        input_fn=input_fn,
+        torch_op=torch.Tensor.cumprod_,
+        dtypes=CUMPROD_DTYPES,
+        is_inplace=True,
+    )
+    bench.run()

--- a/benchmark/test_cumprod.py
+++ b/benchmark/test_cumprod.py
@@ -6,6 +6,14 @@ import flag_gems
 from . import base, consts
 
 CUMPROD_DTYPES = consts.FLOAT_DTYPES + [
+    torch.bool,
+    torch.int8,
+    torch.uint8,
+    torch.int16,
+    torch.int32,
+    torch.int64,
+]
+CUMPROD_INPLACE_DTYPES = consts.FLOAT_DTYPES + [
     torch.int8,
     torch.uint8,
     torch.int16,
@@ -17,6 +25,10 @@ CUMPROD_DTYPES = consts.FLOAT_DTYPES + [
 def _make_input(shape, dtype, device):
     if dtype in consts.FLOAT_DTYPES:
         return torch.empty(shape, dtype=dtype, device=device).uniform_(0.99, 1.01)
+    if dtype is torch.bool:
+        return torch.randint(0, 2, shape, dtype=torch.int8, device="cpu").to(
+            device, dtype=dtype
+        )
     if dtype is torch.uint8:
         return torch.randint(0, 4, shape, dtype=dtype, device="cpu").to(device)
     return torch.randint(-3, 4, shape, dtype=dtype, device="cpu").to(device)
@@ -51,7 +63,7 @@ def test_cumprod_inplace_perf():
         op_name="cumprod_",
         input_fn=input_fn,
         torch_op=torch.Tensor.cumprod_,
-        dtypes=CUMPROD_DTYPES,
+        dtypes=CUMPROD_INPLACE_DTYPES,
         is_inplace=True,
     )
     bench.run()

--- a/benchmark/test_cumprod.py
+++ b/benchmark/test_cumprod.py
@@ -5,14 +5,18 @@ import flag_gems
 
 from . import base, consts
 
-CUMPROD_DTYPES = consts.FLOAT_DTYPES + [
-    torch.bool,
-    torch.int8,
-    torch.uint8,
-    torch.int16,
-    torch.int32,
-    torch.int64,
-]
+CUMPROD_BOOL_DTYPES = [] if flag_gems.vendor_name == "ascend" else [torch.bool]
+CUMPROD_DTYPES = (
+    consts.FLOAT_DTYPES
+    + CUMPROD_BOOL_DTYPES
+    + [
+        torch.int8,
+        torch.uint8,
+        torch.int16,
+        torch.int32,
+        torch.int64,
+    ]
+)
 CUMPROD_INPLACE_DTYPES = consts.FLOAT_DTYPES + [
     torch.int8,
     torch.uint8,

--- a/benchmark/test_cumprod.py
+++ b/benchmark/test_cumprod.py
@@ -2,6 +2,7 @@ import pytest
 import torch
 
 import flag_gems
+from flag_gems.ops import cumprod as flag_gems_cumprod
 
 from . import base, consts
 
@@ -43,6 +44,12 @@ def input_fn(shape, dtype, device):
     yield inp, 1
 
 
+def torch_cumprod(inp, dim):
+    if flag_gems.vendor_name == "ascend" and inp.dtype is torch.bool:
+        return torch.cumprod(inp.to(torch.uint8), dim)
+    return torch.cumprod(inp, dim)
+
+
 class CumprodBenchmark(base.GenericBenchmark2DOnly):
     def set_more_shapes(self):
         if flag_gems.vendor_name == "kunlunxin":
@@ -55,7 +62,8 @@ def test_cumprod_perf():
     bench = CumprodBenchmark(
         op_name="cumprod",
         input_fn=input_fn,
-        torch_op=torch.cumprod,
+        torch_op=torch_cumprod,
+        gems_op=flag_gems_cumprod,
         dtypes=CUMPROD_DTYPES,
     )
     bench.run()

--- a/benchmark/test_cumprod.py
+++ b/benchmark/test_cumprod.py
@@ -5,7 +5,7 @@ import flag_gems
 
 from . import base, consts
 
-CUMPROD_BOOL_DTYPES = [] if flag_gems.vendor_name == "ascend" else [torch.bool]
+CUMPROD_BOOL_DTYPES = [torch.bool]
 CUMPROD_DTYPES = (
     consts.FLOAT_DTYPES
     + CUMPROD_BOOL_DTYPES

--- a/benchmark/test_cumprod.py
+++ b/benchmark/test_cumprod.py
@@ -7,24 +7,15 @@ from flag_gems.ops import cumprod as flag_gems_cumprod
 from . import base, consts
 
 CUMPROD_BOOL_DTYPES = [torch.bool]
-CUMPROD_DTYPES = (
-    consts.FLOAT_DTYPES
-    + CUMPROD_BOOL_DTYPES
-    + [
-        torch.int8,
-        torch.uint8,
-        torch.int16,
-        torch.int32,
-        torch.int64,
-    ]
-)
-CUMPROD_INPLACE_DTYPES = consts.FLOAT_DTYPES + [
+CUMPROD_INT_DTYPES = [
     torch.int8,
     torch.uint8,
     torch.int16,
     torch.int32,
     torch.int64,
 ]
+CUMPROD_DTYPES = consts.FLOAT_DTYPES + CUMPROD_BOOL_DTYPES + CUMPROD_INT_DTYPES
+CUMPROD_INPLACE_DTYPES = consts.FLOAT_DTYPES + CUMPROD_INT_DTYPES
 
 
 def _make_input(shape, dtype, device):
@@ -50,16 +41,9 @@ def torch_cumprod(inp, dim):
     return torch.cumprod(inp, dim)
 
 
-class CumprodBenchmark(base.GenericBenchmark2DOnly):
-    def set_more_shapes(self):
-        if flag_gems.vendor_name == "kunlunxin":
-            return []
-        return super().set_more_shapes()
-
-
 @pytest.mark.cumprod
 def test_cumprod_perf():
-    bench = CumprodBenchmark(
+    bench = base.GenericBenchmark2DOnly(
         op_name="cumprod",
         input_fn=input_fn,
         torch_op=torch_cumprod,
@@ -71,7 +55,7 @@ def test_cumprod_perf():
 
 @pytest.mark.cumprod_
 def test_cumprod_inplace_perf():
-    bench = CumprodBenchmark(
+    bench = base.GenericBenchmark2DOnly(
         op_name="cumprod_",
         input_fn=input_fn,
         torch_op=torch.Tensor.cumprod_,

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -1353,6 +1353,28 @@ ops:
       - Math
     stages:
       - stable: '2.2'
+  - id: cumprod
+    description: Returns the cumulative product of elements of `input` in the dimension `dim`.
+    for:
+      - cumprod
+    labels:
+      - aten
+      - Reduction
+    kind:
+      - Math
+    stages:
+      - beta: '5.1'
+  - id: cumprod_
+    description: This is the in-place version of `cumprod()`.
+    for:
+      - cumprod_
+    labels:
+      - aten
+      - Reduction
+    kind:
+      - Math
+    stages:
+      - beta: '5.1'
   - id: cumsum
     destination: Returns the cumulative sum of elements of `input` in the dimension `dim`.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -168,6 +168,8 @@ _FULL_CONFIG = (
     ("count_nonzero", count_nonzero),
     ("cummax", cummax),
     ("cummin", cummin),
+    ("cumprod", cumprod),
+    ("cumprod_", cumprod_),
     ("cumsum", cumsum),
     ("cumsum.out", cumsum_out),
     ("diag", diag),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -88,6 +88,7 @@ from flag_gems.ops.cosh import cosh, cosh_, cosh_out
 from flag_gems.ops.count_nonzero import count_nonzero
 from flag_gems.ops.cummax import cummax
 from flag_gems.ops.cummin import cummin
+from flag_gems.ops.cumprod import cumprod, cumprod_
 from flag_gems.ops.cumsum import cumsum, cumsum_out, normed_cumsum
 from flag_gems.ops.diag import diag
 from flag_gems.ops.diag_embed import diag_embed
@@ -464,6 +465,8 @@ __all__ = [
     "count_nonzero",
     "cummax",
     "cummin",
+    "cumprod",
+    "cumprod_",
     "cumsum",
     "cumsum_out",
     "conj_physical",

--- a/src/flag_gems/ops/cumprod.py
+++ b/src/flag_gems/ops/cumprod.py
@@ -384,7 +384,12 @@ def cumprod(inp, dim, *, dtype=None):
             return torch.ops.aten.cumprod.default.redispatch(
                 _FALLBACK_KEYSET, inp, dim, dtype=dtype
             )
-        return cumprod_wrapper(inp.to(torch.uint8), dim, out_dtype)
+        uint8_inp = inp.to(torch.uint8)
+        if runtime_device.vendor_name == "ascend":
+            return torch.ops.aten.cumprod.default.redispatch(
+                _FALLBACK_KEYSET, uint8_inp, dim, dtype=dtype
+            )
+        return cumprod_wrapper(uint8_inp, dim, out_dtype)
     if _should_redispatch_on_ascend(out_dtype):
         return torch.ops.aten.cumprod.default.redispatch(
             _FALLBACK_KEYSET, inp, dim, dtype=dtype

--- a/src/flag_gems/ops/cumprod.py
+++ b/src/flag_gems/ops/cumprod.py
@@ -379,10 +379,12 @@ def reduce_then_scan_block_scan_kernel_row(
 def cumprod(inp, dim, *, dtype=None):
     logger.debug("GEMS CUMPROD")
     out_dtype = _get_output_dtype(inp, dtype)
-    if is_boolean_dtype(inp.dtype) and is_boolean_dtype(out_dtype):
-        return torch.ops.aten.cumprod.default.redispatch(
-            _FALLBACK_KEYSET, inp, dim, dtype=dtype
-        )
+    if is_boolean_dtype(inp.dtype):
+        if is_boolean_dtype(out_dtype):
+            return torch.ops.aten.cumprod.default.redispatch(
+                _FALLBACK_KEYSET, inp, dim, dtype=dtype
+            )
+        return cumprod_wrapper(inp.to(torch.uint8), dim, out_dtype)
     if _should_redispatch_on_ascend(out_dtype):
         return torch.ops.aten.cumprod.default.redispatch(
             _FALLBACK_KEYSET, inp, dim, dtype=dtype

--- a/src/flag_gems/ops/cumprod.py
+++ b/src/flag_gems/ops/cumprod.py
@@ -1,0 +1,382 @@
+import functools
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+from torch._prims_common import is_boolean_dtype, is_integer_dtype
+
+from flag_gems.runtime import device as runtime_device
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import get_device_properties, libentry
+from flag_gems.utils import triton_lang_extension as tle
+
+logger = logging.getLogger(__name__)
+
+_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeExplicitAutograd
+)
+
+
+@functools.lru_cache
+def get_num_sms(idx: int) -> int:
+    return get_device_properties(idx).multi_processor_count
+
+
+@tl.constexpr
+def get_prod_accum_type(out_dtype: tl.dtype) -> tl.dtype:
+    if out_dtype.is_bf16() or out_dtype.is_fp16():
+        return tl.float32
+    if out_dtype.is_int():
+        return tl.int64
+    return out_dtype
+
+
+@triton.jit
+def reduce_mul(a, b):
+    return a * b
+
+
+@libentry()
+@triton.jit(do_not_specialize=["n_elements", "part_num"])
+def scan_part_product_kernel(
+    inp,
+    out,
+    partial_product,
+    n_elements,
+    part_num,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tle.program_id(0)
+    offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offset < n_elements
+
+    acc_dtype: tl.constexpr = get_prod_accum_type(out.type.element_ty)
+    inp_vals = tl.load(inp + offset, mask=mask, other=1).to(acc_dtype)
+    result = tl.cumprod(inp_vals, axis=0)
+    part_product = tl.reduce(inp_vals, axis=0, combine_fn=reduce_mul)
+
+    tl.store(out + offset, result, mask=mask)
+    tl.store(partial_product + pid, part_product)
+
+
+@libentry()
+@triton.jit(do_not_specialize=["n_elements", "part_num"])
+def multiply_base_product_kernel(
+    out,
+    partial_product,
+    n_elements,
+    part_num,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tle.program_id(0)
+    offset = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offset < n_elements
+
+    out_vals = tl.load(out + offset, mask=mask)
+
+    if pid > 0:
+        acc_dtype: tl.constexpr = get_prod_accum_type(out.type.element_ty)
+        base_product = tl.load(partial_product + pid - 1).to(acc_dtype)
+        final_vals = out_vals.to(acc_dtype) * base_product
+        tl.store(out + offset, final_vals, mask=mask)
+
+
+@libentry()
+@triton.jit(do_not_specialize=["part_num"])
+def scan_part_product_abc_kernel(
+    inp,
+    out,
+    partial_product,
+    B,
+    C,
+    part_num,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid_a = tle.program_id(0)
+    pid_b = tle.program_id(1)
+    pid_c = tle.program_id(2)
+
+    a_idx = pid_a
+    b_idx = pid_b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    c_idx = pid_c
+
+    offset = a_idx * B * C + b_idx * C + c_idx
+    base_part_offset = a_idx * part_num * C + c_idx
+    part_offset = base_part_offset + pid_b * C
+    mask = b_idx < B
+
+    acc_dtype: tl.constexpr = get_prod_accum_type(out.type.element_ty)
+    inp_vals = tl.load(inp + offset, mask=mask, other=1).to(acc_dtype)
+    result = tl.cumprod(inp_vals, axis=0)
+    part_product = tl.reduce(inp_vals, axis=0, combine_fn=reduce_mul)
+
+    tl.store(out + offset, result, mask=mask)
+    tl.store(partial_product + part_offset, part_product)
+
+
+@libentry()
+@triton.jit(do_not_specialize=["part_num"])
+def multiply_base_product_abc_kernel(
+    out,
+    partial_product,
+    B,
+    C,
+    part_num,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid_a = tle.program_id(0)
+    pid_b = tle.program_id(1)
+    pid_c = tle.program_id(2)
+
+    a_idx = pid_a
+    b_idx = pid_b * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    c_idx = pid_c
+
+    offset = a_idx * B * C + b_idx * C + c_idx
+    base_part_offset = a_idx * part_num * C + c_idx
+    last_part_offset = base_part_offset + (pid_b - 1) * C
+    mask = b_idx < B
+
+    out_vals = tl.load(out + offset, mask=mask)
+
+    if pid_b > 0:
+        acc_dtype: tl.constexpr = get_prod_accum_type(out.type.element_ty)
+        base_product = tl.load(partial_product + last_part_offset).to(acc_dtype)
+        final_vals = out_vals.to(acc_dtype) * base_product
+        tl.store(out + offset, final_vals, mask=mask)
+
+
+def scan_then_fan_col(inp, out, n_ele, dtype):
+    BLOCK_SIZE = 1024
+    if n_ele <= 1024 * 4:
+        BLOCK_SIZE = triton.next_power_of_2(n_ele)
+    part_num = math.ceil(n_ele / BLOCK_SIZE)
+    partial_product = torch.empty(part_num, dtype=dtype, device=inp.device)
+
+    grid = (part_num,)
+    with torch_device_fn.device(inp.device):
+        scan_part_product_kernel[grid](
+            inp, out, partial_product, n_ele, part_num, BLOCK_SIZE
+        )
+
+    if part_num >= 2:
+        scan_then_fan_col(partial_product, partial_product, part_num, dtype)
+        with torch_device_fn.device(inp.device):
+            multiply_base_product_kernel[grid](
+                out, partial_product, n_ele, part_num, BLOCK_SIZE
+            )
+
+
+def scan_then_fan(inp, out, A, B, C, dtype):
+    BLOCK_SIZE = 1024
+    if B <= 1024 * 4:
+        BLOCK_SIZE = triton.next_power_of_2(B)
+    part_num = math.ceil(B / BLOCK_SIZE)
+    partial_product = torch.empty(A, part_num, C, dtype=dtype, device=inp.device)
+
+    grid = (A, part_num, C)
+    with torch_device_fn.device(inp.device):
+        scan_part_product_abc_kernel[grid](
+            inp, out, partial_product, B, C, part_num, BLOCK_SIZE
+        )
+
+    if part_num >= 2:
+        scan_then_fan(partial_product, partial_product, A, part_num, C, dtype)
+        with torch_device_fn.device(inp.device):
+            multiply_base_product_abc_kernel[grid](
+                out, partial_product, B, C, part_num, BLOCK_SIZE
+            )
+
+
+def _get_output_dtype(inp, dtype):
+    if dtype is not None:
+        return dtype
+    if is_integer_dtype(inp.dtype) or is_boolean_dtype(inp.dtype):
+        return torch.int64
+    return inp.dtype
+
+
+def _get_compute_dtype(dtype):
+    if dtype in (torch.float16, torch.bfloat16):
+        return torch.float32
+    if is_integer_dtype(dtype) or is_boolean_dtype(dtype):
+        return torch.int64
+    return dtype
+
+
+def _should_redispatch_on_ascend(dtype):
+    return runtime_device.vendor_name == "ascend" and (
+        is_integer_dtype(dtype) or is_boolean_dtype(dtype)
+    )
+
+
+def cumprod_wrapper(inp, dim, dtype=None, out=None):
+    assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
+    dim = dim % inp.ndim
+    out_dtype = _get_output_dtype(inp, dtype)
+
+    inp = inp.contiguous()
+    if out is None:
+        out = torch.empty_like(inp, dtype=out_dtype)
+
+    if inp.numel() == 0:
+        return out
+
+    shape = inp.shape
+    M = math.prod(shape[:dim])
+    N = shape[dim]
+    K = inp.numel() // M // N
+    compute_dtype = _get_compute_dtype(out.dtype)
+
+    if K == 1:
+        reduce_then_scan_row(inp, out, M, N, compute_dtype)
+    else:
+        scan_then_fan(inp, out, M, N, K, compute_dtype)
+
+    return out
+
+
+def reduce_then_scan_row(x, out, M, N, compute_dtype):
+    if N <= 16384:
+        TILE_SIZE = triton.next_power_of_2(N)
+        num_warps = 8 if TILE_SIZE > 2048 else 4
+        reduce_then_scan_root_scan_kernel_row[(M, 1, 1)](
+            x, out, N, TILE_SIZE, num_warps=num_warps
+        )
+        return out
+
+    TILE_SIZE = min(4096, triton.next_power_of_2(N))
+    num_warps = 8 if TILE_SIZE > 2048 else 4
+    num_tiles = triton.cdiv(N, TILE_SIZE)
+    max_ctas = get_num_sms(x.device.index) * 4
+    num_ctas = min(num_tiles, max_ctas)
+    ROOT_SCAN_TILE_SIZE = triton.next_power_of_2(num_ctas)
+    tiles_per_cta = triton.cdiv(num_tiles, num_ctas)
+
+    block_products = torch.empty((M, num_ctas), dtype=compute_dtype, device=x.device)
+    block_inclusive_prefix = torch.empty_like(block_products)
+
+    reduce_then_scan_block_product_kernel_row[(M, num_ctas, 1, 1)](
+        x, block_products, N, tiles_per_cta, TILE_SIZE, num_warps=num_warps
+    )
+    reduce_then_scan_root_scan_kernel_row[(M, 1, 1)](
+        block_products,
+        block_inclusive_prefix,
+        num_ctas,
+        ROOT_SCAN_TILE_SIZE,
+        num_warps=num_warps,
+    )
+    reduce_then_scan_block_scan_kernel_row[(M, num_ctas, 1)](
+        x,
+        block_inclusive_prefix,
+        out,
+        N,
+        num_ctas,
+        tiles_per_cta,
+        TILE_SIZE,
+        num_warps=num_warps,
+    )
+    return out
+
+
+@triton.jit
+def reduce_then_scan_block_product_kernel_row(
+    in_ptr,
+    block_product_ptr,
+    N,
+    tiles_per_cta,
+    TILE_SIZE: tl.constexpr,
+):
+    pid_n = tl.program_id(1).to(tl.int64)
+    pid_m = tl.program_id(0).to(tl.int64)
+    num_programs_n = tl.num_programs(1)
+    block_offset = pid_n * (tiles_per_cta * TILE_SIZE)
+    block_end = min(block_offset + tiles_per_cta * TILE_SIZE, N)
+
+    acc_dtype: tl.constexpr = get_prod_accum_type(block_product_ptr.type.element_ty)
+    acc = tl.full((TILE_SIZE,), value=1, dtype=acc_dtype)
+    for start in range(block_offset, block_end, TILE_SIZE):
+        offsets = start + tl.arange(0, TILE_SIZE)
+        x = tl.load(in_ptr + pid_m * N + offsets, mask=offsets < N, other=1).to(
+            acc_dtype
+        )
+        acc *= x
+    block_product = tl.reduce(acc, axis=0, combine_fn=reduce_mul)
+    tl.store(
+        block_product_ptr + pid_m * num_programs_n + pid_n,
+        block_product,
+        cache_modifier=".cg",
+    )
+
+
+@triton.jit
+def reduce_then_scan_root_scan_kernel_row(in_ptr, out_ptr, N, TILE_SIZE: tl.constexpr):
+    pid = tl.program_id(0).to(tl.int64)
+    offsets = tl.arange(0, TILE_SIZE)
+    mask = offsets < N
+    acc_dtype: tl.constexpr = get_prod_accum_type(out_ptr.type.element_ty)
+    x = tl.load(in_ptr + pid * N + offsets, mask=mask, other=1).to(acc_dtype)
+    out = tl.cumprod(x, 0)
+    tl.store(out_ptr + pid * N + offsets, out, mask=mask)
+
+
+@triton.jit
+def reduce_then_scan_block_scan_kernel_row(
+    in_ptr,
+    previous_product_ptr,
+    out_ptr,
+    N,
+    num_tiles_n,
+    tiles_per_cta,
+    TILE_SIZE: tl.constexpr,
+):
+    pid_m = tl.program_id(0).to(tl.int64)
+    pid_n = tl.program_id(1).to(tl.int64)
+    block_offset = pid_n * (tiles_per_cta * TILE_SIZE)
+    block_end = min(block_offset + tiles_per_cta * TILE_SIZE, N)
+    acc_dtype: tl.constexpr = get_prod_accum_type(out_ptr.type.element_ty)
+
+    prefix = tl.load(
+        previous_product_ptr + pid_m * num_tiles_n + pid_n - 1,
+        mask=pid_n > 0,
+        other=1,
+    ).to(acc_dtype)
+    for start in range(block_offset, block_end, TILE_SIZE):
+        offsets = start + tl.arange(0, TILE_SIZE)
+        mask = offsets < N
+        x = tl.load(in_ptr + pid_m * N + offsets, mask=mask, other=1).to(acc_dtype)
+        tile_scan = prefix * tl.cumprod(x, 0)
+        prefix *= tl.reduce(x, axis=0, combine_fn=reduce_mul)
+        tl.store(
+            out_ptr + pid_m * N + offsets, tile_scan, mask=mask, cache_modifier=".cg"
+        )
+
+
+def cumprod(inp, dim, *, dtype=None):
+    logger.debug("GEMS CUMPROD")
+    out_dtype = _get_output_dtype(inp, dtype)
+    if _should_redispatch_on_ascend(out_dtype):
+        return torch.ops.aten.cumprod.default.redispatch(
+            _FALLBACK_KEYSET, inp, dim, dtype=dtype
+        )
+    return cumprod_wrapper(inp, dim, dtype)
+
+
+def cumprod_(inp, dim, *, dtype=None):
+    logger.debug("GEMS CUMPROD_")
+    if dtype is not None and dtype != inp.dtype:
+        raise RuntimeError(
+            "Bad in-place call: input tensor dtype and output tensor dtype should match"
+        )
+    if _should_redispatch_on_ascend(inp.dtype):
+        return torch.ops.aten.cumprod_.default.redispatch(
+            _FALLBACK_KEYSET, inp, dim, dtype=dtype
+        )
+    if inp.is_contiguous():
+        return cumprod_wrapper(inp, dim, inp.dtype, inp)
+
+    out = cumprod_wrapper(inp, dim, inp.dtype)
+    inp.copy_(out)
+    return inp

--- a/src/flag_gems/ops/cumprod.py
+++ b/src/flag_gems/ops/cumprod.py
@@ -379,6 +379,10 @@ def reduce_then_scan_block_scan_kernel_row(
 def cumprod(inp, dim, *, dtype=None):
     logger.debug("GEMS CUMPROD")
     out_dtype = _get_output_dtype(inp, dtype)
+    if is_boolean_dtype(inp.dtype) and is_boolean_dtype(out_dtype):
+        return torch.ops.aten.cumprod.default.redispatch(
+            _FALLBACK_KEYSET, inp, dim, dtype=dtype
+        )
     if _should_redispatch_on_ascend(out_dtype):
         return torch.ops.aten.cumprod.default.redispatch(
             _FALLBACK_KEYSET, inp, dim, dtype=dtype
@@ -391,6 +395,10 @@ def cumprod_(inp, dim, *, dtype=None):
     if dtype is not None and dtype != inp.dtype:
         raise RuntimeError(
             "Bad in-place call: input tensor dtype and output tensor dtype should match"
+        )
+    if is_boolean_dtype(inp.dtype):
+        return torch.ops.aten.cumprod_.default.redispatch(
+            _FALLBACK_KEYSET, inp, dim, dtype=dtype
         )
     if _should_redispatch_on_ascend(inp.dtype):
         return torch.ops.aten.cumprod_.default.redispatch(

--- a/src/flag_gems/ops/cumprod.py
+++ b/src/flag_gems/ops/cumprod.py
@@ -17,11 +17,21 @@ logger = logging.getLogger(__name__)
 _FALLBACK_KEYSET = torch._C.DispatchKeySet(
     torch._C.DispatchKey.CompositeExplicitAutograd
 )
+DEFAULT_BLOCK_SIZE = 1024
+CUDA_SMALL_SCAN_LIMIT = 1024 * 4
+ASCEND_SCAN_LIMIT = 1024
+DEFAULT_NUM_SMS = 40
 
 
 @functools.lru_cache
 def get_num_sms(idx: int) -> int:
-    return get_device_properties(idx).multi_processor_count
+    return get_device_properties(idx).multi_processor_count or DEFAULT_NUM_SMS
+
+
+def _get_device_index(torch_device):
+    if torch_device.index is not None:
+        return torch_device.index
+    return torch_device_fn.current_device()
 
 
 @tl.constexpr
@@ -149,9 +159,7 @@ def multiply_base_product_abc_kernel(
 
 
 def scan_then_fan_col(inp, out, n_ele, dtype):
-    BLOCK_SIZE = 1024
-    if n_ele <= 1024 * 4:
-        BLOCK_SIZE = triton.next_power_of_2(n_ele)
+    BLOCK_SIZE = _scan_block_size(n_ele)
     part_num = math.ceil(n_ele / BLOCK_SIZE)
     partial_product = torch.empty(part_num, dtype=dtype, device=inp.device)
 
@@ -162,17 +170,16 @@ def scan_then_fan_col(inp, out, n_ele, dtype):
         )
 
     if part_num >= 2:
-        scan_then_fan_col(partial_product, partial_product, part_num, dtype)
+        partial_prefix = torch.empty_like(partial_product)
+        scan_then_fan_col(partial_product, partial_prefix, part_num, dtype)
         with torch_device_fn.device(inp.device):
             multiply_base_product_kernel[grid](
-                out, partial_product, n_ele, part_num, BLOCK_SIZE
+                out, partial_prefix, n_ele, part_num, BLOCK_SIZE
             )
 
 
 def scan_then_fan(inp, out, A, B, C, dtype):
-    BLOCK_SIZE = 1024
-    if B <= 1024 * 4:
-        BLOCK_SIZE = triton.next_power_of_2(B)
+    BLOCK_SIZE = _scan_block_size(B)
     part_num = math.ceil(B / BLOCK_SIZE)
     partial_product = torch.empty(A, part_num, C, dtype=dtype, device=inp.device)
 
@@ -183,10 +190,11 @@ def scan_then_fan(inp, out, A, B, C, dtype):
         )
 
     if part_num >= 2:
-        scan_then_fan(partial_product, partial_product, A, part_num, C, dtype)
+        partial_prefix = torch.empty_like(partial_product)
+        scan_then_fan(partial_product, partial_prefix, A, part_num, C, dtype)
         with torch_device_fn.device(inp.device):
             multiply_base_product_abc_kernel[grid](
-                out, partial_product, B, C, part_num, BLOCK_SIZE
+                out, partial_prefix, B, C, part_num, BLOCK_SIZE
             )
 
 
@@ -210,6 +218,17 @@ def _should_redispatch_on_ascend(dtype):
     return runtime_device.vendor_name == "ascend" and (
         is_integer_dtype(dtype) or is_boolean_dtype(dtype)
     )
+
+
+def _scan_block_size(length):
+    limit = (
+        ASCEND_SCAN_LIMIT
+        if runtime_device.vendor_name == "ascend"
+        else CUDA_SMALL_SCAN_LIMIT
+    )
+    if length <= limit:
+        return triton.next_power_of_2(length)
+    return DEFAULT_BLOCK_SIZE
 
 
 def cumprod_wrapper(inp, dim, dtype=None, out=None):
@@ -239,7 +258,10 @@ def cumprod_wrapper(inp, dim, dtype=None, out=None):
 
 
 def reduce_then_scan_row(x, out, M, N, compute_dtype):
-    if N <= 16384:
+    persistent_limit = (
+        ASCEND_SCAN_LIMIT if runtime_device.vendor_name == "ascend" else 16384
+    )
+    if N <= persistent_limit:
         TILE_SIZE = triton.next_power_of_2(N)
         num_warps = 8 if TILE_SIZE > 2048 else 4
         reduce_then_scan_root_scan_kernel_row[(M, 1, 1)](
@@ -247,10 +269,10 @@ def reduce_then_scan_row(x, out, M, N, compute_dtype):
         )
         return out
 
-    TILE_SIZE = min(4096, triton.next_power_of_2(N))
+    TILE_SIZE = min(_scan_block_size(N), triton.next_power_of_2(N))
     num_warps = 8 if TILE_SIZE > 2048 else 4
     num_tiles = triton.cdiv(N, TILE_SIZE)
-    max_ctas = get_num_sms(x.device.index) * 4
+    max_ctas = get_num_sms(_get_device_index(x.device)) * 4
     num_ctas = min(num_tiles, max_ctas)
     ROOT_SCAN_TILE_SIZE = triton.next_power_of_2(num_ctas)
     tiles_per_cta = triton.cdiv(num_tiles, num_ctas)
@@ -374,9 +396,6 @@ def cumprod_(inp, dim, *, dtype=None):
         return torch.ops.aten.cumprod_.default.redispatch(
             _FALLBACK_KEYSET, inp, dim, dtype=dtype
         )
-    if inp.is_contiguous():
-        return cumprod_wrapper(inp, dim, inp.dtype, inp)
-
     out = cumprod_wrapper(inp, dim, inp.dtype)
     inp.copy_(out)
     return inp

--- a/tests/test_cumprod.py
+++ b/tests/test_cumprod.py
@@ -35,7 +35,7 @@ else:
         ((16, 1025, 255), 1),
     ]
 
-BOOL_DTYPES = [] if flag_gems.vendor_name == "ascend" else [torch.bool]
+BOOL_DTYPES = [torch.bool]
 INT_DTYPES = list(dict.fromkeys([torch.int8, torch.uint8] + utils.ALL_INT_DTYPES))
 DTYPES = FLOAT_DTYPES + INT_DTYPES
 CUMPROD_DTYPES = DTYPES + BOOL_DTYPES
@@ -44,8 +44,7 @@ CUMPROD_DTYPE_CASES = [
     (torch.uint8, torch.int64),
     (torch.float16, torch.float32),
 ]
-if flag_gems.vendor_name != "ascend":
-    CUMPROD_DTYPE_CASES.append((torch.bool, torch.int64))
+CUMPROD_DTYPE_CASES.append((torch.bool, torch.int64))
 
 
 def _make_input(shape, dtype):
@@ -65,6 +64,8 @@ def _make_input(shape, dtype):
 
 
 def _reference_input(inp):
+    if inp.dtype is torch.bool:
+        return utils.to_reference(inp.to(torch.uint8), False)
     return utils.to_reference(inp, inp.is_floating_point())
 
 

--- a/tests/test_cumprod.py
+++ b/tests/test_cumprod.py
@@ -35,10 +35,17 @@ else:
         ((16, 1025, 255), 1),
     ]
 
-BOOL_DTYPES = [torch.bool]
+BOOL_DTYPES = [] if flag_gems.vendor_name == "ascend" else [torch.bool]
 INT_DTYPES = list(dict.fromkeys([torch.int8, torch.uint8] + utils.ALL_INT_DTYPES))
 DTYPES = FLOAT_DTYPES + INT_DTYPES
 CUMPROD_DTYPES = DTYPES + BOOL_DTYPES
+CUMPROD_DTYPE_CASES = [
+    (torch.int8, torch.int32),
+    (torch.uint8, torch.int64),
+    (torch.float16, torch.float32),
+]
+if flag_gems.vendor_name != "ascend":
+    CUMPROD_DTYPE_CASES.append((torch.bool, torch.int64))
 
 
 def _make_input(shape, dtype):
@@ -78,15 +85,7 @@ def test_cumprod(shape_dim, dtype):
 
 
 @pytest.mark.cumprod
-@pytest.mark.parametrize(
-    "input_dtype, output_dtype",
-    [
-        (torch.int8, torch.int32),
-        (torch.uint8, torch.int64),
-        (torch.bool, torch.int64),
-        (torch.float16, torch.float32),
-    ],
-)
+@pytest.mark.parametrize("input_dtype, output_dtype", CUMPROD_DTYPE_CASES)
 def test_cumprod_dtype(input_dtype, output_dtype):
     inp = _make_input((8, 17), input_dtype)
     ref_inp = _reference_input(inp)

--- a/tests/test_cumprod.py
+++ b/tests/test_cumprod.py
@@ -35,14 +35,20 @@ else:
         ((16, 1025, 255), 1),
     ]
 
+BOOL_DTYPES = [torch.bool]
 INT_DTYPES = list(dict.fromkeys([torch.int8, torch.uint8] + utils.ALL_INT_DTYPES))
 DTYPES = FLOAT_DTYPES + INT_DTYPES
+CUMPROD_DTYPES = DTYPES + BOOL_DTYPES
 
 
 def _make_input(shape, dtype):
     if dtype.is_floating_point:
         return torch.empty(shape, dtype=dtype, device=flag_gems.device).uniform_(
             0.99, 1.01
+        )
+    if dtype is torch.bool:
+        return torch.randint(0, 2, shape, dtype=torch.int8, device="cpu").to(
+            flag_gems.device, dtype=dtype
         )
     if dtype is torch.uint8:
         return torch.randint(0, 4, shape, dtype=dtype, device="cpu").to(
@@ -57,7 +63,7 @@ def _reference_input(inp):
 
 @pytest.mark.cumprod
 @pytest.mark.parametrize("shape_dim", CUMPROD_SHAPE_DIMS)
-@pytest.mark.parametrize("dtype", DTYPES)
+@pytest.mark.parametrize("dtype", CUMPROD_DTYPES)
 def test_cumprod(shape_dim, dtype):
     shape, dim = shape_dim
     inp = _make_input(shape, dtype)
@@ -67,7 +73,7 @@ def test_cumprod(shape_dim, dtype):
     with flag_gems.use_gems():
         res_out = torch.cumprod(inp, dim=dim)
 
-    check_dtype = ref_out.dtype if dtype in INT_DTYPES else dtype
+    check_dtype = ref_out.dtype if dtype in INT_DTYPES + BOOL_DTYPES else dtype
     utils.gems_assert_close(res_out, ref_out, check_dtype, reduce_dim=shape[dim])
 
 
@@ -77,6 +83,7 @@ def test_cumprod(shape_dim, dtype):
     [
         (torch.int8, torch.int32),
         (torch.uint8, torch.int64),
+        (torch.bool, torch.int64),
         (torch.float16, torch.float32),
     ],
 )
@@ -144,3 +151,12 @@ def test_cumprod_inplace_dtype_mismatch():
     with flag_gems.use_gems():
         with pytest.raises(RuntimeError, match="Bad in-place call"):
             inp.cumprod_(1, dtype=torch.int64)
+
+
+@pytest.mark.cumprod_
+def test_cumprod_inplace_bool_unsupported():
+    inp = _make_input((4, 9), torch.bool)
+
+    with flag_gems.use_gems():
+        with pytest.raises((RuntimeError, NotImplementedError)):
+            inp.cumprod_(1)

--- a/tests/test_cumprod.py
+++ b/tests/test_cumprod.py
@@ -8,9 +8,13 @@ from . import conftest as cfg
 
 if cfg.QUICK_MODE:
     FLOAT_DTYPES = [torch.float32]
+    BOOL_DTYPES = [torch.bool]
+    INT_DTYPES = [torch.int32]
     CUMPROD_SHAPE_DIMS = [((2, 32), 1), ((2, 5, 3), 1)]
 else:
     FLOAT_DTYPES = utils.ALL_FLOAT_DTYPES
+    BOOL_DTYPES = [torch.bool]
+    INT_DTYPES = list(dict.fromkeys([torch.int8, torch.uint8] + utils.ALL_INT_DTYPES))
     CUMPROD_SHAPE_DIMS = [
         ((0,), 0),
         ((0, 7), 0),
@@ -35,16 +39,15 @@ else:
         ((16, 1025, 255), 1),
     ]
 
-BOOL_DTYPES = [torch.bool]
-INT_DTYPES = list(dict.fromkeys([torch.int8, torch.uint8] + utils.ALL_INT_DTYPES))
+
 DTYPES = FLOAT_DTYPES + INT_DTYPES
 CUMPROD_DTYPES = DTYPES + BOOL_DTYPES
 CUMPROD_DTYPE_CASES = [
     (torch.int8, torch.int32),
     (torch.uint8, torch.int64),
     (torch.float16, torch.float32),
+    (torch.bool, torch.int64),
 ]
-CUMPROD_DTYPE_CASES.append((torch.bool, torch.int64))
 
 
 def _make_input(shape, dtype):

--- a/tests/test_cumprod.py
+++ b/tests/test_cumprod.py
@@ -1,0 +1,114 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+if cfg.QUICK_MODE:
+    FLOAT_DTYPES = [torch.float32]
+    CUMPROD_SHAPE_DIMS = [((2, 32), 1), ((2, 5, 3), 1)]
+else:
+    FLOAT_DTYPES = utils.ALL_FLOAT_DTYPES
+    CUMPROD_SHAPE_DIMS = [
+        ((1, 2), -1),
+        ((4096, 256), 1),
+        ((200, 2560, 3), 1),
+        ((2637,), 0),
+        ((16, 1025, 255), 1),
+    ]
+
+INT_DTYPES = list(dict.fromkeys([torch.int8, torch.uint8] + utils.ALL_INT_DTYPES))
+DTYPES = FLOAT_DTYPES + INT_DTYPES
+
+
+def _make_input(shape, dtype):
+    if dtype.is_floating_point:
+        return torch.empty(shape, dtype=dtype, device=flag_gems.device).uniform_(
+            0.99, 1.01
+        )
+    if dtype is torch.uint8:
+        return torch.randint(0, 4, shape, dtype=dtype, device="cpu").to(
+            flag_gems.device
+        )
+    return torch.randint(-3, 4, shape, dtype=dtype, device="cpu").to(flag_gems.device)
+
+
+def _reference_input(inp):
+    return utils.to_reference(inp, inp.is_floating_point())
+
+
+@pytest.mark.cumprod
+@pytest.mark.parametrize("shape_dim", CUMPROD_SHAPE_DIMS)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_cumprod(shape_dim, dtype):
+    shape, dim = shape_dim
+    inp = _make_input(shape, dtype)
+    ref_inp = _reference_input(inp)
+
+    ref_out = torch.cumprod(ref_inp, dim=dim)
+    with flag_gems.use_gems():
+        res_out = torch.cumprod(inp, dim=dim)
+
+    check_dtype = ref_out.dtype if dtype in INT_DTYPES else dtype
+    utils.gems_assert_close(res_out, ref_out, check_dtype, reduce_dim=shape[dim])
+
+
+@pytest.mark.cumprod
+@pytest.mark.parametrize(
+    "input_dtype, output_dtype",
+    [
+        (torch.int8, torch.int32),
+        (torch.uint8, torch.int64),
+        (torch.float16, torch.float32),
+    ],
+)
+def test_cumprod_dtype(input_dtype, output_dtype):
+    inp = _make_input((8, 17), input_dtype)
+    ref_inp = _reference_input(inp)
+
+    ref_out = torch.cumprod(ref_inp, dim=1, dtype=output_dtype)
+    with flag_gems.use_gems():
+        res_out = torch.cumprod(inp, dim=1, dtype=output_dtype)
+
+    utils.gems_assert_close(res_out, ref_out, output_dtype, reduce_dim=17)
+
+
+@pytest.mark.cumprod_
+@pytest.mark.parametrize("shape_dim", CUMPROD_SHAPE_DIMS)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_cumprod_inplace(shape_dim, dtype):
+    shape, dim = shape_dim
+    inp = _make_input(shape, dtype)
+    ref_inp = _reference_input(inp)
+    ref_out = torch.cumprod(ref_inp, dim=dim).to(dtype)
+
+    with flag_gems.use_gems():
+        res_out = inp.cumprod_(dim)
+
+    assert res_out.data_ptr() == inp.data_ptr()
+    utils.gems_assert_close(res_out, ref_out, dtype, reduce_dim=shape[dim])
+
+
+@pytest.mark.cumprod_
+def test_cumprod_inplace_non_contiguous():
+    base = _make_input((4, 9), torch.float32)
+    inp = base.t()
+    ref_inp = _reference_input(inp)
+    ref_out = torch.cumprod(ref_inp, dim=1).to(inp.dtype)
+
+    with flag_gems.use_gems():
+        res_out = inp.cumprod_(1)
+
+    assert res_out.data_ptr() == inp.data_ptr()
+    utils.gems_assert_close(res_out, ref_out, inp.dtype, reduce_dim=inp.shape[1])
+
+
+@pytest.mark.cumprod_
+def test_cumprod_inplace_dtype_mismatch():
+    inp = _make_input((4, 9), torch.int16)
+
+    with flag_gems.use_gems():
+        with pytest.raises(RuntimeError, match="Bad in-place call"):
+            inp.cumprod_(1, dtype=torch.int64)

--- a/tests/test_cumprod.py
+++ b/tests/test_cumprod.py
@@ -12,7 +12,23 @@ if cfg.QUICK_MODE:
 else:
     FLOAT_DTYPES = utils.ALL_FLOAT_DTYPES
     CUMPROD_SHAPE_DIMS = [
+        ((0,), 0),
+        ((0, 7), 0),
+        ((3, 0, 5), 1),
+        ((1,), 0),
         ((1, 2), -1),
+        ((1, 1, 1), -1),
+        ((1023,), 0),
+        ((1024,), 0),
+        ((1025,), 0),
+        ((2049,), 0),
+        ((33, 17), 0),
+        ((4, 5, 6), -2),
+        ((2, 1023, 3), 1),
+        ((2, 1024, 3), 1),
+        ((2, 1025, 3), 1),
+        ((2, 7, 1031), -1),
+        ((3, 1, 4097), -1),
         ((4096, 256), 1),
         ((200, 2560, 3), 1),
         ((2637,), 0),
@@ -92,8 +108,9 @@ def test_cumprod_inplace(shape_dim, dtype):
 
 
 @pytest.mark.cumprod_
-def test_cumprod_inplace_non_contiguous():
-    base = _make_input((4, 9), torch.float32)
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_cumprod_inplace_non_contiguous(dtype):
+    base = _make_input((4, 9), dtype)
     inp = base.t()
     ref_inp = _reference_input(inp)
     ref_out = torch.cumprod(ref_inp, dim=1).to(inp.dtype)
@@ -103,6 +120,21 @@ def test_cumprod_inplace_non_contiguous():
 
     assert res_out.data_ptr() == inp.data_ptr()
     utils.gems_assert_close(res_out, ref_out, inp.dtype, reduce_dim=inp.shape[1])
+
+
+@pytest.mark.cumprod_
+@pytest.mark.parametrize("dtype", DTYPES)
+def test_cumprod_inplace_non_contiguous_tile_boundary(dtype):
+    base = _make_input((7, 1025, 3), dtype)
+    inp = base.transpose(0, 1)
+    ref_inp = _reference_input(inp)
+    ref_out = torch.cumprod(ref_inp, dim=0).to(inp.dtype)
+
+    with flag_gems.use_gems():
+        res_out = inp.cumprod_(0)
+
+    assert res_out.data_ptr() == inp.data_ptr()
+    utils.gems_assert_close(res_out, ref_out, inp.dtype, reduce_dim=inp.shape[0])
 
 
 @pytest.mark.cumprod_


### PR DESCRIPTION
### PR Category

Operator | OP Test | Benchmark


### Type of Change

New Feature 


### Description

Add FlagGems implementations for `torch.cumprod` and `Tensor.cumprod_` on CUDA and Ascend.

This PR adds `src/flag_gems/ops/cumprod.py`, registers both functional and in-place variants, and adds accuracy and benchmark coverage in `tests/test_cumprod.py` and `benchmark/test_cumprod.py`.

The implementation uses Triton prefix-product scan kernels. For long scan dimensions, it splits the scan into tiles, computes per-tile products, recursively scans the partial products, and then multiplies each tile by its prefix product. The in-place variant computes into a temporary output first and copies back to avoid input/output aliasing corruption.

#### Dtype support

`torch.cumprod` supports:
- CUDA: `bool`, `float16`, `bfloat16`, `float32`, `float64`, `int8`, `uint8`, `int16`, `int32`, `int64`
- Ascend: `bool`, `float16`, `bfloat16`, `float32`, `int8`, `uint8`, `int16`, `int32`, `int64`

`torch.Tensor.cumprod_` supports:
- CUDA: `float16`, `bfloat16`, `float32`, `float64`, `int8`, `uint8`, `int16`, `int32`, `int64`
- Ascend: `float16`, `bfloat16`, `float32`, `int8`, `uint8`, `int16`, `int32`, `int64`

Notes:
- `bool` is supported for functional `torch.cumprod` only. This matches PyTorch behavior: `torch.cumprod(bool_tensor, dim)` promotes the result to an integer dtype, while `bool_tensor.cumprod_(dim)` is unsupported.
- On Ascend, native `aclnnCumprod` does not accept `DT_BOOL`, so functional bool input is handled by casting 0/1 values to `uint8` and then following cumprod's integer-output semantics.
- On Ascend, integer dtypes redispatch to ATen for correctness.
- `float64` is tested only on devices where the backend reports fp64 support, so it is covered on CUDA but not included in the Ascend matrix here.

#### Accuracy coverage

The main accuracy matrix covers both `torch.cumprod` and `Tensor.cumprod_` across the supported dtype lists above.

Functional `torch.cumprod` additionally covers dtype override cases:
- `int8 -> int32`
- `uint8 -> int64`
- `bool -> int64`
- `float16 -> float32`

In-place `torch.Tensor.cumprod_` additionally covers:
- non-contiguous views
- non-contiguous views crossing the `1025` tile boundary
- dtype mismatch error handling
- bool in-place unsupported behavior

Shape/dim coverage includes:
 - empty tensors
 - single-element tensors
 - negative dims
 - `dim=0`
 - middle-dim scans
 - last-dim scans
 - tile-boundary scan lengths 

Non-contiguous in-place coverage includes:

```python
base=(4, 9), input=base.t(), dim=1
base=(7, 1025, 3), input=base.transpose(0, 1), dim=0
```

#### Benchmark coverage

`cumprod` benchmark dtypes:
 - `bool`
 - `float16`, `bfloat16`, `float32`
 - `int8`, `uint8`, `int16`, `int32`, `int64`

 `cumprod_` benchmark dtypes:
 - `float16`, `bfloat16`, `float32`
 - `int8`, `uint8`, `int16`, `int32`, `int64`

Benchmark shapes are:
```python
(64, 64)
(256, 256)
(1024, 1024)
(4096, 4096)
(1024, 65536)
```

All benchmark cases scan along `dim=1`.

### Issue

 - Resolves [issue#398](https://github.com/flagos-ai/FlagGems/issues/398) [issue#319](https://github.com/flagos-ai/FlagGems/issues/319)
 - Associated with [PR#357](https://github.com/flagos-ai/FlagGems/pull/357)


### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.


### Performance

Benchmarked with:

```bash
pytest -s benchmark/test_cumprod.py --level core --record log --tb=short -x
```

#### Benchmark summary on CUDA device

Functional `cumprod` shows consistent speedups across all benchmarked dtypes, including `bool`:
 - floating dtypes: up to `7.15x`
 - bool: up to `3.05x`
 - integer dtypes: up to `5.00x`

`cumprod_` also improves on medium and large shapes:
 - floating dtypes: up to `3.52x`
 - integer dtypes: up to `3.39x`

For CUDA `cumprod_`, small shapes may be slightly slower because the implementation computes into a temporary tensor and copies back to preserve correct in-place semantics without input/output aliasing issues. Medium and large shapes still benefit from the optimized scan kernels, with speedups up to `3.52x` in the benchmark matrix.

#### Benchmark summary on Ascend device

Functional `cumprod` has large gains for floating dtypes on medium and large shapes:
 - float16: up to `82.88x`
 - float32: up to `63.60x`
 - bfloat16: up to `57.02x`
 
`cumprod_` shows similar floating-point gains:
 - float16: up to `78.93x`
 - float32: up to `62.19x`
 - bfloat16: up to `54.49x`

Ascend integer and bool cases are close to `1x` because they currently use the ATen/aclnn integer path for correctness. Functional bool is supported by casting 0/1 bool values to `uint8` before cumprod, since native `aclnnCumprod` does not accept `DT_BOOL`.

On Ascend, the optimization mainly targets medium and large scan workloads. Small shapes such as `(64, 64)` can be slower than ATen due to Triton launch overhead and temporary-buffer overhead. From `(256, 256)` and larger, floating-point dtypes show clear speedups, reaching up to `82.88x` for functional `cumprod` and `78.93x` for `cumprod_`.

#### Benchmark on CUDA device (1 * NVIDIA H20)

2 passed, 46 warnings in 93.28s.

```text
benchmark/test_cumprod.py 
Operator: cumprod  Performance Test (dtype=torch.float16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.008064            0.006240               1.292          [torch.Size([64, 64]), 1]
SUCCESS               0.015296            0.006752               2.265          [torch.Size([256, 256]), 1]
SUCCESS               0.045248            0.008096               5.589          [torch.Size([1024, 1024]), 1]
SUCCESS               0.184272            0.026688               6.905          [torch.Size([4096, 4096]), 1]
SUCCESS               0.740272            0.160416               4.615          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.float32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.008288            0.005792               1.431          [torch.Size([64, 64]), 1]
SUCCESS               0.015232            0.005824               2.615          [torch.Size([256, 256]), 1]
SUCCESS               0.045760            0.008320               5.500          [torch.Size([1024, 1024]), 1]
SUCCESS               0.194176            0.043840               4.429          [torch.Size([4096, 4096]), 1]
SUCCESS               0.687776            0.271488               2.533          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.bfloat16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007200            0.005504               1.308          [torch.Size([64, 64]), 1]
SUCCESS               0.014432            0.005760               2.506          [torch.Size([256, 256]), 1]
SUCCESS               0.044096            0.007168               6.152          [torch.Size([1024, 1024]), 1]
SUCCESS               0.183648            0.025696               7.147          [torch.Size([4096, 4096]), 1]
SUCCESS               0.739040            0.160224               4.613          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.bool, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.011552            0.009600               1.203          [torch.Size([64, 64]), 1]
SUCCESS               0.018912            0.010080               1.876          [torch.Size([256, 256]), 1]
SUCCESS               0.051072            0.016768               3.046          [torch.Size([1024, 1024]), 1]
SUCCESS               0.328864            0.168480               1.952          [torch.Size([4096, 4096]), 1]
SUCCESS               1.232144            0.675648               1.824          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.int8, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.011552            0.005856               1.973          [torch.Size([64, 64]), 1]
SUCCESS               0.018880            0.006048               3.122          [torch.Size([256, 256]), 1]
SUCCESS               0.051040            0.010208               5.000          [torch.Size([1024, 1024]), 1]
SUCCESS               0.327600            0.089792               3.648          [torch.Size([4096, 4096]), 1]
SUCCESS               1.228064            0.445856               2.754          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.uint8, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.010208            0.005856               1.743          [torch.Size([64, 64]), 1]
SUCCESS               0.017472            0.005952               2.935          [torch.Size([256, 256]), 1]
SUCCESS               0.048800            0.009824               4.967          [torch.Size([1024, 1024]), 1]
SUCCESS               0.297440            0.100544               2.958          [torch.Size([4096, 4096]), 1]
SUCCESS               1.108768            0.410272               2.703          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.int16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.011584            0.005568               2.080          [torch.Size([64, 64]), 1]
SUCCESS               0.019040            0.006080               3.132          [torch.Size([256, 256]), 1]
SUCCESS               0.051232            0.010688               4.793          [torch.Size([1024, 1024]), 1]
SUCCESS               0.331008            0.105504               3.137          [torch.Size([4096, 4096]), 1]
SUCCESS               1.241296            0.422880               2.935          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.int32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.011744            0.005584               2.103          [torch.Size([64, 64]), 1]
SUCCESS               0.019072            0.006048               3.153          [torch.Size([256, 256]), 1]
SUCCESS               0.051648            0.010880               4.747          [torch.Size([1024, 1024]), 1]
SUCCESS               0.336992            0.112384               2.999          [torch.Size([4096, 4096]), 1]
SUCCESS               1.263584            0.458560               2.756          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.int64, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.008000            0.005856               1.366          [torch.Size([64, 64]), 1]
SUCCESS               0.016864            0.005984               2.818          [torch.Size([256, 256]), 1]
SUCCESS               0.053568            0.011296               4.742          [torch.Size([1024, 1024]), 1]
SUCCESS               0.247168            0.114336               2.162          [torch.Size([4096, 4096]), 1]
SUCCESS               0.913888            0.608544               1.502          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.float16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007488            0.007904               0.947          [torch.Size([64, 64]), 1]
SUCCESS               0.014464            0.008384               1.725          [torch.Size([256, 256]), 1]
SUCCESS               0.043712            0.012608               3.467          [torch.Size([1024, 1024]), 1]
SUCCESS               0.183264            0.079072               2.318          [torch.Size([4096, 4096]), 1]
SUCCESS               0.738432            0.375712               1.965          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.float32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007328            0.007840               0.935          [torch.Size([64, 64]), 1]
SUCCESS               0.015040            0.008416               1.787          [torch.Size([256, 256]), 1]
SUCCESS               0.045504            0.013760               3.307          [torch.Size([1024, 1024]), 1]
SUCCESS               0.193632            0.101664               1.905          [torch.Size([4096, 4096]), 1]
SUCCESS               0.687584            0.461520               1.490          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.bfloat16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007520            0.007904               0.951          [torch.Size([64, 64]), 1]
SUCCESS               0.014688            0.008256               1.779          [torch.Size([256, 256]), 1]
SUCCESS               0.043936            0.012480               3.521          [torch.Size([1024, 1024]), 1]
SUCCESS               0.183488            0.078880               2.326          [torch.Size([4096, 4096]), 1]
SUCCESS               0.738464            0.376288               1.962          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.int8, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007072            0.008032               0.880          [torch.Size([64, 64]), 1]
SUCCESS               0.012896            0.008320               1.550          [torch.Size([256, 256]), 1]
SUCCESS               0.038048            0.012416               3.064          [torch.Size([1024, 1024]), 1]
SUCCESS               0.156768            0.070144               2.235          [torch.Size([4096, 4096]), 1]
SUCCESS               0.597248            0.422272               1.414          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.uint8, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007040            0.008000               0.880          [torch.Size([64, 64]), 1]
SUCCESS               0.012640            0.008288               1.525          [torch.Size([256, 256]), 1]
SUCCESS               0.038272            0.012288               3.115          [torch.Size([1024, 1024]), 1]
SUCCESS               0.156544            0.069104               2.265          [torch.Size([4096, 4096]), 1]
SUCCESS               0.597024            0.406144               1.470          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.int16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007232            0.007968               0.908          [torch.Size([64, 64]), 1]
SUCCESS               0.014528            0.008384               1.733          [torch.Size([256, 256]), 1]
SUCCESS               0.043392            0.012800               3.390          [torch.Size([1024, 1024]), 1]
SUCCESS               0.181536            0.085440               2.125          [torch.Size([4096, 4096]), 1]
SUCCESS               0.732000            0.433664               1.688          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.int32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007328            0.007936               0.923          [torch.Size([64, 64]), 1]
SUCCESS               0.015264            0.008448               1.807          [torch.Size([256, 256]), 1]
SUCCESS               0.045248            0.014080               3.214          [torch.Size([1024, 1024]), 1]
SUCCESS               0.193728            0.107296               1.806          [torch.Size([4096, 4096]), 1]
SUCCESS               0.686432            0.502336               1.366          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.int64, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007744            0.008128               0.953          [torch.Size([64, 64]), 1]
SUCCESS               0.017056            0.008640               1.974          [torch.Size([256, 256]), 1]
SUCCESS               0.053024            0.016640               3.187          [torch.Size([1024, 1024]), 1]
SUCCESS               0.245344            0.195472               1.255          [torch.Size([4096, 4096]), 1]
SUCCESS               0.914592            0.825600               1.108          [torch.Size([1024, 65536]), 1]
```

#### Benchmark on Ascend device (1 * Ascend 910B)

2 passed, 47 warnings in 516.71s.

```text
Operator: cumprod  Performance Test (dtype=torch.float16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.131260            0.259080               0.507          [torch.Size([64, 64]), 1]
SUCCESS               1.698260            0.247920               6.850          [torch.Size([256, 256]), 1]
SUCCESS              26.727800            0.332100              80.481          [torch.Size([1024, 1024]), 1]
SUCCESS             448.122131            5.571460              80.432          [torch.Size([4096, 4096]), 1]
SUCCESS            1837.291870           22.169081              82.876          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.float32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.078960            0.264360               0.299          [torch.Size([64, 64]), 1]
SUCCESS               0.928960            0.273560               3.396          [torch.Size([256, 256]), 1]
SUCCESS              14.469700            0.331660              43.628          [torch.Size([1024, 1024]), 1]
SUCCESS             326.937042            5.575760              58.635          [torch.Size([4096, 4096]), 1]
SUCCESS            1424.406250           22.397461              63.597          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.bfloat16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.095740            0.265200               0.361          [torch.Size([64, 64]), 1]
SUCCESS               1.144000            0.256980               4.452          [torch.Size([256, 256]), 1]
SUCCESS              17.750000            0.332040              53.457          [torch.Size([1024, 1024]), 1]
SUCCESS             304.622009            5.571640              54.674          [torch.Size([4096, 4096]), 1]
SUCCESS            1263.269287           22.154499              57.021          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.bool, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.223040            0.251960               0.885          [torch.Size([64, 64]), 1]
SUCCESS               1.017500            0.976460               1.042          [torch.Size([256, 256]), 1]
SUCCESS              15.057040           15.059000               1.000          [torch.Size([1024, 1024]), 1]
SUCCESS             323.241791          319.466797               1.012          [torch.Size([4096, 4096]), 1]
SUCCESS            1259.964355         1278.417847               0.986          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.int8, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.088960            0.208220               0.427          [torch.Size([64, 64]), 1]
SUCCESS               0.969740            0.968320               1.001          [torch.Size([256, 256]), 1]
SUCCESS              15.036660           15.052700               0.999          [torch.Size([1024, 1024]), 1]
SUCCESS             317.385376          319.536774               0.993          [torch.Size([4096, 4096]), 1]
SUCCESS            1255.514160         1316.430420               0.954          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.uint8, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.088820            0.209320               0.424          [torch.Size([64, 64]), 1]
SUCCESS               0.971600            0.970060               1.002          [torch.Size([256, 256]), 1]
SUCCESS              15.039560           15.002280               1.002          [torch.Size([1024, 1024]), 1]
SUCCESS             323.222076          318.310059               1.015          [torch.Size([4096, 4096]), 1]
SUCCESS            1321.029297         1256.455078               1.051          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.int16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.088840            0.209940               0.423          [torch.Size([64, 64]), 1]
SUCCESS               0.971800            0.971080               1.001          [torch.Size([256, 256]), 1]
SUCCESS              15.025880           15.006960               1.001          [torch.Size([1024, 1024]), 1]
SUCCESS             319.545715          319.925354               0.999          [torch.Size([4096, 4096]), 1]
SUCCESS            1268.569580         1258.114624               1.008          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.int32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.089580            0.210240               0.426          [torch.Size([64, 64]), 1]
SUCCESS               0.970400            0.972800               0.998          [torch.Size([256, 256]), 1]
SUCCESS              15.064320           15.043420               1.001          [torch.Size([1024, 1024]), 1]
SUCCESS             315.229431          315.393890               0.999          [torch.Size([4096, 4096]), 1]
SUCCESS            1333.989380         1255.030151               1.063          [torch.Size([1024, 65536]), 1]

Operator: cumprod  Performance Test (dtype=torch.int64, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.081620            0.182560               0.447          [torch.Size([64, 64]), 1]
SUCCESS               0.961900            0.960920               1.001          [torch.Size([256, 256]), 1]
SUCCESS              14.999900           15.028460               0.998          [torch.Size([1024, 1024]), 1]
SUCCESS             313.990021          317.332245               0.989          [torch.Size([4096, 4096]), 1]
SUCCESS            1281.759033         1311.818115               0.977          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.float16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.133160            0.356900               0.373          [torch.Size([64, 64]), 1]
SUCCESS               1.644580            0.366660               4.485          [torch.Size([256, 256]), 1]
SUCCESS              25.806259            0.338660              76.201          [torch.Size([1024, 1024]), 1]
SUCCESS             430.567932            5.581980              77.135          [torch.Size([4096, 4096]), 1]
SUCCESS            1756.937988           22.260120              78.928          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.float32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.097040            0.365060               0.266          [torch.Size([64, 64]), 1]
SUCCESS               0.918520            0.365740               2.511          [torch.Size([256, 256]), 1]
SUCCESS              14.660120            0.340940              42.999          [torch.Size([1024, 1024]), 1]
SUCCESS             332.335327            5.602920              59.315          [torch.Size([4096, 4096]), 1]
SUCCESS            1418.001587           22.799620              62.194          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.bfloat16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.101920            0.356300               0.286          [torch.Size([64, 64]), 1]
SUCCESS               1.139360            0.361760               3.149          [torch.Size([256, 256]), 1]
SUCCESS              17.851940            0.340240              52.469          [torch.Size([1024, 1024]), 1]
SUCCESS             303.775330            5.575080              54.488          [torch.Size([4096, 4096]), 1]
SUCCESS            1210.227051           22.255779              54.378          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.int8, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.088880            0.086060               1.033          [torch.Size([64, 64]), 1]
SUCCESS               0.884040            0.880880               1.004          [torch.Size([256, 256]), 1]
SUCCESS              14.228580           14.235080               1.000          [torch.Size([1024, 1024]), 1]
SUCCESS             222.157639          222.445862               0.999          [torch.Size([4096, 4096]), 1]
SUCCESS             932.065613          942.856873               0.989          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.uint8, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.088220            0.079340               1.112          [torch.Size([64, 64]), 1]
SUCCESS               0.882340            0.881760               1.001          [torch.Size([256, 256]), 1]
SUCCESS              14.186020           14.260660               0.995          [torch.Size([1024, 1024]), 1]
SUCCESS             222.774796          222.318497               1.002          [torch.Size([4096, 4096]), 1]
SUCCESS             939.571411          936.474915               1.003          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.int16, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.091480            0.081420               1.124          [torch.Size([64, 64]), 1]
SUCCESS               0.932540            0.932660               1.000          [torch.Size([256, 256]), 1]
SUCCESS              14.637900           14.629320               1.001          [torch.Size([1024, 1024]), 1]
SUCCESS             251.200195          251.252625               1.000          [torch.Size([4096, 4096]), 1]
SUCCESS             997.522949         1001.309021               0.996          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.int32, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.103060            0.084420               1.221          [torch.Size([64, 64]), 1]
SUCCESS               0.902260            0.902220               1.000          [torch.Size([256, 256]), 1]
SUCCESS              14.050680           14.050080               1.000          [torch.Size([1024, 1024]), 1]
SUCCESS             263.783752          264.566833               0.997          [torch.Size([4096, 4096]), 1]
SUCCESS            1036.247437         1043.436646               0.993          [torch.Size([1024, 65536]), 1]

Operator: cumprod_  Performance Test (dtype=torch.int64, mode=kernel,level=core)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.125720            0.085920               1.463          [torch.Size([64, 64]), 1]
SUCCESS               0.969240            0.971380               0.998          [torch.Size([256, 256]), 1]
SUCCESS              15.059040           15.071620               0.999          [torch.Size([1024, 1024]), 1]
SUCCESS             316.514587          317.295868               0.998          [torch.Size([4096, 4096]), 1]
SUCCESS            1303.086304         1263.903564               1.031          [torch.Size([1024, 65536]), 1]
```