### PR TITLE
Skip `test_scatter_reduce_two_` test

### DIFF
--- a/tests/test_scatter_reduce_two.py
+++ b/tests/test_scatter_reduce_two.py
@@ -9,6 +9,7 @@ from .accuracy_utils import gems_assert_close, to_reference
 from .conftest import QUICK_MODE
 
 
+@pytest.mark.skip(reason="Issue #3435: result not close")
 @pytest.mark.scatter_reduce_two_
 @pytest.mark.parametrize(
     "src_shape", [(32, 8, 4)] if QUICK_MODE else [(128, 16, 4), (256, 32, 8)]


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Other

### Description

The `scatter_reduce_two_` operator fails the daily test, thus has to be skipped.