### PR TITLE
Fix/for hygon adap

### DIFF
--- a/src/flag_gems/runtime/backend/_hygon/ops/pow.py
+++ b/src/flag_gems/runtime/backend/_hygon/ops/pow.py
@@ -16,6 +16,8 @@ def pow_func(x, exponent):
         return _pow(x.to(tl.float32), exponent)
     elif x.type.element_ty == tl.float16:
         return _pow(x.to(tl.float32), exponent)
+    elif x.type.element_ty == tl.float32:
+        return _pow(x.to(tl.float32), exponent)
     else:
         return _pow(x.to(tl.float64), exponent)
 
@@ -37,6 +39,8 @@ def pow_func_tensor_scalar(x, exponent):
         return _pow(x.to(tl.float32), exponent)
     elif x.type.element_ty == tl.float16:
         return _pow(x.to(tl.float32), exponent)
+    elif x.type.element_ty == tl.float32:
+        return _pow(x.to(tl.float32), exponent)
     else:
         return _pow(x.to(tl.float64), exponent)
 
@@ -57,6 +61,8 @@ def pow_func_scalar_tensor(x, exponent):
     if exponent.type.element_ty == tl.bfloat16:
         return _pow(x.to(tl.float32), exponent)
     elif exponent.type.element_ty == tl.float16:
+        return _pow(x.to(tl.float32), exponent)
+    elif exponent.type.element_ty == tl.float32:
         return _pow(x.to(tl.float32), exponent)
     else:
         return _pow(x.to(tl.float64), exponent)

--- a/src/flag_gems/runtime/configloader.py
+++ b/src/flag_gems/runtime/configloader.py
@@ -76,7 +76,10 @@ class ConfigLoader(object):
             "num_stages": current_config["num_stages"],
             "num_ctas": current_config["num_ctas"],
         }
-        if self.device.vendor_name == "hygon" and "num_ldmatrixes" in inspect.signature(triton.Config).parameters:
+        if (
+            self.device.vendor_name == "hygon"
+            and "num_ldmatrixes" in inspect.signature(triton.Config).parameters
+        ):
             kwargs["num_ldmatrixes"] = current_config["num_ldmatrixes"]
         return triton.Config(single_config["META"], **kwargs)
 

--- a/src/flag_gems/runtime/configloader.py
+++ b/src/flag_gems/runtime/configloader.py
@@ -1,4 +1,5 @@
 import copy
+import inspect
 import warnings
 
 import triton
@@ -75,8 +76,8 @@ class ConfigLoader(object):
             "num_stages": current_config["num_stages"],
             "num_ctas": current_config["num_ctas"],
         }
-        if self.device.vendor_name == "hygon":
-            kwargs["num_ldmatrixes"] = current_config["num_ldmatrixes"]
+        if self.device.vendor_name == "hygon" and "num_ldmatrixes" in inspect.signature(triton.Config).parameters:
+            kwargs["num_ldmatrixes"] = current_config.get("num_ldmatrixes", 0)
         return triton.Config(single_config["META"], **kwargs)
 
     def _build_configs_by_op(self, op_name, ranges, pre_hook=None):

--- a/src/flag_gems/runtime/configloader.py
+++ b/src/flag_gems/runtime/configloader.py
@@ -77,7 +77,7 @@ class ConfigLoader(object):
             "num_ctas": current_config["num_ctas"],
         }
         if self.device.vendor_name == "hygon" and "num_ldmatrixes" in inspect.signature(triton.Config).parameters:
-            kwargs["num_ldmatrixes"] = current_config.get("num_ldmatrixes", 0)
+            kwargs["num_ldmatrixes"] = current_config["num_ldmatrixes"]
         return triton.Config(single_config["META"], **kwargs)
 
     def _build_configs_by_op(self, op_name, ranges, pre_hook=None):


### PR DESCRIPTION
### Description
Fix some bugs for hygon device adap.

### Issue
1、[src/flag_gems/runtime/configloader.py]  Since the latest triton(3.6.0+gitc73250c4.staging) version supported by Hygon does not have the parameter "num_ldmatrixes"，Added relevant judgment logic for "num_ldmatrixes".

2、[src/flag_gems/runtime/backend/_hygon/ops/pow.py]  added a judgment logic for tl.float32 in Pow.
Due to the lack of judgment for tl.float32, this will lead to the following problems：

(Worker_TP1 pid=36578) ERROR 05-20 04:39:23 [multiproc_executor.py:870]     if exponent.type.element_ty == tl.bfloat16:
(Worker_TP1 pid=36578) ERROR 05-20 04:39:23 [multiproc_executor.py:870]         return _pow(x.to(tl.float32), exponent)
(Worker_TP1 pid=36578) ERROR 05-20 04:39:23 [multiproc_executor.py:870]     elif exponent.type.element_ty == tl.float16:
(Worker_TP1 pid=36578) ERROR 05-20 04:39:23 [multiproc_executor.py:870]         return _pow(x.to(tl.float32), exponent) 
(Worker_TP1 pid=36578) ERROR 05-20 04:39:23 [multiproc_executor.py:870]     else:
(Worker_TP1 pid=36578) ERROR 05-20 04:39:23 [multiproc_executor.py:870]         return _pow(x.to(tl.float64), exponent)
(Worker_TP1 pid=36578) ERROR 05-20 04:39:23 [multiproc_executor.py:870]                ^
(Worker_TP1 pid=36578) ERROR 05-20 04:39:23 [multiproc_executor.py:870] (triton.language.float64, triton.language.float32)
KeyError: (triton.language.float64, triton.language.float32)

3、Since the latest triton(3.6.0+gitc73250c4.staging) version supported by Hygon, "cat" Flagos has made an error. vllm-plugin-FL use VLLM_FL_FLAGOS_BLACKLIST="cat" blocked this error.
