### PR TITLE
Fix cat_out benchmark OOM

### DIFF
--- a/benchmark/test_cat.py
+++ b/benchmark/test_cat.py
@@ -1,4 +1,5 @@
 from typing import Generator
+import math
 
 import pytest
 import torch
@@ -38,6 +39,49 @@ def test_cat():
     bench = CatBenchmark(
         op_name="cat",
         input_fn=_input_fn,
+        torch_op=torch.cat,
+        dtypes=consts.FLOAT_DTYPES + consts.INT_DTYPES,
+    )
+    bench.run()
+
+
+class CatOutBenchmark(CatBenchmark):
+    """Limit shapes to avoid OOM: cat_out needs 3 inputs + 1 output (3x size)."""
+
+    MAX_ELEMENTS = 2**24
+
+    def set_more_shapes(self):
+        shapes = super().set_more_shapes()
+        return [s for s in shapes if math.prod(s) <= self.MAX_ELEMENTS]
+
+    def init_user_config(self):
+        super().init_user_config()
+        self.shapes = [
+            s for s in self.shapes if math.prod(s) <= self.MAX_ELEMENTS
+        ]
+
+
+def _cat_out_input_fn(shape, dtype, device):
+    inp1 = utils.generate_tensor_input(shape, dtype, device)
+    inp2 = utils.generate_tensor_input(shape, dtype, device)
+    inp3 = utils.generate_tensor_input(shape, dtype, device)
+    out_shape = list(shape)
+    out_shape[0] = out_shape[0] * 3
+    out = torch.empty(out_shape, dtype=dtype, device=device)
+    yield [inp1, inp2, inp3], {"dim": 0, "out": out},
+
+    if base.Config.bench_level == consts.BenchLevel.COMPREHENSIVE:
+        out_shape_last = list(shape)
+        out_shape_last[-1] = out_shape_last[-1] * 3
+        out_last = torch.empty(out_shape_last, dtype=dtype, device=device)
+        yield [inp1, inp2, inp3], {"dim": -1, "out": out_last},
+
+
+@pytest.mark.cat_out
+def test_cat_out():
+    bench = CatOutBenchmark(
+        op_name="cat_out",
+        input_fn=_cat_out_input_fn,
         torch_op=torch.cat,
         dtypes=consts.FLOAT_DTYPES + consts.INT_DTYPES,
     )


### PR DESCRIPTION
## Summary
- Fix CUDA OOM in cat_out benchmark by limiting test shapes
- cat_out needs 3 input tensors + 1 output tensor (3x size), which easily exceeds GPU memory with large shapes
- Add `CatOutBenchmark` class with `MAX_ELEMENTS = 2**24` limit, similar to `MarginRankingLossBenchmark`

## Related
- Fixes CI failure in #3108
- Related to #2673 (original cat benchmark OOM issue)

## Changes
- `benchmark/test_cat.py`: Added `CatOutBenchmark` with shape limits, added `test_cat_out` function