### PR TITLE
add hc_head_fused_kernel op

### DIFF
--- a/benchmark/test_mhc.py
+++ b/benchmark/test_mhc.py
@@ -1,6 +1,10 @@
 import pytest
 import torch
 
+from flag_gems.fused.mhc.hc_head_fused_kernel import (
+    hc_head_fused_kernel,
+    hc_head_fused_kernel_ref,
+)
 from flag_gems.fused.mhc.hc_split_sinkhorn import (
     hc_split_sinkhorn,
     mhc_split_sinkhorn_torch_ref,
@@ -203,5 +207,50 @@ def test_mhc_bwd():
         torch_op=mhc_bwd_ref,
         gems_op=mhc_bwd,
         dtypes=[torch.float32],
+    )
+    bench.run()
+
+
+class HCHeadFusedBenchmark(base.Benchmark):
+    DEFAULT_SHAPE_DESC = "N, hidden_size"
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = [
+            (256, 1280, 2),
+            (256, 1280, 4),
+            (512, 1280, 2),
+            (512, 1280, 4),
+            (512, 2560, 2),
+            (512, 2560, 4),
+            (1024, 2560, 2),
+            (1024, 2560, 4),
+            (2048, 4096, 2),
+            (2048, 4096, 4),
+            (4096, 4096, 2),
+            (4096, 4096, 4),
+        ]
+
+    def get_input_iter(self, dtype):
+        for n, hidden_size, hc_mult in self.shapes:
+            device = self.device
+            torch.manual_seed(42)
+            hs_flat = torch.randn((n, hc_mult, hidden_size), dtype=dtype, device=device)
+            fn = torch.randn(
+                (hc_mult, hc_mult * hidden_size), dtype=torch.float32, device=device
+            )
+            hc_scale = torch.randn((1,), dtype=torch.float32, device=device) * 0.1
+            hc_base = torch.randn((hc_mult,), dtype=torch.float32, device=device) * 0.1
+            out = torch.empty((n, hidden_size), dtype=dtype, device=device)
+
+            yield hs_flat, fn, hc_scale, hc_base, out, hidden_size, 1e-6, 1e-6, hc_mult
+
+
+@pytest.mark.hc_head_fused_kernel
+def test_hc_head_fused_kernel():
+    bench = HCHeadFusedBenchmark(
+        op_name="hc_head_fused_kernel",
+        torch_op=hc_head_fused_kernel_ref,
+        gems_op=hc_head_fused_kernel,
+        dtypes=[torch.float32, torch.float16, torch.bfloat16],
     )
     bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -3557,6 +3557,21 @@ ops:
       - Reduction
     stages:
       - stable: '2.0'
+  - id: hc_head_fused_kernel
+    description: |
+      The head fusion kernel for MHC (Manifold-Constrained Hyper-Connections).
+      This fused implementation computes RMS-normalized hidden states and applies
+      per-head weighted mixing to produce the output activations.
+    for:
+      - mhc_head_fused_kernel
+    labels:
+      - fused
+      - vLLM
+      - DSA
+    kind:
+      - NeuralNetwork
+    stages:
+      - beta: '5.2'
   - id: mhc_bwd
     description: |
       The backward case for MHC (Manifold-Constrained Hyper-Connections).

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -23,6 +23,8 @@ from flag_gems.fused.gelu_and_mul import gelu_and_mul
 from flag_gems.fused.grouped_topk import grouped_topk
 from flag_gems.fused.instance_norm import instance_norm
 from flag_gems.fused.mhc import (
+    hc_head_fused_kernel,
+    hc_head_fused_kernel_ref,
     mhc_bwd,
     mhc_bwd_ref,
     mhc_post,
@@ -73,6 +75,8 @@ __all__ = [
     "geglu",
     "gelu_and_mul",
     "grouped_topk",
+    "hc_head_fused_kernel",
+    "hc_head_fused_kernel_ref",
     "inplace_fused_experts",
     "instance_norm",
     "invoke_fused_moe_triton_kernel",

--- a/src/flag_gems/fused/mhc/__init__.py
+++ b/src/flag_gems/fused/mhc/__init__.py
@@ -1,3 +1,7 @@
+from flag_gems.fused.mhc.hc_head_fused_kernel import (
+    hc_head_fused_kernel,
+    hc_head_fused_kernel_ref,
+)
 from flag_gems.fused.mhc.hc_split_sinkhorn import (
     hc_split_sinkhorn,
     mhc_split_sinkhorn_torch_ref,
@@ -7,11 +11,15 @@ from flag_gems.fused.mhc.mhc_post import mhc_post
 from flag_gems.fused.mhc.mhc_pre import mhc_pre
 
 __all__ = [
+    "hc_head_fused_kernel",
+    "hc_head_fused_kernel_ref",
+    "hc_split_sinkhorn",
     "mhc_bwd",
     "mhc_bwd_ref",
     "mhc_post",
+    "mhc_post_ref",
     "mhc_pre",
-    "hc_split_sinkhorn",
+    "mhc_pre_ref",
     "mhc_split_sinkhorn_torch_ref",
     "sinkhorn_forward",
 ]

--- a/src/flag_gems/fused/mhc/hc_head_fused_kernel.py
+++ b/src/flag_gems/fused/mhc/hc_head_fused_kernel.py
@@ -1,0 +1,153 @@
+import torch
+import triton
+import triton.language as tl
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_H": 128}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_H": 256}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_H": 256}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_H": 512}, num_warps=4, num_stages=1),
+        triton.Config({"BLOCK_H": 512}, num_warps=8, num_stages=1),
+        triton.Config({"BLOCK_H": 1024}, num_warps=8, num_stages=1),
+    ],
+    key=["H", "HC"],
+)
+@triton.jit
+def _hc_head_apply_pre_mix_kernel(
+    hs_ptr,
+    pre_mix_ptr,
+    out_ptr,
+    T,
+    H,
+    hs_stride_t,
+    hs_stride_m,
+    hs_stride_h,
+    pre_stride_t,
+    pre_stride_m,
+    out_stride_t,
+    out_stride_h,
+    HC: tl.constexpr,
+    BLOCK_H: tl.constexpr,
+):
+    pid_t = tl.program_id(0)
+    pid_h = tl.program_id(1)
+
+    if pid_t >= T:
+        return
+
+    h_off = pid_h * BLOCK_H + tl.arange(0, BLOCK_H)
+    h_mask = h_off < H
+
+    acc = tl.zeros([BLOCK_H], dtype=tl.float32)
+    hs_t_base = pid_t * hs_stride_t
+    pre_t_base = pid_t * pre_stride_t
+
+    for i_hc in tl.static_range(HC):
+        pre = tl.load(pre_mix_ptr + pre_t_base + i_hc * pre_stride_m).to(tl.float32)
+        hs_ptrs = hs_ptr + hs_t_base + i_hc * hs_stride_m + h_off * hs_stride_h
+        hs_vals = tl.load(hs_ptrs, mask=h_mask, other=0.0).to(tl.float32)
+        acc += pre * hs_vals
+
+    out_ptrs = out_ptr + pid_t * out_stride_t + h_off * out_stride_h
+    tl.store(out_ptrs, acc, mask=h_mask)
+
+
+def hc_head_fused_kernel_ref(
+    hs_flat: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    out: torch.Tensor,
+    hidden_size: int,
+    rms_eps: float,
+    hc_eps: float,
+    hc_mult: int,
+) -> torch.Tensor:
+    if hs_flat.shape[0] == 0:
+        return out
+    x = hs_flat.reshape(hs_flat.shape[0], hc_mult * hidden_size).to(torch.float32)
+    mixes = torch.matmul(x, fn.t())
+    sqrsum = x.square().sum(dim=-1, keepdim=True)
+    rsqrt = torch.rsqrt(sqrsum / (hc_mult * hidden_size) + rms_eps)
+    pre_mix = torch.sigmoid(mixes * rsqrt * hc_scale[0] + hc_base) + hc_eps
+    result = torch.sum(pre_mix.unsqueeze(-1) * hs_flat.to(torch.float32), dim=1).to(
+        out.dtype
+    )
+    out.copy_(result)
+    return out
+
+
+def hc_head_fused_kernel(
+    hs_flat: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    out: torch.Tensor,
+    hidden_size: int,
+    rms_eps: float,
+    hc_eps: float,
+    hc_mult: int,
+) -> torch.Tensor:
+    assert hs_flat.dtype in [torch.float32, torch.float16, torch.bfloat16]
+    assert fn.dtype == torch.float32
+    assert hc_scale.dtype == torch.float32
+    assert hc_base.dtype == torch.float32
+
+    num_tokens = hs_flat.shape[0]
+    if num_tokens == 0:
+        return out
+
+    assert hs_flat.shape == (num_tokens, hc_mult, hidden_size)
+    assert fn.shape == (hc_mult, hc_mult * hidden_size)
+    assert hc_scale.shape == (1,)
+    assert hc_base.shape == (hc_mult,)
+    assert out.shape == (num_tokens, hidden_size)
+    assert out.dtype == hs_flat.dtype
+
+    x = hs_flat.reshape(num_tokens, hc_mult * hidden_size).to(torch.float32)
+    mixes = torch.matmul(x, fn.t())
+    sqrsum = x.square().sum(dim=-1, keepdim=True)
+    rsqrt = torch.rsqrt(sqrsum / (hc_mult * hidden_size) + rms_eps)
+    pre_mix = torch.sigmoid(mixes * rsqrt * hc_scale[0] + hc_base) + hc_eps
+
+    if hs_flat.device.type != "cuda":
+        return hc_head_fused_kernel_ref(
+            hs_flat,
+            fn,
+            hc_scale,
+            hc_base,
+            out,
+            hidden_size,
+            rms_eps,
+            hc_eps,
+            hc_mult,
+        )
+
+    hs_flat_c = hs_flat.contiguous()
+    pre_mix_c = pre_mix.contiguous()
+    out_c = out.contiguous()
+
+    def grid(meta):
+        return num_tokens, triton.cdiv(hidden_size, meta["BLOCK_H"])
+
+    _hc_head_apply_pre_mix_kernel[grid](
+        hs_flat_c,
+        pre_mix_c,
+        out_c,
+        num_tokens,
+        hidden_size,
+        hs_flat_c.stride(0),
+        hs_flat_c.stride(1),
+        hs_flat_c.stride(2),
+        pre_mix_c.stride(0),
+        pre_mix_c.stride(1),
+        out_c.stride(0),
+        out_c.stride(1),
+        HC=hc_mult,
+    )
+
+    if out.data_ptr() != out_c.data_ptr():
+        out.copy_(out_c)
+    return out

--- a/src/flag_gems/patches/patch_vllm_all.py
+++ b/src/flag_gems/patches/patch_vllm_all.py
@@ -267,6 +267,22 @@ def custom_silu_and_mul_with_clamp(
     flag_gems.silu_and_mul_with_clamp_out(x, y, out, limit)
 
 
+def custom_hc_head_fused_kernel(
+    hs_flat: torch.Tensor,
+    fn: torch.Tensor,
+    hc_scale: torch.Tensor,
+    hc_base: torch.Tensor,
+    out: torch.Tensor,
+    hidden_size: int,
+    rms_eps: float,
+    hc_eps: float,
+    hc_mult: int,
+):
+    return flag_gems.hc_head_fused_kernel(
+        hs_flat, fn, hc_scale, hc_base, out, hidden_size, rms_eps, hc_eps, hc_mult
+    )
+
+
 def custom_moe_align_block_size(
     topk_ids: torch.Tensor,
     num_experts: int,
@@ -603,6 +619,7 @@ def apply_gems_patches_to_vllm(verbose=True):
         ("_C", "rms_norm", custom_rms_norm_out),
         ("_C", "silu_and_mul", custom_silu_and_mul),
         ("_C", "silu_and_mul_with_clamp", custom_silu_and_mul_with_clamp),
+        ("_C", "hc_head_fused_kernel", custom_hc_head_fused_kernel),
         ("_C", "cutlass_scaled_mm", custom_cutlass_scaled_mm),
         ("_moe_C", "moe_align_block_size", custom_moe_align_block_size),
         ("_moe_C", "topk_softmax", custom_topk_softmax),

--- a/tests/test_mhc_ops.py
+++ b/tests/test_mhc_ops.py
@@ -10,6 +10,10 @@ import pytest
 import torch
 
 import flag_gems
+from flag_gems.fused.mhc.hc_head_fused_kernel import (
+    hc_head_fused_kernel,
+    hc_head_fused_kernel_ref,
+)
 from flag_gems.fused.mhc.hc_split_sinkhorn import (
     hc_split_sinkhorn,
     mhc_split_sinkhorn_torch_ref,
@@ -214,3 +218,74 @@ def test_mhc_bwd_vs_ref(seqlen, n_stream, sinkhorn_iters):
     out_ref = mhc_bwd_ref(R.cpu(), dR.cpu())
 
     torch.testing.assert_close(out_triton.cpu(), out_ref, rtol=1e-4, atol=1e-4)
+
+
+MHC_HC_HEAD_FUSED_CONFIGS = [
+    (256, 1280, 2),
+    (256, 1280, 4),
+    (512, 1280, 2),
+    (512, 1280, 4),
+    (512, 2560, 2),
+    (512, 2560, 4),
+    (1024, 2560, 2),
+    (1024, 2560, 4),
+    (2048, 4096, 2),
+    (2048, 4096, 4),
+    (4096, 1280, 2),
+    (4096, 1280, 4),
+]
+
+
+def generate_hc_head_fused_data(
+    n: int,
+    hidden_size: int,
+    hc_mult: int,
+    dtype: torch.dtype,
+    device: str = flag_gems.device,
+):
+    torch.manual_seed(42)
+    hs_flat = torch.randn((n, hc_mult, hidden_size), dtype=dtype, device=device)
+    fn = torch.randn(
+        (hc_mult, hc_mult * hidden_size), dtype=torch.float32, device=device
+    )
+    hc_scale = torch.randn((1,), dtype=torch.float32, device=device) * 0.1
+    hc_base = torch.randn((hc_mult,), dtype=torch.float32, device=device) * 0.1
+    out = torch.empty((n, hidden_size), dtype=dtype, device=device)
+    return dict(
+        hs_flat=hs_flat,
+        fn=fn,
+        hc_scale=hc_scale,
+        hc_base=hc_base,
+        out=out,
+        hidden_size=hidden_size,
+        rms_eps=1e-6,
+        hc_eps=1e-6,
+        hc_mult=hc_mult,
+    )
+
+
+@pytest.mark.hc_head_fused_kernel
+@pytest.mark.parametrize(
+    "dtype",
+    [torch.float32, torch.float16, torch.bfloat16],
+    ids=["fp32", "fp16", "bf16"],
+)
+@pytest.mark.parametrize(
+    "n, hidden_size, hc_mult",
+    MHC_HC_HEAD_FUSED_CONFIGS,
+    ids=[f"n{n}_h{h}_hc{hc}" for n, h, hc in MHC_HC_HEAD_FUSED_CONFIGS],
+)
+def test_hc_head_fused_kernel_vs_ref(n, hidden_size, hc_mult, dtype):
+    data = generate_hc_head_fused_data(n, hidden_size, hc_mult, dtype=dtype)
+    data_ref = generate_hc_head_fused_data(n, hidden_size, hc_mult, dtype=dtype)
+
+    tol_map = {
+        torch.float32: (1e-4, 1e-4),
+        torch.float16: (2e-2, 2e-2),
+        torch.bfloat16: (2e-2, 2e-2),
+    }
+    rtol, atol = tol_map[dtype]
+
+    out_triton = hc_head_fused_kernel(**data)
+    out_ref = hc_head_fused_kernel_ref(**data_ref)
+    torch.testing.assert_close(out_triton, out_ref, rtol=rtol, atol=atol)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
add hc_head_fused_kernel op.

### Issue
null

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
on H20 HBM3
```
FlagGems/benchmark# pytest -s test_mhc.py::test_hc_head_fused_kernel
====================================================== test session starts =======================================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.12.1, xdoctest-1.0.2, rerunfailures-15.1, hypothesis-6.130.8, xdist-3.6.1, flakefinder-1.1.0, shard-0.1.2
collected 1 item                                                                                                                 
Running 1 items in this shard

test_mhc.py 
Operator: hc_head_fused_kernel  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.069184            0.092528               0.748          [torch.Size([256, 2, 1280]), torch.Size([2, 2560]), torch.Size([1]), torch.Size([2]), torch.Size([256, 1280]), 1280, 1e-06, 1e-06, 2]
SUCCESS               0.075072            0.098848               0.759          [torch.Size([256, 4, 1280]), torch.Size([4, 5120]), torch.Size([1]), torch.Size([4]), torch.Size([256, 1280]), 1280, 1e-06, 1e-06, 4]
SUCCESS               0.072000            0.099104               0.727          [torch.Size([512, 2, 1280]), torch.Size([2, 2560]), torch.Size([1]), torch.Size([2]), torch.Size([512, 1280]), 1280, 1e-06, 1e-06, 2]
SUCCESS               0.090080            0.099968               0.901          [torch.Size([512, 4, 1280]), torch.Size([4, 5120]), torch.Size([1]), torch.Size([4]), torch.Size([512, 1280]), 1280, 1e-06, 1e-06, 4]
SUCCESS               0.093792            0.098112               0.956          [torch.Size([512, 2, 2560]), torch.Size([2, 5120]), torch.Size([1]), torch.Size([2]), torch.Size([512, 2560]), 2560, 1e-06, 1e-06, 2]
SUCCESS               0.121120            0.098608               1.228          [torch.Size([512, 4, 2560]), torch.Size([4, 10240]), torch.Size([1]), torch.Size([4]), torch.Size([512, 2560]), 2560, 1e-06, 1e-06, 4]
SUCCESS               0.133248            0.098784               1.349          [torch.Size([1024, 2, 2560]), torch.Size([2, 5120]), torch.Size([1]), torch.Size([2]), torch.Size([1024, 2560]), 2560, 1e-06, 1e-06, 2]
SUCCESS               0.214416            0.148528               1.444          [torch.Size([1024, 4, 2560]), torch.Size([4, 10240]), torch.Size([1]), torch.Size([4]), torch.Size([1024, 2560]), 2560, 1e-06, 1e-06, 4]
SUCCESS               0.318400            0.191200               1.665          [torch.Size([2048, 2, 4096]), torch.Size([2, 8192]), torch.Size([1]), torch.Size([2]), torch.Size([2048, 4096]), 4096, 1e-06, 1e-06, 2]
SUCCESS               0.510192            0.319008               1.599          [torch.Size([2048, 4, 4096]), torch.Size([4, 16384]), torch.Size([1]), torch.Size([4]), torch.Size([2048, 4096]), 4096, 1e-06, 1e-06, 4]
SUCCESS               0.567488            0.324736               1.748          [torch.Size([4096, 2, 4096]), torch.Size([2, 8192]), torch.Size([1]), torch.Size([2]), torch.Size([4096, 4096]), 4096, 1e-06, 1e-06, 2]
SUCCESS               0.996048            0.606560               1.642          [torch.Size([4096, 4, 4096]), torch.Size([4, 16384]), torch.Size([1]), torch.Size([4]), torch.Size([4096, 4096]), 4096, 1e-06, 1e-06, 4]


Operator: hc_head_fused_kernel  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.094096            0.104096               0.904          [torch.Size([256, 2, 1280]), torch.Size([2, 2560]), torch.Size([1]), torch.Size([2]), torch.Size([256, 1280]), 1280, 1e-06, 1e-06, 2]
SUCCESS               0.097984            0.111152               0.882          [torch.Size([256, 4, 1280]), torch.Size([4, 5120]), torch.Size([1]), torch.Size([4]), torch.Size([256, 1280]), 1280, 1e-06, 1e-06, 4]
SUCCESS               0.096704            0.111232               0.869          [torch.Size([512, 2, 1280]), torch.Size([2, 2560]), torch.Size([1]), torch.Size([2]), torch.Size([512, 1280]), 1280, 1e-06, 1e-06, 2]
SUCCESS               0.116224            0.110464               1.052          [torch.Size([512, 4, 1280]), torch.Size([4, 5120]), torch.Size([1]), torch.Size([4]), torch.Size([512, 1280]), 1280, 1e-06, 1e-06, 4]
SUCCESS               0.121056            0.110912               1.091          [torch.Size([512, 2, 2560]), torch.Size([2, 5120]), torch.Size([1]), torch.Size([2]), torch.Size([512, 2560]), 2560, 1e-06, 1e-06, 2]
SUCCESS               0.170944            0.111680               1.531          [torch.Size([512, 4, 2560]), torch.Size([4, 10240]), torch.Size([1]), torch.Size([4]), torch.Size([512, 2560]), 2560, 1e-06, 1e-06, 4]
SUCCESS               0.180576            0.112800               1.601          [torch.Size([1024, 2, 2560]), torch.Size([2, 5120]), torch.Size([1]), torch.Size([2]), torch.Size([1024, 2560]), 2560, 1e-06, 1e-06, 2]
SUCCESS               0.314304            0.188352               1.669          [torch.Size([1024, 4, 2560]), torch.Size([4, 10240]), torch.Size([1]), torch.Size([4]), torch.Size([1024, 2560]), 2560, 1e-06, 1e-06, 4]
SUCCESS               0.478128            0.259264               1.844          [torch.Size([2048, 2, 4096]), torch.Size([2, 8192]), torch.Size([1]), torch.Size([2]), torch.Size([2048, 4096]), 4096, 1e-06, 1e-06, 2]
SUCCESS               0.824000            0.451872               1.824          [torch.Size([2048, 4, 4096]), torch.Size([4, 16384]), torch.Size([1]), torch.Size([4]), torch.Size([2048, 4096]), 4096, 1e-06, 1e-06, 4]
SUCCESS               0.885904            0.456672               1.940          [torch.Size([4096, 2, 4096]), torch.Size([2, 8192]), torch.Size([1]), torch.Size([2]), torch.Size([4096, 4096]), 4096, 1e-06, 1e-06, 2]
SUCCESS               1.569888            0.836560               1.877          [torch.Size([4096, 4, 4096]), torch.Size([4, 16384]), torch.Size([1]), torch.Size([4]), torch.Size([4096, 4096]), 4096, 1e-06, 1e-06, 4]


Operator: hc_head_fused_kernel  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.091664            0.104352               0.878          [torch.Size([256, 2, 1280]), torch.Size([2, 2560]), torch.Size([1]), torch.Size([2]), torch.Size([256, 1280]), 1280, 1e-06, 1e-06, 2]
SUCCESS               0.097936            0.110976               0.882          [torch.Size([256, 4, 1280]), torch.Size([4, 5120]), torch.Size([1]), torch.Size([4]), torch.Size([256, 1280]), 1280, 1e-06, 1e-06, 4]
SUCCESS               0.096864            0.110976               0.873          [torch.Size([512, 2, 1280]), torch.Size([2, 2560]), torch.Size([1]), torch.Size([2]), torch.Size([512, 1280]), 1280, 1e-06, 1e-06, 2]
SUCCESS               0.116288            0.110944               1.048          [torch.Size([512, 4, 1280]), torch.Size([4, 5120]), torch.Size([1]), torch.Size([4]), torch.Size([512, 1280]), 1280, 1e-06, 1e-06, 4]
SUCCESS               0.121984            0.110672               1.102          [torch.Size([512, 2, 2560]), torch.Size([2, 5120]), torch.Size([1]), torch.Size([2]), torch.Size([512, 2560]), 2560, 1e-06, 1e-06, 2]
SUCCESS               0.171376            0.111584               1.536          [torch.Size([512, 4, 2560]), torch.Size([4, 10240]), torch.Size([1]), torch.Size([4]), torch.Size([512, 2560]), 2560, 1e-06, 1e-06, 4]
SUCCESS               0.179552            0.112864               1.591          [torch.Size([1024, 2, 2560]), torch.Size([2, 5120]), torch.Size([1]), torch.Size([2]), torch.Size([1024, 2560]), 2560, 1e-06, 1e-06, 2]
SUCCESS               0.317008            0.187840               1.688          [torch.Size([1024, 4, 2560]), torch.Size([4, 10240]), torch.Size([1]), torch.Size([4]), torch.Size([1024, 2560]), 2560, 1e-06, 1e-06, 4]
SUCCESS               0.480512            0.260416               1.845          [torch.Size([2048, 2, 4096]), torch.Size([2, 8192]), torch.Size([1]), torch.Size([2]), torch.Size([2048, 4096]), 4096, 1e-06, 1e-06, 2]
SUCCESS               0.829216            0.455296               1.821          [torch.Size([2048, 4, 4096]), torch.Size([4, 16384]), torch.Size([1]), torch.Size([4]), torch.Size([2048, 4096]), 4096, 1e-06, 1e-06, 4]
SUCCESS               0.890816            0.459200               1.940          [torch.Size([4096, 2, 4096]), torch.Size([2, 8192]), torch.Size([1]), torch.Size([2]), torch.Size([4096, 4096]), 4096, 1e-06, 1e-06, 2]
SUCCESS               1.578064            0.839728               1.879          [torch.Size([4096, 4, 4096]), torch.Size([4, 16384]), torch.Size([1]), torch.Size([4]), torch.Size([4096, 4096]), 4096, 1e-06, 1e-06, 4]

.

================================================== 1 passed in 79.09s (0:01:19) ==================================================
```
