### PR TITLE
fix: support triton >= 3.7 in libentry and pointwise_dynamic

### DIFF
--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -735,7 +735,7 @@ class LibEntry(triton.KernelInterface):
                 k_args[param_names[i]] = arg
                 dns_args.append(hashable_arg)
             else:
-                if major_version == 3 and 3 <= minor_version <= 6:
+                if major_version == 3 and minor_version >= 3:
                     k_args[param_names[i]] = arg
                 const_args.append(hashable_arg)
         for p in self.jit_function.params[len(args) :]:
@@ -748,7 +748,7 @@ class LibEntry(triton.KernelInterface):
 
             if p.is_constexpr:
                 const_args.append(val)
-                if major_version == 3 and 3 <= minor_version <= 6:
+                if major_version == 3 and minor_version >= 3:
                     k_args[p.name] = val
             elif p.do_not_specialize:
                 dns_args.append(val)
@@ -837,7 +837,7 @@ class LibEntry(triton.KernelInterface):
             for pre_hook, hook_kwargs in launch_pre_hooks:
                 pre_hook({**hook_nargs, **hook_kwargs})
 
-        if major_version == 3 and 3 <= minor_version <= 6:
+        if major_version == 3 and minor_version >= 3:
             all_args = []
             missing_keys = []
             for key in list(self.signature.parameters.keys()):

--- a/src/flag_gems/utils/pointwise_dynamic.py
+++ b/src/flag_gems/utils/pointwise_dynamic.py
@@ -513,7 +513,7 @@ class KernelGenerator:
                 f"out{i}_ptr, ({shape}), ({strides}), ({offsets}), ({tile_sizes}), order=({order}))"
             )
             code.writeline(
-                f"tl.store(out{i}_bptr, out{i}.to(out{i}_bptr.type.element_ty), boundary_check=({order}))"
+                f"tl.store(out{i}_bptr, out{i}.to(out{i}_ptr.type.element_ty), boundary_check=({order}))"
             )
 
     def gen_body_gsl_with_bptr(self, code):


### PR DESCRIPTION
## Summary

Two fixes to support triton 3.7+
• **`pointwise_dynamic.py`**: Block pointer store path accessed `out_bptr.type.element_ty`, but triton 3.7's `_block_ptr` only exposes `.dtype`, not `.type`. Changed to use the raw pointer's type instead, which works on all triton versions, and consist with load op

• **`libentry.py`**: Version guard `3 <= minor_version <= 6` excluded triton 3.7+, causing constexpr arguments to be omitted from kernel launch calls. Since triton 3.3, constexpr arguments must be included in launch calls — this behavior has not changed in 3.7. Relaxed the guard to `minor_version >= 3`.

## Changes

| File | Lines | Description |
|------|-------|-------------|
| `src/flag_gems/utils/pointwise_dynamic.py` | 1 | `out_bptr.type.element_ty` → `out_ptr.type.element_ty` |
| `src/flag_gems/utils/libentry.py` | 3 | `3 <= minor_version <= 6` → `minor_version >= 3` |