### PR TITLE
Bump torch version on H20 again

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,9 +111,8 @@ mthreads = [
 ]
 
 nvidia = [
-    "torch==2.11.0+cu130",
-    "torchvision==0.26.0+cu130",
-    "torchaudio==2.11.0+cu130",
+    "torch==2.12.0+cu132",
+    "torchvision==0.27.0+cu132",
     "triton==3.6.0",
     # "flagtree==0.5.1+3.6",
 ]

--- a/tools/setup_vendor.sh
+++ b/tools/setup_vendor.sh
@@ -161,10 +161,9 @@ case $VENDOR in
   nvidia)
     # We need pytorch first for building C++ wrapped operators
     uv pip install --index ${FLAGOS_PYPI} \
-        "torch==2.11.0+cu130" \
-        "torchvision==0.26.0+cu130" \
-        "torchaudio==2.11.0+cu130" \
-        "triton==3.6.0"
+        "torch==2.12.0+cu132" \
+        "torchvision==0.27.0+cu132" \
+        "triton==3.7.0"
 
     # The follow environments are for C++ wrapped operators
     # export CMAKE_PREFIX_PATH=$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

The CUDA toolkit and driver on the Hopper (H20) backend runner has been upgraded to 13.3 (latest). This PR bumps the torch and triton package accordingly.