### PR TITLE
Fix runner label for mthreads backend

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -5,7 +5,7 @@ on:
   workflow_call:
     inputs:
       vendor:
-        description: 'GEMS_VENDOR value (e.g. iluvatar, ascend, moore)'
+        description: 'GEMS_VENDOR value (e.g. iluvatar, ascend, mthreads)'
         required: true
         type: string
       runner_label:

--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -93,9 +93,6 @@ jobs:
             h20)
               VENDOR="nvidia"
               ;;
-            moore)
-              VENDOR="mthreads"
-              ;;
             *)
               VENDOR="${RUNNER_LABEL}"
               ;;

--- a/.github/workflows/random-test.yaml
+++ b/.github/workflows/random-test.yaml
@@ -79,9 +79,6 @@ jobs:
             h20)
               VENDOR="nvidia"
               ;;
-            moore)
-              VENDOR="mthreads"
-              ;;
             *)
               VENDOR="${RUNNER_LABEL}"
               ;;

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -222,7 +222,7 @@ jobs:
     uses: ./.github/workflows/backend-test.yaml
     with:
       vendor: mthreads
-      runner_label: moore
+      runner_label: mthreads
       gpu_check_script: tools/gpu_check_mthreads.sh
       changed_files: ${{ join(needs.preprocess.outputs.changed_files, ' ') }}
       pr_id: ${{ needs.preprocess.outputs.pr_id }}


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

With the backend runner replaced, we now use 'mthreads' rather than 'moore' as the label for the runners.