### PR TITLE
Split psummary tool into two tools for different purposes

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -107,7 +107,7 @@ jobs:
           source .venv/bin/activate
           source tools/set-env.sh ${VENDOR}
           tools/run_tests.py --ops ${{ needs.preprocess.outputs.op }} --gpus 2 --dump-output
-          tools/psummary --format markdown --single results > results.md
+          tools/psum_text --format markdown --single results > results.md
 
       - name: Upload results
         uses: actions/upload-artifact@v7

--- a/tools/psum_html
+++ b/tools/psum_html
@@ -1,0 +1,166 @@
+#!/usr/bin/env python
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).parent.parent
+DATA = {}
+DEBUG = False
+
+
+def load_data(data_path):
+    try:
+        with data_path.open("r") as f:
+            data = json.load(f)
+        return data, True
+    except Exception as ex:
+        print(f"Failed to load data: {ex}")
+    return {}, False
+
+
+def parse_lines():
+    data = DATA.get("result", {})
+    lines = []
+    for op, item in data.items():
+        fields = []
+        # print(f"{op} ....")
+        accu = item["accuracy"]["status"]
+        accud = "/".join(
+            [
+                str(item["accuracy"]["passed"]),
+                str(item["accuracy"]["failed"]),
+                str(item["accuracy"]["skipped"]),
+            ]
+        )
+        fields.extend([op, accu, accud])
+
+        perf_data = item["performance"]["data"]
+        perf_status = item["performance"]["status"]
+        if perf_status == "NotFound":
+            fields.append("NotFound")
+            fields.extend([""] * 8)
+
+        elif perf_status in ["Failed", "Skipped"]:
+            reason = item["performance"]["reason"]
+            reason = reason.split("\n")[0]
+            fields.append(perf_status)
+            fields.extend([""] * 7)
+            fields.append(f'"{reason}"')
+
+        else:
+            fields.append(perf_status)
+            for dtype in ["fp16", "fb32", "bf16", "cf64", "int16", "int32", "int64"]:
+                dobj = perf_data.get(dtype, {})
+                speedup = dobj.get("speedup", None)
+                if speedup:
+                    fields.append(f"{speedup:6.3f}")
+                else:
+                    fields.append("")
+
+        line = "</rd><td>".join(fields)
+        lines.append("<tr><td>" + line + "</td></tr>")
+
+    return sorted(lines)
+
+
+# TODO: delete this logic?
+def parse_env():
+    timestamp = DATA.get("timestamp", "?")
+    env = DATA.get("env", {})
+    arch = env.get("architecture", "?")
+    os = env.get("os_name") + " " + env.get("os_release")
+    pyver = env.get("python", "?")
+    torch_obj = env.get("torch", {})
+    torch_ver = torch_obj.get("version", "?")
+    flagtree_ver = env.get("flagtree", "?")
+    triton_ver = env.get("triton", {}).get("version", "?")
+    flaggems_ver = env.get("flag_gems", {}).get("version", "?")
+    flaggems_vendor = env.get("flag_gems", {}).get("vendor", "?")
+    flaggems_device = env.get("flag_gems", {}).get("device", "?")
+
+    lines = []
+    lines.append("<H3>Test Environment</H3>")
+    lines.append("<table><thead><tr><th>Env></th><th>Setting</th><tr></thead>")
+    lines.append("<tbody>")
+    lines.append(f"<tr><td>Time</td><td><tt>{timestamp}</tt></td></tr>")
+    lines.append(f"<tr><td>Architecture</td><td><tt>{arch}</tt></td></tr>")
+    lines.append(f"<tr><td>OS</td><td><tt>{os}</tt></td></tr>")
+    lines.append(f"<tr><td>Python</td><td><tt>{pyver}</tt></td></tr>")
+    lines.append(f"<tr><td>Torch</td><td><tt>{torch_ver}</tt></td></tr>")
+    lines.append(f"<tr><td>FlagTree</td><td><tt>{flagtree_ver}</tt></td></tr>")
+    lines.append(f"<tr><td>Triton</td><td><tt>{triton_ver}</tt></td></tr>")
+    lines.append(f"<tr><td>FlagGems</td><td><tt>{flaggems_ver}</tt></td></tr>")
+    lines.append(f"<tr><td>Vendor</td><td><tt>{flaggems_vendor}</tt></td></tr>")
+    lines.append(f"<tr><td>Device</td><td><tt>{flaggems_device}</tt></td></tr>")
+    lines.append("</tbody></table>")
+    lines.append("")
+
+    return lines
+
+
+def parse_data():
+    lines = parse_lines()
+    header_fields = [
+        "ID",
+        "AccRes",
+        "AccStat",
+        "PerfRes",
+        "FP16",
+        "FP32",
+        "BF16",
+        "CF64",
+        "I16",
+        "I32",
+        "I64",
+        "Note",
+    ]
+
+    header = ["<table>", "<thead>", "<tr>"]
+    for field in header_fields:
+        header.append(f"<th>{field}</th>")
+    header.extend(["</tr>", "</thead>", "<tbody>"])
+    lines = header + lines
+    lines.append("</tbody></table")
+
+    return lines
+
+
+def main():
+    global DATA
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("dir", default="result", help="the data directory to process")
+    parser.add_argument(
+        "-o", "--output", default="<stdout>", help="path to the output file."
+    )
+    parser.add_argument(
+        "-d",
+        "--debug",
+        action=argparse.BooleanOptionalAction,
+        help="flag for printing verbose information for debugging",
+    )
+
+    args = parser.parse_args()
+
+    data_path = Path(args.dir) / "summary.json"
+    DATA, res = load_data(data_path)
+    if not res:
+        return 1
+
+    lines = parse_data()
+
+    # never dump debug information to result file
+    if args.output == "<stdout>" or args.debug:
+        for ln in lines:
+            print(ln)
+    else:
+        with open(args.output, "w") as f:
+            f.writelines(lines)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/psum_text
+++ b/tools/psum_text
@@ -28,10 +28,6 @@ def format_record(fields, fmt):
         line = " | ".join(fields)
         return f"| {line} |"
 
-    if fmt == "html":
-        line = "</rd><td>".join(fields)
-        return "<tr><td>" + line + "</td></tr>"
-
     return ""
 
 
@@ -115,22 +111,6 @@ def parse_env(fmt):
         lines.append(f"| Vendor | `{flaggems_vendor}` |")
         lines.append(f"| Device | `{flaggems_device}` |")
         lines.append("")
-    elif fmt == "html":
-        lines.append("<H3>Test Environment</H3>")
-        lines.append("<table><thead><tr><th>Env></th><th>Setting</th><tr></thead>")
-        lines.append("<tbody>")
-        lines.append(f"<tr><td>Time</td><td><tt>{timestamp}</tt></td></tr>")
-        lines.append(f"<tr><td>Architecture</td><td><tt>{arch}</tt></td></tr>")
-        lines.append(f"<tr><td>OS</td><td><tt>{os}</tt></td></tr>")
-        lines.append(f"<tr><td>Python</td><td><tt>{pyver}</tt></td></tr>")
-        lines.append(f"<tr><td>Torch</td><td><tt>{torch_ver}</tt></td></tr>")
-        lines.append(f"<tr><td>FlagTree</td><td><tt>{flagtree_ver}</tt></td></tr>")
-        lines.append(f"<tr><td>Triton</td><td><tt>{triton_ver}</tt></td></tr>")
-        lines.append(f"<tr><td>FlagGems</td><td><tt>{flaggems_ver}</tt></td></tr>")
-        lines.append(f"<tr><td>Vendor</td><td><tt>{flaggems_vendor}</tt></td></tr>")
-        lines.append(f"<tr><td>Device</td><td><tt>{flaggems_device}</tt></td></tr>")
-        lines.append("</tbody></table>")
-        lines.append("")
 
     return lines
 
@@ -179,23 +159,6 @@ def parse_single_accuracy(fmt, op_data):
         f = op_data.get("failed", 0)
         lines.append(f"| {s} | {d:6.2f} sec | {t} | {p} | {k} | {f} |")
         lines.append("")
-
-    elif fmt == "html":
-        lines.append("<H3>Accuracy Result</H3>")
-        lines.append("<H4>Summary</H4>")
-        lines.append("<table><thead><tr>")
-        lines.append("<th>Status</th><th>Duration (s)</th><th>Total</th>")
-        lines.append(
-            "<th>Passed</th><th>Skipped</th><th>Failed</th></tr></thead><tbody>"
-        )
-        lines.append(f"<tr><td>{op_data.get('status', '?')}</td>")
-        lines.append(f"<td>{op_data.get('duration', '?')}</td>")
-        lines.append(f"<td>{op_data.get('total', 0)}</td>")
-        lines.append(f"<td>{op_data.get('passed', 0)}</td>")
-        k = op_data.get("skipped", 0)
-        lines.append(f"<td>{k}</td>")
-        f = op_data.get("failed", 0)
-        lines.append(f"<td>{f}</td></tr></tbody><table>")
 
     # Append failed and skipped cases if any
     details = op_data.get("details", {})
@@ -251,24 +214,6 @@ def parse_single_performance(fmt, op_data):
                 lines.append(f"| | {spd:6.3f} | {base:6.3f} | {gems:6.3f} | `{shp}` |")
         lines.append("")
         return lines
-
-    elif fmt == "html":
-        duration = op_data.get("duration", 0)
-        lines.append("<H3>Performance Result</H3>")
-        lines.append("<H4>Summary</H4>")
-        lines.append("<table><thead><tr>")
-        lines.append("<th>Status</th><th>Duration</th><th>Reason</th>")
-        lines.append(f"<tr><td>{status}</td>")
-        lines.append(f"<td>{duration:6.2f}</td>")
-        if status in ["Skipped", "Failed"]:
-            reason = op_data.get("reason", "Unknown")
-            reason = "<blockquote>" + reason.replace("\n", "<br/>") + "</blockquote>"
-            lines.append("<td>{reason}</td></tr>")
-        elif status == "NotFound":
-            lines.append("<td><i>No test case found.</i></td></tr>")
-        else:
-            lines.append("<td><i>All tests completed.</i></td</tr>")
-        lines.append("</tbody></table>")
 
     if status != "Passed":
         return lines
@@ -332,13 +277,6 @@ def parse_multi(fmt):
         lines.insert(0, header)
         header = "| " + " | ".join(header_fields) + " |"
         lines.insert(0, header)
-    elif fmt == "html":
-        header = ["<table>", "<thead>", "<tr>"]
-        for field in header_fields:
-            header.append(f"<th>{field}</th>")
-        header.extend(["</tr>", "</thead>", "<tbody>"])
-        lines = header + lines
-        lines.append("</tbody></table")
 
     return lines
 
@@ -351,7 +289,7 @@ def main():
     parser.add_argument(
         "-f",
         "--format",
-        choices=["csv", "markdown", "html"],
+        choices=["csv", "markdown"],
         default="csv",
         help="the output format",
     )


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Refactor

### Description

This PR splits the `psummary` tool into two tools: `psum_text` and `psum_html`. The rationales behind this changes are:

- We need a tool that helps the reviewers to determine whether an operator change (be it a new one or a modification) is okay. The feedback is to be simple basic markdowns that can be accepted as PR comments on GitHub. There are many more feature requests coming in on this direction.
- We need a tool that helps generate clean, readable HTML reports. The output is supposed to be a self-contained, user-friendly HTML. There could be more feature requests coming in on this direction.

Having one tool to serve two different purposes is gonna hurt the readability, maintainability of the source. We obviously need two different tools for processing the JSON output from tests.