### PR TITLE
Improve addmm_dtype test coverage

### DIFF
--- a/benchmark/consts.py
+++ b/benchmark/consts.py
@@ -273,5 +273,6 @@ class BenchmarkResult:
     def to_dict(self) -> dict:
         return self.__dict__
 
+
 # Subset dtypes for specific operators
 FP16_BF16_DTYPES = [torch.float16, torch.bfloat16]

--- a/benchmark/consts.py
+++ b/benchmark/consts.py
@@ -272,3 +272,6 @@ class BenchmarkResult:
 
     def to_dict(self) -> dict:
         return self.__dict__
+
+# Subset dtypes for specific operators
+FP16_BF16_DTYPES = [torch.float16, torch.bfloat16]

--- a/benchmark/test_addmm.py
+++ b/benchmark/test_addmm.py
@@ -3,7 +3,7 @@ import torch
 
 import flag_gems
 
-from . import base, consts
+from . import base, consts, utils
 
 
 def _input_fn(b, m, n, k, dtype, device, b_column_major):
@@ -27,6 +27,36 @@ def test_addmm(monkeypatch):
         input_fn=_input_fn,
         torch_op=torch.addmm,
         dtypes=consts.FLOAT_DTYPES,
+    )
+
+    bench.run()
+
+
+def _input_fn_dtype(b, m, n, k, dtype, device, b_column_major):
+    inp1 = torch.randn([m, k], dtype=dtype, device=device)
+    bias = torch.randn([m, n], dtype=torch.float32, device=device)
+    if b_column_major:
+        inp2 = torch.randn([n, k], dtype=dtype, device=device)
+        yield bias, inp1, inp2.t(), torch.float32
+    else:
+        inp2 = torch.randn([k, n], dtype=dtype, device=device)
+        yield bias, inp1, inp2, torch.float32
+
+
+@pytest.mark.addmm_dtype
+@pytest.mark.skipif(
+    utils.SkipVersion("torch", "<2.8"),
+    reason="The operator addmm.dtype was added starting from 2.8.0",
+)
+def test_addmm_dtype(monkeypatch):
+    if flag_gems.vendor_name == "mthreads":
+        monkeypatch.setenv("MUSA_ENABLE_SQMMA", "1")
+
+    bench = base.BlasBenchmark(
+        op_name="addmm_dtype",
+        input_fn=_input_fn_dtype,
+        torch_op=torch.ops.aten.addmm.dtype,
+        dtypes=[torch.float16, torch.bfloat16],
     )
 
     bench.run()

--- a/benchmark/test_addmm.py
+++ b/benchmark/test_addmm.py
@@ -56,7 +56,7 @@ def test_addmm_dtype(monkeypatch):
         op_name="addmm_dtype",
         input_fn=_input_fn_dtype,
         torch_op=torch.ops.aten.addmm.dtype,
-        dtypes=[torch.float16, torch.bfloat16],
+        dtypes=consts.FP16_BF16_DTYPES,
     )
 
     bench.run()


### PR DESCRIPTION
Improve addmm_dtype test coverage: 缺少性能测试,benchmark/test_addmm.py中有mark addmm但缺少mark addmm_dtype