### PR TITLE
Improve remainder test coverage

### DIFF
--- a/benchmark/test_remainder.py
+++ b/benchmark/test_remainder.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from . import base, consts, utils
+from . import base, consts
 
 
 @pytest.mark.remainder_tensor

--- a/benchmark/test_remainder.py
+++ b/benchmark/test_remainder.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from . import base, consts
+from . import base, consts, utils
 
 
 @pytest.mark.remainder_tensor
@@ -22,5 +22,54 @@ def test_remainder_tensor_inplace():
         torch_op=lambda a, b: a.remainder_(b),
         dtypes=consts.INT_DTYPES,
         is_inplace=True,
+    )
+    bench.run()
+
+
+def remainder_scalar_input_fn(shape, dtype, device):
+    inp = torch.randint(
+        torch.iinfo(dtype).min,
+        torch.iinfo(dtype).max,
+        shape,
+        dtype=dtype,
+        device=device,
+    )
+    scalar = torch.randint(
+        torch.iinfo(dtype).min,
+        torch.iinfo(dtype).max,
+        (1,),
+        dtype=dtype,
+        device=device,
+    ).item()
+    if scalar == 0:
+        scalar = 1
+    yield inp, scalar
+
+
+@pytest.mark.remainder_scalar_
+def test_remainder_scalar_inplace():
+    bench = base.GenericBenchmark(
+        input_fn=remainder_scalar_input_fn,
+        op_name="remainder_scalar_",
+        torch_op=lambda a, b: a.remainder_(b),
+        dtypes=consts.INT_DTYPES,
+        is_inplace=True,
+    )
+    bench.run()
+
+
+def scalar_tensor_remainder_input_fn(shape, dtype, device):
+    inp = torch.randint(1, 100, shape, dtype=dtype, device=device)
+    scalar = 7
+    yield scalar, inp
+
+
+@pytest.mark.remainder_scalar_tensor
+def test_remainder_scalar_tensor():
+    bench = base.GenericBenchmark(
+        op_name="remainder_scalar_tensor",
+        torch_op=torch.remainder,
+        input_fn=scalar_tensor_remainder_input_fn,
+        dtypes=consts.INT_DTYPES,
     )
     bench.run()

--- a/tests/test_remainder.py
+++ b/tests/test_remainder.py
@@ -87,3 +87,59 @@ def test_remainder_(shape, dtype):
         with flag_gems.use_gems():
             res_out = inp1.remainder_(d)
         utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.remainder_scalar_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.INT_DTYPES)
+def test_remainder_scalar_(shape, dtype):
+    inp = torch.randint(
+        torch.iinfo(dtype).min, torch.iinfo(dtype).max, shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+    scalar = (
+        torch.randint(
+            torch.iinfo(dtype).min,
+            torch.iinfo(dtype).max,
+            (1,),
+            dtype=dtype,
+            device="cpu",
+        )
+        .to(flag_gems.device)
+        .item()
+    )
+
+    if cfg.TO_CPU and scalar == 0:
+        scalar = 1
+
+    ref_inp = utils.to_reference(inp.clone(), False)
+    ref_out = ref_inp.remainder_(scalar)
+
+    with flag_gems.use_gems():
+        res_out = inp.remainder_(scalar)
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.remainder_scalar_tensor
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.INT_DTYPES)
+def test_remainder_scalar_tensor(shape, dtype):
+    inp = torch.randint(
+        torch.iinfo(dtype).min,
+        torch.iinfo(dtype).max,
+        shape,
+        dtype=dtype,
+        device="cpu",
+    ).to(flag_gems.device)
+
+    if cfg.TO_CPU:
+        inp = replace_zeros(inp)
+
+    ref_inp = utils.to_reference(inp, False)
+
+    scalar = 7
+    ref_out = torch.remainder(torch.tensor(scalar, dtype=dtype), ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.remainder(scalar, inp)
+
+    utils.gems_assert_equal(res_out, ref_out)


### PR DESCRIPTION
## Summary
- Add `remainder_scalar_` benchmark and accuracy test (inplace scalar remainder)
- Add `remainder_scalar_tensor` benchmark and accuracy test (scalar / tensor remainder)

Merge PRs:
- #3189: Add remainder_scalar_ benchmark and test
- #3190: Add remainder_scalar_tensor benchmark and test

🤖 Generated with [Claude Code](https://claude.com/claude-code)