### PR TITLE
Add wrapper workflow for github checkout retries

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -51,19 +51,12 @@ jobs:
         op-test-${{ inputs.vendor }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
     steps:
-      # - name: Set global proxy
-      #   shell: bash
-      #   env:
-      #     RUNNER_LABEL: ${{ inputs.runner_label }}
-      #     PROXY: ${{ secrets.PROXYG }}
-      #   run: |
-      #     if [[ "${RUNNER_LABEL}" != "h20" ]]; then
-      #       echo "HTTP_PROXY=${PROXY}" >> $GITHUB_ENV
-      #       echo "HTTPS_PROXY=${PROXY}" >> $GITHUB_ENV
-      #     fi
-      - uses: actions/checkout@v6
-      #   with:
-      #     ssh-key: ${{ secrets.RUNNER_SSH_KEY }}
+      - uses: Wandalen/wretry.action@v3.8.0
+        with:
+          action: actions/checkout@v6
+          attempt_limit: 5
+          # with:
+          # ssh-key: ${{ secrets.RUNNER_SSH_KEY }}
       - name: Setup FlagGems
         shell: bash
         env:

--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -51,7 +51,10 @@ jobs:
         with:
           version: 2.92.0
       - id: checkout-repo
-        uses: actions/checkout@v6
+        uses: Wandalen/wretry.action@v3.8.0
+        with:
+          action: actions/checkout@v6
+          attempt_limit: 5
       - id: checkout-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cpp-op-test.yaml
+++ b/.github/workflows/cpp-op-test.yaml
@@ -10,7 +10,10 @@ jobs:
   test:
     runs-on: cpp
     steps:
-      - uses: actions/checkout@v6
+      - uses: Wandalen/wretry.action@3.8.0
+        with:
+          action: actions/checkout@v6
+          attempt_limit: 5
       - shell: bash
         run: |
           CXX=/usr/bin/g++-11 CC=/usr/bin/gcc-11 SKBUILD_CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON" pip install --no-build-isolation -v -e .

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -43,7 +43,11 @@ jobs:
       cancel-in-progress: true
     runs-on: jiuding
     steps:
-      - uses: actions/checkout@v6
+      - uses: Wandalen/wretry.action@v3.8.0
+        with:
+          action: actions/checkout@v6
+          attempt_limit: 5
+          attempt_delay: 5000  # in ms
       - run: |
           pip install pytest-md-report
       - shell: bash

--- a/.github/workflows/random-test.yaml
+++ b/.github/workflows/random-test.yaml
@@ -48,7 +48,10 @@ jobs:
     if: needs.check-permission.outputs.authorized == 'true'
     runs-on: ${{ inputs.runner }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: Wandalen/wretry.action@v3.8.0
+        with:
+          action: actions/checkout@v6
+          attempt_limit: 5
       - name: Setup FlagGems
         shell: bash
         env:

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -78,7 +78,10 @@ jobs:
       cancel-in-progress: true
     runs-on: jiuding
     steps:
-      - uses: actions/checkout@v6
+      - uses: Wandalen/wretry.action@v3.8.0
+        with:
+          action: actions/checkout@v6
+          attempt_limit: 5
       - shell: bash
         run: tools/gpu_check.sh
       - shell: bash
@@ -95,7 +98,10 @@ jobs:
       cancel-in-progress: true
     runs-on: jiuding
     steps:
-      - uses: actions/checkout@v6
+      - uses: Wandalen/wretry.action@v3.8.0
+        with:
+          action: actions/checkout@v6
+          attempt_limit: 5
       - shell: bash
         run: tools/gpu_check.sh
       - shell: bash


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

New Feature

### Description

Try increase number of retries when checking out code on self-hosted runners.
With the builtin 3 times retries, this wrapper increases the retries to about 15 times.