### PR TITLE
Add KernelGen label to bincount

### DIFF
--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -733,6 +733,7 @@ ops:
     labels:
       - aten
       - pointwise
+      - KernelGen
     kind:
       - Reduction
     stages:


### PR DESCRIPTION
## Summary
- Add missing `KernelGen` label to `bincount` in `conf/operators.yaml`
- This operator was added in #1722 but missing the KernelGen label

## Changes
- `conf/operators.yaml`: Added `- KernelGen` to `bincount` labels