### PR TITLE
Add benchmarks for router_gemm op

### DIFF
--- a/benchmark/test_blas_perf_parallel.py
+++ b/benchmark/test_blas_perf_parallel.py
@@ -62,13 +62,6 @@ except Exception:
     transform_sf_into_required_layout = None
     DEEPGEMM_AVAILABLE = False
 
-try:
-    from vllm._custom_ops import router_gemm_bf16_fp32 as vllm_router_gemm_bf16_fp32
-
-    VLLM_ROUTER_GEMM_AVAILABLE = True
-except Exception:
-    vllm_router_gemm_bf16_fp32 = None
-    VLLM_ROUTER_GEMM_AVAILABLE = False
 
 PARALLEL_WORKER_ENV = "FLAGGEMS_BENCH_PARALLEL_WORKER"
 PARALLEL_RESULT_FILE_ENV = "FLAGGEMS_BENCH_RESULT_FILE"
@@ -1452,15 +1445,13 @@ def test_addr_benchmark():
 
 @pytest.mark.router_gemm
 def test_perf_router_gemm():
-    if not VLLM_ROUTER_GEMM_AVAILABLE:
-        pytest.skip(
-            "router_gemm benchmark requires vLLM router_gemm_bf16_fp32 baseline"
-        )
+    def torch_router_gemm(x, weight):
+        return torch.mm(x, weight.t()).to(torch.float32)
 
     bench = ParallelRouterGemmBenchmark(
         input_fn=router_gemm_input_fn,
         op_name="router_gemm",
-        torch_op=vllm_router_gemm_bf16_fp32,
+        torch_op=torch_router_gemm,
         dtypes=[torch.bfloat16],
     )
     bench.set_gems(flag_gems.router_gemm)

--- a/benchmark/test_router_gemm.py
+++ b/benchmark/test_router_gemm.py
@@ -1,0 +1,71 @@
+from typing import Generator
+
+import pytest
+import torch
+
+from . import base, consts
+
+ROUTER_GEMM_SHAPES = [
+    (1, 8, 4096),
+    (16, 8, 4096),
+    (64, 8, 4096),
+    (256, 8, 4096),
+    (1024, 8, 4096),
+    (4096, 8, 4096),
+    (64, 64, 7168),
+    (256, 64, 7168),
+    (1024, 128, 7168),
+    (4096, 128, 7168),
+]
+
+
+def torch_router_gemm(x, weight):
+    return torch.mm(x, weight.t()).to(torch.float32)
+
+
+try:
+    from flag_gems.runtime.backend._nvidia.hopper.ops.mm import router_gemm
+
+    ROUTER_GEMM_AVAILABLE = True
+except Exception:
+    router_gemm = None
+    ROUTER_GEMM_AVAILABLE = False
+
+
+class RouterGemmBenchmark(base.Benchmark):
+    DEFAULT_METRICS = consts.DEFAULT_METRICS[:] + ["tflops"]
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.shape_desc = "M, N, K"
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = ROUTER_GEMM_SHAPES[:]
+        self.shape_desc = "M, N, K"
+
+    def get_input_iter(self, dtype) -> Generator:
+        for m, n, k in self.shapes:
+            x = torch.randn((m, k), dtype=torch.bfloat16, device=self.device)
+            weight = torch.randn((n, k), dtype=torch.bfloat16, device=self.device)
+            yield x, weight
+
+    def get_tflops(self, op, *args, **kwargs):
+        x, weight = args[0], args[1]
+        m, k = x.shape
+        n = weight.shape[0]
+        return 2 * m * n * k
+
+
+@pytest.mark.router_gemm
+@pytest.mark.skipif(
+    not ROUTER_GEMM_AVAILABLE,
+    reason="router_gemm benchmark requires NVIDIA Hopper backend",
+)
+def test_perf_router_gemm():
+    bench = RouterGemmBenchmark(
+        op_name="router_gemm",
+        torch_op=torch_router_gemm,
+        gems_op=router_gemm,
+        dtypes=[torch.bfloat16],
+    )
+    bench.run()


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
- Add `test_router_gemm.py`
- Replace the reference implementation with torch.mm in `test_blas_perf_parallel.py`
- FlagGems `router_gemm` achieves an average speedup of **1.308×** on DeepSeek-V4 shapes.
- `dsv3_router_gemm` achieves an average speedup of **1.599×** on DeepSeek-V3.2 shapes.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
