### PR TITLE
[FlagGems Operator Development Competition] Improve pixel_shuffle shape and out support

### DIFF
--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -399,6 +399,7 @@ _FULL_CONFIG = (
     ("ones_like", ones_like),
     ("pad", pad),
     ("pixel_shuffle", pixel_shuffle),
+    ("pixel_shuffle.out", pixel_shuffle_out),
     ("pixel_unshuffle", pixel_unshuffle),
     ("pixel_unshuffle.out", pixel_unshuffle_out),
     ("poisson", poisson),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -269,7 +269,7 @@ from flag_gems.ops.per_token_group_quant_fp8 import (
     SUPPORTED_FP8_DTYPE,
     per_token_group_quant_fp8,
 )
-from flag_gems.ops.pixel_shuffle import pixel_shuffle
+from flag_gems.ops.pixel_shuffle import pixel_shuffle, pixel_shuffle_out
 from flag_gems.ops.pixel_unshuffle import pixel_unshuffle, pixel_unshuffle_out
 from flag_gems.ops.poisson import poisson
 from flag_gems.ops.polar import polar
@@ -737,6 +737,7 @@ __all__ = [
     "pad",
     "per_token_group_quant_fp8",
     "pixel_shuffle",
+    "pixel_shuffle_out",
     "pixel_unshuffle",
     "pixel_unshuffle_out",
     "poisson",

--- a/src/flag_gems/ops/pixel_shuffle.py
+++ b/src/flag_gems/ops/pixel_shuffle.py
@@ -1,4 +1,5 @@
 import logging
+from math import prod
 
 import torch
 import triton
@@ -10,7 +11,7 @@ from flag_gems.utils import libentry
 logger = logging.getLogger(__name__)
 
 
-# Pixel Shuffle: (N, C*r^2, H, W) -> (N, C, H*r, W*r)
+# Pixel Shuffle: (*, C*r^2, H, W) -> (*, C, H*r, W*r)
 # Direct index mapping kernel - each output element reads from the correct
 # input position without intermediate tensors.
 @libentry()
@@ -65,27 +66,56 @@ def pixel_shuffle_kernel(
     tl.store(out_ptr + offsets, val, mask=mask)
 
 
-def pixel_shuffle(input, upscale_factor):
-    logger.debug("GEMS PIXEL_SHUFFLE")
+def _check_pixel_shuffle(input, upscale_factor):
     r = int(upscale_factor)
-    assert input.ndim == 4
-    N, C, H, W = input.shape
-    assert C % (r * r) == 0
+    if r <= 0:
+        raise RuntimeError(
+            f"pixel_shuffle expects a positive upscale_factor, but got {r}"
+        )
+    if input.ndim < 3:
+        raise RuntimeError(
+            "pixel_shuffle expects input to have at least 3 dimensions, "
+            f"but got input with {input.ndim} dimension(s)"
+        )
 
-    C_out = C // (r * r)
-    H_out = H * r
-    W_out = W * r
+    C, H, W = input.shape[-3:]
+    r2 = r * r
+    if C % r2 != 0:
+        raise RuntimeError(
+            "pixel_shuffle expects its input's 'channel' dimension to be divisible "
+            f"by the square of upscale_factor, but input.size(-3)={C} is not "
+            f"divisible by {r2}"
+        )
 
-    input = input.contiguous()
-    output = torch.empty(
-        (N, C_out, H_out, W_out), device=input.device, dtype=input.dtype
-    )
+    output_shape = (*input.shape[:-3], C // r2, H * r, W * r)
+    return r, C, H, W, output_shape
 
+
+def _flatten_input(input, C, H, W):
+    batch = prod(input.shape[:-3])
+    return input.contiguous().reshape(batch, C, H, W)
+
+
+def _tensors_overlap(left: torch.Tensor, right: torch.Tensor):
+    try:
+        return torch._C._overlaps(left, right)
+    except AttributeError:
+        return True
+
+
+def _launch_pixel_shuffle(input, output, r, C, H, W):
     n_elements = output.numel()
     if n_elements == 0:
         return output
 
-    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    C_out = C // (r * r)
+    H_out = H * r
+    W_out = W * r
+    input = input.contiguous()
+
+    def grid(meta):
+        return (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+
     with torch_device_fn.device(input.device):
         pixel_shuffle_kernel[grid](
             input,
@@ -100,3 +130,37 @@ def pixel_shuffle(input, upscale_factor):
             W_out,
         )
     return output
+
+
+def pixel_shuffle(input, upscale_factor):
+    logger.debug("GEMS PIXEL_SHUFFLE")
+    r, C, H, W, output_shape = _check_pixel_shuffle(input, upscale_factor)
+    input = _flatten_input(input, C, H, W)
+    output = torch.empty(output_shape, device=input.device, dtype=input.dtype)
+    return _launch_pixel_shuffle(input, output, r, C, H, W)
+
+
+def pixel_shuffle_out(input, upscale_factor, out):
+    logger.debug("GEMS PIXEL_SHUFFLE_OUT")
+    r, C, H, W, output_shape = _check_pixel_shuffle(input, upscale_factor)
+    if out.dtype != input.dtype:
+        raise RuntimeError(
+            f"Expected out tensor to have dtype {input.dtype}, but got {out.dtype} instead"
+        )
+    if out.device != input.device:
+        raise RuntimeError("Expected out tensor to be on the same device as input")
+
+    input_flat = _flatten_input(input, C, H, W)
+    if _tensors_overlap(input, out):
+        input_flat = input_flat.clone()
+
+    if tuple(out.shape) != tuple(output_shape):
+        out.resize_(output_shape)
+
+    if out.is_contiguous():
+        return _launch_pixel_shuffle(input_flat, out, r, C, H, W)
+
+    out_contiguous = torch.empty(output_shape, device=input.device, dtype=input.dtype)
+    _launch_pixel_shuffle(input_flat, out_contiguous, r, C, H, W)
+    out.copy_(out_contiguous)
+    return out

--- a/tests/test_pixel_shuffle.py
+++ b/tests/test_pixel_shuffle.py
@@ -5,7 +5,6 @@ import flag_gems
 
 from . import accuracy_utils as utils
 
-
 PIXEL_SHUFFLE_CASES = [
     ((4, 4, 5), 2),
     ((1, 12, 4, 4), 2),

--- a/tests/test_pixel_shuffle.py
+++ b/tests/test_pixel_shuffle.py
@@ -6,11 +6,26 @@ import flag_gems
 from . import accuracy_utils as utils
 
 
+PIXEL_SHUFFLE_CASES = [
+    ((4, 4, 5), 2),
+    ((1, 12, 4, 4), 2),
+    ((2, 18, 3, 3), 3),
+    ((1, 4, 8, 8), 2),
+    ((4, 36, 2, 2), 3),
+    ((2, 3, 4, 2, 3), 2),
+    ((0, 4, 2, 3), 2),
+    ((2, 0, 4, 2, 3), 2),
+]
+
+
+def _pixel_shuffle_output_shape(shape, upscale_factor):
+    r = upscale_factor
+    *leading, channels, height, width = shape
+    return (*leading, channels // (r * r), height * r, width * r)
+
+
 @pytest.mark.pixel_shuffle
-@pytest.mark.parametrize(
-    "shape_factor",
-    [((1, 12, 4, 4), 2), ((2, 18, 3, 3), 3), ((1, 4, 8, 8), 2), ((4, 36, 2, 2), 3)],
-)
+@pytest.mark.parametrize("shape_factor", PIXEL_SHUFFLE_CASES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
 def test_pixel_shuffle(shape_factor, dtype):
     shape, upscale_factor = shape_factor
@@ -26,16 +41,11 @@ def test_pixel_shuffle(shape_factor, dtype):
 
 
 @pytest.mark.pixel_shuffle_out
-@pytest.mark.parametrize(
-    "shape_factor",
-    [((1, 12, 4, 4), 2), ((2, 18, 3, 3), 3), ((1, 4, 8, 8), 2), ((4, 36, 2, 2), 3)],
-)
+@pytest.mark.parametrize("shape_factor", PIXEL_SHUFFLE_CASES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
 def test_pixel_shuffle_out(shape_factor, dtype):
     shape, upscale_factor = shape_factor
-    N, C, H, W = shape
-    r = upscale_factor
-    out_shape = (N, C // (r * r), H * r, W * r)
+    out_shape = _pixel_shuffle_output_shape(shape, upscale_factor)
 
     input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     ref_input = utils.to_reference(input_tensor, True)
@@ -50,3 +60,37 @@ def test_pixel_shuffle_out(shape_factor, dtype):
         )
 
     utils.gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.pixel_shuffle_out
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_pixel_shuffle_out_noncontiguous_out(dtype):
+    shape = (4, 2, 3)
+    upscale_factor = 2
+    out_shape = _pixel_shuffle_output_shape(shape, upscale_factor)
+
+    input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_input = utils.to_reference(input_tensor, True)
+
+    out_ref_base = torch.empty(
+        (*out_shape[:-1], out_shape[-1] * 2),
+        dtype=ref_input.dtype,
+        device=ref_input.device,
+    )
+    out_ref = out_ref_base[..., ::2]
+    ref_out = torch.ops.aten.pixel_shuffle.out(ref_input, upscale_factor, out=out_ref)
+
+    out_act_base = torch.empty(
+        (*out_shape[:-1], out_shape[-1] * 2),
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+    out_act = out_act_base[..., ::2]
+    assert not out_act.is_contiguous()
+    with flag_gems.use_gems():
+        act_out = torch.ops.aten.pixel_shuffle.out(
+            input_tensor, upscale_factor, out=out_act
+        )
+
+    utils.gems_assert_close(act_out, ref_out, dtype=dtype)
+    assert act_out.data_ptr() == out_act.data_ptr()


### PR DESCRIPTION
## Summary
- support `torch.pixel_shuffle` inputs with arbitrary leading dimensions, matching PyTorch's `(*, C*r^2, H, W)` contract
- register and implement `aten.pixel_shuffle.out`
- add coverage for 3D, 5D, empty-batch, empty-leading-dim, and non-contiguous `out` tensors

## Verification
- `python3 -m compileall -q src/flag_gems/ops/pixel_shuffle.py src/flag_gems/ops/__init__.py src/flag_gems/__init__.py tests/test_pixel_shuffle.py`
- `python3 -m ruff check src/flag_gems/ops/pixel_shuffle.py src/flag_gems/ops/__init__.py src/flag_gems/__init__.py tests/test_pixel_shuffle.py`
- `python3 -m ruff format --check src/flag_gems/ops/pixel_shuffle.py src/flag_gems/ops/__init__.py src/flag_gems/__init__.py tests/test_pixel_shuffle.py`
- local helper smoke check for N-D shape flattening and validation errors

Note: `PYTHONPATH=src pytest -q tests/test_pixel_shuffle.py` is not runnable in this local shell because `triton` is not installed (`ModuleNotFoundError: No module named 'triton'`).
