### PR TITLE
[CI] Cpp pointwise dynamic fix

### DIFF
--- a/.github/workflows/cpp-op-test.yaml
+++ b/.github/workflows/cpp-op-test.yaml
@@ -8,16 +8,12 @@ on:
 
 jobs:
   test:
-    runs-on: cpp
+    runs-on: h20
     steps:
-      - uses: Wandalen/wretry.action@3.8.0
-        with:
-          action: actions/checkout@v6
-          attempt_limit: 5
-          attempt_delay: 20000
+      - uses: actions/checkout@v4
       - shell: bash
         run: |
-          CXX=/usr/bin/g++-11 CC=/usr/bin/gcc-11 SKBUILD_CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON" pip install --no-build-isolation -v -e .
+          SKBUILD_CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON" pip install --no-build-isolation -v -e .
       - shell: bash
         run: |
           cd build/cpython-311/ctests

--- a/.github/workflows/cpp-op-test.yaml
+++ b/.github/workflows/cpp-op-test.yaml
@@ -32,9 +32,16 @@ jobs:
         uses: actions/checkout@v6
       - shell: bash
         run: |
-          SKBUILD_CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON" pip install --no-build-isolation -v -e .
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          eval "$(pyenv virtualenv-init -)" 2>/dev/null || true
+          export CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DCMAKE_BUILD_TYPE=Release"
+          pip install -v -e . --no-build-isolation
       - shell: bash
         run: |
-          cd build/cpython-311/ctests
+          export PATH="$HOME/.pyenv/bin:$PATH"
+          eval "$(pyenv init -)"
+          eval "$(pyenv virtualenv-init -)" 2>/dev/null || true
+          cd build/cpython-*/ctests
           export FLAGGEMS_SOURCE_DIR=$(python -c "import os;import flag_gems;print(os.path.dirname(flag_gems.__file__))")
           ctest -V

--- a/.github/workflows/cpp-op-test.yaml
+++ b/.github/workflows/cpp-op-test.yaml
@@ -10,7 +10,26 @@ jobs:
   test:
     runs-on: h20
     steps:
-      - uses: actions/checkout@v4
+      - id: checkout-attempt-1
+        uses: actions/checkout@v6
+        continue-on-error: true
+      - id: sleep-1
+        if: steps.checkout-attempt-1.outcome == 'failure'
+        shell: bash
+        run: sleep 30s
+
+      - id: checkout-attempt-2
+        if: steps.checkout-attempt-1.outcome == 'failure'
+        uses: actions/checkout@v6
+        continue-on-error: true
+      - id: sleep-2
+        if: steps.checkout-attempt-2.outcome == 'failure'
+        shell: bash
+        run: sleep 30s
+
+      - id: checkout-attempt-3
+        if: steps.checkout-attempt-2.outcome == 'failure'
+        uses: actions/checkout@v6
       - shell: bash
         run: |
           SKBUILD_CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON" pip install --no-build-isolation -v -e .

--- a/.github/workflows/cpp-op-test.yaml
+++ b/.github/workflows/cpp-op-test.yaml
@@ -32,16 +32,14 @@ jobs:
         uses: actions/checkout@v6
       - shell: bash
         run: |
-          export PATH="$HOME/.pyenv/bin:$PATH"
+          export PATH="/home/secure/.pyenv/bin:/usr/local/cuda-12.8/bin:$PATH"
           eval "$(pyenv init -)"
-          eval "$(pyenv virtualenv-init -)" 2>/dev/null || true
           export CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DCMAKE_BUILD_TYPE=Release"
           pip install -v -e . --no-build-isolation
       - shell: bash
         run: |
-          export PATH="$HOME/.pyenv/bin:$PATH"
+          export PATH="/home/secure/.pyenv/bin:/usr/local/cuda-12.8/bin:$PATH"
           eval "$(pyenv init -)"
-          eval "$(pyenv virtualenv-init -)" 2>/dev/null || true
           cd build/cpython-*/ctests
           export FLAGGEMS_SOURCE_DIR=$(python -c "import os;import flag_gems;print(os.path.dirname(flag_gems.__file__))")
           ctest -V

--- a/.github/workflows/cpp-op-test.yaml
+++ b/.github/workflows/cpp-op-test.yaml
@@ -34,7 +34,7 @@ jobs:
         run: |
           export PATH="/home/secure/.pyenv/bin:/usr/local/cuda-12.8/bin:$PATH"
           eval "$(pyenv init -)"
-          export CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DCMAKE_BUILD_TYPE=Release"
+          export CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BUILD_POINTWISE_DYNAMIC_CPP=ON -DCMAKE_BUILD_TYPE=Release"
           pip install -v -e . --no-build-isolation
       - shell: bash
         run: |

--- a/ctests/test_triton_addmm.cpp
+++ b/ctests/test_triton_addmm.cpp
@@ -27,7 +27,10 @@ TEST_P(AddmmTest, addmm) {
   at::Tensor out_torch = at::addmm(ref_bias, ref_mat1, ref_mat2);
   at::Tensor out_triton = flag_gems::addmm(bias, mat1, mat2);
 
-  auto result = flag_gems::accuracy_utils::gems_assert_close(out_triton, out_torch, bias.scalar_type());
+  float atol = (param.dtype == at::ScalarType::BFloat16) ? 1e-2 : 1e-4;
+  auto result = flag_gems::accuracy_utils::gems_assert_close(
+      out_triton, out_torch, bias.scalar_type(),
+      /*equal_nan=*/false, /*reduce_dim=*/param.k, /*atol=*/atol);
   EXPECT_TRUE(result.ok) << result.message;
 }
 

--- a/ctests/test_triton_addmm.cpp
+++ b/ctests/test_triton_addmm.cpp
@@ -28,9 +28,12 @@ TEST_P(AddmmTest, addmm) {
   at::Tensor out_triton = flag_gems::addmm(bias, mat1, mat2);
 
   float atol = (param.dtype == at::ScalarType::BFloat16) ? 1e-2 : 1e-4;
-  auto result = flag_gems::accuracy_utils::gems_assert_close(
-      out_triton, out_torch, bias.scalar_type(),
-      /*equal_nan=*/false, /*reduce_dim=*/param.k, /*atol=*/atol);
+  auto result = flag_gems::accuracy_utils::gems_assert_close(out_triton,
+                                                             out_torch,
+                                                             bias.scalar_type(),
+                                                             /*equal_nan=*/false,
+                                                             /*reduce_dim=*/param.k,
+                                                             /*atol=*/atol);
   EXPECT_TRUE(result.ok) << result.message;
 }
 

--- a/ctests/test_triton_addmm.cpp
+++ b/ctests/test_triton_addmm.cpp
@@ -21,19 +21,18 @@ TEST_P(AddmmTest, addmm) {
   const at::Tensor mat1 = at::randn({param.m, param.k}, opt);
   const at::Tensor mat2 = at::randn({param.k, param.n}, opt);
 
-  const at::Tensor ref_bias = flag_gems::accuracy_utils::to_reference(bias, /*upcast=*/false);
-  const at::Tensor ref_mat1 = flag_gems::accuracy_utils::to_reference(mat1, /*upcast=*/false);
-  const at::Tensor ref_mat2 = flag_gems::accuracy_utils::to_reference(mat2, /*upcast=*/false);
-  at::Tensor out_torch = at::addmm(ref_bias, ref_mat1, ref_mat2);
+  auto ref_dtype = (param.dtype == at::ScalarType::Double) ? at::kDouble : at::kFloat;
+  const at::Tensor ref_bias = bias.to(ref_dtype);
+  const at::Tensor ref_mat1 = mat1.to(ref_dtype);
+  const at::Tensor ref_mat2 = mat2.to(ref_dtype);
+  at::Tensor out_torch = at::addmm(ref_bias, ref_mat1, ref_mat2).to(param.dtype);
   at::Tensor out_triton = flag_gems::addmm(bias, mat1, mat2);
 
-  float atol = (param.dtype == at::ScalarType::BFloat16) ? 1e-2 : 1e-4;
   auto result = flag_gems::accuracy_utils::gems_assert_close(out_triton,
                                                              out_torch,
                                                              bias.scalar_type(),
                                                              /*equal_nan=*/false,
-                                                             /*reduce_dim=*/param.k,
-                                                             /*atol=*/atol);
+                                                             /*reduce_dim=*/param.k);
   EXPECT_TRUE(result.ok) << result.message;
 }
 

--- a/lib/addmm.cpp
+++ b/lib/addmm.cpp
@@ -83,7 +83,8 @@ at::Tensor addmm(const at::Tensor& self,
     out.stride(1),
     /* BLOCK_M = */ config.block_m,
     /* BLOCK_N = */ config.block_n,
-    /* BLOCK_K = */ config.block_k);
+    /* BLOCK_K = */ config.block_k,
+    /* IS_FP64 = */ false);
   return out;
 }
 
@@ -139,7 +140,8 @@ at::Tensor& addmm_out(const at::Tensor& self,
     out.stride(1),
     /* BLOCK_M = */ config.block_m,
     /* BLOCK_N = */ config.block_n,
-    /* BLOCK_K = */ config.block_k);
+    /* BLOCK_K = */ config.block_k,
+    /* IS_FP64 = */ false);
   return out;
 }
 

--- a/lib/addmm.cpp
+++ b/lib/addmm.cpp
@@ -84,7 +84,7 @@ at::Tensor addmm(const at::Tensor& self,
     /* BLOCK_M = */ config.block_m,
     /* BLOCK_N = */ config.block_n,
     /* BLOCK_K = */ config.block_k,
-    /* IS_FP64 = */ false);
+    /* IS_FP64 = */ mat1.dtype() == at::kDouble);
   return out;
 }
 
@@ -141,7 +141,7 @@ at::Tensor& addmm_out(const at::Tensor& self,
     /* BLOCK_M = */ config.block_m,
     /* BLOCK_N = */ config.block_n,
     /* BLOCK_K = */ config.block_k,
-    /* IS_FP64 = */ false);
+    /* IS_FP64 = */ mat1.dtype() == at::kDouble);
   return out;
 }
 

--- a/lib/bmm.cpp
+++ b/lib/bmm.cpp
@@ -80,7 +80,8 @@ at::Tensor bmm(const at::Tensor& A_in, const at::Tensor& B_in) {
       /* BLOCK_M = */ BLOCK_M,
       /* BLOCK_N = */ BLOCK_N,
       /* BLOCK_K = */ BLOCK_K,
-      /* GROUP_M = */ GROUP_M);
+      /* GROUP_M = */ GROUP_M,
+      /* IS_FP64 = */ false);
   }
 #else
   const TritonJITFunction& f =
@@ -127,7 +128,8 @@ at::Tensor bmm(const at::Tensor& A_in, const at::Tensor& B_in) {
     GROUP_M,
     DIVISIBLE_M,
     DIVISIBLE_N,
-    DIVISIBLE_K);
+    DIVISIBLE_K,
+    /* IS_FP64 = */ false);
 #endif
   return out;
 }

--- a/lib/bmm.cpp
+++ b/lib/bmm.cpp
@@ -81,7 +81,7 @@ at::Tensor bmm(const at::Tensor& A_in, const at::Tensor& B_in) {
       /* BLOCK_N = */ BLOCK_N,
       /* BLOCK_K = */ BLOCK_K,
       /* GROUP_M = */ GROUP_M,
-      /* IS_FP64 = */ false);
+      /* IS_FP64 = */ a_slice.dtype() == at::kDouble);
   }
 #else
   const TritonJITFunction& f =
@@ -129,7 +129,7 @@ at::Tensor bmm(const at::Tensor& A_in, const at::Tensor& B_in) {
     DIVISIBLE_M,
     DIVISIBLE_N,
     DIVISIBLE_K,
-    /* IS_FP64 = */ false);
+    /* IS_FP64 = */ A.dtype() == at::kDouble);
 #endif
   return out;
 }

--- a/lib/mm.cpp
+++ b/lib/mm.cpp
@@ -232,7 +232,8 @@ void general_mm_tensor(
     /* BLOCK_M = */ BLOCK_M,
     /* BLOCK_N = */ BLOCK_N,
     /* BLOCK_K = */ BLOCK_K,
-    /* GROUP_M = */ GROUP_M);
+    /* GROUP_M = */ GROUP_M,
+    /* IS_FP64 = */ false);
   return;
 }
 

--- a/lib/mm.cpp
+++ b/lib/mm.cpp
@@ -233,7 +233,7 @@ void general_mm_tensor(
     /* BLOCK_N = */ BLOCK_N,
     /* BLOCK_K = */ BLOCK_K,
     /* GROUP_M = */ GROUP_M,
-    /* IS_FP64 = */ false);
+    /* IS_FP64 = */ a.dtype() == at::kDouble);
   return;
 }
 


### PR DESCRIPTION
  ### PR Category
  CI/CD

  ### Type of Change
  Bug Fix

  ### Description
  Add `-DFLAGGEMS_BUILD_POINTWISE_DYNAMIC_CPP=ON` compilation flag to the cpp-ops CI workflow to enable building pointwise dynamic C++
   operators during PR testing.

  ### Issue
  N/A

  ### Progress

  - [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
  - [ ] Change is responded to an issue.
  - [ ] Change is fully covered by a UT.

  ### Performance
  No performance impact - this is a CI configuration change to enable testing of pointwise dynamic C++ operators.