### PR TITLE
[FlagGems Operator Development Competition] perf(tanh): explicit autotune sweep

### DIFF
--- a/src/flag_gems/ops/tanh.py
+++ b/src/flag_gems/ops/tanh.py
@@ -1,41 +1,100 @@
 import logging
 
+import torch
 import triton
 import triton.language as tl
 
-from flag_gems.utils import pointwise_dynamic, tl_extra_shim
+from flag_gems.utils import libentry, tl_extra_shim
 
-pow = tl_extra_shim.pow
 _tanh = tl_extra_shim.tanh
 logger = logging.getLogger(__name__)
 
+_AUTOTUNE_CFGS = [
+    triton.Config({"BLOCK_SIZE": 1024}, num_warps=4, num_stages=2),
+    triton.Config({"BLOCK_SIZE": 2048}, num_warps=4, num_stages=2),
+    triton.Config({"BLOCK_SIZE": 2048}, num_warps=8, num_stages=2),
+    triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=2),
+    triton.Config({"BLOCK_SIZE": 4096}, num_warps=8, num_stages=3),
+    triton.Config({"BLOCK_SIZE": 8192}, num_warps=8, num_stages=2),
+]
 
-@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
+
+@libentry()
+@triton.autotune(configs=_AUTOTUNE_CFGS, key=["n_elements"])
 @triton.jit
-def tanh_kernel(x):
-    return _tanh(x.to(tl.float32))
+def _tanh_kernel(
+    x_ptr,
+    y_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+    x = tl.load(x_ptr + offs, mask=mask, other=0.0)
+    # Promote fp16/bf16 to fp32 then cast back. Uses the platform's
+    # hardware tanh via tl_extra_shim for parity with the existing
+    # FlagGems implementation.
+    y = _tanh(x.to(tl.float32)).to(x.dtype)
+    tl.store(y_ptr + offs, y, mask=mask)
 
 
-@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
+@libentry()
+@triton.autotune(configs=_AUTOTUNE_CFGS, key=["n_elements"])
 @triton.jit
-def tanh_backward_kernel(y, dy):
-    y = y.to(tl.float32)
-    return dy.to(tl.float32) * (1.0 - y * y)
+def _tanh_backward_kernel(
+    y_ptr,
+    dy_ptr,
+    dx_ptr,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    pid = tl.program_id(axis=0)
+    offs = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offs < n_elements
+    y_raw = tl.load(y_ptr + offs, mask=mask, other=0.0)
+    dy_raw = tl.load(dy_ptr + offs, mask=mask, other=0.0)
+    y = y_raw.to(tl.float32)
+    dy = dy_raw.to(tl.float32)
+    dx = dy * (1.0 - y * y)
+    tl.store(dx_ptr + offs, dx.to(y_raw.dtype), mask=mask)
 
 
-def tanh(self):
+def _launch_fwd(inp: torch.Tensor, out: torch.Tensor) -> torch.Tensor:
+    n = inp.numel()
+    if n == 0:
+        return out
+    if not inp.is_contiguous():
+        inp = inp.contiguous()
+    grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]),)
+    _tanh_kernel[grid](inp, out, n)
+    return out
+
+
+def tanh(self: torch.Tensor) -> torch.Tensor:
     logger.debug("GEMS TANH FORWARD")
-    out = tanh_kernel(self)
-    return out
+    if not self.is_floating_point():
+        self = self.to(torch.float32)
+    return _launch_fwd(self, torch.empty_like(self))
 
 
-def tanh_backward(grad_output, output):
-    logger.debug("GEMS TANH BACKWARD")
-    in_grad = tanh_backward_kernel(output, grad_output)
-    return in_grad
-
-
-def tanh_(A):
+def tanh_(A: torch.Tensor) -> torch.Tensor:
     logger.debug("GEMS TANH_ FORWARD")
-    out = tanh_kernel(A, out0=A)
-    return out
+    if not A.is_floating_point():
+        raise RuntimeError("tanh_: in-place op requires a floating-point tensor")
+    return _launch_fwd(A, A)
+
+
+def tanh_backward(grad_output: torch.Tensor, output: torch.Tensor) -> torch.Tensor:
+    logger.debug("GEMS TANH BACKWARD")
+    if not output.is_contiguous():
+        output = output.contiguous()
+    if not grad_output.is_contiguous():
+        grad_output = grad_output.contiguous()
+    dx = torch.empty_like(output)
+    n = output.numel()
+    if n == 0:
+        return dx
+    grid = lambda meta: (triton.cdiv(n, meta["BLOCK_SIZE"]),)
+    _tanh_backward_kernel[grid](output, grad_output, dx, n)
+    return dx


### PR DESCRIPTION
﻿### PR Category

Operator

### Type of Change

Performance Optimization

### Description

Rewrites `src/flag_gems/ops/tanh.py` to replace the `pointwise_dynamic`
template with a hand-rolled `@libentry()`-decorated Triton kernel that
exposes an explicit `triton.autotune` sweep over `BLOCK_SIZE`,
`num_warps`, and `num_stages`. Same pattern used in the companion PR
[#3400 (perf log10)](https://github.com/FlagOpen/FlagGems/pull/3400).

What changed:

- Single hand-rolled kernel with autotune over six configs:
  `BLOCK_SIZE` âˆˆ {1024, 2048, 4096, 8192}, `num_warps` âˆˆ {4, 8},
  `num_stages` âˆˆ {2, 3}, keyed on `n_elements`.
- Contiguous-input fast path (`if not inp.is_contiguous(): inp.contiguous()`)
  so the kernel can use a simple linear index.
- Empty-tensor short-circuit (`if n == 0: return out`) before launching.
- fp16 / bf16 inputs are promoted to fp32 inside the kernel for compute
  and cast back to storage dtype on store, matching the accumulator
  contract `torch.tanh` uses.
- Integer inputs are promoted to fp32 in the Python wrapper to match the
  semantics of the existing `pointwise_dynamic(..., INT_TO_FLOAT)`
  decorator. In-place variants reject integer inputs (dtype cannot
  change in place).
- The public Python API is unchanged.

Risk / regression surface:

- The `pointwise_dynamic` decorator is no longer used for this op. If
  the project prefers to keep the template for consistency with the
  other simple element-wise ops, happy to rework as an additive
  autotune-aware fallback rather than a replacement.
- Benchmarks on the maintainers' target hardware (Hopper / Ampere /
  AMD / Iluvatar / etc.) are the deciding factor for whether the
  explicit sweep beats the template default at any given shape; happy
  to extend the config list or add per-vendor configs under
  `runtime/backend/_<vendor>/` if useful.

### Progress

- [x] Implementation changes are local to `src/flag_gems/ops/tanh.py`
- [x] Existing `tests/test_tanh.py` covers every public path
- [ ] Maintainer-side benchmarks on target hardware

### Related PRs (same series, same template)

This PR is part of a coherent series of five element-wise perf PRs that all apply the same template (replace `pointwise_dynamic` with a hand-rolled `@libentry()`-decorated kernel + explicit `triton.autotune` sweep over `BLOCK_SIZE`, `num_warps`, `num_stages`, keyed on `n_elements`). Each is independently mergeable; reviewers can pick the ones whose benchmarks land best on their target hardware.

- [#3400](https://github.com/FlagOpen/FlagGems/pull/3400) `perf(log10)`
- [#3401](https://github.com/FlagOpen/FlagGems/pull/3401) `perf(abs)`
- [#3402](https://github.com/FlagOpen/FlagGems/pull/3402) `perf(exp)`
- [#3403](https://github.com/FlagOpen/FlagGems/pull/3403) `perf(log)`
- [#3404](https://github.com/FlagOpen/FlagGems/pull/3404) `perf(tanh)` <-- this PR

---

**Broader context:** the same author's main entry for the FlagOS Open Computing Global Challenge Track 1 (which references these five upstream PRs) lives at [github.com/ladyFaye1998/flagos-track1](https://github.com/ladyFaye1998/flagos-track1) (Apache-2.0). That repo carries the standalone 20-operator implementation, the test suite, the benchmarks and the demo video. These five PRs are the direct upstream contribution part of that submission.
