### PR TITLE
Improve bitwise_or test coverage

### DIFF
--- a/benchmark/test_bitwise_or.py
+++ b/benchmark/test_bitwise_or.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from . import base, consts
+from . import base, consts, utils
 
 
 @pytest.mark.bitwise_or_tensor
@@ -21,5 +21,56 @@ def test_bitwise_or_inplace():
         torch_op=lambda a, b: a.bitwise_or_(b),
         dtypes=consts.INT_DTYPES + consts.BOOL_DTYPES,
         is_inplace=True,
+    )
+    bench.run()
+
+
+def _scalar_input_fn(shape, dtype, device):
+    inp = utils.generate_tensor_input(shape, dtype, device)
+    scalar = True if dtype == torch.bool else 0x00FF
+    yield inp, scalar
+
+
+@pytest.mark.bitwise_or_scalar
+def test_bitwise_or_scalar():
+    bench = base.GenericBenchmark(
+        op_name="bitwise_or_scalar",
+        torch_op=torch.bitwise_or,
+        input_fn=_scalar_input_fn,
+        dtypes=consts.INT_DTYPES + consts.BOOL_DTYPES,
+    )
+    bench.run()
+
+
+def _scalar_input_fn_inplace(shape, dtype, device):
+    inp = utils.generate_tensor_input(shape, dtype, device)
+    yield inp, 0x5A
+
+
+@pytest.mark.bitwise_or_scalar_
+def test_bitwise_or_scalar_():
+    bench = base.GenericBenchmark(
+        input_fn=_scalar_input_fn_inplace,
+        op_name="bitwise_or_scalar_",
+        torch_op=torch.Tensor.bitwise_or_,
+        dtypes=consts.INT_DTYPES + consts.BOOL_DTYPES,
+        inplace=True,
+    )
+    bench.run()
+
+
+def scalar_tensor_input_fn(shape, cur_dtype, device):
+    scalar = 0x00FF if cur_dtype != torch.bool else True
+    tensor = utils.generate_tensor_input(shape, cur_dtype, device)
+    yield scalar, tensor
+
+
+@pytest.mark.bitwise_or_scalar_tensor
+def test_bitwise_or_scalar_tensor():
+    bench = base.GenericBenchmark(
+        op_name="bitwise_or_scalar_tensor",
+        torch_op=torch.bitwise_or,
+        dtypes=consts.INT_DTYPES + consts.BOOL_DTYPES,
+        input_fn=scalar_tensor_input_fn,
     )
     bench.run()

--- a/benchmark/test_bitwise_or.py
+++ b/benchmark/test_bitwise_or.py
@@ -52,9 +52,9 @@ def test_bitwise_or_scalar_():
     bench = base.GenericBenchmark(
         input_fn=_scalar_input_fn_inplace,
         op_name="bitwise_or_scalar_",
-        torch_op=torch.Tensor.bitwise_or_,
+        torch_op=lambda a, b: a.bitwise_or_(b),
         dtypes=consts.INT_DTYPES + consts.BOOL_DTYPES,
-        inplace=True,
+        is_inplace=True,
     )
     bench.run()
 

--- a/benchmark/test_bitwise_or.py
+++ b/benchmark/test_bitwise_or.py
@@ -44,7 +44,8 @@ def test_bitwise_or_scalar():
 
 def _scalar_input_fn_inplace(shape, dtype, device):
     inp = utils.generate_tensor_input(shape, dtype, device)
-    yield inp, 0x5A
+    scalar = True if dtype == torch.bool else 0x5A
+    yield inp, scalar
 
 
 @pytest.mark.bitwise_or_scalar_


### PR DESCRIPTION
This PR consolidates test coverage improvements for bitwise_or operations.

**Merged PRs:**
- #3103: Add bitwise_or_scalar test
- #3104: Add bitwise_or_scalar_ test  
- #3105: Add bitwise_or_scalar_tensor test

**Changes:**
- Added 3 new benchmark tests for bitwise_or scalar variants
- Total: +52 lines in benchmark/test_bitwise_or.py