### PR TITLE
Improve bitwise_and test coverage

### DIFF
--- a/benchmark/test_bitwise_and.py
+++ b/benchmark/test_bitwise_and.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from . import base, consts
+from . import base, consts, utils
 
 
 @pytest.mark.bitwise_and_tensor
@@ -21,5 +21,59 @@ def test_bitwise_and_inplace():
         torch_op=lambda a, b: a.bitwise_and_(b),
         dtypes=consts.INT_DTYPES + consts.BOOL_DTYPES,
         is_inplace=True,
+    )
+    bench.run()
+
+
+def _scalar_input_fn(shape, dtype, device):
+    inp = utils.generate_tensor_input(shape, dtype, device)
+    yield inp, 0x3F
+
+
+@pytest.mark.bitwise_and_scalar
+def test_bitwise_and_scalar():
+    bench = base.GenericBenchmark(
+        input_fn=_scalar_input_fn,
+        op_name="bitwise_and_scalar",
+        torch_op=torch.bitwise_and,
+        dtypes=consts.INT_DTYPES + consts.BOOL_DTYPES,
+    )
+    bench.run()
+
+
+def bitwise_and_scalar_input_fn(shape, cur_dtype, device):
+    inp1 = base.generate_tensor_input(shape, cur_dtype, device)
+    if cur_dtype == torch.bool:
+        inp2 = True
+    else:
+        inp2 = 0x00FF
+    yield inp1, inp2
+
+
+@pytest.mark.bitwise_and_scalar_
+def test_bitwise_and_scalar_():
+    bench = base.GenericBenchmark(
+        op_name="bitwise_and_scalar_",
+        torch_op=lambda a, b: a.bitwise_and_(b),
+        dtypes=consts.INT_DTYPES + consts.BOOL_DTYPES,
+        input_fn=bitwise_and_scalar_input_fn,
+        is_inplace=True,
+    )
+    bench.run()
+
+
+def scalar_tensor_input_fn(shape, cur_dtype, device):
+    scalar = 0x96 if cur_dtype != torch.bool else True
+    inp = base.generate_tensor_input(shape, cur_dtype, device)
+    yield scalar, inp
+
+
+@pytest.mark.bitwise_and_scalar_tensor
+def test_bitwise_and_scalar_tensor():
+    bench = base.GenericBenchmark(
+        op_name="bitwise_and_scalar_tensor",
+        torch_op=torch.bitwise_and,
+        input_fn=scalar_tensor_input_fn,
+        dtypes=consts.INT_DTYPES + consts.BOOL_DTYPES,
     )
     bench.run()


### PR DESCRIPTION
This PR consolidates test coverage improvements for bitwise_and operations.

**Merged PRs:**
- #3100: Add bitwise_and_scalar test
- #3101: Add bitwise_and_scalar_ test  
- #3102: Add bitwise_and_scalar_tensor test

**Changes:**
- Added 3 new benchmark tests for bitwise_and scalar variants
- Total: +55 lines in benchmark/test_bitwise_and.py