### PR TITLE
Bump Pytorch for the NVIDIA backend (#3383)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,10 +110,10 @@ mthreads = [
 ]
 
 nvidia = [
-    "torch==2.9.0+cu128",
-    "torchvision==0.24.0+cu128",
-    "torchaudio==2.9.0+cu128",
-    "triton==3.6",
+    "torch==2.10.0+cu128",
+    "torchvision==0.25.0+cu128",
+    "torchaudio==2.10.0+cu128",
+    "triton==3.6.0",
     # "flagtree==0.5.1+3.6",
 ]
 

--- a/tools/setup_vendor.sh
+++ b/tools/setup_vendor.sh
@@ -162,10 +162,10 @@ case $VENDOR in
     uv pip install ".[nvidia,test]"
 
     uv pip install --index ${FLAGOS_PYPI} \
-        "torch==2.9.0+cu128" \
-        "torchvision==0.24.0+cu128" \
-        "torchaudio==2.9.0+cu128" \
-        "triton==3.6"
+        "torch==2.10.0+cu128" \
+        "torchvision==0.25.0+cu128" \
+        "torchaudio==2.10.0+cu128" \
+        "triton==3.6.0"
 
     # We don't have flagtree for triton 3.6 yet
     # if [ -n "${USE_TRITON}" ]; then


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The expected version matrix is that for Triton 3.6 (version 3.6.0), we'd better use pytorch 2.10. This PR bumps the pytorch version for the NVIDIA backend.