### PR TITLE
Add KernelGen label to one_hot operator

### DIFF
--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -4445,6 +4445,7 @@ ops:
     labels:
       - aten
       - nn.functional
+      - KernelGen
     kind:
       - NeuralNetwork
     stages:


### PR DESCRIPTION
## Summary
- Add missing `KernelGen` label to the `one_hot` operator entry in `conf/operators.yaml`
- The `one_hot` operator is generated by KernelGen but was missing the label
- Related: #1756

## Changes
- `conf/operators.yaml`: Added `- KernelGen` to one_hot labels