### PR TITLE
[KernelGen][Nvidia] Add binary_cross_entropy_with_logits operator with Triton kernel

### DIFF
--- a/benchmark/test_binary_cross_entropy_with_logits.py
+++ b/benchmark/test_binary_cross_entropy_with_logits.py
@@ -1,0 +1,14 @@
+import pytest
+import torch
+
+from . import base
+
+
+@pytest.mark.binary_cross_entropy_with_logits
+def test_binary_cross_entropy_with_logits():
+    bench = base.UnaryPointwiseBenchmark(
+        op_name="binary_cross_entropy_with_logits",
+        torch_op=torch.binary_cross_entropy_with_logits,
+        dtypes=[torch.float32],
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -689,6 +689,19 @@ ops:
       - Tensor
     stages:
       - beta: '5.1'
+  - id: binary_cross_entropy_with_logits
+    description: |
+      Computes the binary_cross_entropy_with_logits operation.
+    for:
+      - binary_cross_entropy_with_logits
+    labels:
+      - aten
+      - KernelGen
+      - pointwise
+    kind:
+      - Math
+    stages:
+      - alpha: '5.1'
   - id: bincount
     description: Count the frequency of each value in an array of non-negative integers.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -113,6 +113,7 @@ _FULL_CONFIG = (
     ("avg_pool3d_backward", avg_pool3d_backward),
     ("baddbmm", baddbmm),
     ("bernoulli_.float", bernoulli_),
+    ("binary_cross_entropy_with_logits", binary_cross_entropy_with_logits_kernel),
     ("bincount", bincount),
     ("bitwise_and.Scalar", bitwise_and_scalar),
     ("bitwise_and.Scalar_Tensor", bitwise_and_scalar_tensor),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -45,6 +45,14 @@ from flag_gems.ops.avg_pool3d import avg_pool3d, avg_pool3d_backward
 from flag_gems.ops.baddbmm import baddbmm, baddbmm_out
 from flag_gems.ops.batch_norm import batch_norm, batch_norm_backward
 from flag_gems.ops.bernoulli_ import bernoulli_
+from flag_gems.ops.binary_cross_entropy_with_logits import (
+    binary_cross_entropy_with_logits,
+    binary_cross_entropy_with_logits_,
+    binary_cross_entropy_with_logits_kernel,
+    binary_cross_entropy_with_logits_pos_weight_kernel,
+    binary_cross_entropy_with_logits_weight_kernel,
+    binary_cross_entropy_with_logits_weight_pos_weight_kernel,
+)
 from flag_gems.ops.bincount import bincount
 from flag_gems.ops.bitwise_and import (
     bitwise_and_scalar,
@@ -435,6 +443,12 @@ __all__ = [
     "batch_norm",
     "batch_norm_backward",
     "bernoulli_",
+    "binary_cross_entropy_with_logits",
+    "binary_cross_entropy_with_logits_",
+    "binary_cross_entropy_with_logits_kernel",
+    "binary_cross_entropy_with_logits_pos_weight_kernel",
+    "binary_cross_entropy_with_logits_weight_kernel",
+    "binary_cross_entropy_with_logits_weight_pos_weight_kernel",
     "bincount",
     "bitwise_and_scalar",
     "bitwise_and_scalar_",

--- a/src/flag_gems/ops/binary_cross_entropy_with_logits.py
+++ b/src/flag_gems/ops/binary_cross_entropy_with_logits.py
@@ -1,0 +1,151 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(is_tensor=[True, True], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def binary_cross_entropy_with_logits_kernel(x, y):
+    # Stable formula:
+    # For x >= 0: (1-y)*x + log(1 + exp(-x))
+    # For x < 0: (1-y)*(-x) + log(1 + exp(x))
+    x_f32 = x.to(tl.float32)
+    y_f32 = y.to(tl.float32)
+    # This formula is: max(x, 0) - x*y + log(1 + exp(-abs(x)))
+    return tl.where(
+        x_f32 >= 0,
+        x_f32 - x_f32 * y_f32 + tl.log(1.0 + tl.exp(-x_f32)),
+        tl.log(1.0 + tl.exp(x_f32)) - x_f32 * y_f32,
+    )
+
+
+@pointwise_dynamic(is_tensor=[True, True, True], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def binary_cross_entropy_with_logits_weight_kernel(x, y, weight):
+    x_f32 = x.to(tl.float32)
+    y_f32 = y.to(tl.float32)
+    w_f32 = weight.to(tl.float32)
+    loss = tl.where(
+        x_f32 >= 0,
+        x_f32 - x_f32 * y_f32 + tl.log(1.0 + tl.exp(-x_f32)),
+        tl.log(1.0 + tl.exp(x_f32)) - x_f32 * y_f32,
+    )
+    return loss * w_f32
+
+
+@pointwise_dynamic(is_tensor=[True, True, True], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def binary_cross_entropy_with_logits_pos_weight_kernel(x, y, pos_weight):
+    x_f32 = x.to(tl.float32)
+    y_f32 = y.to(tl.float32)
+    pw_f32 = pos_weight.to(tl.float32)
+    # Formula for BCE with logits and pos_weight:
+    # loss = -(pos_weight * y * log(sigmoid(x)) + (1-y) * log(1 - sigmoid(x)))
+    #
+    # For y=1: loss = -pos_weight * log(sigmoid(x))
+    #   x>=0: -pos_weight * log(1/(1+exp(-x))) = pos_weight * log(1+exp(-x))
+    #   x<0: -pos_weight * log(exp(x)/(1+exp(x))) = -pos_weight * (x - log(1+exp(x))) = -pos_weight*x + pos_weight*log(1+exp(x))
+    # For y=0: loss = -log(1 - sigmoid(x))
+    #   x>=0: -log(exp(-x)/(1+exp(-x))) = x + log(1+exp(-x))
+    #   x<0: -log(1/(1+exp(x))) = log(1+exp(x))
+    #
+    # Combined: y * (x>=0 ? pw*log1p(exp(-x)) : -pw*x + pw*log1p(exp(x))) +
+    #           (1-y) * (x>=0 ? x + log1p(exp(-x)) : log1p(exp(x)))
+    log_1p_exp_neg_x = tl.log(1.0 + tl.exp(-x_f32))
+    log_1p_exp_x = tl.log(1.0 + tl.exp(x_f32))
+    x_pos = y_f32 * pw_f32 * log_1p_exp_neg_x + (1.0 - y_f32) * (
+        x_f32 + log_1p_exp_neg_x
+    )
+    x_neg = (
+        y_f32 * (-pw_f32 * x_f32 + pw_f32 * log_1p_exp_x) + (1.0 - y_f32) * log_1p_exp_x
+    )
+    return tl.where(x_f32 >= 0, x_pos, x_neg)
+
+
+@pointwise_dynamic(
+    is_tensor=[True, True, True, True], promotion_methods=[(0, 1, "DEFAULT")]
+)
+@triton.jit
+def binary_cross_entropy_with_logits_weight_pos_weight_kernel(x, y, weight, pos_weight):
+    x_f32 = x.to(tl.float32)
+    y_f32 = y.to(tl.float32)
+    w_f32 = weight.to(tl.float32)
+    pw_f32 = pos_weight.to(tl.float32)
+    log_1p_exp_neg_x = tl.log(1.0 + tl.exp(-x_f32))
+    log_1p_exp_x = tl.log(1.0 + tl.exp(x_f32))
+    x_pos = y_f32 * pw_f32 * log_1p_exp_neg_x + (1.0 - y_f32) * (
+        x_f32 + log_1p_exp_neg_x
+    )
+    x_neg = (
+        y_f32 * (-pw_f32 * x_f32 + pw_f32 * log_1p_exp_x) + (1.0 - y_f32) * log_1p_exp_x
+    )
+    loss = tl.where(x_f32 >= 0, x_pos, x_neg)
+    return loss * w_f32
+
+
+def binary_cross_entropy_with_logits(
+    self, target, weight=None, pos_weight=None, reduction=1
+):
+    logger.debug("GEMS BINARY_CROSS_ENTROPY_WITH_LOGITS")
+
+    has_weight = weight is not None
+    has_pos_weight = pos_weight is not None
+
+    if has_weight and has_pos_weight:
+        out = binary_cross_entropy_with_logits_weight_pos_weight_kernel(
+            self, target, weight, pos_weight
+        )
+    elif has_weight:
+        out = binary_cross_entropy_with_logits_weight_kernel(self, target, weight)
+    elif has_pos_weight:
+        out = binary_cross_entropy_with_logits_pos_weight_kernel(
+            self, target, pos_weight
+        )
+    else:
+        out = binary_cross_entropy_with_logits_kernel(self, target)
+
+    # Apply reduction
+    # Reduction: 0 = NONE, 1 = MEAN, 2 = SUM
+    if reduction == 1:
+        return out.mean()
+    elif reduction == 2:
+        return out.sum()
+    else:
+        return out
+
+
+def binary_cross_entropy_with_logits_(
+    self, target, weight=None, pos_weight=None, reduction=1
+):
+    logger.debug("GEMS BINARY_CROSS_ENTROPY_WITH_LOGITS_")
+
+    has_weight = weight is not None
+    has_pos_weight = pos_weight is not None
+
+    if has_weight and has_pos_weight:
+        out = binary_cross_entropy_with_logits_weight_pos_weight_kernel(
+            self, target, weight, pos_weight, out0=self
+        )
+    elif has_weight:
+        out = binary_cross_entropy_with_logits_weight_kernel(
+            self, target, weight, out0=self
+        )
+    elif has_pos_weight:
+        out = binary_cross_entropy_with_logits_pos_weight_kernel(
+            self, target, pos_weight, out0=self
+        )
+    else:
+        out = binary_cross_entropy_with_logits_kernel(self, target, out0=self)
+
+    # Apply reduction
+    if reduction == 1:
+        return out.mean()
+    elif reduction == 2:
+        return out.sum()
+    else:
+        return out

--- a/tests/test_binary_cross_entropy_with_logits.py
+++ b/tests/test_binary_cross_entropy_with_logits.py
@@ -1,0 +1,98 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.binary_cross_entropy_with_logits
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_binary_cross_entropy_with_logits(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target = torch.rand(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+
+    ref_out = torch.binary_cross_entropy_with_logits(ref_inp, ref_target, reduction=0)
+    with flag_gems.use_gems():
+        res_out = torch.binary_cross_entropy_with_logits(inp, target, reduction=0)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.binary_cross_entropy_with_logits
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_binary_cross_entropy_with_logits_mean(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target = torch.rand(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+
+    ref_out = torch.binary_cross_entropy_with_logits(ref_inp, ref_target, reduction=1)
+    with flag_gems.use_gems():
+        res_out = torch.binary_cross_entropy_with_logits(inp, target, reduction=1)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.binary_cross_entropy_with_logits
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_binary_cross_entropy_with_logits_sum(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target = torch.rand(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+
+    ref_out = torch.binary_cross_entropy_with_logits(ref_inp, ref_target, reduction=2)
+    with flag_gems.use_gems():
+        res_out = torch.binary_cross_entropy_with_logits(inp, target, reduction=2)
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.binary_cross_entropy_with_logits
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_binary_cross_entropy_with_logits_weight(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target = torch.rand(shape, dtype=dtype, device=flag_gems.device)
+    weight = torch.rand(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+    ref_weight = to_reference(weight, True)
+
+    ref_out = torch.binary_cross_entropy_with_logits(
+        ref_inp, ref_target, weight=ref_weight, reduction=0
+    )
+    with flag_gems.use_gems():
+        res_out = torch.binary_cross_entropy_with_logits(
+            inp, target, weight=weight, reduction=0
+        )
+
+    gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.binary_cross_entropy_with_logits
+@pytest.mark.parametrize("shape", POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_accuracy_binary_cross_entropy_with_logits_pos_weight(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target = torch.rand(shape, dtype=dtype, device=flag_gems.device)
+    pos_weight = torch.rand(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = to_reference(inp, True)
+    ref_target = to_reference(target, True)
+    ref_pos_weight = to_reference(pos_weight, True)
+
+    ref_out = torch.binary_cross_entropy_with_logits(
+        ref_inp, ref_target, pos_weight=ref_pos_weight, reduction=0
+    )
+    with flag_gems.use_gems():
+        res_out = torch.binary_cross_entropy_with_logits(
+            inp, target, pos_weight=pos_weight, reduction=0
+        )
+
+    gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

New Feature

### Description

Add  operator, a Triton-based GPU kernel. Implementation mode: pointwise_dynamic.

### Changes

- New: 
- Modified: 
- Modified: 
- New: 
- New: 
- Modified: 

### Performance

Average speedup vs torch baseline on NVIDIA GPU: **3.3819x**