### PR TITLE
Add back MKL for mthreads backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ mthreads = [
     "torch_musa==2.9.0",
     "numpy==1.26.4",
     "triton==3.6.0+git89458660",
-    # "mkl==2024.0.0",
+    "mkl==2026.0.0",
     # "flagtree==0.5.1+mthreads3.6",
 ]
 

--- a/tools/setup_vendor.sh
+++ b/tools/setup_vendor.sh
@@ -142,6 +142,7 @@ case $VENDOR in
         "torch==2.9.0" \
         "torch_musa==2.9.0" \
         "numpy==1.26.4" \
+        "mkl==2026.0.0" \
         "triton==3.6.0+git89458660"
 
     # Replace flagtree with Triton if requested


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The dependency over MKL in mthreads backend is a hard requirement.