### PR TITLE
Add KernelGen label to bernoulli_

### DIFF
--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -722,6 +722,7 @@ ops:
     labels:
       - aten
       - skip_precision_check
+      - KernelGen
     kind:
       - Tensor
     stages:


### PR DESCRIPTION
## Summary
- Add missing `KernelGen` label to `bernoulli_` in `conf/operators.yaml`
- This operator was added in #1721 but missing the KernelGen label

## Changes
- `conf/operators.yaml`: Added `- KernelGen` to `bernoulli_` labels