### PR TITLE
[KernelGen][Nvidia] Add special_erfcx operator with Triton kernel

### DIFF
--- a/benchmark/test_special_erfcx.py
+++ b/benchmark/test_special_erfcx.py
@@ -1,0 +1,14 @@
+import pytest
+import torch
+
+from . import base
+
+
+@pytest.mark.special_erfcx
+def test_special_erfcx():
+    bench = base.UnaryPointwiseBenchmark(
+        op_name="special_erfcx",
+        torch_op=torch.special.erfcx,
+        dtypes=[torch.float32],
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -5394,6 +5394,19 @@ ops:
       - DSA
     stages:
       - beta: '5.0'
+  - id: special_erfcx
+    description: |
+      Computes the scaled complementary error function for each element of input.
+    for:
+      - special_erfcx
+    labels:
+      - aten
+      - KernelGen
+      - pointwise
+    kind:
+      - Math
+    stages:
+      - alpha: '5.1'
   - id: special_i0e
     description: |
       Computes the exponentially scaled zeroth order modified Bessel function

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -463,6 +463,7 @@ _FULL_CONFIG = (
     ("softshrink.out", softshrink_out),
     ("sort", sort),
     ("sort.stable", sort_stable),
+    ("special_erfcx", special_erfcx),
     ("special_i0e", special_i0e),
     ("special_i0e.out", special_i0e_out),
     ("special_i1", special_i1),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -321,6 +321,7 @@ from flag_gems.ops.softmax import (
 from flag_gems.ops.softplus import softplus
 from flag_gems.ops.softshrink import softshrink, softshrink_out
 from flag_gems.ops.sort import sort, sort_stable
+from flag_gems.ops.special_erfcx import special_erfcx, special_erfcx_
 from flag_gems.ops.special_i0e import special_i0e, special_i0e_out
 from flag_gems.ops.special_i1 import special_i1, special_i1_out
 from flag_gems.ops.sqrt import sqrt, sqrt_
@@ -513,6 +514,8 @@ __all__ = [
     "equal",
     "erf",
     "erf_",
+    "special_erfcx",
+    "special_erfcx_",
     "exp",
     "exp_",
     "exp_out",

--- a/src/flag_gems/ops/special_erfcx.py
+++ b/src/flag_gems/ops/special_erfcx.py
@@ -1,0 +1,25 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(promotion_methods=[(0, "DEFAULT")])
+@triton.jit
+def special_erfcx_func(x):
+    # Use libdevice erfcx for accurate computation
+    return tl.extra.cuda.libdevice.erfcx(x)
+
+
+def special_erfcx(x):
+    logger.debug("GEMS SPECIAL_ERFCX")
+    return special_erfcx_func(x)
+
+
+def special_erfcx_(x):
+    logger.debug("GEMS SPECIAL_ERFCX_")
+    return special_erfcx_func(x, out0=x)

--- a/tests/test_special_erfcx.py
+++ b/tests/test_special_erfcx.py
@@ -1,0 +1,20 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.special_erfcx
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", [torch.float32])
+def test_special_erfcx(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp)
+
+    ref_out = torch.special.erfcx(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.special.erfcx(inp)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

New Feature

### Description

Add `special_erfcx` operator, a Triton-based GPU kernel for computing the scaled complementary error function element-wise. Uses `pointwise_dynamic` decorator with `libdevice.erfcx` for accurate computation.

### Changes

- Add Triton kernel using `pointwise_dynamic` with `libdevice.erfcx`
- Support float32 input dtype
- Add in-place variant `special_erfcx_`
- New: `src/flag_gems/ops/special_erfcx.py`
- Modified: `src/flag_gems/ops/__init__.py`
- Modified: `src/flag_gems/__init__.py`
- New: `tests/test_special_erfcx.py`
- New: `benchmark/test_special_erfcx.py`
- Modified: `conf/operators.yaml`

### Performance

Average speedup vs torch baseline on NVIDIA GPU: **98.54x**