### PR TITLE
[KMcompiler]added the unpack_seq_triton op for Deepseek V4

### DIFF
--- a/benchmark/test_unpack_seq.py
+++ b/benchmark/test_unpack_seq.py
@@ -1,0 +1,141 @@
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.fused import unpack_seq_triton
+
+from . import base
+
+# =============================================================================
+# vLLM availability check
+# =============================================================================
+
+try:
+    from vllm.v1.attention.ops.common import unpack_seq_triton as vllm_unpack_seq
+
+    HAS_VLLM = True
+except ImportError:
+    HAS_VLLM = False
+
+
+# =============================================================================
+# CUDA available check for FP8
+# =============================================================================
+
+
+def is_cuda_available():
+    if flag_gems.device != "cuda":
+        return False
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    sm_version_num = major * 10 + minor
+    return sm_version_num >= 90 and sm_version_num < 100
+
+
+CUDA_AVAILABLE = is_cuda_available()
+
+FP8_DTYPE = torch.float8_e4m3fn if CUDA_AVAILABLE else None
+
+# =============================================================================
+# Benchmark shapes: (N, D, B, lengths_list)
+# =============================================================================
+
+UNPACK_BENCH_SHAPES = [
+    (512, 64, 5, [64, 128, 64, 128, 128]),
+    (4096, 128, 4, [1024, 1024, 1024, 1024]),
+    (8192, 256, 5, [1024, 2048, 1024, 2048, 2048]),
+    (2048, 512, 4, [512, 512, 512, 512]),
+    (16384, 64, 8, [2048] * 8),
+    (1024, 1024, 4, [256] * 4),
+]
+
+FP8_BENCH_SHAPES = [
+    (512, 64, 5, [64, 128, 64, 128, 128]),
+    (4096, 128, 4, [1024, 1024, 1024, 1024]),
+    (2048, 512, 4, [512, 512, 512, 512]),
+]
+
+
+# =============================================================================
+# Custom Benchmark class — unpack_seq (float dtypes)
+# =============================================================================
+
+
+class UnpackSeqBenchmark(base.Benchmark):
+    DEFAULT_DTYPES = [torch.float16, torch.float32, torch.bfloat16]
+
+    def __init__(self, op_name, torch_op, dtypes):
+        super().__init__(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = UNPACK_BENCH_SHAPES
+
+    def get_input_iter(self, cur_dtype):
+        for config in self.shapes:
+            yield from self._unpack_input_fn(config, cur_dtype)
+
+    def _unpack_input_fn(self, config, dtype):
+        N, D, B, lengths_list = config
+        Lmax = max(lengths_list)
+        device = flag_gems.device
+        lengths = torch.tensor(lengths_list, dtype=torch.int32, device=device)
+        packed = torch.randn(B, Lmax, D, dtype=dtype, device=device)
+        yield packed, lengths
+
+
+# =============================================================================
+# Custom Benchmark class — unpack_seq (FP8)
+# =============================================================================
+
+
+class UnpackSeqFP8Benchmark(base.Benchmark):
+    def __init__(self, op_name, torch_op, dtypes):
+        super().__init__(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = FP8_BENCH_SHAPES
+
+    def get_input_iter(self, cur_dtype):
+        del cur_dtype
+        for config in self.shapes:
+            yield from self._fp8_input_fn(config)
+
+    def _fp8_input_fn(self, config):
+        N, D, B, lengths_list = config
+        Lmax = max(lengths_list)
+        device = flag_gems.device
+        lengths = torch.tensor(lengths_list, dtype=torch.int32, device=device)
+        packed = torch.randn(B, Lmax, D, dtype=torch.float32, device=device) * 0.1
+        packed_fp8 = packed.to(FP8_DTYPE)
+        yield packed_fp8, lengths
+
+
+@pytest.mark.unpack_seq_triton
+@pytest.mark.skipif(
+    not HAS_VLLM,
+    reason="requires vLLM to be installed for reference comparison",
+)
+def test_unpack_seq():
+    bench = UnpackSeqBenchmark(
+        op_name="unpack_seq_triton",
+        torch_op=vllm_unpack_seq,
+        dtypes=[torch.float16, torch.float32, torch.bfloat16],
+    )
+    bench.set_gems(unpack_seq_triton)
+    bench.run()
+
+
+@pytest.mark.unpack_seq_triton
+@pytest.mark.skipif(
+    not (HAS_VLLM and CUDA_AVAILABLE),
+    reason="requires vLLM and NVIDIA Hopper architecture for FP8",
+)
+def test_unpack_seq_fp8():
+    bench = UnpackSeqFP8Benchmark(
+        op_name="unpack_seq_triton",
+        torch_op=vllm_unpack_seq,
+        dtypes=[FP8_DTYPE],
+    )
+    bench.set_gems(unpack_seq_triton)
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -6133,6 +6133,18 @@ ops:
       - Distribution
     stages:
       - beta: '5.1'
+  - id: unpack_seq_triton
+    description: Unpack a packed sequence tensor back to its original variable-length form.
+    for:
+      - unpack_seq_triton
+    labels:
+      - fused
+      - vLLM
+      - DeepSeekV4
+    kind:
+      - NeuralNetwork
+    stages:
+      - beta: '5.1'
   # - id: unsafe_view
   #   description: |
   #     Creates a new view of an existing tensor with a different shape without

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -60,6 +60,7 @@ from flag_gems.fused.top_k_per_row_decode import top_k_per_row_decode
 from flag_gems.fused.top_k_per_row_prefill import top_k_per_row_prefill
 from flag_gems.fused.topk_softmax import topk_softmax
 from flag_gems.fused.topk_softplus_sqrt import topk_softplus_sqrt
+from flag_gems.fused.unpack_seq import unpack_seq_triton
 from flag_gems.fused.weight_norm import weight_norm
 
 __all__ = [
@@ -116,6 +117,7 @@ __all__ = [
     "top_k_per_row_prefill",
     "topk_softmax",
     "topk_softplus_sqrt",
+    "unpack_seq_triton",
     "weight_norm",
     "sparse_attn_triton",
 ]

--- a/src/flag_gems/fused/unpack_seq.py
+++ b/src/flag_gems/fused/unpack_seq.py
@@ -1,0 +1,91 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def _unpack_seq_triton_kernel(
+    packed_ptr,  # [B, Lmax, D]
+    out_ptr,  # [N, D]
+    lengths_ptr,  # *i32, [B]
+    B: tl.constexpr,
+    Lmax: tl.constexpr,
+    D: tl.constexpr,
+    BLOCK_T: tl.constexpr,  # timesteps per program
+    BLOCK_D: tl.constexpr,  # features per program
+):
+    pid_b = tl.program_id(0)  # batch id
+    pid_t = tl.program_id(1)  # block over time dimension
+    pid_d = tl.program_id(2)  # block over feature dimension
+    off_t = pid_t * BLOCK_T + tl.arange(0, BLOCK_T)  # [BLOCK_T]
+    off_d = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)  # [BLOCK_D]
+
+    # bounds: compute start from cumulative lengths
+    in_start = 0
+    for i in range(pid_b):
+        in_start += tl.load(lengths_ptr + i)
+    seq_len = tl.load(lengths_ptr + pid_b)
+
+    # valid time positions for this block
+    t_mask = off_t < Lmax
+    valid_row = (off_t < seq_len) & t_mask
+
+    # compute output row indices for valid (b, t)
+    out_row = in_start + off_t
+
+    # Pointers
+    # packed_ptr: row-major [B, Lmax, D]
+    packed_row_ptr = packed_ptr + (pid_b * Lmax + off_t)[:, None] * D + off_d[None, :]
+
+    # out_ptr: row-major [N, D]
+    out_row_ptr = out_ptr + out_row[:, None] * D + off_d[None, :]
+
+    # Load from packed tensor and store to output
+    d_mask = off_d[None, :] < D
+    packed_vals = tl.load(packed_row_ptr, mask=valid_row[:, None] & d_mask)
+    tl.store(out_row_ptr, packed_vals, mask=valid_row[:, None] & d_mask)
+
+
+def unpack_seq_triton(
+    packed_tensor: torch.Tensor,
+    lengths: torch.Tensor,
+    block_t: int = 64,
+    block_d: int = 64,
+) -> torch.Tensor:
+    logger.debug("GEMS UNPACK_SEQ_TRITON")
+    original_shape = packed_tensor.shape
+    if len(original_shape) > 3:
+        B, Lmax = original_shape[:2]
+        packed_reshaped = packed_tensor.reshape(B, Lmax, -1)
+        D = packed_reshaped.shape[2]
+    else:
+        B, Lmax, D = packed_tensor.shape
+        packed_reshaped = packed_tensor
+
+    N = int(lengths.sum().item())
+
+    out = torch.empty((N, D), device=packed_tensor.device, dtype=packed_tensor.dtype)
+
+    grid = (B, triton.cdiv(Lmax, block_t), triton.cdiv(D, block_d))
+    _unpack_seq_triton_kernel[grid](
+        packed_reshaped,
+        out,
+        lengths.int(),
+        B,
+        Lmax,
+        D,
+        BLOCK_T=block_t,
+        BLOCK_D=block_d,
+        num_warps=4,
+        num_stages=2,
+    )
+
+    if len(original_shape) > 3:
+        output_shape = (N,) + original_shape[2:]
+        out = out.reshape(output_shape)
+
+    return out

--- a/tests/test_unpack_seq.py
+++ b/tests/test_unpack_seq.py
@@ -1,0 +1,220 @@
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.fused import unpack_seq_triton
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+# =============================================================================
+# CUDA available check for FP8
+# =============================================================================
+
+
+def _is_cuda_available():
+    if flag_gems.device != "cuda":
+        return False
+    if not torch.cuda.is_available():
+        return False
+    major, minor = torch.cuda.get_device_capability()
+    sm_version_num = major * 10 + minor
+    return sm_version_num >= 90 and sm_version_num < 100
+
+
+CUDA_AVAILABLE = _is_cuda_available()
+
+
+def _ref_pack_seq(x, lengths, pad_value=-float("inf")):
+    """Pure PyTorch reference for pack_seq_triton."""
+    if isinstance(lengths, torch.Tensor):
+        lengths = lengths.tolist()
+    B = len(lengths)
+    Lmax = max(lengths)
+    original_shape = x.shape
+    if len(original_shape) > 2:
+        D_flat = original_shape[1:].numel()
+        x_flat = x.reshape(original_shape[0], -1)
+    else:
+        D_flat = x.shape[1]
+        x_flat = x
+
+    # Always use float32 to hold the fill value so that values like -inf
+    # are representable even when the target dtype is fp8 or uint8.
+    out_reshaped = torch.full(
+        (B, Lmax, D_flat), pad_value, device=x.device, dtype=torch.float32
+    )
+    offset = 0
+    for b in range(B):
+        seq_len = lengths[b]
+        out_reshaped[b, :seq_len] = x_flat[offset : offset + seq_len]
+        offset += seq_len
+
+    out_reshaped = out_reshaped.to(x.dtype)
+
+    if len(original_shape) > 2:
+        return out_reshaped.reshape((B, Lmax) + original_shape[1:])
+    return out_reshaped
+
+
+def _ref_unpack_seq(packed_tensor, lengths):
+    """Pure PyTorch reference for unpack_seq_triton."""
+    if isinstance(lengths, torch.Tensor):
+        lengths = lengths.tolist()
+    original_shape = packed_tensor.shape
+    if len(original_shape) > 3:
+        B, Lmax = original_shape[:2]
+        D_flat = original_shape[2:].numel()
+        packed_flat = packed_tensor.reshape(B, Lmax, -1)
+    else:
+        B, Lmax, D_flat = packed_tensor.shape
+        packed_flat = packed_tensor
+
+    N = sum(lengths)
+    out_reshaped = torch.empty(
+        (N, D_flat), device=packed_tensor.device, dtype=packed_tensor.dtype
+    )
+    offset = 0
+    for b in range(B):
+        seq_len = lengths[b]
+        out_reshaped[offset : offset + seq_len] = packed_flat[b, :seq_len]
+        offset += seq_len
+
+    if len(original_shape) > 3:
+        return out_reshaped.reshape((N,) + original_shape[2:])
+    return out_reshaped
+
+
+# =============================================================================
+# Test shapes
+# =============================================================================
+
+if cfg.QUICK_MODE:
+    FLOAT_DTYPES = [torch.float32]
+    UNPACK_SHAPES_2D = [(32, 64, [4, 7, 1, 8, 12])]
+    UNPACK_SHAPES_3D = [(6, 8, 4, [3, 3])]
+else:
+    FLOAT_DTYPES = utils.FLOAT_DTYPES
+    UNPACK_SHAPES_2D = [
+        (32, 64, [4, 7, 1, 8, 12]),
+        (128, 256, [32, 64, 32]),
+        (16, 32, [1] * 16),
+        (200, 128, [100, 50, 30, 20]),
+    ]
+    UNPACK_SHAPES_3D = [
+        (6, 8, 4, [3, 3]),
+        (10, 4, 8, [2, 4, 4]),
+        (20, 16, 32, [5, 5, 5, 5]),
+        (15, 8, 16, [7, 5, 3]),
+    ]
+
+
+@pytest.mark.unpack_seq_triton
+@pytest.mark.parametrize("N, D, lengths_list", UNPACK_SHAPES_2D)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_unpack_seq_accuracy_2d(N, D, lengths_list, dtype):
+    B = len(lengths_list)
+    Lmax = max(lengths_list)
+    lengths = torch.tensor(lengths_list, dtype=torch.int32, device=flag_gems.device)
+
+    packed = torch.randn(B, Lmax, D, dtype=dtype, device=flag_gems.device)
+    ref_packed = utils.to_reference(packed, True)
+
+    ref_out = _ref_unpack_seq(ref_packed, lengths_list)
+    res_out = unpack_seq_triton(packed, lengths)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.unpack_seq_triton
+@pytest.mark.parametrize("N, D, lengths_list", UNPACK_SHAPES_2D)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_pack_unpack_roundtrip_2d(N, D, lengths_list, dtype):
+    lengths = torch.tensor(lengths_list, dtype=torch.int32, device=flag_gems.device)
+    x = torch.randn(N, D, dtype=dtype, device=flag_gems.device)
+
+    packed = _ref_pack_seq(x, lengths_list)
+    unpacked = unpack_seq_triton(packed, lengths)
+
+    assert unpacked.shape == x.shape
+    ref_x = utils.to_reference(x, True)
+    utils.gems_assert_close(unpacked, ref_x, dtype)
+
+
+@pytest.mark.unpack_seq_triton
+@pytest.mark.parametrize("N, H, D, lengths_list", UNPACK_SHAPES_3D)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_pack_unpack_roundtrip_3d(N, H, D, lengths_list, dtype):
+    lengths = torch.tensor(lengths_list, dtype=torch.int32, device=flag_gems.device)
+    x = torch.randn(N, H, D, dtype=dtype, device=flag_gems.device)
+
+    packed = _ref_pack_seq(x, lengths_list)
+    unpacked = unpack_seq_triton(packed, lengths)
+
+    assert unpacked.shape == x.shape
+    ref_x = utils.to_reference(x, True)
+    utils.gems_assert_close(unpacked, ref_x, dtype)
+
+
+@pytest.mark.unpack_seq_triton
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_unpack_seq_single_batch(dtype):
+    x = torch.randn(10, 16, dtype=dtype, device=flag_gems.device)
+    lengths = torch.tensor([10], dtype=torch.int32, device=flag_gems.device)
+    packed = _ref_pack_seq(x, [10])
+    unpacked = unpack_seq_triton(packed, lengths)
+    assert unpacked.shape == x.shape
+
+    ref_x = utils.to_reference(x, True)
+    utils.gems_assert_close(unpacked, ref_x, dtype)
+
+
+@pytest.mark.unpack_seq_triton
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_unpack_seq_short_sequences(dtype):
+    x = torch.randn(20, 4, dtype=dtype, device=flag_gems.device)
+    lengths = torch.tensor([1, 1, 1], dtype=torch.int32, device=flag_gems.device)
+    packed = _ref_pack_seq(x, [1, 1, 1])
+    unpacked = unpack_seq_triton(packed, lengths)
+
+    ref_x = utils.to_reference(x[:3], True)
+    utils.gems_assert_close(unpacked, ref_x, dtype)
+
+
+@pytest.mark.unpack_seq_triton
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_unpack_seq_3d_edge_cases(dtype):
+    x = torch.randn(15, 8, 16, dtype=dtype, device=flag_gems.device)
+    lengths = torch.tensor([5, 7, 3], dtype=torch.int32, device=flag_gems.device)
+    packed = _ref_pack_seq(x, [5, 7, 3])
+    unpacked = unpack_seq_triton(packed, lengths)
+    assert unpacked.shape == x.shape
+
+    ref_x = utils.to_reference(x, True)
+    utils.gems_assert_close(unpacked, ref_x, dtype)
+
+
+@pytest.mark.unpack_seq_triton
+@pytest.mark.skipif(
+    not CUDA_AVAILABLE,
+    reason="requires NVIDIA Hopper architecture for FP8",
+)
+def test_pack_unpack_fp8_roundtrip():
+    FP8 = torch.float8_e4m3fn
+    for N, H, D, lengths_list in [
+        (6, 8, 4, [3, 3]),
+        (10, 4, 8, [2, 4, 4]),
+        (15, 8, 16, [7, 5, 3]),
+    ]:
+        lengths = torch.tensor(lengths_list, dtype=torch.int32, device=flag_gems.device)
+        x = torch.randn(N, H, D, dtype=torch.float32, device=flag_gems.device) * 0.1
+        x_fp8 = x.to(FP8)
+        packed = _ref_pack_seq(x_fp8, lengths_list)
+        unpacked = unpack_seq_triton(packed, lengths)
+        assert unpacked.shape == x_fp8.shape
+        torch.testing.assert_close(
+            x_fp8.to(torch.float32),
+            unpacked.to(torch.float32),
+            rtol=1e-3,
+            atol=1e-3,
+        )


### PR DESCRIPTION
### PR Category
Operator | OP Test | Benchmark 

### Type of Change
New Feature

### Description
This PR added unpack_seq_triton operator, which ported from vllm.v1.attention.ops.common.unpack_seq_triton. This operator unpacks a padded batched tensor [B, Lmax, ...] back into a flat concatenated tensor [N, ...] using per-batch sequence lengths, where N = sum(lengths).

Triton kernel _unpack_seq_triton_kernel with a 3D launch grid (B, ceil(Lmax / BLOCK_T), ceil(D / BLOCK_D)) (default BLOCK_T=BLOCK_D=64, 4 warps)

For each batch element, computes the cumulative input offset from lengths, reads valid (non-padded) rows from the packed tensor, and writes them to contiguous output

Supports multi-dimensional inputs (>3 dims) by internally flattening to (B, Lmax, -1) and reshaping back

### Issue

N/A

### Correctness

The correctness test cases for the unpack_seq_triton operator have been ported from vLLM. All tests pass when executed with:
pytest tests/test_unpack_seq.py -s
<img width="1665" height="764" alt="image" src="https://github.com/user-attachments/assets/ac27bc40-07de-4b30-b452-67d669ab8e1f" />

### Performance
Benchmark configuration:

- Operator: unpack_seq_triton
- Comparison target: vLLM unpack_seq_triton
- Mode: kerel
- Warmup: 1000
- Iterations: 100
- Test command: pytest benchmark/test_unpack_seq.py -s

dtype | [N, D] | B | vLLM Latency(ms) | FlagGems latency(ms) | vLLM / FlagGems
-- | -- | -- | -- | -- | --
torch.float16 | [128, 64] | 5 | 0.050944 | 0.051008 | 0.999
torch.float16 | [1024, 128] | 4 | 0.05328 | 0.053408 | 0.998
torch.float16 | [2048, 256] | 5 | 0.05392 | 0.052096 | 1.035
torch.float16 | [512, 512] | 4 | 0.049504 | 0.048992 | 1.01
torch.float16 | [2048, 64] | 8 | 0.052288 | 0.051936 | 1.007
torch.float16 | [256, 1024 | 4 | 0.052288 | 0.052448 | 0.997
torch.float8_e4m3f | [128, 64] | 5 | 0.0528 | 0.049568 | 1.065
torch.float8_e4m3f | [1024, 128] | 4 | 0.049472 | 0.050464 | 0.98
torch.float8_e4m3f | [512, 512] | 4 | 0.04992 | 0.051168 | 0.976
