### PR TITLE
Repeat checkout if failed

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -78,13 +78,30 @@ jobs:
       cancel-in-progress: true
     runs-on: jiuding
     steps:
-      - uses: Wandalen/wretry.action@v3.8.0
-        with:
-          action: actions/checkout@v6
-          attempt_limit: 5
-          attempt_delay: 20000
+      - id: checkout-attempt-1
+        uses: actions/checkout@v6
+        continue-on-error: true
+      - id: sleep-1
+        if: steps.checkout.outcome == 'failure'
+        shell: bash
+        run: sleep 30s
+
+      - id: checkout-attempt-2
+        if: steps.checkout-attempt-1.outcome == 'failure'
+        uses: actions/checkout@v6
+        continue-on-error: true
+      - id: sleep-2
+        if: steps.checkout-attempt-2.outcome == 'failure'
+        shell: bash
+        run: sleep 30s
+
+      - id: checkout-attempt-3
+        if: steps.checkout-attempt-2.outcome == 'failure'
+        uses: actions/checkout@v6
+
       - shell: bash
         run: tools/gpu_check.sh
+
       - shell: bash
         env:
           CHANGED_FILES: ${{ join(needs.preprocess.outputs.changed_files, ' ') }}


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Improvement

### Description

The previous `wretry.action` was not a success given that the action itself needs to be checked out from github, and the action will check out the `actions/checkout` from github as well. This turned out to be a bad solution for github connection problem. So ... a dumb solution would be just repeat the step for a few times.