### PR TITLE
Add retry delay to all checkout actions on self-hosted runners

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -35,10 +35,6 @@ on:
     secrets:
       RUNNER_SSH_KEY:
         required: true
-      PROXYC:
-        required: true
-      PROXYG:
-        required: true
 
 permissions:
   contents: read
@@ -55,20 +51,16 @@ jobs:
         with:
           action: actions/checkout@v6
           attempt_limit: 5
+          attempt_delay: 20000
           # with:
           # ssh-key: ${{ secrets.RUNNER_SSH_KEY }}
       - name: Setup FlagGems
         shell: bash
         env:
           RUNNER_LABEL: ${{ inputs.runner_label }}
-        #  PROXY: ${{ secrets.PROXYC }}
         run: |
-          # if [[ "${RUNNER_LABEL}" != "h20" ]]; then
-          #   export HTTP_PROXY="${PROXY}"
-          #   export HTTPS_PROXY="${PROXY}"
-          # fi
           ./setup.sh ${{ inputs.vendor }}
-      - name: Check GPU availability
+      - id: check-gpu
         if: ${{ inputs.gpu_check_script != '' }}
         shell: bash
         run: |

--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           action: actions/checkout@v6
           attempt_limit: 5
-          attempt_delay: 10000
+          attempt_delay: 20000
       - id: checkout-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cpp-op-test.yaml
+++ b/.github/workflows/cpp-op-test.yaml
@@ -14,6 +14,7 @@ jobs:
         with:
           action: actions/checkout@v6
           attempt_limit: 5
+          attempt_delay: 20000
       - shell: bash
         run: |
           CXX=/usr/bin/g++-11 CC=/usr/bin/gcc-11 SKBUILD_CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON" pip install --no-build-isolation -v -e .

--- a/.github/workflows/daily.yaml
+++ b/.github/workflows/daily.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           action: actions/checkout@v6
           attempt_limit: 5
-          attempt_delay: 5000  # in ms
+          attempt_delay: 20000  # in ms
       - run: |
           pip install pytest-md-report
       - shell: bash

--- a/.github/workflows/random-test.yaml
+++ b/.github/workflows/random-test.yaml
@@ -52,6 +52,7 @@ jobs:
         with:
           action: actions/checkout@v6
           attempt_limit: 5
+          attempt_delay: 20000
       - name: Setup FlagGems
         shell: bash
         env:

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -82,6 +82,7 @@ jobs:
         with:
           action: actions/checkout@v6
           attempt_limit: 5
+          attempt_delay: 20000
       - shell: bash
         run: tools/gpu_check.sh
       - shell: bash
@@ -102,6 +103,7 @@ jobs:
         with:
           action: actions/checkout@v6
           attempt_limit: 5
+          attempt_delay: 20000
       - shell: bash
         run: tools/gpu_check.sh
       - shell: bash
@@ -122,8 +124,6 @@ jobs:
       pr_id: ${{ needs.preprocess.outputs.pr_id }}
     secrets:
       RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}
-      PROXYC: ${{ secrets.PROXYC }}
-      PROXYG: ${{ secrets.PROXYG }}
 
   backend-hygon:
     needs: preprocess
@@ -137,8 +137,6 @@ jobs:
       pr_id: ${{ needs.preprocess.outputs.pr_id }}
     secrets:
       RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}
-      PROXYC: ${{ secrets.PROXYC }}
-      PROXYG: ${{ secrets.PROXYG }}
 
   backend-iluvatar:
     needs: preprocess
@@ -152,8 +150,6 @@ jobs:
       pr_id: ${{ needs.preprocess.outputs.pr_id }}
     secrets:
       RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}
-      PROXYC: ${{ secrets.PROXYC }}
-      PROXYG: ${{ secrets.PROXYG }}
 
   backend-kunlunxin:
     needs: preprocess
@@ -169,8 +165,6 @@ jobs:
       pr_id: ${{ needs.preprocess.outputs.pr_id }}
     secrets:
       RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}
-      PROXYC: ${{ secrets.PROXYC }}
-      PROXYG: ${{ secrets.PROXYG }}
 
   backend-metax:
     needs: preprocess
@@ -184,8 +178,6 @@ jobs:
       pr_id: ${{ needs.preprocess.outputs.pr_id }}
     secrets:
       RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}
-      PROXYC: ${{ secrets.PROXYC }}
-      PROXYG: ${{ secrets.PROXYG }}
 
   backend-mthreads:
     needs: preprocess
@@ -199,8 +191,6 @@ jobs:
       pr_id: ${{ needs.preprocess.outputs.pr_id }}
     secrets:
       RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}
-      PROXYC: ${{ secrets.PROXYC }}
-      PROXYG: ${{ secrets.PROXYG }}
 
   backend-nvidia:
     needs: preprocess
@@ -214,8 +204,6 @@ jobs:
       pr_id: ${{ needs.preprocess.outputs.pr_id }}
     secrets:
       RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}
-      PROXYC: ${{ secrets.PROXYC }}
-      PROXYG: ${{ secrets.PROXYG }}
 
   backend-tsingmicro:
     needs: preprocess
@@ -229,8 +217,6 @@ jobs:
       pr_id: ${{ needs.preprocess.outputs.pr_id }}
     secrets:
       RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}
-      PROXYC: ${{ secrets.PROXYC }}
-      PROXYG: ${{ secrets.PROXYG }}
 
   backend-thead:
     needs: preprocess
@@ -244,8 +230,6 @@ jobs:
       pr_id: ${{ needs.preprocess.outputs.pr_id }}
     secrets:
       RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}
-      PROXYC: ${{ secrets.PROXYC }}
-      PROXYG: ${{ secrets.PROXYG }}
 
   # TODO(Qiming): This job doesn't require an nvidia backend, the generic
   # test-op workflow should be fine.
@@ -261,5 +245,3 @@ jobs:
       changed_files: ${{ needs.preprocess.outputs.changed_files }}
     secrets:
       RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}
-      PROXYC: ${{ secrets.PROXYC }}
-      PROXYG: ${{ secrets.PROXYG }}


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

Add `attempt_delay` parameter to all `Wandalen/wretry.action` actions. Without this delay value, most retries become some failures in a row.