### PR TITLE
Improve addmm_dtype_out test coverage

### DIFF
--- a/benchmark/consts.py
+++ b/benchmark/consts.py
@@ -273,5 +273,6 @@ class BenchmarkResult:
     def to_dict(self) -> dict:
         return self.__dict__
 
+
 # Subset dtypes for specific operators
 FP16_BF16_DTYPES = [torch.float16, torch.bfloat16]

--- a/benchmark/consts.py
+++ b/benchmark/consts.py
@@ -272,3 +272,6 @@ class BenchmarkResult:
 
     def to_dict(self) -> dict:
         return self.__dict__
+
+# Subset dtypes for specific operators
+FP16_BF16_DTYPES = [torch.float16, torch.bfloat16]

--- a/benchmark/test_addmm.py
+++ b/benchmark/test_addmm.py
@@ -55,7 +55,7 @@ def test_addmm_dtype_out(monkeypatch):
         torch_op=lambda bias, mat1, mat2, out_dtype, out: torch.ops.aten.addmm.dtype_out(
             bias, mat1, mat2, out_dtype, beta=1.0, alpha=1.0, out=out
         ),
-        dtypes=[torch.float16, torch.bfloat16],
+        dtypes=consts.FP16_BF16_DTYPES,
     )
 
     bench.run()

--- a/benchmark/test_addmm.py
+++ b/benchmark/test_addmm.py
@@ -30,3 +30,32 @@ def test_addmm(monkeypatch):
     )
 
     bench.run()
+
+
+def _input_fn_dtype_out(b, m, n, k, dtype, device, b_column_major):
+    inp1 = torch.randn([m, k], dtype=dtype, device=device)
+    bias = torch.randn([m, n], dtype=torch.float32, device=device)
+    out = torch.empty([m, n], dtype=torch.float32, device=device)
+    if b_column_major:
+        inp2 = torch.randn([n, k], dtype=dtype, device=device)
+        yield bias, inp1, inp2.t(), torch.float32, out
+    else:
+        inp2 = torch.randn([k, n], dtype=dtype, device=device)
+        yield bias, inp1, inp2, torch.float32, out
+
+
+@pytest.mark.addmm_dtype_out
+def test_addmm_dtype_out(monkeypatch):
+    if flag_gems.vendor_name == "mthreads":
+        monkeypatch.setenv("MUSA_ENABLE_SQMMA", "1")
+
+    bench = base.BlasBenchmark(
+        op_name="addmm",
+        input_fn=_input_fn_dtype_out,
+        torch_op=lambda bias, mat1, mat2, out_dtype, out: torch.ops.aten.addmm.dtype_out(
+            bias, mat1, mat2, out_dtype, beta=1.0, alpha=1.0, out=out
+        ),
+        dtypes=[torch.float16, torch.bfloat16],
+    )
+
+    bench.run()


### PR DESCRIPTION
Improve addmm_dtype_out test coverage: 缺少性能测试,benchmark/test_addmm.py中有mark addmm但缺少mark addmm_dtype_out