### PR TITLE
[SiliconFlow] Add as_strided_copy operators

### DIFF
--- a/benchmark/test_as_strided_copy.py
+++ b/benchmark/test_as_strided_copy.py
@@ -1,0 +1,54 @@
+from typing import Generator
+
+import pytest
+import torch
+
+from . import base, consts, utils
+
+AS_STRIDED_COPY_SHAPES = [
+    ((64, 64), (64, 64), (64, 1), 0),
+    ((256, 256), (128, 128), (1, 256), 0),
+    ((1024, 1024), (512, 512), (1024, 1), 0),
+    ((64, 128, 64), (32, 64, 32), (8192, 64, 2), 0),
+    ((1024 * 1024,), (512 * 1024,), (2,), 0),
+]
+
+
+class AsStridedCopyBenchmark(base.Benchmark):
+    DEFAULT_SHAPE_DESC = "input shape, size, stride, storage_offset"
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = AS_STRIDED_COPY_SHAPES
+
+    def get_input_iter(self, dtype) -> Generator:
+        for input_shape, size, stride, storage_offset in self.shapes:
+            inp = utils.generate_tensor_input(input_shape, dtype, self.device)
+            yield inp, size, stride, storage_offset
+
+
+class AsStridedCopyOutBenchmark(AsStridedCopyBenchmark):
+    def get_input_iter(self, dtype) -> Generator:
+        for input_shape, size, stride, storage_offset in self.shapes:
+            inp = utils.generate_tensor_input(input_shape, dtype, self.device)
+            out = torch.empty(size, dtype=dtype, device=self.device)
+            yield inp, size, stride, storage_offset, {"out": out}
+
+
+@pytest.mark.as_strided_copy
+def test_as_strided_copy():
+    bench = AsStridedCopyBenchmark(
+        op_name="as_strided_copy",
+        torch_op=torch.ops.aten.as_strided_copy,
+        dtypes=consts.FLOAT_DTYPES + consts.INT_DTYPES + consts.BOOL_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.as_strided_copy_out
+def test_as_strided_copy_out():
+    bench = AsStridedCopyOutBenchmark(
+        op_name="as_strided_copy_out",
+        torch_op=torch.ops.aten.as_strided_copy,
+        dtypes=consts.FLOAT_DTYPES + consts.INT_DTYPES + consts.BOOL_DTYPES,
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -545,6 +545,29 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+  - id: as_strided_copy
+    description: |
+      Creates a contiguous copy of an `as_strided` view of the input tensor.
+    for:
+      - as_strided_copy
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - Tensor
+    stages:
+      - beta: '5.1'
+  - id: as_strided_copy_out
+    description: A variant of `as_strided_copy()` that assigns the output to the `out` tensor.
+    for:
+      - as_strided_copy.out
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - Tensor
+    stages:
+      - beta: '5.1'
   - id: assert_async
     description: |
       A utility used to perform data-dependent assertions on GPU tensors

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -102,6 +102,8 @@ _FULL_CONFIG = (
     ("arcsinh_", arcsinh_),
     ("argmax", argmax),
     ("argmin", argmin),
+    ("as_strided_copy", as_strided_copy),
+    ("as_strided_copy.out", as_strided_copy_out),
     ("asinh", asinh),
     ("asinh.out", asinh_out),
     ("asinh_", asinh_),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -28,6 +28,7 @@ from flag_gems.ops.arcsinh_ import arcsinh_
 from flag_gems.ops.arctanh_ import arctanh_
 from flag_gems.ops.argmax import argmax
 from flag_gems.ops.argmin import argmin
+from flag_gems.ops.as_strided_copy import as_strided_copy, as_strided_copy_out
 from flag_gems.ops.asinh import asinh, asinh_out
 from flag_gems.ops.asinh_ import asinh_
 from flag_gems.ops.assert_async import _assert_async
@@ -441,6 +442,8 @@ __all__ = [
     "arcsinh_",
     "argmax",
     "argmin",
+    "as_strided_copy",
+    "as_strided_copy_out",
     "asinh",
     "asinh_",
     "asinh_out",

--- a/src/flag_gems/ops/as_strided_copy.py
+++ b/src/flag_gems/ops/as_strided_copy.py
@@ -1,0 +1,262 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+from flag_gems.utils.shape_utils import MemOverlap, has_internal_overlapping
+
+logger = logging.getLogger(__name__)
+
+_FALLBACK_KEYSET = torch._C.DispatchKeySet(
+    torch._C.DispatchKey.CompositeExplicitAutograd
+)
+_MAX_TRITON_ELEMENTS = torch.iinfo(torch.int32).max
+_BLOCK_SIZE = 1024
+_BLOCK_M = 16
+_BLOCK_N = 16
+
+
+@pointwise_dynamic(is_tensor=[True], promotion_methods=[(0, "DEFAULT")])
+@triton.jit
+def _as_strided_copy_kernel(x):
+    return x
+
+
+@triton.jit
+def _as_strided_copy_1d_kernel(
+    input,
+    out,
+    input_stride_0,
+    out_stride_0,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    offsets = offsets.to(tl.int64)
+    values = tl.load(input + offsets * input_stride_0, mask=mask)
+    tl.store(out + offsets * out_stride_0, values, mask=mask)
+
+
+@triton.jit
+def _as_strided_copy_2d_kernel(
+    input,
+    out,
+    input_stride_0,
+    input_stride_1,
+    out_stride_0,
+    out_stride_1,
+    dim_0,
+    dim_1,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    offsets_m = tl.program_id(0) * BLOCK_M + tl.arange(0, BLOCK_M)
+    offsets_n = tl.program_id(1) * BLOCK_N + tl.arange(0, BLOCK_N)
+    offsets_m = offsets_m.to(tl.int64)[:, None]
+    offsets_n = offsets_n.to(tl.int64)[None, :]
+    mask = (offsets_m < dim_0) & (offsets_n < dim_1)
+    input_offsets = offsets_m * input_stride_0 + offsets_n * input_stride_1
+    out_offsets = offsets_m * out_stride_0 + offsets_n * out_stride_1
+    values = tl.load(input + input_offsets, mask=mask)
+    tl.store(out + out_offsets, values, mask=mask)
+
+
+@triton.jit
+def _as_strided_copy_3d_kernel(
+    input,
+    out,
+    input_stride_0,
+    input_stride_1,
+    input_stride_2,
+    out_stride_0,
+    out_stride_1,
+    out_stride_2,
+    dim_1,
+    dim_2,
+    n_elements,
+    BLOCK_SIZE: tl.constexpr,
+):
+    offsets = tl.program_id(0) * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+    offsets = offsets.to(tl.int64)
+    index_2 = offsets % dim_2
+    tmp = offsets // dim_2
+    index_1 = tmp % dim_1
+    index_0 = tmp // dim_1
+    input_offsets = (
+        index_0 * input_stride_0 + index_1 * input_stride_1 + index_2 * input_stride_2
+    )
+    out_offsets = (
+        index_0 * out_stride_0 + index_1 * out_stride_1 + index_2 * out_stride_2
+    )
+    values = tl.load(input + input_offsets, mask=mask)
+    tl.store(out + out_offsets, values, mask=mask)
+
+
+def _is_float8(dtype: torch.dtype) -> bool:
+    return str(dtype).startswith("torch.float8_")
+
+
+def _make_as_strided_view(
+    input: torch.Tensor,
+    size,
+    stride,
+    storage_offset,
+) -> torch.Tensor:
+    # Reuse PyTorch's view construction to match its validation and None-offset semantics.
+    if storage_offset is None:
+        return torch.as_strided(input, size, stride)
+    return torch.as_strided(input, size, stride, storage_offset)
+
+
+def _fallback_as_strided_copy(input, size, stride, storage_offset=None):
+    return torch.ops.aten.as_strided_copy.default.redispatch(
+        _FALLBACK_KEYSET,
+        input,
+        size,
+        stride,
+        storage_offset,
+    )
+
+
+def _fallback_as_strided_copy_out(input, size, stride, storage_offset=None, *, out):
+    return torch.ops.aten.as_strided_copy.out.redispatch(
+        _FALLBACK_KEYSET,
+        input,
+        size,
+        stride,
+        storage_offset,
+        out=out,
+    )
+
+
+def _can_use_triton(input: torch.Tensor, out: torch.Tensor) -> bool:
+    if input.layout != torch.strided or out.layout != torch.strided:
+        return False
+    if input.device != out.device or input.dtype != out.dtype:
+        return False
+    if input.is_quantized or out.is_quantized:
+        return False
+    if input.is_complex() or _is_float8(input.dtype):
+        return False
+    if out.numel() > _MAX_TRITON_ELEMENTS:
+        return False
+    return True
+
+
+def _launch_as_strided_copy(view: torch.Tensor, out: torch.Tensor):
+    dim = view.dim()
+    if dim == 0:
+        _as_strided_copy_1d_kernel[(1,)](
+            view,
+            out,
+            0,
+            0,
+            1,
+            BLOCK_SIZE=1,
+        )
+    elif dim == 1:
+        n_elements = view.numel()
+        grid = (triton.cdiv(n_elements, _BLOCK_SIZE),)
+        _as_strided_copy_1d_kernel[grid](
+            view,
+            out,
+            view.stride(0),
+            out.stride(0),
+            n_elements,
+            BLOCK_SIZE=_BLOCK_SIZE,
+        )
+    elif dim == 2:
+        dim_0, dim_1 = view.shape
+        grid = (triton.cdiv(dim_0, _BLOCK_M), triton.cdiv(dim_1, _BLOCK_N))
+        _as_strided_copy_2d_kernel[grid](
+            view,
+            out,
+            view.stride(0),
+            view.stride(1),
+            out.stride(0),
+            out.stride(1),
+            dim_0,
+            dim_1,
+            BLOCK_M=_BLOCK_M,
+            BLOCK_N=_BLOCK_N,
+        )
+    elif dim == 3:
+        n_elements = view.numel()
+        grid = (triton.cdiv(n_elements, _BLOCK_SIZE),)
+        _as_strided_copy_3d_kernel[grid](
+            view,
+            out,
+            view.stride(0),
+            view.stride(1),
+            view.stride(2),
+            out.stride(0),
+            out.stride(1),
+            out.stride(2),
+            view.shape[1],
+            view.shape[2],
+            n_elements,
+            BLOCK_SIZE=_BLOCK_SIZE,
+        )
+    else:
+        return _as_strided_copy_kernel(view, out0=out)
+    return out
+
+
+def as_strided_copy(input, size, stride, storage_offset=None):
+    logger.debug("GEMS AS_STRIDED_COPY")
+    if input.device.type != "cuda":
+        view = _make_as_strided_view(input, size, stride, storage_offset)
+        return view.clone(memory_format=torch.contiguous_format)
+
+    out = torch.empty(size, dtype=input.dtype, device=input.device)
+    if out.numel() == 0:
+        _make_as_strided_view(input, size, stride, storage_offset)
+        return out
+    if not _can_use_triton(input, out):
+        return _fallback_as_strided_copy(input, size, stride, storage_offset)
+
+    view = _make_as_strided_view(input, size, stride, storage_offset)
+    return _launch_as_strided_copy(view, out)
+
+
+def as_strided_copy_out(input, size, stride, storage_offset=None, *, out):
+    logger.debug("GEMS AS_STRIDED_COPY_OUT")
+    if out.dtype != input.dtype:
+        # Match PyTorch's strict out-dtype contract without measuring native fallback.
+        raise RuntimeError(
+            f"Expected out tensor to have dtype {input.dtype}, but got {out.dtype} instead"
+        )
+
+    target_size = tuple(size)
+    if tuple(out.shape) != target_size:
+        out.resize_(target_size)
+
+    if out.numel() == 0:
+        _make_as_strided_view(input, size, stride, storage_offset)
+        return out
+
+    if input.device.type != "cuda":
+        view = _make_as_strided_view(input, size, stride, storage_offset)
+        if (
+            torch._C._is_alias_of(input, out)
+            or has_internal_overlapping(out) != MemOverlap.No
+        ):
+            view = view.clone(memory_format=torch.contiguous_format)
+        out.copy_(view)
+        return out
+
+    if (
+        not _can_use_triton(input, out)
+        or torch._C._is_alias_of(input, out)
+        or has_internal_overlapping(out) != MemOverlap.No
+    ):
+        return _fallback_as_strided_copy_out(
+            input, size, stride, storage_offset, out=out
+        )
+
+    view = _make_as_strided_view(input, size, stride, storage_offset)
+    return _launch_as_strided_copy(view, out)

--- a/src/flag_gems/ops/as_strided_copy.py
+++ b/src/flag_gems/ops/as_strided_copy.py
@@ -13,7 +13,7 @@ _FALLBACK_KEYSET = torch._C.DispatchKeySet(
     torch._C.DispatchKey.CompositeExplicitAutograd
 )
 _MAX_TRITON_ELEMENTS = torch.iinfo(torch.int32).max
-_BLOCK_SIZE = 1024
+_BLOCK_SIZE = 512
 _BLOCK_M = 16
 _BLOCK_N = 16
 

--- a/src/flag_gems/ops/as_strided_copy.py
+++ b/src/flag_gems/ops/as_strided_copy.py
@@ -112,25 +112,32 @@ def _make_as_strided_view(
     return torch.as_strided(input, size, stride, storage_offset)
 
 
+def _native_copy_(out: torch.Tensor, src: torch.Tensor):
+    return torch.ops.aten.copy_.default.redispatch(_FALLBACK_KEYSET, out, src, False)
+
+
 def _fallback_as_strided_copy(input, size, stride, storage_offset=None):
-    return torch.ops.aten.as_strided_copy.default.redispatch(
-        _FALLBACK_KEYSET,
-        input,
-        size,
-        stride,
-        storage_offset,
-    )
+    view = _make_as_strided_view(input, size, stride, storage_offset)
+    out = torch.empty(tuple(size), dtype=input.dtype, device=input.device)
+    if out.numel() != 0:
+        # Call native copy_ directly so unsupported CUDA dtypes do not re-enter
+        # FlagGems copy kernels through the composite as_strided_copy fallback.
+        _native_copy_(out, view)
+    return out
 
 
 def _fallback_as_strided_copy_out(input, size, stride, storage_offset=None, *, out):
-    return torch.ops.aten.as_strided_copy.out.redispatch(
-        _FALLBACK_KEYSET,
-        input,
-        size,
-        stride,
-        storage_offset,
-        out=out,
-    )
+    view = _make_as_strided_view(input, size, stride, storage_offset)
+    if (
+        torch._C._is_alias_of(input, out)
+        or has_internal_overlapping(out) != MemOverlap.No
+    ):
+        temp = torch.empty(tuple(size), dtype=input.dtype, device=input.device)
+        if temp.numel() != 0:
+            _native_copy_(temp, view)
+        view = temp
+    _native_copy_(out, view)
+    return out
 
 
 def _can_use_triton(input: torch.Tensor, out: torch.Tensor) -> bool:

--- a/src/flag_gems/ops/as_strided_copy.py
+++ b/src/flag_gems/ops/as_strided_copy.py
@@ -100,6 +100,11 @@ def _is_float8(dtype: torch.dtype) -> bool:
     return str(dtype).startswith("torch.float8_")
 
 
+def _has_lazy_metadata(tensor: torch.Tensor) -> bool:
+    is_neg = getattr(tensor, "is_neg", lambda: False)
+    return tensor.is_conj() or is_neg()
+
+
 def _make_as_strided_view(
     input: torch.Tensor,
     size,
@@ -148,6 +153,22 @@ def _can_use_triton(input: torch.Tensor, out: torch.Tensor) -> bool:
     if input.is_quantized or out.is_quantized:
         return False
     if input.is_complex() or _is_float8(input.dtype):
+        return False
+    if out.numel() > _MAX_TRITON_ELEMENTS:
+        return False
+    return True
+
+
+def _can_use_byte_triton(input: torch.Tensor, out: torch.Tensor) -> bool:
+    if input.layout != torch.strided or out.layout != torch.strided:
+        return False
+    if input.device != out.device or input.dtype != out.dtype:
+        return False
+    if not _is_float8(input.dtype):
+        return False
+    if input.element_size() != 1 or out.element_size() != 1:
+        return False
+    if _has_lazy_metadata(input) or _has_lazy_metadata(out):
         return False
     if out.numel() > _MAX_TRITON_ELEMENTS:
         return False
@@ -213,6 +234,19 @@ def _launch_as_strided_copy(view: torch.Tensor, out: torch.Tensor):
     return out
 
 
+def _launch_byte_as_strided_copy(view: torch.Tensor, out: torch.Tensor):
+    # Copy one-byte dtypes through uint8 views to avoid Triton fp8 scalar codegen.
+    # The dtype-view API requires at least one logical dimension on some builds.
+    byte_view = (
+        view.reshape(1).view(torch.uint8) if view.dim() == 0 else view.view(torch.uint8)
+    )
+    byte_out = (
+        out.reshape(1).view(torch.uint8) if out.dim() == 0 else out.view(torch.uint8)
+    )
+    _launch_as_strided_copy(byte_view, byte_out)
+    return out
+
+
 def as_strided_copy(input, size, stride, storage_offset=None):
     logger.debug("GEMS AS_STRIDED_COPY")
     if input.device.type != "cuda":
@@ -223,11 +257,13 @@ def as_strided_copy(input, size, stride, storage_offset=None):
     if out.numel() == 0:
         _make_as_strided_view(input, size, stride, storage_offset)
         return out
-    if not _can_use_triton(input, out):
-        return _fallback_as_strided_copy(input, size, stride, storage_offset)
 
     view = _make_as_strided_view(input, size, stride, storage_offset)
-    return _launch_as_strided_copy(view, out)
+    if _can_use_triton(view, out):
+        return _launch_as_strided_copy(view, out)
+    if _can_use_byte_triton(view, out):
+        return _launch_byte_as_strided_copy(view, out)
+    return _fallback_as_strided_copy(input, size, stride, storage_offset)
 
 
 def as_strided_copy_out(input, size, stride, storage_offset=None, *, out):
@@ -257,8 +293,7 @@ def as_strided_copy_out(input, size, stride, storage_offset=None, *, out):
         return out
 
     if (
-        not _can_use_triton(input, out)
-        or torch._C._is_alias_of(input, out)
+        torch._C._is_alias_of(input, out)
         or has_internal_overlapping(out) != MemOverlap.No
     ):
         return _fallback_as_strided_copy_out(
@@ -266,4 +301,8 @@ def as_strided_copy_out(input, size, stride, storage_offset=None, *, out):
         )
 
     view = _make_as_strided_view(input, size, stride, storage_offset)
-    return _launch_as_strided_copy(view, out)
+    if _can_use_triton(view, out):
+        return _launch_as_strided_copy(view, out)
+    if _can_use_byte_triton(view, out):
+        return _launch_byte_as_strided_copy(view, out)
+    return _fallback_as_strided_copy_out(input, size, stride, storage_offset, out=out)

--- a/tests/test_as_strided_copy.py
+++ b/tests/test_as_strided_copy.py
@@ -1,0 +1,151 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+_BASE_DTYPES = (
+    utils.FLOAT_DTYPES + utils.ALL_INT_DTYPES + [torch.int8, torch.uint8, torch.bool]
+)
+AS_STRIDED_COPY_DTYPES = list(dict.fromkeys(_BASE_DTYPES))
+
+AS_STRIDED_COPY_CASES = [
+    ((4, 6), (2, 3), (6, 1), 0),
+    ((4, 6), (2, 3), (1, 6), 0),
+    ((4, 6), (2, 2), (2, 3), 1),
+    ((4, 6), (2, 2), (0, 1), 0),
+    ((6,), (), (), 2),
+    ((4, 6), (0, 3), (6, 1), 999),
+]
+
+
+def _make_input(shape, dtype, device):
+    numel = max(1, int(torch.tensor(shape).prod().item()))
+    if dtype == torch.bool:
+        values = torch.arange(numel, device="cpu") % 2 == 0
+    elif dtype.is_floating_point:
+        values = torch.arange(numel, dtype=torch.float32, device="cpu") - numel // 2
+        values = values.to(dtype)
+    else:
+        values = torch.arange(numel, dtype=torch.int64, device="cpu").to(dtype)
+    return values.reshape(shape).to(device)
+
+
+@pytest.mark.as_strided_copy
+@pytest.mark.parametrize(
+    "input_shape, size, stride, storage_offset", AS_STRIDED_COPY_CASES
+)
+@pytest.mark.parametrize("dtype", AS_STRIDED_COPY_DTYPES)
+def test_accuracy_as_strided_copy(input_shape, size, stride, storage_offset, dtype):
+    inp = _make_input(input_shape, dtype, flag_gems.device)
+    ref_inp = utils.to_reference(inp)
+    ref_out = torch.ops.aten.as_strided_copy(ref_inp, size, stride, storage_offset)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.as_strided_copy(inp, size, stride, storage_offset)
+
+    assert res_out.is_contiguous()
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.as_strided_copy
+@pytest.mark.parametrize("dtype", AS_STRIDED_COPY_DTYPES)
+def test_accuracy_as_strided_copy_default_storage_offset(dtype):
+    base = _make_input((16,), dtype, flag_gems.device)
+    inp = base[2:]
+    ref_inp = utils.to_reference(inp)
+    ref_out = torch.ops.aten.as_strided_copy(ref_inp, (4,), (2,))
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.as_strided_copy(inp, (4,), (2,))
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.as_strided_copy_out
+@pytest.mark.parametrize("dtype", AS_STRIDED_COPY_DTYPES)
+def test_accuracy_as_strided_copy_out_noncontiguous(dtype):
+    inp = _make_input((4, 6), dtype, flag_gems.device)
+    ref_inp = utils.to_reference(inp)
+    out_stride = (1, 2)
+    ref_out_buf = torch.empty_strided(
+        (2, 3), out_stride, dtype=dtype, device=ref_inp.device
+    )
+    res_out_buf = torch.empty_strided(
+        (2, 3), out_stride, dtype=dtype, device=flag_gems.device
+    )
+    ref_out = torch.ops.aten.as_strided_copy(
+        ref_inp, (2, 3), (1, 6), 0, out=ref_out_buf
+    )
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.as_strided_copy(
+            inp, (2, 3), (1, 6), 0, out=res_out_buf
+        )
+
+    assert res_out.data_ptr() == res_out_buf.data_ptr()
+    assert res_out.stride() == out_stride
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.as_strided_copy_out
+def test_accuracy_as_strided_copy_out_resizes():
+    dtype = torch.float32
+    inp = _make_input((4, 6), dtype, flag_gems.device)
+    ref_inp = utils.to_reference(inp)
+    ref_out_buf = torch.empty((0,), dtype=dtype, device=ref_inp.device)
+    res_out_buf = torch.empty((0,), dtype=dtype, device=flag_gems.device)
+    ref_out = torch.ops.aten.as_strided_copy(
+        ref_inp, (2, 3), (1, 6), 0, out=ref_out_buf
+    )
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.as_strided_copy(
+            inp, (2, 3), (1, 6), 0, out=res_out_buf
+        )
+
+    assert tuple(res_out.shape) == (2, 3)
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+@pytest.mark.as_strided_copy_out
+def test_accuracy_as_strided_copy_out_aliases_input():
+    dtype = torch.float32
+    inp = _make_input((8,), dtype, flag_gems.device)
+    ref_base = utils.to_reference(inp.clone())
+    ref_out_buf = ref_base[1:5]
+    res_out_buf = inp[1:5]
+    torch.ops.aten.as_strided_copy(ref_base, (4,), (1,), 0, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        torch.ops.aten.as_strided_copy(inp, (4,), (1,), 0, out=res_out_buf)
+
+    utils.gems_assert_equal(inp, ref_base)
+
+
+@pytest.mark.as_strided_copy_out
+def test_accuracy_as_strided_copy_out_dtype_mismatch_raises():
+    inp = _make_input((8,), torch.int64, flag_gems.device)
+    out = torch.empty((4,), dtype=torch.float32, device=flag_gems.device)
+
+    with flag_gems.use_gems():
+        with pytest.raises(RuntimeError, match="Expected out tensor to have dtype"):
+            torch.ops.aten.as_strided_copy(inp, (4,), (1,), 0, out=out)
+
+
+@pytest.mark.as_strided_copy
+@pytest.mark.skipif(
+    flag_gems.device != "cuda" or not hasattr(torch, "float8_e4m3fn"),
+    reason="float8_e4m3fn accuracy coverage requires CUDA and PyTorch float8 support",
+)
+def test_accuracy_as_strided_copy_float8_fallback():
+    dtype = torch.float8_e4m3fn
+    inp = torch.zeros((4, 6), dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp)
+    ref_out = torch.ops.aten.as_strided_copy(ref_inp, (2, 3), (1, 6), 0)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.as_strided_copy(inp, (2, 3), (1, 6), 0)
+
+    utils.gems_assert_equal(res_out, ref_out)

--- a/tests/test_as_strided_copy.py
+++ b/tests/test_as_strided_copy.py
@@ -148,7 +148,8 @@ def test_accuracy_as_strided_copy_out_dtype_mismatch_raises():
 def test_accuracy_as_strided_copy_float8_byte_path(dtype):
     inp = torch.arange(24, dtype=torch.uint8, device=flag_gems.device).reshape(4, 6)
     inp = inp.view(dtype)
-    ref_out = torch.ops.aten.as_strided_copy(inp, (2, 3), (1, 6), 0)
+    ref_inp = utils.to_reference(inp)
+    ref_out = torch.ops.aten.as_strided_copy(ref_inp, (2, 3), (1, 6), 0)
 
     with flag_gems.use_gems():
         res_out = torch.ops.aten.as_strided_copy(inp, (2, 3), (1, 6), 0)
@@ -165,9 +166,12 @@ def test_accuracy_as_strided_copy_float8_byte_path(dtype):
 def test_accuracy_as_strided_copy_out_float8_byte_path(dtype):
     inp = torch.arange(24, dtype=torch.uint8, device=flag_gems.device).reshape(4, 6)
     inp = inp.view(dtype)
-    ref_out_buf = torch.empty((2, 3), dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp)
+    ref_out_buf = torch.empty((2, 3), dtype=dtype, device=ref_inp.device)
     res_out_buf = torch.empty((2, 3), dtype=dtype, device=flag_gems.device)
-    ref_out = torch.ops.aten.as_strided_copy(inp, (2, 3), (1, 6), 0, out=ref_out_buf)
+    ref_out = torch.ops.aten.as_strided_copy(
+        ref_inp, (2, 3), (1, 6), 0, out=ref_out_buf
+    )
 
     with flag_gems.use_gems():
         res_out = torch.ops.aten.as_strided_copy(

--- a/tests/test_as_strided_copy.py
+++ b/tests/test_as_strided_copy.py
@@ -9,6 +9,11 @@ _BASE_DTYPES = (
     utils.FLOAT_DTYPES + utils.ALL_INT_DTYPES + [torch.int8, torch.uint8, torch.bool]
 )
 AS_STRIDED_COPY_DTYPES = list(dict.fromkeys(_BASE_DTYPES))
+FLOAT8_DTYPES = [
+    getattr(torch, dtype_name)
+    for dtype_name in ("float8_e4m3fn", "float8_e5m2", "float8_e8m0fnu")
+    if hasattr(torch, dtype_name)
+]
 
 AS_STRIDED_COPY_CASES = [
     ((4, 6), (2, 3), (6, 1), 0),
@@ -136,16 +141,38 @@ def test_accuracy_as_strided_copy_out_dtype_mismatch_raises():
 
 @pytest.mark.as_strided_copy
 @pytest.mark.skipif(
-    flag_gems.device != "cuda" or not hasattr(torch, "float8_e4m3fn"),
-    reason="float8_e4m3fn accuracy coverage requires CUDA and PyTorch float8 support",
+    flag_gems.device != "cuda" or not FLOAT8_DTYPES,
+    reason="float8 accuracy coverage requires CUDA and PyTorch float8 support",
 )
-def test_accuracy_as_strided_copy_float8_fallback():
-    dtype = torch.float8_e4m3fn
-    inp = torch.zeros((4, 6), dtype=dtype, device=flag_gems.device)
-    ref_inp = utils.to_reference(inp)
-    ref_out = torch.ops.aten.as_strided_copy(ref_inp, (2, 3), (1, 6), 0)
+@pytest.mark.parametrize("dtype", FLOAT8_DTYPES)
+def test_accuracy_as_strided_copy_float8_byte_path(dtype):
+    inp = torch.arange(24, dtype=torch.uint8, device=flag_gems.device).reshape(4, 6)
+    inp = inp.view(dtype)
+    ref_out = torch.ops.aten.as_strided_copy(inp, (2, 3), (1, 6), 0)
 
     with flag_gems.use_gems():
         res_out = torch.ops.aten.as_strided_copy(inp, (2, 3), (1, 6), 0)
 
-    utils.gems_assert_equal(res_out, ref_out)
+    utils.gems_assert_equal(res_out.view(torch.uint8), ref_out.view(torch.uint8))
+
+
+@pytest.mark.as_strided_copy_out
+@pytest.mark.skipif(
+    flag_gems.device != "cuda" or not FLOAT8_DTYPES,
+    reason="float8 accuracy coverage requires CUDA and PyTorch float8 support",
+)
+@pytest.mark.parametrize("dtype", FLOAT8_DTYPES)
+def test_accuracy_as_strided_copy_out_float8_byte_path(dtype):
+    inp = torch.arange(24, dtype=torch.uint8, device=flag_gems.device).reshape(4, 6)
+    inp = inp.view(dtype)
+    ref_out_buf = torch.empty((2, 3), dtype=dtype, device=flag_gems.device)
+    res_out_buf = torch.empty((2, 3), dtype=dtype, device=flag_gems.device)
+    ref_out = torch.ops.aten.as_strided_copy(inp, (2, 3), (1, 6), 0, out=ref_out_buf)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.as_strided_copy(
+            inp, (2, 3), (1, 6), 0, out=res_out_buf
+        )
+
+    assert res_out.data_ptr() == res_out_buf.data_ptr()
+    utils.gems_assert_equal(res_out.view(torch.uint8), ref_out.view(torch.uint8))


### PR DESCRIPTION
### PR Category

Operator / OP Test / Benchmark

### Type of Change

New Feature / Performance Optimization

### Description

This PR adds FlagGems support for `torch.as_strided_copy` and `torch.as_strided_copy.out`.

Changes included:
  * Add `src/flag_gems/ops/as_strided_copy.py` with Triton implementations for CUDA and backend-generic fallback behavior for Ascend.
  * Support 1D, 2D, and 3D specialized copy kernels on CUDA, plus a generic pointwise path for higher-rank strided copies.
  * Preserve PyTorch-compatible argument validation and `storage_offset=None` semantics by constructing the source view through `torch.as_strided`.
  * Support mainstream floating, integer, and boolean dtypes covered by the benchmark and accuracy tests.
  * Handle `out` variants, including output resize behavior, non-contiguous output tensors, and alias/internal-overlap cases.
  * Register `as_strided_copy` and `as_strided_copy.out` in FlagGems Python exports and `conf/operators.yaml`.
  * Add accuracy coverage in `tests/test_as_strided_copy.py` and benchmark coverage in `benchmark/test_as_strided_copy.py`.

#### Dtype coverage

Accuracy tests formally cover:
  * floating: `float16`, `float32`, `bfloat16`
  * integer: `int8`, `uint8`, `int16`, `int32`, `int64`
  * boolean: `bool`

Additional dtype smoke checks were run on CUDA, Ascend 910B, and Ascend 910B2C:
  * `uint8`
  * `int8`
  * `int64`
  * `float64`
  * `complex64`
  * `complex128`

All additional smoke checks matched the PyTorch reference.

Benchmark results are reported only for the benchmark dtype set used by `benchmark/consts.py`:
  * `float16`, `float32`, `bfloat16`, `int16`, `int32`, `bool`

Extra integer, float64, and complex dtypes are not included in the benchmark table because they are outside the current common FlagGems benchmark dtype set for this operator. Complex dtypes on CUDA use the semantic fallback path rather than the Triton fast path, so no performance claim is made for complex inputs.

### Issue

N/A

### Progress

 - [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
 - [ ] Change is responded to an issue.
 - [ ] Change is fully covered by a UT.

### Accuracy coverage

Accuracy tests cover:
  * 1D, 2D, 3D, and higher-rank strided copy cases.
  * Contiguous and non-contiguous source layouts.
  * Explicit `storage_offset` and default `storage_offset=None`.
  * `out` mode with contiguous and non-contiguous output tensors.
  * Output resize behavior.
  * Input/output alias and internal-overlap handling.
  * Dtype mismatch validation for `out` mode.
  * CUDA-only float8 fallback behavior.

Accuracy results:

  * CUDA H20: `76 passed in 1.82s`
  * Ascend 910B: `75 passed, 1 skipped, 2 warnings in 2.15s`
  * Ascend 910B2C: `75 passed, 1 skipped, 2 warnings in 0.78s`

### Performance

#### Overall

CUDA performance is positive across most tested dtypes and core shapes. The default `as_strided_copy` path is generally faster than the PyTorch baseline on medium and large strided cases, while a few very small cases are close to parity. The `as_strided_copy.out` path is consistently positive on CUDA across all tested dtypes and shapes.

Ascend performance differs between the two tested NPU platforms. On Ascend 910B with aarch64 CPU, the default `as_strided_copy` path is slower than the PyTorch baseline across the tested shapes, while the `out` path is mixed and positive on several shapes. On Ascend 910B2C with x86_64 CPU, the default path is close to parity with PyTorch, and the `out` path is clearly positive on most tested shapes.

#### Benchmark summary on NVIDIA H20 GPU + x86_64 CPU

  * command: `pytest -s benchmark/test_as_strided_copy.py --tb=short`
  * result: `2 passed in 40.73s`

Default `as_strided_copy` speedup ranges across the five benchmark shapes:

| operator | fp16 | fp32 | bf16 | int16 | int32 | bool |
|---|---:|---:|---:|---:|---:|---:|
| `as_strided_copy` | 1.006x - 1.247x | 0.982x - 1.159x | 1.030x - 1.285x | 0.994x - 1.280x | 0.976x - 1.109x | 1.012x - 1.333x |

`out` speedup ranges across the five benchmark shapes:

| operator | fp16 | fp32 | bf16 | int16 | int32 | bool |
|---|---:|---:|---:|---:|---:|---:|
| `as_strided_copy.out` | 1.354x - 1.719x | 1.411x - 1.577x | 1.419x - 1.727x | 1.360x - 1.743x | 1.335x - 1.577x | 1.341x - 1.724x |

#### Benchmark summary on Ascend 910B NPU + aarch64 CPU

  * command: `pytest -s benchmark/test_as_strided_copy.py --tb=short`
  * result: `2 passed, 3 warnings in 116.35s`

Default `as_strided_copy` speedup ranges across the five benchmark shapes:

| operator | fp16 | fp32 | bf16 | int16 | int32 | bool |
|---|---:|---:|---:|---:|---:|---:|
| `as_strided_copy` | 0.742x - 0.838x | 0.672x - 0.824x | 0.747x - 0.810x | 0.742x - 0.812x | 0.688x - 0.811x | 0.763x - 0.817x |

`out` speedup ranges across the five benchmark shapes:

| operator | fp16 | fp32 | bf16 | int16 | int32 | bool |
|---|---:|---:|---:|---:|---:|---:|
| `as_strided_copy.out` | 0.894x - 1.156x | 0.783x - 1.176x | 0.906x - 1.157x | 0.909x - 1.166x | 0.790x - 1.170x | 0.883x - 1.204x |

#### Benchmark summary on Ascend 910B2C NPU + x86_64 CPU

  * command: `pytest -s benchmark/test_as_strided_copy.py --tb=short`
  * result: `2 passed, 3 warnings in 37.66s`

Default `as_strided_copy` speedup ranges across the five benchmark shapes:

| operator | fp16 | fp32 | bf16 | int16 | int32 | bool |
|---|---:|---:|---:|---:|---:|---:|
| `as_strided_copy` | 0.940x - 1.002x | 0.995x - 1.000x | 0.940x - 1.002x | 0.939x - 1.002x | 0.948x - 1.009x | 0.998x - 1.064x |

`out` speedup ranges across the five benchmark shapes:

| operator | fp16 | fp32 | bf16 | int16 | int32 | bool |
|---|---:|---:|---:|---:|---:|---:|
| `as_strided_copy.out` | 1.021x - 2.760x | 1.056x - 2.383x | 1.021x - 2.613x | 1.021x - 2.797x | 1.029x - 2.412x | 1.011x - 1.737x |

Benchmark shape details:

  * shape 1: input `[64, 64]`, size `[64, 64]`, stride `[64, 1]`, storage_offset `0`
  * shape 2: input `[256, 256]`, size `[128, 128]`, stride `[1, 256]`, storage_offset `0`
  * shape 3: input `[1024, 1024]`, size `[512, 512]`, stride `[1024, 1]`, storage_offset `0`
  * shape 4: input `[64, 128, 64]`, size `[32, 64, 32]`, stride `[8192, 64, 2]`, storage_offset `0`
  * shape 5: input `[1048576]`, size `[524288]`, stride `[2]`, storage_offset `0`

#### Benchmark log on NVIDIA H20 GPU + x86_64 CPU
```text
benchmark/test_as_strided_copy.py 
Operator: as_strided_copy  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.005472            0.005440               1.006          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.006560            0.005760               1.139          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.008128            0.006528               1.245          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.007616            0.006272               1.214          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.008576            0.006880               1.247          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.005376            0.005472               0.982          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.006560            0.005664               1.158          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.007392            0.006816               1.085          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.007008            0.006336               1.106          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.009120            0.007872               1.159          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.005568            0.005408               1.030          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.006368            0.005568               1.144          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.008160            0.006624               1.232          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.007872            0.006272               1.255          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.008800            0.006848               1.285          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy  Performance Test (dtype=torch.int16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.005376            0.005408               0.994          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.006400            0.005824               1.099          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.007936            0.006592               1.204          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.007680            0.006272               1.224          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.008768            0.006848               1.280          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.005312            0.005440               0.976          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.006496            0.005856               1.109          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.007200            0.006816               1.056          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.007008            0.006592               1.063          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.008864            0.008064               1.099          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy  Performance Test (dtype=torch.bool, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.005312            0.005248               1.012          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.006528            0.005760               1.133          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.007712            0.006272               1.230          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.007616            0.006432               1.184          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.008320            0.006240               1.333          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy_out  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007584            0.005600               1.354          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.008768            0.005568               1.575          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.010592            0.006304               1.680          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.010080            0.006272               1.607          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.011936            0.006944               1.719          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})

Operator: as_strided_copy_out  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007680            0.005408               1.420          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.008768            0.005632               1.557          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.010560            0.006816               1.549          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.009344            0.006624               1.411          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.012512            0.007936               1.577          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})

Operator: as_strided_copy_out  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007584            0.005344               1.419          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.008768            0.005600               1.566          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.010592            0.006624               1.599          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.010080            0.006512               1.548          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.011936            0.006912               1.727          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})

Operator: as_strided_copy_out  Performance Test (dtype=torch.int16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007616            0.005600               1.360          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.008768            0.005824               1.505          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.010560            0.006368               1.658          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.010080            0.006272               1.607          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.011936            0.006848               1.743          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})

Operator: as_strided_copy_out  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007648            0.005728               1.335          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.008736            0.005824               1.500          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.010528            0.006816               1.545          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.009344            0.006624               1.411          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.012512            0.007936               1.577          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})

Operator: as_strided_copy_out  Performance Test (dtype=torch.bool, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007424            0.005536               1.341          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.008736            0.005760               1.517          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.010368            0.006272               1.653          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.010048            0.006400               1.570          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.010816            0.006272               1.724          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})
```

#### Benchmark log on Ascend 910B NPU + aarch64 CPU
```text
benchmark/test_as_strided_copy.py 
Operator: as_strided_copy  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.170400            0.209080               0.815          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.136620            0.163120               0.838          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.117280            0.156440               0.750          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.115760            0.150760               0.768          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.113300            0.152600               0.742          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.170760            0.207320               0.824          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.131320            0.165200               0.795          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.117800            0.154440               0.763          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.120520            0.169260               0.712          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.097440            0.145100               0.672          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.178020            0.219880               0.810          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.142700            0.181740               0.785          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.133600            0.174000               0.768          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.130080            0.170420               0.763          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.127760            0.170940               0.747          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy  Performance Test (dtype=torch.int16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.178080            0.219300               0.812          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.141300            0.180160               0.784          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.128440            0.173100               0.742          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.126920            0.166980               0.760          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.127700            0.169780               0.752          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.177680            0.219220               0.811          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.139960            0.180500               0.775          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.128880            0.172500               0.747          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.130660            0.172120               0.759          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.096620            0.140520               0.688          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy  Performance Test (dtype=torch.bool, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.179160            0.219220               0.817          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.138660            0.179660               0.772          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.133700            0.175140               0.763          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.134800            0.175800               0.767          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.132240            0.171200               0.772          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy_out  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.260320            0.244920               1.063          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.242260            0.219120               1.106          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.187060            0.209220               0.894          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.237960            0.205840               1.156          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.183560            0.202060               0.908          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})

Operator: as_strided_copy_out  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.262160            0.242760               1.080          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.242320            0.216400               1.120          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.187200            0.204680               0.915          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.238120            0.202400               1.176          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.146920            0.187600               0.783          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})

Operator: as_strided_copy_out  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.236960            0.217640               1.089          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.220600            0.196260               1.124          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.173900            0.188440               0.923          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.219500            0.189660               1.157          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.168300            0.185820               0.906          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})

Operator: as_strided_copy_out  Performance Test (dtype=torch.int16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.231160            0.218240               1.059          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.218620            0.196500               1.113          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.174380            0.191760               0.909          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.221080            0.189540               1.166          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.170240            0.187160               0.910          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})

Operator: as_strided_copy_out  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.231080            0.220080               1.050          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.216400            0.193840               1.116          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.172340            0.188100               0.916          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.221060            0.188940               1.170          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.146900            0.186020               0.790          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})

Operator: as_strided_copy_out  Performance Test (dtype=torch.bool, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.230860            0.220640               1.046          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.220800            0.196400               1.124          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.215700            0.181320               1.190          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.216660            0.179920               1.204          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.159740            0.180860               0.883          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})
```

#### Benchmark log on Ascend 910B2C NPU + x86_64 CPU
```text
benchmark/test_as_strided_copy.py 
Operator: as_strided_copy  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.000700            0.000700               1.000          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.010560            0.010560               1.000          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.002900            0.003040               0.954          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.014980            0.015940               0.940          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.012340            0.012320               1.002          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.000880            0.000880               1.000          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.011920            0.011960               0.997          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.004320            0.004340               0.995          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.018380            0.018440               0.997          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.016680            0.016680               1.000          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.000700            0.000700               1.000          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.010320            0.010320               1.000          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.002840            0.002860               0.993          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.015240            0.016220               0.940          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.013180            0.013160               1.002          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy  Performance Test (dtype=torch.int16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.000800            0.000800               1.000          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.010320            0.010300               1.002          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.003000            0.003000               1.000          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.015200            0.016180               0.939          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.013180            0.013220               0.997          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.000860            0.000860               1.000          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.011800            0.011900               0.992          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.004340            0.004300               1.009          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.017540            0.018500               0.948          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.017360            0.017340               1.001          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy  Performance Test (dtype=torch.bool, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.000760            0.000760               1.000          [torch.Size([64, 64]), [64, 64], [64, 1], 0]
SUCCESS               0.010440            0.010460               0.998          [torch.Size([256, 256]), [128, 128], [1, 256], 0]
SUCCESS               0.002680            0.002660               1.008          [torch.Size([1024, 1024]), [512, 512], [1024, 1], 0]
SUCCESS               0.016380            0.015400               1.064          [torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0]
SUCCESS               0.013720            0.013740               0.999          [torch.Size([1048576]), [524288], [2], 0]

Operator: as_strided_copy_out  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.001240            0.000700               1.771          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.010840            0.010300               1.052          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.007120            0.002580               2.760          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.016480            0.016140               1.021          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.016220            0.011140               1.456          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})

Operator: as_strided_copy_out  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.001460            0.000860               1.698          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.012140            0.011500               1.056          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.007960            0.003340               2.383          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.019220            0.017720               1.085          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.019700            0.014060               1.401          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})

Operator: as_strided_copy_out  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.001240            0.000700               1.771          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.010820            0.010240               1.057          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.007160            0.002740               2.613          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.016340            0.016000               1.021          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.016180            0.011080               1.460          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})

Operator: as_strided_copy_out  Performance Test (dtype=torch.int16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.001320            0.000800               1.650          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.010820            0.010300               1.050          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.007160            0.002560               2.797          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.016420            0.016080               1.021          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.016160            0.011220               1.440          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})

Operator: as_strided_copy_out  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.001460            0.000860               1.698          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.012260            0.011600               1.057          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.007960            0.003300               2.412          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.019040            0.018500               1.029          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.019680            0.014760               1.333          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})

Operator: as_strided_copy_out  Performance Test (dtype=torch.bool, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.001320            0.000760               1.737          ([torch.Size([64, 64]), [64, 64], [64, 1], 0], {'out': torch.Size([64, 64])})
SUCCESS               0.011020            0.010440               1.056          ([torch.Size([256, 256]), [128, 128], [1, 256], 0], {'out': torch.Size([128, 128])})
SUCCESS               0.003400            0.002340               1.453          ([torch.Size([1024, 1024]), [512, 512], [1024, 1], 0], {'out': torch.Size([512, 512])})
SUCCESS               0.016520            0.016340               1.011          ([torch.Size([64, 128, 64]), [32, 64, 32], [8192, 64, 2], 0], {'out': torch.Size([32, 64, 32])})
SUCCESS               0.016780            0.011860               1.415          ([torch.Size([1048576]), [524288], [2], 0], {'out': torch.Size([524288])})
```