### PR TITLE
[KernelGen][Nvidia] Add alpha_dropout operator with Triton kernel

### DIFF
--- a/benchmark/test_alpha_dropout.py
+++ b/benchmark/test_alpha_dropout.py
@@ -1,0 +1,14 @@
+import pytest
+import torch
+
+from . import base, consts
+
+
+@pytest.mark.alpha_dropout
+def test_alpha_dropout():
+    bench = base.UnaryPointwiseBenchmark(
+        op_name="alpha_dropout",
+        torch_op=torch.nn.AlphaDropout(p=0.5),
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -269,6 +269,19 @@ ops:
       - Tensor
     stages:
       - beta: '5.0'
+  - id: alpha_dropout
+    description: |
+      Applies alpha dropout to the input tensor during training.
+    for:
+      - alpha_dropout
+    labels:
+      - aten
+      - NeuralNetwork
+      - KernelGen
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.1'
   - id: all
     description: Tests if all elements in input evaluate to True.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -81,6 +81,7 @@ _FULL_CONFIG = (
     ("addmm.dtype_out", addmm_dtype_out),
     ("addr", addr),
     ("alias_copy", alias_copy),
+    ("alpha_dropout", alpha_dropout),
     ("all", all),
     ("all.dim", all_dim),
     ("all.dims", all_dims),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -16,6 +16,7 @@ from flag_gems.ops.addmv import addmv, addmv_out
 from flag_gems.ops.addr import addr
 from flag_gems.ops.alias_copy import alias_copy, alias_copy_out
 from flag_gems.ops.all import all, all_dim, all_dims
+from flag_gems.ops.alpha_dropout import alpha_dropout
 from flag_gems.ops.amax import amax
 from flag_gems.ops.aminmax import aminmax
 from flag_gems.ops.angle import angle
@@ -401,6 +402,7 @@ __all__ = [
     "addr",
     "alias_copy",
     "alias_copy_out",
+    "alpha_dropout",
     "all",
     "all_dim",
     "all_dims",

--- a/src/flag_gems/ops/alpha_dropout.py
+++ b/src/flag_gems/ops/alpha_dropout.py
@@ -1,0 +1,123 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils.random_utils import (
+    philox_backend_seed_offset,
+    uint_to_uniform_float,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# SELU constants for alpha dropout
+LAMBDA: tl.constexpr = 1.0507010293579108
+ALPHA: tl.constexpr = 1.6732632423543772
+
+
+def compute_alpha_dropout_scales(p):
+    """
+    Compute the scaling factors for alpha dropout.
+
+    The scaling factors are computed such that:
+    - E[output] = 0 for standardized input
+    - Var[output] = 1 for standardized input
+
+    Using the formula:
+    - keep_scale = LAMBDA * sqrt(p / (1-p))
+    - drop_scale = -LAMBDA * sqrt(p * (1-p))
+
+    This is derived from the self-normalizing property of alpha dropout.
+    """
+    keep_scale = LAMBDA * triton.math.sqrt(p / (1 - p))
+    drop_scale = -LAMBDA * triton.math.sqrt(p * (1 - p))
+    return keep_scale, drop_scale
+
+
+@triton.heuristics(runtime.get_heuristic_config("dropout"))
+@triton.jit(do_not_specialize=["p", "philox_seed", "philox_offset"])
+def alpha_dropout_forward_kernel(
+    X,
+    Y,
+    N,
+    p,
+    philox_seed,
+    philox_offset,
+    BLOCK: tl.constexpr,
+):
+    UNROLL: tl.constexpr = 4
+    philox_seed = philox_seed.to(tl.int64)
+    philox_offset = philox_offset.to(tl.int64)
+    c0 = (philox_offset & 0xFFFFFFFF).to(tl.uint32)
+    c1 = ((philox_offset >> 32) & 0xFFFFFFFF).to(tl.uint32)
+    i4 = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    c0 += i4
+    _O = c0 * 0
+    r0, r1, r2, r3 = tl.philox(philox_seed, c0, c1, _O, _O)
+    r0 = uint_to_uniform_float(r0)
+    r1 = uint_to_uniform_float(r1)
+    r2 = uint_to_uniform_float(r2)
+    r3 = uint_to_uniform_float(r3)
+
+    # Generate mask: keep when random > p
+    mask0 = r0 > p
+    mask1 = r1 > p
+    mask2 = r2 > p
+    mask3 = r3 > p
+
+    # Compute alpha dropout scaling factors
+    # keep_scale = LAMBDA * sqrt(p / (1-p))
+    # drop_scale = -LAMBDA * sqrt(p * (1-p))
+    keep_scale = LAMBDA * tl.sqrt(p / (1.0 - p))
+    drop_scale = -LAMBDA * tl.sqrt(p * (1.0 - p))
+
+    off_0 = tl.program_id(0) * BLOCK * UNROLL + tl.arange(0, BLOCK)
+    off_1 = off_0 + BLOCK
+    off_2 = off_1 + BLOCK
+    off_3 = off_2 + BLOCK
+
+    x0 = tl.load(X + off_0, mask=off_0 < N, other=0.0, eviction_policy="evict_first")
+    x1 = tl.load(X + off_1, mask=off_1 < N, other=0.0, eviction_policy="evict_first")
+    x2 = tl.load(X + off_2, mask=off_2 < N, other=0.0, eviction_policy="evict_first")
+    x3 = tl.load(X + off_3, mask=off_3 < N, other=0.0, eviction_policy="evict_first")
+
+    # Apply alpha dropout: keep_scale for kept elements, drop_scale for dropped
+    y0 = tl.where(mask0, x0 * keep_scale, x0 * drop_scale)
+    y1 = tl.where(mask1, x1 * keep_scale, x1 * drop_scale)
+    y2 = tl.where(mask2, x2 * keep_scale, x2 * drop_scale)
+    y3 = tl.where(mask3, x3 * keep_scale, x3 * drop_scale)
+
+    tl.store(Y + off_0, y0, mask=off_0 < N, eviction_policy="evict_first")
+    tl.store(Y + off_1, y1, mask=off_1 < N, eviction_policy="evict_first")
+    tl.store(Y + off_2, y2, mask=off_2 < N, eviction_policy="evict_first")
+    tl.store(Y + off_3, y3, mask=off_3 < N, eviction_policy="evict_first")
+
+
+UNROLL = 4
+
+
+def alpha_dropout(input, p=0.5, train=True):
+    logger.debug("GEMS ALPHA_DROPOUT FORWARD")
+    if not train or p == 0:
+        return input.clone()
+    if p == 1:
+        return torch.zeros_like(input)
+
+    assert 0.0 < p < 1.0, "p must be in (0, 1)"
+
+    device = input.device
+    input = input.contiguous()
+    out = torch.empty_like(input)
+    N = input.numel()
+    grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK"] * UNROLL),)
+    increment = triton.cdiv(N, UNROLL)
+    with torch_device_fn.device(device):
+        philox_seed, philox_offset = philox_backend_seed_offset(increment)
+        alpha_dropout_forward_kernel[grid_fn](
+            input, out, N, p, philox_seed, philox_offset
+        )
+    return out

--- a/tests/test_alpha_dropout.py
+++ b/tests/test_alpha_dropout.py
@@ -1,0 +1,39 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.alpha_dropout
+@pytest.mark.parametrize("shape", utils.SPECIAL_SHAPES)
+@pytest.mark.parametrize("p", [0.3, 0.6, 0.9])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_alpha_dropout(shape, p, dtype):
+    utils.init_seed(0)
+
+    if shape == (1,):
+        shape = (32768,)
+
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.alpha_dropout(inp, p, True)
+
+    res_ref = utils.to_reference(res_out)
+    inp_ref = utils.to_reference(inp)
+
+    unique_vals = torch.unique(res_ref)
+    assert len(unique_vals) > 1, "Output should not be all same value"
+
+    kept = torch.isclose(res_ref, inp_ref, rtol=0.1, atol=0.1)
+    keep_ratio = kept.float().mean().item()
+    assert (
+        abs(keep_ratio - (1 - p)) <= 0.1
+    ), f"keep_ratio: {keep_ratio}, expected: {1 - p}"
+
+    with flag_gems.use_gems():
+        res_eval = torch.nn.functional.alpha_dropout(inp, p, False)
+    ref_eval = inp.clone()
+    utils.gems_assert_close(res_eval, ref_eval, dtype)


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

New Feature

### Description

新增 `alpha_dropout` 算子的 Triton kernel 实现。

该算子用于在训练过程中对输入张量施加 Alpha Dropout，是 SELU 网络中保持自归一化性质的关键组件。

**实现细节：**
- 实现 `alpha_dropout_forward_kernel`，使用 Philox 随机数生成器进行随机掩码
- 保留元素使用 `keep_scale = λ * sqrt(p/(1-p))` 缩放，丢弃元素使用 `drop_scale = -λ * sqrt(p*(1-p))` 缩放
- 采用 4x unroll 优化吞吐量

**精度测试：**
- 覆盖 SPECIAL_SHAPES、多种 dropout rate（0.3, 0.6, 0.9）和 FLOAT_DTYPES
- 验证保留比例的统计一致性
- eval 模式下使用 `gems_assert_close` 验证恒等映射

**性能测试：**
- 使用 UnaryPointwiseBenchmark
- 覆盖 FLOAT_DTYPES

### Changes

- 新增：`src/flag_gems/ops/alpha_dropout.py` — Triton kernel 实现
- 修改：`src/flag_gems/ops/__init__.py` — 注册 import 和 `__all__`
- 修改：`src/flag_gems/__init__.py` — 注册到 `_FULL_CONFIG`
- 新增：`tests/test_alpha_dropout.py` — 精度测试
- 新增：`benchmark/test_alpha_dropout.py` — 性能基准测试
- 修改：`conf/operators.yaml` — 新增算子条目（kind: NeuralNetwork，stage: alpha 5.1）