### PR TITLE
Re-enable mthreads backend tests

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -217,9 +217,7 @@ jobs:
 
   backend-mthreads:
     needs: preprocess
-    # mthreads runners are gone.
-    if: false
-    # if: contains(needs.preprocess.outputs.labels, 'vendor/MooreThreads')
+    if: contains(needs.preprocess.outputs.labels, 'vendor/MooreThreads')
     uses: ./.github/workflows/backend-test.yaml
     with:
       vendor: mthreads


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

A new mthreads self-hosted runner is added. We can re-enable the backend tests now.