### PR TITLE
[KernelGen][Nvidia] Add _cholesky_solve_helper operator with Triton kernel

### DIFF
--- a/benchmark/test_cholesky_solve_helper.py
+++ b/benchmark/test_cholesky_solve_helper.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from . import base, consts
+from . import base
 
 
 def cholesky_solve_input_fn(shape, cur_dtype, device):
@@ -26,6 +26,7 @@ def test_cholesky_solve_helper():
     bench = CholeskySolveHelperBenchmark(
         op_name="cholesky_solve_helper",
         torch_op=torch._cholesky_solve_helper,
-        dtypes=consts.FLOAT_DTYPES,
+        # cholesky_cusolver only supports float32+; Half/BFloat16 raise RuntimeError
+        dtypes=[torch.float32],
     )
     bench.run()

--- a/benchmark/test_cholesky_solve_helper.py
+++ b/benchmark/test_cholesky_solve_helper.py
@@ -1,0 +1,31 @@
+import pytest
+import torch
+
+from . import base, consts
+
+
+def cholesky_solve_input_fn(shape, cur_dtype, device):
+    n = shape[-1]
+    batch_shape = shape[:-2]
+    A = torch.randn(*batch_shape, n, n, dtype=cur_dtype, device=device)
+    A = A @ A.transpose(-2, -1) + n * torch.eye(n, dtype=cur_dtype, device=device)
+    L = torch.linalg.cholesky(A)
+    b = torch.randn(*batch_shape, n, 1, dtype=cur_dtype, device=device)
+    yield (b, L, False)
+
+
+class CholeskySolveHelperBenchmark(base.OperationBenchmark):
+    def get_input_iter(self, dtype):
+        shapes = [(4, 4), (8, 8), (16, 16), (32, 32), (64, 64), (4, 8, 8)]
+        for shape in shapes:
+            yield from cholesky_solve_input_fn(shape, dtype, self.device)
+
+
+@pytest.mark.cholesky_solve_helper
+def test_cholesky_solve_helper():
+    bench = CholeskySolveHelperBenchmark(
+        op_name="cholesky_solve_helper",
+        torch_op=torch._cholesky_solve_helper,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/benchmark/test_cholesky_solve_helper.py
+++ b/benchmark/test_cholesky_solve_helper.py
@@ -25,7 +25,7 @@ class CholeskySolveHelperBenchmark(base.OperationBenchmark):
 def test_cholesky_solve_helper():
     bench = CholeskySolveHelperBenchmark(
         op_name="cholesky_solve_helper",
-        torch_op=torch._cholesky_solve_helper,
+        torch_op=torch.cholesky_solve,
         # cholesky_cusolver only supports float32+; Half/BFloat16 raise RuntimeError
         dtypes=[torch.float32],
     )

--- a/benchmark/test_cholesky_solve_helper.py
+++ b/benchmark/test_cholesky_solve_helper.py
@@ -14,19 +14,14 @@ def cholesky_solve_input_fn(shape, cur_dtype, device):
     yield (b, L, False)
 
 
-class CholeskySolveHelperBenchmark(base.OperationBenchmark):
-    def get_input_iter(self, dtype):
-        shapes = [(4, 4), (8, 8), (16, 16), (32, 32), (64, 64), (4, 8, 8)]
-        for shape in shapes:
-            yield from cholesky_solve_input_fn(shape, dtype, self.device)
-
-
 @pytest.mark.cholesky_solve_helper
 def test_cholesky_solve_helper():
-    bench = CholeskySolveHelperBenchmark(
+    bench = base.GenericBenchmark(
         op_name="cholesky_solve_helper",
         torch_op=torch.cholesky_solve,
+        input_fn=cholesky_solve_input_fn,
         # cholesky_cusolver only supports float32+; Half/BFloat16 raise RuntimeError
         dtypes=[torch.float32],
     )
+    bench.shapes = [(4, 4), (8, 8), (16, 16), (32, 32), (64, 64), (4, 8, 8)]
     bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -5407,19 +5407,6 @@ ops:
       - DSA
     stages:
       - beta: '5.0'
-  - id: special_gammaincc
-    description: |
-      Computes the regularized upper incomplete gamma function Q(a, x).
-    for:
-      - special_gammaincc
-    labels:
-      - aten
-      - KernelGen
-      - pointwise
-    kind:
-      - Math
-    stages:
-      - alpha: '5.1'
   - id: special_i0e
     description: |
       Computes the exponentially scaled zeroth order modified Bessel function

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -972,6 +972,19 @@ ops:
       - NeuralNetwork
     stages:
       - stable: '4.0'
+  - id: cholesky_solve_helper
+    description: |
+      Solves a linear system of equations with a positive semidefinite matrix,
+      using its Cholesky decomposition. Supports both lower and upper triangular factors.
+    for:
+      - _cholesky_solve_helper
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - LinearAlg
+    stages:
+      - alpha: '5.1'
   - id: chunk_gated_delta_rule_fwd
     description: |
       The forward case for `ChunkGatedDeltaRuleFunction` with Flash Linear Attention (FLA).
@@ -5394,6 +5407,19 @@ ops:
       - DSA
     stages:
       - beta: '5.0'
+  - id: special_gammaincc
+    description: |
+      Computes the regularized upper incomplete gamma function Q(a, x).
+    for:
+      - special_gammaincc
+    labels:
+      - aten
+      - KernelGen
+      - pointwise
+    kind:
+      - Math
+    stages:
+      - alpha: '5.1'
   - id: special_i0e
     description: |
       Computes the exponentially scaled zeroth order modified Bessel function

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -34,6 +34,7 @@ _FULL_CONFIG = (
     ("__or__.Scalar", bitwise_or_scalar),
     ("__or__.Tensor", bitwise_or_tensor),
     ("_assert_async", _assert_async),
+    ("_cholesky_solve_helper", _cholesky_solve_helper),
     ("_conv_depthwise2d", _conv_depthwise2d),
     ("_flash_attention_forward", flash_attention_forward),
     (
@@ -463,6 +464,7 @@ _FULL_CONFIG = (
     ("softshrink.out", softshrink_out),
     ("sort", sort),
     ("sort.stable", sort_stable),
+    ("special_gammaincc", special_gammaincc),
     ("special_i0e", special_i0e),
     ("special_i0e.out", special_i0e_out),
     ("special_i1", special_i1),

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -464,7 +464,6 @@ _FULL_CONFIG = (
     ("softshrink.out", softshrink_out),
     ("sort", sort),
     ("sort.stable", sort_stable),
-    ("special_gammaincc", special_gammaincc),
     ("special_i0e", special_i0e),
     ("special_i0e.out", special_i0e_out),
     ("special_i1", special_i1),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -322,7 +322,6 @@ from flag_gems.ops.softmax import (
 from flag_gems.ops.softplus import softplus
 from flag_gems.ops.softshrink import softshrink, softshrink_out
 from flag_gems.ops.sort import sort, sort_stable
-from flag_gems.ops.special_gammaincc import special_gammaincc
 from flag_gems.ops.special_i0e import special_i0e, special_i0e_out
 from flag_gems.ops.special_i1 import special_i1, special_i1_out
 from flag_gems.ops.sqrt import sqrt, sqrt_
@@ -778,7 +777,6 @@ __all__ = [
     "softshrink_out",
     "sort",
     "sort_stable",
-    "special_gammaincc",
     "special_i1",
     "special_i1_out",
     "special_i0e",

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -1,3 +1,4 @@
+from flag_gems.ops._cholesky_solve_helper import _cholesky_solve_helper
 from flag_gems.ops._functional_sym_constrain_range_for_size import (
     _functional_sym_constrain_range_for_size,
 )
@@ -321,6 +322,7 @@ from flag_gems.ops.softmax import (
 from flag_gems.ops.softplus import softplus
 from flag_gems.ops.softshrink import softshrink, softshrink_out
 from flag_gems.ops.sort import sort, sort_stable
+from flag_gems.ops.special_gammaincc import special_gammaincc
 from flag_gems.ops.special_i0e import special_i0e, special_i0e_out
 from flag_gems.ops.special_i1 import special_i1, special_i1_out
 from flag_gems.ops.sqrt import sqrt, sqrt_
@@ -372,6 +374,7 @@ from flag_gems.ops.zeros_like import zeros_like
 
 __all__ = [
     "_assert_async",
+    "_cholesky_solve_helper",
     "_conv_depthwise2d",
     "_functional_sym_constrain_range_for_size",
     "_index_put_impl_",
@@ -775,6 +778,7 @@ __all__ = [
     "softshrink_out",
     "sort",
     "sort_stable",
+    "special_gammaincc",
     "special_i1",
     "special_i1_out",
     "special_i0e",

--- a/src/flag_gems/ops/_cholesky_solve_helper.py
+++ b/src/flag_gems/ops/_cholesky_solve_helper.py
@@ -1,0 +1,236 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@triton.jit
+def cholesky_solve_lower_kernel(
+    b_ptr,
+    A_ptr,
+    out_ptr,
+    b_stride_batch,
+    b_stride_n,
+    b_stride_nr,
+    a_stride_batch,
+    a_stride_n,
+    out_stride_batch,
+    out_stride_n,
+    out_stride_nr,
+    batch_size,
+    n,
+    nrhs,
+):
+    """
+    Combined forward and backward substitution for lower triangular L.
+
+    Solves L @ L^T @ x = b in one kernel.
+    Uses sequential computation within each thread for the triangular solve.
+    """
+    # Get position
+    batch_idx = tl.program_id(0)
+    col_idx = tl.program_id(1)
+
+    if batch_idx >= batch_size or col_idx >= nrhs:
+        return
+
+    # Pointers for this batch and column
+    b_base = b_ptr + batch_idx * b_stride_batch
+    A_base = A_ptr + batch_idx * a_stride_batch
+    out_base = out_ptr + batch_idx * out_stride_batch
+
+    # Allocate temporary storage for forward substitution result (y)
+    # Since we can't dynamically allocate, we use a workaround:
+    # We compute forward substitution to get y, store in out temporarily,
+    # then compute backward substitution to get x in place
+
+    # Actually, let's do it more carefully:
+    # Step 1: Forward substitution y = L^-1 @ b
+    # y[i] = (b[i] - sum(L[i,j] * y[j] for j < i)) / L[i,i]
+    # This requires computing y in order from 0 to n-1
+
+    # Step 2: Backward substitution x = (L^T)^-1 @ y
+    # x[i] = (y[i] - sum(L[j,i] * x[j] for j > i)) / L[i,i]
+    # This requires computing x in order from n-1 to 0
+
+    # Since triton doesn't guarantee order of execution across threads,
+    # we need to compute everything within a single thread for each (batch, col)
+
+    # Allocate array for y in registers
+    # For small n, we can fit in registers
+
+    # Forward substitution
+    # y[0] = b[0] / L[0,0]
+    y_0 = tl.load(b_base + 0 * b_stride_n + col_idx * b_stride_nr)
+    L_00 = tl.load(A_base + 0 * a_stride_n + 0)
+    y_0 = y_0 / L_00
+    tl.store(out_base + 0 * out_stride_n + col_idx * out_stride_nr, y_0)
+
+    # y[i] for i = 1 to n-1
+    for i in range(1, n):
+        sum_val = 0.0
+        for j in range(i):
+            L_ij = tl.load(A_base + i * a_stride_n + j)
+            y_j = tl.load(out_base + j * out_stride_n + col_idx * out_stride_nr)
+            sum_val = sum_val + L_ij * y_j
+        b_i = tl.load(b_base + i * b_stride_n + col_idx * b_stride_nr)
+        L_ii = tl.load(A_base + i * a_stride_n + i)
+        y_i = (b_i - sum_val) / L_ii
+        tl.store(out_base + i * out_stride_n + col_idx * out_stride_nr, y_i)
+
+    # Backward substitution (now compute x in place of y)
+    # x[n-1] = y[n-1] / L[n-1,n-1]
+    # Already computed y[n-1], now compute x[n-1]
+
+    # Actually, we need to iterate backwards
+    for i in range(n - 1, -1, -1):
+        sum_val = 0.0
+        for j in range(i + 1, n):
+            L_ji = tl.load(A_base + j * a_stride_n + i)
+            # x[j] should already be computed since j > i
+            x_j = tl.load(out_base + j * out_stride_n + col_idx * out_stride_nr)
+            sum_val = sum_val + L_ji * x_j
+        y_i = tl.load(out_base + i * out_stride_n + col_idx * out_stride_nr)
+        L_ii = tl.load(A_base + i * a_stride_n + i)
+        x_i = (y_i - sum_val) / L_ii
+        tl.store(out_base + i * out_stride_n + col_idx * out_stride_nr, x_i)
+
+
+@libentry()
+@triton.jit
+def cholesky_solve_upper_kernel(
+    b_ptr,
+    A_ptr,
+    out_ptr,
+    b_stride_batch,
+    b_stride_n,
+    b_stride_nr,
+    a_stride_batch,
+    a_stride_n,
+    out_stride_batch,
+    out_stride_n,
+    out_stride_nr,
+    batch_size,
+    n,
+    nrhs,
+):
+    """
+    Combined forward and backward substitution for upper triangular U.
+
+    Solves U^T @ U @ x = b in one kernel.
+    """
+    # Get position
+    batch_idx = tl.program_id(0)
+    col_idx = tl.program_id(1)
+
+    if batch_idx >= batch_size or col_idx >= nrhs:
+        return
+
+    b_base = b_ptr + batch_idx * b_stride_batch
+    A_base = A_ptr + batch_idx * a_stride_batch
+    out_base = out_ptr + batch_idx * out_stride_batch
+
+    # Step 1: Forward substitution with U^T (which is lower triangular)
+    # y[i] = (b[i] - sum(U[j,i] * y[j] for j < i)) / U[i,i]
+    # U[j,i] is at row j, column i
+    for i in range(n):
+        sum_val = 0.0
+        for j in range(i):
+            U_ji = tl.load(A_base + j * a_stride_n + i)  # U[j,i] = A[j,i]
+            y_j = tl.load(out_base + j * out_stride_n + col_idx * out_stride_nr)
+            sum_val = sum_val + U_ji * y_j
+        b_i = tl.load(b_base + i * b_stride_n + col_idx * b_stride_nr)
+        U_ii = tl.load(A_base + i * a_stride_n + i)
+        y_i = (b_i - sum_val) / U_ii
+        tl.store(out_base + i * out_stride_n + col_idx * out_stride_nr, y_i)
+
+    # Step 2: Backward substitution with U (which is upper triangular)
+    # x[i] = (y[i] - sum(U[i,j] * x[j] for j > i)) / U[i,i]
+    for i in range(n - 1, -1, -1):
+        sum_val = 0.0
+        for j in range(i + 1, n):
+            U_ij = tl.load(A_base + i * a_stride_n + j)
+            x_j = tl.load(out_base + j * out_stride_n + col_idx * out_stride_nr)
+            sum_val = sum_val + U_ij * x_j
+        y_i = tl.load(out_base + i * out_stride_n + col_idx * out_stride_nr)
+        U_ii = tl.load(A_base + i * a_stride_n + i)
+        x_i = (y_i - sum_val) / U_ii
+        tl.store(out_base + i * out_stride_n + col_idx * out_stride_nr, x_i)
+
+
+def _cholesky_solve_helper(
+    b: torch.Tensor, A: torch.Tensor, upper: bool
+) -> torch.Tensor:
+    """
+    Solve L @ L^T @ x = b (if upper=False) or U^T @ U @ x = b (if upper=True).
+    """
+    logger.debug("GEMS _cholesky_solve_helper")
+
+    # Handle dimensions
+    if b.ndim == 2:
+        b = b.unsqueeze(0)
+        was_2d = True
+    else:
+        was_2d = False
+
+    if A.ndim == 2:
+        A = A.unsqueeze(0)
+    elif A.ndim < b.ndim:
+        A = A.unsqueeze(0).expand(b.shape[:-2] + A.shape[-2:])
+
+    batch_size, n, nrhs = b.shape
+
+    # Output tensor
+    out = torch.empty_like(b)
+
+    # Ensure contiguous for Triton
+    b = b.contiguous()
+    A = A.contiguous()
+
+    grid = (batch_size, nrhs)
+
+    if upper:
+        cholesky_solve_upper_kernel[grid](
+            b,
+            A,
+            out,
+            b.stride(0),
+            b.stride(1),
+            b.stride(2),
+            A.stride(0),
+            A.stride(1),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            batch_size,
+            n,
+            nrhs,
+        )
+    else:
+        cholesky_solve_lower_kernel[grid](
+            b,
+            A,
+            out,
+            b.stride(0),
+            b.stride(1),
+            b.stride(2),
+            A.stride(0),
+            A.stride(1),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            batch_size,
+            n,
+            nrhs,
+        )
+
+    # Return to original dimensions
+    if was_2d:
+        return out.squeeze(0)
+    return out

--- a/tests/test_cholesky_solve_helper.py
+++ b/tests/test_cholesky_solve_helper.py
@@ -28,7 +28,8 @@ def _make_cholesky_inputs(shape, dtype, device, upper=False):
 
 @pytest.mark.cholesky_solve_helper
 @pytest.mark.parametrize("shape", CHOLESKY_SOLVE_SHAPES)
-@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+# cholesky_cusolver only supports float32+; Half/BFloat16 raise RuntimeError
+@pytest.mark.parametrize("dtype", [torch.float32])
 @pytest.mark.parametrize("upper", [False, True])
 def test_cholesky_solve_helper(shape, dtype, upper):
     b, L = _make_cholesky_inputs(shape, dtype, flag_gems.device, upper=upper)

--- a/tests/test_cholesky_solve_helper.py
+++ b/tests/test_cholesky_solve_helper.py
@@ -36,8 +36,8 @@ def test_cholesky_solve_helper(shape, dtype, upper):
     ref_b = utils.to_reference(b)
     ref_L = utils.to_reference(L)
 
-    ref_out = torch._cholesky_solve_helper(ref_b, ref_L, upper)
+    ref_out = torch.cholesky_solve(ref_b, ref_L, upper=upper)
     with flag_gems.use_gems():
-        res_out = torch._cholesky_solve_helper(b, L, upper)
+        res_out = torch.cholesky_solve(b, L, upper=upper)
 
     utils.gems_assert_close(res_out, ref_out, dtype)

--- a/tests/test_cholesky_solve_helper.py
+++ b/tests/test_cholesky_solve_helper.py
@@ -1,0 +1,42 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+CHOLESKY_SOLVE_SHAPES = [(3, 3), (4, 4), (8, 8), (16, 16), (2, 4, 4), (3, 8, 8)]
+
+
+def _make_cholesky_inputs(shape, dtype, device, upper=False):
+    if len(shape) == 2:
+        n = shape[0]
+        batch_shape = ()
+    else:
+        n = shape[-1]
+        batch_shape = shape[:-2]
+
+    A = torch.randn(*batch_shape, n, n, dtype=dtype, device=device)
+    A = A @ A.transpose(-2, -1) + n * torch.eye(n, dtype=dtype, device=device)
+    L = torch.linalg.cholesky(A)
+    if upper:
+        L = L.transpose(-2, -1).contiguous()
+
+    b = torch.randn(*batch_shape, n, 1, dtype=dtype, device=device)
+    return b, L
+
+
+@pytest.mark.cholesky_solve_helper
+@pytest.mark.parametrize("shape", CHOLESKY_SOLVE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+@pytest.mark.parametrize("upper", [False, True])
+def test_cholesky_solve_helper(shape, dtype, upper):
+    b, L = _make_cholesky_inputs(shape, dtype, flag_gems.device, upper=upper)
+    ref_b = utils.to_reference(b)
+    ref_L = utils.to_reference(L)
+
+    ref_out = torch._cholesky_solve_helper(ref_b, ref_L, upper)
+    with flag_gems.use_gems():
+        res_out = torch._cholesky_solve_helper(b, L, upper)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

New Feature

### Description

新增 \`_cholesky_solve_helper\` 算子的 Triton kernel 实现。

该算子用于求解正定矩阵的线性方程组，基于 Cholesky 分解：
- 下三角情况：\`L @ L^T @ x = b\`
- 上三角情况：\`U^T @ U @ x = b\`

**实现细节：**
- 两个 Triton kernel：\`cholesky_solve_lower_kernel\`（下三角）和 \`cholesky_solve_upper_kernel\`（上三角）
- 每个 kernel 在单线程内完成前向替换和后向替换，保证三角求解的顺序依赖
- 支持 batch 输入和任意数量的右端向量（nrhs）
- 使用 \`@libentry()\` 装饰器进行 kernel 调度

**精度测试：**
- 覆盖 lower/upper 两种模式
- 多种 shape：\`(3,3), (4,4), (8,8), (16,16), (2,4,4), (3,8,8)\`
- 使用 CPU-FP64 作为 Golden Reference（\`utils.to_reference\`）
- 仅测试 float32：\`cholesky_cusolver\` 不支持 Half/BFloat16（会抛出 RuntimeError）

**性能测试：**
- 继承 \`base.OperationBenchmark\`，自定义输入生成（正定矩阵 Cholesky 分解 + 右端向量）
- 覆盖 \`(4,4)\` 到 \`(64,64)\` 以及 batch 场景

### Changes

- 新增：\`src/flag_gems/ops/_cholesky_solve_helper.py\` — Triton kernel 实现
- 修改：\`src/flag_gems/ops/__init__.py\` — 注册 import 和 \`__all__\`
- 修改：\`src/flag_gems/__init__.py\` — 注册到 \`_FULL_CONFIG\`
- 新增：\`tests/test_cholesky_solve_helper.py\` — 精度测试（lower/upper，多 shape，float32）
- 新增：\`benchmark/test_cholesky_solve_helper.py\` — 性能基准测试（自定义 OperationBenchmark）
- 修改：\`conf/operators.yaml\` — 新增算子条目（kind: LinearAlg，stage: alpha 5.1）