### PR TITLE
Refactor import organization and setup logic for spacemit

### DIFF
--- a/src/flag_gems/runtime/backend/_spacemit/__init__.py
+++ b/src/flag_gems/runtime/backend/_spacemit/__init__.py
@@ -1,17 +1,18 @@
+import importlib.util
 from typing import Any
 
 from backend_utils import VendorInfoBase  # noqa: E402
 
-from .utils.config_pre_hook import setup_triton_config
+if importlib.util.find_spec("triton.backends.spine_triton") is not None:
+    from .utils.config_pre_hook import setup_triton_config
 
-# from .heuristics_config_utils import HEURISTICS_CONFIGS
+    setup_triton_config()
 
-setup_triton_config()
+    import triton  # noqa: E402
+    from triton.backends.spine_triton.driver import CPUDriver  # noqa: E402
 
-import triton  # noqa: E402
-from triton.backends.spine_triton.driver import CPUDriver  # noqa: E402
+    triton.runtime.driver.set_active(CPUDriver())  # noqa: E402
 
-triton.runtime.driver.set_active(CPUDriver())  # noqa: E402
 
 vendor_info = VendorInfoBase(
     vendor_name="spacemit", device_name="cpu", device_query_cmd="lscpu"


### PR DESCRIPTION
This pull request updates the initialization logic for the `spacemit` backend to conditionally set up Triton configuration only if the `triton.backends.spine_triton` module is available. This prevents import errors when the optional dependency is missing and ensures safer initialization.

Backend initialization improvements:

* The import and execution of `setup_triton_config` from `.utils.config_pre_hook` are now wrapped in a check that verifies the presence of the `triton.backends.spine_triton` module using `importlib.util.find_spec`. This prevents errors if the module is not installed.

Other minor changes:

* Minor formatting and whitespace adjustments for clarity and separation of logic.### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
