### PR TITLE
Improve psum_text tool

### DIFF
--- a/tools/psum_text
+++ b/tools/psum_text
@@ -5,8 +5,20 @@ import json
 import sys
 from pathlib import Path
 
-import consts
-
+DTYPE_MAP = {
+    "torch.float16": "fp16",
+    "torch.float32": "fp32",
+    "torch.bfloat16": "bf16",
+    "torch.complex64": "cf64",
+    "torch.int16": "int16",
+    "torch.int32": "int32",
+    "torch.int8": "int8",
+    "torch.uint8": "uint8",
+    "torch.int64": "int64",
+    "torch.bool": "bool",
+    "torch.float8_e4m3fn": "f8-e4m3fn",
+    "torch.float8_e5m2": "f8-e5m2",
+}
 DATA = {}
 DEBUG = False
 DATA_DIR = None
@@ -30,72 +42,6 @@ def format_record(fields):
     # markdown
     line = " | ".join(fields)
     return f"| {line} |"
-
-
-def parse_lines():
-    """Write result.
-
-    The layout is as follows:
-    <id>,<astatus>,<pass/fail/skip>,<pstatus>,<fp16>,<fp32>,<bf16>,<cf64>,<i16>,<i32>,<i64>,<note>
-    """
-    data = DATA.get("result", {})
-    lines = []
-    for op, item in data.items():
-        if ARGS.debug:
-            print(f"[DEBUG] processing {op}", file=sys.stderr)
-
-        fields = []
-        accu = item["accuracy"]["status"]
-        accud = "/".join(
-            [
-                str(item["accuracy"]["passed"]),
-                str(item["accuracy"]["failed"]),
-                str(item["accuracy"]["skipped"]),
-            ]
-        )
-        fields.extend([op, accu, accud])
-
-        perf_data = item["performance"]["data"]
-        perf_status = item["performance"]["status"]
-        if perf_status == "NotFound":
-            fields.append("NotFound")
-            fields.extend(
-                [""] * (len(consts.DTYPE_MAP) + 2)
-            )  # OPAverageSpeedUp + dtypes + note
-
-        elif perf_status in ["Failed", "Skipped"]:
-            reason = item["performance"]["reason"]
-            reason = reason.split("\n")[0]
-            fields.append(perf_status)
-            fields.extend(
-                [""] * (len(consts.DTYPE_MAP) + 1)
-            )  # OPAverageSpeedUp + dtypes
-            fields.append(f'"{reason}"')
-
-        else:
-            fields.append(perf_status)
-            speedup_values = []
-            for dtype in list(consts.DTYPE_MAP.values()):
-                dobj = perf_data.get(dtype, {})
-                speedup = dobj.get("speedup", None)
-                if speedup is None:
-                    fields.append("")
-                else:
-                    fields.append(f"{speedup:6.3f}")
-                    speedup_values.append(speedup)
-            # Compute avg_speedup
-            if speedup_values:
-                avg_speedup = sum(speedup_values) / len(speedup_values)
-                op_avg_field = f"{avg_speedup:6.3f}"
-            else:
-                op_avg_field = ""
-
-            fields.insert(4, op_avg_field)
-            fields.append("")  # note
-
-        lines.append(format_record(fields))
-
-    return sorted(lines)
 
 
 def parse_env():
@@ -338,7 +284,7 @@ def parse_single_performance():
                 b2 = res2.get("base", 0)
                 g2 = res2.get("gems", 0)
 
-                spd_str = f"{s1:6.3f} -> {s2:6.3f}"
+                spd_str = f"{s1:.3f} -> {s2:.3f}"
                 if s2 > s1:
                     spd_str = f"<span style='color:Green'>{spd_str}</span>"
                 else:
@@ -346,8 +292,8 @@ def parse_single_performance():
 
                 line = (
                     f"| | {spd_str} |"
-                    f" {b1:6.3f} -> {b2:6.3f} |"
-                    f" {g1:6.3f} -> {g2:6.3f} |"
+                    f" {b1:.3f} -> {b2:.3f} |"
+                    f" {g1:.3f} -> {g2:.3f} |"
                     f" `{shp}` |"
                 )
             else:
@@ -364,15 +310,92 @@ def parse_single_performance():
                 b2 = res2.get("base", 0)
                 g2 = res2.get("gems", 0)
                 line = (
-                    f"| | 0 -> {s2:6.3f} |"
-                    f" 0 -> {b2:6.3f} |"
-                    f" 0 -> {g2:6.3f} |"
+                    f"| | 0 -> {s2:.3f} |"
+                    f" 0 -> {b2:.3f} |"
+                    f" 0 -> {g2:.3f} |"
                     f" `{shp}` |"
                 )
                 lines.append(line)
 
     lines.append("")
     return lines
+
+
+def parse_lines():
+    """Write result.
+
+    The layout is as follows:
+    <id>,<astatus>,<pass/fail/skip>,<pstatus>,[<metric for each dtype>],<note>
+    """
+    data = DATA.get("result", {})
+    lines = []
+    for op, item in data.items():
+        if ARGS.debug:
+            print(f"[DEBUG] processing {op}", file=sys.stderr)
+
+        fields = []
+        accu = item["accuracy"]["status"]
+        accud = "/".join(
+            [
+                str(item["accuracy"]["passed"]),
+                str(item["accuracy"]["failed"]),
+                str(item["accuracy"]["skipped"]),
+            ]
+        )
+        fields.extend([op, accu, accud])
+
+        perf_data = item["performance"]["data"]
+        perf_status = item["performance"]["status"]
+        if perf_status == "NotFound":
+            fields.append("NotFound")
+            fields.extend([""] * (len(DTYPE_MAP) + 1))
+
+        elif perf_status in ["Failed", "Skipped"]:
+            reason = item["performance"]["reason"]
+            reason = reason.split("\n")[0]
+            fields.append(perf_status)
+            fields.extend([""] * (len(DTYPE_MAP)))
+            fields.append(f'"{reason}"')
+
+        else:
+            fields.append(perf_status)
+            metric_list = []
+            for dtype in list(DTYPE_MAP.values()):
+                dobj = perf_data.get(dtype, {})
+
+                if ARGS.metric == "speedup":
+                    # Process `speedup`
+                    metric = dobj.get("speedup", None)
+                else:
+                    # Process `base` by averaging across all shapes
+                    total = 0
+                    count = 0
+                    for sdata in dobj.get("details", {}).values():
+                        total += sdata.get("base", 0)
+                        count += 1
+
+                    if count == 0:
+                        metric = None
+                    else:
+                        metric = total / count
+
+                if metric is None:
+                    fields.append("")
+                else:
+                    fields.append(f"{metric:.3f}")
+                    metric_list.append(metric)
+
+            if len(metric_list) > 0:
+                metric_avg = sum(metric_list) / len(metric_list)
+                fields.append(f"{metric_avg:.3f}")
+            else:
+                fields.append("")
+            # The note column
+            fields.append("")
+
+        lines.append(format_record(fields))
+
+    return sorted(lines)
 
 
 def parse_single():
@@ -391,10 +414,9 @@ def parse_multi():
             "AccRes",
             "AccStat(pass/fail/skip)",
             "PerfRes",
-            "OPAverageSpeedUp",
         ]
-        + list(consts.DTYPE_MAP.values())
-        + ["Note"]
+        + list(DTYPE_MAP.values())
+        + ["PerfAvg", "Note"]
     )
 
     # Add sequence number to each sorted line
@@ -450,6 +472,13 @@ def main():
         "--debug",
         action=argparse.BooleanOptionalAction,
         help="flag for printing verbose information for debugging",
+    )
+    parser.add_argument(
+        "-m",
+        "--metric",
+        choices=["speedup", "base"],
+        default="speedup",
+        help="metric to summarize from the summary JSON",
     )
 
     ARGS = parser.parse_args()


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

New Feature

### Description

Add a new option to the `psum_text` tool so that it can extract not only just `speedup` from performance data, but also the `base` value. The `base` value can be used for cross-backend basline comparison. We intentionally avoid extracting both metrics from the underlying data to keep the tool simple.