### PR TITLE
Bump flagtree version for mthreads

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,7 @@ metax = [
 mthreads = [
     "torch==2.7.1+musa.4.0.0",
     "torch_musa==2.7.1",
-    "flagtree==0.5.0+mthreads3.1",
+    "flagtree==0.5.1+mthreads3.6",
     # "triton==3.1.0+musa1.4.6",
     "numpy==1.26.4",
     "mkl==2024.0.0",

--- a/tools/setup_vendor.sh
+++ b/tools/setup_vendor.sh
@@ -153,7 +153,7 @@ case $VENDOR in
     else
       uv pip uninstall triton
       uv pip install --index $FLAGOS_PYPI \
-        "flagtree==0.5.0+mthreads3.1"
+        "flagtree==0.5.1+mthreads3.6"
     fi
     ;;
 


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

This PR bumps the flagtree release to `0.5.1+mthreads3.6`.