### PR TITLE
fix copy fp8

### DIFF
--- a/src/flag_gems/ops/copy.py
+++ b/src/flag_gems/ops/copy.py
@@ -33,7 +33,7 @@ def _can_use_triton(dst: torch.Tensor, src: torch.Tensor) -> bool:
         # by forcing the redispatch path, which issues the warning internally.
         return False
     if _FLOAT8_E8M0FNU is not None and (
-        src.dtype == torch.float8_e8m0fnu or dst.dtype == torch.float8_e8m0fnu
+        src.dtype == _FLOAT8_E8M0FNU or dst.dtype == _FLOAT8_E8M0FNU
     ):
         # Triton does not support float8 yet, so defer to PyTorch which has a reference implementation.
         return False
@@ -86,7 +86,9 @@ def copy_(dst: torch.Tensor, src: torch.Tensor, non_blocking: bool = False):
             _FALLBACK_KEYSET, dst, src, non_blocking
         )
 
-    if src.dtype == torch.float8_e8m0fnu or dst.dtype == torch.float8_e8m0fnu:
+    if _FLOAT8_E8M0FNU is not None and (
+        src.dtype == _FLOAT8_E8M0FNU or dst.dtype == _FLOAT8_E8M0FNU
+    ):
         return torch.ops.aten.copy_.default.redispatch(
             _FALLBACK_KEYSET, dst, src, non_blocking
         )


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description
Fixes the torch.float8_e8m0fnu error in older PyTorch versions.

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
N/A
