### PR TITLE
[FlagGems Operator Development Competition] Add replication_pad1d_bac…

### DIFF
--- a/benchmark/test_replication_pad1d_backward.py
+++ b/benchmark/test_replication_pad1d_backward.py
@@ -1,0 +1,35 @@
+"""Performance benchmark for ``aten::replication_pad1d_backward``."""
+
+import pytest
+import torch
+
+from . import base, consts
+
+
+class ReplicationPad1dBackwardBenchmark(base.Benchmark):
+    DEFAULT_SHAPE_FILES = "benchmark/core_shapes.yaml"
+    DEFAULT_SHAPES = [
+        (1, 16, 128),
+        (4, 32, 256),
+        (8, 64, 512),
+        (16, 64, 1024),
+    ]
+    DEFAULT_SHAPE_DESC = "N, C, L"
+
+    def get_input_iter(self, dtype):
+        pad_left, pad_right = 3, 5
+        for shape in self.shapes:
+            inp = torch.randn(shape, device=self.device, dtype=dtype)
+            out_shape = shape[:-1] + (shape[-1] + pad_left + pad_right,)
+            grad_output = torch.randn(out_shape, device=self.device, dtype=dtype)
+            yield grad_output, inp, [pad_left, pad_right]
+
+
+@pytest.mark.replication_pad1d_backward
+def test_replication_pad1d_backward():
+    bench = ReplicationPad1dBackwardBenchmark(
+        op_name="replication_pad1d_backward",
+        torch_op=torch.ops.aten.replication_pad1d_backward,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -5054,6 +5054,26 @@ ops:
       - Tensor
     stages:
       - beta: '5.0'
+  - id: replication_pad1d_backward
+    description: Compute the gradient of `replication_pad1d` with respect to the input tensor.
+    for:
+      - replication_pad1d_backward
+    labels:
+      - aten
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.1'
+  - id: replication_pad1d_backward_grad_input
+    description: A variant of `replication_pad1d_backward` that writes the gradient into a pre-allocated tensor.
+    for:
+      - replication_pad1d_backward.grad_input
+    labels:
+      - aten
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.1'
   - id: replication_pad3d
     description: Pads the edge of a 3D input tensor by repeating the boundary values.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -441,6 +441,11 @@ _FULL_CONFIG = (
     ("repeat_interleave.Tensor", repeat_interleave_tensor),
     ("replication_pad1d", replication_pad1d),
     ("replication_pad1d.out", replication_pad1d_out),
+    ("replication_pad1d_backward", replication_pad1d_backward),
+    (
+        "replication_pad1d_backward.grad_input",
+        replication_pad1d_backward_grad_input,
+    ),
     ("replication_pad3d", replication_pad3d),
     ("resolve_conj", resolve_conj),
     ("resolve_neg", resolve_neg),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -302,6 +302,10 @@ from flag_gems.ops.repeat_interleave import (
     repeat_interleave_tensor,
 )
 from flag_gems.ops.replication_pad1d import replication_pad1d, replication_pad1d_out
+from flag_gems.ops.replication_pad1d_backward import (
+    replication_pad1d_backward,
+    replication_pad1d_backward_grad_input,
+)
 from flag_gems.ops.replication_pad3d import replication_pad3d
 from flag_gems.ops.resolve_conj import resolve_conj
 from flag_gems.ops.resolve_neg import resolve_neg
@@ -774,6 +778,8 @@ __all__ = [
     "repeat_interleave_self_tensor",
     "repeat_interleave_tensor",
     "replication_pad1d",
+    "replication_pad1d_backward",
+    "replication_pad1d_backward_grad_input",
     "replication_pad1d_out",
     "replication_pad3d",
     "resolve_conj",

--- a/src/flag_gems/ops/replication_pad1d_backward.py
+++ b/src/flag_gems/ops/replication_pad1d_backward.py
@@ -1,0 +1,159 @@
+"""Triton implementation of ``aten::replication_pad1d_backward``.
+
+Replication padding fills the padded region by *replicating* the boundary
+input values.  For a 1-D input with shape ``(*, L_in)`` and padding
+``(pad_left, pad_right)`` the forward maps each output position ``j``
+to the input position ``i = clamp(j - pad_left, 0, L_in - 1)``.  The
+backward therefore needs to accumulate ``grad_output[j]`` into
+``grad_input[clamp(j - pad_left, 0, L_in - 1)]`` -- a scatter-add along
+the spatial dimension.  We do this with a single Triton kernel using
+``tl.atomic_add`` (the same pattern ``reflection_pad1d_backward`` uses).
+
+aten schema::
+
+    replication_pad1d_backward(Tensor grad_output, Tensor self,
+                               SymInt[2] padding) -> Tensor
+    replication_pad1d_backward.grad_input(Tensor grad_output, Tensor self,
+                                          SymInt[2] padding, *,
+                                          Tensor(a!) grad_input)
+                                          -> Tensor(a!)
+"""
+
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def _replication_pad1d_backward_kernel(
+    grad_output_ptr,
+    grad_input_ptr,
+    B,
+    L_in,
+    pad_left,
+    L_out,
+    BLOCK_W: tl.constexpr,
+):
+    """One program handles a row (``pid_b``) and a tile of ``BLOCK_W`` output
+    positions.  Each loaded grad_output element is atomically added to its
+    corresponding clamped input index."""
+    pid_b = tl.program_id(axis=0)
+    pid_w = tl.program_id(axis=1)
+
+    offs_w = pid_w * BLOCK_W + tl.arange(0, BLOCK_W)
+    mask_out = offs_w < L_out
+
+    base_out = pid_b * L_out
+    base_in = pid_b * L_in
+
+    grad = tl.load(grad_output_ptr + base_out + offs_w, mask=mask_out, other=0.0)
+    grad_f32 = grad.to(tl.float32)
+
+    # Map each output column to the replicated input column.
+    # input_index = clamp(out_index - pad_left, 0, L_in - 1)
+    x = offs_w.to(tl.int32) - pad_left
+    iw = tl.where(x < 0, 0, tl.where(x > L_in - 1, L_in - 1, x))
+
+    tl.atomic_add(grad_input_ptr + base_in + iw, grad_f32, mask=mask_out)
+
+
+@triton.jit
+def _copy_rows_kernel(in_ptr, out_ptr, B, W, BLOCK_W: tl.constexpr):
+    pid_b = tl.program_id(axis=0)
+    pid_w = tl.program_id(axis=1)
+
+    offs_w = pid_w * BLOCK_W + tl.arange(0, BLOCK_W)
+    mask = (offs_w < W) & (pid_b < B)
+
+    base = pid_b * W
+    vals = tl.load(in_ptr + base + offs_w, mask=mask, other=0)
+    tl.store(out_ptr + base + offs_w, vals, mask=mask)
+
+
+def _launch(grad_output: torch.Tensor, self: torch.Tensor, padding, grad_input=None):
+    if not isinstance(padding, (list, tuple)) or len(padding) != 2:
+        raise ValueError(
+            "padding must be a sequence of length 2: (pad_left, pad_right)"
+        )
+    pad_left, pad_right = int(padding[0]), int(padding[1])
+    if pad_left < 0 or pad_right < 0:
+        raise ValueError("padding values must be >= 0")
+    if self.dim() < 1:
+        raise ValueError("self must have at least 1 dimension")
+
+    grad_output_c = grad_output.contiguous()
+    x = self.contiguous()
+
+    L_in = int(x.shape[-1])
+    if L_in <= 0:
+        raise ValueError("last dimension (width) must be > 0")
+
+    L_out = L_in + pad_left + pad_right
+    if int(grad_output_c.shape[-1]) != L_out:
+        raise ValueError(
+            f"grad_output last-dim ({int(grad_output_c.shape[-1])}) does not "
+            f"match expected L_in + pad_left + pad_right ({L_out})."
+        )
+
+    leading_shape = x.shape[:-1]
+    B = int(math.prod(leading_shape)) if len(leading_shape) > 0 else 1
+
+    # Accumulate in float32 so atomic adds are safe across dtypes.
+    grad_input_f32 = torch.zeros_like(x, dtype=torch.float32)
+
+    if pad_left == 0 and pad_right == 0:
+        # Degenerate case: just copy grad_output as the gradient.
+        grid = (B, triton.cdiv(L_in, 256))
+        with torch_device_fn.device(x.device):
+            _copy_rows_kernel[grid](grad_output_c, grad_input_f32, B, L_in, BLOCK_W=256)
+    else:
+        grid = (B, triton.cdiv(L_out, 256))
+        with torch_device_fn.device(x.device):
+            _replication_pad1d_backward_kernel[grid](
+                grad_output_c, grad_input_f32, B, L_in, pad_left, L_out, BLOCK_W=256
+            )
+
+    # Cast to the requested output dtype.
+    target_dtype = x.dtype if grad_input is None else grad_input.dtype
+    if target_dtype == torch.float32:
+        casted = grad_input_f32
+    else:
+        casted = torch.empty(x.shape, device=x.device, dtype=target_dtype)
+        grid = (B, triton.cdiv(L_in, 256))
+        with torch_device_fn.device(x.device):
+            _copy_rows_kernel[grid](grad_input_f32, casted, B, L_in, BLOCK_W=256)
+
+    if grad_input is None:
+        return casted
+
+    if tuple(grad_input.shape) != tuple(x.shape):
+        grad_input.resize_(x.shape)
+    grad_input.copy_(casted)
+    return grad_input
+
+
+def replication_pad1d_backward(
+    grad_output: torch.Tensor, self: torch.Tensor, padding
+) -> torch.Tensor:
+    logger.debug("GEMS REPLICATION_PAD1D_BACKWARD")
+    return _launch(grad_output, self, padding, grad_input=None)
+
+
+def replication_pad1d_backward_grad_input(
+    grad_output: torch.Tensor,
+    self: torch.Tensor,
+    padding,
+    *,
+    grad_input: torch.Tensor,
+) -> torch.Tensor:
+    """``replication_pad1d_backward.grad_input`` writes into the supplied
+    tensor and returns it (PyTorch's ``out=``-style convention)."""
+    logger.debug("GEMS REPLICATION_PAD1D_BACKWARD GRAD_INPUT")
+    return _launch(grad_output, self, padding, grad_input=grad_input)

--- a/tests/test_replication_pad1d_backward.py
+++ b/tests/test_replication_pad1d_backward.py
@@ -1,0 +1,119 @@
+"""Accuracy tests for ``aten::replication_pad1d_backward``."""
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.replication_pad1d_backward
+@pytest.mark.parametrize(
+    "shape",
+    [
+        # (C, L) -- 2D input (unbatched)
+        (4, 8),
+        # (N, C, L) -- 3D input (batched)
+        (1, 1, 1),
+        (1, 1, 4),
+        (1, 3, 5),
+        (2, 4, 7),
+        (8, 16, 32),
+        (4, 8, 64),
+    ],
+)
+@pytest.mark.parametrize(
+    "padding",
+    [
+        (0, 0),
+        (1, 0),
+        (0, 1),
+        (1, 1),
+        (2, 3),
+        (3, 2),
+    ],
+)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_replication_pad1d_backward(shape, padding, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    L_out = inp.shape[-1] + padding[0] + padding[1]
+    out_shape = inp.shape[:-1] + (L_out,)
+    grad_output = torch.randn(out_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+    ref_grad_output = utils.to_reference(grad_output).to(torch.float32)
+    ref_out = torch.ops.aten.replication_pad1d_backward(
+        ref_grad_output, ref_inp, padding
+    ).to(dtype)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.replication_pad1d_backward(grad_output, inp, padding)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, atol=2e-2)
+
+
+@pytest.mark.replication_pad1d_backward
+def test_replication_pad1d_backward_grad_input_variant():
+    inp = torch.randn((2, 3, 5), dtype=torch.float32, device=flag_gems.device)
+    grad_output = torch.randn((2, 3, 8), dtype=torch.float32, device=flag_gems.device)
+    out_buf = torch.empty_like(inp)
+    ref_buf = torch.empty_like(inp)
+
+    torch.ops.aten.replication_pad1d_backward.grad_input(
+        grad_output, inp, (1, 2), grad_input=ref_buf
+    )
+    with flag_gems.use_gems():
+        res = torch.ops.aten.replication_pad1d_backward.grad_input(
+            grad_output, inp, (1, 2), grad_input=out_buf
+        )
+
+    assert res is out_buf
+    utils.gems_assert_close(out_buf, ref_buf, torch.float32)
+
+
+@pytest.mark.replication_pad1d_backward
+def test_replication_pad1d_backward_no_padding():
+    """`(0, 0)` padding -> backward is just an identity copy."""
+    inp = torch.randn((2, 4, 9), dtype=torch.float32, device=flag_gems.device)
+    grad_output = torch.randn_like(inp)
+
+    ref = torch.ops.aten.replication_pad1d_backward(grad_output, inp, (0, 0))
+    with flag_gems.use_gems():
+        res = torch.ops.aten.replication_pad1d_backward(grad_output, inp, (0, 0))
+
+    utils.gems_assert_close(res, ref, torch.float32)
+
+
+@pytest.mark.replication_pad1d_backward
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_replication_pad1d_backward_single_input(dtype):
+    """L_in == 1 collapses both boundaries to the same input element."""
+    inp = torch.randn((2, 3, 1), dtype=dtype, device=flag_gems.device)
+    grad_output = torch.randn((2, 3, 6), dtype=dtype, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+    ref_grad_output = utils.to_reference(grad_output).to(torch.float32)
+    ref_out = torch.ops.aten.replication_pad1d_backward(
+        ref_grad_output, ref_inp, (2, 3)
+    ).to(dtype)
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.replication_pad1d_backward(grad_output, inp, (2, 3))
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, atol=2e-2)
+
+
+@pytest.mark.replication_pad1d_backward
+def test_replication_pad1d_backward_invalid_padding_length():
+    inp = torch.randn((1, 2, 4), device=flag_gems.device)
+    grad_output = torch.randn((1, 2, 6), device=flag_gems.device)
+    with flag_gems.use_gems(), pytest.raises(ValueError, match="length 2"):
+        # padding must be length-2 sequence
+        flag_gems.replication_pad1d_backward(grad_output, inp, (1, 1, 1))
+
+
+@pytest.mark.replication_pad1d_backward
+def test_replication_pad1d_backward_negative_padding():
+    inp = torch.randn((1, 2, 4), device=flag_gems.device)
+    grad_output = torch.randn((1, 2, 5), device=flag_gems.device)
+    with flag_gems.use_gems(), pytest.raises(ValueError, match=">= 0"):
+        flag_gems.replication_pad1d_backward(grad_output, inp, (-1, 2))


### PR DESCRIPTION
…kward operator

Adds a Triton implementation of `aten::replication_pad1d_backward` (and its `.grad_input` variant).

For 1-D replication padding, the forward maps each output position `j` to the input position `i = clamp(j - pad_left, 0, L_in - 1)`. The backward therefore needs to accumulate `grad_output[j]` into `grad_input[clamp(j - pad_left, 0, L_in - 1)]` -- a scatter-add along the spatial dimension. The kernel does this with a single `tl.atomic_add` launch (the same pattern `reflection_pad1d_backward` uses) accumulating in float32 for safety across input dtypes.

Test coverage (133 cases, all green):

* Main matrix: 7 shape variants (incl. (C, L) unbatched, L_in=1 collapsed boundary, and large (8, 16, 32) / (4, 8, 64) batched) x 6 padding combos (incl. asymmetric and (0, 0)) x 3 dtypes (fp16/fp32/bf16).
* `grad_input` variant write-in-place semantics.
* (0, 0) padding identity path.
* L_in == 1 single-element collapse (both boundaries coincide).
* Negative padding -> ValueError.
* Wrong-length padding sequence -> ValueError.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
