### PR TITLE
Fix test case for grid_sample

### DIFF
--- a/tests/test_grid_sample.py
+++ b/tests/test_grid_sample.py
@@ -33,7 +33,10 @@ ATOL_DICT = {
     torch.bfloat16: 0.016,
 }
 
-gpu_memory_available = torch.cuda.get_device_properties(0).total_memory
+try:
+    gpu_memory_available = torch.cuda.get_device_properties(0).total_memory
+except Exception:
+    gpu_memory_availabel = 32 * 1024**3
 
 
 def assert_close(actual, expected, rtol=1e-4, atol=None, dtype=torch.float32):


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

The initialization logic for global variable does not work on all platforms. Use a temporary constant as a workaround for unblocking other tests.