### PR TITLE
[ENFLAME] revert scatter.py

### DIFF
--- a/src/flag_gems/runtime/backend/_enflame/gcu400/ops/scatter.py
+++ b/src/flag_gems/runtime/backend/_enflame/gcu400/ops/scatter.py
@@ -4,8 +4,6 @@ import os
 from typing import Any, Callable, List, Mapping, Tuple
 
 import torch
-import triton
-import triton.language as tl
 
 from flag_gems.utils.code_cache import code_cache_dir
 from flag_gems.utils.code_utils import IndentedBuffer, write_atomic
@@ -18,71 +16,6 @@ from flag_gems.utils.shape_utils import (
 logger = logging.getLogger(__name__)
 
 
-@triton.jit
-def scatter_add_2d_kernel(
-    out_ptr,
-    src_ptr,
-    index_ptr,
-    M,
-    N,
-    out_stride0,
-    out_stride1,
-    src_stride0,
-    src_stride1,
-    idx_stride0,
-    idx_stride1,
-    scatter_dim: tl.constexpr,
-    BLOCK: tl.constexpr,
-    LOOP: tl.constexpr,
-):
-    pid = tl.program_id(0)
-    total = M * N
-    base = pid * LOOP * BLOCK
-    for _i in tl.static_range(LOOP):
-        offs = base + tl.arange(0, BLOCK)
-        mask = offs < total
-        row = offs // N
-        col = offs % N
-
-        src_off = row * src_stride0 + col * src_stride1
-        idx_off = row * idx_stride0 + col * idx_stride1
-
-        cur_src = tl.load(src_ptr + src_off, mask=mask, other=0.0)
-        cur_idx = tl.load(index_ptr + idx_off, mask=mask, other=0)
-
-        if scatter_dim == 0:
-            out_off = cur_idx * out_stride0 + col * out_stride1
-        else:
-            out_off = row * out_stride0 + cur_idx * out_stride1
-
-        tl.atomic_add(out_ptr + out_off, cur_src, mask=mask, sem="relaxed")
-        base += BLOCK
-
-
-@triton.jit
-def scatter_add_row_kernel(
-    out_ptr,
-    src_ptr,
-    index_ptr,
-    N,
-    out_stride0,
-    src_stride0,
-    idx_stride0,
-    BLOCK_N: tl.constexpr,
-):
-    row = tl.program_id(0)
-    out_base = row * out_stride0
-    src_base = row * src_stride0
-    idx_base = row * idx_stride0
-
-    for col_start in range(0, N, BLOCK_N):
-        offs = col_start + tl.arange(0, BLOCK_N)
-        mask = offs < N
-        s = tl.load(src_ptr + src_base + offs, mask=mask, other=0.0)
-        i = tl.load(index_ptr + idx_base + offs, mask=mask, other=0)
-        tl.atomic_add(out_ptr + out_base + i, s, mask=mask, sem="relaxed")
-
-
 def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("import torch")
     code.writeline("import triton")
@@ -91,7 +24,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("from flag_gems.utils import libentry")
     code.writeline("from flag_gems import runtime")
     code.writeline("import flag_gems")
-    # code.writeline("from flag_gems.utils import triton_lang_extension as ext")
+    # code.writeline("from flag_gems.utils import triton_lang_extension as tle")
     code.newline()
     code.newline()
     return code
@@ -124,6 +57,14 @@ def generate_scatter_kernel(
 
     # the decorators
     code.writeline("@libentry()")
+    code.writeline("@triton.heuristics(")
+    with code.indent():
+        code.writeline("{")
+        with code.indent():
+            code.writeline('"BLOCK": heur_block,')
+            code.writeline('"LOOP": loop_count,')
+        code.writeline("}")
+    code.writeline(")")
     inp_stride_vars = ",".join(f"'inp_stride_{i}'" for i in range(rank))
     index_stride_vars = ",".join(f"'index_stride_{i}'" for i in range(rank))
     src_stride_vars = ",".join(f"'src_stride_{i}'" for i in range(rank))
@@ -289,15 +230,7 @@ def generate_destination_passing_wrapper(
         code.writeline('IS_MUL = reduce == "multiply"')
         code.writeline("int32_offset = int32_offset or True")
 
-        code.writeline("import math")
-        code.writeline("BLOCK = 128")
-        code.writeline("LOOP = 4")
-        code.writeline("while math.ceil(N / (BLOCK * LOOP)) > 65535:")
-        code.writeline("    if BLOCK < 1024:")
-        code.writeline("        BLOCK *= 2")
-        code.writeline("    else:")
-        code.writeline("        LOOP *= 2")
-
+        # kernel launch
         code.writeline("grid = lambda meta: (")
         with code.indent():
             code.writeline('triton.cdiv(N, meta["BLOCK"] * meta["LOOP"]), ')
@@ -324,10 +257,9 @@ def generate_destination_passing_wrapper(
                 code.writeline("inp_size_dim,")
                 code.writeline("stride_dim,")
                 code.writeline("N,")
+                # reduce options
                 code.writeline("IS_ADD,")
                 code.writeline("IS_MUL,")
-                code.writeline("BLOCK=BLOCK,")
-                code.writeline("LOOP=LOOP,")
                 code.writeline("INT32_OFFSET=int32_offset,")
         code.writeline(")")
         code.writeline("return out")
@@ -395,14 +327,6 @@ class ScatterFunction:
 _scatter_func = ScatterFunction()
 
 
-def _reduce_name_to_scatter_reduce(reduce):
-    if reduce == "add":
-        return "sum"
-    elif reduce == "multiply":
-        return "prod"
-    return reduce
-
-
 def scatter(inp, dim, index, src, reduce=None):
     logger.debug("GEMS SCATTER")
 
@@ -412,20 +336,16 @@ def scatter(inp, dim, index, src, reduce=None):
         inp = inp.to(torch.float32)
         src = src.to(torch.float32)
 
-    if reduce is not None:
-        out = inp.clone()
-        scatter_(out, dim, index, src, reduce=reduce)
-        if needs_upcast:
-            out = out.to(orig_dtype)
-        return out
-
     out = inp.clone()
+
+    if reduce is not None:
+        assert inp.dtype not in (
+            torch.bfloat16,
+        ), "Unsupported operation: reduce scatter bfloat tensors."
 
     if has_internal_overlapping(out) == MemOverlap.Yes:
         out = out.contiguous()
 
-    if index.dtype == torch.int64:
-        index = index.to(torch.int32)
     src_strided = src.as_strided(index.shape, src.stride())
     inp_restrided = restride_dim(inp, dim, index.shape)
     dim_size = inp.size(dim)
@@ -451,82 +371,6 @@ def scatter(inp, dim, index, src, reduce=None):
     return out
 
 
-def _adaptive_scatter_config(total):
-    if total <= 8192:
-        return 256, 4
-    elif total <= 131072:
-        return 256, 8
-    else:
-        return 1024, 4
-
-
-@triton.jit(do_not_specialize=["total_elements"])
-def scatter_src_2d_kernel(
-    out_ptr,
-    src_ptr,
-    index_ptr,
-    total_elements,
-    N,
-    out_stride0,
-    out_stride1,
-    src_stride0,
-    src_stride1,
-    idx_stride0,
-    idx_stride1,
-    scatter_dim: tl.constexpr,
-    BLOCK: tl.constexpr,
-):
-    pid = tl.program_id(0)
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
-    mask = offs < total_elements
-    row = offs // N
-    col = offs % N
-
-    src_off = row * src_stride0 + col * src_stride1
-    idx_off = row * idx_stride0 + col * idx_stride1
-
-    cur_src = tl.load(src_ptr + src_off, mask=mask, other=0.0)
-    cur_idx = tl.load(index_ptr + idx_off, mask=mask, other=0)
-
-    if scatter_dim == 0:
-        out_off = cur_idx * out_stride0 + col * out_stride1
-    else:
-        out_off = row * out_stride0 + cur_idx * out_stride1
-
-    tl.store(out_ptr + out_off, cur_src, mask=mask)
-
-
-@triton.jit(do_not_specialize=["N", "M", "out_stride0", "src_stride0", "idx_stride0"])
-def scatter_src_row_kernel(
-    out_ptr,
-    src_ptr,
-    index_ptr,
-    N,
-    M,
-    out_stride0,
-    src_stride0,
-    idx_stride0,
-    scatter_dim: tl.constexpr,
-    BLOCK_N: tl.constexpr,
-):
-    pid = tl.program_id(0)
-    num_progs = tl.num_programs(0)
-    for row in tl.range(pid, M, num_progs):
-        out_base = row * out_stride0
-        src_base = row * src_stride0
-        idx_base = row * idx_stride0
-
-        for col_start in range(0, N, BLOCK_N):
-            offs = col_start + tl.arange(0, BLOCK_N)
-            mask = offs < N
-            s = tl.load(src_ptr + src_base + offs, mask=mask, other=0.0)
-            i = tl.load(index_ptr + idx_base + offs, mask=mask, other=0)
-            if scatter_dim == 0:
-                tl.store(out_ptr + i * out_stride0 + offs, s, mask=mask)
-            else:
-                tl.store(out_ptr + out_base + i, s, mask=mask)
-
-
 def scatter_(inp, dim, index, src, reduce=None):
     logger.debug("GEMS SCATTER_")
 
@@ -543,151 +387,10 @@ def scatter_(inp, dim, index, src, reduce=None):
             torch.bfloat16,
         ), "Unsupported operation: reduce scatter bfloat tensors."
 
-    if reduce is None and inp.ndim == 2:
-        dim_actual = dim % inp.ndim
-        if index.dtype == torch.int64:
-            index = index.to(torch.int32)
-        M, N_col = index.shape
-        total = M * N_col
-        src_strided = src.as_strided(index.shape, src.stride())
-        use_row = (
-            dim_actual == 1
-            and inp.stride(1) == 1
-            and src_strided.stride(1) == 1
-            and index.stride(1) == 1
-            and N_col >= 64
-            and total > 4096
-        )
-        MAX_GRID = 48
-        if use_row:
-            BLOCK_N = min(N_col, 8192)
-            if BLOCK_N < 32:
-                BLOCK_N = 32
-            nw = 1 if N_col <= 512 else 4
-            grid_size = min(M, MAX_GRID)
-            scatter_src_row_kernel[(grid_size,)](
-                inp,
-                src_strided,
-                index,
-                N_col,
-                M,
-                inp.stride(0),
-                src_strided.stride(0),
-                index.stride(0),
-                dim_actual,
-                BLOCK_N=BLOCK_N,
-                num_warps=nw,
-            )
-        else:
-            if total <= 8192:
-                BLOCK = 1024
-                nw = 1
-            elif total <= 131072:
-                BLOCK = 4096
-                nw = 1
-            else:
-                BLOCK = 8192
-                nw = 4
-            grid = (triton.cdiv(total, BLOCK),)
-            scatter_src_2d_kernel[grid](
-                inp,
-                src_strided,
-                index,
-                total,
-                N_col,
-                inp.stride(0),
-                inp.stride(1),
-                src.stride(0),
-                src.stride(1),
-                index.stride(0),
-                index.stride(1),
-                dim_actual,
-                BLOCK=BLOCK,
-                num_warps=nw,
-            )
-        return inp
-
-    if reduce == "add" and inp.ndim == 2:
-        dim_actual = dim % inp.ndim
-        total = index.numel()
-        M, N_col = index.shape
-        mem_bytes = total * 4 * 3
-        if mem_bytes > 5_000_000_000:
-            CHUNK = max(1, 4_000_000_000 // (N_col * 4 * 3))
-            for row_start in range(0, M, CHUNK):
-                row_end = min(row_start + CHUNK, M)
-                chunk_M = row_end - row_start
-                idx_c = index[row_start:row_end]
-                if idx_c.dtype == torch.int64:
-                    idx_c = idx_c.to(torch.int32)
-                if dim_actual == 1:
-                    scatter_add_row_kernel[(chunk_M,)](
-                        inp[row_start:row_end],
-                        src[row_start:row_end],
-                        idx_c,
-                        N_col,
-                        inp.stride(0),
-                        src.stride(0),
-                        idx_c.stride(0),
-                        BLOCK_N=1024,
-                        num_warps=4,
-                    )
-                else:
-                    ct = chunk_M * N_col
-                    BLOCK, num_warps = _adaptive_scatter_config(ct)
-                    LOOP = 4
-                    while triton.cdiv(ct, BLOCK * LOOP) > 65535:
-                        LOOP *= 2
-                    grid = (triton.cdiv(ct, BLOCK * LOOP),)
-                    scatter_add_2d_kernel[grid](
-                        inp,
-                        src[row_start:row_end],
-                        idx_c,
-                        chunk_M,
-                        N_col,
-                        inp.stride(0),
-                        inp.stride(1),
-                        src.stride(0),
-                        src.stride(1),
-                        idx_c.stride(0),
-                        idx_c.stride(1),
-                        dim_actual,
-                        BLOCK=BLOCK,
-                        LOOP=LOOP,
-                        num_warps=num_warps,
-                    )
-            return inp
-        idx = index.to(torch.int32) if index.dtype == torch.int64 else index
-        BLOCK, num_warps = _adaptive_scatter_config(total)
-        LOOP = 4
-        while triton.cdiv(total, BLOCK * LOOP) > 65535:
-            LOOP *= 2
-        grid = (triton.cdiv(total, BLOCK * LOOP),)
-        scatter_add_2d_kernel[grid](
-            inp,
-            src,
-            idx,
-            M,
-            N_col,
-            inp.stride(0),
-            inp.stride(1),
-            src.stride(0),
-            src.stride(1),
-            idx.stride(0),
-            idx.stride(1),
-            dim_actual,
-            BLOCK=BLOCK,
-            LOOP=LOOP,
-            num_warps=num_warps,
-        )
-        return inp
-
     assert (
         has_internal_overlapping(out) != MemOverlap.Yes
     ), "Unsupported operation: trying to inplace write to an internally overlapping tensor."
 
-    if index.dtype == torch.int64:
-        index = index.to(torch.int32)
     src_restrided = src.as_strided(index.shape, src.stride())
     inp_restrided = restride_dim(out, dim, index.shape)
     dim_size = out.size(dim)


### PR DESCRIPTION
### PR Category
Operator 
### Type of Change
Bug Fix
### Description
revert op

### Progress

- [ ] Change is fully covered by a UT.

### Performance

Operator: scatter_add_  Performance Test (dtype=torch.float32, mode=kernel,level=core)

Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail

-----------------------------------------------------------------------------------------------
SUCCESS               0.107086            1.378850               0.078          [torch.Size([64, 64]), -1, torch.Size([64, 128]), torch.Size([80, 144])]
SUCCESS               0.355257            3.342871               0.106          [torch.Size([256, 256]), -1, torch.Size([256, 512]), torch.Size([272, 528])]
SUCCESS               1.804428            9.989829               0.181          [torch.Size([1024, 1024]), -1, torch.Size([1024, 2048]), torch.Size([1040, 2064])]
SUCCESS              13.050986          142.807266               0.091          [torch.Size([4096, 4096]), -1, torch.Size([4096, 8192]), torch.Size([4112, 8208])]
SUCCESS             158.301132          567.531311               0.279          [torch.Size([1024, 65536]), -1, torch.Size([1024, 131072]), torch.Size([1040, 131088])]