### PR TITLE
Fix import error and set device query command for spacemit

### DIFF
--- a/src/flag_gems/runtime/backend/_spacemit/__init__.py
+++ b/src/flag_gems/runtime/backend/_spacemit/__init__.py
@@ -13,9 +13,11 @@ if importlib.util.find_spec("triton.backends.spine_triton") is not None:
 
     triton.runtime.driver.set_active(CPUDriver())  # noqa: E402
 
-# TODO: Fix import error on other devices
+
 vendor_info = VendorInfoBase(
-    vendor_name="spacemit", device_name="cpu", device_query_cmd=""
+    vendor_name="spacemit",
+    device_name="cpu",
+    device_query_cmd="spacemit-tcm-smi",
 )
 
 


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Other

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
This pull request makes a minor update to the `src/flag_gems/runtime/backend/_spacemit/__init__.py` file, specifically updating the `device_query_cmd` parameter for the `VendorInfoBase` initialization.

- Updated the `device_query_cmd` in the `VendorInfoBase` initialization from an empty string to `"spacemit-tcm-smi"` to enable proper device querying for the "spacemit" CPU backend.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
