### PR TITLE
Improve sum test coverage

### DIFF
--- a/benchmark/test_sum.py
+++ b/benchmark/test_sum.py
@@ -1,12 +1,47 @@
 import pytest
 import torch
 
-from . import base, consts
+from . import base, consts, utils
 
 
 @pytest.mark.sum
 def test_sum():
     bench = base.UnaryReductionBenchmark(
         op_name="sum", torch_op=torch.sum, dtypes=consts.FLOAT_DTYPES
+    )
+    bench.run()
+
+
+def sum_dim_out_input_fn(shape, dtype, device):
+    inp = utils.generate_tensor_input(shape, dtype, device)
+    dim = 1 if len(shape) > 1 else 0
+    out = torch.sum(inp, dim=dim)
+    yield inp, dim, {"out": out}
+
+
+@pytest.mark.sum_dim_out
+def test_sum_dim_out():
+    bench = base.GenericBenchmark(
+        op_name="sum_dim_out",
+        torch_op=torch.sum,
+        input_fn=sum_dim_out_input_fn,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()
+
+
+def sum_out_input_fn(shape, dtype, device):
+    inp = torch.randn(shape, dtype=dtype, device=device)
+    out = torch.empty([], dtype=dtype, device=device)
+    yield inp, {"out": out}
+
+
+@pytest.mark.sum_out
+def test_sum_out():
+    bench = base.GenericBenchmark(
+        op_name="sum_out",
+        torch_op=torch.ops.aten.sum.out,
+        input_fn=sum_out_input_fn,
+        dtypes=consts.FLOAT_DTYPES,
     )
     bench.run()

--- a/benchmark/test_sum_dim.py
+++ b/benchmark/test_sum_dim.py
@@ -1,0 +1,12 @@
+import pytest
+import torch
+
+from . import base, consts
+
+
+@pytest.mark.sum_dim
+def test_sum_dim():
+    bench = base.UnaryReductionBenchmark(
+        op_name="sum_dim", torch_op=torch.sum, dtypes=consts.FLOAT_DTYPES
+    )
+    bench.run()

--- a/tests/test_sum.py
+++ b/tests/test_sum.py
@@ -90,3 +90,20 @@ def test_sum_dim_out(shape, dim, keepdim, dtype):
         _dim = inp.numel()
     utils.gems_assert_close(res_result, ref_result, dtype, reduce_dim=_dim)
     utils.gems_assert_close(out, ref_result, dtype, reduce_dim=_dim)
+
+
+@pytest.mark.sum_out
+@pytest.mark.parametrize("shape", utils.REDUCTION_SHAPES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_sum_out(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.sum(ref_inp)
+
+    out = torch.empty([], dtype=dtype, device=flag_gems.device)
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.sum.out(inp, out=out)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, reduce_dim=inp.numel())
+    utils.gems_assert_close(out, ref_out, dtype, reduce_dim=inp.numel())


### PR DESCRIPTION
## Summary
- Add `sum_dim` benchmark (new file `benchmark/test_sum_dim.py`)
- Add `sum_dim_out` benchmark
- Add `sum_out` benchmark and accuracy test

Merge PRs:
- #3203: Add sum_dim benchmark
- #3204: Add sum_dim_out benchmark
- #3205: Add sum_out benchmark and test

🤖 Generated with [Claude Code](https://claude.com/claude-code)