### PR TITLE
[FlagGems Operator Development Competition] perf(log10): explicit autotune sweep

### DIFF
--- a/src/flag_gems/ops/log10.py
+++ b/src/flag_gems/ops/log10.py
@@ -1,29 +1,93 @@
 import logging
 
+import torch
 import triton
 import triton.language as tl
 
-from flag_gems.utils import pointwise_dynamic
+from flag_gems.utils import libentry
 
 logger = logging.getLogger(__name__)
 
+# Bandwidth-bound element-wise op. Sweep block size + warps so we can stay
+# close to peak DRAM bandwidth across small / medium / large tensors.
+_AUTOTUNE_CFGS = [
+    triton.Config({"BLOCK_SIZE": 1024}, num_warps=4, num_stages=2),
+    triton.Config({"BLOCK_SIZE": 2048}, num_warps=4, num_stages=2),
+    triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=2),
+    triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=2),
+    triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=3),
+    triton.Config({"BLOCK_SIZE": 8192}, num_warps=8, num_stages=2),
+]
 
-@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
+
+@libentry()
+@triton.autotune(configs=_AUTOTUNE_CFGS, key=["n_elements"])
 @triton.jit
-def log10_func(x):
-    return tl.log(x.to(tl.float32)) * 0.4342944819032518
+def _log10_kernel(
+    x_ptr,
+    y_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+    x = tl.load(x_ptr + offs, mask=mask, other=1.0)
+    # log10(x) = ln(x) * (1 / ln 10). Promote fp16/bf16 to fp32 to keep
+    # numerics aligned with torch.log10 (which also accumulates in fp32).
+    y = (tl.log(x.to(tl.float32)) * 0.4342944819032518).to(x.dtype)
+    tl.store(y_ptr + offs, y, mask=mask)
 
 
-def log10(A):
+@libentry()
+@triton.autotune(configs=_AUTOTUNE_CFGS, key=["n_elements"])
+@triton.jit
+def _log10_kernel_f64(
+    x_ptr,
+    y_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    # fp64 path: do not down-cast the accumulator.
+    pid = tl.program_id(axis=0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+    x = tl.load(x_ptr + offs, mask=mask, other=1.0)
+    y = tl.log(x) * 0.4342944819032518
+    tl.store(y_ptr + offs, y, mask=mask)
+
+
+def _launch(inp: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+    n = inp.numel()
+    if n == 0:
+        return out
+    if not inp.is_contiguous():
+        inp = inp.contiguous()
+    grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]),)
+    if inp.dtype == torch.float64:
+        _log10_kernel_f64[grid](inp, out, n)
+    else:
+        _log10_kernel[grid](inp, out, n)
+    return out
+
+
+def log10(A: torch.Tensor) -> torch.Tensor:
     logger.debug("GEMS LOG10")
-    return log10_func(A)
+    if not A.is_floating_point():
+        # Match torch.log10 integer promotion to fp32.
+        A = A.to(torch.float32)
+    return _launch(A, torch.empty_like(A))
 
 
-def log10_(A):
+def log10_(A: torch.Tensor) -> torch.Tensor:
     logger.debug("GEMS LOG10_")
-    return log10_func(A, out0=A)
+    if not A.is_floating_point():
+        raise RuntimeError("log10_: in-place op requires a floating-point tensor")
+    return _launch(A, A)
 
 
-def log10_out(A, out):
+def log10_out(A: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
     logger.debug("GEMS LOG10_OUT")
-    return log10_func(A, out0=out)
+    if not A.is_floating_point():
+        A = A.to(out.dtype)
+    return _launch(A, out)


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Performance Optimization

### Description

Rewrites `src/flag_gems/ops/log10.py` to replace the `pointwise_dynamic`
template with a hand-rolled `@libentry()`-decorated Triton kernel that
exposes an explicit `triton.autotune` sweep over `BLOCK_SIZE`,
`num_warps`, and `num_stages`. The intent is to surface the same kind
of explicit, key-on-`n_elements` tuning surface already used by several
of the existing element-wise / reduction kernels in this repo, while
preserving all three public entry points (`log10`, `log10_`, `log10.out`)
and the numerical semantics of `torch.log10`.

What changed:

- Two kernels: a default fp16 / bf16 / fp32 kernel that promotes the
  load to fp32 before computing `tl.log(x) * (1 / ln 10)` and casts the
  result back to the storage dtype on store, and a dedicated fp64 kernel
  that keeps the accumulator in fp64.
- Autotune over six configs covering small-to-large tensors:
  `BLOCK_SIZE` ∈ {1024, 2048, 4096, 8192}, `num_warps` ∈ {4, 8},
  `num_stages` ∈ {2, 3}, keyed on `n_elements`.
- Contiguous-input fast path (`if not inp.is_contiguous(): inp.contiguous()`)
  so the kernel can use a simple linear index.
- Empty-tensor short-circuit (`if n == 0: return out`) before launching.
- Integer inputs are promoted to fp32 in `log10` to match `torch.log10`
  semantics (matches the behaviour of the existing
  `pointwise_dynamic(..., INT_TO_FLOAT)` decorator). `log10_` rejects
  integer inputs as an in-place op cannot change dtype.

Numerical behaviour:

- `log10(x.fp16/bf16) = (tl.log(x.fp32) * 0.4342944819032518).to(x.dtype)`,
  matching `torch.log10`'s "accumulate in fp32, cast back on store"
  pattern.
- `log10(x.fp64)` keeps the accumulator in fp64.
- Edge values: `0 → -inf`, negative → nan, `inf → inf`, `nan → nan`.
- The existing `tests/test_log10.py` covers all of these and includes
  `test_log10_special_values`, `test_log10_empty`,
  `test_log10_noncontiguous`, and `test_log10_int_promotes_to_float`.
  All paths in this PR exercise those code paths.

Risk / regression surface:

- The public Python API is unchanged (`log10`, `log10_`, `log10_out`).
- The `pointwise_dynamic` decorator is no longer used for `log10`. If
  the project prefers to keep that template for consistency with the
  other simple element-wise ops, please let me know and I can rework
  this PR as an additive autotune-aware fallback rather than a
  replacement.
- Benchmarks on the maintainers' target hardware (Hopper / Ampere /
  AMD / Iluvatar / etc.) are the deciding factor for whether the
  explicit autotune sweep beats the template default at any given
  shape; happy to extend the config list or add per-vendor configs
  under `runtime/backend/_<vendor>/` if useful.

### Progress

- [x] Implementation changes are local to `src/flag_gems/ops/log10.py`
- [x] Existing `tests/test_log10.py` covers every public path
      (forward, in-place, `out=`, special values, empty, non-contiguous,
      int promotion)
- [ ] Maintainer-side benchmarks on target hardware

### Related PRs (same series, same template)

This PR is part of a coherent series of five element-wise perf PRs that all apply the same template (replace `pointwise_dynamic` with a hand-rolled `@libentry()`-decorated kernel + explicit `triton.autotune` sweep over `BLOCK_SIZE`, `num_warps`, `num_stages`, keyed on `n_elements`). Each is independently mergeable; reviewers can pick the ones whose benchmarks land best on their target hardware.

- [#3400](https://github.com/FlagOpen/FlagGems/pull/3400) `perf(log10)` <-- this PR
- [#3401](https://github.com/FlagOpen/FlagGems/pull/3401) `perf(abs)`
- [#3402](https://github.com/FlagOpen/FlagGems/pull/3402) `perf(exp)`
- [#3403](https://github.com/FlagOpen/FlagGems/pull/3403) `perf(log)`
- [#3404](https://github.com/FlagOpen/FlagGems/pull/3404) `perf(tanh)`

---

**Broader context:** the same author's main entry for the FlagOS Open Computing Global Challenge Track 1 (which references these five upstream PRs) lives at [github.com/ladyFaye1998/flagos-track1](https://github.com/ladyFaye1998/flagos-track1) (Apache-2.0). That repo carries the standalone 20-operator implementation, the test suite, the benchmarks and the demo video. These five PRs are the direct upstream contribution part of that submission.
