### PR TITLE
[MTHREADS] restore pre_hook and libtuner for SQMMA 

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/addmm.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/addmm.py
@@ -154,6 +154,38 @@ def addmm_fma(bias, mat1, mat2, *, beta=1, alpha=1):
     return out
 
 
+def addmm_sqmma_descriptor_pre_hook(nargs):
+    nargs["a_desc"].block_shape = [nargs["BLOCK_SIZE_M"], nargs["BLOCK_SIZE_K"]]
+    nargs["b_desc"].block_shape = [nargs["BLOCK_SIZE_K"], nargs["BLOCK_SIZE_N"]]
+    nargs["bias_desc"].block_shape = [nargs["BLOCK_SIZE_M"], nargs["BLOCK_SIZE_N"]]
+    nargs["c_desc"].block_shape = [nargs["BLOCK_SIZE_M"], nargs["BLOCK_SIZE_N"]]
+
+
+@libentry()
+@libtuner(
+    configs=runtime.ops_get_configs(
+        "addmm_sqmma",
+        pre_hook=addmm_sqmma_descriptor_pre_hook,
+        yaml_path=EXPAND_CONFIG_FILENAME,
+    )
+    if os.environ.get("USE_FLAGTUNE") == "1"
+    else [
+        triton.Config(
+            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 64},
+            num_stages=1,
+            num_warps=4,
+            pre_hook=addmm_sqmma_descriptor_pre_hook,
+        )
+    ],
+    key=["M", "N", "K"],
+    strategy=runtime.get_expand_config("addmm_sqmma", yaml_path=EXPAND_CONFIG_FILENAME)[
+        "strategy"
+    ]
+    if os.environ.get("USE_FLAGTUNE") == "1"
+    else ["default", "default", "default"],
+    warmup=5,
+    rep=5,
+)
 @triton.jit(do_not_specialize=["alpha", "beta"])
 def addmm_sqmma_kernel(
     a_desc,
@@ -165,6 +197,7 @@ def addmm_sqmma_kernel(
     K,
     alpha,
     beta,
+    DTYPE: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr,
     BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_K: tl.constexpr,
@@ -188,15 +221,6 @@ def addmm_sqmma_kernel(
     tl.store_tensor_descriptor(c_desc, [offs_am, offs_bn], result)
 
 
-def get_triton_type(elem_type):
-    type_map = {
-        torch.float16: tl.float16,
-        torch.bfloat16: tl.bfloat16,
-        torch.float8_e4m3fn: tl.float8e4nv,
-    }
-    return type_map.get(elem_type, None)
-
-
 def addmm_sqmma(mat1, mat2, bias, elem_type, alpha, beta, M, N, K):
     logger.debug("GEMS_MTHREADS ADDMM(SQMMA)")
     device = mat1.device
@@ -213,15 +237,12 @@ def addmm_sqmma(mat1, mat2, bias, elem_type, alpha, beta, M, N, K):
     c_type = a_type
     C = torch.empty((M, N), dtype=c_type, device=device)
     bias = bias.broadcast_to(C.shape).contiguous()
-    BLOCK_SIZE_M = 128
-    BLOCK_SIZE_N = 128
-    BLOCK_SIZE_K = 64
-    desc_a = TensorDescriptor.from_tensor(mat1, [BLOCK_SIZE_M, BLOCK_SIZE_K])
-    desc_b = TensorDescriptor.from_tensor(mat2, [BLOCK_SIZE_K, BLOCK_SIZE_N])
-    desc_bias = TensorDescriptor.from_tensor(bias, [BLOCK_SIZE_M, BLOCK_SIZE_N])
-    desc_c = TensorDescriptor.from_tensor(C, [BLOCK_SIZE_M, BLOCK_SIZE_N])
+    desc_a = TensorDescriptor.from_tensor(mat1, [1, 1])
+    desc_b = TensorDescriptor.from_tensor(mat2, [1, 1])
+    desc_bias = TensorDescriptor.from_tensor(bias, [1, 1])
+    desc_c = TensorDescriptor.from_tensor(C, [1, 1])
     grid = lambda META: (
-        triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
         1,
         1,
     )
@@ -235,11 +256,7 @@ def addmm_sqmma(mat1, mat2, bias, elem_type, alpha, beta, M, N, K):
         K,
         alpha,
         beta,
-        BLOCK_SIZE_M,
-        BLOCK_SIZE_N,
-        BLOCK_SIZE_K,
-        num_warps=4,
-        num_stages=1,
+        str(a_type).split(".")[-1],
     )
     return C
 

--- a/src/flag_gems/runtime/backend/_mthreads/ops/bmm.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/bmm.py
@@ -165,6 +165,37 @@ def bmm_fma(A, B):
     return out
 
 
+def bmm_sqmma_descriptor_pre_hook(nargs):
+    nargs["a_desc"].block_shape = [nargs["BLOCK_SIZE_M"], nargs["BLOCK_SIZE_K"]]
+    nargs["b_desc"].block_shape = [nargs["BLOCK_SIZE_K"], nargs["BLOCK_SIZE_N"]]
+    nargs["c_desc"].block_shape = [nargs["BLOCK_SIZE_M"], nargs["BLOCK_SIZE_N"]]
+
+
+@libentry()
+@libtuner(
+    configs=runtime.ops_get_configs(
+        "bmm_sqmma",
+        pre_hook=bmm_sqmma_descriptor_pre_hook,
+        yaml_path=EXPAND_CONFIG_FILENAME,
+    )
+    if os.environ.get("USE_FLAGTUNE") == "1"
+    else [
+        triton.Config(
+            {"BLOCK_SIZE_M": 128, "BLOCK_SIZE_N": 128, "BLOCK_SIZE_K": 64},
+            num_stages=1,
+            num_warps=4,
+            pre_hook=bmm_sqmma_descriptor_pre_hook,
+        )
+    ],
+    key=["M", "N", "K"],
+    strategy=runtime.get_expand_config("bmm_sqmma", yaml_path=EXPAND_CONFIG_FILENAME)[
+        "strategy"
+    ][:3]
+    if os.environ.get("USE_FLAGTUNE") == "1"
+    else ["align32", "align32", "align32"],
+    warmup=5,
+    rep=5,
+)
 @triton.jit
 def bmm_sqmma_kernel(
     a_desc,
@@ -198,33 +229,15 @@ def bmm_sqmma_kernel(
     tl.store_tensor_descriptor(c_desc, [offs_am, offs_bn], accumulator.to(c_desc.dtype))
 
 
-def get_triton_type(elem_type):
-    type_map = {
-        torch.float16: tl.float16,
-        torch.bfloat16: tl.bfloat16,
-        torch.float8_e4m3fn: tl.float8e4nv,
-    }
-    return type_map.get(elem_type, None)
-
-
 def bmm_sqmma(A, B, elem_type, batch, M, N, K):
     device = "musa"
     c_type = elem_type if (elem_type != torch.bfloat16) else torch.float16
     C = torch.empty((batch, M, N), dtype=torch.float16, device=device).to(c_type)
-    BLOCK_SIZE_M = 128
-    BLOCK_SIZE_N = 128
-    BLOCK_SIZE_K = 64
-    desc_a = TensorDescriptor.from_tensor(
-        A.reshape(batch * M, K), [BLOCK_SIZE_M, BLOCK_SIZE_K]
-    )
-    desc_b = TensorDescriptor.from_tensor(
-        B.reshape(batch * K, N), [BLOCK_SIZE_K, BLOCK_SIZE_N]
-    )
-    desc_c = TensorDescriptor.from_tensor(
-        C.reshape(batch * M, N), [BLOCK_SIZE_M, BLOCK_SIZE_N]
-    )
+    desc_a = TensorDescriptor.from_tensor(A.reshape(batch * M, K), [1, 1])
+    desc_b = TensorDescriptor.from_tensor(B.reshape(batch * K, N), [1, 1])
+    desc_c = TensorDescriptor.from_tensor(C.reshape(batch * M, N), [1, 1])
     grid = lambda META: (
-        triton.cdiv(M, BLOCK_SIZE_M) * triton.cdiv(N, BLOCK_SIZE_N),
+        triton.cdiv(M, META["BLOCK_SIZE_M"]) * triton.cdiv(N, META["BLOCK_SIZE_N"]),
         batch,
         1,
     )
@@ -236,11 +249,6 @@ def bmm_sqmma(A, B, elem_type, batch, M, N, K):
         M,
         N,
         K,
-        BLOCK_SIZE_M,
-        BLOCK_SIZE_N,
-        BLOCK_SIZE_K,
-        num_warps=4,
-        num_stages=1,
     )
     return C
 

--- a/src/flag_gems/runtime/backend/_mthreads/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/mm.py
@@ -318,37 +318,36 @@ def mm_out(a, b, *, out):
     return c
 
 
-def matmul_sqmma_set_block_size_hook(nargs):
-    BLOCK_M = nargs["BLOCK_M"]
-    BLOCK_N = nargs["BLOCK_N"]
-    BLOCK_K = nargs["BLOCK_K"]
-    nargs["a_desc"].block_shape = [BLOCK_M, BLOCK_K]
-    nargs["b_desc"].block_shape = [BLOCK_K, BLOCK_N]
-    nargs["c_desc"].block_shape = [BLOCK_M, BLOCK_N]
-
-
-def sqmma_get_configs(pre_hook=matmul_sqmma_set_block_size_hook):
-    return [
-        triton.Config(
-            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 128},
-            num_stages=1,
-            num_warps=4,
-            pre_hook=pre_hook,
-        ),
-        triton.Config(
-            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 64},
-            num_stages=1,
-            num_warps=4,
-            pre_hook=pre_hook,
-        ),
-    ]
+def sqmma_descriptor_pre_hook(nargs):
+    nargs["a_desc"].block_shape = [nargs["BLOCK_M"], nargs["BLOCK_K"]]
+    nargs["b_desc"].block_shape = [nargs["BLOCK_K"], nargs["BLOCK_N"]]
+    nargs["c_desc"].block_shape = [nargs["BLOCK_M"], nargs["BLOCK_N"]]
 
 
 @libentry()
 @libtuner(
-    configs=sqmma_get_configs(),
-    key=["M", "N", "K", "dtype"],
-    strategy=["align32", "align32", "align32", "default"],
+    configs=runtime.ops_get_configs(
+        "mm_general_tma",
+        pre_hook=sqmma_descriptor_pre_hook,
+        yaml_path=EXPAND_CONFIG_FILENAME,
+    )
+    if os.environ.get("USE_FLAGTUNE") == "1"
+    else [
+        triton.Config(
+            {"BLOCK_M": 128, "BLOCK_N": 128, "BLOCK_K": 64, "GROUP_M": 8},
+            num_stages=1,
+            num_warps=4,
+            pre_hook=sqmma_descriptor_pre_hook,
+        )
+    ],
+    key=["M", "N", "K", "stride_am", "stride_bk", "dtype"],
+    strategy=runtime.get_expand_config(
+        "mm_general_tma", yaml_path=EXPAND_CONFIG_FILENAME
+    )["strategy"]
+    if os.environ.get("USE_FLAGTUNE") == "1"
+    else ["align32", "align32", "align32", "align32", "align32", "default"],
+    warmup=5,
+    rep=5,
 )
 @triton.jit
 def mm_sqmma_kernel(
@@ -385,16 +384,7 @@ def mm_sqmma_kernel(
     tl.store_tensor_descriptor(c_desc, [offs_am, offs_bn], accumulator.to(c_desc.dtype))
 
 
-def get_triton_type(elem_type):
-    type_map = {
-        torch.float16: tl.float16,
-        torch.bfloat16: tl.bfloat16,
-        torch.float8_e4m3fn: tl.float8e4nv,
-    }
-    return type_map.get(elem_type, None)
-
-
-def mm_sqmma(A, B, M, N, K, GROUP_M):
+def mm_sqmma(A, B, M, N, K):
     logger.debug("GEMS_MTHREADS MM(SQMMA)")
     device = A.device
     if not A.is_contiguous():
@@ -406,12 +396,9 @@ def mm_sqmma(A, B, M, N, K, GROUP_M):
     assert a_type == b_type, "Mat A and Mat B should have the same dtype"
     c_dtype = get_higher_dtype(a_type, b_type)
     C = torch.empty((M, N), dtype=c_dtype, device=device)
-    # Real block_shape values are filled in by matmul_sqmma_set_block_size_hook
-    # at autotune/launch time based on the BLOCK_M/N/K selected by libtuner.
-    dummy_block = [1, 1]
-    desc_a = TensorDescriptor(A, A.shape, A.stride(), dummy_block)
-    desc_b = TensorDescriptor(B, B.shape, B.stride(), dummy_block)
-    desc_c = TensorDescriptor(C, C.shape, C.stride(), dummy_block)
+    desc_a = TensorDescriptor.from_tensor(A, [1, 1])
+    desc_b = TensorDescriptor.from_tensor(B, [1, 1])
+    desc_c = TensorDescriptor.from_tensor(C, [1, 1])
     grid = lambda META: (
         triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
         1,
@@ -424,8 +411,7 @@ def mm_sqmma(A, B, M, N, K, GROUP_M):
         M,
         N,
         K,
-        dtype=str(a_type).split(".")[-1],
-        GROUP_M=GROUP_M,
+        str(a_type).split(".")[-1],
     )
     return C
 
@@ -441,14 +427,12 @@ def mm(a, b):
         return gemv_mm(a, b, c, M, K)
 
     if is_sqmma_compatible(a, b, N, K):
-        GROUP_M = 8
         return mm_sqmma(
             a,
             b,
             M,
             N,
             K,
-            GROUP_M,
         )
     else:
         return mm_fma(a, b)

--- a/src/flag_gems/runtime/backend/_mthreads/ops/w8a8_block_fp8_matmul.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/w8a8_block_fp8_matmul.py
@@ -7,6 +7,7 @@ import triton
 import triton.language as tl
 from triton.tools.tensor_descriptor import TensorDescriptor
 
+from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry, libtuner
 from flag_gems.utils import triton_lang_extension as ext
@@ -43,16 +44,6 @@ def is_sqmma_compatible(a, b, output_dtype, n, k):
         and n % 16 == 0
         and k % 16 == 0
     )
-
-
-def get_triton_type(elem_type):
-    type_map = {
-        torch.float16: tl.float16,
-        torch.bfloat16: tl.bfloat16,
-        torch.float32: tl.float32,
-        torch.float8_e4m3fn: tl.float8e4nv,
-    }
-    return type_map.get(elem_type, None)
 
 
 def matmul_get_configs():
@@ -152,6 +143,37 @@ def w8a8_block_fp8_matmul_kernel(
     tl.store(c_ptrs, c, mask=c_mask)
 
 
+def sqmma_descriptor_pre_hook(nargs):
+    nargs["a_desc"].block_shape = [nargs["BLOCK_M"], nargs["BLOCK_K"]]
+    nargs["b_desc"].block_shape = [nargs["BLOCK_K"], nargs["BLOCK_N"]]
+    nargs["c_desc"].block_shape = [nargs["BLOCK_M"], nargs["BLOCK_N"]]
+
+
+@libentry()
+@libtuner(
+    configs=runtime.ops_get_configs(
+        "w8a8_block_fp8_general_tma",
+        pre_hook=sqmma_descriptor_pre_hook,
+        yaml_path=EXPAND_CONFIG_FILENAME,
+    )
+    if os.environ.get("USE_FLAGTUNE") == "1"
+    else [
+        triton.Config(
+            {"BLOCK_M": 64, "BLOCK_N": 64, "BLOCK_K": 128, "GROUP_M": 8},
+            num_stages=3,
+            num_warps=4,
+            pre_hook=sqmma_descriptor_pre_hook,
+        )
+    ],
+    key=["M", "N", "K"],
+    strategy=runtime.get_expand_config(
+        "w8a8_block_fp8_general_tma", yaml_path=EXPAND_CONFIG_FILENAME
+    )["strategy"][:3]
+    if os.environ.get("USE_FLAGTUNE") == "1"
+    else ["align32", "align32", "align32"],
+    warmup=5,
+    rep=5,
+)
 @triton.jit
 def w8a8_block_fp8_matmul_sqmma_kernel(
     a_desc,
@@ -290,14 +312,9 @@ def sqmma_w8a8_block_fp8_matmul(
     if not b.is_contiguous():
         b = b.contiguous()
 
-    BLOCK_M = 64
-    BLOCK_N = 64
-    BLOCK_K = 128
-    GROUP_M = 8
-
-    desc_a = TensorDescriptor.from_tensor(a, [BLOCK_M, BLOCK_K])
-    desc_b = TensorDescriptor.from_tensor(b, [BLOCK_K, BLOCK_N])
-    desc_c = TensorDescriptor.from_tensor(c, [BLOCK_M, BLOCK_N])
+    desc_a = TensorDescriptor.from_tensor(a, [1, 1])
+    desc_b = TensorDescriptor.from_tensor(b, [1, 1])
+    desc_c = TensorDescriptor.from_tensor(c, [1, 1])
 
     grid = lambda meta: (
         triton.cdiv(M, meta["BLOCK_M"]) * triton.cdiv(N, meta["BLOCK_N"]),
@@ -321,12 +338,6 @@ def sqmma_w8a8_block_fp8_matmul(
             a_s.stride(1),
             b_s.stride(0),
             b_s.stride(1),
-            GROUP_M,
-            BLOCK_M,
-            BLOCK_N,
-            BLOCK_K,
-            num_warps=4,
-            num_stages=3,
         )
     return c
 


### PR DESCRIPTION
Reference NVIDIA hopper backend design: create TensorDescriptor with dummy [1,1] block_shape, then use pre_hook to mutate .block_shape in-place with tuner-resolved BLOCK sizes. This restores USE_FLAGTUNE=1 support.

All 137 tests pass: mm(42) addmm(72) bmm(18) w8a8_block_fp8(5)
