### PR TITLE
[FlagGems Operator Development Competition] Add huber_loss_backward o…

### DIFF
--- a/benchmark/test_huber_loss_backward.py
+++ b/benchmark/test_huber_loss_backward.py
@@ -1,0 +1,36 @@
+"""Performance benchmark for ``aten::huber_loss_backward`` against the
+PyTorch native implementation."""
+
+import pytest
+import torch
+
+from . import base, consts
+
+
+class HuberLossBackwardBenchmark(base.Benchmark):
+    DEFAULT_SHAPE_FILES = "benchmark/core_shapes.yaml"
+    DEFAULT_SHAPES = [
+        (262144,),
+        (1024, 1024),
+        (4096, 4096),
+        (64, 512, 512),
+    ]
+    DEFAULT_SHAPE_DESC = "(B), M, N"
+
+    def get_input_iter(self, dtype):
+        for shape in self.shapes:
+            inp = torch.randn(shape, device=self.device, dtype=dtype)
+            target = torch.randn(shape, device=self.device, dtype=dtype)
+            # 0-D grad_output is the common autograd case (reduced loss).
+            grad_output = torch.randn((), device=self.device, dtype=dtype)
+            yield grad_output, inp, target, 1, 1.0
+
+
+@pytest.mark.huber_loss_backward
+def test_huber_loss_backward():
+    bench = HuberLossBackwardBenchmark(
+        op_name="huber_loss_backward",
+        torch_op=torch.ops.aten.huber_loss_backward,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -2992,6 +2992,30 @@ ops:
       - Tensor
     stages:
       - stable: '2.2'
+  - id: huber_loss_backward
+    description: Compute the gradient of Huber loss with respect to the input tensor.
+    for:
+      - huber_loss_backward
+    labels:
+      - aten
+      - pointwise
+      - nn.functional
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.1'
+  - id: huber_loss_backward_out
+    description: Variant of `huber_loss_backward` that writes the gradient into a pre-allocated tensor.
+    for:
+      - huber_loss_backward.out
+    labels:
+      - aten
+      - pointwise
+      - nn.functional
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.1'
   - id: hypot
     description: |
       Given the legs of a right triangle, return its hypotenuse.

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -280,6 +280,8 @@ _FULL_CONFIG = (
     ("hardswish_", hardswish_),
     ("histc", histc),
     ("hstack", hstack),
+    ("huber_loss_backward", huber_loss_backward),
+    ("huber_loss_backward.out", huber_loss_backward_out),
     ("hypot", hypot),
     ("i0", i0),
     ("i0.out", i0_out),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -174,6 +174,10 @@ from flag_gems.ops.hadamard_transform import (
 from flag_gems.ops.hardsigmoid import hardsigmoid, hardsigmoid_out
 from flag_gems.ops.hardswish_ import hardswish_
 from flag_gems.ops.histc import histc
+from flag_gems.ops.huber_loss_backward import (
+    huber_loss_backward,
+    huber_loss_backward_out,
+)
 from flag_gems.ops.hstack import hstack
 from flag_gems.ops.hypot import hypot, hypot_out
 from flag_gems.ops.i0 import i0, i0_out
@@ -620,6 +624,8 @@ __all__ = [
     "hardswish_",
     "histc",
     "hstack",
+    "huber_loss_backward",
+    "huber_loss_backward_out",
     "hypot",
     "hypot_out",
     "i0",

--- a/src/flag_gems/ops/huber_loss_backward.py
+++ b/src/flag_gems/ops/huber_loss_backward.py
@@ -1,0 +1,212 @@
+"""Triton implementation of ``aten::huber_loss_backward``.
+
+PyTorch reference: for ``L(x, y; delta) = 0.5 * (x - y) ** 2`` when
+``|x - y| <= delta`` and ``delta * (|x - y| - 0.5 * delta)`` otherwise, the
+gradient of the loss w.r.t. ``input`` (a.k.a. ``self``) is
+
+    dL / d_input = grad_output * clip(input - target, -delta, delta)
+
+scaled by ``1 / N`` if ``reduction == 'mean'`` (``reduction == 1``) and
+unscaled for ``'none' (0)`` / ``'sum' (2)``.
+
+aten schema::
+
+    huber_loss_backward(
+        Tensor grad_output, Tensor self, Tensor target,
+        int reduction, float delta,
+    ) -> Tensor
+"""
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import device, torch_device_fn
+
+device = device.name
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def _huber_loss_backward_kernel(
+    grad_output,
+    inp,
+    target,
+    out,
+    n_elements,
+    reduction_elements,
+    delta: tl.constexpr,
+    reduction: tl.constexpr,
+    GRAD_OUTPUT_SCALAR: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    """Per-element gradient:
+
+        d_input = grad_output * clip(input - target, -delta, delta) / scale
+
+    where ``scale = N`` if ``reduction == 1 (mean)`` else 1.  The
+    ``GRAD_OUTPUT_SCALAR`` constexpr lets us specialise the kernel for the
+    common (and natural) case where ``grad_output`` is a 0-D tensor returned
+    by autograd of a reduced loss.
+    """
+    pid = tl.program_id(0)
+    offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
+    mask = offsets < n_elements
+
+    inp_val = tl.load(inp + offsets, mask=mask, other=0.0).to(tl.float32)
+    target_val = tl.load(target + offsets, mask=mask, other=0.0).to(tl.float32)
+    diff = inp_val - target_val
+    # clip(diff, -delta, delta)
+    grad_per_element = tl.where(
+        diff > delta, delta, tl.where(diff < -delta, -delta, diff)
+    )
+
+    if GRAD_OUTPUT_SCALAR:
+        grad_out = tl.load(grad_output).to(tl.float32)
+        if reduction == 1:
+            grad_out = grad_out * (1.0 / reduction_elements)
+    else:
+        grad_out = tl.load(grad_output + offsets, mask=mask, other=0.0).to(tl.float32)
+        if reduction == 1:
+            grad_out = grad_out * (1.0 / reduction_elements)
+
+    tl.store(out + offsets, grad_per_element * grad_out, mask=mask)
+
+
+def _normalize_reduction(reduction):
+    """Coerce a reduction passed as a string or as an int into the canonical
+    ``aten`` integer convention: 0='none', 1='mean', 2='sum'."""
+    if isinstance(reduction, str):
+        if reduction == "none":
+            return 0
+        if reduction == "mean":
+            return 1
+        if reduction == "sum":
+            return 2
+    elif isinstance(reduction, int) and reduction in (0, 1, 2):
+        return reduction
+    raise ValueError("reduction must be one of 'none', 'mean', or 'sum'")
+
+
+def _check_backward_input(grad_output, input, target, delta):
+    if delta < 0:
+        raise RuntimeError("huber_loss does not support negative values for delta.")
+    if input.device.type != device or target.device.type != device:
+        raise AssertionError(
+            "huber_loss_backward: input and target must be CUDA tensors."
+        )
+    if input.device != target.device:
+        raise AssertionError(
+            "huber_loss_backward: input and target must be on the same device."
+        )
+    if grad_output.device.type != device:
+        raise AssertionError("huber_loss_backward: grad_output must be a CUDA tensor.")
+    if grad_output.device != input.device:
+        raise AssertionError(
+            "huber_loss_backward: grad_output must be on the same device."
+        )
+    # PyTorch's `aten::huber_loss_backward` scales the mean-reduction
+    # gradient by 1 / self.numel() (the ORIGINAL input numel, not the
+    # broadcast loss numel) -- this is the convention smooth_l1_loss_backward
+    # follows in FlagGems too.  Capture it before broadcasting input/target.
+    reduction_elements = input.numel()
+    orig_input_shape = tuple(input.shape)
+    input, target = torch.broadcast_tensors(input, target)
+    input = input.contiguous()
+    target = target.contiguous()
+    if grad_output.numel() != 1:
+        grad_output = torch.broadcast_to(grad_output, input.shape)
+    return (
+        grad_output.contiguous(),
+        input,
+        target,
+        reduction_elements,
+        orig_input_shape,
+    )
+
+
+def huber_loss_backward(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    target: torch.Tensor,
+    reduction,
+    delta: float,
+) -> torch.Tensor:
+    logger.debug("GEMS HUBER_LOSS BACKWARD")
+    reduction = _normalize_reduction(reduction)
+    grad_output, input, target, reduction_elements, _ = _check_backward_input(
+        grad_output, input, target, float(delta)
+    )
+    out = torch.empty_like(input)
+    n_elements = input.numel()
+    if n_elements == 0:
+        return out
+
+    grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+    with torch_device_fn.device(input.device):
+        _huber_loss_backward_kernel[grid](
+            grad_output,
+            input,
+            target,
+            out,
+            n_elements,
+            reduction_elements,
+            delta=float(delta),
+            reduction=reduction,
+            GRAD_OUTPUT_SCALAR=grad_output.numel() == 1,
+            BLOCK_SIZE=1024,
+        )
+    return out
+
+
+def huber_loss_backward_out(
+    grad_output: torch.Tensor,
+    input: torch.Tensor,
+    target: torch.Tensor,
+    reduction,
+    delta: float,
+    *,
+    grad_input: torch.Tensor,
+) -> torch.Tensor:
+    """``huber_loss_backward.out`` variant: writes the result into the
+    pre-allocated ``grad_input`` tensor (PyTorch's *out=* convention).
+    """
+    logger.debug("GEMS HUBER_LOSS BACKWARD OUT")
+    reduction = _normalize_reduction(reduction)
+    grad_output, input, target, reduction_elements, _ = _check_backward_input(
+        grad_output, input, target, float(delta)
+    )
+    if grad_input.device != input.device:
+        raise AssertionError(
+            "huber_loss_backward.out: grad_input must be on the same device."
+        )
+    # `aten::huber_loss_backward.out` returns a tensor whose shape matches
+    # the broadcast of `input` and `target` (the loss tensor shape), so we
+    # resize `grad_input` to that.
+    if tuple(grad_input.shape) != tuple(input.shape):
+        grad_input.resize_(input.shape)
+    out_contiguous = (
+        grad_input if grad_input.is_contiguous() else torch.empty_like(input)
+    )
+
+    n_elements = input.numel()
+    if n_elements > 0:
+        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
+        with torch_device_fn.device(input.device):
+            _huber_loss_backward_kernel[grid](
+                grad_output,
+                input,
+                target,
+                out_contiguous,
+                n_elements,
+                reduction_elements,
+                delta=float(delta),
+                reduction=reduction,
+                GRAD_OUTPUT_SCALAR=grad_output.numel() == 1,
+                BLOCK_SIZE=1024,
+            )
+    if out_contiguous is not grad_input:
+        grad_input.copy_(out_contiguous)
+    return grad_input

--- a/tests/test_huber_loss_backward.py
+++ b/tests/test_huber_loss_backward.py
@@ -1,0 +1,272 @@
+"""Accuracy tests for ``aten::huber_loss_backward``.
+
+Verified against PyTorch native by routing the gradient through
+``torch.ops.aten.huber_loss_backward`` directly so we exercise the exact
+schema FlagGems registers.
+"""
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+
+@pytest.mark.huber_loss_backward
+@pytest.mark.parametrize(
+    "shape,target_shape",
+    [
+        ((0,), (0,)),
+        ((1,), (1,)),
+        ((2, 3), (2, 3)),
+        ((32, 17), (32, 17)),
+        ((4, 8, 16), (4, 8, 16)),
+        ((2, 3, 16, 16), (2, 3, 16, 16)),
+        ((2, 3, 4), (4,)),
+        ((2, 1, 4), (3, 4)),
+    ],
+)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+@pytest.mark.parametrize("reduction", [0, 1, 2])
+@pytest.mark.parametrize("delta", [0.25, 0.5, 1.0, 2.0])
+def test_huber_loss_backward(shape, target_shape, dtype, reduction, delta):
+    """Main matrix: shape x dtype x reduction x delta with both reduced and
+    non-reduced grad_output shapes."""
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    target = torch.randn(target_shape, dtype=dtype, device=flag_gems.device)
+    out_shape = torch.broadcast_shapes(shape, target_shape)
+
+    # Exercise the non-contiguous code path occasionally to ensure
+    # `.contiguous()` is applied as expected.
+    if len(shape) >= 2 and shape[0] > 0:
+        inp = inp.transpose(0, 1).contiguous().transpose(0, 1)
+
+    if reduction == 0:
+        grad_output = torch.randn(out_shape, dtype=dtype, device=flag_gems.device)
+        if len(out_shape) >= 2 and out_shape[0] > 0:
+            grad_output = grad_output.transpose(0, 1).contiguous().transpose(0, 1)
+    else:
+        grad_output = torch.randn((), dtype=dtype, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+    ref_target = utils.to_reference(target).to(torch.float32)
+    ref_grad_output = utils.to_reference(grad_output).to(torch.float32)
+    ref_out = torch.ops.aten.huber_loss_backward(
+        ref_grad_output, ref_inp, ref_target, reduction, delta
+    ).to(dtype)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.huber_loss_backward(
+            grad_output, inp, target, reduction, delta
+        )
+
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, atol=2e-2)
+
+
+@pytest.mark.huber_loss_backward
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_huber_loss_backward_quadratic_region(dtype):
+    """When |diff| <= delta, the gradient equals grad_output * (input - target),
+    i.e. matches the mse_loss gradient.  Exercise that branch explicitly."""
+    inp = torch.tensor([0.0, 0.1, -0.2, 0.3], dtype=dtype, device=flag_gems.device)
+    target = torch.zeros_like(inp)
+    grad_output = torch.tensor(2.0, dtype=dtype, device=flag_gems.device)
+    delta = 1.0
+
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+    ref_target = utils.to_reference(target).to(torch.float32)
+    ref_grad_output = utils.to_reference(grad_output).to(torch.float32)
+    ref_out = torch.ops.aten.huber_loss_backward(
+        ref_grad_output, ref_inp, ref_target, 2, delta
+    ).to(dtype)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.huber_loss_backward(grad_output, inp, target, 2, delta)
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, atol=2e-2)
+
+
+@pytest.mark.huber_loss_backward
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_huber_loss_backward_linear_region(dtype):
+    """When |diff| > delta, the gradient saturates to +/- delta scaled by
+    grad_output.  Exercise that branch explicitly."""
+    inp = torch.tensor([5.0, -3.0, 7.0, -10.0], dtype=dtype, device=flag_gems.device)
+    target = torch.zeros_like(inp)
+    grad_output = torch.tensor(1.0, dtype=dtype, device=flag_gems.device)
+    delta = 1.0
+
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+    ref_target = utils.to_reference(target).to(torch.float32)
+    ref_grad_output = utils.to_reference(grad_output).to(torch.float32)
+    ref_out = torch.ops.aten.huber_loss_backward(
+        ref_grad_output, ref_inp, ref_target, 2, delta
+    ).to(dtype)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.huber_loss_backward(grad_output, inp, target, 2, delta)
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, atol=2e-2)
+
+
+@pytest.mark.huber_loss_backward
+def test_huber_loss_backward_scalar_grad_output():
+    """A 0-D grad_output (the natural output of autograd on a reduced loss)
+    should broadcast across the input."""
+    inp = torch.tensor([-1.0, -0.5, 1.0], device=flag_gems.device)
+    target = torch.zeros_like(inp)
+    grad_output = torch.tensor(2.0, device=flag_gems.device)
+    delta = 0.75
+
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+    ref_target = utils.to_reference(target).to(torch.float32)
+    ref_grad_output = utils.to_reference(grad_output).to(torch.float32)
+
+    ref_out = torch.ops.aten.huber_loss_backward(
+        ref_grad_output, ref_inp, ref_target, 0, delta
+    )
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.huber_loss_backward(grad_output, inp, target, 0, delta)
+
+    utils.gems_assert_close(res_out, ref_out, torch.float32)
+
+
+@pytest.mark.huber_loss_backward
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_huber_loss_backward_broadcast(dtype):
+    """Mismatched but broadcastable input / target shapes."""
+    inp = torch.randn((2, 3, 4), dtype=dtype, device=flag_gems.device)
+    target = torch.randn((4,), dtype=dtype, device=flag_gems.device)
+    grad_output = torch.randn((), dtype=dtype, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+    ref_target = utils.to_reference(target).to(torch.float32)
+    ref_grad_output = utils.to_reference(grad_output).to(torch.float32)
+    ref_out = torch.ops.aten.huber_loss_backward(
+        ref_grad_output, ref_inp, ref_target, 1, 1.0
+    ).to(dtype)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.huber_loss_backward(grad_output, inp, target, 1, 1.0)
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, atol=2e-2)
+
+
+@pytest.mark.huber_loss_backward
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_huber_loss_backward_special_values(dtype):
+    """Verify behaviour on +/- 0, +/- inf, and NaN inputs."""
+    inp = torch.tensor(
+        [0.0, -0.0, 1.0, -2.0, float("inf"), float("-inf"), float("nan")],
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+    target = torch.tensor(
+        [0.0, 1.0, -1.0, -2.0, 1.0, float("-inf"), 0.0],
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+    grad_output = torch.tensor(1.0, dtype=dtype, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+    ref_target = utils.to_reference(target).to(torch.float32)
+    ref_grad_output = utils.to_reference(grad_output).to(torch.float32)
+    ref_out = torch.ops.aten.huber_loss_backward(
+        ref_grad_output, ref_inp, ref_target, 0, 1.0
+    ).to(dtype)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.huber_loss_backward(grad_output, inp, target, 0, 1.0)
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, atol=2e-2)
+
+
+@pytest.mark.huber_loss_backward
+def test_huber_loss_backward_out():
+    """``huber_loss_backward.out`` writes into the supplied tensor."""
+    inp = torch.randn((8, 16), dtype=torch.float32, device=flag_gems.device)
+    target = torch.randn((8, 16), dtype=torch.float32, device=flag_gems.device)
+    grad_output = torch.randn((), dtype=torch.float32, device=flag_gems.device)
+    out = torch.empty_like(inp)
+
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+    ref_target = utils.to_reference(target).to(torch.float32)
+    ref_grad_output = utils.to_reference(grad_output).to(torch.float32)
+    ref_out = torch.empty_like(ref_inp)
+
+    torch.ops.aten.huber_loss_backward.out(
+        ref_grad_output, ref_inp, ref_target, 1, 0.5, grad_input=ref_out
+    )
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.huber_loss_backward.out(
+            grad_output, inp, target, 1, 0.5, grad_input=out
+        )
+
+    assert res_out is out
+    utils.gems_assert_close(out, ref_out, torch.float32)
+
+
+@pytest.mark.huber_loss_backward
+def test_huber_loss_backward_negative_delta():
+    """Negative `delta` should raise -- it's mathematically nonsensical."""
+    grad_output = torch.randn((), dtype=torch.float32, device=flag_gems.device)
+    inp = torch.randn((8,), dtype=torch.float32, device=flag_gems.device)
+    target = torch.randn((8,), dtype=torch.float32, device=flag_gems.device)
+
+    with flag_gems.use_gems(), pytest.raises(RuntimeError, match="negative"):
+        torch.ops.aten.huber_loss_backward(grad_output, inp, target, 1, -1.0)
+
+
+@pytest.mark.huber_loss_backward
+def test_huber_loss_backward_empty():
+    """Empty tensors are a no-op but must not crash."""
+    inp = torch.empty((0,), dtype=torch.float32, device=flag_gems.device)
+    target = torch.empty((0,), dtype=torch.float32, device=flag_gems.device)
+    grad_output = torch.randn((), dtype=torch.float32, device=flag_gems.device)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.huber_loss_backward(grad_output, inp, target, 1, 1.0)
+    assert res_out.shape == inp.shape
+
+
+@pytest.mark.huber_loss_backward
+@pytest.mark.parametrize("reduction", [0, 1, 2])
+def test_huber_loss_backward_autograd_round_trip(reduction):
+    """A round-trip via autograd of huber_loss forward should hit our backward
+    kernel and agree numerically with PyTorch's native gradient."""
+    if cfg.TO_CPU:
+        pytest.skip("Round-trip requires CUDA dispatch.")
+
+    inp = torch.randn(
+        (4, 7), dtype=torch.float32, device=flag_gems.device, requires_grad=True
+    )
+    target = torch.randn((4, 7), dtype=torch.float32, device=flag_gems.device)
+    delta = 0.5
+
+    # PyTorch reference gradient.
+    ref_inp = inp.detach().clone().requires_grad_(True)
+    ref_loss = torch.nn.functional.huber_loss(
+        ref_inp,
+        target,
+        reduction={0: "none", 1: "mean", 2: "sum"}[reduction],
+        delta=delta,
+    )
+    if ref_loss.dim() == 0:
+        ref_loss.backward()
+    else:
+        ref_loss.sum().backward()
+    ref_grad = ref_inp.grad
+
+    # Same path through flag_gems' dispatch.
+    with flag_gems.use_gems():
+        gems_loss = torch.nn.functional.huber_loss(
+            inp,
+            target,
+            reduction={0: "none", 1: "mean", 2: "sum"}[reduction],
+            delta=delta,
+        )
+        if gems_loss.dim() == 0:
+            gems_loss.backward()
+        else:
+            gems_loss.sum().backward()
+    gems_grad = inp.grad
+
+    utils.gems_assert_close(gems_grad, ref_grad, torch.float32, atol=2e-2)


### PR DESCRIPTION
…perator

Adds a Triton implementation of `aten::huber_loss_backward` (and its `.out` variant). The kernel is a single fused elementwise pass that:

- Loads `input`, `target`, and (broadcast) `grad_output`.
- Computes `clip(input - target, -delta, delta)` to handle the quadratic and linear branches of the Huber loss without divergent control flow.
- Multiplies by `grad_output` (with an extra `1/N` factor for mean reduction, where `N` is `self.numel()` -- the convention smooth_l1_loss backward follows).
- Specialises on a `GRAD_OUTPUT_SCALAR` constexpr for the common autograd case where the loss has been reduced to a 0-D tensor.

Test coverage (307 cases, all green):

* 8 shape pairs (incl. broadcast and empty) x 3 dtypes (fp16/fp32/bf16) x 3 reductions x 4 deltas.
* Quadratic / linear region branch tests.
* Scalar grad_output broadcast.
* Broadcastable but non-equal input/target shapes.
* Special values (+/- 0, +/- inf, NaN).
* huber_loss_backward.out in-place semantics.
* Negative delta -> RuntimeError.
* Empty tensors.
* Autograd round-trip via torch.nn.functional.huber_loss.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
