### PR TITLE
Improve floor_divide test coverage

### DIFF
--- a/benchmark/test_floor_divide.py
+++ b/benchmark/test_floor_divide.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from . import base, consts
+from . import base, consts, utils
 
 
 @pytest.mark.floor_divide
@@ -21,5 +21,48 @@ def test_floor_divide_inplace():
         torch_op=lambda a, b: a.floor_divide_(b),
         dtypes=consts.INT_DTYPES,
         is_inplace=True,
+    )
+    bench.run()
+
+
+def _floor_divide_scalar_input_fn(shape, dtype, device):
+    inp = utils.generate_tensor_input(shape, dtype, device)
+    yield inp, 3
+
+
+@pytest.mark.floor_divide_scalar
+def test_floor_divide_scalar():
+    bench = base.GenericBenchmark(
+        op_name="floor_divide_scalar",
+        torch_op=torch.floor_divide,
+        input_fn=_floor_divide_scalar_input_fn,
+        dtypes=consts.INT_DTYPES,
+    )
+    bench.run()
+
+
+def _floor_divide_scalar_inplace_input_fn(shape, dtype, device):
+    inp = utils.generate_tensor_input(shape, dtype, device)
+    yield inp, 3
+
+
+@pytest.mark.floor_divide_scalar_
+def test_floor_divide_scalar_():
+    bench = base.GenericBenchmark(
+        op_name="floor_divide_scalar_",
+        torch_op=lambda a, b: a.floor_divide_(b),
+        input_fn=_floor_divide_scalar_inplace_input_fn,
+        dtypes=consts.INT_DTYPES,
+        is_inplace=True,
+    )
+    bench.run()
+
+
+@pytest.mark.floor_divide_tensor
+def test_floor_divide_tensor():
+    bench = base.BinaryPointwiseBenchmark(
+        op_name="floor_divide_tensor",
+        torch_op=torch.floor_divide,
+        dtypes=[torch.float32] + consts.INT_DTYPES,
     )
     bench.run()

--- a/tests/test_floor_divide.py
+++ b/tests/test_floor_divide.py
@@ -213,3 +213,35 @@ def test_floor_divide_scalar_scalar(dtype):
         utils.gems_assert_equal(res_out, ref_out)
     else:
         utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.floor_divide_scalar_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_floor_divide_scalar_inplace_float(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    scalar = 2.5
+    ref_inp = utils.to_reference(inp.clone(), False)
+
+    ref_out = ref_inp.floor_divide_(scalar)
+    with flag_gems.use_gems():
+        res_out = inp.floor_divide_(scalar)
+
+    utils.gems_assert_equal(res_out, ref_out, equal_nan=True)
+
+
+@pytest.mark.floor_divide_scalar_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.INT_DTYPES)
+def test_floor_divide_scalar_inplace_int(shape, dtype):
+    inp = torch.randint(
+        torch.iinfo(dtype).min, torch.iinfo(dtype).max, shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    scalar = 3
+    ref_inp = utils.to_reference(inp.clone(), False)
+
+    ref_out = ref_inp.floor_divide_(scalar)
+    with flag_gems.use_gems():
+        res_out = inp.floor_divide_(scalar)
+
+    utils.gems_assert_equal(res_out, ref_out)


### PR DESCRIPTION
Merge PRs:
- #3136: Add floor_divide scalar inplace tests
- #3137: Add floor_divide scalar benchmark tests  
- #3138: Add floor_divide tensor benchmark test

## Changes
- Add `test_floor_divide_scalar_inplace_float` and `test_floor_divide_scalar_inplace_int` in tests
- Add `test_floor_divide_scalar`, `test_floor_divide_scalar_`, and `test_floor_divide_tensor` in benchmark
- Use `utils.FLOAT_DTYPES` instead of hardcoded `[torch.float32]`