### PR TITLE
Skip gh download in on-demand testing workflow

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -46,10 +46,11 @@ jobs:
     if: needs.process-command.outputs.continue == 'true'
     runs-on: ${{ needs.process-command.outputs.runner }}
     steps:
-      - name: Install GitHub CLI
-        uses: ksivamuthu/actions-setup-gh-cli@v2
-        with:
-          version: 2.92.0
+      # The gh tool is pre-installed on all runners
+      # - name: Install GitHub CLI
+      #   uses: ksivamuthu/actions-setup-gh-cli@v2
+      #   with:
+      #     version: 2.92.0
       - id: checkout-repo
         uses: Wandalen/wretry.action@v3.8.0
         with:


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Optimization

### Description

We cannot afford installing `gh` **from github** every time while the network stability sucks.