### PR TITLE
Add KernelGen label to var

### DIFF
--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -6524,6 +6524,7 @@ ops:
       - var
     labels:
       - aten
+      - KernelGen
     kind:
       - Tensor
     stages:


### PR DESCRIPTION
## Summary
- Add missing `KernelGen` label to `var` in `conf/operators.yaml`
- This operator was added in #1774 but missing the KernelGen label

## Changes
- `conf/operators.yaml`: Added `- KernelGen` to `var` labels