### PR TITLE
 Fix issues#595 KeyError

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -175,18 +175,21 @@ def get_reason(report):
 
 @pytest.hookimpl(tryfirst=True)
 def pytest_runtest_logreport(report):
+    result = TEST_RESULTS.setdefault(
+        report.nodeid, {"params": None, "result": None, "opname": None}
+    )
     if report.when == "setup":
         if report.outcome == "skipped":
             reason = get_reason(report)
-            TEST_RESULTS[report.nodeid]["result"] = "skipped"
-            TEST_RESULTS[report.nodeid]["reason"] = reason
+            result["result"] = "skipped"
+            result["reason"] = reason
     elif report.when == "call":
-        TEST_RESULTS[report.nodeid]["result"] = report.outcome
+        result["result"] = report.outcome
         if report.outcome in ["skipped", "failed"]:
             reason = get_reason(report)
-            TEST_RESULTS[report.nodeid]["reason"] = reason
+            result["reason"] = reason
         else:
-            TEST_RESULTS[report.nodeid]["reason"] = None
+            result["reason"] = None
 
 
 def pytest_terminal_summary(terminalreporter):


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Other

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
  This change fixes a potential KeyError in pytest_runtest_logreport when pytest is executed with multiple processes.
  
  The previous implementation assumed that TEST_RESULTS[report.nodeid] had already been initialized before the test report was handled. However, with multiprocessing, global variables are process-local and are not shared between the main process and worker processes. As a result, a report may be processed in a process where the corresponding nodeid has not been inserted into TEST_RESULTS, which can lead to a KeyError.

  The updated code uses TEST_RESULTS.setdefault(...) before updating the report result. This guarantees that a default entry exists for the current nodeid.

  - In the normal single-process path, if the entry already exists, the existing data is reused and the behavior stays unchanged.
  - In multiprocessing runs, if the entry does not exist in the current process, a default record is created before writing result and reason.
  - The change only makes result collection more robust; it does not change test execution, assertions, parametrization, or skip/fail behavior.

  About “Will the modification of this file affect the tests of other operators?”
  No. This change should not affect the actual tests of other operators. It only changes how the test result metadata is recorded in TEST_RESULTS inside the pytest reporting hook. If an entry already exists, setdefault returns the existing record and keeps the previous behavior. If it does not exist, the code creates a default record to avoid KeyError.
  So the execution flow, operator implementation, test assertions, parameterization, and skip/fail decisions are not changed. The only expected impact is that result reporting becomes more robust when tests are run with multiple processes.

### Issue
595

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
