### PR TITLE
scaled_dot_product_attention_backward support non-square tuning, non-causal, and unequal lengths of q and kv sequences

### DIFF
--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -672,91 +672,90 @@ def _attn_bwd(
         dk_ptrs = DK + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
         tl.store(dk_ptrs, dk, mask=offs_n_mask[:, None])
 
-    # THIS BLOCK DOES DQ:
+    # dQ: only execute when this pid covers a valid Q block
     MASK_BLOCK_N2: tl.constexpr = BLOCK_N2 // BLK_SLICE_FACTOR
     start_m = pid * BLOCK_M2
-    end_n = min(start_m + BLOCK_M2, KV_CTX)  # Ensure end_n does not exceed N_CTX
-    num_steps = (end_n - start_n + MASK_BLOCK_N2 - 1) // MASK_BLOCK_N2
 
-    offs_m = start_m + tl.arange(0, BLOCK_M2)
-    offs_m_mask = offs_m < Q_CTX
+    if start_m < Q_CTX:
+        # Causal boundary: for Q rows [start_m, start_m+BLOCK_M2), the diagonal
+        # is at column start_m (not pid*BLOCK_N1 which differs when BLOCK_N1 != BLOCK_M2)
+        diag_n = start_m
+        end_n = min(start_m + BLOCK_M2, KV_CTX)
+        num_steps = (end_n - diag_n + MASK_BLOCK_N2 - 1) // MASK_BLOCK_N2
 
-    query = tl.load(
-        Q + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d,
-        mask=offs_m_mask[:, None],
-        other=0.0,
-    )
-    dq = tl.zeros([BLOCK_M2, BLOCK_DMODEL], dtype=tl.float32)
-    do = tl.load(
-        DO + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d,
-        mask=offs_m_mask[:, None],
-        other=0.0,
-    )
+        offs_m = start_m + tl.arange(0, BLOCK_M2)
+        offs_m_mask = offs_m < Q_CTX
 
-    m = tl.load(M + offs_m, mask=offs_m_mask, other=float("inf"))
-    m = m[:, None]
-
-    # Stage 1 - Compute dQ for masked (diagonal) blocks.
-    # NOTE: This code scans each row of QK^T backward (from right to left,
-    # but inside each call to _attn_bwd_dq, from left to right), but that's
-    # not due to anything important.  I just wanted to reuse the loop
-    # structure for dK & dV above as much as possible.
-
-    if num_steps > 0:
-        dq = _attn_bwd_dq(
-            dq,
-            query,
-            K,
-            V,  #
-            do,
-            m,
-            D,  #
-            stride_tok,
-            stride_d,  #
-            H,
-            Q_CTX,  #
-            KV_CTX,  #
-            BLOCK_M2,
-            MASK_BLOCK_N2,
-            BLOCK_DMODEL,  #
-            start_m,
-            start_n,
-            num_steps,  #
-            MASK=True,  #
+        query = tl.load(
+            Q + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d,
+            mask=offs_m_mask[:, None],
+            other=0.0,
+        )
+        dq = tl.zeros([BLOCK_M2, BLOCK_DMODEL], dtype=tl.float32)
+        do = tl.load(
+            DO + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d,
+            mask=offs_m_mask[:, None],
+            other=0.0,
         )
 
-    # Stage 2 - non-masked blocks
-    stage2_end_n = start_n
-    stage2_num_steps = (stage2_end_n + BLOCK_N2 - 1) // BLOCK_N2
+        m = tl.load(M + offs_m, mask=offs_m_mask, other=float("inf"))
+        m = m[:, None]
 
-    if stage2_num_steps > 0:
-        dq = _attn_bwd_dq(
-            dq,
-            query,
-            K,
-            V,  #
-            do,
-            m,
-            D,  #
-            stride_tok,
-            stride_d,  #
-            H,
-            Q_CTX,  #
-            KV_CTX,  #
-            BLOCK_M2,
-            BLOCK_N2,
-            BLOCK_DMODEL,  #
-            start_m,
-            stage2_end_n - stage2_num_steps * BLOCK_N2,
-            stage2_num_steps,  #
-            MASK=False,  #
-        )
-    # Write back dQ.
-    dq_ptrs = DQ + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d
-    dq *= LN2
-    # tl.store(dq_ptrs, dq)
+        # Stage 1 - Compute dQ for masked (diagonal) blocks.
+        if num_steps > 0:
+            dq = _attn_bwd_dq(
+                dq,
+                query,
+                K,
+                V,  #
+                do,
+                m,
+                D,  #
+                stride_tok,
+                stride_d,  #
+                H,
+                Q_CTX,  #
+                KV_CTX,  #
+                BLOCK_M2,
+                MASK_BLOCK_N2,
+                BLOCK_DMODEL,  #
+                start_m,
+                diag_n,
+                num_steps,  #
+                MASK=True,  #
+            )
 
-    tl.store(dq_ptrs, dq, mask=offs_m_mask[:, None])
+        # Stage 2 - non-masked blocks (columns before the diagonal)
+        stage2_end_n = diag_n
+        stage2_num_steps = (stage2_end_n + BLOCK_N2 - 1) // BLOCK_N2
+
+        if stage2_num_steps > 0:
+            dq = _attn_bwd_dq(
+                dq,
+                query,
+                K,
+                V,  #
+                do,
+                m,
+                D,  #
+                stride_tok,
+                stride_d,  #
+                H,
+                Q_CTX,  #
+                KV_CTX,  #
+                BLOCK_M2,
+                BLOCK_N2,
+                BLOCK_DMODEL,  #
+                start_m,
+                stage2_end_n - stage2_num_steps * BLOCK_N2,
+                stage2_num_steps,  #
+                MASK=False,  #
+            )
+
+        # Write back dQ.
+        dq_ptrs = DQ + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d
+        dq *= LN2
+        tl.store(dq_ptrs, dq, mask=offs_m_mask[:, None])
 
 
 def scaled_dot_product_attention_forward(

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -584,8 +584,6 @@ def _attn_bwd(
     # dK/dV: only execute when this pid covers a valid KV block
     start_n = pid * BLOCK_N1
     if start_n < KV_CTX:
-        start_m = start_n
-
         dv = tl.zeros([BLOCK_N1, BLOCK_DMODEL], dtype=tl.float32)
         dk = tl.zeros([BLOCK_N1, BLOCK_DMODEL], dtype=tl.float32)
 
@@ -604,38 +602,44 @@ def _attn_bwd(
         )
 
         MASK_BLOCK_M1: tl.constexpr = BLOCK_M1 // BLK_SLICE_FACTOR
-        num_steps = BLOCK_N1 // MASK_BLOCK_M1
 
-        dk, dv = _attn_bwd_dkdv(
-            dk,
-            dv,  #
-            Q,
-            key,
-            value,
-            sm_scale,  #
-            DO,  #
-            M,
-            D,  #
-            stride_tok,
-            stride_d,  #
-            H,
-            Q_CTX,  #
-            KV_CTX,  #
-            MASK_BLOCK_M1,
-            BLOCK_N1,
-            BLOCK_DMODEL,  #
-            start_n,
-            start_m,
-            num_steps,  #
-            MASK=True,  #
-        )
+        # Causal: masked diagonal phase, then unmasked above-diagonal phase.
+        # Non-causal: skip masked phase, single unmasked pass over all Q rows.
+        if IS_CAUSAL:
+            start_m = start_n
+            num_steps = BLOCK_N1 // MASK_BLOCK_M1
+            dk, dv = _attn_bwd_dkdv(
+                dk,
+                dv,  #
+                Q,
+                key,
+                value,
+                sm_scale,  #
+                DO,  #
+                M,
+                D,  #
+                stride_tok,
+                stride_d,  #
+                H,
+                Q_CTX,  #
+                KV_CTX,  #
+                MASK_BLOCK_M1,
+                BLOCK_N1,
+                BLOCK_DMODEL,  #
+                start_n,
+                start_m,
+                num_steps,  #
+                MASK=True,  #
+            )
+            start_m += num_steps * MASK_BLOCK_M1
+        else:
+            start_m = 0
 
-        # Compute dK and dV for non-masked blocks.
-        start_m += num_steps * MASK_BLOCK_M1
+        # Unmasked phase (shared): traverse remaining Q rows.
         remaining_m = Q_CTX - start_m
         num_steps = (remaining_m + BLOCK_M1 - 1) // BLOCK_M1
         if num_steps > 0:
-            dk, dv = _attn_bwd_dkdv(  #
+            dk, dv = _attn_bwd_dkdv(
                 dk,
                 dv,  #
                 Q,

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -425,7 +425,9 @@ def _attn_bwd_dkdv(
             mask &= offs_m[None, :] >= offs_n[:, None]
         pT = tl.where(mask, pT, 0.0)  # (BLOCK_N1, BLOCK_M1)
 
-        do = tl.load(do_ptrs, mask=offs_m_mask[:, None], other=0.0) # (BLOCK_M1, BLOCK_DMODEL)
+        do = tl.load(
+            do_ptrs, mask=offs_m_mask[:, None], other=0.0
+        )  # (BLOCK_M1, BLOCK_DMODEL)
 
         # Compute dV.
         dv += tl.dot(pT, do.to(tl.float32))  # (BLOCK_N1, BLOCK_DMODEL)
@@ -960,8 +962,12 @@ def scaled_dot_product_attention_backward(
 
     grid = lambda meta: (
         max(
-            triton.cdiv(KV_CTX, meta["BLOCK_N1"]), # _attn_bwd_dq traverse the key-value sequence
-            triton.cdiv(Q_CTX, meta["BLOCK_M2"]),  # _attn_bwd_dkdv traverse the query sequence
+            triton.cdiv(
+                KV_CTX, meta["BLOCK_N1"]
+            ),  # _attn_bwd_dq traverse the key-value sequence
+            triton.cdiv(
+                Q_CTX, meta["BLOCK_M2"]
+            ),  # _attn_bwd_dkdv traverse the query sequence
         ),
         1,
         BATCH * Q_HEAD,

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -69,7 +69,7 @@ def _attn_fwd_inner(
         if PRE_LOAD_V:
             value = tl.load(V_block_ptr, mask=kv_load_mask[:, None], other=0.0)
 
-        qk = tl.dot(query, key, allow_tf32=False)
+        qk = tl.dot(query, key)
         # incase not divisible.
         qk = tl.where(kv_load_mask[None, :], qk, -float("inf"))
         # qk = qk.to(tl.float32)
@@ -115,7 +115,7 @@ def _attn_fwd_inner(
         else:
             p = p.to(query.dtype)
         p = p.to(value.dtype)
-        acc = tl.dot(p, value, acc, allow_tf32=False)
+        acc = tl.dot(p, value, acc)
         # update m_i and l_i
         m_i = m_ij
 
@@ -411,7 +411,7 @@ def _attn_bwd_dkdv(
         m = tl.load(M + offs_m, mask=offs_m_mask, other=float("inf"))  # (BLOCK_M1, )
 
         # key: (BLOCK_N1, BLOCK_DMODEL)
-        qkT = tl.dot(key, qT, allow_tf32=False)  # (BLOCK_N1, BLOCK_M1)
+        qkT = tl.dot(key, qT)  # (BLOCK_N1, BLOCK_M1)
         m = tl.broadcast_to(m[None, :], (BLOCK_N1, BLOCK_M1))  # (BLOCK_N1, BLOCK_M1)
         m = tl.where(offs_n_mask[:, None], m, float("inf"))  # (BLOCK_N1, BLOCK_M1)
         pT = tl.math.exp2(qkT - m)
@@ -430,12 +430,12 @@ def _attn_bwd_dkdv(
         )  # (BLOCK_M1, BLOCK_DMODEL)
 
         # Compute dV.
-        dv += tl.dot(pT, do.to(tl.float32), allow_tf32=False)  # (BLOCK_N1, BLOCK_DMODEL)
+        dv += tl.dot(pT, do.to(tl.float32))  # (BLOCK_N1, BLOCK_DMODEL)
         # D (= delta) is pre-divided by ds_scale.
         Di = tl.load(D + offs_m, mask=offs_m_mask, other=0.0)  # (BLOCK_M1, )
 
         # Compute dP and dS.
-        dpT = tl.dot(value, tl.trans(do), allow_tf32=False).to(
+        dpT = tl.dot(value, tl.trans(do)).to(
             tl.float32
         )  # (BLOCK_N1, BLOCK_DMODEL) @ (BLOCK_M1, BLOCK_DMODEL).T -> (BLOCK_N1, BLOCK_M1)
         dsT = pT * (dpT - Di[None, :])  # (BLOCK_N1, BLOCK_M1)
@@ -445,7 +445,7 @@ def _attn_bwd_dkdv(
             offs_m_mask[None, :] & offs_n_mask[:, None], dsT, 0.0
         )  # (BLOCK_N1, BLOCK_M1)
         dk += tl.dot(
-            dsT, tl.trans(qT), allow_tf32=False
+            dsT, tl.trans(qT)
         )  # (BLOCK_N1, BLOCK_M1) @ (BLOCK_DMODEL, BLOCK_M1).T -> (BLOCK_N1, BLOCK_DMODEL)
         # Increment pointers.
         curr_m += step_m
@@ -496,7 +496,7 @@ def _attn_bwd_dq(
 
         kT = tl.load(kT_ptrs, mask=offs_n_mask[None, :], other=0.0)
         vT = tl.load(vT_ptrs, mask=offs_n_mask[None, :], other=0.0)
-        qk = tl.dot(query, kT, allow_tf32=False)
+        qk = tl.dot(query, kT)
         p = tl.math.exp2(qk - m)
         mask = (offs_m < Q_CTX)[:, None] & (offs_n < KV_CTX)[None, :]
         # Autoregressive masking.
@@ -506,12 +506,12 @@ def _attn_bwd_dq(
             mask &= offs_m[:, None] >= offs_n[None, :]
         p = tl.where(mask, p, 0.0)
         # Compute dP and dS.
-        dp = tl.dot(do, vT, allow_tf32=False).to(tl.float32)
+        dp = tl.dot(do, vT).to(tl.float32)
         ds = p * (dp - Di[:, None])
         ds = tl.where(mask, ds, 0.0).to(kT.dtype)
         # Compute dQ.
         # NOTE: We need to de-scale dq in the end, because kT was pre-scaled.
-        dq += tl.dot(ds, tl.trans(kT), allow_tf32=False)
+        dq += tl.dot(ds, tl.trans(kT))
         # Increment pointers.
         curr_n += step_n
     return dq

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -411,7 +411,7 @@ def _attn_bwd_dkdv(
         m = tl.load(M + offs_m, mask=offs_m_mask, other=float("inf"))  # (BLOCK_M1, )
 
         # key: (BLOCK_N1, BLOCK_DMODEL)
-        qkT = tl.dot(key, qT)  # (BLOCK_N1, BLOCK_M1)
+        qkT = tl.dot(key, qT, allow_tf32=False)  # (BLOCK_N1, BLOCK_M1)
         m = tl.broadcast_to(m[None, :], (BLOCK_N1, BLOCK_M1))  # (BLOCK_N1, BLOCK_M1)
         m = tl.where(offs_n_mask[:, None], m, float("inf"))  # (BLOCK_N1, BLOCK_M1)
         pT = tl.math.exp2(qkT - m)
@@ -430,12 +430,12 @@ def _attn_bwd_dkdv(
         )  # (BLOCK_M1, BLOCK_DMODEL)
 
         # Compute dV.
-        dv += tl.dot(pT, do.to(tl.float32))  # (BLOCK_N1, BLOCK_DMODEL)
+        dv += tl.dot(pT, do.to(tl.float32), allow_tf32=False)  # (BLOCK_N1, BLOCK_DMODEL)
         # D (= delta) is pre-divided by ds_scale.
         Di = tl.load(D + offs_m, mask=offs_m_mask, other=0.0)  # (BLOCK_M1, )
 
         # Compute dP and dS.
-        dpT = tl.dot(value, tl.trans(do)).to(
+        dpT = tl.dot(value, tl.trans(do), allow_tf32=False).to(
             tl.float32
         )  # (BLOCK_N1, BLOCK_DMODEL) @ (BLOCK_M1, BLOCK_DMODEL).T -> (BLOCK_N1, BLOCK_M1)
         dsT = pT * (dpT - Di[None, :])  # (BLOCK_N1, BLOCK_M1)
@@ -445,7 +445,7 @@ def _attn_bwd_dkdv(
             offs_m_mask[None, :] & offs_n_mask[:, None], dsT, 0.0
         )  # (BLOCK_N1, BLOCK_M1)
         dk += tl.dot(
-            dsT, tl.trans(qT)
+            dsT, tl.trans(qT), allow_tf32=False
         )  # (BLOCK_N1, BLOCK_M1) @ (BLOCK_DMODEL, BLOCK_M1).T -> (BLOCK_N1, BLOCK_DMODEL)
         # Increment pointers.
         curr_m += step_m
@@ -496,7 +496,7 @@ def _attn_bwd_dq(
 
         kT = tl.load(kT_ptrs, mask=offs_n_mask[None, :], other=0.0)
         vT = tl.load(vT_ptrs, mask=offs_n_mask[None, :], other=0.0)
-        qk = tl.dot(query, kT)
+        qk = tl.dot(query, kT, allow_tf32=False)
         p = tl.math.exp2(qk - m)
         mask = (offs_m < Q_CTX)[:, None] & (offs_n < KV_CTX)[None, :]
         # Autoregressive masking.
@@ -506,12 +506,12 @@ def _attn_bwd_dq(
             mask &= offs_m[:, None] >= offs_n[None, :]
         p = tl.where(mask, p, 0.0)
         # Compute dP and dS.
-        dp = tl.dot(do, vT).to(tl.float32)
+        dp = tl.dot(do, vT, allow_tf32=False).to(tl.float32)
         ds = p * (dp - Di[:, None])
         ds = tl.where(mask, ds, 0.0).to(kT.dtype)
         # Compute dQ.
         # NOTE: We need to de-scale dq in the end, because kT was pre-scaled.
-        dq += tl.dot(ds, tl.trans(kT))
+        dq += tl.dot(ds, tl.trans(kT), allow_tf32=False)
         # Increment pointers.
         curr_n += step_n
     return dq

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -553,9 +553,8 @@ def _attn_bwd(
     BLOCK_N2: tl.constexpr,  #
     BLK_SLICE_FACTOR: tl.constexpr,  #
     BLOCK_DMODEL: tl.constexpr,
+    IS_CAUSAL: tl.constexpr = True,
 ):
-    tl.device_assert(Q_CTX % BLOCK_M1 == 0, "Q_CTX must be a multiple of BLOCK_M1.")
-
     LN2: tl.constexpr = 0.6931471824645996  # = ln(2)
 
     bhid = tl.program_id(2)

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -731,7 +731,7 @@ def _attn_bwd(
         else:
             # Non-causal: single unmasked pass over all KV columns.
             stage2_num_steps = (KV_CTX + BLOCK_N2 - 1) // BLOCK_N2
-            stage2_end_n = stage2_num_steps * BLOCK_N2
+            stage2_end_n = KV_CTX
 
         if stage2_num_steps > 0:
             dq = _attn_bwd_dq(
@@ -751,7 +751,7 @@ def _attn_bwd(
                 BLOCK_N2,
                 BLOCK_DMODEL,  #
                 start_m,
-                stage2_end_n - stage2_num_steps * BLOCK_N2,
+                0,
                 stage2_num_steps,  #
                 MASK=False,  #
             )

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -583,20 +583,17 @@ def _attn_bwd(
     # load scales
     offs_k = tl.arange(0, BLOCK_DMODEL)
 
-    start_n = pid * BLOCK_N1
-    MASK_BLOCK_M1: tl.constexpr = BLOCK_M1 // BLK_SLICE_FACTOR
-
     # dK/dV: only execute when this pid covers a valid KV block
+    start_n = pid * BLOCK_N1
     if start_n < KV_CTX:
         start_m = start_n
-
-        offs_n = start_n + tl.arange(0, BLOCK_N1)
-        offs_n_mask = offs_n < KV_CTX
 
         dv = tl.zeros([BLOCK_N1, BLOCK_DMODEL], dtype=tl.float32)
         dk = tl.zeros([BLOCK_N1, BLOCK_DMODEL], dtype=tl.float32)
 
         # load K and V: they stay in SRAM throughout the inner loop.
+        offs_n = start_n + tl.arange(0, BLOCK_N1)
+        offs_n_mask = offs_n < KV_CTX
         key = tl.load(
             K + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d,
             mask=offs_n_mask[:, None],
@@ -608,6 +605,7 @@ def _attn_bwd(
             other=0.0,
         )
 
+        MASK_BLOCK_M1: tl.constexpr = BLOCK_M1 // BLK_SLICE_FACTOR
         num_steps = BLOCK_N1 // MASK_BLOCK_M1
 
         dk, dv = _attn_bwd_dkdv(
@@ -638,8 +636,7 @@ def _attn_bwd(
         start_m += num_steps * MASK_BLOCK_M1
         remaining_m = Q_CTX - start_m
         num_steps = (remaining_m + BLOCK_M1 - 1) // BLOCK_M1
-
-        if num_steps > 0 and start_m < Q_CTX:
+        if num_steps > 0:
             dk, dv = _attn_bwd_dkdv(  #
                 dk,
                 dv,  #
@@ -673,19 +670,10 @@ def _attn_bwd(
         tl.store(dk_ptrs, dk, mask=offs_n_mask[:, None])
 
     # dQ: only execute when this pid covers a valid Q block
-    MASK_BLOCK_N2: tl.constexpr = BLOCK_N2 // BLK_SLICE_FACTOR
     start_m = pid * BLOCK_M2
-
     if start_m < Q_CTX:
-        # Causal boundary: for Q rows [start_m, start_m+BLOCK_M2), the diagonal
-        # is at column start_m (not pid*BLOCK_N1 which differs when BLOCK_N1 != BLOCK_M2)
-        diag_n = start_m
-        end_n = min(start_m + BLOCK_M2, KV_CTX)
-        num_steps = (end_n - diag_n + MASK_BLOCK_N2 - 1) // MASK_BLOCK_N2
-
         offs_m = start_m + tl.arange(0, BLOCK_M2)
         offs_m_mask = offs_m < Q_CTX
-
         query = tl.load(
             Q + offs_m[:, None] * stride_tok + offs_k[None, :] * stride_d,
             mask=offs_m_mask[:, None],
@@ -697,9 +685,15 @@ def _attn_bwd(
             mask=offs_m_mask[:, None],
             other=0.0,
         )
-
         m = tl.load(M + offs_m, mask=offs_m_mask, other=float("inf"))
         m = m[:, None]
+
+        # Causal boundary: for Q rows [start_m, start_m+BLOCK_M2), the diagonal
+        # is at column start_m (not pid*BLOCK_N1 which differs when BLOCK_N1 != BLOCK_M2)
+        end_n = min(start_m + BLOCK_M2, KV_CTX)
+        MASK_BLOCK_N2: tl.constexpr = BLOCK_N2 // BLK_SLICE_FACTOR
+        diag_n = start_m
+        num_steps = (end_n - diag_n + MASK_BLOCK_N2 - 1) // MASK_BLOCK_N2
 
         # Stage 1 - Compute dQ for masked (diagonal) blocks.
         if num_steps > 0:
@@ -948,12 +942,6 @@ def scaled_dot_product_attention_backward(
         D_HEAD=BLOCK_DMODEL,  #
     )
 
-    max_block_n1 = (
-        max([cfg.kwargs["BLOCK_N1"] for cfg in config_backward])
-        if config_backward
-        else 128
-    )
-    grid = (triton.cdiv(Q_CTX, max_block_n1), 1, BATCH * Q_HEAD)
     grid = lambda meta: (
         max(
             triton.cdiv(KV_CTX, meta["BLOCK_N1"]), # _attn_bwd_dq traverse the key-value sequence

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -690,40 +690,44 @@ def _attn_bwd(
         m = tl.load(M + offs_m, mask=offs_m_mask, other=float("inf"))
         m = m[:, None]
 
-        # Causal boundary: for Q rows [start_m, start_m+BLOCK_M2), the diagonal
-        # is at column start_m (not pid*BLOCK_N1 which differs when BLOCK_N1 != BLOCK_M2)
-        end_n = min(start_m + BLOCK_M2, KV_CTX)
         MASK_BLOCK_N2: tl.constexpr = BLOCK_N2 // BLK_SLICE_FACTOR
-        diag_n = start_m
-        num_steps = (end_n - diag_n + MASK_BLOCK_N2 - 1) // MASK_BLOCK_N2
 
-        # Stage 1 - Compute dQ for masked (diagonal) blocks.
-        if num_steps > 0:
-            dq = _attn_bwd_dq(
-                dq,
-                query,
-                K,
-                V,  #
-                do,
-                m,
-                D,  #
-                stride_tok,
-                stride_d,  #
-                H,
-                Q_CTX,  #
-                KV_CTX,  #
-                BLOCK_M2,
-                MASK_BLOCK_N2,
-                BLOCK_DMODEL,  #
-                start_m,
-                diag_n,
-                num_steps,  #
-                MASK=True,  #
-            )
+        if IS_CAUSAL:
+            # Masked diagonal phase: KV columns [diag_n, end_n)
+            diag_n = start_m
+            end_n = min(start_m + BLOCK_M2, KV_CTX)
+            num_steps = (end_n - diag_n + MASK_BLOCK_N2 - 1) // MASK_BLOCK_N2
 
-        # Stage 2 - non-masked blocks (columns before the diagonal)
-        stage2_end_n = diag_n
-        stage2_num_steps = (stage2_end_n + BLOCK_N2 - 1) // BLOCK_N2
+            if num_steps > 0:
+                dq = _attn_bwd_dq(
+                    dq,
+                    query,
+                    K,
+                    V,  #
+                    do,
+                    m,
+                    D,  #
+                    stride_tok,
+                    stride_d,  #
+                    H,
+                    Q_CTX,  #
+                    KV_CTX,  #
+                    BLOCK_M2,
+                    MASK_BLOCK_N2,
+                    BLOCK_DMODEL,  #
+                    start_m,
+                    diag_n,
+                    num_steps,  #
+                    MASK=True,  #
+                )
+
+            # Unmasked phase: KV columns [0, diag_n), all fully visible.
+            stage2_end_n = min(diag_n, KV_CTX)
+            stage2_num_steps = (stage2_end_n + BLOCK_N2 - 1) // BLOCK_N2
+        else:
+            # Non-causal: single unmasked pass over all KV columns.
+            stage2_num_steps = (KV_CTX + BLOCK_N2 - 1) // BLOCK_N2
+            stage2_end_n = stage2_num_steps * BLOCK_N2
 
         if stage2_num_steps > 0:
             dq = _attn_bwd_dq(

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -542,6 +542,9 @@ def _attn_bwd(
     stride_d,  #
     kv_stride_z,
     kv_stride_h,  #
+    dk_stride_z,
+    dk_stride_h,
+    dk_stride_tok,  #
     H,  # query head num
     Q_CTX,  #
     KV_CTX,  #
@@ -564,6 +567,7 @@ def _attn_bwd(
     kv_head_id = q_head_id // GROUP_HEAD
     adj = (stride_h * q_head_id + stride_z * batch_id).to(tl.int64)
     kv_adj = (kv_stride_h * kv_head_id + kv_stride_z * batch_id).to(tl.int64)
+    dk_adj = (dk_stride_h * q_head_id + dk_stride_z * batch_id).to(tl.int64)
 
     pid = tl.program_id(0)
 
@@ -573,8 +577,8 @@ def _attn_bwd(
     V += kv_adj
     DO += adj
     DQ += adj
-    DK += adj
-    DV += adj
+    DK += dk_adj
+    DV += dk_adj
     M += off_chz
     D += off_chz
 
@@ -663,12 +667,12 @@ def _attn_bwd(
                 MASK=False,  #
             )
 
-        dv_ptrs = DV + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
+        dv_ptrs = DV + offs_n[:, None] * dk_stride_tok + offs_k[None, :] * stride_d
         tl.store(dv_ptrs, dv, mask=offs_n_mask[:, None])
 
         # Write back dK.
         dk *= sm_scale
-        dk_ptrs = DK + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
+        dk_ptrs = DK + offs_n[:, None] * dk_stride_tok + offs_k[None, :] * stride_d
         tl.store(dk_ptrs, dk, mask=offs_n_mask[:, None])
 
     # dQ: only execute when this pid covers a valid Q block
@@ -976,6 +980,9 @@ def scaled_dot_product_attention_backward(
         query.stride(3),  #
         key.stride(0),
         key.stride(1),  #
+        dk.stride(0),
+        dk.stride(1),
+        dk.stride(2),  #
         Q_HEAD,
         Q_CTX,  #
         KV_CTX,  #
@@ -987,8 +994,7 @@ def scaled_dot_product_attention_backward(
         # BLOCK_N2=BLOCK_N2,  #
         BLK_SLICE_FACTOR=BLK_SLICE_FACTOR,  #
         BLOCK_DMODEL=BLOCK_DMODEL,  #
-        # num_warps=NUM_WARPS,  #
-        # num_stages=NUM_STAGES,  #
+        IS_CAUSAL=is_causal,  #
     )
 
     if group_head > 1:

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -610,32 +610,38 @@ def _attn_bwd(
         # Causal: masked diagonal phase, then unmasked above-diagonal phase.
         # Non-causal: skip masked phase, single unmasked pass over all Q rows.
         if IS_CAUSAL:
+            # The causal mask is q_idx >= kv_idx, so for KV block starting at
+            # start_n, the first Q row that can attend is start_n itself.
             start_m = start_n
-            num_steps = BLOCK_N1 // MASK_BLOCK_M1
-            dk, dv = _attn_bwd_dkdv(
-                dk,
-                dv,  #
-                Q,
-                key,
-                value,
-                sm_scale,  #
-                DO,  #
-                M,
-                D,  #
-                stride_tok,
-                stride_d,  #
-                H,
-                Q_CTX,  #
-                KV_CTX,  #
-                MASK_BLOCK_M1,
-                BLOCK_N1,
-                BLOCK_DMODEL,  #
-                start_n,
-                start_m,
-                num_steps,  #
-                MASK=True,  #
-            )
-            start_m += num_steps * MASK_BLOCK_M1
+            # Clamp to valid Q range
+            if start_m < Q_CTX:
+                end_m = min(start_m + BLOCK_N1, Q_CTX)
+                num_steps = (end_m - start_m + MASK_BLOCK_M1 - 1) // MASK_BLOCK_M1
+                dk, dv = _attn_bwd_dkdv(
+                    dk,
+                    dv,  #
+                    Q,
+                    key,
+                    value,
+                    sm_scale,  #
+                    DO,  #
+                    M,
+                    D,  #
+                    stride_tok,
+                    stride_d,  #
+                    H,
+                    Q_CTX,  #
+                    KV_CTX,  #
+                    MASK_BLOCK_M1,
+                    BLOCK_N1,
+                    BLOCK_DMODEL,  #
+                    start_n,
+                    start_m,
+                    num_steps,  #
+                    MASK=True,  #
+                )
+                start_m += num_steps * MASK_BLOCK_M1
+            # else: start_n >= Q_CTX, no Q rows can attend to this KV block
         else:
             start_m = 0
 
@@ -698,7 +704,9 @@ def _attn_bwd(
 
         if IS_CAUSAL:
             # Masked diagonal phase: KV columns [diag_n, end_n)
-            diag_n = start_m
+            # diag_n is the KV position where the causal boundary starts for
+            # this Q block. Only needed when diag_n < KV_CTX.
+            diag_n = min(start_m, KV_CTX)
             end_n = min(start_m + BLOCK_M2, KV_CTX)
             num_steps = (end_n - diag_n + MASK_BLOCK_N2 - 1) // MASK_BLOCK_N2
 
@@ -726,12 +734,10 @@ def _attn_bwd(
                 )
 
             # Unmasked phase: KV columns [0, diag_n), all fully visible.
-            stage2_end_n = min(diag_n, KV_CTX)
-            stage2_num_steps = (stage2_end_n + BLOCK_N2 - 1) // BLOCK_N2
+            stage2_num_steps = (diag_n + BLOCK_N2 - 1) // BLOCK_N2
         else:
             # Non-causal: single unmasked pass over all KV columns.
             stage2_num_steps = (KV_CTX + BLOCK_N2 - 1) // BLOCK_N2
-            stage2_end_n = KV_CTX
 
         if stage2_num_steps > 0:
             dq = _attn_bwd_dq(

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -425,8 +425,7 @@ def _attn_bwd_dkdv(
             mask &= offs_m[None, :] >= offs_n[:, None]
         pT = tl.where(mask, pT, 0.0)  # (BLOCK_N1, BLOCK_M1)
 
-        do = tl.load(do_ptrs)
-        # do = tl.load(do_ptrs, mask=offs_m_mask[:, None], other=0.0) # (BLOCK_M1, BLOCK_DMODEL)
+        do = tl.load(do_ptrs, mask=offs_m_mask[:, None], other=0.0) # (BLOCK_M1, BLOCK_DMODEL)
 
         # Compute dV.
         dv += tl.dot(pT, do.to(tl.float32))  # (BLOCK_N1, BLOCK_DMODEL)

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -584,60 +584,33 @@ def _attn_bwd(
     offs_k = tl.arange(0, BLOCK_DMODEL)
 
     start_n = pid * BLOCK_N1
-    start_m = start_n
-
     MASK_BLOCK_M1: tl.constexpr = BLOCK_M1 // BLK_SLICE_FACTOR
-    offs_n = start_n + tl.arange(0, BLOCK_N1)
-    offs_n_mask = offs_n < KV_CTX
 
-    dv = tl.zeros([BLOCK_N1, BLOCK_DMODEL], dtype=tl.float32)
-    dk = tl.zeros([BLOCK_N1, BLOCK_DMODEL], dtype=tl.float32)
+    # dK/dV: only execute when this pid covers a valid KV block
+    if start_n < KV_CTX:
+        start_m = start_n
 
-    # load K and V: they stay in SRAM throughout the inner loop.
-    key = tl.load(
-        K + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d,
-        mask=offs_n_mask[:, None],
-        other=0.0,
-    )
-    value = tl.load(
-        V + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d,
-        mask=offs_n_mask[:, None],
-        other=0.0,
-    )
+        offs_n = start_n + tl.arange(0, BLOCK_N1)
+        offs_n_mask = offs_n < KV_CTX
 
-    num_steps = BLOCK_N1 // MASK_BLOCK_M1
+        dv = tl.zeros([BLOCK_N1, BLOCK_DMODEL], dtype=tl.float32)
+        dk = tl.zeros([BLOCK_N1, BLOCK_DMODEL], dtype=tl.float32)
 
-    dk, dv = _attn_bwd_dkdv(
-        dk,
-        dv,  #
-        Q,
-        key,
-        value,
-        sm_scale,  #
-        DO,  #
-        M,
-        D,  #
-        stride_tok,
-        stride_d,  #
-        H,
-        Q_CTX,  #
-        KV_CTX,  #
-        MASK_BLOCK_M1,
-        BLOCK_N1,
-        BLOCK_DMODEL,  #
-        start_n,
-        start_m,
-        num_steps,  #
-        MASK=True,  #
-    )
+        # load K and V: they stay in SRAM throughout the inner loop.
+        key = tl.load(
+            K + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d,
+            mask=offs_n_mask[:, None],
+            other=0.0,
+        )
+        value = tl.load(
+            V + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d,
+            mask=offs_n_mask[:, None],
+            other=0.0,
+        )
 
-    # Compute dK and dV for non-masked blocks.
-    start_m += num_steps * MASK_BLOCK_M1
-    remaining_m = Q_CTX - start_m
-    num_steps = (remaining_m + BLOCK_M1 - 1) // BLOCK_M1
+        num_steps = BLOCK_N1 // MASK_BLOCK_M1
 
-    if num_steps > 0 and start_m < Q_CTX:
-        dk, dv = _attn_bwd_dkdv(  #
+        dk, dv = _attn_bwd_dkdv(
             dk,
             dv,  #
             Q,
@@ -652,23 +625,52 @@ def _attn_bwd(
             H,
             Q_CTX,  #
             KV_CTX,  #
-            BLOCK_M1,
+            MASK_BLOCK_M1,
             BLOCK_N1,
             BLOCK_DMODEL,  #
             start_n,
             start_m,
             num_steps,  #
-            MASK=False,  #
+            MASK=True,  #
         )
-    # tl.device_print("dv: ", dv)
 
-    dv_ptrs = DV + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
-    tl.store(dv_ptrs, dv, mask=offs_n_mask[:, None])
+        # Compute dK and dV for non-masked blocks.
+        start_m += num_steps * MASK_BLOCK_M1
+        remaining_m = Q_CTX - start_m
+        num_steps = (remaining_m + BLOCK_M1 - 1) // BLOCK_M1
 
-    # Write back dK.
-    dk *= sm_scale
-    dk_ptrs = DK + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
-    tl.store(dk_ptrs, dk, mask=offs_n_mask[:, None])
+        if num_steps > 0 and start_m < Q_CTX:
+            dk, dv = _attn_bwd_dkdv(  #
+                dk,
+                dv,  #
+                Q,
+                key,
+                value,
+                sm_scale,  #
+                DO,  #
+                M,
+                D,  #
+                stride_tok,
+                stride_d,  #
+                H,
+                Q_CTX,  #
+                KV_CTX,  #
+                BLOCK_M1,
+                BLOCK_N1,
+                BLOCK_DMODEL,  #
+                start_n,
+                start_m,
+                num_steps,  #
+                MASK=False,  #
+            )
+
+        dv_ptrs = DV + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
+        tl.store(dv_ptrs, dv, mask=offs_n_mask[:, None])
+
+        # Write back dK.
+        dk *= sm_scale
+        dk_ptrs = DK + offs_n[:, None] * stride_tok + offs_k[None, :] * stride_d
+        tl.store(dk_ptrs, dk, mask=offs_n_mask[:, None])
 
     # THIS BLOCK DOES DQ:
     MASK_BLOCK_N2: tl.constexpr = BLOCK_N2 // BLK_SLICE_FACTOR

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -953,6 +953,14 @@ def scaled_dot_product_attention_backward(
         else 128
     )
     grid = (triton.cdiv(Q_CTX, max_block_n1), 1, BATCH * Q_HEAD)
+    grid = lambda meta: (
+        max(
+            triton.cdiv(KV_CTX, meta["BLOCK_N1"]), # _attn_bwd_dq traverse the key-value sequence
+            triton.cdiv(Q_CTX, meta["BLOCK_M2"]),  # _attn_bwd_dkdv traverse the query sequence
+        ),
+        1,
+        BATCH * Q_HEAD,
+    )
     # logger.info(f"{triton.cdiv(Q_CTX, BLOCK_N1)=}")
     # logger.info(f"{M.shape=}")
 

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -69,7 +69,7 @@ def _attn_fwd_inner(
         if PRE_LOAD_V:
             value = tl.load(V_block_ptr, mask=kv_load_mask[:, None], other=0.0)
 
-        qk = tl.dot(query, key)
+        qk = tl.dot(query, key, allow_tf32=False)
         # incase not divisible.
         qk = tl.where(kv_load_mask[None, :], qk, -float("inf"))
         # qk = qk.to(tl.float32)
@@ -115,7 +115,7 @@ def _attn_fwd_inner(
         else:
             p = p.to(query.dtype)
         p = p.to(value.dtype)
-        acc = tl.dot(p, value, acc)
+        acc = tl.dot(p, value, acc, allow_tf32=False)
         # update m_i and l_i
         m_i = m_ij
 

--- a/tests/test_scaled_dot_product_attention.py
+++ b/tests/test_scaled_dot_product_attention.py
@@ -185,7 +185,6 @@ def test_scaled_dot_product_attention_legacy(
     utils.gems_assert_close(gems_result, torch_result, dtype)
 
 
-@pytest.mark.skip(reason="Issue #2848: Not working")
 @pytest.mark.skipif(flag_gems.vendor_name == "metax", reason="Issue #2849: Not working")
 @pytest.mark.skipif(
     flag_gems.vendor_name == "hygon", reason="Issue #2849: RuntimeError"

--- a/tests/test_scaled_dot_product_attention.py
+++ b/tests/test_scaled_dot_product_attention.py
@@ -293,7 +293,9 @@ def test_scaled_dot_product_attention_legacy_backward(
             v_atol = 2e-3
         else:
             v_atol = 3e-4
-    utils.gems_assert_close(gems_v_grad, torch_v_grad, dtype, equal_nan=True, atol=v_atol)
+    utils.gems_assert_close(
+        gems_v_grad, torch_v_grad, dtype, equal_nan=True, atol=v_atol
+    )
 
 
 @pytest.mark.scaled_dot_product_attention

--- a/tests/test_scaled_dot_product_attention.py
+++ b/tests/test_scaled_dot_product_attention.py
@@ -225,9 +225,9 @@ def test_scaled_dot_product_attention_legacy_backward(
         device,
         requires_grad=True,
     )
-    ref_q = utils.to_reference(q, False)
-    ref_k = utils.to_reference(k, False)
-    ref_v = utils.to_reference(v, False)
+    ref_q = utils.to_reference(q, False).detach().requires_grad_(True)
+    ref_k = utils.to_reference(k, False).detach().requires_grad_(True)
+    ref_v = utils.to_reference(v, False).detach().requires_grad_(True)
     scale = float(1.0 / np.sqrt(head_size))
 
     # forward

--- a/tests/test_scaled_dot_product_attention.py
+++ b/tests/test_scaled_dot_product_attention.py
@@ -259,9 +259,9 @@ def test_scaled_dot_product_attention_legacy_backward(
     utils.gems_assert_close(gems_result, torch_result, dtype)
 
     # backward
-    dout = torch.randn_like(ref_q)
-    torch_result.backward(dout)
-    gems_result.backward(dout)
+    ref_dout = torch.randn_like(ref_q)
+    torch_result.backward(ref_dout)
+    gems_result.backward(ref_dout.to(gems_result.device))
     torch_q_grad = ref_q.grad.clone() if ref_q.grad is not None else None
     torch_k_grad = ref_k.grad.clone() if ref_k.grad is not None else None
     torch_v_grad = ref_v.grad.clone() if ref_v.grad is not None else None

--- a/tests/test_scaled_dot_product_attention.py
+++ b/tests/test_scaled_dot_product_attention.py
@@ -272,7 +272,28 @@ def test_scaled_dot_product_attention_legacy_backward(
     # NOTE: NaN may arise in the gradients, this behavior aligns with PyTorch's SDPA
     utils.gems_assert_close(gems_q_grad, torch_q_grad, dtype, equal_nan=True)
     utils.gems_assert_close(gems_k_grad, torch_k_grad, dtype, equal_nan=True)
-    utils.gems_assert_close(gems_v_grad, torch_v_grad, dtype, equal_nan=True)
+
+    # dV is more sensitive to softmax recomputation errors in flash attention backward
+    # because it lacks the centering term (dP - D) that suppresses errors in dK/dQ.
+    # GQA: different float accumulation order across Q heads vs PyTorch kernel
+    # bf16: only 8 mantissa bits → largest recomputation error
+    # fp16: 11 mantissa bits → moderate error
+    is_gqa = enable_gqa and num_q_head != num_kv_head
+    if is_gqa:
+        if dtype == torch.bfloat16:
+            v_atol = 2e-2
+        elif dtype == torch.float16:
+            v_atol = 4e-3
+        else:
+            v_atol = 5e-4
+    else:
+        if dtype == torch.bfloat16:
+            v_atol = 5e-3
+        elif dtype == torch.float16:
+            v_atol = 2e-3
+        else:
+            v_atol = 3e-4
+    utils.gems_assert_close(gems_v_grad, torch_v_grad, dtype, equal_nan=True, atol=v_atol)
 
 
 @pytest.mark.scaled_dot_product_attention


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
 Bug Fix

### Description

1. Added `mask=offs_m_mask[:, None], other=0.0` to the do load to prevent out‑of‑bounds reads when `Q_CTX` is not aligned.
2. Added `IS_CAUSAL: tl.constexpr = True` and removed `tl.device_assert(Q_CTX % BLOCK_M1 == 0)`.
3.  dK/dV:
    -   For causal: first execute a masked diagonal phase, then set `start_m`.
    -   For non‑causal: directly set `start_m = 0`.
    -   Both share the same unmasked `_attn_bwd_dkdv` call to process the remaining Q rows.
    -   Added an `if start_m < Q_CTX` guard to prevent executing an invalid masked phase when `start_n >= Q_CTX`.
    -   Replaced the fixed `BLOCK_N1 // MASK_BLOCK_M1` with `end_m = min(start_m + BLOCK_N1, Q_CTX)` to compute the actual number of steps.        
4. dQ:
    -   For causal: first execute a masked diagonal phase, then compute `stage2_end_n = min(diag_n, KV_CTX)` (fixes out‑of‑bounds when `Q_CTX > KV_CTX`). 
    -   For non‑causal: directly iterate over all KV columns.   
    -   Both share the same unmasked `_attn_bwd_dq` call.
    -   Used `diag_n = min(start_m, KV_CTX)` to ensure the diagonal index does not exceed the KV range.
    -   The number of steps for the unmasked phase is now computed directly based on `diag_n`.    
        
5. Changed the grid to a lambda (to support autotuning) and passed `IS_CAUSAL=is_causal`. 
6. Added three new kernel arguments: `dk_stride_z`, `dk_stride_h`, `dk_stride_tok`. Used a separate `dk_adj` offset for DK/DV pointers. DK/DV stores now use `dk_stride_tok` instead of `stride_tok`.        
6.  Changed `start_n` from `stage2_end_n - stage2_num_steps * BLOCK_N2` (which could be negative) to `0`, and restored ceiling division to ensure full coverage. `_attn_bwd_dq` already has an `offs_n < KV_CTX` mask to protect out‑of‑bounds accesses.
7. Fix gradient test and relax dv threshold.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #3395
- Resolves #2848
-->

- Resolves #3395
- Related to #2848

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
