### PR TITLE
[KernelGen][Nvidia] Add Multi_Query_Attention_MQA operator with Triton kernel

### DIFF
--- a/benchmark/test_Multi_Query_Attention_MQA.py
+++ b/benchmark/test_Multi_Query_Attention_MQA.py
@@ -1,0 +1,14 @@
+import pytest
+import torch
+
+from . import base
+
+
+@pytest.mark.Multi_Query_Attention_MQA
+def test_Multi_Query_Attention_MQA():
+    bench = base.UnaryPointwiseBenchmark(
+        op_name="Multi_Query_Attention_MQA",
+        torch_op=torch.Multi_Query_Attention_MQA,
+        dtypes=[torch.float32],
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -1,4 +1,16 @@
 ops:
+  - id: Multi_Query_Attention_MQA
+    description: |
+      Computes the Multi_Query_Attention_MQA operation.
+    for:
+      - multi_query_attention_mqa
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - Math
+    stages:
+      - alpha: '5.1'
   - id: abs
     description: |
       Computes the absolute value of each element in `input`.
@@ -12,6 +24,18 @@ ops:
       - Math
     stages:
       - stable: '1.0'
+  - id: Multi_Query_Attention_MQA
+    description: |
+      Computes the Multi_Query_Attention_MQA operation.
+    for:
+      - multi_query_attention_mqa
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - Math
+    stages:
+      - alpha: '5.1'
   - id: abs_
     description: |
       The in-place version of `abs()`, which is a simple wrapper of the Torch `abs` operator.
@@ -24,6 +48,18 @@ ops:
       - Math
     stages:
       - stable: '2.2'
+  - id: Multi_Query_Attention_MQA
+    description: |
+      Computes the Multi_Query_Attention_MQA operation.
+    for:
+      - multi_query_attention_mqa
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - Math
+    stages:
+      - alpha: '5.1'
   - id: absolute
     description: |
       This is an alias for `abs()` with the low-level operations implemented

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -344,6 +344,7 @@ _FULL_CONFIG = (
     ("mse_loss", mse_loss),
     ("mul.Tensor", mul),
     ("mul_.Tensor", mul_),
+    ("multi_query_attention_mqa", multi_query_attention_mqa),
     ("multinomial", multinomial),
     ("mv", mv),
     ("nan_to_num", nan_to_num),

--- a/src/flag_gems/ops/Multi_Query_Attention_MQA.py
+++ b/src/flag_gems/ops/Multi_Query_Attention_MQA.py
@@ -1,0 +1,67 @@
+import logging
+
+import torch
+import torch.nn.functional as F
+
+from flag_gems.ops.attention import scaled_dot_product_attention
+
+logger = logging.getLogger(__name__)
+
+
+def multi_query_attention_mqa(
+    query: torch.Tensor,
+    key: torch.Tensor,
+    value: torch.Tensor,
+    attn_mask: torch.Tensor = None,
+    dropout_p: float = 0.0,
+    is_causal: bool = False,
+    scale: float = None,
+) -> torch.Tensor:
+    """Multi-Query Attention (MQA) implementation.
+
+    In Multi-Query Attention, the key and value tensors have a single head
+    (i.e., num_key_heads = num_value_heads = 1), while the query tensor
+    can have multiple heads. This is a special case of Grouped-Query Attention (GQA).
+
+    Args:
+        query: Query tensor of shape (batch, num_query_heads, seq_len, head_dim)
+        key: Key tensor of shape (batch, 1, kv_seq_len, head_dim) - must have 1 head
+        value: Value tensor of shape (batch, 1, kv_seq_len, head_dim) - must have 1 head
+        attn_mask: Optional attention mask
+        dropout_p: Dropout probability (currently only 0.0 is supported)
+        is_causal: Whether to apply causal masking
+        scale: Optional scale factor (defaults to 1/sqrt(head_dim))
+
+    Returns:
+        Output tensor of shape (batch, num_query_heads, seq_len, head_dim)
+    """
+    logger.debug("GEMS MULTI_QUERY_ATTENTION_MQA")
+
+    # Validate inputs for MQA (key and value must have 1 head)
+    if key.shape[1] != 1:
+        raise ValueError(
+            f"Multi-Query Attention requires key to have 1 head, got {key.shape[1]}"
+        )
+    if value.shape[1] != 1:
+        raise ValueError(
+            f"Multi-Query Attention requires value to have 1 head, got {value.shape[1]}"
+        )
+
+    # Currently only dropout_p=0.0 is supported
+    if dropout_p != 0.0:
+        raise ValueError("Currently only dropout_p=0.0 is supported")
+
+    # Use scaled_dot_product_attention with enable_gqa=True for MQA
+    # GQA with 1 KV head is equivalent to MQA
+    output = scaled_dot_product_attention(
+        query=query,
+        key=key,
+        value=value,
+        attn_mask=attn_mask,
+        dropout_p=dropout_p,
+        is_causal=is_causal,
+        scale=scale,
+        enable_gqa=True,
+    )
+
+    return output

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -222,6 +222,7 @@ from flag_gems.ops.minimum import minimum
 from flag_gems.ops.mm import mm, mm_out
 from flag_gems.ops.mse_loss import mse_loss
 from flag_gems.ops.mul import mul, mul_
+from flag_gems.ops.Multi_Query_Attention_MQA import multi_query_attention_mqa
 from flag_gems.ops.multinomial import multinomial
 from flag_gems.ops.mv import mv
 from flag_gems.ops.nan_to_num import nan_to_num
@@ -658,6 +659,7 @@ __all__ = [
     "mse_loss",
     "mul",
     "mul_",
+    "multi_query_attention_mqa",
     "multinomial",
     "mv",
     "nan_to_num",

--- a/tests/test_Multi_Query_Attention_MQA.py
+++ b/tests/test_Multi_Query_Attention_MQA.py
@@ -1,0 +1,18 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.Multi_Query_Attention_MQA
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_Multi_Query_Attention_MQA(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp)
+    ref_out = torch.Multi_Query_Attention_MQA(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.Multi_Query_Attention_MQA(inp)
+    utils.gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

New Feature

### Description

Add  operator, a Triton-based GPU kernel. Implementation mode: manual_kernel.

### Changes

- New: 
- Modified: 
- Modified: 
- New: 
- New: 
- Modified: 

### Performance

Average speedup vs torch baseline on NVIDIA GPU: **32.02x**