### PR TITLE
fix(setup): downgrade spacemit supported Python version to 3.12

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -24,7 +24,7 @@ declare -A PYTHON_SUPPORTED=(
   ["metax"]="3.12"
   ["mthreads"]="3.10"
   ["nvidia"]="3.12"
-  ["spacemit"]="3.14"
+  ["spacemit"]="3.12"
   ["tsingmicro"]="3.10"
 )
 


### PR DESCRIPTION
Update the `PYTHON_SUPPORTED` mapping in `setup.sh` to change `spacemit` from Python 3.14 to 3.12 for compatibility with the defined supported versions.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Other

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Other

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
