### PR TITLE
Add DeepSeek V4 attention compute_global_topk_indices_and_lens op

### DIFF
--- a/benchmark/test_deepseek_v4_attention_compute_global_topk_indices_and_lens.py
+++ b/benchmark/test_deepseek_v4_attention_compute_global_topk_indices_and_lens.py
@@ -8,11 +8,43 @@ from flag_gems.fused.deepseek_v4_attention_compute_global_topk_indices_and_lens 
 from . import base
 
 
+def torch_compute_global_topk_indices_and_lens(
+    topk_indices,
+    token_to_req_indices,
+    block_table,
+    block_size,
+    is_valid_token=None,
+):
+    if is_valid_token is None:
+        is_valid_token = torch.ones(
+            (topk_indices.shape[0],), device=topk_indices.device, dtype=torch.int32
+        )
+    global_indices = torch.empty_like(topk_indices, dtype=torch.int32)
+    lens = torch.empty(
+        (topk_indices.shape[0],), device=topk_indices.device, dtype=torch.int32
+    )
+    for token_idx in range(topk_indices.shape[0]):
+        req_idx = int(token_to_req_indices[token_idx].item())
+        valid_count = 0
+        for topk_idx in range(topk_indices.shape[1]):
+            local_idx = int(topk_indices[token_idx, topk_idx].item())
+            if local_idx >= 0:
+                block_idx = local_idx // block_size
+                block_off = local_idx % block_size
+                block_no = int(block_table[req_idx, block_idx].item())
+                global_indices[token_idx, topk_idx] = block_no * block_size + block_off
+                valid_count += 1
+            else:
+                global_indices[token_idx, topk_idx] = -1
+        lens[token_idx] = valid_count if bool(is_valid_token[token_idx].item()) else 0
+    return global_indices, lens
+
+
 class ComputeGlobalTopkIndicesAndLensBenchmark(base.Benchmark):
     def __init__(self):
         super().__init__(
             "compute_global_topk_indices_and_lens",
-            compute_global_topk_indices_and_lens,
+            torch_compute_global_topk_indices_and_lens,
             [torch.int32],
             gems_op=compute_global_topk_indices_and_lens,
         )

--- a/benchmark/test_deepseek_v4_attention_compute_global_topk_indices_and_lens.py
+++ b/benchmark/test_deepseek_v4_attention_compute_global_topk_indices_and_lens.py
@@ -1,0 +1,41 @@
+import pytest
+import torch
+
+from flag_gems.fused.deepseek_v4_attention_compute_global_topk_indices_and_lens import (
+    compute_global_topk_indices_and_lens,
+)
+
+from . import base
+
+
+class ComputeGlobalTopkIndicesAndLensBenchmark(base.Benchmark):
+    def __init__(self):
+        super().__init__(
+            "compute_global_topk_indices_and_lens",
+            compute_global_topk_indices_and_lens,
+            [torch.int32],
+            gems_op=compute_global_topk_indices_and_lens,
+        )
+
+    def set_shapes(self, shape_file_path=None):
+        _ = shape_file_path
+        self.shapes = [(4096, 128)]
+
+    def get_input_iter(self, dtype):
+        _ = dtype
+        for num_tokens, topk in self.shapes:
+            topk_indices = torch.randint(
+                -1, 64, (num_tokens, topk), device="cuda", dtype=torch.int32
+            )
+            token_to_req_indices = torch.zeros(
+                (num_tokens,), device="cuda", dtype=torch.int32
+            )
+            block_table = torch.arange(0, 256, device="cuda", dtype=torch.int32).view(
+                1, -1
+            )
+            yield (topk_indices, token_to_req_indices, block_table, 64, None)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
+def test_compute_global_topk_indices_and_lens_benchmark():
+    ComputeGlobalTopkIndicesAndLensBenchmark().run()

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -4,6 +4,10 @@ from flag_gems.fused.chunk_gated_delta_rule import chunk_gated_delta_rule
 from flag_gems.fused.concat_and_cache_mla import concat_and_cache_mla
 from flag_gems.fused.cross_entropy_loss import cross_entropy_loss
 from flag_gems.fused.cutlass_scaled_mm import cutlass_scaled_mm
+from flag_gems.fused.deepseek_v4_attention_compute_global_topk_indices_and_lens import (
+    compute_global_topk_indices_and_lens,
+    dsv4_compute_global_topk_indices_and_lens,
+)
 from flag_gems.fused.DSA.bin_topk import bucket_sort_topk
 from flag_gems.fused.FLA import (
     chunk_gated_delta_rule_fwd,
@@ -62,6 +66,8 @@ from flag_gems.fused.topk_softplus_sqrt import topk_softplus_sqrt
 from flag_gems.fused.weight_norm import weight_norm
 
 __all__ = [
+    "compute_global_topk_indices_and_lens",
+    "dsv4_compute_global_topk_indices_and_lens",
     "apply_repetition_penalties",
     "apply_rotary_pos_emb",
     "bincount",

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -6,7 +6,6 @@ from flag_gems.fused.cross_entropy_loss import cross_entropy_loss
 from flag_gems.fused.cutlass_scaled_mm import cutlass_scaled_mm
 from flag_gems.fused.deepseek_v4_attention_compute_global_topk_indices_and_lens import (
     compute_global_topk_indices_and_lens,
-    dsv4_compute_global_topk_indices_and_lens,
 )
 from flag_gems.fused.DSA.bin_topk import bucket_sort_topk
 from flag_gems.fused.FLA import (
@@ -67,7 +66,6 @@ from flag_gems.fused.weight_norm import weight_norm
 
 __all__ = [
     "compute_global_topk_indices_and_lens",
-    "dsv4_compute_global_topk_indices_and_lens",
     "apply_repetition_penalties",
     "apply_rotary_pos_emb",
     "bincount",

--- a/src/flag_gems/fused/deepseek_v4_attention_compute_global_topk_indices_and_lens.py
+++ b/src/flag_gems/fused/deepseek_v4_attention_compute_global_topk_indices_and_lens.py
@@ -1,0 +1,90 @@
+from typing import Optional, Tuple
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+
+
+@triton.jit
+def _compute_global_topk_indices_and_lens_kernel(
+    global_indices_ptr,
+    global_stride,
+    lens_ptr,
+    local_indices_ptr,
+    local_stride,
+    topk,
+    token_to_req_indices_ptr,
+    block_table_ptr,
+    block_table_stride,
+    block_size,
+    is_valid_token_ptr,
+    BLOCK: tl.constexpr,
+):
+    token_idx = tl.program_id(0)
+    is_valid_token = tl.load(is_valid_token_ptr + token_idx)
+    req_idx = tl.load(token_to_req_indices_ptr + token_idx)
+    count = tl.zeros((), dtype=tl.int32)
+
+    for start in range(0, topk, BLOCK):
+        offs = start + tl.arange(0, BLOCK)
+        mask = offs < topk
+        local_idx = tl.load(
+            local_indices_ptr + token_idx * local_stride + offs, mask=mask, other=-1
+        )
+        valid = local_idx >= 0
+        block_idx = local_idx // block_size
+        block_off = local_idx - block_idx * block_size
+        block_no = tl.load(
+            block_table_ptr + req_idx * block_table_stride + block_idx,
+            mask=mask & valid,
+            other=0,
+        )
+        slot = block_no * block_size + block_off
+        slot = tl.where(valid, slot, -1)
+        tl.store(global_indices_ptr + token_idx * global_stride + offs, slot, mask=mask)
+        count += tl.sum(valid.to(tl.int32), axis=0)
+
+    tl.store(lens_ptr + token_idx, tl.where(is_valid_token, count, 0))
+
+
+def compute_global_topk_indices_and_lens(
+    topk_indices: torch.Tensor,
+    token_to_req_indices: torch.Tensor,
+    block_table: torch.Tensor,
+    block_size: int,
+    is_valid_token: Optional[torch.Tensor] = None,
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    assert topk_indices.ndim == 2
+    if is_valid_token is None:
+        is_valid_token = torch.ones(
+            (topk_indices.shape[0],), device=topk_indices.device, dtype=torch.int32
+        )
+    num_tokens, topk = topk_indices.shape
+    global_indices = torch.empty_like(topk_indices, dtype=torch.int32)
+    lens = torch.empty((num_tokens,), device=topk_indices.device, dtype=torch.int32)
+    with torch_device_fn.device(topk_indices.device):
+        _compute_global_topk_indices_and_lens_kernel[(num_tokens,)](
+            global_indices,
+            global_indices.stride(0),
+            lens,
+            topk_indices,
+            topk_indices.stride(0),
+            topk,
+            token_to_req_indices,
+            block_table,
+            block_table.stride(0),
+            block_size,
+            is_valid_token,
+            BLOCK=1024,
+        )
+    return global_indices, lens
+
+
+dsv4_compute_global_topk_indices_and_lens = compute_global_topk_indices_and_lens
+
+__all__ = [
+    "compute_global_topk_indices_and_lens",
+    "dsv4_compute_global_topk_indices_and_lens",
+]

--- a/src/flag_gems/fused/deepseek_v4_attention_compute_global_topk_indices_and_lens.py
+++ b/src/flag_gems/fused/deepseek_v4_attention_compute_global_topk_indices_and_lens.py
@@ -82,9 +82,6 @@ def compute_global_topk_indices_and_lens(
     return global_indices, lens
 
 
-dsv4_compute_global_topk_indices_and_lens = compute_global_topk_indices_and_lens
-
 __all__ = [
     "compute_global_topk_indices_and_lens",
-    "dsv4_compute_global_topk_indices_and_lens",
 ]

--- a/tests/test_deepseek_v4_attention_compute_global_topk_indices_and_lens.py
+++ b/tests/test_deepseek_v4_attention_compute_global_topk_indices_and_lens.py
@@ -1,0 +1,42 @@
+import pytest
+import torch
+
+import flag_gems.testing as fg_testing
+from flag_gems.fused.deepseek_v4_attention_compute_global_topk_indices_and_lens import (
+    compute_global_topk_indices_and_lens,
+)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="requires cuda")
+def test_compute_global_topk_indices_and_lens_accuracy():
+    device = "cuda"
+    topk_indices = torch.tensor(
+        [[0, 3, -1, 7], [2, -1, 4, 5], [1, 0, -1, -1]], device=device, dtype=torch.int32
+    )
+    token_to_req_indices = torch.tensor([0, 1, 0], device=device, dtype=torch.int32)
+    block_table = torch.tensor([[5, 6], [9, 10]], device=device, dtype=torch.int32)
+    is_valid_token = torch.tensor([1, 1, 0], device=device, dtype=torch.int32)
+    block_size = 4
+
+    actual_indices, actual_lens = compute_global_topk_indices_and_lens(
+        topk_indices, token_to_req_indices, block_table, block_size, is_valid_token
+    )
+
+    expected = torch.full_like(topk_indices, -1)
+    expected_lens = torch.zeros((3,), device=device, dtype=torch.int32)
+    for token in range(topk_indices.shape[0]):
+        req = int(token_to_req_indices[token].item())
+        count = 0
+        for i in range(topk_indices.shape[1]):
+            local = int(topk_indices[token, i].item())
+            if local >= 0:
+                block_idx = local // block_size
+                block_off = local % block_size
+                expected[token, i] = (
+                    block_table[req, block_idx] * block_size + block_off
+                )
+                count += 1
+        expected_lens[token] = count if int(is_valid_token[token].item()) else 0
+
+    fg_testing.assert_equal(actual_indices, expected)
+    fg_testing.assert_equal(actual_lens, expected_lens)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add DeepSeek V4 attention compute_global_topk_indices_and_lens op

### Issue


### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
```
benchmark/test_deepseek_v4_attention_compute_global_topk_indices_and_lens.py 
Operator: compute_global_topk_indices_and_lens  Performance Test (dtype=torch.int32, mode=operator,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS           22520.084143            0.258684           87056.294          [torch.Size([4096, 128]), torch.Size([4096]), torch.Size([1, 256]), 64, None]
```
