### PR TITLE
Add KernelGen label to scatter_reduce_

### DIFF
--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -5360,6 +5360,7 @@ ops:
       - scatter_.reduce
     labels:
       - aten
+      - KernelGen
     kind:
       - Tensor
     stages:


### PR DESCRIPTION
## Summary
- Add missing `KernelGen` label to `scatter_reduce_` in `conf/operators.yaml`
- This operator was added in #1762 but missing the KernelGen label

## Changes
- `conf/operators.yaml`: Added `- KernelGen` to `scatter_reduce_` labels