### PR TITLE
Tune pyproject setup

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [build-system]
 # cmake locks to '>=3.20,<4.0' to sync with FlagTree
 
-requires = ["setuptools>=64.0", "scikit-build-core==0.12.2", "pybind11==3.0.3", "cmake>=3.20,<4.0", "ninja==1.13.0"]
+requires = ["setuptools>=64.0,<80.0", "scikit-build-core==0.12.2", "pybind11==3.0.3", "cmake>=3.20,<4.0", "ninja==1.13.0"]
 
 build-backend = "scikit_build_core.build"
 
@@ -60,7 +60,7 @@ ascend = [
 enflame = [
     "torch==2.9.1+cpu",
     "torch-gcu==2.9.1+3.7.1",
-    "triton==3.3.1",
+    "triton==3.3.0",
     "triton-gcu==3.3.1+1.0.20260323",
     "flash-attn==2.7.2+torch.2.9.1.gcu.3.4.20260323",
 ]


### PR DESCRIPTION
### PR Category

Other

### Type of Change

Bug Fix

### Description

Fix pyproject requirement for `setuptools` so that it works on all backends.
This also fixes the Triton version requirement for enflame.