### PR TITLE
Add KernelGen label to unique_consecutive

### DIFF
--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -6381,6 +6381,7 @@ ops:
       - unique_consecutive
     labels:
       - aten
+      - KernelGen
     kind:
       - Distribution
     stages:


### PR DESCRIPTION
## Summary
- Add missing `KernelGen` label to `unique_consecutive` in `conf/operators.yaml`
- This operator was added in #1766 but missing the KernelGen label

## Changes
- `conf/operators.yaml`: Added `- KernelGen` to `unique_consecutive` labels