### PR TITLE
Bump Triton to 3.6 for the NVIDIA backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,8 +113,8 @@ nvidia = [
     "torch==2.9.0+cu128",
     "torchvision==0.24.0+cu128",
     "torchaudio==2.9.0+cu128",
-    "flagtree==0.5.0+3.5",
-    # "triton==3.5",
+    "triton==3.6",
+    # "flagtree==0.5.1+3.6",
 ]
 
 spacemit = [

--- a/tools/setup_vendor.sh
+++ b/tools/setup_vendor.sh
@@ -165,13 +165,14 @@ case $VENDOR in
         "torch==2.9.0+cu128" \
         "torchvision==0.24.0+cu128" \
         "torchaudio==2.9.0+cu128" \
-        "flagtree==0.5.0+3.5"
+        "triton==3.6"
 
-    if [ -n "${USE_TRITON}" ]; then
-      uv pip uninstall flagtree
-      uv pip install --index ${FLAGOS_PYPI} \
-        "triton==3.5"
-    fi
+    # We don't have flagtree for triton 3.6 yet
+    # if [ -n "${USE_TRITON}" ]; then
+    #   uv pip uninstall triton
+    #   uv pip install --index ${FLAGOS_PYPI} \
+    #     "flagtree==0.5.1+3.6"
+    # fi
     ;;
 
   spacemit)


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

We are gradually shifting to Triton 3.6 now. This PR bumps the Triton version for the NVIDIA backend.