### PR TITLE
Add KernelGen label to roll

### DIFF
--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -5127,6 +5127,7 @@ ops:
       - roll
     labels:
       - aten
+      - KernelGen
     kind:
       - BLAS
     stages:


### PR DESCRIPTION
## Summary
- Add missing `KernelGen` label to `roll` in `conf/operators.yaml`
- This operator was added in #1759 but missing the KernelGen label

## Changes
- `conf/operators.yaml`: Added `- KernelGen` to `roll` labels