### PR TITLE
[KernelGen][Nvidia] Fix topk_softplus_sqrt compliance: logger, yaml registration, test naming

### DIFF
--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -5962,6 +5962,20 @@ ops:
       - MoE
     stages:
       - stable: '4.0'
+  - id: topk_softplus_sqrt
+    description: |
+      Fused softplus + sqrt + top-k selection and optional renormalization
+      for MoE gating in models like DeepSeek-V3/V4.
+    for:
+      - topk_softplus_sqrt
+    labels:
+      - fused
+      - KernelGen
+      - vLLM
+    kind:
+      - MoE
+    stages:
+      - beta: '5.1'
   - id: trace
     description: Returns the sum of the elements of the diagonal of the input 2-D matrix.
     for:

--- a/src/flag_gems/fused/topk_softplus_sqrt.py
+++ b/src/flag_gems/fused/topk_softplus_sqrt.py
@@ -22,8 +22,12 @@ Eliminates the store-load-store pattern for renormalization by storing weights
 during the loop and re-reading with scale at the end.
 """
 
+import logging
+
 import triton
 import triton.language as tl
+
+logger = logging.getLogger(__name__)
 
 
 @triton.jit
@@ -205,6 +209,7 @@ def topk_softplus_sqrt(
         input_ids: Token IDs for hash mode [num_tokens]
         tid2eid: Hash table mapping tokens to expert indices
     """
+    logger.debug("GEMS TOPK_SOFTPLUS_SQRT")
     num_tokens, num_experts = gating_output.shape
     topk = topk_weights.shape[1]
 

--- a/tests/test_topk_softplus_sqrt.py
+++ b/tests/test_topk_softplus_sqrt.py
@@ -96,7 +96,7 @@ def _check_topk_results(
 @pytest.mark.parametrize("dtype", DTYPE_LIST)
 @pytest.mark.parametrize("renormalize", RENORMALIZE_LIST)
 @pytest.mark.parametrize("routed_scaling_factor", RSF_LIST)
-def test_topk_softplus_sqrt_standard(
+def test_topk_softplus_sqrt(
     num_tokens, num_experts, topk, dtype, renormalize, routed_scaling_factor
 ):
     """Test topk_softplus_sqrt in standard mode (with bias) against PyTorch reference."""


### PR DESCRIPTION
## Summary

Follow-up to #3046 to align `topk_softplus_sqrt` with KernelGen PR standards.

- Add `logger.debug("GEMS TOPK_SOFTPLUS_SQRT")` to operator entry point
- Register `topk_softplus_sqrt` in `conf/operators.yaml` with `KernelGen` label
- Rename `test_topk_softplus_sqrt_standard` → `test_topk_softplus_sqrt` per naming convention

## Test plan

- [ ] Verify `conf/operators.yaml` passes YAML lint
- [ ] Verify pre-commit checks pass
- [ ] Verify test discovery still works with renamed test function