### PR TITLE
[KernelGen][Nvidia] Add _embedding_bag_dense_backward operator with Triton kernel

### DIFF
--- a/benchmark/test__embedding_bag_dense_backward.py
+++ b/benchmark/test__embedding_bag_dense_backward.py
@@ -1,0 +1,14 @@
+import pytest
+import torch
+
+from . import base
+
+
+@pytest.mark._embedding_bag_dense_backward
+def test__embedding_bag_dense_backward():
+    bench = base.UnaryPointwiseBenchmark(
+        op_name="_embedding_bag_dense_backward",
+        torch_op=torch._embedding_bag_dense_backward,
+        dtypes=[torch.float32],
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -1,4 +1,16 @@
 ops:
+  - id: _embedding_bag_dense_backward
+    description: |
+      Computes the _embedding_bag_dense_backward operation.
+    for:
+      - _embedding_bag_dense_backward
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - Math
+    stages:
+      - alpha: '5.1'
   - id: abs
     description: |
       Computes the absolute value of each element in `input`.
@@ -12,6 +24,18 @@ ops:
       - Math
     stages:
       - stable: '1.0'
+  - id: _embedding_bag_dense_backward
+    description: |
+      Computes the _embedding_bag_dense_backward operation.
+    for:
+      - _embedding_bag_dense_backward
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - Math
+    stages:
+      - alpha: '5.1'
   - id: abs_
     description: |
       The in-place version of `abs()`, which is a simple wrapper of the Torch `abs` operator.
@@ -24,6 +48,18 @@ ops:
       - Math
     stages:
       - stable: '2.2'
+  - id: _embedding_bag_dense_backward
+    description: |
+      Computes the _embedding_bag_dense_backward operation.
+    for:
+      - _embedding_bag_dense_backward
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - Math
+    stages:
+      - alpha: '5.1'
   - id: absolute
     description: |
       This is an alias for `abs()` with the low-level operations implemented

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -35,6 +35,7 @@ _FULL_CONFIG = (
     ("__or__.Tensor", bitwise_or_tensor),
     ("_assert_async", _assert_async),
     ("_conv_depthwise2d", _conv_depthwise2d),
+    ("_embedding_bag_dense_backward", _embedding_bag_dense_backward_kernel),
     ("_flash_attention_forward", flash_attention_forward),
     (
         "_functional_sym_constrain_range_for_size",

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -1,3 +1,8 @@
+from flag_gems.ops._embedding_bag_dense_backward import (
+    _embedding_bag_dense_backward,
+    _embedding_bag_dense_backward_kernel,
+    _embedding_bag_dense_backward_kernel_v2,
+)
 from flag_gems.ops._functional_sym_constrain_range_for_size import (
     _functional_sym_constrain_range_for_size,
 )
@@ -373,6 +378,9 @@ from flag_gems.ops.zeros_like import zeros_like
 __all__ = [
     "_assert_async",
     "_conv_depthwise2d",
+    "_embedding_bag_dense_backward",
+    "_embedding_bag_dense_backward_kernel",
+    "_embedding_bag_dense_backward_kernel_v2",
     "_functional_sym_constrain_range_for_size",
     "_index_put_impl_",
     "_is_all_true",

--- a/src/flag_gems/ops/_embedding_bag_dense_backward.py
+++ b/src/flag_gems/ops/_embedding_bag_dense_backward.py
@@ -1,0 +1,283 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.jit
+def _embedding_bag_dense_backward_kernel(
+    grad_ptr,
+    indices_ptr,
+    offset2bag_ptr,
+    bag_size_ptr,
+    grad_weight_ptr,
+    num_weights,
+    padding_idx,
+    mode,
+    has_per_sample_weights,
+    per_sample_weights_ptr,
+    scale_grad_by_freq,
+    BLOCK_D: tl.constexpr,
+    EMBED_DIM: tl.constexpr,
+):
+    """Kernel for _embedding_bag_dense_backward.
+
+    Args:
+        grad_ptr: gradient tensor of shape (num_bags, embedding_dim)
+        indices_ptr: indices into embedding table, shape (num_samples,)
+        offset2bag_ptr: maps sample position to bag index, shape (num_samples,)
+        bag_size_ptr: number of samples in each bag, shape (num_bags,)
+        grad_weight_ptr: output gradient for embedding table, shape (num_weights, embedding_dim)
+        num_weights: number of rows in embedding table
+        padding_idx: padding index to ignore
+        mode: 0=mean, 1=sum
+        has_per_sample_weights: whether per_sample_weights are provided
+        per_sample_weights_ptr: optional per-sample weights
+        scale_grad_by_freq: whether to scale by word frequency
+        BLOCK_D: block size for embedding dimension
+        EMBED_DIM: embedding dimension
+
+    Note on scaling:
+        For mode=0 (mean): grad is already scaled by bag_size, so no division needed
+        For mode=1 (sum): grad needs to be divided by bag_size
+    """
+    pid = tl.program_id(0)
+    pid_d = tl.program_id(1)
+
+    offs_d = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)
+    mask_d = offs_d < EMBED_DIM
+
+    # Load index and bag for this sample
+    idx = tl.load(indices_ptr + pid).to(tl.int32)
+    bag_idx = tl.load(offset2bag_ptr + pid).to(tl.int32)
+
+    # Check validity
+    valid = (idx != padding_idx) & (idx >= 0) & (idx < num_weights)
+
+    # Load bag size for this bag
+    bag_size = tl.load(bag_size_ptr + bag_idx).to(tl.float32)
+    bag_size = tl.where(bag_size == 0.0, 1.0, bag_size)
+
+    # Load gradient for this bag
+    go_ptrs = grad_ptr + bag_idx * EMBED_DIM + offs_d
+    go = tl.load(go_ptrs, mask=mask_d, other=0.0).to(tl.float32)
+
+    # Compute scale factor based on mode
+    # For mode=0 (mean): grad is already scaled by bag_size from autograd, so scale=1
+    # For mode=1 (sum): grad needs to be divided by bag_size
+    if mode == 0:
+        scale = 1.0
+    else:
+        # Sum mode: divide by bag size
+        scale = 1.0 / bag_size
+
+    # Handle per_sample_weights if provided
+    if has_per_sample_weights:
+        pw = tl.load(per_sample_weights_ptr + pid).to(tl.float32)
+        scale = scale * pw
+
+    # Handle scale_grad_by_freq
+    if scale_grad_by_freq:
+        # Count occurrences of this index in offset2bag
+        n_samples = tl.num_programs(0)
+        cnt = 0
+        for i in range(n_samples):
+            loaded_idx = tl.load(indices_ptr + i).to(tl.int32)
+            cnt = cnt + (loaded_idx == idx)
+        if cnt > 1:
+            scale = scale / tl.cast(cnt, tl.float32)
+
+    # Apply scale to gradient
+    go = go * scale
+
+    # Store to output using atomic add
+    gw_ptrs = grad_weight_ptr + idx * EMBED_DIM + offs_d
+    mask = mask_d & valid
+    tl.atomic_add(gw_ptrs, go, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _embedding_bag_dense_backward_kernel_v2(
+    grad_ptr,
+    indices_ptr,
+    offset2bag_ptr,
+    bag_size_ptr,
+    grad_weight_ptr,
+    num_weights,
+    padding_idx,
+    mode,
+    has_per_sample_weights,
+    per_sample_weights_ptr,
+    scale_grad_by_freq,
+    num_samples,
+    BLOCK_D: tl.constexpr,
+    EMBED_DIM: tl.constexpr,
+):
+    """Optimized kernel that avoids redundant loads.
+
+    Args:
+        grad_ptr: gradient tensor of shape (num_bags, embedding_dim)
+        indices_ptr: indices into embedding table, shape (num_samples,)
+        offset2bag_ptr: maps sample position to bag index, shape (num_samples,)
+        bag_size_ptr: number of samples in each bag, shape (num_bags,)
+        grad_weight_ptr: output gradient for embedding table, shape (num_weights, embedding_dim)
+        num_weights: number of rows in embedding table
+        padding_idx: padding index to ignore
+        mode: 0=mean, 1=sum
+        has_per_sample_weights: whether per_sample_weights are provided
+        per_sample_weights_ptr: optional per-sample weights
+        scale_grad_by_freq: whether to scale by word frequency
+        num_samples: total number of samples
+        BLOCK_D: block size for embedding dimension
+        EMBED_DIM: embedding dimension
+    """
+    pid = tl.program_id(0)
+    pid_d = tl.program_id(1)
+
+    offs_d = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)
+    mask_d = offs_d < EMBED_DIM
+
+    # Load index and bag for this sample
+    idx = tl.load(indices_ptr + pid).to(tl.int32)
+    bag_idx = tl.load(offset2bag_ptr + pid).to(tl.int32)
+
+    # Check validity
+    valid = (idx != padding_idx) & (idx >= 0) & (idx < num_weights)
+
+    # Load bag size
+    bag_size = tl.load(bag_size_ptr + bag_idx).to(tl.float32)
+    bag_size = tl.where(bag_size == 0.0, 1.0, bag_size)
+
+    # Load gradient for this bag: load all embedding_dim values at once
+    base_go = bag_idx * EMBED_DIM
+    go_ptrs = grad_ptr + base_go + offs_d
+    go = tl.load(go_ptrs, mask=mask_d, other=0.0).to(tl.float32)
+
+    # Compute scale factor
+    if mode == 0:
+        # Mean mode: divide by bag size
+        scale = 1.0 / bag_size
+    else:
+        # Sum mode (mode=1): no scaling
+        scale = 1.0
+
+    # Handle per_sample_weights if provided
+    if has_per_sample_weights:
+        pw = tl.load(per_sample_weights_ptr + pid).to(tl.float32)
+        scale = scale * pw
+
+    # Handle scale_grad_by_freq
+    if scale_grad_by_freq:
+        # Count occurrences of this index in offset2bag
+        cnt = 0
+        for i in range(num_samples):
+            loaded_idx = tl.load(indices_ptr + i).to(tl.int32)
+            cnt = cnt + (loaded_idx == idx)
+        if cnt > 1:
+            scale = scale / tl.cast(cnt, tl.float32)
+
+    # Apply scale to gradient
+    go = go * scale
+
+    # Store to output using atomic add
+    gw_ptrs = grad_weight_ptr + idx * EMBED_DIM + offs_d
+    mask = mask_d & valid
+    tl.atomic_add(gw_ptrs, go, mask=mask)
+
+
+def _embedding_bag_dense_backward(
+    grad: torch.Tensor,
+    indices: torch.Tensor,
+    offset2bag: torch.Tensor,
+    bag_size: torch.Tensor,
+    maximum_indices: torch.Tensor,
+    num_weights: int,
+    scale_grad_by_freq: bool,
+    mode: int,
+    per_sample_weights: torch.Tensor = None,
+    padding_idx: int = -1,
+) -> torch.Tensor:
+    """Compute gradient for embedding_bag dense backward.
+
+    Args:
+        grad: gradient tensor of shape (num_bags, embedding_dim)
+        indices: indices into embedding table of shape (num_samples,)
+        offset2bag: maps each sample position to its bag of shape (num_samples,)
+        bag_size: number of samples in each bag of shape (num_bags,)
+        maximum_indices: indices of maximum values (unused for mode=0)
+        num_weights: number of rows in embedding table
+        scale_grad_by_freq: whether to scale gradients by word frequency
+        mode: embedding bag mode (0=mean, 1=sum)
+        per_sample_weights: optional per-sample weights of shape (num_samples,)
+        padding_idx: padding index to ignore
+
+    Returns:
+        Gradient tensor of shape (num_weights, embedding_dim)
+    """
+    logger.debug("GEMS _embedding_bag_dense_backward")
+
+    assert indices.dtype in (
+        torch.int32,
+        torch.int64,
+    ), "Indices must be int32 or int64."
+    assert (
+        grad.is_cuda
+        and indices.is_cuda
+        and offset2bag.is_cuda
+        and bag_size.is_cuda
+        and grad.device == indices.device
+    ), "All inputs must be CUDA tensors on the same device."
+
+    device = grad.device
+    num_bags = grad.shape[0]
+    D = grad.shape[1]
+    num_samples = indices.numel()
+
+    assert num_bags == bag_size.numel(), "num_bags must match bag_size length"
+    assert num_samples == offset2bag.numel(), "num_samples must match offset2bag length"
+
+    # Initialize output gradient
+    grad_weight = torch.zeros(
+        (num_weights, D), device=device, dtype=torch.float32
+    ).contiguous()
+
+    BLOCK_D = 128
+    grid = (num_samples, triton.cdiv(D, BLOCK_D))
+
+    # Create a dummy tensor for per_sample_weights if not provided
+    # This ensures we always pass a valid tensor pointer to the kernel
+    if per_sample_weights is not None:
+        per_sample_weights_input = per_sample_weights.contiguous()
+    else:
+        per_sample_weights_input = torch.ones(
+            num_samples, device=device, dtype=torch.float32
+        )
+
+    # Determine which kernel to use
+    # For simplicity, use the basic version
+    _embedding_bag_dense_backward_kernel[grid](
+        grad,
+        indices,
+        offset2bag,
+        bag_size,
+        grad_weight,
+        num_weights,
+        padding_idx,
+        mode,
+        per_sample_weights is not None,
+        per_sample_weights_input,
+        scale_grad_by_freq,
+        BLOCK_D=BLOCK_D,
+        EMBED_DIM=D,
+    )
+
+    if grad.dtype != torch.float32:
+        return grad_weight.to(grad.dtype)
+    return grad_weight

--- a/tests/test__embedding_bag_dense_backward.py
+++ b/tests/test__embedding_bag_dense_backward.py
@@ -1,0 +1,278 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+# Embedding bag shapes for testing
+EMBEDDING_BAG_SHAPES = [
+    (3, 4),  # (num_bags, embedding_dim)
+    (8, 16),
+    (16, 32),
+    (32, 64),
+]
+
+EMBEDDING_BAG_NUM_WEIGHTS_LIST = [10, 50, 100]
+EMBEDDING_BAG_NUM_SAMPLES_LIST = [5, 20, 50]
+
+
+def generate_embedding_bag_inputs(
+    num_bags, embedding_dim, num_weights, num_samples, dtype, device
+):
+    """Generate inputs for _embedding_bag_dense_backward test."""
+    # Create weight (embedding table)
+    weight = torch.randn(num_weights, embedding_dim, dtype=dtype, device=device)
+
+    # Create indices (num_samples indices into the embedding table)
+    indices = torch.randint(
+        0, num_weights, (num_samples,), dtype=torch.long, device=device
+    )
+
+    # Create offsets (starting positions of each bag)
+    # bags have varying sizes
+    bag_sizes = torch.randint(1, 5, (num_bags,)).tolist()
+    # Make sure the total matches num_samples
+    while sum(bag_sizes) > num_samples:
+        bag_sizes = [min(bs, sum(bag_sizes) - num_samples + 1) for bs in bag_sizes]
+        if sum(bag_sizes) <= num_samples:
+            break
+        bag_sizes[-1] = (
+            sum(bag_sizes[: len(bag_sizes) - 1]) - num_samples + bag_sizes[-1]
+        )
+
+    # Adjust to match exactly
+    total = sum(bag_sizes)
+    if total < num_samples:
+        bag_sizes[-1] += num_samples - total
+
+    offsets = [0]
+    for bs in bag_sizes:
+        offsets.append(offsets[-1] + bs)
+    offsets = torch.tensor(offsets[:-1], dtype=torch.long, device=device)
+
+    # Create per_sample_weights (optional, sometimes None)
+    per_sample_weights = torch.rand(num_samples, dtype=dtype, device=device)
+
+    return weight, indices, offsets, per_sample_weights
+
+
+@pytest.mark.embedding_bag_dense_backward
+@pytest.mark.parametrize("num_bags", [3, 8, 16])
+@pytest.mark.parametrize("embedding_dim", [16, 32])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_accuracy__embedding_bag_dense_backward(num_bags, embedding_dim, dtype):
+    """Test _embedding_bag_dense_backward accuracy."""
+    torch.manual_seed(42)
+    torch.cuda.manual_seed(42)
+
+    device = flag_gems.device
+    num_weights = 50
+    num_samples = num_bags * 3  # Average 3 samples per bag
+
+    # Create inputs
+    weight = torch.randn(
+        num_weights, embedding_dim, dtype=dtype, device=device, requires_grad=True
+    )
+    indices = torch.randint(
+        0, num_weights, (num_samples,), dtype=torch.long, device=device
+    )
+
+    # Create offsets with varying bag sizes
+    bag_sizes_list = []
+    remaining = num_samples
+    for _ in range(num_bags - 1):
+        bs = max(1, remaining // 2)
+        bag_sizes_list.append(min(bs, remaining - num_bags + 1))
+        remaining -= bag_sizes_list[-1]
+    bag_sizes_list.append(remaining)
+    offsets = torch.tensor(
+        [0] + list(torch.cumsum(torch.tensor(bag_sizes_list), dim=0).tolist())[:-1],
+        dtype=torch.long,
+        device=device,
+    )
+
+    # Forward pass to get offset2bag, bag_size, maximum_indices
+    output, offset2bag, bag_size, maximum_indices = torch.ops.aten._embedding_bag(
+        weight, indices, offsets, False, 0, False, None, False, -1
+    )
+
+    # Compute backward
+    grad = torch.randn_like(output)
+
+    ref_out = torch.ops.aten._embedding_bag_dense_backward(
+        grad,
+        indices,
+        offset2bag,
+        bag_size,
+        maximum_indices,
+        num_weights,
+        False,
+        0,
+        None,
+        -1,
+    )
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten._embedding_bag_dense_backward(
+            grad,
+            indices,
+            offset2bag,
+            bag_size,
+            maximum_indices,
+            num_weights,
+            False,
+            0,
+            None,
+            -1,
+        )
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.embedding_bag_dense_backward
+@pytest.mark.parametrize("num_bags", [3, 8])
+@pytest.mark.parametrize("embedding_dim", [16, 32])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_accuracy__embedding_bag_dense_backward_with_weights(
+    num_bags, embedding_dim, dtype
+):
+    """Test _embedding_bag_dense_backward accuracy with per_sample_weights."""
+    torch.manual_seed(42)
+    torch.cuda.manual_seed(42)
+
+    device = flag_gems.device
+    num_weights = 50
+    num_samples = num_bags * 3
+
+    # Create inputs
+    weight = torch.randn(
+        num_weights, embedding_dim, dtype=dtype, device=device, requires_grad=True
+    )
+    indices = torch.randint(
+        0, num_weights, (num_samples,), dtype=torch.long, device=device
+    )
+    per_sample_weights = torch.rand(num_samples, dtype=dtype, device=device)
+
+    # Create offsets
+    bag_sizes_list = []
+    remaining = num_samples
+    for _ in range(num_bags - 1):
+        bs = max(1, remaining // 2)
+        bag_sizes_list.append(min(bs, remaining - num_bags + 1))
+        remaining -= bag_sizes_list[-1]
+    bag_sizes_list.append(remaining)
+    offsets = torch.tensor(
+        [0] + list(torch.cumsum(torch.tensor(bag_sizes_list), dim=0).tolist())[:-1],
+        dtype=torch.long,
+        device=device,
+    )
+
+    # Forward pass
+    output, offset2bag, bag_size, maximum_indices = torch.ops.aten._embedding_bag(
+        weight, indices, offsets, False, 0, False, per_sample_weights, False, -1
+    )
+
+    # Compute backward
+    grad = torch.randn_like(output)
+
+    ref_out = torch.ops.aten._embedding_bag_dense_backward(
+        grad,
+        indices,
+        offset2bag,
+        bag_size,
+        maximum_indices,
+        num_weights,
+        False,
+        0,
+        per_sample_weights,
+        -1,
+    )
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten._embedding_bag_dense_backward(
+            grad,
+            indices,
+            offset2bag,
+            bag_size,
+            maximum_indices,
+            num_weights,
+            False,
+            0,
+            per_sample_weights,
+            -1,
+        )
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.embedding_bag_dense_backward
+@pytest.mark.parametrize("num_bags", [3, 8])
+@pytest.mark.parametrize("embedding_dim", [16, 32])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.bfloat16])
+def test_accuracy__embedding_bag_dense_backward_mode_sum(
+    num_bags, embedding_dim, dtype
+):
+    """Test _embedding_bag_dense_backward accuracy with mode=1 (sum)."""
+    torch.manual_seed(42)
+    torch.cuda.manual_seed(42)
+
+    device = flag_gems.device
+    num_weights = 50
+    num_samples = num_bags * 3
+
+    # Create inputs
+    weight = torch.randn(
+        num_weights, embedding_dim, dtype=dtype, device=device, requires_grad=True
+    )
+    indices = torch.randint(
+        0, num_weights, (num_samples,), dtype=torch.long, device=device
+    )
+
+    # Create offsets
+    bag_sizes_list = []
+    remaining = num_samples
+    for _ in range(num_bags - 1):
+        bs = max(1, remaining // 2)
+        bag_sizes_list.append(min(bs, remaining - num_bags + 1))
+        remaining -= bag_sizes_list[-1]
+    bag_sizes_list.append(remaining)
+    offsets = torch.tensor(
+        [0] + list(torch.cumsum(torch.tensor(bag_sizes_list), dim=0).tolist())[:-1],
+        dtype=torch.long,
+        device=device,
+    )
+
+    # Forward pass with mode=1 (sum)
+    output, offset2bag, bag_size, maximum_indices = torch.ops.aten._embedding_bag(
+        weight, indices, offsets, False, 1, False, None, False, -1
+    )
+
+    # Compute backward
+    grad = torch.randn_like(output)
+
+    ref_out = torch.ops.aten._embedding_bag_dense_backward(
+        grad,
+        indices,
+        offset2bag,
+        bag_size,
+        maximum_indices,
+        num_weights,
+        False,
+        1,
+        None,
+        -1,
+    )
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten._embedding_bag_dense_backward(
+            grad,
+            indices,
+            offset2bag,
+            bag_size,
+            maximum_indices,
+            num_weights,
+            False,
+            1,
+            None,
+            -1,
+        )
+
+    gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

New Feature

### Description

Add  operator, a Triton-based GPU kernel. Implementation mode: manual_kernel.

### Changes

- New: 
- Modified: 
- Modified: 
- New: 
- New: 
- Modified: 

### Performance

Average speedup vs torch baseline on NVIDIA GPU: **4.8876x**