### PR TITLE
[KMCompiler]added the pack_seq_triton op

### DIFF
--- a/benchmark/test_pack_seq.py
+++ b/benchmark/test_pack_seq.py
@@ -17,51 +17,24 @@ try:
 except ImportError:
     HAS_VLLM = False
 
-
 # =============================================================================
-# CUDA / Hopper check for FP8
+# CUDA available check for FP8
 # =============================================================================
 
 
-def _is_cuda_hopper():
+def is_cuda_available():
     if flag_gems.device != "cuda":
         return False
     if not torch.cuda.is_available():
         return False
     major, minor = torch.cuda.get_device_capability()
-    return major >= 9
+    sm_version_num = major * 10 + minor
+    return sm_version_num >= 90 and sm_version_num < 100
 
 
-CUDA_HOPPER = _is_cuda_hopper()
+CUDA_AVAILABLE = is_cuda_available()
 
-FP8_DTYPE = torch.float8_e4m3fn if CUDA_HOPPER else None
-
-
-# =============================================================================
-# Wrapper functions — vllm
-# =============================================================================
-
-
-def _vllm_pack_seq(x, lengths):
-    return vllm_pack_seq(x, lengths)
-
-
-def _vllm_pack_seq_fp8(x, lengths):
-    return vllm_pack_seq(x, lengths)
-
-
-# =============================================================================
-# Wrapper functions — FlagGems
-# =============================================================================
-
-
-def _gems_pack_seq(x, lengths):
-    return pack_seq_triton(x, lengths)
-
-
-def _gems_pack_seq_fp8(x, lengths):
-    return pack_seq_triton(x, lengths)
-
+FP8_DTYPE = torch.float8_e4m3fn if CUDA_AVAILABLE else None
 
 # =============================================================================
 # Benchmark shapes: (N, D, B, lengths_list)
@@ -135,36 +108,31 @@ class PackSeqFP8Benchmark(base.Benchmark):
         yield x_fp8, lengths
 
 
-# =============================================================================
-# Benchmark tests
-# =============================================================================
-
-
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 @pytest.mark.skipif(
     not HAS_VLLM,
     reason="requires vLLM to be installed for reference comparison",
 )
 def test_pack_seq():
     bench = PackSeqBenchmark(
-        op_name="pack_seq",
-        torch_op=_vllm_pack_seq,
+        op_name="pack_seq_triton",
+        torch_op=vllm_pack_seq,
         dtypes=[torch.float16, torch.float32, torch.bfloat16],
     )
-    bench.set_gems(_gems_pack_seq)
+    bench.set_gems(pack_seq_triton)
     bench.run()
 
 
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 @pytest.mark.skipif(
-    not (HAS_VLLM and CUDA_HOPPER),
+    not (HAS_VLLM and CUDA_AVAILABLE),
     reason="requires vLLM and NVIDIA Hopper architecture for FP8",
 )
 def test_pack_seq_fp8():
     bench = PackSeqFP8Benchmark(
-        op_name="pack_seq_fp8",
-        torch_op=_vllm_pack_seq_fp8,
+        op_name="pack_seq_triton",
+        torch_op=vllm_pack_seq,
         dtypes=[FP8_DTYPE],
     )
-    bench.set_gems(_gems_pack_seq_fp8)
+    bench.set_gems(pack_seq_triton)
     bench.run()

--- a/benchmark/test_pack_seq.py
+++ b/benchmark/test_pack_seq.py
@@ -1,0 +1,170 @@
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.fused import pack_seq_triton
+
+from . import base
+
+# =============================================================================
+# vLLM availability check
+# =============================================================================
+
+try:
+    from vllm.v1.attention.ops.common import pack_seq_triton as vllm_pack_seq
+
+    HAS_VLLM = True
+except ImportError:
+    HAS_VLLM = False
+
+
+# =============================================================================
+# CUDA / Hopper check for FP8
+# =============================================================================
+
+
+def _is_cuda_hopper():
+    if flag_gems.device != "cuda":
+        return False
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    return major >= 9
+
+
+CUDA_HOPPER = _is_cuda_hopper()
+
+FP8_DTYPE = torch.float8_e4m3fn if CUDA_HOPPER else None
+
+
+# =============================================================================
+# Wrapper functions — vllm
+# =============================================================================
+
+
+def _vllm_pack_seq(x, lengths):
+    return vllm_pack_seq(x, lengths)
+
+
+def _vllm_pack_seq_fp8(x, lengths):
+    return vllm_pack_seq(x, lengths)
+
+
+# =============================================================================
+# Wrapper functions — FlagGems
+# =============================================================================
+
+
+def _gems_pack_seq(x, lengths):
+    return pack_seq_triton(x, lengths)
+
+
+def _gems_pack_seq_fp8(x, lengths):
+    return pack_seq_triton(x, lengths)
+
+
+# =============================================================================
+# Benchmark shapes: (N, D, B, lengths_list)
+# =============================================================================
+
+PACK_BENCH_SHAPES = [
+    (512, 64, 5, [64, 128, 64, 128, 128]),
+    (4096, 128, 4, [1024, 1024, 1024, 1024]),
+    (8192, 256, 5, [1024, 2048, 1024, 2048, 2048]),
+    (2048, 512, 4, [512, 512, 512, 512]),
+    (16384, 64, 8, [2048] * 8),
+    (1024, 1024, 4, [256] * 4),
+]
+
+FP8_BENCH_SHAPES = [
+    (512, 64, 5, [64, 128, 64, 128, 128]),
+    (4096, 128, 4, [1024, 1024, 1024, 1024]),
+    (2048, 512, 4, [512, 512, 512, 512]),
+]
+
+
+# =============================================================================
+# Custom Benchmark class — pack_seq (float dtypes)
+# =============================================================================
+
+
+class PackSeqBenchmark(base.Benchmark):
+    DEFAULT_DTYPES = [torch.float16, torch.float32, torch.bfloat16]
+
+    def __init__(self, op_name, torch_op, dtypes):
+        super().__init__(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = PACK_BENCH_SHAPES
+
+    def get_input_iter(self, cur_dtype):
+        for config in self.shapes:
+            yield from self._pack_input_fn(config, cur_dtype)
+
+    def _pack_input_fn(self, config, dtype):
+        N, D, B, lengths_list = config
+        device = flag_gems.device
+        lengths = torch.tensor(lengths_list, dtype=torch.int32, device=device)
+        x = torch.randn(N, D, dtype=dtype, device=device)
+        yield x, lengths
+
+
+# =============================================================================
+# Custom Benchmark class — pack_seq (FP8)
+# =============================================================================
+
+
+class PackSeqFP8Benchmark(base.Benchmark):
+    def __init__(self, op_name, torch_op, dtypes):
+        super().__init__(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = FP8_BENCH_SHAPES
+
+    def get_input_iter(self, cur_dtype):
+        del cur_dtype
+        for config in self.shapes:
+            yield from self._fp8_input_fn(config)
+
+    def _fp8_input_fn(self, config):
+        N, D, B, lengths_list = config
+        device = flag_gems.device
+        lengths = torch.tensor(lengths_list, dtype=torch.int32, device=device)
+        x = torch.randn(N, D, dtype=torch.float32, device=device) * 0.1
+        x_fp8 = x.to(FP8_DTYPE)
+        yield x_fp8, lengths
+
+
+# =============================================================================
+# Benchmark tests
+# =============================================================================
+
+
+@pytest.mark.pack_seq
+@pytest.mark.skipif(
+    not HAS_VLLM,
+    reason="requires vLLM to be installed for reference comparison",
+)
+def test_pack_seq():
+    bench = PackSeqBenchmark(
+        op_name="pack_seq",
+        torch_op=_vllm_pack_seq,
+        dtypes=[torch.float16, torch.float32, torch.bfloat16],
+    )
+    bench.set_gems(_gems_pack_seq)
+    bench.run()
+
+
+@pytest.mark.pack_seq
+@pytest.mark.skipif(
+    not (HAS_VLLM and CUDA_HOPPER),
+    reason="requires vLLM and NVIDIA Hopper architecture for FP8",
+)
+def test_pack_seq_fp8():
+    bench = PackSeqFP8Benchmark(
+        op_name="pack_seq_fp8",
+        torch_op=_vllm_pack_seq_fp8,
+        dtypes=[FP8_DTYPE],
+    )
+    bench.set_gems(_gems_pack_seq_fp8)
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -4300,6 +4300,18 @@ ops:
       - MoE
     stages:
       - beta: '5.0'
+  - id: pack_seq_triton
+    description: Pack variable-length token sequences into a padded batched tensor.
+    for:
+      - pack_seq_triton
+    labels:
+      - fused
+      - vLLM
+      - DeepSeekV4
+    kind:
+      - NeuralNetwork
+    stages:
+      - beta: '5.1'
   - id: pad
     description: This pads a tenor using the specified mode.
     for:

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -107,7 +107,6 @@ __all__ = [
     "fused_inv_rope_fp8_quant",
     "rwkv_ka_fusion",
     "rwkv_mm_sparsity",
-    "unpack_seq_triton",
     "silu_and_mul",
     "silu_and_mul_out",
     "silu_and_mul_with_clamp",

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -42,6 +42,7 @@ from flag_gems.fused.moe_align_block_size import (
 )
 from flag_gems.fused.moe_sum import moe_sum
 from flag_gems.fused.outer import outer
+from flag_gems.fused.pack_seq import pack_seq_triton
 from flag_gems.fused.reglu import dreglu, reglu
 from flag_gems.fused.reshape_and_cache import reshape_and_cache
 from flag_gems.fused.reshape_and_cache_flash import reshape_and_cache_flash
@@ -99,12 +100,14 @@ __all__ = [
     "moe_align_block_size_triton",
     "outer",
     "outplace_fused_experts",
+    "pack_seq_triton",
     "reglu",
     "reshape_and_cache",
     "reshape_and_cache_flash",
     "fused_inv_rope_fp8_quant",
     "rwkv_ka_fusion",
     "rwkv_mm_sparsity",
+    "unpack_seq_triton",
     "silu_and_mul",
     "silu_and_mul_out",
     "silu_and_mul_with_clamp",

--- a/src/flag_gems/fused/pack_seq.py
+++ b/src/flag_gems/fused/pack_seq.py
@@ -1,0 +1,114 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def _pack_seq_kernel(
+    x_ptr,  # [N, D]
+    out_ptr,  # [B, Lmax, D]
+    lengths_ptr,  # *i32, [B]
+    N: tl.constexpr,
+    D: tl.constexpr,
+    Lmax: tl.constexpr,
+    PAD_VALUE: tl.constexpr,
+    PAD_IS_UINT8: tl.constexpr,
+    BLOCK_T: tl.constexpr,  # timesteps per program
+    BLOCK_D: tl.constexpr,  # features per program
+):
+    pid_b = tl.program_id(0)  # batch id
+    pid_t = tl.program_id(1)  # block over time dimension
+    pid_d = tl.program_id(2)  # block over feature dimension
+    off_t = pid_t * BLOCK_T + tl.arange(0, BLOCK_T)  # [BLOCK_T]
+    off_d = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)  # [BLOCK_D]
+
+    # Compute start index and sequence length from cumulative lengths
+    in_start = 0
+    for i in range(pid_b):
+        in_start += tl.load(lengths_ptr + i)
+    seq_len = tl.load(lengths_ptr + pid_b)
+
+    # valid time positions for this block
+    t_mask = off_t < Lmax
+
+    # compute input row indices for valid (b, t)
+    in_row = in_start + off_t
+    valid_row = (off_t < seq_len) & t_mask
+
+    # Pointers
+    # x_ptr: row-major [N, D]
+    x_row_ptr = x_ptr + in_row[:, None] * D + off_d[None, :]
+
+    # out_ptr: row-major [B, Lmax, D]
+    out_row_ptr = out_ptr + (pid_b * Lmax + off_t)[:, None] * D + off_d[None, :]
+
+    # Initialize with PAD. PAD_IS_UINT8 selects the pad tensor's dtype so
+    # integer-typed outputs (e.g. MXFP4 packed nibbles, ue8m0 scale bytes)
+    # get an exact-byte pad rather than going through an fp32→uint8 cast
+    # that's implementation-defined outside of value 0.
+    d_mask = off_d[None, :] < D
+    if PAD_IS_UINT8:
+        pad_vals = tl.full([BLOCK_T, BLOCK_D], PAD_VALUE, tl.uint8)
+    else:
+        pad_vals = tl.full([BLOCK_T, BLOCK_D], PAD_VALUE, tl.float32)
+    tl.store(out_row_ptr, pad_vals, mask=t_mask[:, None] & d_mask)
+
+    # Load & write only where within seq_len
+    x_vals = tl.load(x_row_ptr, mask=valid_row[:, None] & d_mask)
+    tl.store(out_row_ptr, x_vals, mask=valid_row[:, None] & d_mask)
+
+
+def pack_seq_triton(
+    x: torch.Tensor,
+    lengths: torch.Tensor,
+    pad_value: float | int = -float("inf"),
+    block_t: int = 64,
+    block_d: int = 64,
+) -> torch.Tensor:
+    is_uint8 = x.dtype == torch.uint8
+    if is_uint8:
+        assert (
+            isinstance(pad_value, int) and 0 <= pad_value <= 255
+        ), f"uint8 pack requires an integer pad in [0, 255], got {pad_value!r}"
+        pad_constexpr: int | float = int(pad_value)
+    else:
+        pad_constexpr = float(pad_value)
+
+    original_shape = x.shape
+    if len(original_shape) > 2:
+        N = original_shape[0]
+        x_reshaped = x.reshape(N, -1)
+        D = x_reshaped.shape[1]
+    else:
+        N, D = x.shape
+        x_reshaped = x
+
+    B = lengths.numel()
+    Lmax = int(lengths.max().item())
+
+    out = torch.empty((B, Lmax, D), device=x.device, dtype=x.dtype)
+
+    grid = (B, triton.cdiv(Lmax, block_t), triton.cdiv(D, block_d))
+    _pack_seq_kernel[grid](
+        x_reshaped,
+        out,
+        lengths.int(),
+        N,
+        D,
+        Lmax,
+        PAD_VALUE=pad_constexpr,
+        PAD_IS_UINT8=is_uint8,
+        BLOCK_T=block_t,
+        BLOCK_D=block_d,
+        num_warps=4,
+        num_stages=2,
+    )
+
+    if len(original_shape) > 2:
+        out = out.reshape((B, Lmax) + original_shape[1:])
+
+    return out

--- a/src/flag_gems/fused/pack_seq.py
+++ b/src/flag_gems/fused/pack_seq.py
@@ -69,6 +69,7 @@ def pack_seq_triton(
     block_t: int = 64,
     block_d: int = 64,
 ) -> torch.Tensor:
+    logger.debug("GEMS PACK_SEQ_TRITON")
     is_uint8 = x.dtype == torch.uint8
     if is_uint8:
         assert (

--- a/tests/test_pack_seq.py
+++ b/tests/test_pack_seq.py
@@ -1,0 +1,333 @@
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.fused import pack_seq_triton
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+# =============================================================================
+# CUDA / Hopper check for FP8
+# =============================================================================
+
+
+def _is_cuda_hopper():
+    if flag_gems.device != "cuda":
+        return False
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    return major >= 9
+
+
+CUDA_HOPPER = _is_cuda_hopper()
+
+
+def _ref_pack_seq(x, lengths, pad_value=-float("inf")):
+    """Pure PyTorch reference for pack_seq_triton."""
+    if isinstance(lengths, torch.Tensor):
+        lengths = lengths.tolist()
+    B = len(lengths)
+    Lmax = max(lengths)
+    original_shape = x.shape
+    if len(original_shape) > 2:
+        D_flat = original_shape[1:].numel()
+        x_flat = x.reshape(original_shape[0], -1)
+    else:
+        D_flat = x.shape[1]
+        x_flat = x
+
+    # Always use float32 to hold the fill value so that values like -inf
+    # are representable even when the target dtype is fp8 or uint8.
+    out_reshaped = torch.full(
+        (B, Lmax, D_flat), pad_value, device=x.device, dtype=torch.float32
+    )
+    offset = 0
+    for b in range(B):
+        seq_len = lengths[b]
+        out_reshaped[b, :seq_len] = x_flat[offset : offset + seq_len]
+        offset += seq_len
+
+    out_reshaped = out_reshaped.to(x.dtype)
+
+    if len(original_shape) > 2:
+        return out_reshaped.reshape((B, Lmax) + original_shape[1:])
+    return out_reshaped
+
+
+# =============================================================================
+# Test shapes
+# =============================================================================
+
+if cfg.QUICK_MODE:
+    FLOAT_DTYPES = [torch.float32]
+    PACK_SHAPES_2D = [(32, 64, [4, 7, 1, 8, 12])]
+    PACK_SHAPES_3D = [(6, 8, 4, [3, 3])]
+else:
+    FLOAT_DTYPES = utils.FLOAT_DTYPES
+    PACK_SHAPES_2D = [
+        (32, 64, [4, 7, 1, 8, 12]),
+        (128, 256, [32, 64, 32]),
+        (16, 32, [1] * 16),
+        (200, 128, [100, 50, 30, 20]),
+    ]
+    PACK_SHAPES_3D = [
+        (6, 8, 4, [3, 3]),
+        (10, 4, 8, [2, 4, 4]),
+        (20, 16, 32, [5, 5, 5, 5]),
+        (15, 8, 16, [7, 5, 3]),
+    ]
+
+
+# =============================================================================
+# accuracy — 2D / 3D
+# =============================================================================
+
+
+@pytest.mark.pack_seq
+@pytest.mark.parametrize("N, D, lengths_list", PACK_SHAPES_2D)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_pack_seq_accuracy_2d(N, D, lengths_list, dtype):
+    lengths = torch.tensor(lengths_list, dtype=torch.int32, device=flag_gems.device)
+    x = torch.randn(N, D, dtype=dtype, device=flag_gems.device)
+
+    ref_x = utils.to_reference(x, True)
+    ref_out = _ref_pack_seq(ref_x, lengths_list)
+    res_out = pack_seq_triton(x, lengths)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.pack_seq
+@pytest.mark.parametrize("N, H, D, lengths_list", PACK_SHAPES_3D)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_pack_seq_accuracy_3d(N, H, D, lengths_list, dtype):
+    lengths = torch.tensor(lengths_list, dtype=torch.int32, device=flag_gems.device)
+    B = len(lengths_list)
+    Lmax = max(lengths_list)
+    x = torch.randn(N, H, D, dtype=dtype, device=flag_gems.device)
+
+    result = pack_seq_triton(x, lengths)
+
+    expected_shape = (B, Lmax, H, D)
+    assert result.shape == expected_shape, f"{result.shape} != {expected_shape}"
+    assert result.dtype == dtype
+    assert result.device.type == flag_gems.device
+
+    ref_x = utils.to_reference(x, True)
+    ref_out = _ref_pack_seq(ref_x, lengths_list)
+    utils.gems_assert_close(result, ref_out, dtype)
+
+
+# =============================================================================
+# shape consistency
+# =============================================================================
+
+
+@pytest.mark.pack_seq
+@pytest.mark.parametrize(
+    "N, H, D, lengths_list",
+    [(6, 8, 4, [3, 3])]
+    if cfg.QUICK_MODE
+    else [(20, 8, 16, [10, 10]), (15, 4, 8, [5, 7, 3])],
+)
+def test_pack_seq_shape_consistency(N, H, D, lengths_list):
+    lengths = torch.tensor(lengths_list, dtype=torch.int32, device=flag_gems.device)
+    B = len(lengths_list)
+    x = torch.randn(N, H, D, dtype=torch.float32, device=flag_gems.device)
+
+    result = pack_seq_triton(x, lengths)
+    assert result.shape[0] == B
+    assert result.shape[1] == max(lengths_list)
+    assert result.shape[2:] == x.shape[1:]
+
+
+# =============================================================================
+# custom padding
+# =============================================================================
+
+
+@pytest.mark.pack_seq
+@pytest.mark.parametrize("pad_value", [-100.0, -10.0, 0.0, 10.0, 100.0])
+def test_pack_seq_custom_padding(pad_value):
+    N, D = 20, 16
+    lengths = torch.tensor([10, 10], dtype=torch.int32, device=flag_gems.device)
+    x = torch.randn(N, D, dtype=torch.float32, device=flag_gems.device)
+
+    result = pack_seq_triton(x, lengths, pad_value=pad_value)
+
+    ref_x = utils.to_reference(x, True)
+    ref_out = _ref_pack_seq(ref_x, [10, 10], pad_value=pad_value)
+    utils.gems_assert_close(result, ref_out, torch.float32)
+
+    padded_data = result[:, 10:].to(torch.float32)
+    assert torch.allclose(
+        padded_data, torch.full_like(padded_data, pad_value), atol=1e-5
+    )
+
+
+# =============================================================================
+# default -inf padding
+# =============================================================================
+
+
+@pytest.mark.pack_seq
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_pack_seq_default_inf_padding(dtype):
+    N, D = 20, 16
+    lengths = torch.tensor([10, 10], dtype=torch.int32, device=flag_gems.device)
+    x = torch.randn(N, D, dtype=dtype, device=flag_gems.device)
+
+    result = pack_seq_triton(x, lengths)
+
+    padded_data = result[:, 10:].to(torch.float32)
+    assert torch.all(torch.isinf(padded_data) & (padded_data < 0))
+
+
+# =============================================================================
+# edge cases
+# =============================================================================
+
+
+@pytest.mark.pack_seq
+def test_pack_seq_single_batch():
+    lengths = torch.tensor([10], dtype=torch.int32, device=flag_gems.device)
+    x = torch.randn(10, 16, dtype=torch.float32, device=flag_gems.device)
+    result = pack_seq_triton(x, lengths)
+    assert result.shape == (1, 10, 16)
+
+
+@pytest.mark.pack_seq
+def test_pack_seq_short_sequences():
+    lengths = torch.tensor([1, 1, 1], dtype=torch.int32, device=flag_gems.device)
+    x = torch.randn(20, 4, dtype=torch.float32, device=flag_gems.device)
+    result = pack_seq_triton(x, lengths)
+    assert result.shape == (3, 1, 4)
+
+
+@pytest.mark.pack_seq
+def test_pack_seq_3d_single_batch():
+    lengths = torch.tensor([10], dtype=torch.int32, device=flag_gems.device)
+    x = torch.randn(10, 8, 16, dtype=torch.float32, device=flag_gems.device)
+    result = pack_seq_triton(x, lengths)
+    assert result.shape == (1, 10, 8, 16)
+
+
+@pytest.mark.pack_seq
+def test_pack_seq_3d_short_sequences():
+    lengths = torch.tensor([1, 1, 1], dtype=torch.int32, device=flag_gems.device)
+    x = torch.randn(20, 4, 8, dtype=torch.float32, device=flag_gems.device)
+    result = pack_seq_triton(x, lengths)
+    assert result.shape == (3, 1, 4, 8)
+
+
+# =============================================================================
+# block sizes
+# =============================================================================
+
+
+@pytest.mark.pack_seq
+@pytest.mark.parametrize("block_t, block_d", [(32, 32), (64, 64), (128, 128)])
+def test_pack_seq_block_sizes(block_t, block_d):
+    N, D = 100, 32
+    lengths_list = [25, 25, 25, 25]
+    lengths = torch.tensor(lengths_list, dtype=torch.int32, device=flag_gems.device)
+    x = torch.randn(N, D, dtype=torch.float32, device=flag_gems.device)
+
+    result = pack_seq_triton(x, lengths, block_t=block_t, block_d=block_d)
+    assert result.shape == (4, 25, 32)
+
+    ref_x = utils.to_reference(x, True)
+    ref_out = _ref_pack_seq(ref_x, lengths_list)
+    utils.gems_assert_close(result, ref_out, torch.float32)
+
+
+# =============================================================================
+# fp8 tests
+# =============================================================================
+
+
+@pytest.mark.pack_seq
+@pytest.mark.skipif(
+    not CUDA_HOPPER,
+    reason="requires NVIDIA Hopper architecture for FP8",
+)
+@pytest.mark.parametrize(
+    "N, H, D, lengths_list",
+    [(6, 8, 4, [3, 3]), (10, 4, 8, [2, 4, 4]), (20, 16, 32, [5, 5, 5, 5])],
+)
+def test_pack_seq_fp8_basic(N, H, D, lengths_list):
+    FP8 = torch.float8_e4m3fn
+    lengths = torch.tensor(lengths_list, dtype=torch.int32, device=flag_gems.device)
+    B = len(lengths_list)
+    Lmax = max(lengths_list)
+    x = torch.randn(N, H, D, dtype=torch.float32, device=flag_gems.device) * 0.1
+    x_fp8 = x.to(FP8)
+    packed = pack_seq_triton(x_fp8, lengths)
+    assert packed.shape == (B, Lmax, H, D)
+    assert packed.dtype == FP8
+    for b in range(B):
+        start_idx = sum(lengths_list[:b])
+        seq_len = lengths_list[b]
+        expected = x_fp8[start_idx : start_idx + seq_len].to(torch.float32)
+        actual = packed[b, :seq_len].to(torch.float32)
+        torch.testing.assert_close(actual, expected, rtol=1e-1, atol=1e-2)
+
+
+@pytest.mark.pack_seq
+@pytest.mark.skipif(
+    not CUDA_HOPPER,
+    reason="requires NVIDIA Hopper architecture for FP8",
+)
+def test_pack_seq_fp8_custom_padding():
+    FP8 = torch.float8_e4m3fn
+    N, H, D = 20, 8, 16
+    lengths = torch.tensor([10, 10], dtype=torch.int32, device=flag_gems.device)
+    x = torch.randn(N, H, D, dtype=torch.float32, device=flag_gems.device) * 0.1
+    x_fp8 = x.to(FP8)
+    for pad_value in [-100.0, 0.0, 100.0]:
+        result = pack_seq_triton(x_fp8, lengths, pad_value=pad_value)
+        padded_data = result[:, 10:].to(torch.float32)
+        if pad_value < 0:
+            assert torch.all(padded_data < -50)
+        elif pad_value > 0:
+            assert torch.all(padded_data > 50)
+        else:
+            assert torch.allclose(padded_data, torch.zeros_like(padded_data), atol=1e-2)
+
+
+@pytest.mark.pack_seq
+@pytest.mark.skipif(
+    not CUDA_HOPPER,
+    reason="requires NVIDIA Hopper architecture for FP8",
+)
+def test_pack_seq_fp8_default_inf_padding():
+    FP8 = torch.float8_e4m3fn
+    N, H, D = 20, 8, 16
+    lengths = torch.tensor([10, 10], dtype=torch.int32, device=flag_gems.device)
+    x = torch.randn(N, H, D, dtype=torch.float32, device=flag_gems.device) * 0.1
+    x_fp8 = x.to(FP8)
+    result = pack_seq_triton(x_fp8, lengths)
+    padded_data = result[:, 10:].to(torch.float32)
+    assert torch.all(padded_data < -100)
+
+
+@pytest.mark.pack_seq
+@pytest.mark.skipif(
+    not CUDA_HOPPER,
+    reason="requires NVIDIA Hopper architecture for FP8",
+)
+@pytest.mark.parametrize("block_t, block_d", [(32, 32), (64, 64), (128, 128)])
+def test_pack_seq_fp8_block_sizes(block_t, block_d):
+    FP8 = torch.float8_e4m3fn
+    N, H, D = 100, 16, 32
+    lengths = torch.tensor([25, 25, 25, 25], dtype=torch.int32, device=flag_gems.device)
+    x = torch.randn(N, H, D, dtype=torch.float32, device=flag_gems.device) * 0.1
+    x_fp8 = x.to(FP8)
+    result = pack_seq_triton(x_fp8, lengths, block_t=block_t, block_d=block_d)
+    assert result.shape == (4, 25, 16, 32)
+    for b in range(4):
+        expected = x_fp8[b * 25 : b * 25 + 25].to(torch.float32)
+        actual = result[b, :25].to(torch.float32)
+        torch.testing.assert_close(actual, expected, rtol=1e-1, atol=1e-2)

--- a/tests/test_pack_seq.py
+++ b/tests/test_pack_seq.py
@@ -12,16 +12,17 @@ from . import conftest as cfg
 # =============================================================================
 
 
-def _is_cuda_hopper():
+def is_cuda_available():
     if flag_gems.device != "cuda":
         return False
     if not torch.cuda.is_available():
         return False
     major, minor = torch.cuda.get_device_capability()
-    return major >= 9
+    sm_version_num = major * 10 + minor
+    return sm_version_num >= 90 and sm_version_num < 100
 
 
-CUDA_HOPPER = _is_cuda_hopper()
+CUDA_AVAILABLE = is_cuda_available()
 
 
 def _ref_pack_seq(x, lengths, pad_value=-float("inf")):
@@ -80,12 +81,7 @@ else:
     ]
 
 
-# =============================================================================
-# accuracy — 2D / 3D
-# =============================================================================
-
-
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 @pytest.mark.parametrize("N, D, lengths_list", PACK_SHAPES_2D)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_pack_seq_accuracy_2d(N, D, lengths_list, dtype):
@@ -99,7 +95,7 @@ def test_pack_seq_accuracy_2d(N, D, lengths_list, dtype):
     utils.gems_assert_close(res_out, ref_out, dtype)
 
 
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 @pytest.mark.parametrize("N, H, D, lengths_list", PACK_SHAPES_3D)
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_pack_seq_accuracy_3d(N, H, D, lengths_list, dtype):
@@ -120,12 +116,7 @@ def test_pack_seq_accuracy_3d(N, H, D, lengths_list, dtype):
     utils.gems_assert_close(result, ref_out, dtype)
 
 
-# =============================================================================
-# shape consistency
-# =============================================================================
-
-
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 @pytest.mark.parametrize(
     "N, H, D, lengths_list",
     [(6, 8, 4, [3, 3])]
@@ -143,12 +134,7 @@ def test_pack_seq_shape_consistency(N, H, D, lengths_list):
     assert result.shape[2:] == x.shape[1:]
 
 
-# =============================================================================
-# custom padding
-# =============================================================================
-
-
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 @pytest.mark.parametrize("pad_value", [-100.0, -10.0, 0.0, 10.0, 100.0])
 def test_pack_seq_custom_padding(pad_value):
     N, D = 20, 16
@@ -167,12 +153,7 @@ def test_pack_seq_custom_padding(pad_value):
     )
 
 
-# =============================================================================
-# default -inf padding
-# =============================================================================
-
-
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
 def test_pack_seq_default_inf_padding(dtype):
     N, D = 20, 16
@@ -185,12 +166,7 @@ def test_pack_seq_default_inf_padding(dtype):
     assert torch.all(torch.isinf(padded_data) & (padded_data < 0))
 
 
-# =============================================================================
-# edge cases
-# =============================================================================
-
-
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 def test_pack_seq_single_batch():
     lengths = torch.tensor([10], dtype=torch.int32, device=flag_gems.device)
     x = torch.randn(10, 16, dtype=torch.float32, device=flag_gems.device)
@@ -198,7 +174,7 @@ def test_pack_seq_single_batch():
     assert result.shape == (1, 10, 16)
 
 
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 def test_pack_seq_short_sequences():
     lengths = torch.tensor([1, 1, 1], dtype=torch.int32, device=flag_gems.device)
     x = torch.randn(20, 4, dtype=torch.float32, device=flag_gems.device)
@@ -206,7 +182,7 @@ def test_pack_seq_short_sequences():
     assert result.shape == (3, 1, 4)
 
 
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 def test_pack_seq_3d_single_batch():
     lengths = torch.tensor([10], dtype=torch.int32, device=flag_gems.device)
     x = torch.randn(10, 8, 16, dtype=torch.float32, device=flag_gems.device)
@@ -214,7 +190,7 @@ def test_pack_seq_3d_single_batch():
     assert result.shape == (1, 10, 8, 16)
 
 
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 def test_pack_seq_3d_short_sequences():
     lengths = torch.tensor([1, 1, 1], dtype=torch.int32, device=flag_gems.device)
     x = torch.randn(20, 4, 8, dtype=torch.float32, device=flag_gems.device)
@@ -222,12 +198,7 @@ def test_pack_seq_3d_short_sequences():
     assert result.shape == (3, 1, 4, 8)
 
 
-# =============================================================================
-# block sizes
-# =============================================================================
-
-
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 @pytest.mark.parametrize("block_t, block_d", [(32, 32), (64, 64), (128, 128)])
 def test_pack_seq_block_sizes(block_t, block_d):
     N, D = 100, 32
@@ -243,14 +214,9 @@ def test_pack_seq_block_sizes(block_t, block_d):
     utils.gems_assert_close(result, ref_out, torch.float32)
 
 
-# =============================================================================
-# fp8 tests
-# =============================================================================
-
-
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 @pytest.mark.skipif(
-    not CUDA_HOPPER,
+    not CUDA_AVAILABLE,
     reason="requires NVIDIA Hopper architecture for FP8",
 )
 @pytest.mark.parametrize(
@@ -275,9 +241,9 @@ def test_pack_seq_fp8_basic(N, H, D, lengths_list):
         torch.testing.assert_close(actual, expected, rtol=1e-1, atol=1e-2)
 
 
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 @pytest.mark.skipif(
-    not CUDA_HOPPER,
+    not CUDA_AVAILABLE,
     reason="requires NVIDIA Hopper architecture for FP8",
 )
 def test_pack_seq_fp8_custom_padding():
@@ -297,9 +263,9 @@ def test_pack_seq_fp8_custom_padding():
             assert torch.allclose(padded_data, torch.zeros_like(padded_data), atol=1e-2)
 
 
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 @pytest.mark.skipif(
-    not CUDA_HOPPER,
+    not CUDA_AVAILABLE,
     reason="requires NVIDIA Hopper architecture for FP8",
 )
 def test_pack_seq_fp8_default_inf_padding():
@@ -313,9 +279,9 @@ def test_pack_seq_fp8_default_inf_padding():
     assert torch.all(padded_data < -100)
 
 
-@pytest.mark.pack_seq
+@pytest.mark.pack_seq_triton
 @pytest.mark.skipif(
-    not CUDA_HOPPER,
+    not CUDA_AVAILABLE,
     reason="requires NVIDIA Hopper architecture for FP8",
 )
 @pytest.mark.parametrize("block_t, block_d", [(32, 32), (64, 64), (128, 128)])


### PR DESCRIPTION
### PR Category
Operator | OP Test | Benchmark

### Type of Change
New Feature

### Description
This  PR added  pack_seq_triton, a Triton-based fused kernel that packs a flattened sequence tensor [N, D] into a padded batched tensor [B, Lmax, D] using per-sample sequence lengths. 

- Supports float32, float16, bfloat16, float8_e4m3fn, and uint8 dtypes
- Handles arbitrary input dimensions (2D and 3D+) by internally reshaping
- Configurable pad value (defaults to -inf) and tunable block sizes (block_t, block_d)
- Includes accuracy tests, edge-case tests, and benchmarks comparing against the vLLM reference

### Issue

N/A

### Correctness
The correctness test cases for the pack_seq_triton operator have been ported from vLLM. All tests pass when executed with: 
pytest tests/test_pack_seq.py -s

<img width="1894" height="743" alt="image" src="https://github.com/user-attachments/assets/a6815950-e5e1-45b6-8d8f-831e75889e7e" />


### Performance
Benchmark configuration:

- Operator: pack_seq_triton 
- Comparison target: vLLM pack_seq_triton
- Mode: kerel
- Warmup: 1000
- Iterations: 100
- Test command: pytest benchmark/test_pack_seq.py -v

dtype | [N, D] | B | vLLM Latency(ms) | FlagGems latency(ms) | vLLM / FlagGems
-- | -- | -- | -- | -- | --
torch.float16 | [512, 64] | 5 | 0.048176 | 0.047232 | 1.020
torch.float16 | [4096, 128] | 4 | 0.047328 | 0.048192 | 0.982
torch.float16 | [8192, 256] | 5 | 0.048032 | 0.047232 | 1.017
torch.float16 | [2048, 512] | 4 | 0.046960 | 0.046592 | 1.008
torch.float16 | [16384, 64] | 8 | 0.047456 | 0.047472 | 1.000
torch.float16 | [1024, 1024 | 4 | 0.046560 | 0.046944 | 0.992
torch.float8_e4m3f | [512, 64] | 5 | 0.047168 | 0.047072 | 1.002
torch.float8_e4m3f | [4096, 128] | 4 | 0.047056 | 0.046336 | 1.016
torch.float8_e4m3f | [2048, 512] | 4 | 0.047520 | 0.047936 | 0.991
