### PR TITLE
[FlagGems Operator Development Competition] Add log_sigmoid_backward

### DIFF
--- a/benchmark/test_log_sigmoid.py
+++ b/benchmark/test_log_sigmoid.py
@@ -12,3 +12,13 @@ def test_log_sigmoid():
         dtypes=consts.FLOAT_DTYPES,
     )
     bench.run()
+
+
+@pytest.mark.log_sigmoid_backward
+def test_log_sigmoid_backward():
+    bench = base.UnaryPointwiseBenchmark(
+        op_name="log_sigmoid_backward",
+        torch_op=torch.ops.aten.log_sigmoid_backward,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -318,6 +318,7 @@ _FULL_CONFIG = (
     ("log1p", log1p),
     ("log1p_", log1p_),
     ("log_sigmoid", log_sigmoid),
+    ("log_sigmoid_backward", log_sigmoid_backward),
     ("logaddexp", logaddexp),
     ("logaddexp.out", logaddexp_out),
     ("logical_and", logical_and),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -201,7 +201,7 @@ from flag_gems.ops.log import log
 from flag_gems.ops.log1p import log1p
 from flag_gems.ops.log1p_ import log1p_
 from flag_gems.ops.log10 import log10, log10_, log10_out
-from flag_gems.ops.log_sigmoid import log_sigmoid
+from flag_gems.ops.log_sigmoid import log_sigmoid, log_sigmoid_backward
 from flag_gems.ops.log_softmax import (
     log_softmax,
     log_softmax_backward,
@@ -659,6 +659,7 @@ __all__ = [
     "log10_out",
     "log1p_",
     "log_sigmoid",
+    "log_sigmoid_backward",
     "log_softmax",
     "log_softmax_backward",
     "log_softmax_backward_out",

--- a/src/flag_gems/ops/log_sigmoid.py
+++ b/src/flag_gems/ops/log_sigmoid.py
@@ -14,7 +14,23 @@ def log_sigmoid_forward(x):
     return tl.minimum(x, 0.0) - tl.log(1.0 + tl.exp(-tl.abs(x).to(tl.float32)))
 
 
+@pointwise_dynamic(is_tensor=[True, True], promotion_methods=[(0, "DEFAULT")])
+@triton.jit
+def log_sigmoid_backward_kernel(dy, x):
+    dy_f32 = dy.to(tl.float32)
+    x_f32 = x.to(tl.float32)
+    # d/dx log_sigmoid(x) = 1 - sigmoid(x) = sigmoid(-x)
+    sig_neg = 1.0 / (1.0 + tl.exp(x_f32))
+    return (dy_f32 * sig_neg).to(x.dtype)
+
+
 def log_sigmoid(x):
     logger.debug("GEMS LOG_SIGMOID FORWARD")
 
     return log_sigmoid_forward(x)
+
+
+def log_sigmoid_backward(grad_output, self, buffer=None):
+    logger.debug("GEMS LOG_SIGMOID BACKWARD")
+    grad_input = log_sigmoid_backward_kernel(grad_output, self)
+    return grad_input

--- a/tests/test_log_sigmoid.py
+++ b/tests/test_log_sigmoid.py
@@ -25,3 +25,30 @@ def test_log_sigmoid(shape, dtype):
         res_out = torch.nn.functional.logsigmoid(inp)
 
     utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.log_sigmoid_backward
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_log_sigmoid_backward(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    if len(shape) == 1:
+        special_inputs = torch.tensor(
+            SPECIAL_VALUES, dtype=dtype, device=flag_gems.device
+        )
+        inp = torch.cat((inp, special_inputs))
+    res_inp = inp.detach().requires_grad_(True)
+    ref_inp = utils.to_reference(inp, True)
+
+    ref_out = torch.nn.functional.logsigmoid(ref_inp)
+    with flag_gems.use_gems():
+        res_out = torch.nn.functional.logsigmoid(res_inp)
+
+    out_grad = torch.randn_like(res_out)
+    ref_grad = utils.to_reference(out_grad, True)
+    (ref_in_grad,) = torch.autograd.grad(ref_out, ref_inp, ref_grad)
+
+    with flag_gems.use_gems():
+        (res_in_grad,) = torch.autograd.grad(res_out, res_inp, out_grad)
+
+    utils.gems_assert_close(res_in_grad, ref_in_grad, dtype)


### PR DESCRIPTION
## Summary
- Add `log_sigmoid_backward` with ATen dispatch registration using Triton pointwise_dynamic

## Implementation Details
- Formula: `grad_input = grad_output * sigmoid(-x)` (numerically stable computation)
- Uses `pointwise_dynamic` for element-wise parallel computation
- Accepts `buffer` parameter for ATen API compatibility (not used in computation)

## Testing
All tests passed on NVIDIA RTX PRO 6000 Blackwell:
```
max diff: 3.576279e-07 (float32 precision)
allclose: True
```
Edge cases verified at extreme values (x = -100, 0, +100).

## Hardware Environment
- GPU: NVIDIA RTX PRO 6000 Blackwell
- PyTorch: 2.11+cu128
- Triton: 3.6