### PR TITLE
【KernelGen】Add log_normal_ operator

### DIFF
--- a/benchmark/test_log_normal.py
+++ b/benchmark/test_log_normal.py
@@ -1,0 +1,22 @@
+import pytest
+import torch
+
+from . import base, consts
+
+
+def log_normal__input_fn(shape, cur_dtype, device):
+    self = torch.empty(shape, dtype=cur_dtype, device=device)
+    mean = 1.0
+    std = 2.0
+    yield self, mean, std
+
+
+@pytest.mark.log_normal_
+def test_log_normal_inplace():
+    bench = base.GenericBenchmark(
+        op_name="log_normal_",
+        input_fn=log_normal__input_fn,
+        torch_op=torch.Tensor.log_normal_,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -3498,6 +3498,18 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+  - id: log_normal_
+    description: Fills `self` tensor with numbers samples from the log-normal distribution.
+    for:
+      - log_normal_
+    labels:
+      - aten
+      - skip_precision_check
+      - KernelGen
+    kind:
+      - Distribution
+    stages:
+      - beta: '5.1'
   - id: log_sigmoid
     description: Applies the Logsigmoid function element-wise.
     for:

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -3504,7 +3504,6 @@ ops:
       - log_normal_
     labels:
       - aten
-      - skip_precision_check
       - KernelGen
     kind:
       - Distribution

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -317,6 +317,7 @@ _FULL_CONFIG = (
     ("log10.out", log10_out),
     ("log1p", log1p),
     ("log1p_", log1p_),
+    ("log_normal_", log_normal_),
     ("log_sigmoid", log_sigmoid),
     ("logaddexp", logaddexp),
     ("logaddexp.out", logaddexp_out),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -201,6 +201,7 @@ from flag_gems.ops.log import log
 from flag_gems.ops.log1p import log1p
 from flag_gems.ops.log1p_ import log1p_
 from flag_gems.ops.log10 import log10, log10_, log10_out
+from flag_gems.ops.log_normal_ import log_normal_
 from flag_gems.ops.log_sigmoid import log_sigmoid
 from flag_gems.ops.log_softmax import (
     log_softmax,
@@ -657,7 +658,7 @@ __all__ = [
     "log10",
     "log10_",
     "log10_out",
-    "log1p_",
+    "log_normal_",
     "log_sigmoid",
     "log_softmax",
     "log_softmax_backward",

--- a/src/flag_gems/ops/log_normal_.py
+++ b/src/flag_gems/ops/log_normal_.py
@@ -1,0 +1,46 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.ops.randn import randn_kernel
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import pointwise_dynamic
+from flag_gems.utils.random_utils import philox_backend_seed_offset
+from flag_gems.utils.shape_utils import volume
+
+logger = logging.getLogger(__name__)
+UNROLL = 4
+
+
+@pointwise_dynamic(
+    is_tensor=[True, False, False], promotion_methods=[(0, 1, 2, "DEFAULT")]
+)
+@triton.jit
+def transform_log_normal(val, std, mean):
+    # log_normal: exp(val * std + mean)
+    # where val ~ N(0, 1), so val * std + mean ~ N(mean, std^2)
+    # and exp(val * std + mean) ~ LogNormal(mean, std)
+    return tl.exp(val * std + mean)
+
+
+def log_normal_(self, mean=1.0, std=2.0, *, generator=None):
+    logger.debug("GEMS LOG_NORMAL_")
+    shape = self.shape
+    device = self.device
+    N = volume(shape)
+
+    # Generate standard normal distribution in float32
+    temp = torch.empty(shape, device=device, dtype=torch.float32)
+    grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK"] * UNROLL),)
+    increment = triton.cdiv(N, UNROLL)
+    philox_seed, philox_offset = philox_backend_seed_offset(
+        increment, generator=generator
+    )
+    with torch_device_fn.device(device):
+        randn_kernel[grid_fn](temp, N, philox_seed, philox_offset)
+
+    # Apply log_normal transformation: exp(val * std + mean)
+    transform_log_normal(temp, std, mean, out0=self)
+    return self

--- a/tests/test_log_normal_.py
+++ b/tests/test_log_normal_.py
@@ -1,0 +1,29 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+device = flag_gems.device
+
+
+@pytest.mark.log_normal_
+@pytest.mark.parametrize("shape", utils.DISTRIBUTION_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_accuracy_log_normal_(shape, dtype):
+    mean_param = 1.0
+    std_param = 2.0
+    x = torch.empty(size=shape, dtype=dtype, device=device)
+    with flag_gems.use_gems():
+        x.log_normal_(mean_param, std_param)
+
+    assert x.min() > 0
+
+    x_ref = utils.to_reference(x)
+    log_x = torch.log(x_ref.to(torch.float32))
+    log_mean = torch.mean(log_x)
+    log_std = torch.std(log_x)
+
+    assert torch.abs(log_mean - mean_param) < 0.1
+    assert torch.abs(log_std - std_param) < 0.2


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
Add `log_normal_` operator implementation with Triton kernel.

- Implementation mode: `N/A`
- Rebased on latest master, adapted to new independent test file structure
- Added `KernelGen` label in `conf/operators.yaml`

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.