### PR TITLE
[MTHREADS] migrate SQMMA descriptor to triton 3.6 TensorDescriptor API

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/addmm.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/addmm.py
@@ -4,13 +4,12 @@ import os
 import torch
 import triton
 import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
 
 from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import broadcastable_to, libentry, libtuner
 from flag_gems.utils import triton_lang_extension as ext
-
-from .utils import create_tma_device_descriptor, get_cached_tma_device_descriptor
 
 logger = logging.getLogger(
     f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
@@ -155,63 +154,12 @@ def addmm_fma(bias, mat1, mat2, *, beta=1, alpha=1):
     return out
 
 
-def addmm_sqmma_descriptor_pre_hook(nargs):
-    a = nargs["A"]
-    b = nargs["B"]
-    bias = nargs["Bias"]
-    c = nargs["C"]
-    block_m = nargs["BLOCK_SIZE_M"]
-    block_n = nargs["BLOCK_SIZE_N"]
-    block_k = nargs["BLOCK_SIZE_K"]
-    device = c.device
-
-    nargs["a_desc_ptr"].copy_(
-        get_cached_tma_device_descriptor(a, block_m, block_k, device)
-    )
-    nargs["b_desc_ptr"].copy_(
-        get_cached_tma_device_descriptor(b, block_k, block_n, device)
-    )
-    nargs["bias_desc_ptr"].copy_(
-        get_cached_tma_device_descriptor(bias, block_m, block_n, device)
-    )
-    nargs["c_desc_ptr"].copy_(create_tma_device_descriptor(c, block_m, block_n, device))
-
-
-@libentry()
-@libtuner(
-    configs=runtime.ops_get_configs(
-        "addmm_sqmma",
-        pre_hook=addmm_sqmma_descriptor_pre_hook,
-        yaml_path=EXPAND_CONFIG_FILENAME,
-    )
-    if os.environ.get("USE_FLAGTUNE") == "1"
-    else [
-        triton.Config(
-            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 64},
-            num_stages=1,
-            num_warps=4,
-            pre_hook=addmm_sqmma_descriptor_pre_hook,
-        )
-    ],
-    key=["M", "N", "K"],
-    strategy=runtime.get_expand_config("addmm_sqmma", yaml_path=EXPAND_CONFIG_FILENAME)[
-        "strategy"
-    ]
-    if os.environ.get("USE_FLAGTUNE") == "1"
-    else ["default", "default", "default"],
-    warmup=5,
-    rep=5,
-)
 @triton.jit(do_not_specialize=["alpha", "beta"])
 def addmm_sqmma_kernel(
-    A,
-    B,
-    Bias,
-    C,
-    a_desc_ptr,
-    b_desc_ptr,
-    bias_desc_ptr,
-    c_desc_ptr,
+    a_desc,
+    b_desc,
+    bias_desc,
+    c_desc,
     M,
     N,
     K,
@@ -220,43 +168,24 @@ def addmm_sqmma_kernel(
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
-    ab_type: tl.constexpr,
-    c_type: tl.constexpr,
-    is_transpose_a: tl.constexpr = False,
-    is_transpose_b: tl.constexpr = False,
 ):
     pid = tl.program_id(axis=0)
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
     pid_m = pid % num_pid_m
     pid_n = pid // num_pid_m
-    offs_am = pid_m * BLOCK_SIZE_M
-    offs_bn = pid_n * BLOCK_SIZE_N
+    offs_am = (pid_m * BLOCK_SIZE_M).to(tl.int32)
+    offs_bn = (pid_n * BLOCK_SIZE_N).to(tl.int32)
     offs_k = 0
-    input_type = ab_type
-    output_type = c_type
+    offs_k = offs_k.to(tl.int32)
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
-        a = tl._experimental_descriptor_load(
-            a_desc_ptr,
-            [offs_am, offs_k],
-            [BLOCK_SIZE_M, BLOCK_SIZE_K],
-            input_type,
-            is_transpose_a,
-        )
-        b = tl._experimental_descriptor_load(
-            b_desc_ptr,
-            [offs_k, offs_bn],
-            [BLOCK_SIZE_K, BLOCK_SIZE_N],
-            input_type,
-            is_transpose_b,
-        )
+        a = tl.load_tensor_descriptor(a_desc, [offs_am, offs_k])
+        b = tl.load_tensor_descriptor(b_desc, [offs_k, offs_bn])
         accumulator = tl.dot(a, b, acc=accumulator)
         offs_k += BLOCK_SIZE_K
-    bias = tl._experimental_descriptor_load(
-        bias_desc_ptr, [offs_am, offs_bn], [BLOCK_SIZE_M, BLOCK_SIZE_N], input_type
-    )
-    result = (alpha * accumulator + beta * bias).to(output_type)
-    tl._experimental_descriptor_store(c_desc_ptr, result, [offs_am, offs_bn])
+    bias = tl.load_tensor_descriptor(bias_desc, [offs_am, offs_bn])
+    result = (alpha * accumulator + beta * bias).to(c_desc.dtype)
+    tl.store_tensor_descriptor(c_desc, [offs_am, offs_bn], result)
 
 
 def get_triton_type(elem_type):
@@ -274,40 +203,29 @@ def addmm_sqmma(mat1, mat2, bias, elem_type, alpha, beta, M, N, K):
     assert broadcastable_to(
         bias.shape, (mat1.shape[0], mat2.shape[1])
     ), "Incompatible input shape"
-    # handle non-contiguous inputs if necessary
-    is_transpose_a = False
-    is_transpose_b = False
     if not mat1.is_contiguous():
-        if mat1.stride(0) == 1 and mat1.stride(1) == mat1.shape[0]:
-            is_transpose_a = True
-        else:
-            mat1 = mat1.contiguous()
+        mat1 = mat1.contiguous()
     if not mat2.is_contiguous():
-        if mat2.stride(0) == 1 and mat2.stride(1) == mat2.shape[0]:
-            is_transpose_b = True
-        else:
-            mat2 = mat2.contiguous()
-    ab_type = elem_type
+        mat2 = mat2.contiguous()
     a_type = mat1.dtype
     b_type = mat2.dtype
     assert a_type == b_type, "Mat A and Mat B should have the same dtype"
     c_type = a_type
     C = torch.empty((M, N), dtype=c_type, device=device)
     bias = bias.broadcast_to(C.shape).contiguous()
-    desc_a = torch.empty((64,), dtype=torch.int8, device=device)
-    desc_b = torch.empty((64,), dtype=torch.int8, device=device)
-    desc_bias = torch.empty((64,), dtype=torch.int8, device=device)
-    desc_c = torch.empty((64,), dtype=torch.int8, device=device)
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 128
+    BLOCK_SIZE_K = 64
+    desc_a = TensorDescriptor.from_tensor(mat1, [BLOCK_SIZE_M, BLOCK_SIZE_K])
+    desc_b = TensorDescriptor.from_tensor(mat2, [BLOCK_SIZE_K, BLOCK_SIZE_N])
+    desc_bias = TensorDescriptor.from_tensor(bias, [BLOCK_SIZE_M, BLOCK_SIZE_N])
+    desc_c = TensorDescriptor.from_tensor(C, [BLOCK_SIZE_M, BLOCK_SIZE_N])
     grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
         1,
         1,
     )
     addmm_sqmma_kernel[grid](
-        mat1,
-        mat2,
-        bias,
-        C,
         desc_a,
         desc_b,
         desc_bias,
@@ -317,10 +235,11 @@ def addmm_sqmma(mat1, mat2, bias, elem_type, alpha, beta, M, N, K):
         K,
         alpha,
         beta,
-        ab_type=get_triton_type(ab_type),
-        c_type=get_triton_type(c_type),
-        is_transpose_a=is_transpose_a,
-        is_transpose_b=is_transpose_b,
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        num_warps=4,
+        num_stages=1,
     )
     return C
 

--- a/src/flag_gems/runtime/backend/_mthreads/ops/bmm.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/bmm.py
@@ -4,13 +4,12 @@ import os
 import torch
 import triton
 import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
 
 from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry, libtuner
 from flag_gems.utils import triton_lang_extension as ext
-
-from .utils import create_tma_device_descriptor, get_cached_tma_device_descriptor
 
 logger = logging.getLogger(
     f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
@@ -166,67 +165,11 @@ def bmm_fma(A, B):
     return out
 
 
-def bmm_sqmma_descriptor_pre_hook(nargs):
-    a = nargs["A"]
-    b = nargs["B"]
-    c = nargs["C"]
-    batch = nargs["batch"]
-    M = nargs["M"]
-    N = nargs["N"]
-    K = nargs["K"]
-    block_m = nargs["BLOCK_SIZE_M"]
-    block_n = nargs["BLOCK_SIZE_N"]
-    block_k = nargs["BLOCK_SIZE_K"]
-    device = c.device
-
-    nargs["a_desc_ptr"].copy_(
-        get_cached_tma_device_descriptor(
-            a.reshape(batch * M, K), block_m, block_k, device
-        )
-    )
-    nargs["b_desc_ptr"].copy_(
-        get_cached_tma_device_descriptor(
-            b.reshape(batch * K, N), block_k, block_n, device
-        )
-    )
-    nargs["c_desc_ptr"].copy_(
-        create_tma_device_descriptor(c.reshape(batch * M, N), block_m, block_n, device)
-    )
-
-
-@libentry()
-@libtuner(
-    configs=runtime.ops_get_configs(
-        "bmm_sqmma",
-        pre_hook=bmm_sqmma_descriptor_pre_hook,
-        yaml_path=EXPAND_CONFIG_FILENAME,
-    )
-    if os.environ.get("USE_FLAGTUNE") == "1"
-    else [
-        triton.Config(
-            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 64},
-            num_stages=1,
-            num_warps=4,
-            pre_hook=bmm_sqmma_descriptor_pre_hook,
-        )
-    ],
-    key=["M", "N", "K"],
-    strategy=runtime.get_expand_config("bmm_sqmma", yaml_path=EXPAND_CONFIG_FILENAME)[
-        "strategy"
-    ][:3]
-    if os.environ.get("USE_FLAGTUNE") == "1"
-    else ["align32", "align32", "align32"],
-    warmup=5,
-    rep=5,
-)
 @triton.jit
 def bmm_sqmma_kernel(
-    A,
-    B,
-    C,
-    a_desc_ptr,
-    b_desc_ptr,
-    c_desc_ptr,
+    a_desc,
+    b_desc,
+    c_desc,
     batch,
     M,
     N,
@@ -234,32 +177,25 @@ def bmm_sqmma_kernel(
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
-    ab_type: tl.constexpr,
-    d_type: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
     batch_index = tl.program_id(axis=1)
     num_pid_m = tl.cdiv(M, BLOCK_SIZE_M)
     pid_m = pid % num_pid_m
     pid_n = pid // num_pid_m
-    offs_am = pid_m * BLOCK_SIZE_M + batch_index * M
-    offs_bn = pid_n * BLOCK_SIZE_N
+    offs_am = (pid_m * BLOCK_SIZE_M + batch_index * M).to(tl.int32)
+    offs_bn = (pid_n * BLOCK_SIZE_N).to(tl.int32)
     offs_ak = 0
-    offs_bk = batch_index * K
-    tme_load_type = ab_type
+    offs_ak = offs_ak.to(tl.int32)
+    offs_bk = (batch_index * K).to(tl.int32)
     accumulator = tl.zeros((BLOCK_SIZE_M, BLOCK_SIZE_N), dtype=tl.float32)
     for k in range(0, tl.cdiv(K, BLOCK_SIZE_K)):
-        a = tl._experimental_descriptor_load(
-            a_desc_ptr, [offs_am, offs_ak], [BLOCK_SIZE_M, BLOCK_SIZE_K], tme_load_type
-        )
-        b = tl._experimental_descriptor_load(
-            b_desc_ptr, [offs_bk, offs_bn], [BLOCK_SIZE_K, BLOCK_SIZE_N], tme_load_type
-        )
+        a = tl.load_tensor_descriptor(a_desc, [offs_am, offs_ak])
+        b = tl.load_tensor_descriptor(b_desc, [offs_bk, offs_bn])
         accumulator = tl.dot(a, b, acc=accumulator)
         offs_ak += BLOCK_SIZE_K
         offs_bk += BLOCK_SIZE_K
-    accumulator = accumulator.to(d_type)
-    tl._experimental_descriptor_store(c_desc_ptr, accumulator, [offs_am, offs_bn])
+    tl.store_tensor_descriptor(c_desc, [offs_am, offs_bn], accumulator.to(c_desc.dtype))
 
 
 def get_triton_type(elem_type):
@@ -273,21 +209,26 @@ def get_triton_type(elem_type):
 
 def bmm_sqmma(A, B, elem_type, batch, M, N, K):
     device = "musa"
-    ab_type = elem_type
     c_type = elem_type if (elem_type != torch.bfloat16) else torch.float16
     C = torch.empty((batch, M, N), dtype=torch.float16, device=device).to(c_type)
-    desc_a = torch.empty((64,), dtype=torch.int8, device=device)
-    desc_b = torch.empty((64,), dtype=torch.int8, device=device)
-    desc_c = torch.empty((64,), dtype=torch.int8, device=device)
+    BLOCK_SIZE_M = 128
+    BLOCK_SIZE_N = 128
+    BLOCK_SIZE_K = 64
+    desc_a = TensorDescriptor.from_tensor(
+        A.reshape(batch * M, K), [BLOCK_SIZE_M, BLOCK_SIZE_K]
+    )
+    desc_b = TensorDescriptor.from_tensor(
+        B.reshape(batch * K, N), [BLOCK_SIZE_K, BLOCK_SIZE_N]
+    )
+    desc_c = TensorDescriptor.from_tensor(
+        C.reshape(batch * M, N), [BLOCK_SIZE_M, BLOCK_SIZE_N]
+    )
     grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
+        triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
         batch,
         1,
     )
     bmm_sqmma_kernel[grid](
-        A,
-        B,
-        C,
         desc_a,
         desc_b,
         desc_c,
@@ -295,8 +236,11 @@ def bmm_sqmma(A, B, elem_type, batch, M, N, K):
         M,
         N,
         K,
-        ab_type=get_triton_type(ab_type),
-        d_type=get_triton_type(c_type),
+        BLOCK_SIZE_M,
+        BLOCK_SIZE_N,
+        BLOCK_SIZE_K,
+        num_warps=4,
+        num_stages=1,
     )
     return C
 
@@ -313,7 +257,7 @@ def bmm(a, b):
     else:
         os.environ.pop("MUSA_ENABLE_SQMMA", None)
     try:
-        if is_sqmma_compatible(a, b, N, K):
+        if is_sqmma_compatible(a, b, N, K) and M >= 128:
             return bmm_sqmma(a, b, a_dtype, batch, M, N, K)
         else:
             return bmm_fma(a, b)

--- a/src/flag_gems/runtime/backend/_mthreads/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/mm.py
@@ -4,13 +4,12 @@ import os
 import torch
 import triton
 import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
 
 from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry, libtuner
 from flag_gems.utils import triton_lang_extension as ext
-
-from .utils import create_tma_device_descriptor, get_cached_tma_device_descriptor
 
 logger = logging.getLogger("flag_gems.runtime.backend._mthreads.ops.mm")
 
@@ -322,73 +321,19 @@ def mm_out(a, b, *, out):
     return c
 
 
-def sqmma_descriptor_pre_hook(nargs):
-    a = nargs["A"]
-    b = nargs["B"]
-    c = nargs["C"]
-    block_m = nargs["BLOCK_M"]
-    block_n = nargs["BLOCK_N"]
-    block_k = nargs["BLOCK_K"]
-    device = c.device
-
-    nargs["a_desc_ptr"].copy_(
-        get_cached_tma_device_descriptor(a, block_m, block_k, device)
-    )
-    nargs["b_desc_ptr"].copy_(
-        get_cached_tma_device_descriptor(b, block_k, block_n, device)
-    )
-    nargs["c_desc_ptr"].copy_(create_tma_device_descriptor(c, block_m, block_n, device))
-
-
-@libentry()
-@libtuner(
-    configs=runtime.ops_get_configs(
-        "mm_general_tma",
-        pre_hook=sqmma_descriptor_pre_hook,
-        yaml_path=EXPAND_CONFIG_FILENAME,
-    )
-    if os.environ.get("USE_FLAGTUNE") == "1"
-    else [
-        triton.Config(
-            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 64},
-            num_stages=1,
-            num_warps=4,
-            pre_hook=sqmma_descriptor_pre_hook,
-        )
-    ],
-    key=["M", "N", "K", "stride_am", "stride_bk", "dtype"],
-    strategy=runtime.get_expand_config(
-        "mm_general_tma", yaml_path=EXPAND_CONFIG_FILENAME
-    )["strategy"]
-    if os.environ.get("USE_FLAGTUNE") == "1"
-    else ["align32", "align32", "align32", "align32", "align32", "default"],
-    warmup=5,
-    rep=5,
-)
 @triton.jit
 def mm_sqmma_kernel(
-    A,
-    B,
-    C,
-    a_desc_ptr,
-    b_desc_ptr,
-    c_desc_ptr,
+    a_desc,
+    b_desc,
+    c_desc,
     M,
     N,
     K,
-    stride_am,
-    stride_ak,
-    stride_bk,
-    stride_bn,
     dtype: tl.constexpr,
     GROUP_M: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
-    ab_dtype: tl.constexpr,
-    c_dtype: tl.constexpr,
-    is_transpose_a: tl.constexpr = False,
-    is_transpose_b: tl.constexpr = False,
 ):
     pid = ext.program_id(0)
     grid_m = tl.cdiv(M, BLOCK_M)
@@ -398,50 +343,17 @@ def mm_sqmma_kernel(
     group_size = min(grid_m - group_id * GROUP_M, GROUP_M)
     pid_m = group_id * GROUP_M + (pid % group_size)
     pid_n = (pid % width) // (group_size)
-    offs_am = pid_m * BLOCK_M
-    offs_bn = pid_n * BLOCK_N
+    offs_am = (pid_m * BLOCK_M).to(tl.int32)
+    offs_bn = (pid_n * BLOCK_N).to(tl.int32)
     offs_k = 0
-    offs_am = offs_am.to(tl.int32)
-    offs_bn = offs_bn.to(tl.int32)
     offs_k = offs_k.to(tl.int32)
     accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-    tme_load_ab_dtype = ab_dtype
-    c_store_dtype = c_dtype
     for k in range(0, tl.cdiv(K, BLOCK_K)):
-        if is_transpose_a:
-            a = tl._experimental_descriptor_load(
-                a_desc_ptr,
-                [offs_k, offs_am],
-                [BLOCK_K, BLOCK_M],
-                tme_load_ab_dtype,
-            )
-            a = tl.trans(a)
-        else:
-            a = tl._experimental_descriptor_load(
-                a_desc_ptr,
-                [offs_am, offs_k],
-                [BLOCK_M, BLOCK_K],
-                tme_load_ab_dtype,
-            )
-        if is_transpose_b:
-            b = tl._experimental_descriptor_load(
-                b_desc_ptr,
-                [offs_bn, offs_k],
-                [BLOCK_N, BLOCK_K],
-                tme_load_ab_dtype,
-            )
-            b = tl.trans(b)
-        else:
-            b = tl._experimental_descriptor_load(
-                b_desc_ptr,
-                [offs_k, offs_bn],
-                [BLOCK_K, BLOCK_N],
-                tme_load_ab_dtype,
-            )
-        accumulator += tl.dot(a, b, out_dtype=tl.float32, allow_tf32=False)
+        a = tl.load_tensor_descriptor(a_desc, [offs_am, offs_k])
+        b = tl.load_tensor_descriptor(b_desc, [offs_k, offs_bn])
+        accumulator = tl.dot(a, b, acc=accumulator)
         offs_k += BLOCK_K
-    accumulator = accumulator.to(c_store_dtype)
-    tl._experimental_descriptor_store(c_desc_ptr, accumulator, [offs_am, offs_bn])
+    tl.store_tensor_descriptor(c_desc, [offs_am, offs_bn], accumulator.to(c_desc.dtype))
 
 
 def get_triton_type(elem_type):
@@ -456,52 +368,40 @@ def get_triton_type(elem_type):
 def mm_sqmma(A, B, M, N, K, GROUP_M):
     logger.debug("GEMS_MTHREADS MM(SQMMA)")
     device = A.device
-    # handle non-contiguous inputs if necessary
-    is_transpose_a = False
-    is_transpose_b = False
     if not A.is_contiguous():
-        if A.stride(0) == 1 and A.stride(1) == A.shape[0]:
-            is_transpose_a = True
-        else:
-            A = A.contiguous()
+        A = A.contiguous()
     if not B.is_contiguous():
-        if B.stride(0) == 1 and B.stride(1) == B.shape[0]:
-            is_transpose_b = True
-        else:
-            B = B.contiguous()
+        B = B.contiguous()
     a_type = A.dtype
     b_type = B.dtype
     assert a_type == b_type, "Mat A and Mat B should have the same dtype"
     c_dtype = get_higher_dtype(a_type, b_type)
     C = torch.empty((M, N), dtype=c_dtype, device=device)
-    desc_a = torch.empty((64,), dtype=torch.int8, device=device)
-    desc_b = torch.empty((64,), dtype=torch.int8, device=device)
-    desc_c = torch.empty((64,), dtype=torch.int8, device=device)
+    BLOCK_M = 128
+    BLOCK_N = 128
+    BLOCK_K = 64
+    desc_a = TensorDescriptor.from_tensor(A, [BLOCK_M, BLOCK_K])
+    desc_b = TensorDescriptor.from_tensor(B, [BLOCK_K, BLOCK_N])
+    desc_c = TensorDescriptor.from_tensor(C, [BLOCK_M, BLOCK_N])
     grid = lambda META: (
-        triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+        triton.cdiv(M, BLOCK_M) * triton.cdiv(N, BLOCK_N),
         1,
         1,
     )
     mm_sqmma_kernel[grid](
-        A,
-        B,
-        C,
         desc_a,
         desc_b,
         desc_c,
         M,
         N,
         K,
-        A.stride(0),
-        A.stride(1),
-        B.stride(0),
-        B.stride(1),
         str(a_type).split(".")[-1],
-        GROUP_M=GROUP_M,
-        ab_dtype=get_triton_type(a_type),
-        c_dtype=get_triton_type(c_dtype),
-        is_transpose_a=is_transpose_a,
-        is_transpose_b=is_transpose_b,
+        GROUP_M,
+        BLOCK_M,
+        BLOCK_N,
+        BLOCK_K,
+        num_warps=4,
+        num_stages=1,
     )
     return C
 

--- a/src/flag_gems/runtime/backend/_mthreads/ops/utils.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/utils.py
@@ -1,71 +1,7 @@
 import os
-from collections import OrderedDict
 
-import numpy as np
 import torch
-import triton
 import triton.language as tl
-
-_TMA_DESCRIPTOR_CACHE_MAXSIZE = 256
-_tma_descriptor_cache = OrderedDict()
-
-# Detect once whether fill_2d_tma_descriptor expects a pointer (int) or numpy array.
-# triton >= 3.2 changed the last parameter from numpy array to int pointer.
-_fill_2d_tma = triton.runtime.driver.active.utils.fill_2d_tma_descriptor
-_tma_desc_wants_ptr = tuple(int(x) for x in triton.__version__.split(".")[:2]) >= (3, 2)
-
-
-def _tma_desc_arg(desc_np):
-    return int(desc_np.ctypes.data) if _tma_desc_wants_ptr else desc_np
-
-
-def create_tma_device_descriptor(tensor, block_m, block_n, device):
-    assert tensor.dim() == 2, "TMA descriptor only supports 2D tensors"
-    TMA_DESCRIPTOR_SIZE = 64
-    desc_np = np.empty(TMA_DESCRIPTOR_SIZE, dtype=np.int8)
-    shapes = [tensor.shape[0], tensor.shape[1]]
-    if not tensor.is_contiguous():
-        assert (
-            tensor.stride(0) == 1 and tensor.stride(1) == tensor.shape[0]
-        ), "TMA descriptor only supports contiguous or transposed 2D tensors"
-        shapes.reverse()
-    _fill_2d_tma(
-        tensor.data_ptr(),
-        shapes[0],
-        shapes[1],
-        block_m,
-        block_n,
-        tensor.element_size(),
-        _tma_desc_arg(desc_np),
-    )
-    desc = torch.tensor(desc_np, device=device)
-    return desc
-
-
-def _tma_descriptor_cache_key(tensor, block_m, block_n, device):
-    return (
-        tensor.data_ptr(),
-        tuple(tensor.shape),
-        tuple(tensor.stride()),
-        str(tensor.dtype),
-        block_m,
-        block_n,
-        str(device),
-    )
-
-
-def get_cached_tma_device_descriptor(tensor, block_m, block_n, device):
-    key = _tma_descriptor_cache_key(tensor, block_m, block_n, device)
-    desc = _tma_descriptor_cache.get(key)
-    if desc is not None:
-        _tma_descriptor_cache.move_to_end(key)
-        return desc
-
-    desc = create_tma_device_descriptor(tensor, block_m, block_n, device)
-    _tma_descriptor_cache[key] = desc
-    if len(_tma_descriptor_cache) > _TMA_DESCRIPTOR_CACHE_MAXSIZE:
-        _tma_descriptor_cache.popitem(last=False)
-    return desc
 
 
 def get_triton_dtype(dtype):

--- a/src/flag_gems/runtime/backend/_mthreads/ops/w8a8_block_fp8_matmul.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/w8a8_block_fp8_matmul.py
@@ -5,13 +5,12 @@ from typing import List
 import torch
 import triton
 import triton.language as tl
+from triton.tools.tensor_descriptor import TensorDescriptor
 
 from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry, libtuner
 from flag_gems.utils import triton_lang_extension as ext
-
-from .utils import create_tma_device_descriptor, get_cached_tma_device_descriptor
 
 logger = logging.getLogger(
     "flag_gems.runtime.backend._mthreads.ops.w8a8_block_fp8_matmul"
@@ -162,88 +161,26 @@ def w8a8_block_fp8_matmul_kernel(
     tl.store(c_ptrs, c, mask=c_mask)
 
 
-def sqmma_descriptor_pre_hook(nargs):
-    a = nargs["A"]
-    b = nargs["B"]
-    c = nargs["C"]
-    block_m = nargs["BLOCK_M"]
-    block_n = nargs["BLOCK_N"]
-    block_k = nargs["BLOCK_K"]
-    device = c.device
-
-    nargs["a_desc_ptr"].copy_(
-        get_cached_tma_device_descriptor(a, block_m, block_k, device)
-    )
-    nargs["b_desc_ptr"].copy_(
-        get_cached_tma_device_descriptor(b, block_k, block_n, device)
-    )
-    nargs["c_desc_ptr"].copy_(create_tma_device_descriptor(c, block_m, block_n, device))
-
-
-def sqmma_get_configs(pre_hook=sqmma_descriptor_pre_hook):
-    return [
-        triton.Config(
-            {
-                "BLOCK_M": 64,
-                "BLOCK_N": 64,
-                "BLOCK_K": 128,
-                "GROUP_M": 8,
-            },
-            num_stages=3,
-            num_warps=4,
-            pre_hook=pre_hook,
-        )
-    ]
-
-
-@libentry()
-@libtuner(
-    configs=runtime.ops_get_configs(
-        "w8a8_block_fp8_general_tma",
-        pre_hook=sqmma_descriptor_pre_hook,
-        yaml_path=EXPAND_CONFIG_FILENAME,
-    )
-    if os.environ.get("USE_FLAGTUNE") == "1"
-    else sqmma_get_configs(),
-    key=["M", "N", "K", "stride_am", "stride_bk", "dtype"],
-    strategy=runtime.get_expand_config(
-        "w8a8_block_fp8_general_tma", yaml_path=EXPAND_CONFIG_FILENAME
-    )["strategy"]
-    if os.environ.get("USE_FLAGTUNE") == "1"
-    else ["align32", "align32", "align32", "align32", "align32", "default"],
-    warmup=5,
-    rep=5,
-)
 @triton.jit
 def w8a8_block_fp8_matmul_sqmma_kernel(
-    A,
-    B,
-    C,
+    a_desc,
+    b_desc,
+    c_desc,
     As,
     Bs,
-    a_desc_ptr,
-    b_desc_ptr,
-    c_desc_ptr,
     M,
     N,
     K,
     group_n,
     group_k,
-    stride_am,
-    stride_bk,
     stride_As_m,
     stride_As_k,
     stride_Bs_n,
     stride_Bs_k,
-    dtype: tl.constexpr,
-    input_dtype: tl.constexpr,
-    output_dtype: tl.constexpr,
     GROUP_M: tl.constexpr,
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
-    is_transpose_a: tl.constexpr = False,
-    is_transpose_b: tl.constexpr = True,
 ):
     pid = ext.program_id(0)
     grid_m = tl.cdiv(M, BLOCK_M)
@@ -261,24 +198,10 @@ def w8a8_block_fp8_matmul_sqmma_kernel(
     row_offset = offs_am + tl.arange(0, BLOCK_M)
     col_offset = offs_bn + tl.arange(0, BLOCK_N)
     acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
-    tme_load_input_dtype = input_dtype
-    c_store_dtype = output_dtype
 
     for _ in range(0, tl.cdiv(K, BLOCK_K)):
-        a = tl._experimental_descriptor_load(
-            a_desc_ptr,
-            [offs_am, offs_k],
-            [BLOCK_M, BLOCK_K],
-            tme_load_input_dtype,
-            is_transpose_a,
-        )
-        b = tl._experimental_descriptor_load(
-            b_desc_ptr,
-            [offs_k, offs_bn],
-            [BLOCK_K, BLOCK_N],
-            tme_load_input_dtype,
-            is_transpose_b,
-        )
+        a = tl.load_tensor_descriptor(a_desc, [offs_am, offs_k])
+        b = tl.load_tensor_descriptor(b_desc, [offs_k, offs_bn])
 
         scale_k = offs_k // group_k
         a_s = tl.load(
@@ -298,9 +221,7 @@ def w8a8_block_fp8_matmul_sqmma_kernel(
         )
         offs_k += BLOCK_K
 
-    tl._experimental_descriptor_store(
-        c_desc_ptr, acc.to(c_store_dtype), [offs_am, offs_bn]
-    )
+    tl.store_tensor_descriptor(c_desc, [offs_am, offs_bn], acc.to(c_desc.dtype))
 
 
 def general_w8a8_block_fp8_matmul(
@@ -373,24 +294,19 @@ def sqmma_w8a8_block_fp8_matmul(
         b.stride(0) == 1,
     )
     device = a.device
-    is_transpose_a = False
-    is_transpose_b = True
-
     if not a.is_contiguous():
-        if a.stride(0) == 1 and a.stride(1) == a.shape[0]:
-            is_transpose_a = True
-        else:
-            a = a.contiguous()
+        a = a.contiguous()
     if not b.is_contiguous():
-        if b.stride(0) == 1 and b.stride(1) == b.shape[0]:
-            is_transpose_b = False
-        else:
-            b = b.contiguous()
-            is_transpose_b = True
+        b = b.contiguous()
 
-    desc_a = torch.empty((64,), dtype=torch.int8, device=device)
-    desc_b = torch.empty((64,), dtype=torch.int8, device=device)
-    desc_c = torch.empty((64,), dtype=torch.int8, device=device)
+    BLOCK_M = 64
+    BLOCK_N = 64
+    BLOCK_K = 128
+    GROUP_M = 8
+
+    desc_a = TensorDescriptor.from_tensor(a, [BLOCK_M, BLOCK_K])
+    desc_b = TensorDescriptor.from_tensor(b, [BLOCK_K, BLOCK_N])
+    desc_c = TensorDescriptor.from_tensor(c, [BLOCK_M, BLOCK_N])
 
     grid = lambda meta: (
         triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]),
@@ -400,30 +316,26 @@ def sqmma_w8a8_block_fp8_matmul(
 
     with torch_device_fn.device(device):
         w8a8_block_fp8_matmul_sqmma_kernel[grid](
-            a,
-            b,
-            c,
-            a_s,
-            b_s,
             desc_a,
             desc_b,
             desc_c,
+            a_s,
+            b_s,
             M,
             N,
             K,
             group_n,
             group_k,
-            a.stride(0),
-            b.stride(1),
             a_s.stride(0),
             a_s.stride(1),
             b_s.stride(0),
             b_s.stride(1),
-            dtype=str(a.dtype).split(".")[-1],
-            input_dtype=get_triton_type(a.dtype),
-            output_dtype=get_triton_type(c.dtype),
-            is_transpose_a=is_transpose_a,
-            is_transpose_b=is_transpose_b,
+            GROUP_M,
+            BLOCK_M,
+            BLOCK_N,
+            BLOCK_K,
+            num_warps=4,
+            num_stages=3,
         )
     return c
 


### PR DESCRIPTION
- Replace fill_2d_tma_descriptor / _experimental_descriptor_load/store with TensorDescriptor.from_tensor / load_tensor_descriptor / store_tensor_descriptor
- Remove descriptor pre_hook and libtuner from all SQMMA kernels
- Replace raw int8 descriptor tensors with TensorDescriptor objects
- Remove unused low-level TMA utilities from utils.py
- Fix offsets to tl.int32 for triton 3.6 requirement
- Add M >= 128 guard in bmm to prevent batch mixing with flat 2D descriptors
- All 137 tests pass: mm(42) addmm(72) bmm(18) w8a8_block_fp8(5)
