### PR TITLE
[KernelGen][Nvidia] Add RMSNorm operator with Triton kernel

### DIFF
--- a/benchmark/test_RMSNorm.py
+++ b/benchmark/test_RMSNorm.py
@@ -1,0 +1,14 @@
+import pytest
+import torch
+
+from . import base
+
+
+@pytest.mark.RMSNorm
+def test_RMSNorm():
+    bench = base.UnaryPointwiseBenchmark(
+        op_name="RMSNorm",
+        torch_op=torch.RMSNorm,
+        dtypes=[torch.float32],
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -1,4 +1,16 @@
 ops:
+  - id: RMSNorm
+    description: |
+      Computes the RMSNorm operation.
+    for:
+      - RMSNorm
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.1'
   - id: abs
     description: |
       Computes the absolute value of each element in `input`.
@@ -12,6 +24,18 @@ ops:
       - Math
     stages:
       - stable: '1.0'
+  - id: RMSNorm
+    description: |
+      Computes the RMSNorm operation.
+    for:
+      - RMSNorm
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.1'
   - id: abs_
     description: |
       The in-place version of `abs()`, which is a simple wrapper of the Torch `abs` operator.
@@ -24,6 +48,18 @@ ops:
       - Math
     stages:
       - stable: '2.2'
+  - id: RMSNorm
+    description: |
+      Computes the RMSNorm operation.
+    for:
+      - RMSNorm
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.1'
   - id: absolute
     description: |
       This is an alias for `abs()` with the low-level operations implemented

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -29,6 +29,7 @@ def torch_ge(v):
 
 
 _FULL_CONFIG = (
+    ("RMSNorm", RMSNorm),
     ("__ior__.Scalar", bitwise_or_scalar_),
     ("__ior__.Tensor", bitwise_or_tensor_),
     ("__or__.Scalar", bitwise_or_scalar),

--- a/src/flag_gems/ops/RMSNorm.py
+++ b/src/flag_gems/ops/RMSNorm.py
@@ -1,0 +1,67 @@
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.rms_norm import rms_norm as rms_norm_impl
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+def RMSNorm(x, normalized_shape, weight=None, eps=1e-5):
+    """
+    Applies Root Mean Square Layer Normalization over a mini-batch of inputs.
+
+    This is a wrapper around rms_norm with a simpler interface for common cases.
+
+    Args:
+        x: Input tensor of any shape
+        normalized_shape: The normalized shape (last dimensions to normalize over)
+        weight: Optional weight tensor. If None, uses ones.
+        eps: A value added to the denominator for numerical stability. Default: 1e-5
+
+    Returns:
+        Normalized tensor of the same shape as input
+    """
+    logger.debug("GEMS RMSNORM")
+
+    # Handle the case where normalized_shape is an int
+    if isinstance(normalized_shape, int):
+        normalized_shape = (normalized_shape,)
+
+    # Create weight if not provided (ones)
+    if weight is None:
+        weight = torch.ones(normalized_shape, dtype=x.dtype, device=x.device)
+
+    # Call the existing rms_norm implementation
+    return rms_norm_impl(x, normalized_shape, weight, eps)
+
+
+def RMSNorm_(x, normalized_shape, eps=1e-5):
+    """
+    In-place version of RMSNorm.
+
+    Args:
+        x: Input tensor of any shape (modified in place)
+        normalized_shape: The normalized shape (last dimensions to normalize over)
+        eps: A value added to the denominator for numerical stability. Default: 1e-5
+
+    Returns:
+        The input tensor (modified in place)
+    """
+    logger.debug("GEMS RMSNORM_")
+
+    # Handle the case where normalized_shape is an int
+    if isinstance(normalized_shape, int):
+        normalized_shape = (normalized_shape,)
+
+    # Create weight (ones)
+    weight = torch.ones(normalized_shape, dtype=x.dtype, device=x.device)
+
+    # Call the existing rms_norm implementation and copy result back
+    result = rms_norm_impl(x, normalized_shape, weight, eps)
+    x.copy_(result)
+    return x

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -285,6 +285,7 @@ from flag_gems.ops.replication_pad3d import replication_pad3d
 from flag_gems.ops.resolve_conj import resolve_conj
 from flag_gems.ops.resolve_neg import resolve_neg
 from flag_gems.ops.rms_norm import rms_norm, rms_norm_backward, rms_norm_forward
+from flag_gems.ops.RMSNorm import RMSNorm, RMSNorm_
 from flag_gems.ops.roll import roll
 from flag_gems.ops.round import round, round_, round_out
 from flag_gems.ops.rrelu_with_noise_backward import rrelu_with_noise_backward
@@ -371,6 +372,8 @@ from flag_gems.ops.zeros import zero_, zeros
 from flag_gems.ops.zeros_like import zeros_like
 
 __all__ = [
+    "RMSNorm",
+    "RMSNorm_",
     "_assert_async",
     "_conv_depthwise2d",
     "_functional_sym_constrain_range_for_size",

--- a/tests/test_RMSNorm.py
+++ b/tests/test_RMSNorm.py
@@ -1,0 +1,70 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.RMSNorm
+@pytest.mark.parametrize("shape", REDUCTION_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_RMSNorm(shape, dtype):
+    """Test RMSNorm with simple interface (no explicit weight)."""
+    # RMSNorm normalizes over the last dimension
+    N = shape[1]
+
+    np.random.seed(0)
+    np_inp = np.random.uniform(-0.1, 0.1, shape[:2]).astype(np.float32)
+    np_grad = np.random.uniform(-0.01, 0.01, shape[:2]).astype(np.float32)
+
+    inp = torch.tensor(np_inp, dtype=dtype, device=flag_gems.device, requires_grad=True)
+    eps = 1e-5
+
+    ref_inp = to_reference(inp)
+
+    # Reference implementation using torch.nn.RMSNorm
+    rms_norm_module = torch.nn.RMSNorm(N, eps=eps, elementwise_affine=False)
+    ref_out = rms_norm_module(ref_inp)
+
+    # Test with flag_gems - signature: RMSNorm(input, normalized_shape, weight=None, eps=1e-5)
+    with flag_gems.use_gems():
+        res_out = flag_gems.RMSNorm(inp, (N,), None, eps)
+
+    # Test gradients
+    res_grad = torch.tensor(
+        np_grad, dtype=dtype, device=flag_gems.device, requires_grad=True
+    )
+    ref_grad = to_reference(res_grad)
+
+    res_gradients = torch.autograd.grad(res_out, inp, res_grad)
+    ref_gradients = torch.autograd.grad(ref_out, ref_inp, ref_grad)
+
+    gems_assert_close(res_out, ref_out, dtype)
+    gems_assert_close(res_gradients[0], ref_gradients[0], dtype)
+
+
+@pytest.mark.RMSNorm_
+@pytest.mark.parametrize("shape", REDUCTION_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_RMSNorm_inplace(shape, dtype):
+    """Test in-place RMSNorm."""
+    N = shape[1]
+
+    np.random.seed(0)
+    np_inp = np.random.uniform(-0.1, 0.1, shape[:2]).astype(np.float32)
+
+    inp = torch.tensor(np_inp, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp.clone())
+
+    eps = 1e-5
+
+    # Reference: use nn.RMSNorm module then copy back
+    rms_norm_module = torch.nn.RMSNorm(N, eps=eps, elementwise_affine=False)
+    ref_out = rms_norm_module(ref_inp)
+
+    # Test in-place with flag_gems - signature: RMSNorm_(input, normalized_shape, eps=1e-5)
+    with flag_gems.use_gems():
+        res_out = flag_gems.RMSNorm_(inp, (N,), eps)
+
+    gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

New Feature

### Description

Add  operator, a Triton-based GPU kernel. Implementation mode: manual_kernel.

### Changes

- New: 
- Modified: 
- Modified: 
- New: 
- New: 
- Modified: 

### Performance

Average speedup vs torch baseline on NVIDIA GPU: **5.08x**