### PR TITLE
fix(copy): fallback to PyTorch for float8_e8m0fnu dtype unsupported b…

### DIFF
--- a/src/flag_gems/ops/copy.py
+++ b/src/flag_gems/ops/copy.py
@@ -12,6 +12,8 @@ _FALLBACK_KEYSET = torch._C.DispatchKeySet(
     torch._C.DispatchKey.CompositeExplicitAutograd
 )
 
+_FLOAT8_E8M0FNU = getattr(torch, "float8_e8m0fnu", None)
+
 
 @pointwise_dynamic(is_tensor=[True], promotion_methods=[(0, "DEFAULT")])
 @triton.jit
@@ -29,6 +31,11 @@ def _can_use_triton(dst: torch.Tensor, src: torch.Tensor) -> bool:
     if src.is_complex() or dst.is_complex():
         # Preserve PyTorch's behaviour of warning when casting complex to real
         # by forcing the redispatch path, which issues the warning internally.
+        return False
+    if _FLOAT8_E8M0FNU is not None and (
+        src.dtype == torch.float8_e8m0fnu or dst.dtype == torch.float8_e8m0fnu
+    ):
+        # Triton does not support float8 yet, so defer to PyTorch which has a reference implementation.
         return False
     return True
 

--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -75,6 +75,61 @@ def test_copy_inplace_dtype_fallback():
 
 
 @pytest.mark.copy_
+@pytest.mark.skipif(
+    not hasattr(torch, "float8_e8m0fnu"),
+    reason="PyTorch does not support float8_e8m0fnu",
+)
+@pytest.mark.parametrize("shape", [(8,), (4, 4), (2, 3, 4)])
+def test_copy_inplace_float8_e8m0fnu(shape):
+    """Test that copy_ works correctly with float8_e8m0fnu (e8m0) dtype tensors.
+
+    Triton does not recognize float8_e8m0fnu, so FlagGems should fallback to
+    PyTorch's native copy_ implementation for this dtype.
+    """
+    device = flag_gems.device
+
+    # e8m0 is an exponent-only format, create via view from uint8
+    src_uint8 = torch.randint(0, 255, shape, dtype=torch.uint8, device=device)
+    src = src_uint8.view(torch.float8_e8m0fnu)
+    ref_src = utils.to_reference(src)
+
+    ref_dst = utils.to_reference(
+        torch.zeros(shape, dtype=torch.float8_e8m0fnu, device=device)
+    )
+    res_dst = torch.zeros(shape, dtype=torch.float8_e8m0fnu, device=device)
+    ref_dst.copy_(ref_src)
+
+    with flag_gems.use_gems():
+        res_dst.copy_(src)
+
+    utils.gems_assert_equal(res_dst, ref_dst)
+
+
+@pytest.mark.copy_
+@pytest.mark.skipif(
+    not hasattr(torch, "float8_e8m0fnu"),
+    reason="PyTorch does not support float8_e8m0fnu",
+)
+def test_copy_inplace_float8_e8m0fnu_to_float32():
+    """Test copy_ from float8_e8m0fnu to float32."""
+    device = flag_gems.device
+    shape = (8,)
+
+    src_uint8 = torch.randint(1, 200, shape, dtype=torch.uint8, device=device)
+    src = src_uint8.view(torch.float8_e8m0fnu)
+    ref_src = utils.to_reference(src)
+
+    ref_dst = utils.to_reference(torch.zeros(shape, dtype=torch.float32, device=device))
+    res_dst = torch.zeros(shape, dtype=torch.float32, device=device)
+    ref_dst.copy_(ref_src)
+
+    with flag_gems.use_gems():
+        res_dst.copy_(src)
+
+    utils.gems_assert_equal(res_dst, ref_dst)
+
+
+@pytest.mark.copy_
 @pytest.mark.parametrize(
     "src_dtype,dst_dtype",
     [


### PR DESCRIPTION

  Triton's type_canonicalisation_dict does not include float8_e8m0fnu,
  causing KeyError when FlagGems' copy_ kernel receives e8m0 scale tensors
  (e.g. from MX-format quantized GEMM pipelines). Add dtype check in
  _can_use_triton() to redispatch to native PyTorch implementation.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

  Triton's type_canonicalisation_dict does not include float8_e8m0fnu,
  causing KeyError when FlagGems' copy_ kernel receives e8m0 scale tensors
  (e.g. from MX-format quantized GEMM pipelines). Add dtype check in
  _can_use_triton() to redispatch to native PyTorch implementation.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
