### PR TITLE
[FlagGems Operator Development Competition] Add replication_pad2d_bac…

### DIFF
--- a/benchmark/test_replication_pad2d_backward.py
+++ b/benchmark/test_replication_pad2d_backward.py
@@ -1,0 +1,39 @@
+"""Performance benchmark for ``aten::replication_pad2d_backward``."""
+
+import pytest
+import torch
+
+from . import base, consts
+
+
+class ReplicationPad2dBackwardBenchmark(base.Benchmark):
+    DEFAULT_SHAPE_FILES = "benchmark/core_shapes.yaml"
+    DEFAULT_SHAPES = [
+        (1, 16, 32, 32),
+        (4, 32, 64, 64),
+        (8, 64, 128, 128),
+        (16, 64, 256, 256),
+    ]
+    DEFAULT_SHAPE_DESC = "N, C, H, W"
+
+    def get_input_iter(self, dtype):
+        pad_left, pad_right, pad_top, pad_bottom = 2, 3, 1, 4
+        for shape in self.shapes:
+            inp = torch.randn(shape, device=self.device, dtype=dtype)
+            out_shape = (
+                shape[:-2]
+                + (shape[-2] + pad_top + pad_bottom,)
+                + (shape[-1] + pad_left + pad_right,)
+            )
+            grad_output = torch.randn(out_shape, device=self.device, dtype=dtype)
+            yield grad_output, inp, [pad_left, pad_right, pad_top, pad_bottom]
+
+
+@pytest.mark.replication_pad2d_backward
+def test_replication_pad2d_backward():
+    bench = ReplicationPad2dBackwardBenchmark(
+        op_name="replication_pad2d_backward",
+        torch_op=torch.ops.aten.replication_pad2d_backward,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -5054,6 +5054,26 @@ ops:
       - Tensor
     stages:
       - beta: '5.0'
+  - id: replication_pad2d_backward
+    description: Compute the gradient of `replication_pad2d` with respect to the input tensor.
+    for:
+      - replication_pad2d_backward
+    labels:
+      - aten
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.1'
+  - id: replication_pad2d_backward_grad_input
+    description: A variant of `replication_pad2d_backward` that writes into a pre-allocated tensor.
+    for:
+      - replication_pad2d_backward.grad_input
+    labels:
+      - aten
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.1'
   - id: replication_pad3d
     description: Pads the edge of a 3D input tensor by repeating the boundary values.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -441,6 +441,11 @@ _FULL_CONFIG = (
     ("repeat_interleave.Tensor", repeat_interleave_tensor),
     ("replication_pad1d", replication_pad1d),
     ("replication_pad1d.out", replication_pad1d_out),
+    ("replication_pad2d_backward", replication_pad2d_backward),
+    (
+        "replication_pad2d_backward.grad_input",
+        replication_pad2d_backward_grad_input,
+    ),
     ("replication_pad3d", replication_pad3d),
     ("resolve_conj", resolve_conj),
     ("resolve_neg", resolve_neg),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -302,6 +302,10 @@ from flag_gems.ops.repeat_interleave import (
     repeat_interleave_tensor,
 )
 from flag_gems.ops.replication_pad1d import replication_pad1d, replication_pad1d_out
+from flag_gems.ops.replication_pad2d_backward import (
+    replication_pad2d_backward,
+    replication_pad2d_backward_grad_input,
+)
 from flag_gems.ops.replication_pad3d import replication_pad3d
 from flag_gems.ops.resolve_conj import resolve_conj
 from flag_gems.ops.resolve_neg import resolve_neg
@@ -775,6 +779,8 @@ __all__ = [
     "repeat_interleave_tensor",
     "replication_pad1d",
     "replication_pad1d_out",
+    "replication_pad2d_backward",
+    "replication_pad2d_backward_grad_input",
     "replication_pad3d",
     "resolve_conj",
     "resolve_neg",

--- a/src/flag_gems/ops/replication_pad2d_backward.py
+++ b/src/flag_gems/ops/replication_pad2d_backward.py
@@ -1,0 +1,196 @@
+"""Triton implementation of ``aten::replication_pad2d_backward``.
+
+For a 2-D input with shape ``(*, H_in, W_in)`` and padding
+``(pad_left, pad_right, pad_top, pad_bottom)`` the forward maps each
+output position ``(y, x)`` to the input position
+
+    (h, w) = (clamp(y - pad_top, 0, H_in - 1),
+              clamp(x - pad_left, 0, W_in - 1))
+
+The backward therefore accumulates ``grad_output[y, x]`` into
+``grad_input[clamp(y - pad_top, 0, H_in - 1),
+             clamp(x - pad_left, 0, W_in - 1)]`` -- a scatter-add over the
+spatial dimensions.  We do this with a single Triton kernel using
+``tl.atomic_add`` (the same pattern ``replication_pad1d_backward`` and
+``reflection_pad1d_backward`` use).
+
+aten schema::
+
+    replication_pad2d_backward(Tensor grad_output, Tensor self,
+                               SymInt[4] padding) -> Tensor
+    replication_pad2d_backward.grad_input(Tensor grad_output, Tensor self,
+                                          SymInt[4] padding, *,
+                                          Tensor(a!) grad_input)
+                                          -> Tensor(a!)
+"""
+
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def _replication_pad2d_backward_kernel(
+    grad_output_ptr,
+    grad_input_ptr,
+    B,
+    H_in,
+    W_in,
+    pad_left,
+    pad_top,
+    H_out,
+    W_out,
+    BLOCK_W: tl.constexpr,
+):
+    """One program handles a row ``pid_b`` (a flattened (N, C) index) and a
+    tile of ``BLOCK_W`` output spatial positions on a particular output row
+    ``pid_h``.  Each loaded ``grad_output`` element is atomically added to
+    its clamped input position."""
+    pid_b = tl.program_id(axis=0)
+    pid_h = tl.program_id(axis=1)
+    pid_w = tl.program_id(axis=2)
+
+    offs_w = pid_w * BLOCK_W + tl.arange(0, BLOCK_W)
+    mask_out = offs_w < W_out
+
+    base_out = pid_b * H_out * W_out + pid_h * W_out
+    base_in = pid_b * H_in * W_in
+
+    grad = tl.load(grad_output_ptr + base_out + offs_w, mask=mask_out, other=0.0)
+    grad_f32 = grad.to(tl.float32)
+
+    # Map output (y, x) to input (h, w) via clamp.
+    y = pid_h - pad_top
+    h = tl.where(y < 0, 0, tl.where(y > H_in - 1, H_in - 1, y))
+
+    x = offs_w.to(tl.int32) - pad_left
+    w = tl.where(x < 0, 0, tl.where(x > W_in - 1, W_in - 1, x))
+
+    tl.atomic_add(
+        grad_input_ptr + base_in + h * W_in + w,
+        grad_f32,
+        mask=mask_out,
+    )
+
+
+@triton.jit
+def _copy_rows_kernel(in_ptr, out_ptr, B, N, BLOCK_W: tl.constexpr):
+    """Generic ``BLOCK_W``-tile row copy used both for the ``pad == 0`` fast
+    path and for the final f32 -> input-dtype cast."""
+    pid_b = tl.program_id(axis=0)
+    pid_w = tl.program_id(axis=1)
+
+    offs_w = pid_w * BLOCK_W + tl.arange(0, BLOCK_W)
+    mask = (offs_w < N) & (pid_b < B)
+
+    base = pid_b * N
+    vals = tl.load(in_ptr + base + offs_w, mask=mask, other=0)
+    tl.store(out_ptr + base + offs_w, vals, mask=mask)
+
+
+def _launch(grad_output: torch.Tensor, self: torch.Tensor, padding, grad_input=None):
+    if not isinstance(padding, (list, tuple)) or len(padding) != 4:
+        raise ValueError(
+            "padding must be a sequence of length 4: "
+            "(pad_left, pad_right, pad_top, pad_bottom)"
+        )
+    pad_left = int(padding[0])
+    pad_right = int(padding[1])
+    pad_top = int(padding[2])
+    pad_bottom = int(padding[3])
+    if min(pad_left, pad_right, pad_top, pad_bottom) < 0:
+        raise ValueError("padding values must be >= 0")
+    if self.dim() < 2:
+        raise ValueError("self must have at least 2 dimensions (H, W)")
+
+    grad_output_c = grad_output.contiguous()
+    x = self.contiguous()
+
+    H_in = int(x.shape[-2])
+    W_in = int(x.shape[-1])
+    if H_in <= 0 or W_in <= 0:
+        raise ValueError("input spatial dims (H, W) must both be > 0")
+
+    H_out = H_in + pad_top + pad_bottom
+    W_out = W_in + pad_left + pad_right
+    if int(grad_output_c.shape[-2]) != H_out or int(grad_output_c.shape[-1]) != W_out:
+        raise ValueError(
+            f"grad_output spatial shape ({int(grad_output_c.shape[-2])}, "
+            f"{int(grad_output_c.shape[-1])}) does not match expected "
+            f"({H_out}, {W_out})."
+        )
+
+    leading_shape = x.shape[:-2]
+    B = int(math.prod(leading_shape)) if len(leading_shape) > 0 else 1
+
+    # Accumulate in float32 for safe atomic adds across dtypes.
+    grad_input_f32 = torch.zeros_like(x, dtype=torch.float32)
+
+    if pad_left == 0 and pad_right == 0 and pad_top == 0 and pad_bottom == 0:
+        # Degenerate case: backward is a plain copy.
+        n_per_row = H_in * W_in
+        grid = (B, triton.cdiv(n_per_row, 256))
+        with torch_device_fn.device(x.device):
+            _copy_rows_kernel[grid](
+                grad_output_c, grad_input_f32, B, n_per_row, BLOCK_W=256
+            )
+    else:
+        grid = (B, H_out, triton.cdiv(W_out, 256))
+        with torch_device_fn.device(x.device):
+            _replication_pad2d_backward_kernel[grid](
+                grad_output_c,
+                grad_input_f32,
+                B,
+                H_in,
+                W_in,
+                pad_left,
+                pad_top,
+                H_out,
+                W_out,
+                BLOCK_W=256,
+            )
+
+    target_dtype = x.dtype if grad_input is None else grad_input.dtype
+    if target_dtype == torch.float32:
+        casted = grad_input_f32
+    else:
+        casted = torch.empty(x.shape, device=x.device, dtype=target_dtype)
+        n_per_row = H_in * W_in
+        grid = (B, triton.cdiv(n_per_row, 256))
+        with torch_device_fn.device(x.device):
+            _copy_rows_kernel[grid](grad_input_f32, casted, B, n_per_row, BLOCK_W=256)
+
+    if grad_input is None:
+        return casted
+
+    if tuple(grad_input.shape) != tuple(x.shape):
+        grad_input.resize_(x.shape)
+    grad_input.copy_(casted)
+    return grad_input
+
+
+def replication_pad2d_backward(
+    grad_output: torch.Tensor, self: torch.Tensor, padding
+) -> torch.Tensor:
+    logger.debug("GEMS REPLICATION_PAD2D_BACKWARD")
+    return _launch(grad_output, self, padding, grad_input=None)
+
+
+def replication_pad2d_backward_grad_input(
+    grad_output: torch.Tensor,
+    self: torch.Tensor,
+    padding,
+    *,
+    grad_input: torch.Tensor,
+) -> torch.Tensor:
+    """``replication_pad2d_backward.grad_input`` writes into ``grad_input``
+    and returns it (preserves the ``grad_input=`` kwarg identity)."""
+    logger.debug("GEMS REPLICATION_PAD2D_BACKWARD GRAD_INPUT")
+    return _launch(grad_output, self, padding, grad_input=grad_input)

--- a/tests/test_replication_pad2d_backward.py
+++ b/tests/test_replication_pad2d_backward.py
@@ -1,0 +1,146 @@
+"""Accuracy tests for ``aten::replication_pad2d_backward``."""
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.replication_pad2d_backward
+@pytest.mark.parametrize(
+    "shape",
+    [
+        # (C, H, W) unbatched
+        (3, 4, 5),
+        # (N, C, H, W) batched
+        (1, 1, 1, 1),
+        (1, 1, 4, 4),
+        (1, 3, 5, 7),
+        (2, 4, 8, 6),
+        (4, 8, 16, 16),
+    ],
+)
+@pytest.mark.parametrize(
+    "padding",
+    [
+        (0, 0, 0, 0),
+        (1, 1, 0, 0),
+        (0, 0, 1, 1),
+        (1, 1, 1, 1),
+        (2, 3, 1, 0),
+        (1, 0, 2, 3),
+    ],
+)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_replication_pad2d_backward(shape, padding, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    pad_left, pad_right, pad_top, pad_bottom = padding
+    H_in, W_in = inp.shape[-2], inp.shape[-1]
+    out_shape = (
+        inp.shape[:-2] + (H_in + pad_top + pad_bottom,) + (W_in + pad_left + pad_right,)
+    )
+    grad_output = torch.randn(out_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+    ref_grad_output = utils.to_reference(grad_output).to(torch.float32)
+    ref_out = torch.ops.aten.replication_pad2d_backward(
+        ref_grad_output, ref_inp, padding
+    ).to(dtype)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.replication_pad2d_backward(grad_output, inp, padding)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, atol=2e-2)
+
+
+@pytest.mark.replication_pad2d_backward
+def test_replication_pad2d_backward_grad_input_variant():
+    inp = torch.randn((2, 3, 5, 4), dtype=torch.float32, device=flag_gems.device)
+    grad_output = torch.randn(
+        (2, 3, 8, 7), dtype=torch.float32, device=flag_gems.device
+    )
+    out_buf = torch.empty_like(inp)
+    ref_buf = torch.empty_like(inp)
+
+    torch.ops.aten.replication_pad2d_backward.grad_input(
+        grad_output, inp, (1, 2, 1, 2), grad_input=ref_buf
+    )
+    with flag_gems.use_gems():
+        res = torch.ops.aten.replication_pad2d_backward.grad_input(
+            grad_output, inp, (1, 2, 1, 2), grad_input=out_buf
+        )
+
+    assert res is out_buf
+    utils.gems_assert_close(out_buf, ref_buf, torch.float32)
+
+
+@pytest.mark.replication_pad2d_backward
+def test_replication_pad2d_backward_no_padding():
+    """`(0, 0, 0, 0)` -> identity copy fast path."""
+    inp = torch.randn((2, 4, 9, 11), dtype=torch.float32, device=flag_gems.device)
+    grad_output = torch.randn_like(inp)
+
+    ref = torch.ops.aten.replication_pad2d_backward(grad_output, inp, (0, 0, 0, 0))
+    with flag_gems.use_gems():
+        res = torch.ops.aten.replication_pad2d_backward(grad_output, inp, (0, 0, 0, 0))
+
+    utils.gems_assert_close(res, ref, torch.float32)
+
+
+@pytest.mark.replication_pad2d_backward
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_replication_pad2d_backward_single_pixel(dtype):
+    """Single-pixel input: all output sums into the same (0, 0) input pixel."""
+    inp = torch.randn((2, 3, 1, 1), dtype=dtype, device=flag_gems.device)
+    grad_output = torch.randn((2, 3, 4, 5), dtype=dtype, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+    ref_grad_output = utils.to_reference(grad_output).to(torch.float32)
+    ref_out = torch.ops.aten.replication_pad2d_backward(
+        ref_grad_output, ref_inp, (2, 2, 1, 2)
+    ).to(dtype)
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.replication_pad2d_backward(
+            grad_output, inp, (2, 2, 1, 2)
+        )
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, atol=2e-2)
+
+
+@pytest.mark.replication_pad2d_backward
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_replication_pad2d_backward_asymmetric(dtype):
+    """Asymmetric padding on H and W -- exercises distinct pad_left/pad_top
+    arithmetic in the kernel."""
+    inp = torch.randn((1, 2, 5, 7), dtype=dtype, device=flag_gems.device)
+    grad_output = torch.randn(
+        (1, 2, 5 + 2 + 3, 7 + 1 + 4), dtype=dtype, device=flag_gems.device
+    )
+
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+    ref_grad_output = utils.to_reference(grad_output).to(torch.float32)
+    ref_out = torch.ops.aten.replication_pad2d_backward(
+        ref_grad_output, ref_inp, (1, 4, 2, 3)
+    ).to(dtype)
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.replication_pad2d_backward(
+            grad_output, inp, (1, 4, 2, 3)
+        )
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, atol=2e-2)
+
+
+@pytest.mark.replication_pad2d_backward
+def test_replication_pad2d_backward_invalid_padding_length():
+    inp = torch.randn((1, 2, 4, 4), device=flag_gems.device)
+    grad_output = torch.randn((1, 2, 5, 5), device=flag_gems.device)
+    with flag_gems.use_gems(), pytest.raises(ValueError, match="length 4"):
+        flag_gems.replication_pad2d_backward(grad_output, inp, (1, 1))
+
+
+@pytest.mark.replication_pad2d_backward
+def test_replication_pad2d_backward_negative_padding():
+    inp = torch.randn((1, 2, 4, 4), device=flag_gems.device)
+    grad_output = torch.randn((1, 2, 5, 5), device=flag_gems.device)
+    with flag_gems.use_gems(), pytest.raises(ValueError, match=">= 0"):
+        flag_gems.replication_pad2d_backward(grad_output, inp, (-1, 1, 0, 0))


### PR DESCRIPTION
…kward operator

Adds a Triton implementation of `aten::replication_pad2d_backward` (and its `.grad_input` variant).

For 2-D replication padding, the forward maps each output position (y, x) to the input position (clamp(y - pad_top, 0, H_in - 1), clamp(x - pad_left, 0, W_in - 1)). The backward therefore needs to accumulate `grad_output[y, x]` into the clamped input cell -- a scatter-add over the H and W dimensions. The kernel does this with a single `tl.atomic_add` launch (the same pattern `replication_pad1d_backward` and `reflection_pad1d_backward` use) accumulating in float32 for safety across input dtypes.

Test coverage (118 cases, all green):

* Main matrix: 6 shape variants (incl. (C, H, W) unbatched, (1,1,1,1) minimum, large (4, 8, 16, 16)) x 6 padding combos (incl. asymmetric (2, 3, 1, 0), (1, 0, 2, 3), and (0, 0, 0, 0)) x 3 dtypes (fp16/fp32/bf16).
* `grad_input` variant write-in-place semantics.
* (0, 0, 0, 0) padding identity path.
* (1, 1) single-pixel input -- all output sums into the same input cell.
* Asymmetric padding on both H and W.
* Negative padding -> ValueError.
* Wrong-length padding sequence -> ValueError.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
