### PR TITLE
Add KernelGen label to fill_scalar_out and fill_tensor_out

### DIFF
--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -2217,6 +2217,7 @@ ops:
     labels:
       - aten
       - pointwise
+      - KernelGen
     kind:
       - Tensor
     stages:
@@ -2252,6 +2253,7 @@ ops:
     labels:
       - aten
       - pointwise
+      - KernelGen
     kind:
       - Tensor
     stages:


### PR DESCRIPTION
## Summary
- Add missing `KernelGen` label to `fill_scalar_out` and `fill_tensor_out` in `conf/operators.yaml`
- These operators were added in #1674 but missing the KernelGen label

## Changes
- `conf/operators.yaml`: Added `- KernelGen` to `fill_scalar_out` and `fill_tensor_out` labels