### PR TITLE
[FlagGems Operator Development Competition] add chunk_gated_delta_rule operator

### DIFF
--- a/benchmark/test_FLA/test_chunk_gated_delta_rule.py
+++ b/benchmark/test_FLA/test_chunk_gated_delta_rule.py
@@ -2,16 +2,11 @@
 
 import pytest
 import torch
+import triton
 
 import flag_gems
+import flag_gems.fused.FLA.utils as fla_utils
 from benchmark.base import Benchmark
-
-try:
-    import triton
-
-    HAS_TRITON = True
-except ImportError:
-    HAS_TRITON = False
 
 
 def _naive_recurrent_reference(q, k, v, beta, g, scale=None):
@@ -48,25 +43,6 @@ def _naive_recurrent_reference(q, k, v, beta, g, scale=None):
     return o.to(orig_dtype)
 
 
-def _torch_reference_wrapper(*args, **kwargs):
-    """Wrapper that unpacks benchmark args and calls the naive reference."""
-    q, k, v, beta, g, scale = args
-    return _naive_recurrent_reference(q, k, v, beta, g, scale)
-
-
-def _gems_wrapper(*args, **kwargs):
-    """Wrapper that unpacks benchmark args and calls the FlagGems chunked op."""
-    q, k, v, beta, g, scale = args
-    return flag_gems.chunk_gated_delta_rule(
-        q=q,
-        k=k,
-        v=v,
-        beta=beta,
-        g=g,
-        scale=scale,
-    )[0]
-
-
 class ChunkGatedDeltaRuleBenchmark(Benchmark):
     """Benchmark for chunk_gated_delta_rule operator.
 
@@ -99,19 +75,16 @@ class ChunkGatedDeltaRuleBenchmark(Benchmark):
 
     @staticmethod
     def _setup_device_flags():
-        import flag_gems.fused.FLA.utils as fla_utils
-
         if torch.cuda.is_available():
             major, _ = torch.cuda.get_device_capability()
             if major >= 10:  # Blackwell and newer
                 fla_utils.is_tma_supported = False
                 fla_utils.is_nvidia_hopper = False
-        if HAS_TRITON:
 
-            def _alloc_fn(size, align, stream):
-                return torch.empty(size, dtype=torch.int8, device=flag_gems.device)
+        def _alloc_fn(size, align, stream):
+            return torch.empty(size, dtype=torch.int8, device=flag_gems.device)
 
-            triton.set_allocator(_alloc_fn)
+        triton.set_allocator(_alloc_fn)
 
     def set_more_shapes(self):
         """Provide additional sequence lengths for comprehensive benchmarking."""
@@ -150,7 +123,7 @@ class ChunkGatedDeltaRuleBenchmark(Benchmark):
 def test_perf_chunk_gated_delta_rule():
     bench = ChunkGatedDeltaRuleBenchmark(
         op_name="chunk_gated_delta_rule",
-        torch_op=_torch_reference_wrapper,
+        torch_op=_naive_recurrent_reference,
     )
-    bench.set_gems(_gems_wrapper)
+    bench.set_gems(lambda *a, **kw: flag_gems.chunk_gated_delta_rule(*a, **kw)[0])
     bench.run()

--- a/benchmark/test_FLA/test_chunk_gated_delta_rule.py
+++ b/benchmark/test_FLA/test_chunk_gated_delta_rule.py
@@ -84,7 +84,8 @@ class ChunkGatedDeltaRuleBenchmark(Benchmark):
         def _alloc_fn(size, align, stream):
             return torch.empty(size, dtype=torch.int8, device=flag_gems.device)
 
-        triton.set_allocator(_alloc_fn)
+        if hasattr(triton, "set_allocator"):
+            triton.set_allocator(_alloc_fn)
 
     def set_more_shapes(self):
         """Provide additional sequence lengths for comprehensive benchmarking."""

--- a/benchmark/test_FLA/test_chunk_gated_delta_rule_perf.py
+++ b/benchmark/test_FLA/test_chunk_gated_delta_rule_perf.py
@@ -1,0 +1,156 @@
+# Copyright (c) 2025 FlagGems. All rights reserved.
+
+import pytest
+import torch
+
+import flag_gems
+from benchmark.base import Benchmark
+
+try:
+    import triton
+
+    HAS_TRITON = True
+except ImportError:
+    HAS_TRITON = False
+
+
+def _naive_recurrent_reference(q, k, v, beta, g, scale=None):
+    """Naive token-by-token recurrent reference in pure PyTorch.
+
+    Computes the same gated delta rule as the chunked operator, but one token
+    at a time. Used as the baseline for performance comparison.
+    All computation done in float32 for numerical stability, cast back at the end.
+    """
+    orig_dtype = q.dtype
+    q, k, v, beta, g = map(lambda x: x.float(), [q, k, v, beta, g])
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    B, T, H, K = q.shape
+    V = v.shape[-1]
+
+    S = torch.zeros(B, H, K, V, device=q.device, dtype=torch.float32)
+    o = torch.zeros(B, T, H, V, device=q.device, dtype=torch.float32)
+    q_s = q * scale
+
+    for i in range(T):
+        k_i = k[:, i]
+        q_i = q_s[:, i]
+        v_i = v[:, i].clone()
+        beta_i = beta[:, i]
+        g_i = g[:, i]
+
+        v_i = v_i - (S * k_i.unsqueeze(-1)).sum(-2)
+        v_i = v_i * beta_i.unsqueeze(-1)
+        S = S * g_i.exp().unsqueeze(-1).unsqueeze(-1)
+        S = S + k_i.unsqueeze(-1) * v_i.unsqueeze(-2)
+        o[:, i] = torch.einsum("bhd,bhdv->bhv", q_i, S)
+
+    return o.to(orig_dtype)
+
+
+def _torch_reference_wrapper(*args, **kwargs):
+    """Wrapper that unpacks benchmark args and calls the naive reference."""
+    q, k, v, beta, g, scale = args
+    return _naive_recurrent_reference(q, k, v, beta, g, scale)
+
+
+def _gems_wrapper(*args, **kwargs):
+    """Wrapper that unpacks benchmark args and calls the FlagGems chunked op."""
+    q, k, v, beta, g, scale = args
+    return flag_gems.chunk_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        beta=beta,
+        g=g,
+        scale=scale,
+    )[0]
+
+
+class ChunkGatedDeltaRuleBenchmark(Benchmark):
+    """Benchmark for chunk_gated_delta_rule operator.
+
+    Compares the FlagGems chunked implementation against a naive PyTorch
+    recurrent reference, measuring latency and speedup across different
+    sequence lengths and data types.
+    """
+
+    DEFAULT_DTYPES = [torch.float16, torch.float32, torch.bfloat16]
+    DEFAULT_METRICS = ["latency_base", "latency", "speedup"]
+    DEFAULT_SHAPE_DESC = "T"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._setup_device_flags()
+
+    def set_shapes(self, shape_file_path=None):
+        """Override to use operator-specific shapes, ignoring the global YAML config.
+
+        The global core_shapes.yaml contains 1D shapes like (1024*1024*1024,)
+        which cause OOM when interpreted as sequence length for this 4D operator.
+        """
+        self.shapes = [
+            (64,),
+            (128,),
+            (256,),
+            (512,),
+            (1024,),
+        ]
+
+    @staticmethod
+    def _setup_device_flags():
+        import flag_gems.fused.FLA.utils as fla_utils
+
+        if torch.cuda.is_available():
+            major, _ = torch.cuda.get_device_capability()
+            if major >= 10:  # Blackwell and newer
+                fla_utils.is_tma_supported = False
+                fla_utils.is_nvidia_hopper = False
+        if HAS_TRITON:
+
+            def _alloc_fn(size, align, stream):
+                return torch.empty(size, dtype=torch.int8, device=flag_gems.device)
+
+            triton.set_allocator(_alloc_fn)
+
+    def set_more_shapes(self):
+        """Provide additional sequence lengths for comprehensive benchmarking."""
+        return [
+            (48,),
+            (96,),
+            (192,),
+            (384,),
+            (768,),
+            (1536,),
+            (2048,),
+        ]
+
+    def get_input_iter(self, cur_dtype):
+        """Yield (q, k, v, beta, g, scale) for each shape."""
+        for (T,) in self.shapes:
+            yield self._build_inputs(T, cur_dtype)
+
+    def _build_inputs(self, T: int, dtype: torch.dtype):
+        device = flag_gems.device
+        B, H, K, V = 1, 8, 64, 64
+
+        q = torch.randn(B, T, H, K, device=device, dtype=dtype)
+        k = torch.randn(B, T, H, K, device=device, dtype=dtype)
+        k = torch.nn.functional.normalize(k.float(), dim=-1, p=2).to(dtype)
+        v = torch.randn(B, T, H, V, device=device, dtype=dtype)
+        beta = torch.rand(B, T, H, device=device, dtype=dtype).sigmoid()
+        g = torch.empty(B, T, H, device=device, dtype=dtype).uniform_(0.01, 0.03).log()
+
+        scale = float(K**-0.5)
+        return q, k, v, beta, g, scale
+
+
+@pytest.mark.skipif(flag_gems.device != "cuda", reason="benchmark requires CUDA device")
+@pytest.mark.chunk_gated_delta_rule
+def test_perf_chunk_gated_delta_rule():
+    bench = ChunkGatedDeltaRuleBenchmark(
+        op_name="chunk_gated_delta_rule",
+        torch_op=_torch_reference_wrapper,
+    )
+    bench.set_gems(_gems_wrapper)
+    bench.run()

--- a/src/flag_gems/fused/FLA/__init__.py
+++ b/src/flag_gems/fused/FLA/__init__.py
@@ -2,10 +2,11 @@
 # The original source code was licensed under the MIT license and included
 # the following copyright notice:
 # Copyright (c) 2023-2025, Songlin Yang, Yu Zhang
-from flag_gems.fused.FLA.chunk import chunk_gated_delta_rule_fwd
+from flag_gems.fused.FLA.chunk import chunk_gated_delta_rule, chunk_gated_delta_rule_fwd
 from flag_gems.fused.FLA.fused_recurrent import fused_recurrent_gated_delta_rule_fwd
 
 __all__ = [
+    "chunk_gated_delta_rule",
     "chunk_gated_delta_rule_fwd",
     "fused_recurrent_gated_delta_rule_fwd",
 ]

--- a/src/flag_gems/fused/FLA/chunk.py
+++ b/src/flag_gems/fused/FLA/chunk.py
@@ -7,7 +7,9 @@
 import logging
 
 import torch
+import torch.nn.functional as F
 
+from flag_gems.fused.FLA.chunk_bwd import chunk_bwd_dhu, chunk_bwd_dqkw, fwd_prepare_du
 from flag_gems.fused.FLA.chunk_delta_h import chunk_gated_delta_rule_fwd_h
 from flag_gems.fused.FLA.chunk_o import chunk_fwd_o
 from flag_gems.fused.FLA.fused_cumsum_kkt_solve_tril import (
@@ -15,6 +17,7 @@ from flag_gems.fused.FLA.fused_cumsum_kkt_solve_tril import (
 )
 from flag_gems.fused.FLA.utils import SUPPRESS_LEVEL
 from flag_gems.fused.FLA.wy_fast import recompute_w_u_fwd
+from flag_gems.fused.FLA.wy_fast_bwd import bwd_prepare_wy_repr
 
 logger = logging.getLogger(__name__)
 
@@ -64,3 +67,270 @@ def chunk_gated_delta_rule_fwd(
         return g, o, A, final_state, None, None, None
     elif SUPPRESS_LEVEL >= 3:
         return g, o, A, final_state, w, h, v_new
+
+
+class ChunkGatedDeltaRuleFunction(torch.autograd.Function):
+    """Autograd Function for chunk_gated_delta_rule with full forward+backward.
+
+    This wraps the chunked gated delta rule computation used in Qwen3-Next architecture.
+    It supports both training (with gradient computation) and inference.
+    """
+
+    @staticmethod
+    def forward(
+        ctx,
+        q: torch.Tensor,
+        k: torch.Tensor,
+        v: torch.Tensor,
+        beta: torch.Tensor,
+        g: torch.Tensor,
+        scale: float,
+        initial_state: torch.Tensor | None,
+        output_final_state: bool,
+        cu_seqlens: torch.LongTensor | None = None,
+    ):
+        # Step 1: cumsum + KKT + tril_solve
+        # Use float32 for internal computation for numerical stability
+        q_f32 = q.float()
+        k_f32 = k.float()
+        v_f32 = v.float()
+        beta_f32 = beta.float()
+        g_f32 = g.float()
+        g_cumsum, A_inv = chunk_gated_delta_rule_fused_cumsum_kkt_solve_tril(
+            g=g_f32,
+            k=k_f32,
+            beta=beta_f32,
+            cu_seqlens=cu_seqlens,
+            chunk_size=64,
+            output_dtype=torch.float32,
+        )
+
+        # Step 2: WY representation
+        w, u = recompute_w_u_fwd(
+            k=k_f32,
+            v=v_f32,
+            beta=beta_f32,
+            A=A_inv,
+            g_cumsum=g_cumsum,
+            cu_seqlens=cu_seqlens,
+        )
+
+        # Step 3: Hidden state recurrence
+        h, v_new, final_state = chunk_gated_delta_rule_fwd_h(
+            k=k_f32,
+            w=w,
+            u=u,
+            g=g_cumsum,
+            initial_state=initial_state,
+            output_final_state=output_final_state,
+            cu_seqlens=cu_seqlens,
+        )
+
+        # Step 4: Output computation
+        o = chunk_fwd_o(
+            q=q_f32,
+            k=k_f32,
+            v=v_new,
+            h=h,
+            g=g_cumsum,
+            scale=scale,
+            cu_seqlens=cu_seqlens,
+        )
+
+        # Save for backward: include w, h, v_new to avoid recomputation.
+        # Memory cost (float32, T=1024): w=2MB, h=2MB, v_new=2MB → 6MB total.
+        ctx.save_for_backward(
+            q_f32,
+            k_f32,
+            v_f32,
+            beta_f32,
+            g_f32,
+            A_inv,
+            g_cumsum,
+            initial_state,
+            w,  # saved to skip recompute_w_u_fwd in backward
+            h,  # saved to skip chunk_fwd_h recomputation
+            v_new,  # saved to skip chunk_fwd_h recomputation
+        )
+        ctx.cu_seqlens = cu_seqlens
+        ctx.output_final_state = output_final_state
+        ctx.original_dtype = q.dtype
+
+        return o.to(ctx.original_dtype), final_state
+
+    @staticmethod
+    def backward(ctx, do: torch.Tensor, d_final_state: torch.Tensor | None = None):
+        (
+            q,
+            k,
+            v,
+            beta,
+            g,
+            A_inv,
+            g_cumsum,
+            initial_state,
+            w,
+            h,
+            v_new,
+        ) = ctx.saved_tensors
+        cu_seqlens = ctx.cu_seqlens
+
+        # Cast do to float32 for numerical stability
+        do = do.float()
+
+        # Step 1: fwd_prepare_du - initial dv from do
+        du = fwd_prepare_du(
+            q=q,
+            k=k,
+            g=g_cumsum,
+            do=do,
+            cu_seqlens=cu_seqlens,
+        )
+
+        # Step 2: chunk_bwd_dhu - backward through hidden state
+        dh, du = chunk_bwd_dhu(
+            q=q,
+            k=k,
+            w=w,
+            g=g_cumsum,
+            do=do,
+            dv=du,
+            cu_seqlens=cu_seqlens,
+        )
+
+        # Get shapes from saved tensors
+        B, T, Hg_val, K_val = q.shape
+        H_val = beta.shape[-1]
+
+        # Step 3: chunk_bwd_dqkw - compute dq, dk, dw, dg
+        dq, dk, dw, dg_flat = chunk_bwd_dqkw(
+            q=q,
+            k=k,
+            v_new=v_new,
+            w=w,
+            g=g_cumsum,
+            h=h,
+            do=do,
+            dh=dh,
+            dv=du,
+            cu_seqlens=cu_seqlens,
+        )
+        # dg from dqkw has shape (B*H, T), reshape to (B, T, H)
+        dg = dg_flat.reshape(B, H_val, T).transpose(1, 2).contiguous()
+
+        # Step 4: bwd_prepare_wy_repr - invert WY representation
+        dk2, dv, dbeta, dg2 = bwd_prepare_wy_repr(
+            k=k,
+            v=v,
+            beta=beta,
+            g=g_cumsum,
+            A_inv=A_inv,
+            dw=dw,
+            du=du,
+            cu_seqlens=cu_seqlens,
+        )
+
+        dk = dk + dk2
+        dg = dg + dg2
+
+        # Reverse the cumsum on gate gradients
+        # Forward does cumsum within each chunk: g_cumsum[t] = sum_{i=0}^{t} g[i] within chunk
+        # Backward: reverse_cumsum(dg_cumsum) to get dg_original
+        dg = dg.float()
+        B, T, H = dg.shape
+        BT = 64
+        # Reshape: (B, T, H) -> (B, NT, BT, H)
+        dg = dg.reshape(B, -1, BT, H)
+        # Reverse cumsum along the BT dimension
+        cumsum_dg = dg.cumsum(-2)
+        rev_cumsum_dg = cumsum_dg[..., -1, None, :] - cumsum_dg
+        dg = rev_cumsum_dg + dg
+        # Reshape back: (B, NT, BT, H) -> (B, T, H)
+        dg = dg.reshape(B, T, H)
+
+        orig_dtype = ctx.original_dtype
+        return (
+            dq.to(orig_dtype),
+            dk.to(orig_dtype),
+            dv.to(orig_dtype),
+            dbeta.to(orig_dtype),
+            dg.to(orig_dtype),
+            None,  # scale
+            None,  # initial_state
+            None,  # output_final_state
+            None,  # cu_seqlens
+        )
+
+
+def chunk_gated_delta_rule(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g: torch.Tensor,
+    scale: float | None = None,
+    initial_state: torch.Tensor | None = None,
+    output_final_state: bool = False,
+    cu_seqlens: torch.LongTensor | None = None,
+    BT: int = 64,
+) -> tuple[torch.Tensor, torch.Tensor | None]:
+    """Chunked Gated Delta Rule operator for Qwen3-Next architecture.
+
+    Implements the chunked parallel form of the gated delta rule using
+    the WY representation for efficient linear attention.
+
+    Args:
+        q: Query tensor of shape (B, T, Hg, K) where Hg = H or H * tp_size
+        k: Key tensor of shape (B, T, Hg, K)
+        v: Value tensor of shape (B, T, H, V)
+        beta: Gate tensor of shape (B, T, H) in range [0, 1]
+        g: Log decay tensor of shape (B, T, H), typically negative values
+        scale: Optional scaling factor for QK attention (default: K^{-0.5})
+        initial_state: Optional initial hidden state of shape (B, H, K, V)
+        output_final_state: Whether to return final hidden state
+        cu_seqlens: Optional cumulative sequence lengths for varlen support
+        BT: Chunk size (default: 64)
+
+    Returns:
+        o: Output tensor of shape (B, T, H, V)
+        final_state: Optional final hidden state of shape (B, H, K, V)
+    """
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+
+    assert q.dtype == k.dtype == v.dtype, "q, k, v must have the same dtype"
+    # q shape: (B, T, Hg, K), so sequence length is at dim=1
+    L = q.shape[1]
+
+    # Pad sequence length to multiple of BT
+    if L % BT != 0:
+        pad_len = BT - L % BT
+        # q, k shape: (B, T, Hg, K), pad the T dimension (dim=1)
+        q = F.pad(q, (0, 0, 0, 0, 0, pad_len))
+        k = F.pad(k, (0, 0, 0, 0, 0, pad_len))
+        # v shape: (B, T, H, V), pad the T dimension (dim=1)
+        v = F.pad(v, (0, 0, 0, 0, 0, pad_len))
+        # beta, g shape: (B, T, H), pad the T dimension (dim=1)
+        beta = F.pad(beta, (0, 0, 0, pad_len))
+        g = F.pad(g, (0, 0, 0, pad_len))
+
+    if initial_state is not None:
+        initial_state = initial_state.detach()
+
+    o, final_state = ChunkGatedDeltaRuleFunction.apply(
+        q.contiguous(),
+        k.contiguous(),
+        v.contiguous(),
+        beta,
+        g,
+        scale,
+        initial_state,
+        output_final_state,
+        cu_seqlens,
+    )
+
+    # Unpad output
+    if L % BT != 0:
+        o = o[:, :L]
+
+    return o, final_state

--- a/src/flag_gems/fused/FLA/chunk_bwd.py
+++ b/src/flag_gems/fused/FLA/chunk_bwd.py
@@ -1,0 +1,738 @@
+# Copyright (c) 2025 FlagGems. All rights reserved.
+# Backward kernels for chunk_gated_delta_rule operator.
+# ruff: noqa: E501
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.fused.FLA.index import prepare_chunk_indices
+from flag_gems.fused.FLA.triton_ops_helper import exp
+from flag_gems.utils import libentry, libtuner
+
+# ======================== fwd_prepare_du ========================
+# Computes initial dv gradient using causal attention matrix A = (k @ q^T) * exp(g_j - g_i)
+
+
+@libentry()
+@triton.heuristics(
+    {
+        "USE_G": lambda args: args["g"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@libtuner(
+    configs=[
+        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in [32, 64]
+        for BV in [32, 64]
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["H", "K", "V", "BT"],
+)
+@triton.jit(do_not_specialize=["T"])
+def fwd_prepare_du_kernel(
+    q,
+    k,
+    g,
+    do,
+    dv,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    b_A = tl.zeros([BT, BT], dtype=tl.float32)
+    for i_k in range(tl.cdiv(K, BK)):
+        p_q = tl.make_block_ptr(
+            q + (bos * Hg + i_h // (H // Hg)) * K,
+            (K, T),
+            (1, Hg * K),
+            (i_k * BK, i_t * BT),
+            (BK, BT),
+            (0, 1),
+        )
+        p_k = tl.make_block_ptr(
+            k + (bos * Hg + i_h // (H // Hg)) * K,
+            (T, K),
+            (Hg * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        b_k = tl.load(p_k, boundary_check=(0, 1))
+        b_q = tl.load(p_q, boundary_check=(0, 1))
+        b_q = (b_q * scale).to(b_k.dtype)
+        b_A += tl.dot(b_k, b_q)
+
+    if USE_G:
+        p_g = tl.make_block_ptr(
+            g + (bos * H + i_h), (T,), (H,), (i_t * BT,), (BT,), (0,)
+        )
+        b_g = tl.load(p_g, boundary_check=(0,))
+        b_A = b_A * exp(b_g[None, :] - b_g[:, None])
+
+    o_t = i_t * BT + tl.arange(0, BT)
+    m_t = o_t < T
+    b_A = tl.where((o_t[:, None] <= o_t[None, :]) & (m_t[:, None] & m_t), b_A, 0).to(
+        do.dtype.element_ty
+    )
+
+    for i_v in range(tl.cdiv(V, BV)):
+        p_do = tl.make_block_ptr(
+            do + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        p_dv = tl.make_block_ptr(
+            dv + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_dv = tl.dot(b_A, b_do)
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+
+
+def fwd_prepare_du(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    g: torch.Tensor,
+    do: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+) -> torch.Tensor:
+    B, T, Hg, K, V = *k.shape, do.shape[-1]
+    H = do.shape[-2]
+    BT = chunk_size
+    chunk_indices = (
+        prepare_chunk_indices(cu_seqlens, BT) if cu_seqlens is not None else None
+    )
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    dv = torch.empty_like(do)
+
+    def grid(meta):
+        return (NT, B * H)
+
+    fwd_prepare_du_kernel[grid](
+        q=q,
+        k=k,
+        g=g,
+        do=do,
+        dv=dv,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=K**-0.5,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BT=BT,
+    )
+    return dv
+
+
+# ======================== chunk_bwd_dhu ========================
+# Backward through hidden state recurrence
+
+
+@libentry()
+@triton.heuristics(
+    {
+        "USE_G": lambda args: args["g"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@libtuner(
+    configs=[
+        triton.Config({"BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4]
+        for num_stages in [2, 3, 4]
+        for BV in [32, 64]
+    ],
+    key=["H", "K", "V", "BT"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gated_delta_rule_bwd_kernel_dhu(
+    q,
+    k,
+    w,
+    g,
+    do,
+    dh,
+    dv,
+    dv2,
+    cu_seqlens,
+    chunk_offsets,
+    scale,
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_v, i_nh = tl.program_id(0), tl.program_id(1)
+    i_n, i_h = i_nh // H, i_nh % H
+    if IS_VARLEN:
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+        boh = tl.load(chunk_offsets + i_n).to(tl.int32)
+    else:
+        bos, eos = i_n * T, i_n * T + T
+        NT = tl.cdiv(T, BT)
+        boh = i_n * NT
+
+    # [BK=64, BV]
+    b_dh1 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 64:
+        b_dh2 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 128:
+        b_dh3 = tl.zeros([64, BV], dtype=tl.float32)
+    if K > 192:
+        b_dh4 = tl.zeros([64, BV], dtype=tl.float32)
+
+    # offset calculation
+    dh_offset = (boh * H + i_h).to(tl.int64) * K * V
+    do_offset = (bos * H + i_h) * V
+    v_offset = (bos * H + i_h) * V
+    q_offset = (bos * Hg + i_h // (H // Hg)) * K
+    k_offset = (bos * Hg + i_h // (H // Hg)) * K
+    w_offset = (bos * H + i_h) * K
+    stride_h = H * K * V
+    stride_v = H * V
+    stride_k = Hg * K
+    stride_w = H * K
+
+    for i_t in range(NT - 1, -1, -1):
+        # store dh for this chunk
+        p_dh1 = tl.make_block_ptr(
+            dh + dh_offset + i_t * stride_h,
+            (K, V),
+            (V, 1),
+            (0, i_v * BV),
+            (64, BV),
+            (1, 0),
+        )
+        tl.store(p_dh1, b_dh1.to(p_dh1.dtype.element_ty), boundary_check=(0, 1))
+        if K > 64:
+            p_dh2 = tl.make_block_ptr(
+                dh + dh_offset + i_t * stride_h,
+                (K, V),
+                (V, 1),
+                (64, i_v * BV),
+                (64, BV),
+                (1, 0),
+            )
+            tl.store(p_dh2, b_dh2.to(p_dh2.dtype.element_ty), boundary_check=(0, 1))
+        if K > 128:
+            p_dh3 = tl.make_block_ptr(
+                dh + dh_offset + i_t * stride_h,
+                (K, V),
+                (V, 1),
+                (128, i_v * BV),
+                (64, BV),
+                (1, 0),
+            )
+            tl.store(p_dh3, b_dh3.to(p_dh3.dtype.element_ty), boundary_check=(0, 1))
+        if K > 192:
+            p_dh4 = tl.make_block_ptr(
+                dh + dh_offset + i_t * stride_h,
+                (K, V),
+                (V, 1),
+                (192, i_v * BV),
+                (64, BV),
+                (1, 0),
+            )
+            tl.store(p_dh4, b_dh4.to(p_dh4.dtype.element_ty), boundary_check=(0, 1))
+
+        b_dh_tmp1 = tl.zeros([64, BV], dtype=tl.float32)
+        b_dh_tmp2 = tl.zeros([64, BV], dtype=tl.float32) if K > 64 else None
+        b_dh_tmp3 = tl.zeros([64, BV], dtype=tl.float32) if K > 128 else None
+        b_dh_tmp4 = tl.zeros([64, BV], dtype=tl.float32) if K > 192 else None
+
+        last_idx = min((i_t + 1) * BT, T) - 1
+        b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
+
+        p_w1 = tl.make_block_ptr(
+            w + w_offset, (T, K), (stride_w, 1), (i_t * BT, 0), (BT, 64), (1, 0)
+        )
+        p_q1 = tl.make_block_ptr(
+            q + q_offset, (K, T), (1, stride_k), (0, i_t * BT), (64, BT), (0, 1)
+        )
+        p_dv = tl.make_block_ptr(
+            dv + v_offset, (T, V), (stride_v, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
+        p_do = tl.make_block_ptr(
+            do + do_offset,
+            (T, V),
+            (stride_v, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+
+        p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+        b_g_chunk = tl.load(p_g, boundary_check=(0,))
+
+        # q * scale * exp(g)
+        b_q1 = tl.load(p_q1, boundary_check=(0, 1))
+        b_do_chunk = tl.load(p_do, boundary_check=(0, 1))
+        b_q1 = (b_q1 * scale * exp(b_g_chunk)[None, :]).to(b_q1.dtype)
+        b_dh_tmp1 += tl.dot(b_q1, b_do_chunk.to(b_q1.dtype))
+        if K > 64:
+            p_q2 = tl.make_block_ptr(
+                q + q_offset, (K, T), (1, stride_k), (64, i_t * BT), (64, BT), (0, 1)
+            )
+            b_q2 = tl.load(p_q2, boundary_check=(0, 1))
+            b_q2 = (b_q2 * scale * exp(b_g_chunk)[None, :]).to(b_q2.dtype)
+            b_dh_tmp2 += tl.dot(b_q2, b_do_chunk.to(b_q2.dtype))
+        if K > 128:
+            p_q3 = tl.make_block_ptr(
+                q + q_offset, (K, T), (1, stride_k), (128, i_t * BT), (64, BT), (0, 1)
+            )
+            b_q3 = tl.load(p_q3, boundary_check=(0, 1))
+            b_q3 = (b_q3 * scale * exp(b_g_chunk)[None, :]).to(b_q3.dtype)
+            b_dh_tmp3 += tl.dot(b_q3, b_do_chunk.to(b_q3.dtype))
+        if K > 192:
+            p_q4 = tl.make_block_ptr(
+                q + q_offset, (K, T), (1, stride_k), (192, i_t * BT), (64, BT), (0, 1)
+            )
+            b_q4 = tl.load(p_q4, boundary_check=(0, 1))
+            b_q4 = (b_q4 * scale * exp(b_g_chunk)[None, :]).to(b_q4.dtype)
+            b_dh_tmp4 += tl.dot(b_q4, b_do_chunk.to(b_q4.dtype))
+
+        # k * exp(g_last - g)
+        p_k1 = tl.make_block_ptr(
+            k + k_offset, (T, K), (stride_k, 1), (i_t * BT, 0), (BT, 64), (1, 0)
+        )
+        b_k1 = tl.load(p_k1, boundary_check=(0, 1))
+        b_k1 = (b_k1 * exp(b_g_last - b_g_chunk)[:, None]).to(b_k1.dtype)
+
+        # w * exp(g)
+        b_w1 = tl.load(p_w1, boundary_check=(0, 1))
+        b_w1 = (b_w1 * exp(b_g_chunk)[:, None]).to(b_w1.dtype)
+
+        b_dv_chunk = tl.load(p_dv, boundary_check=(0, 1))
+        b_dv_chunk += tl.dot(b_k1, b_dh1.to(b_k1.dtype))
+        if K > 64:
+            p_k2 = tl.make_block_ptr(
+                k + k_offset, (T, K), (stride_k, 1), (i_t * BT, 64), (BT, 64), (1, 0)
+            )
+            b_k2 = tl.load(p_k2, boundary_check=(0, 1))
+            b_k2 = (b_k2 * exp(b_g_last - b_g_chunk)[:, None]).to(b_k2.dtype)
+            b_dv_chunk += tl.dot(b_k2, b_dh2.to(b_k2.dtype))
+        if K > 128:
+            p_k3 = tl.make_block_ptr(
+                k + k_offset, (T, K), (stride_k, 1), (i_t * BT, 128), (BT, 64), (1, 0)
+            )
+            b_k3 = tl.load(p_k3, boundary_check=(0, 1))
+            b_k3 = (b_k3 * exp(b_g_last - b_g_chunk)[:, None]).to(b_k3.dtype)
+            b_dv_chunk += tl.dot(b_k3, b_dh3.to(b_k3.dtype))
+        if K > 192:
+            p_k4 = tl.make_block_ptr(
+                k + k_offset, (T, K), (stride_k, 1), (i_t * BT, 192), (BT, 64), (1, 0)
+            )
+            b_k4 = tl.load(p_k4, boundary_check=(0, 1))
+            b_k4 = (b_k4 * exp(b_g_last - b_g_chunk)[:, None]).to(b_k4.dtype)
+            b_dv_chunk += tl.dot(b_k4, b_dh4.to(b_k4.dtype))
+
+        p_dv2 = tl.make_block_ptr(
+            dv2 + v_offset,
+            (T, V),
+            (stride_v, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        tl.store(p_dv2, b_dv_chunk.to(p_dv2.dtype.element_ty), boundary_check=(0, 1))
+
+        b_dh_tmp1 -= tl.dot(b_w1, b_dv_chunk.to(b_w1.dtype))
+        if K > 64:
+            p_w2 = tl.make_block_ptr(
+                w + w_offset, (T, K), (stride_w, 1), (i_t * BT, 64), (BT, 64), (1, 0)
+            )
+            b_w2 = tl.load(p_w2, boundary_check=(0, 1))
+            b_w2 = (b_w2 * exp(b_g_chunk)[:, None]).to(b_w2.dtype)
+            b_dh_tmp2 -= tl.dot(b_w2, b_dv_chunk.to(b_w2.dtype))
+        if K > 128:
+            p_w3 = tl.make_block_ptr(
+                w + w_offset, (T, K), (stride_w, 1), (i_t * BT, 128), (BT, 64), (1, 0)
+            )
+            b_w3 = tl.load(p_w3, boundary_check=(0, 1))
+            b_w3 = (b_w3 * exp(b_g_chunk)[:, None]).to(b_w3.dtype)
+            b_dh_tmp3 -= tl.dot(b_w3, b_dv_chunk.to(b_w3.dtype))
+        if K > 192:
+            p_w4 = tl.make_block_ptr(
+                w + w_offset, (T, K), (stride_w, 1), (i_t * BT, 192), (BT, 64), (1, 0)
+            )
+            b_w4 = tl.load(p_w4, boundary_check=(0, 1))
+            b_w4 = (b_w4 * exp(b_g_chunk)[:, None]).to(b_w4.dtype)
+            b_dh_tmp4 -= tl.dot(b_w4, b_dv_chunk.to(b_w4.dtype))
+
+        b_g_last_exp = exp(b_g_last)
+        b_dh1 = b_dh1 * b_g_last_exp + b_dh_tmp1
+        if K > 64:
+            b_dh2 = b_dh2 * b_g_last_exp + b_dh_tmp2
+        if K > 128:
+            b_dh3 = b_dh3 * b_g_last_exp + b_dh_tmp3
+        if K > 192:
+            b_dh4 = b_dh4 * b_g_last_exp + b_dh_tmp4
+
+
+def chunk_bwd_dhu(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    w: torch.Tensor,
+    g: torch.Tensor | None,
+    do: torch.Tensor,
+    dv: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    B, T, Hg, K, V = *k.shape, do.shape[-1]
+    H = do.shape[-2]
+    BT = chunk_size
+    if cu_seqlens is None:
+        N, NT, chunk_offsets = B, triton.cdiv(T, BT), None
+    else:
+        from flag_gems.fused.FLA.index import (
+            prepare_chunk_indices,
+            prepare_chunk_offsets,
+        )
+
+        chunk_indices_tmp = prepare_chunk_indices(cu_seqlens, BT)
+        N, NT, chunk_offsets = (
+            len(cu_seqlens) - 1,
+            len(chunk_indices_tmp),
+            prepare_chunk_offsets(cu_seqlens, BT),
+        )
+    assert K <= 256, "current kernel does not support head dimension larger than 256."
+
+    dh = q.new_empty(B, NT, H, K, V, dtype=torch.float32)
+    dv2 = torch.empty_like(dv)
+
+    def grid(meta):
+        return (triton.cdiv(V, meta["BV"]), N * H)
+
+    chunk_gated_delta_rule_bwd_kernel_dhu[grid](
+        q=q,
+        k=k,
+        w=w,
+        g=g,
+        do=do,
+        dh=dh,
+        dv=dv,
+        dv2=dv2,
+        cu_seqlens=cu_seqlens,
+        chunk_offsets=chunk_offsets,
+        scale=K**-0.5,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BT=BT,
+    )
+    return dh, dv2
+
+
+# ======================== chunk_bwd_dqkw ========================
+# Computes dq, dk, dw, dg
+
+
+@libentry()
+@triton.heuristics(
+    {
+        "USE_G": lambda args: args["g"] is not None,
+        "IS_VARLEN": lambda args: args["cu_seqlens"] is not None,
+    }
+)
+@libtuner(
+    configs=[
+        triton.Config({"BK": BK, "BV": BV}, num_warps=num_warps, num_stages=num_stages)
+        for BK in [32, 64]
+        for BV in [32, 64]
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["H", "K", "V", "BT"],
+)
+@triton.jit(do_not_specialize=["T"])
+def chunk_gated_delta_rule_bwd_kernel_dqkw(
+    q,
+    k,
+    v,
+    w,
+    g,
+    h,
+    do,
+    dh,
+    dv,
+    dq,
+    dk,
+    dw,
+    dg,
+    cu_seqlens,
+    chunk_indices,
+    scale,
+    T,
+    B: tl.constexpr,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    USE_G: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    i_k, i_t, i_bh = tl.program_id(0), tl.program_id(1), tl.program_id(2)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+        NT = tl.cdiv(T, BT)
+    else:
+        NT = tl.cdiv(T, BT)
+        bos, eos = i_b * T, i_b * T + T
+
+    o_i = tl.arange(0, BT)
+    b_dq = tl.zeros([BT, BK], dtype=tl.float32)
+    b_dk = tl.zeros([BT, BK], dtype=tl.float32)
+    b_dw = tl.zeros([BT, BK], dtype=tl.float32)
+    b_ds = tl.zeros([BT, BT], dtype=tl.float32)
+    b_dg_last = tl.zeros(
+        [
+            1,
+        ],
+        dtype=tl.float32,
+    )
+    b_dg = tl.zeros(
+        [
+            BT,
+        ],
+        dtype=tl.float32,
+    )
+
+    last_idx = min((i_t + 1) * BT, T) - 1
+    b_g_last = tl.load(g + bos * H + last_idx * H + i_h)
+
+    h_base = h + ((i_b * NT + i_t) * H + i_h).to(tl.int64) * K * V
+    q_base = q + (bos * Hg + i_h // (H // Hg)) * K
+    k_base = k + (bos * Hg + i_h // (H // Hg)) * K
+    v_base = v + (bos * H + i_h) * V
+    do_base = do + (bos * H + i_h) * V
+    dh_base = dh + ((i_b * NT + i_t) * H + i_h).to(tl.int64) * K * V
+
+    for i_v in range(tl.cdiv(V, BV)):
+        p_v = tl.make_block_ptr(
+            v_base, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
+        p_h = tl.make_block_ptr(
+            h_base, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1)
+        )
+        p_do = tl.make_block_ptr(
+            do_base, (T, V), (H * V, 1), (i_t * BT, i_v * BV), (BT, BV), (1, 0)
+        )
+        p_dh = tl.make_block_ptr(
+            dh_base, (V, K), (1, V), (i_v * BV, i_k * BK), (BV, BK), (0, 1)
+        )
+        p_dv_in = tl.make_block_ptr(
+            dv + (bos * H + i_h) * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        b_v = tl.load(p_v, boundary_check=(0, 1))
+        b_do = tl.load(p_do, boundary_check=(0, 1))
+        b_h = tl.load(p_h, boundary_check=(0, 1))
+        b_dh = tl.load(p_dh, boundary_check=(0, 1))
+        b_dv_in = tl.load(p_dv_in, boundary_check=(0, 1))
+        b_dg_last += tl.sum(b_h * b_dh)
+        b_ds += tl.dot(b_do, tl.trans(b_v))
+        b_dq += tl.dot(b_do, b_h.to(b_do.dtype))
+        b_dk += tl.dot(b_v, b_dh.to(b_v.dtype))
+        b_dw += tl.dot(b_dv_in, b_h.to(b_dv_in.dtype))
+
+    b_dg_last *= exp(b_g_last)
+
+    p_q = tl.make_block_ptr(
+        q_base, (T, K), (Hg * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
+    p_k = tl.make_block_ptr(
+        k_base, (T, K), (Hg * K, 1), (i_t * BT, i_k * BK), (BT, BK), (1, 0)
+    )
+    b_q = tl.load(p_q, boundary_check=(0, 1))
+    b_k = tl.load(p_k, boundary_check=(0, 1))
+
+    if USE_G:
+        p_g_chunk = tl.make_block_ptr(
+            g + (bos * H + i_h), (T,), (H,), (i_t * BT,), (BT,), (0,)
+        )
+        b_g = tl.load(p_g_chunk, boundary_check=(0,))
+        b_g_exp_qw = exp(b_g)
+        b_dq = b_dq * b_g_exp_qw[:, None] * scale
+        b_dg += tl.sum(b_dq * b_q, axis=1)
+        b_dk = b_dk * exp(b_g_last - b_g)[:, None]
+        b_dg -= tl.sum(b_dk * b_k, axis=1)
+        b_dg_last += tl.sum(b_dk * b_k)
+        b_ds = tl.where(
+            o_i[:, None] >= o_i[None, :],
+            b_ds * scale * exp(b_g[:, None] - b_g[None, :]),
+            0,
+        ).to(b_q.dtype)
+        b_dg_mask = tl.dot(b_q, tl.trans(b_k)) * b_ds
+        b_dg += tl.sum(b_dg_mask, axis=1)
+        b_dg -= tl.sum(b_dg_mask, axis=0)
+    else:
+        b_dq = b_dq * scale
+        b_ds = tl.where(o_i[:, None] >= o_i[None, :], b_ds * scale, 0).to(b_q.dtype)
+
+    b_dq += tl.dot(b_ds, b_k)
+    b_dk += tl.trans(tl.dot(tl.trans(b_q), b_ds))
+
+    p_dq = tl.make_block_ptr(
+        dq + (bos * Hg + i_h // (H // Hg)) * K,
+        (T, K),
+        (Hg * K, 1),
+        (i_t * BT, i_k * BK),
+        (BT, BK),
+        (1, 0),
+    )
+    p_dk = tl.make_block_ptr(
+        dk + (bos * Hg + i_h // (H // Hg)) * K,
+        (T, K),
+        (Hg * K, 1),
+        (i_t * BT, i_k * BK),
+        (BT, BK),
+        (1, 0),
+    )
+    p_dw = tl.make_block_ptr(
+        dw + (bos * H + i_h) * K,
+        (T, K),
+        (H * K, 1),
+        (i_t * BT, i_k * BK),
+        (BT, BK),
+        (1, 0),
+    )
+    tl.store(p_dq, b_dq.to(p_dq.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+    tl.store(p_dw, -b_dw.to(p_dw.dtype.element_ty), boundary_check=(0, 1))
+
+    # store dg partial results
+    dg_idx = i_bh + i_k * B * H
+    tl.store(dg + dg_idx * T + i_t * BT + tl.arange(0, BT), b_dg)
+    # accumulate dg_last
+    b_dg_last_prev = tl.load(dg + dg_idx * T + i_t * BT + BT - 1)
+    b_dg_last += b_dg_last_prev
+    tl.store(dg + dg_idx * T + i_t * BT + BT - 1 + tl.arange(0, 1), b_dg_last)
+
+
+def chunk_bwd_dqkw(
+    q: torch.Tensor,
+    k: torch.Tensor,
+    v_new: torch.Tensor,
+    w: torch.Tensor,
+    g: torch.Tensor | None,
+    h: torch.Tensor,
+    do: torch.Tensor,
+    dh: torch.Tensor,
+    dv: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    B, T, Hg, K, V = *q.shape, v_new.shape[-1]
+    H = v_new.shape[-2]
+    BT = chunk_size
+    chunk_indices = (
+        prepare_chunk_indices(cu_seqlens, BT) if cu_seqlens is not None else None
+    )
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    NK = triton.cdiv(K, 64)
+
+    dq = torch.empty_like(q)
+    dk = torch.empty_like(q)  # k has same shape as q
+    dw = torch.empty(B, T, H, K, device=k.device, dtype=k.dtype)
+    # dg is accessed as (NK, B*H, T) in the kernel; use this flat layout
+    dg = torch.zeros(NK, B * H, T, device=g.device, dtype=torch.float32)
+
+    def grid(meta):
+        return (NK, NT, B * H)
+
+    chunk_gated_delta_rule_bwd_kernel_dqkw[grid](
+        q=q,
+        k=k,
+        v=v_new,
+        w=w,
+        g=g,
+        h=h,
+        do=do,
+        dh=dh,
+        dv=dv,
+        dq=dq,
+        dk=dk,
+        dw=dw,
+        dg=dg,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        scale=K**-0.5,
+        T=T,
+        B=B,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BT=BT,
+    )
+    dg = dg.sum(0)
+    return dq, dk, dw, dg

--- a/src/flag_gems/fused/FLA/wy_fast_bwd.py
+++ b/src/flag_gems/fused/FLA/wy_fast_bwd.py
@@ -1,0 +1,282 @@
+# Copyright (c) 2025 FlagGems. All rights reserved.
+# Backward pass for WY representation preparation in chunk_gated_delta_rule.
+# ruff: noqa: E501
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.fused.FLA.index import prepare_chunk_indices
+from flag_gems.fused.FLA.triton_ops_helper import exp
+from flag_gems.utils import libentry, libtuner
+
+
+@libentry()
+@triton.heuristics({"IS_VARLEN": lambda args: args["cu_seqlens"] is not None})
+@libtuner(
+    configs=[
+        triton.Config({}, num_warps=num_warps, num_stages=num_stages)
+        for num_warps in [2, 4, 8]
+        for num_stages in [2, 3, 4]
+    ],
+    key=["H", "K", "V", "BT", "BK", "BV", "IS_VARLEN"],
+)
+@triton.jit(do_not_specialize=["T"])
+def bwd_prepare_wy_repr_kernel(
+    k,
+    v,
+    beta,
+    g,
+    A_inv,
+    dw,
+    du,
+    dk_out,
+    dv_out,
+    dbeta_out,
+    dg_out,
+    cu_seqlens,
+    chunk_indices,
+    T,
+    H: tl.constexpr,
+    Hg: tl.constexpr,
+    K: tl.constexpr,
+    V: tl.constexpr,
+    BT: tl.constexpr,
+    BK: tl.constexpr,
+    BV: tl.constexpr,
+    IS_VARLEN: tl.constexpr,
+):
+    """Backward through WY preparation: computes dk, dv, dbeta, dg from dw, du.
+
+    Accumulates dbeta and dg locally (across K/V blocks) to avoid atomics.
+    """
+    i_t, i_bh = tl.program_id(0), tl.program_id(1)
+    i_b, i_h = i_bh // H, i_bh % H
+    if IS_VARLEN:
+        i_n, i_t = (
+            tl.load(chunk_indices + i_t * 2).to(tl.int32),
+            tl.load(chunk_indices + i_t * 2 + 1).to(tl.int32),
+        )
+        bos, eos = (
+            tl.load(cu_seqlens + i_n).to(tl.int32),
+            tl.load(cu_seqlens + i_n + 1).to(tl.int32),
+        )
+        T = eos - bos
+    else:
+        bos, eos = i_b * T, i_b * T + T
+
+    # Load beta and g for this chunk
+    p_beta = tl.make_block_ptr(
+        beta + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,)
+    )
+    p_g = tl.make_block_ptr(g + bos * H + i_h, (T,), (H,), (i_t * BT,), (BT,), (0,))
+    b_beta = tl.load(p_beta, boundary_check=(0,)).to(tl.float32)
+    b_g = tl.load(p_g, boundary_check=(0,)).to(tl.float32)
+    b_g_exp = exp(b_g)
+
+    # Load A_inv_chunk (BT x BT)
+    p_A_inv = tl.make_block_ptr(
+        A_inv + (bos * H + i_h) * BT,
+        (T, BT),
+        (H * BT, 1),
+        (i_t * BT, 0),
+        (BT, BT),
+        (1, 0),
+    )
+    b_A_inv = tl.load(p_A_inv, boundary_check=(0, 1)).to(tl.float32)
+    b_A_inv_T = tl.trans(b_A_inv)
+
+    k_offset = bos * Hg + i_h // (H // Hg)
+    v_offset = bos * H + i_h
+    w_offset = bos * H + i_h
+
+    # Accumulate dbeta and dg locally across K and V blocks
+    b_dbeta_acc = tl.zeros(
+        [
+            BT,
+        ],
+        dtype=tl.float32,
+    )
+    b_dg_acc = tl.zeros(
+        [
+            BT,
+        ],
+        dtype=tl.float32,
+    )
+
+    # Process K dimension in blocks
+    for i_k in range(tl.cdiv(K, BK)):
+        p_k = tl.make_block_ptr(
+            k + k_offset * K,
+            (T, K),
+            (Hg * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        p_dw = tl.make_block_ptr(
+            dw + w_offset * K,
+            (T, K),
+            (H * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        b_k = tl.load(p_k, boundary_check=(0, 1)).to(tl.float32)
+        b_dw = tl.load(p_dw, boundary_check=(0, 1)).to(tl.float32)
+
+        # Direct gradient: d(k_beta_g) = A_inv^T @ dw
+        b_d_k_beta_g = tl.dot(b_A_inv_T, b_dw)
+
+        # dk from k_beta_g: dk += d(k_beta_g) * beta * exp(g)
+        b_dk = b_d_k_beta_g * b_beta[:, None] * b_g_exp[:, None]
+
+        # Accumulate dbeta and dg from this K block
+        b_dbeta_acc += tl.sum(b_d_k_beta_g * b_k * b_g_exp[:, None], axis=1)
+        b_dg_acc += tl.sum(
+            b_d_k_beta_g * b_k * b_beta[:, None] * b_g_exp[:, None], axis=1
+        )
+
+        # Store dk
+        p_dk = tl.make_block_ptr(
+            dk_out + k_offset * K,
+            (T, K),
+            (Hg * K, 1),
+            (i_t * BT, i_k * BK),
+            (BT, BK),
+            (1, 0),
+        )
+        tl.store(p_dk, b_dk.to(p_dk.dtype.element_ty), boundary_check=(0, 1))
+
+    # Process V dimension in blocks
+    for i_v in range(tl.cdiv(V, BV)):
+        p_v = tl.make_block_ptr(
+            v + v_offset * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        p_du = tl.make_block_ptr(
+            du + v_offset * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        b_v = tl.load(p_v, boundary_check=(0, 1)).to(tl.float32)
+        b_du = tl.load(p_du, boundary_check=(0, 1)).to(tl.float32)
+
+        # Direct gradient: d(v_beta) = A_inv^T @ du
+        b_d_v_beta = tl.dot(b_A_inv_T, b_du)
+
+        # dv = d(v_beta) * beta
+        b_dv = b_d_v_beta * b_beta[:, None]
+
+        # Accumulate dbeta from this V block
+        b_dbeta_acc += tl.sum(b_d_v_beta * b_v, axis=1)
+
+        # Store dv
+        p_dv = tl.make_block_ptr(
+            dv_out + v_offset * V,
+            (T, V),
+            (H * V, 1),
+            (i_t * BT, i_v * BV),
+            (BT, BV),
+            (1, 0),
+        )
+        tl.store(p_dv, b_dv.to(p_dv.dtype.element_ty), boundary_check=(0, 1))
+
+    # Write accumulated dbeta and dg
+    p_dbeta_out = tl.make_block_ptr(
+        dbeta_out + bos * H + i_h,
+        (T,),
+        (H,),
+        (i_t * BT,),
+        (BT,),
+        (0,),
+    )
+    p_dg_out = tl.make_block_ptr(
+        dg_out + bos * H + i_h,
+        (T,),
+        (H,),
+        (i_t * BT,),
+        (BT,),
+        (0,),
+    )
+    tl.store(
+        p_dbeta_out, b_dbeta_acc.to(p_dbeta_out.dtype.element_ty), boundary_check=(0,)
+    )
+    tl.store(p_dg_out, b_dg_acc.to(p_dg_out.dtype.element_ty), boundary_check=(0,))
+
+
+def bwd_prepare_wy_repr(
+    k: torch.Tensor,
+    v: torch.Tensor,
+    beta: torch.Tensor,
+    g: torch.Tensor,
+    A_inv: torch.Tensor,
+    dw: torch.Tensor,
+    du: torch.Tensor,
+    cu_seqlens: torch.LongTensor | None = None,
+    chunk_size: int = 64,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Backward through WY representation preparation.
+
+    Args:
+        k, v, beta, g: Saved tensors from forward pass
+        A_inv: The inverse matrix from tril_solve (B, T, H, BT)
+        dw: Gradient w.r.t. w (B, T, H, K)
+        du: Gradient w.r.t. u (B, T, H, V)
+        cu_seqlens: Optional cumulative sequence lengths
+        chunk_size: Chunk size (BT)
+
+    Returns:
+        dk2, dv, dbeta, dg2: Additional gradients to be added to existing ones
+    """
+    B, T, Hg, K = k.shape
+    H = beta.shape[-1]
+    V = v.shape[-1]
+    BT = chunk_size
+
+    chunk_indices = (
+        prepare_chunk_indices(cu_seqlens, BT) if cu_seqlens is not None else None
+    )
+    NT = triton.cdiv(T, BT) if cu_seqlens is None else len(chunk_indices)
+    BK = min(triton.next_power_of_2(K), 64)
+    BV = min(triton.next_power_of_2(V), 64)
+
+    dk2 = torch.zeros_like(k)
+    dv = torch.zeros_like(v)
+    dbeta = torch.zeros_like(beta)
+    dg2 = torch.zeros_like(g)
+
+    def grid(meta):
+        return (NT, B * H)
+
+    bwd_prepare_wy_repr_kernel[grid](
+        k=k,
+        v=v,
+        beta=beta,
+        g=g,
+        A_inv=A_inv,
+        dw=dw,
+        du=du,
+        dk_out=dk2,
+        dv_out=dv,
+        dbeta_out=dbeta,
+        dg_out=dg2,
+        cu_seqlens=cu_seqlens,
+        chunk_indices=chunk_indices,
+        T=T,
+        H=H,
+        Hg=Hg,
+        K=K,
+        V=V,
+        BT=BT,
+        BK=BK,
+        BV=BV,
+    )
+    return dk2, dv, dbeta, dg2

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -5,6 +5,7 @@ from flag_gems.fused.cross_entropy_loss import cross_entropy_loss
 from flag_gems.fused.cutlass_scaled_mm import cutlass_scaled_mm
 from flag_gems.fused.DSA.bin_topk import bucket_sort_topk
 from flag_gems.fused.FLA import (
+    chunk_gated_delta_rule,
     chunk_gated_delta_rule_fwd,
     fused_recurrent_gated_delta_rule_fwd,
 )
@@ -59,6 +60,7 @@ __all__ = [
     "apply_rotary_pos_emb",
     "bincount",
     "bucket_sort_topk",
+    "chunk_gated_delta_rule",
     "chunk_gated_delta_rule_fwd",
     "concat_and_cache_mla",
     "cutlass_scaled_mm",

--- a/tests/test_FLA/test_chunk_gated_delta_rule.py
+++ b/tests/test_FLA/test_chunk_gated_delta_rule.py
@@ -1,0 +1,362 @@
+# Copyright (c) 2025 FlagGems. All rights reserved.
+
+import random
+from typing import Dict, List
+
+import pytest
+import torch
+import triton
+
+import flag_gems
+import flag_gems.fused.FLA.utils as _fla_utils
+
+
+# Set up Triton allocator for global scratch memory (required by TMA ops)
+def _alloc_fn(size, align, stream):
+    return torch.empty(size, dtype=torch.int8, device=flag_gems.device)
+
+
+triton.set_allocator(_alloc_fn)
+
+# Disable TMA for Blackwell GPUs (compute capability 12.x) to avoid numerical issues
+_device_major, _device_minor = torch.cuda.get_device_capability()
+if _device_major >= 10:  # Blackwell and newer, TMA path may have issues
+    _fla_utils.is_tma_supported = False
+    _fla_utils.is_nvidia_hopper = False
+
+random.seed(42)
+torch.manual_seed(42)
+
+
+def is_cuda_available() -> bool:
+    return torch.cuda.is_available() and flag_gems.device == "cuda"
+
+
+CUDA_AVAILABLE = is_cuda_available()
+
+
+def _naive_recurrent_reference(q, k, v, beta, g, scale=None):
+    """Naive recurrent reference implementation for correctness checking.
+
+    Computes the gated delta rule one token at a time using the recurrence:
+      S_t = S_{t-1} * exp(g_t) + k_t^T @ v_t
+      v'_t = v_t - S_{t-1} @ k_t^T
+      o_t = q_t @ S_t
+
+    All computations in float32 for numerical stability.
+    """
+    q, k, v, beta, g = map(lambda x: x.float(), [q, k, v, beta, g])
+    if scale is None:
+        scale = k.shape[-1] ** -0.5
+    B, T, H, K = q.shape
+    V = v.shape[-1]
+
+    S = torch.zeros(B, H, K, V, device=q.device, dtype=torch.float32)
+    o = torch.zeros(B, T, H, V, device=q.device, dtype=torch.float32)
+
+    q = q * scale
+
+    for i in range(T):
+        k_i = k[:, i]
+        q_i = q[:, i]
+        v_i = v[:, i].clone()
+        beta_i = beta[:, i]
+        g_i = g[:, i]
+
+        # v_new = v - w @ S = v - (S * k[..., None]).sum(-2)
+        v_i = v_i - (S * k_i.unsqueeze(-1)).sum(-2)
+        v_i = v_i * beta_i.unsqueeze(-1)
+
+        # S_new = S * exp(g) + k^T @ v_new
+        S = S * g_i.exp().unsqueeze(-1).unsqueeze(-1)
+        S = S + k_i.unsqueeze(-1) * v_i.unsqueeze(-2)
+
+        # o = q @ S
+        o[:, i] = torch.einsum("bhd,bhdv->bhv", q_i, S)
+
+    return o
+
+
+class ChunkGatedDeltaRuleTestKit:
+    """Test kit for chunk_gated_delta_rule operator."""
+
+    base_dtype = torch.float32
+
+    @staticmethod
+    def _cases() -> List[Dict]:
+        cases = [
+            {"B": 1, "H": 2, "T": 64, "K": 32, "V": 16},
+            {"B": 1, "H": 4, "T": 128, "K": 64, "V": 32},
+            {"B": 2, "H": 2, "T": 128, "K": 64, "V": 32},
+            {"B": 1, "H": 4, "T": 256, "K": 64, "V": 64},
+            {"B": 2, "H": 4, "T": 64, "K": 32, "V": 16},
+        ]
+        return cases
+
+    @classmethod
+    def get_test_params(cls) -> List[Dict]:
+        return cls._cases()
+
+    @classmethod
+    def build_inputs(cls, cfg: Dict, dtype=None) -> Dict:
+        device = flag_gems.device
+        if dtype is None:
+            dtype = cls.base_dtype
+
+        B, H, T, K, V = cfg["B"], cfg["H"], cfg["T"], cfg["K"], cfg["V"]
+
+        q = torch.randn(B, T, H, K, device=device, dtype=dtype)
+        k = torch.randn(B, T, H, K, device=device, dtype=dtype)
+        k = torch.nn.functional.normalize(k, dim=-1, p=2)
+        v = torch.randn(B, T, H, V, device=device, dtype=dtype)
+        beta = torch.rand(B, T, H, device=device, dtype=dtype).sigmoid()
+        g = torch.empty(B, T, H, device=device, dtype=dtype).uniform_(0.01, 0.03).log()
+
+        scale = float(K**-0.5)
+
+        return {
+            "q": q,
+            "k": k,
+            "v": v,
+            "beta": beta,
+            "g": g,
+            "scale": scale,
+        }
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires CUDA device")
+@pytest.mark.chunk_gated_delta_rule
+@pytest.mark.parametrize("cfg", ChunkGatedDeltaRuleTestKit.get_test_params())
+def test_chunk_gated_delta_rule_forward(cfg):
+    """Test forward pass produces finite outputs."""
+    kit = ChunkGatedDeltaRuleTestKit
+    inputs = kit.build_inputs(cfg)
+
+    o, final_state = flag_gems.chunk_gated_delta_rule(
+        q=inputs["q"],
+        k=inputs["k"],
+        v=inputs["v"],
+        beta=inputs["beta"],
+        g=inputs["g"],
+        scale=inputs["scale"],
+    )
+
+    assert (
+        o.shape == inputs["v"].shape
+    ), f"Output shape mismatch: {o.shape} vs {inputs['v'].shape}"
+    assert not torch.isnan(o).any(), "Output contains NaN"
+    assert not torch.isinf(o).any(), "Output contains Inf"
+    assert (
+        final_state is None
+    ), "final_state should be None when output_final_state=False"
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires CUDA device")
+@pytest.mark.chunk_gated_delta_rule
+@pytest.mark.parametrize("cfg", ChunkGatedDeltaRuleTestKit.get_test_params())
+def test_chunk_gated_delta_rule_backward(cfg):
+    """Test backward pass produces finite gradients."""
+    kit = ChunkGatedDeltaRuleTestKit
+    inputs = kit.build_inputs(cfg)
+
+    q = inputs["q"].clone().requires_grad_(True)
+    k = inputs["k"].clone().requires_grad_(True)
+    v = inputs["v"].clone().requires_grad_(True)
+    beta = inputs["beta"].clone().requires_grad_(True)
+    g = inputs["g"].clone().requires_grad_(True)
+
+    o, _ = flag_gems.chunk_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        beta=beta,
+        g=g,
+        scale=inputs["scale"],
+    )
+
+    do = torch.randn_like(o)
+    o.backward(do)
+
+    for name, grad in [
+        ("q", q.grad),
+        ("k", k.grad),
+        ("v", v.grad),
+        ("beta", beta.grad),
+        ("g", g.grad),
+    ]:
+        assert grad is not None, f"{name}.grad is None"
+        assert not torch.isnan(grad).any(), f"{name}.grad contains NaN"
+        assert not torch.isinf(grad).any(), f"{name}.grad contains Inf"
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires CUDA device")
+@pytest.mark.chunk_gated_delta_rule
+@pytest.mark.parametrize("cfg", ChunkGatedDeltaRuleTestKit.get_test_params())
+def test_chunk_gated_delta_rule_vs_reference(cfg):
+    """Test operator output approximately matches naive recurrent reference.
+
+    Note: The chunked algorithm introduces numerical differences vs the recurrent
+    form, so we use relaxed tolerances.
+    """
+    kit = ChunkGatedDeltaRuleTestKit
+    inputs = kit.build_inputs(cfg, dtype=torch.float32)
+
+    o, _ = flag_gems.chunk_gated_delta_rule(
+        q=inputs["q"],
+        k=inputs["k"],
+        v=inputs["v"],
+        beta=inputs["beta"],
+        g=inputs["g"],
+        scale=inputs["scale"],
+    )
+
+    # Compute naive reference
+    ref_o = _naive_recurrent_reference(
+        q=inputs["q"],
+        k=inputs["k"],
+        v=inputs["v"],
+        beta=inputs["beta"],
+        g=inputs["g"],
+        scale=inputs["scale"],
+    )
+
+    # Use relaxed tolerances for chunked vs recurrent comparison.
+    # The chunked algorithm introduces numerical differences, especially
+    # for near-zero values where relative error can be large.
+    torch.testing.assert_close(o, ref_o, rtol=5e-1, atol=2e-1)
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires CUDA device")
+@pytest.mark.chunk_gated_delta_rule
+def test_chunk_gated_delta_rule_padded_sequence():
+    """Test that padding works correctly when sequence length is not a multiple of BT."""
+    B, H, L, K, V = 1, 2, 100, 32, 16
+    dtype = torch.float32
+    device = flag_gems.device
+
+    q = torch.randn(B, L, H, K, device=device, dtype=dtype, requires_grad=True)
+    k = torch.randn(B, L, H, K, device=device, dtype=dtype)
+    k = torch.nn.functional.normalize(k, dim=-1, p=2).requires_grad_(True)
+    v = torch.randn(B, L, H, V, device=device, dtype=dtype, requires_grad=True)
+    beta = (
+        torch.rand(B, L, H, device=device, dtype=dtype).sigmoid().requires_grad_(True)
+    )
+    g = (
+        torch.empty(B, L, H, device=device, dtype=dtype)
+        .uniform_(0.01, 0.03)
+        .log()
+        .requires_grad_(True)
+    )
+
+    o, _ = flag_gems.chunk_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        beta=beta,
+        g=g,
+        BT=64,
+    )
+
+    assert o.shape == (B, L, H, V), f"Output shape mismatch: {o.shape}"
+    assert not torch.isnan(o).any(), "Output contains NaN"
+
+    # Test backward
+    do = torch.randn_like(o)
+    o.backward(do)
+    assert not torch.isnan(q.grad).any(), "q.grad contains NaN"
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires CUDA device")
+@pytest.mark.chunk_gated_delta_rule
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_chunk_gated_delta_rule_dtypes(dtype):
+    """Test operator works with float16 and bfloat16 dtypes.
+
+    Note: The fused cumsum/KKT kernel internally uses float32 for numerical
+    stability, so Q/K/V are cast to float32 for that computation.
+    """
+    B, H, L, K, V = 1, 2, 64, 32, 16
+    device = flag_gems.device
+
+    # Use float32 for inputs that go through the fused cumsum kernel
+    q = torch.randn(B, L, H, K, device=device, dtype=dtype, requires_grad=True)
+    k = torch.randn(B, L, H, K, device=device, dtype=dtype)
+    k = (
+        torch.nn.functional.normalize(k.float(), dim=-1, p=2)
+        .to(dtype)
+        .requires_grad_(True)
+    )
+    v = torch.randn(B, L, H, V, device=device, dtype=dtype, requires_grad=True)
+    beta = (
+        torch.rand(B, L, H, device=device, dtype=dtype).sigmoid().requires_grad_(True)
+    )
+    g = (
+        torch.empty(B, L, H, device=device, dtype=dtype)
+        .uniform_(0.01, 0.03)
+        .log()
+        .requires_grad_(True)
+    )
+
+    # The chunk_gated_delta_rule internally upcasts where needed
+    o, _ = flag_gems.chunk_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        beta=beta,
+        g=g,
+    )
+
+    assert o.shape == (B, L, H, V), f"Output shape mismatch: {o.shape}"
+    assert o.dtype == dtype, f"Output dtype mismatch: {o.dtype} vs {dtype}"
+    assert not torch.isnan(o.float()).any(), f"Output contains NaN for dtype {dtype}"
+    assert not torch.isinf(o.float()).any(), f"Output contains Inf for dtype {dtype}"
+
+    # Test backward
+    do = torch.randn_like(o)
+    o.backward(do)
+    for name, grad in [("q", q.grad), ("k", k.grad), ("v", v.grad)]:
+        assert grad is not None, f"{name}.grad is None"
+        assert not torch.isnan(
+            grad.float()
+        ).any(), f"{name}.grad contains NaN for dtype {dtype}"
+
+
+@pytest.mark.skipif(not CUDA_AVAILABLE, reason="requires CUDA device")
+@pytest.mark.chunk_gated_delta_rule
+@pytest.mark.parametrize("cfg", ChunkGatedDeltaRuleTestKit.get_test_params())
+def test_chunk_gated_delta_rule_gradient_finite(cfg):
+    """Verify gradients are finite and produce correct loss gradient."""
+    kit = ChunkGatedDeltaRuleTestKit
+    inputs = kit.build_inputs(cfg, dtype=torch.float32)
+
+    q = inputs["q"].clone().requires_grad_(True)
+    k = inputs["k"].clone().requires_grad_(True)
+    v = inputs["v"].clone().requires_grad_(True)
+    beta = inputs["beta"].clone().requires_grad_(True)
+    g = inputs["g"].clone().requires_grad_(True)
+
+    o, _ = flag_gems.chunk_gated_delta_rule(
+        q=q,
+        k=k,
+        v=v,
+        beta=beta,
+        g=g,
+        scale=inputs["scale"],
+    )
+
+    # Scalar loss
+    loss = o.sum()
+    loss.backward()
+
+    # Verify all gradients exist and are finite
+    for name, grad in [
+        ("q", q.grad),
+        ("k", k.grad),
+        ("v", v.grad),
+        ("beta", beta.grad),
+        ("g", g.grad),
+    ]:
+        assert grad is not None, f"{name}.grad is None"
+        assert not torch.isnan(grad).any(), f"{name}.grad contains NaN"
+        assert not torch.isinf(grad).any(), f"{name}.grad contains Inf"
+        assert grad.abs().max() > 0, f"{name}.grad is all zeros"

--- a/tests/test_FLA/test_chunk_gated_delta_rule.py
+++ b/tests/test_FLA/test_chunk_gated_delta_rule.py
@@ -6,9 +6,33 @@ from typing import Dict, List
 import pytest
 import torch
 import triton
+from triton.runtime.autotuner import Autotuner as _Autotuner
 
 import flag_gems
 import flag_gems.fused.FLA.utils as _fla_utils
+from flag_gems.utils.libentry import LibTuner
+
+# Patch both Autotuner.run and LibTuner.run to skip autotuning loop.
+# LibTuner overrides Autotuner.run, so both must be patched for the patch to
+# take effect. Without this, cold Triton cache tests time out on CI.
+_original_autotuner_run = _Autotuner.run
+_original_libtuner_run = LibTuner.run
+
+
+def _no_autotune_run(self, *args, **kwargs):
+    if len(self.configs) > 1:
+        self.configs = self.configs[:1]
+    return _original_autotuner_run(self, *args, **kwargs)
+
+
+def _no_libtuner_run(self, *args, **kwargs):
+    if len(self.configs) > 1:
+        self.configs = self.configs[:1]
+    return _original_libtuner_run(self, *args, **kwargs)
+
+
+_Autotuner.run = _no_autotune_run
+LibTuner.run = _no_libtuner_run
 
 
 # Set up Triton allocator for global scratch memory (required by TMA ops)
@@ -60,7 +84,7 @@ def _naive_recurrent_reference(q, k, v, beta, g, scale=None):
     for i in range(T):
         k_i = k[:, i]
         q_i = q[:, i]
-        v_i = v[:, i].clone()
+        v_i = v[:, i]
         beta_i = beta[:, i]
         g_i = g[:, i]
 

--- a/tests/test_FLA/test_chunk_gated_delta_rule.py
+++ b/tests/test_FLA/test_chunk_gated_delta_rule.py
@@ -16,7 +16,8 @@ def _alloc_fn(size, align, stream):
     return torch.empty(size, dtype=torch.int8, device=flag_gems.device)
 
 
-triton.set_allocator(_alloc_fn)
+if hasattr(triton, "set_allocator"):
+    triton.set_allocator(_alloc_fn)
 
 # Disable TMA for Blackwell GPUs (compute capability 12.x) to avoid numerical issues
 _device_major, _device_minor = torch.cuda.get_device_capability()


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
 - [ ] Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
 - [ ] New Feature
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
 - [ ] Add chunk_gated_delta_rule  operator.
 - [ ] Add accuracy tests for chunk_gated_delta_rule  operator.
 - [ ] Add benchmark for chunk_gated_delta_rule  operator.

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
Run benchmark with: `python3 -m pytest benchmark/test_FLA/test_chunk_gated_delta_rule_perf.py -s`
#### Device: 5060Ti
```
[INFO] : FlagGems Unsupported GPU arch  specialization
======================================================================================================== test session starts ========================================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/yichaoxiong/FlagGems
configfile: pytest.ini
plugins: anyio-4.12.1, cov-7.1.0, hypothesis-6.151.9
collected 1 item                                                                                                                                                                                                                    

benchmark/test_FLA/test_chunk_gated_delta_rule_perf.py 
Operator: chunk_gated_delta_rule  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               7.714656            0.063488             121.514          [torch.Size([1, 64, 8, 64]), torch.Size([1, 64, 8, 64]), torch.Size([1, 64, 8, 64]), torch.Size([1, 64, 8]), torch.Size([1, 64, 8]), 0.125]
SUCCESS              16.053761            0.067584             237.538          [torch.Size([1, 128, 8, 64]), torch.Size([1, 128, 8, 64]), torch.Size([1, 128, 8, 64]), torch.Size([1, 128, 8]), torch.Size([1, 128, 8]), 0.125]
SUCCESS              33.204367            0.077824             426.660          [torch.Size([1, 256, 8, 64]), torch.Size([1, 256, 8, 64]), torch.Size([1, 256, 8, 64]), torch.Size([1, 256, 8]), torch.Size([1, 256, 8]), 0.125]
SUCCESS              67.133408            0.106496             630.384          [torch.Size([1, 512, 8, 64]), torch.Size([1, 512, 8, 64]), torch.Size([1, 512, 8, 64]), torch.Size([1, 512, 8]), torch.Size([1, 512, 8]), 0.125]
SUCCESS             137.473022            0.178176             771.557          [torch.Size([1, 1024, 8, 64]), torch.Size([1, 1024, 8, 64]), torch.Size([1, 1024, 8, 64]), torch.Size([1, 1024, 8]), torch.Size([1, 1024, 8]), 0.125]


Operator: chunk_gated_delta_rule  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               7.743200            0.043008             180.041          [torch.Size([1, 64, 8, 64]), torch.Size([1, 64, 8, 64]), torch.Size([1, 64, 8, 64]), torch.Size([1, 64, 8]), torch.Size([1, 64, 8]), 0.125]
SUCCESS              16.063376            0.045056             356.520          [torch.Size([1, 128, 8, 64]), torch.Size([1, 128, 8, 64]), torch.Size([1, 128, 8, 64]), torch.Size([1, 128, 8]), torch.Size([1, 128, 8]), 0.125]
SUCCESS              32.795425            0.057344             571.907          [torch.Size([1, 256, 8, 64]), torch.Size([1, 256, 8, 64]), torch.Size([1, 256, 8, 64]), torch.Size([1, 256, 8]), torch.Size([1, 256, 8]), 0.125]
SUCCESS              67.080574            0.081920             818.855          [torch.Size([1, 512, 8, 64]), torch.Size([1, 512, 8, 64]), torch.Size([1, 512, 8, 64]), torch.Size([1, 512, 8]), torch.Size([1, 512, 8]), 0.125]
SUCCESS             141.336700            0.135168            1045.637          [torch.Size([1, 1024, 8, 64]), torch.Size([1, 1024, 8, 64]), torch.Size([1, 1024, 8, 64]), torch.Size([1, 1024, 8]), torch.Size([1, 1024, 8]), 0.125]


Operator: chunk_gated_delta_rule  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               7.780320            0.063488             122.548          [torch.Size([1, 64, 8, 64]), torch.Size([1, 64, 8, 64]), torch.Size([1, 64, 8, 64]), torch.Size([1, 64, 8]), torch.Size([1, 64, 8]), 0.125]
SUCCESS              17.624161            0.067584             260.774          [torch.Size([1, 128, 8, 64]), torch.Size([1, 128, 8, 64]), torch.Size([1, 128, 8, 64]), torch.Size([1, 128, 8]), torch.Size([1, 128, 8]), 0.125]
SUCCESS              32.826704            0.077824             421.807          [torch.Size([1, 256, 8, 64]), torch.Size([1, 256, 8, 64]), torch.Size([1, 256, 8, 64]), torch.Size([1, 256, 8]), torch.Size([1, 256, 8]), 0.125]
SUCCESS              73.058594            0.106496             686.022          [torch.Size([1, 512, 8, 64]), torch.Size([1, 512, 8, 64]), torch.Size([1, 512, 8, 64]), torch.Size([1, 512, 8]), torch.Size([1, 512, 8]), 0.125]
SUCCESS             136.900070            0.178176             768.342          [torch.Size([1, 1024, 8, 64]), torch.Size([1, 1024, 8, 64]), torch.Size([1, 1024, 8, 64]), torch.Size([1, 1024, 8]), torch.Size([1, 1024, 8]), 0.125]

.

======================================================================================================== 1 passed in 30.31s =========================================================================================================
```

### Tests
Run tests with: `python3 -m pytest tests/test_FLA/test_chunk_gated_delta_rule.py`
#### Device: 5060Ti
```
[INFO] : FlagGems Unsupported GPU arch  specialization
======================================================================================================== test session starts ========================================================================================================
platform linux -- Python 3.12.12, pytest-9.0.2, pluggy-1.6.0
rootdir: /home/yichaoxiong/FlagGems
configfile: pytest.ini
plugins: anyio-4.12.1, cov-7.1.0, hypothesis-6.151.9
collected 23 items                                                                                                                                                                                                                  

tests/test_FLA/test_chunk_gated_delta_rule.py .......................

================================================================================================== 23 passed in 417.66s (0:06:57) ===================================================================================================
```
