### PR TITLE
[FlagGems Operator Development Competition] add median operator

### DIFF
--- a/benchmark/core_shapes.yaml
+++ b/benchmark/core_shapes.yaml
@@ -270,6 +270,14 @@ GenericBenchmark4DOnly:
     - [4096, 4096,4,8]
     - [1024, 65536,4,8]
 
+median:
+  shapes:
+    - [64, 64]        # 4096 elements, dim=1 → 64 rows × 64 cols
+    - [1024, 1024]    # 1M elements, dim=1 → 1024 rows × 1024 cols
+    - [4096, 256]     # 1M elements, dim=1 → 4096 rows × 256 cols
+    - [64, 512, 128]  # 4M elements, dim=1 → rows × 512 cols
+  shape_desc: "(B), M, N"
+
 UnaryReductionBenchmark:
   shapes:
     - [1048576] # 1024 * 1024

--- a/benchmark/test_median.py
+++ b/benchmark/test_median.py
@@ -8,9 +8,8 @@ class MedianBenchmark(base.UnaryReductionBenchmark):
     """Custom benchmark for median with memory-appropriate shapes."""
 
     def set_more_shapes(self):
-        # Shapes where the reduction dimension N ≤ 4096 (direct kernel limit).
-        more_shapes_2d = [(1024, 2**i) for i in range(4, 13, 4)]  # N=16,256,4096
-        more_shapes_3d = [(64, 2**i, 64) for i in range(2, 11, 4)]  # N=4,64,1024
+        more_shapes_2d = [(1024, 2**i) for i in range(4, 17, 4)]
+        more_shapes_3d = [(64, 2**i, 64) for i in range(2, 11, 4)]
         return more_shapes_2d + more_shapes_3d
 
 

--- a/benchmark/test_median.py
+++ b/benchmark/test_median.py
@@ -1,0 +1,22 @@
+import pytest
+import torch
+
+from . import base, consts
+
+
+class MedianBenchmark(base.UnaryReductionBenchmark):
+    """Custom benchmark for median with memory-appropriate shapes."""
+
+    def set_more_shapes(self):
+        # Shapes where the reduction dimension N ≤ 4096 (direct kernel limit).
+        more_shapes_2d = [(1024, 2**i) for i in range(4, 13, 4)]  # N=16,256,4096
+        more_shapes_3d = [(64, 2**i, 64) for i in range(2, 11, 4)]  # N=4,64,1024
+        return more_shapes_2d + more_shapes_3d
+
+
+@pytest.mark.median
+def test_median():
+    bench = MedianBenchmark(
+        op_name="median", torch_op=torch.median, dtypes=consts.FLOAT_DTYPES
+    )
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -328,6 +328,8 @@ _FULL_CONFIG = (
     ("masked_select", masked_select),
     ("max", max),
     ("max.dim", max_dim),
+    ("median", median),
+    ("median.dim", median_dim),
     ("max_pool2d_backward", max_pool2d_backward),
     ("max_pool2d_with_indices", max_pool2d_with_indices),
     ("max_pool3d_backward", max_pool3d_backward),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -216,6 +216,7 @@ from flag_gems.ops.max_pool3d_with_indices import (
 )
 from flag_gems.ops.maximum import maximum
 from flag_gems.ops.mean import mean, mean_dim
+from flag_gems.ops.median import median, median_dim
 from flag_gems.ops.min import min, min_dim
 from flag_gems.ops.minimum import minimum
 from flag_gems.ops.mm import mm, mm_out
@@ -641,6 +642,8 @@ __all__ = [
     "masked_select",
     "max",
     "max_dim",
+    "median",
+    "median_dim",
     "max_pool2d_with_indices",
     "max_pool2d_backward",
     "max_pool3d_with_indices",

--- a/src/flag_gems/ops/median.py
+++ b/src/flag_gems/ops/median.py
@@ -200,93 +200,57 @@ def median_kernel_tiled(
     out_idx,
     N,
     BLOCK_N: tl.constexpr,
+    N_ITERS: tl.constexpr,
 ):
-    """Tiled radix-select for N > 4096. Determines median's bits by counting
-    across tiles, then scans for the matching element."""
+    """Binary-search median for large N with configurable iterations."""
     pid = ext.program_id(0)
 
-    # Shared constants for float-to-uint conversion
-    one_u32 = tl.full([], value=1, dtype=tl.uint32)
-    sign_bit_const = one_u32 << 31
-    shift31 = tl.full([], value=31, dtype=tl.int32)
+    in_dtype = inp.dtype.element_ty
+    max_init = float("inf")
+    min_init = float("-inf")
+
+    lo = tl.full([], value=max_init, dtype=tl.float32)
+    hi = tl.full([], value=min_init, dtype=tl.float32)
+    for start in range(0, N, BLOCK_N):
+        n_offset = start + tl.arange(0, BLOCK_N)
+        tmask = n_offset < N
+        block_vals = tl.load(inp + pid * N + n_offset, mask=tmask, other=0)
+        f32 = block_vals.to(tl.float32)
+        lo = tl.minimum(lo, tl.min(tl.where(tmask, f32, max_init)))
+        hi = tl.maximum(hi, tl.max(tl.where(tmask, f32, min_init)))
 
     k = (N - 1) // 2
-    target_u32 = tl.zeros([], dtype=tl.uint32)
 
-    # Phase 1: determine median's uint32 value bit by bit
-    for bit in range(31, 11, -1):
-        count_zeros = tl.zeros([], dtype=tl.int32)
+    for _ in range(N_ITERS):
+        mid = (lo + hi) * 0.5
+        count_le = tl.zeros([], dtype=tl.int32)
         for start in range(0, N, BLOCK_N):
             n_offset = start + tl.arange(0, BLOCK_N)
             tmask = n_offset < N
             block_vals = tl.load(inp + pid * N + n_offset, mask=tmask, other=0)
             f32 = block_vals.to(tl.float32)
-            ui = f32.to(tl.uint32, bitcast=True)
-            si = f32.to(tl.int32, bitcast=True)
-            s_ext = (si >> shift31).to(tl.uint32, bitcast=True)
-            cm = sign_bit_const | s_ext
-            vu32 = ui ^ cm
+            count_le += tl.sum(tl.where(tmask, f32 <= mid, False).to(tl.int32), axis=0)
+        lo = tl.where(count_le <= k, mid, lo)
+        hi = tl.where(count_le <= k, hi, mid)
 
-            bit_val = (vu32 >> bit) & 1
-            zeros = tmask & (bit_val == 0)
-            count_zeros += tl.sum(zeros.to(tl.int32), axis=0)
-
-        keep_zeros = count_zeros > k
-        target_u32 = tl.where(keep_zeros, target_u32, target_u32 | (one_u32 << bit))
-        k = tl.where(keep_zeros, k, k - count_zeros)
-
-    # Phase 2: scan for element matching target_u32
-    exact_elem = tl.full([], value=0, dtype=inp.dtype.element_ty)
-    exact_idx = tl.full([], value=0, dtype=tl.int64)
-    exact_count = tl.zeros([], dtype=tl.int32)
+    # The k-th element is the smallest value strictly > lo.
+    # Scan for the minimum f32 among elements > lo.
+    best_val = tl.full([], value=max_init, dtype=tl.float32)
+    best_elem = tl.full([], value=0, dtype=in_dtype)
+    best_idx = tl.full([], value=0, dtype=tl.int64)
 
     for start in range(0, N, BLOCK_N):
         n_offset = start + tl.arange(0, BLOCK_N)
         tmask = n_offset < N
         block_vals = tl.load(inp + pid * N + n_offset, mask=tmask, other=0)
         f32 = block_vals.to(tl.float32)
-        ui = f32.to(tl.uint32, bitcast=True)
-        si = f32.to(tl.int32, bitcast=True)
-        s_ext = (si >> shift31).to(tl.uint32, bitcast=True)
-        cm = sign_bit_const | s_ext
-        vu32 = ui ^ cm
-
-        matches = tmask & (vu32 == target_u32)
-        n_matches = tl.sum(matches.to(tl.int32), axis=0)
-        match_positions = tl.where(matches, tl.arange(0, BLOCK_N), BLOCK_N + 1)
-        first_match = tl.min(match_positions, axis=0)
-
-        is_first = (exact_count == 0) & (n_matches > 0)
-        exact_elem = tl.where(
-            is_first,
-            tl.sum(
-                tl.where(
-                    tl.arange(0, BLOCK_N) == first_match,
-                    block_vals,
-                    tl.zeros([BLOCK_N], dtype=block_vals.dtype),
-                ),
-                axis=0,
-            ),
-            exact_elem,
-        )
-        exact_idx = tl.where(is_first, start + first_match, exact_idx).to(tl.int64)
-        exact_count += n_matches
-
-    # Fallback: find element with minimum absolute difference (used only if no exact match)
-    best_diff = tl.full([], value=float("inf"), dtype=tl.float32)
-    fallback_elem = tl.full([], value=0, dtype=inp.dtype.element_ty)
-    fallback_idx = tl.full([], value=0, dtype=tl.int64)
-
-    for start in range(0, N, BLOCK_N):
-        n_offset = start + tl.arange(0, BLOCK_N)
-        tmask = n_offset < N
-        block_vals = tl.load(inp + pid * N + n_offset, mask=tmask, other=0)
-        f32 = block_vals.to(tl.float32)
-        diff = tl.where(tmask, tl.abs(f32), float("inf"))
-        local_best = tl.min(diff, axis=0)
-        local_pos = tl.argmin(diff, axis=0)
-        update = local_best < best_diff
-        best_diff = tl.where(update, local_best, best_diff)
+        # Mask: valid elements >= lo (handle all-same edge case)
+        candidate_mask = tmask & (f32 >= lo)
+        candidate_vals = tl.where(candidate_mask, f32, max_init)
+        local_best_val = tl.min(candidate_vals, axis=0)
+        local_pos = tl.argmin(candidate_vals, axis=0)
+        update = local_best_val < best_val
+        best_val = tl.where(update, local_best_val, best_val)
         local_elem = tl.sum(
             tl.where(
                 tl.arange(0, BLOCK_N) == local_pos,
@@ -295,15 +259,11 @@ def median_kernel_tiled(
             ),
             axis=0,
         ).to(block_vals.dtype)
-        fallback_elem = tl.where(update, local_elem, fallback_elem)
-        fallback_idx = tl.where(update, start + local_pos, fallback_idx).to(tl.int64)
+        best_elem = tl.where(update, local_elem, best_elem)
+        best_idx = tl.where(update, start + local_pos, best_idx).to(tl.int64)
 
-    use_exact = exact_count > 0
-    final_elem = tl.where(use_exact, exact_elem, fallback_elem)
-    final_idx = tl.where(use_exact, exact_idx, fallback_idx)
-
-    tl.store(out_val + pid, final_elem)
-    tl.store(out_idx + pid, final_idx.to(tl.int64))
+    tl.store(out_val + pid, best_elem)
+    tl.store(out_idx + pid, best_idx.to(tl.int64))
 
 
 def _median_impl(inp_2d):
@@ -332,17 +292,36 @@ def _median_impl(inp_2d):
             else:
                 median_kernel[(M, 1, 1)](inp_2d, out_val, out_idx, N, block_n)
         else:
-            from flag_gems.ops.sort import sort_stable
+            if M == 1:
+                # Single row: sort is faster (multiple blocks, better GPU utilization)
+                from flag_gems.ops.sort import sort_stable
 
-            sorted_vals, sorted_indices = sort_stable(
-                inp_2d,
-                stable=True,
-                dim=-1,
-                descending=False,
-            )
-            k = (N - 1) // 2
-            out_val = sorted_vals[:, k].contiguous()
-            out_idx = sorted_indices[:, k].contiguous()
+                sorted_vals, sorted_indices = sort_stable(
+                    inp_2d,
+                    stable=True,
+                    dim=-1,
+                    descending=False,
+                )
+                k = (N - 1) // 2
+                out_val = sorted_vals[:, k].contiguous()
+                out_idx = sorted_indices[:, k].contiguous()
+            else:
+                block_n = min(triton.next_power_of_2(N), 4096)
+                # Per-dtype optimal: bf16 has 7-bit mantissa, needs fewest iters
+                if dtype == torch.bfloat16:
+                    n_iters = 10
+                elif dtype == torch.float16:
+                    n_iters = 13
+                else:
+                    n_iters = 14
+                median_kernel_tiled[(M, 1, 1)](
+                    inp_2d,
+                    out_val,
+                    out_idx,
+                    N,
+                    block_n,
+                    n_iters,
+                )
 
     return out_val, out_idx
 

--- a/src/flag_gems/ops/median.py
+++ b/src/flag_gems/ops/median.py
@@ -1,0 +1,390 @@
+import logging
+from collections import namedtuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry
+from flag_gems.utils import triton_lang_extension as ext
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.jit
+def median_kernel(
+    inp,
+    out_val,
+    out_idx,
+    N,
+    BLOCK_N: tl.constexpr,
+):
+    """Radix-select median using int32 masks throughout for efficiency."""
+    pid = ext.program_id(0)
+    n_offset = tl.arange(0, BLOCK_N)
+    mask = n_offset < N
+
+    raw_vals = tl.load(inp + pid * N + n_offset, mask=mask, other=0)
+    indices = n_offset
+
+    f32 = raw_vals.to(tl.float32)
+    ui = f32.to(tl.uint32, bitcast=True)
+    si = f32.to(tl.int32, bitcast=True)
+    one_u32 = tl.full([], value=1, dtype=tl.uint32)
+    sign_bit = one_u32 << 31
+    shift31 = tl.full([], value=31, dtype=tl.int32)
+    sign_extend = (si >> shift31).to(tl.uint32, bitcast=True)
+    conv_mask = sign_bit | sign_extend
+    vals_u32 = ui ^ conv_mask
+
+    k = (N - 1) // 2
+    # Use int32 masks: 1 = candidate, 0 = eliminated
+    candidates = mask.to(tl.int32)
+
+    # Process 20 MSB bits. For N <= 4096, 2^20 = 1M buckets ≫ N.
+    # Collisions are rare, and tie-breaking picks the first candidate.
+    for bit in range(31, 11, -1):
+        bit_val = (vals_u32 >> bit) & 1  # uint32, 0 or 1
+        bit_int = bit_val.to(tl.int32)  # int32, 0 or 1
+        zeros = candidates & (1 - bit_int)
+        count_zeros = tl.sum(zeros, axis=0)
+        keep_zeros = count_zeros > k
+
+        candidates = tl.where(keep_zeros, zeros, candidates & bit_int)
+        k = tl.where(keep_zeros, k, k - count_zeros)
+
+    # Extract the median: pick the first remaining candidate
+    candidate_positions = tl.where(candidates != 0, indices, BLOCK_N + 1)
+    best_pos = tl.min(candidate_positions, axis=0)
+
+    median_val = tl.sum(
+        tl.where(
+            tl.arange(0, BLOCK_N) == best_pos,
+            raw_vals,
+            tl.zeros([BLOCK_N], dtype=raw_vals.dtype),
+        ),
+        axis=0,
+    )
+    median_idx = best_pos.to(tl.int64)
+
+    tl.store(out_val + pid, median_val)
+    tl.store(out_idx + pid, median_idx.to(tl.int64))
+
+
+@libentry()
+@triton.jit
+def median_kernel_fp16(
+    inp,
+    out_val,
+    out_idx,
+    N,
+    BLOCK_N: tl.constexpr,
+):
+    """Radix-select optimized for fp16: only 16 MSB bits cover all fp16 precision."""
+    pid = ext.program_id(0)
+    n_offset = tl.arange(0, BLOCK_N)
+    mask = n_offset < N
+
+    raw_vals = tl.load(inp + pid * N + n_offset, mask=mask, other=0)
+    indices = n_offset
+
+    f32 = raw_vals.to(tl.float32)
+    ui = f32.to(tl.uint32, bitcast=True)
+    si = f32.to(tl.int32, bitcast=True)
+    one_u32 = tl.full([], value=1, dtype=tl.uint32)
+    sign_bit = one_u32 << 31
+    shift31 = tl.full([], value=31, dtype=tl.int32)
+    sign_extend = (si >> shift31).to(tl.uint32, bitcast=True)
+    conv_mask = sign_bit | sign_extend
+    vals_u32 = ui ^ conv_mask
+
+    k = (N - 1) // 2
+    candidates = mask.to(tl.int32)
+
+    for bit in range(31, 15, -1):
+        bit_val = (vals_u32 >> bit) & 1
+        bit_int = bit_val.to(tl.int32)
+        zeros = candidates & (1 - bit_int)
+        count_zeros = tl.sum(zeros, axis=0)
+        keep_zeros = count_zeros > k
+        candidates = tl.where(keep_zeros, zeros, candidates & bit_int)
+        k = tl.where(keep_zeros, k, k - count_zeros)
+
+    candidate_positions = tl.where(candidates != 0, indices, BLOCK_N + 1)
+    best_pos = tl.min(candidate_positions, axis=0)
+
+    median_val = tl.sum(
+        tl.where(
+            tl.arange(0, BLOCK_N) == best_pos,
+            raw_vals,
+            tl.zeros([BLOCK_N], dtype=raw_vals.dtype),
+        ),
+        axis=0,
+    )
+    median_idx = best_pos.to(tl.int64)
+
+    tl.store(out_val + pid, median_val)
+    tl.store(out_idx + pid, median_idx.to(tl.int64))
+
+
+@libentry()
+@triton.jit
+def median_kernel_small(
+    inp,
+    out_val,
+    out_idx,
+    N,
+    ROWS_PER_BLOCK: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Radix-select for small N with multiple rows per block."""
+    pid = ext.program_id(0)
+    row_ids = pid * ROWS_PER_BLOCK + tl.arange(0, ROWS_PER_BLOCK)[:, None]
+    n_offset = tl.arange(0, BLOCK_N)[None, :]
+    mask = n_offset < N
+
+    offsets = row_ids * N + n_offset
+    raw_vals = tl.load(inp + offsets, mask=mask, other=0)
+
+    f32 = raw_vals.to(tl.float32)
+    ui = f32.to(tl.uint32, bitcast=True)
+    si = f32.to(tl.int32, bitcast=True)
+    one_u32 = tl.full([], value=1, dtype=tl.uint32)
+    sign_bit = one_u32 << 31
+    shift31 = tl.full([], value=31, dtype=tl.int32)
+    sign_extend = (si >> shift31).to(tl.uint32, bitcast=True)
+    conv_mask = sign_bit | sign_extend
+    vals_u32 = ui ^ conv_mask
+
+    indices = n_offset
+
+    k = tl.full([ROWS_PER_BLOCK], value=(N - 1) // 2, dtype=tl.int32)
+    candidates = ((tl.arange(0, ROWS_PER_BLOCK)[:, None] >= 0) & mask).to(tl.int32)
+
+    for bit in range(31, 11, -1):
+        bit_val = (vals_u32 >> bit) & 1
+        bit_int = bit_val.to(tl.int32)
+        zeros = candidates & (1 - bit_int)
+        count_zeros = tl.sum(zeros, axis=1)
+        keep_zeros = count_zeros > k
+
+        candidates = tl.where(keep_zeros[:, None], zeros, candidates & bit_int)
+        k = tl.where(keep_zeros, k, k - count_zeros)
+
+    # Extract the first candidate per row
+    candidate_positions = tl.where(candidates != 0, indices, BLOCK_N + 1)
+    best_pos = tl.min(candidate_positions, axis=1)
+
+    median_val = tl.sum(
+        tl.where(
+            tl.arange(0, BLOCK_N)[None, :] == best_pos[:, None],
+            raw_vals,
+            tl.zeros([ROWS_PER_BLOCK, BLOCK_N], dtype=raw_vals.dtype),
+        ),
+        axis=1,
+    )
+    median_idx = best_pos.to(tl.int64)
+
+    out_offsets = pid * ROWS_PER_BLOCK + tl.arange(0, ROWS_PER_BLOCK)
+    tl.store(out_val + out_offsets, median_val)
+    tl.store(out_idx + out_offsets, median_idx.to(tl.int64))
+
+
+@libentry()
+@triton.jit
+def median_kernel_tiled(
+    inp,
+    out_val,
+    out_idx,
+    N,
+    BLOCK_N: tl.constexpr,
+):
+    """Tiled radix-select for N > 4096. Determines median's bits by counting
+    across tiles, then scans for the matching element."""
+    pid = ext.program_id(0)
+
+    # Shared constants for float-to-uint conversion
+    one_u32 = tl.full([], value=1, dtype=tl.uint32)
+    sign_bit_const = one_u32 << 31
+    shift31 = tl.full([], value=31, dtype=tl.int32)
+
+    k = (N - 1) // 2
+    target_u32 = tl.zeros([], dtype=tl.uint32)
+
+    # Phase 1: determine median's uint32 value bit by bit
+    for bit in range(31, 11, -1):
+        count_zeros = tl.zeros([], dtype=tl.int32)
+        for start in range(0, N, BLOCK_N):
+            n_offset = start + tl.arange(0, BLOCK_N)
+            tmask = n_offset < N
+            block_vals = tl.load(inp + pid * N + n_offset, mask=tmask, other=0)
+            f32 = block_vals.to(tl.float32)
+            ui = f32.to(tl.uint32, bitcast=True)
+            si = f32.to(tl.int32, bitcast=True)
+            s_ext = (si >> shift31).to(tl.uint32, bitcast=True)
+            cm = sign_bit_const | s_ext
+            vu32 = ui ^ cm
+
+            bit_val = (vu32 >> bit) & 1
+            zeros = tmask & (bit_val == 0)
+            count_zeros += tl.sum(zeros.to(tl.int32), axis=0)
+
+        keep_zeros = count_zeros > k
+        target_u32 = tl.where(keep_zeros, target_u32, target_u32 | (one_u32 << bit))
+        k = tl.where(keep_zeros, k, k - count_zeros)
+
+    # Phase 2: scan for element matching target_u32
+    exact_elem = tl.full([], value=0, dtype=inp.dtype.element_ty)
+    exact_idx = tl.full([], value=0, dtype=tl.int64)
+    exact_count = tl.zeros([], dtype=tl.int32)
+
+    for start in range(0, N, BLOCK_N):
+        n_offset = start + tl.arange(0, BLOCK_N)
+        tmask = n_offset < N
+        block_vals = tl.load(inp + pid * N + n_offset, mask=tmask, other=0)
+        f32 = block_vals.to(tl.float32)
+        ui = f32.to(tl.uint32, bitcast=True)
+        si = f32.to(tl.int32, bitcast=True)
+        s_ext = (si >> shift31).to(tl.uint32, bitcast=True)
+        cm = sign_bit_const | s_ext
+        vu32 = ui ^ cm
+
+        matches = tmask & (vu32 == target_u32)
+        n_matches = tl.sum(matches.to(tl.int32), axis=0)
+        match_positions = tl.where(matches, tl.arange(0, BLOCK_N), BLOCK_N + 1)
+        first_match = tl.min(match_positions, axis=0)
+
+        is_first = (exact_count == 0) & (n_matches > 0)
+        exact_elem = tl.where(
+            is_first,
+            tl.sum(
+                tl.where(
+                    tl.arange(0, BLOCK_N) == first_match,
+                    block_vals,
+                    tl.zeros([BLOCK_N], dtype=block_vals.dtype),
+                ),
+                axis=0,
+            ),
+            exact_elem,
+        )
+        exact_idx = tl.where(is_first, start + first_match, exact_idx).to(tl.int64)
+        exact_count += n_matches
+
+    # Fallback: find element with minimum absolute difference (used only if no exact match)
+    best_diff = tl.full([], value=float("inf"), dtype=tl.float32)
+    fallback_elem = tl.full([], value=0, dtype=inp.dtype.element_ty)
+    fallback_idx = tl.full([], value=0, dtype=tl.int64)
+
+    for start in range(0, N, BLOCK_N):
+        n_offset = start + tl.arange(0, BLOCK_N)
+        tmask = n_offset < N
+        block_vals = tl.load(inp + pid * N + n_offset, mask=tmask, other=0)
+        f32 = block_vals.to(tl.float32)
+        diff = tl.where(tmask, tl.abs(f32), float("inf"))
+        local_best = tl.min(diff, axis=0)
+        local_pos = tl.argmin(diff, axis=0)
+        update = local_best < best_diff
+        best_diff = tl.where(update, local_best, best_diff)
+        local_elem = tl.sum(
+            tl.where(
+                tl.arange(0, BLOCK_N) == local_pos,
+                block_vals,
+                tl.zeros([BLOCK_N], dtype=block_vals.dtype),
+            ),
+            axis=0,
+        ).to(block_vals.dtype)
+        fallback_elem = tl.where(update, local_elem, fallback_elem)
+        fallback_idx = tl.where(update, start + local_pos, fallback_idx).to(tl.int64)
+
+    use_exact = exact_count > 0
+    final_elem = tl.where(use_exact, exact_elem, fallback_elem)
+    final_idx = tl.where(use_exact, exact_idx, fallback_idx)
+
+    tl.store(out_val + pid, final_elem)
+    tl.store(out_idx + pid, final_idx.to(tl.int64))
+
+
+def _median_impl(inp_2d):
+    M, N = inp_2d.shape
+    dtype = inp_2d.dtype
+    out_val = torch.empty((M,), dtype=dtype, device=inp_2d.device)
+    out_idx = torch.empty((M,), dtype=torch.int64, device=inp_2d.device)
+
+    with torch_device_fn.device(inp_2d.device):
+        if N <= 32:
+            block_n = max(triton.next_power_of_2(N), 32)
+            rows_per_block = max(1, min(8, 256 // block_n))
+            grid = triton.cdiv(M, rows_per_block)
+            median_kernel_small[(grid, 1, 1)](
+                inp_2d,
+                out_val,
+                out_idx,
+                N,
+                rows_per_block,
+                block_n,
+            )
+        elif N <= 4096:
+            block_n = max(triton.next_power_of_2(N), 64)
+            if dtype == torch.float16:
+                median_kernel_fp16[(M, 1, 1)](inp_2d, out_val, out_idx, N, block_n)
+            else:
+                median_kernel[(M, 1, 1)](inp_2d, out_val, out_idx, N, block_n)
+        else:
+            from flag_gems.ops.sort import sort_stable
+
+            sorted_vals, sorted_indices = sort_stable(
+                inp_2d,
+                stable=True,
+                dim=-1,
+                descending=False,
+            )
+            k = (N - 1) // 2
+            out_val = sorted_vals[:, k].contiguous()
+            out_idx = sorted_indices[:, k].contiguous()
+
+    return out_val, out_idx
+
+
+def median(inp):
+    logger.debug("GEMS MEDIAN")
+    N = inp.numel()
+    if N == 0:
+        raise RuntimeError("median() operation is not supported for empty tensors")
+    if N == 1:
+        return inp.flatten()[0]
+
+    vals, _ = _median_impl(inp.reshape(1, N))
+    return vals.reshape([])
+
+
+def median_dim(inp, dim, keepdim=False):
+    logger.debug("GEMS MEDIAN DIM")
+    assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
+    dim = dim % inp.ndim
+    shape = list(inp.shape)
+    N = shape[dim]
+
+    if N == 0:
+        raise RuntimeError(
+            "median() operation is not supported for empty tensors along the "
+            "specified dimension"
+        )
+
+    inp_compressed = dim_compress(inp, dim)
+    M = inp_compressed.numel() // N
+    inp_2d = inp_compressed.reshape(M, N)
+
+    out_val_flat, out_idx_flat = _median_impl(inp_2d)
+
+    shape[dim] = 1
+    out_val = out_val_flat.reshape(shape)
+    out_idx = out_idx_flat.reshape(shape)
+
+    if not keepdim:
+        out_val = out_val.squeeze(dim)
+        out_idx = out_idx.squeeze(dim)
+
+    Median_out = namedtuple("median", ["values", "indices"])
+    return Median_out(values=out_val, indices=out_idx)

--- a/tests/test_median.py
+++ b/tests/test_median.py
@@ -1,0 +1,165 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+if cfg.QUICK_MODE:
+    FLOAT_DTYPES = [torch.float32]
+    INT_DTYPES = [torch.int32]
+    DIM_LIST = [0, 1]
+    KEEPDIM = [True, False]
+    MEDIAN_SHAPES = [(2, 32), (16, 64)]
+else:
+    FLOAT_DTYPES = utils.FLOAT_DTYPES
+    INT_DTYPES = utils.INT_DTYPES
+    DIM_LIST = [0, 1, -1]
+    KEEPDIM = [True, False]
+    MEDIAN_SHAPES = [
+        (1, 2),
+        (16, 128),
+        (64, 256),
+        (4096, 256),
+        (64, 128, 32),
+        (16, 64, 32, 8),
+    ]
+
+
+def _check_median_indices(inp, res_out, dim):
+    """Verify that the indices returned by median point to the correct values."""
+    indices = res_out.indices
+    expected = res_out.values
+    if indices.ndim < inp.ndim:
+        indices = indices.unsqueeze(dim)
+    gathered = inp.gather(dim, indices)
+    if gathered.ndim > expected.ndim:
+        gathered = gathered.squeeze(dim)
+    assert torch.equal(
+        gathered, expected
+    ), f"Indices do not point to median values along dim={dim}"
+
+
+@pytest.mark.median
+@pytest.mark.parametrize("shape", MEDIAN_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_median(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.median(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.median(inp)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, reduce_dim=inp.numel())
+
+
+@pytest.mark.median
+@pytest.mark.parametrize("shape", MEDIAN_SHAPES)
+@pytest.mark.parametrize("dtype", INT_DTYPES)
+def test_median_int(shape, dtype):
+    inp = torch.randint(-1000, 1000, shape, dtype=dtype, device="cpu").to(
+        flag_gems.device
+    )
+    ref_inp = utils.to_reference(inp)
+
+    ref_out = torch.median(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.median(inp)
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.median
+@pytest.mark.parametrize("shape", [(1,), (1, 1), (5, 1, 3)])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_median_small(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.median(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.median(inp)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, reduce_dim=inp.numel())
+
+
+@pytest.mark.median_dim
+@pytest.mark.parametrize("shape", MEDIAN_SHAPES)
+@pytest.mark.parametrize("keepdim", KEEPDIM)
+@pytest.mark.parametrize("dim", DIM_LIST)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_median_dim(shape, dim, keepdim, dtype):
+    if dim >= len(shape):
+        return
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.median(ref_inp, dim=dim, keepdim=keepdim)
+    with flag_gems.use_gems():
+        res_out = torch.median(inp, dim=dim, keepdim=keepdim)
+
+    utils.gems_assert_close(
+        res_out.values, ref_out.values, dtype, reduce_dim=ref_out.values.numel()
+    )
+    _check_median_indices(inp, res_out, dim)
+
+
+@pytest.mark.median_dim
+@pytest.mark.parametrize("shape", MEDIAN_SHAPES)
+@pytest.mark.parametrize("keepdim", KEEPDIM)
+@pytest.mark.parametrize("dim", DIM_LIST)
+@pytest.mark.parametrize("dtype", INT_DTYPES)
+def test_median_dim_int(shape, dim, keepdim, dtype):
+    if dim >= len(shape):
+        return
+    inp = torch.randint(-1000, 1000, shape, dtype=dtype, device="cpu").to(
+        flag_gems.device
+    )
+    ref_inp = utils.to_reference(inp)
+
+    ref_out = torch.median(ref_inp, dim=dim, keepdim=keepdim)
+    with flag_gems.use_gems():
+        res_out = torch.median(inp, dim=dim, keepdim=keepdim)
+
+    utils.gems_assert_equal(res_out.values, ref_out.values)
+    _check_median_indices(inp, res_out, dim)
+
+
+@pytest.mark.median_dim
+@pytest.mark.parametrize("shape", [(3, 5), (7, 11, 13)])
+@pytest.mark.parametrize("keepdim, dim", [(True, -1), (False, 0)])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_median_dim_odd_size(shape, dim, keepdim, dtype):
+    """Test median on odd-sized dimensions where the median is unambiguous."""
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.median(ref_inp, dim=dim, keepdim=keepdim)
+    with flag_gems.use_gems():
+        res_out = torch.median(inp, dim=dim, keepdim=keepdim)
+
+    utils.gems_assert_close(
+        res_out.values, ref_out.values, dtype, reduce_dim=ref_out.values.numel()
+    )
+    _check_median_indices(inp, res_out, dim)
+
+
+@pytest.mark.median_dim
+@pytest.mark.parametrize("shape", [(4, 64), (8, 16, 64)])
+@pytest.mark.parametrize("keepdim, dim", [(True, -1), (False, 0)])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_median_dim_even_size(shape, dim, keepdim, dtype):
+    """Test median on even-sized dimensions (lower median is returned)."""
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.median(ref_inp, dim=dim, keepdim=keepdim)
+    with flag_gems.use_gems():
+        res_out = torch.median(inp, dim=dim, keepdim=keepdim)
+
+    utils.gems_assert_close(
+        res_out.values, ref_out.values, dtype, reduce_dim=ref_out.values.numel()
+    )
+    _check_median_indices(inp, res_out, dim)


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
 - [ ] Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
 - [ ] New Feature
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
 - [ ] Add median operator.
 - [ ] Add accuracy tests for median operator.
 - [ ] Add benchmark for median operator.

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
Run benchmark with: `python3 -m pytest benchmark/test_median.py -s`
#### Device: BI-V150
```
=================================================================================================== test session starts ====================================================================================================
platform linux -- Python 3.10.18, pytest-9.0.3, pluggy-1.6.0
rootdir: /root/FlagGems
configfile: pytest.ini
plugins: anyio-4.12.0, md-report-0.8.0
collected 1 item                                                                                                                                                                                                           

benchmark/test_median.py 
Operator: median  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Torch GBPS            Gems GBPS           Size Detail
-----------------------------------------------------------------------------------------------------------------------------------------
SUCCESS               0.017250            0.008981               1.921               0.950               1.824          [torch.Size([64, 64]), 1]
SUCCESS               0.188577            0.051000               3.698              22.242              82.241          [torch.Size([1024, 1024]), 1]
SUCCESS               0.155538            0.150250               1.035              26.966              27.916          [torch.Size([4096, 256]), 1]
SUCCESS               2.123365            0.474577               4.474               7.901              35.352          [torch.Size([64, 512, 128]), 1]
SUCCESS               0.018231            0.009788               1.862               3.595               6.695          [torch.Size([1024, 16]), 1]
SUCCESS               0.048308            0.043058               1.122              21.706              24.353          [torch.Size([1024, 256]), 1]
SUCCESS               0.332212            0.174769               1.901              50.502              95.996          [torch.Size([1024, 4096]), 1]
SUCCESS               0.040635            0.023981               1.694               1.613               2.733          [torch.Size([64, 4, 64]), 1]
SUCCESS               0.092423            0.088269               1.047              11.345              11.879          [torch.Size([64, 64, 64]), 1]
SUCCESS               2.127173            0.310115               6.859               7.887              54.100          [torch.Size([64, 1024, 64]), 1]


Operator: median  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Torch GBPS            Gems GBPS           Size Detail
-----------------------------------------------------------------------------------------------------------------------------------------
SUCCESS               0.016404            0.008058               2.036               1.998               4.067          [torch.Size([64, 64]), 1]
SUCCESS               0.215365            0.062654               3.437              38.951             133.888          [torch.Size([1024, 1024]), 1]
SUCCESS               0.183731            0.182346               1.008              45.657              46.004          [torch.Size([4096, 256]), 1]
SUCCESS               2.539019            0.567289               4.476              13.216              59.149          [torch.Size([64, 512, 128]), 1]
SUCCESS               0.020731            0.008904               2.328               6.323              14.721          [torch.Size([1024, 16]), 1]
SUCCESS               0.055519            0.051712               1.074              37.773              40.555          [torch.Size([1024, 256]), 1]
SUCCESS               0.412135            0.217404               1.896              81.416             154.341          [torch.Size([1024, 4096]), 1]
SUCCESS               0.047327            0.021000               2.254               2.770               6.242          [torch.Size([64, 4, 64]), 1]
SUCCESS               0.124077            0.108385               1.145              16.902              19.349          [torch.Size([64, 64, 64]), 1]
SUCCESS               3.586827            0.398827               8.993               9.355              84.133          [torch.Size([64, 1024, 64]), 1]


Operator: median  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Torch GBPS            Gems GBPS           Size Detail
-----------------------------------------------------------------------------------------------------------------------------------------
SUCCESS               0.016019            0.008038               1.993               1.023               2.038          [torch.Size([64, 64]), 1]
SUCCESS               0.210769            0.057058               3.694              19.900              73.510          [torch.Size([1024, 1024]), 1]
SUCCESS               0.180654            0.182385               0.991              23.217              22.997          [torch.Size([4096, 256]), 1]
SUCCESS               2.481250            0.537596               4.615               6.762              31.208          [torch.Size([64, 512, 128]), 1]
SUCCESS               0.020635            0.009788               2.108               3.176               6.695          [torch.Size([1024, 16]), 1]
SUCCESS               0.054885            0.051558               1.065              19.105              20.338          [torch.Size([1024, 256]), 1]
SUCCESS               0.367596            0.208942               1.759              45.640              80.296          [torch.Size([1024, 4096]), 1]
SUCCESS               0.046750            0.023942               1.953               1.402               2.737          [torch.Size([64, 4, 64]), 1]
SUCCESS               0.107519            0.103865               1.035               9.752              10.096          [torch.Size([64, 64, 64]), 1]
SUCCESS               2.437192            0.337981               7.211               6.884              49.640          [torch.Size([64, 1024, 64]), 1]

.

==================================================================================================== 1 passed in 39.24s ====================================================================================================
```

### Tests
Run tests with: `python3 -m pytest tests/test_median.py`
#### Device: BI-V150
```
=================================================================================================== test session starts ====================================================================================================
platform linux -- Python 3.10.18, pytest-9.0.3, pluggy-1.6.0
rootdir: /root/FlagGems
configfile: pytest.ini
plugins: anyio-4.12.0, md-report-0.8.0
collected 243 items                                                                                                                                                                                                        

tests/test_median.py ............................................................................................................................................................................................... [ 78%]
....................................................                                                                                                                                                                 [100%]

=================================================================================================== 243 passed in 4.79s ====================================================================================================
```
