### PR TITLE
Downgrade MKL on mthreads to 2024.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,7 +106,7 @@ mthreads = [
     "torch_musa==2.9.0",
     "numpy==1.26.4",
     "triton==3.6.0+git89458660",
-    "mkl==2026.0.0",
+    "mkl==2024.0.0",
     # "flagtree==0.5.1+mthreads3.6",
 ]
 

--- a/tools/setup_vendor.sh
+++ b/tools/setup_vendor.sh
@@ -142,7 +142,7 @@ case $VENDOR in
         "torch==2.9.0" \
         "torch_musa==2.9.0" \
         "numpy==1.26.4" \
-        "mkl==2026.0.0" \
+        "mkl==2024.0.0" \
         "triton==3.6.0+git89458660"
 
     # Replace flagtree with Triton if requested


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The pytorch package for mthreads has a dependency over mkl (Intel Math Library). The previous attempt to upgrade mkl to 2026.0.0 was a failure because torch has a dependency over ` libmkl_intel_lp64.so.2` rather than ` libmkl_intel_lp64.so.3`. Downgrade mkl to 2025.3.1 didn't work either. The error message is `ImportError: /home/secure/FlagGems/.venv/lib/python3.10/site-packages/torch/lib/libtorch_cpu.so: undefined symbol: iJIT_NotifyEvent`. This means the version compatibility in pytorch is still there to be resolved. We have to downgrade mkl to 2024.0.0.