### PR TITLE
Add delay between retries

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -55,6 +55,7 @@ jobs:
         with:
           action: actions/checkout@v6
           attempt_limit: 5
+          attempt_delay: 10000
       - id: checkout-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

Looks like if we don't have a delay between retry attempts, the result would be failures in a row.