### PR TITLE
[FlagGems Operator Development Competition] Add replication_pad3d_bac…

### DIFF
--- a/benchmark/test_replication_pad3d_backward.py
+++ b/benchmark/test_replication_pad3d_backward.py
@@ -1,0 +1,40 @@
+"""Performance benchmark for ``aten::replication_pad3d_backward``."""
+
+import pytest
+import torch
+
+from . import base, consts
+
+
+class ReplicationPad3dBackwardBenchmark(base.Benchmark):
+    DEFAULT_SHAPE_FILES = "benchmark/core_shapes.yaml"
+    DEFAULT_SHAPES = [
+        (1, 8, 4, 16, 16),
+        (2, 16, 8, 32, 32),
+        (4, 32, 8, 64, 64),
+        (4, 32, 16, 32, 32),
+    ]
+    DEFAULT_SHAPE_DESC = "N, C, D, H, W"
+
+    def get_input_iter(self, dtype):
+        pl, pr, pt, pb, pf, pbk = 2, 3, 1, 4, 1, 2
+        for shape in self.shapes:
+            inp = torch.randn(shape, device=self.device, dtype=dtype)
+            out_shape = (
+                shape[:-3]
+                + (shape[-3] + pf + pbk,)
+                + (shape[-2] + pt + pb,)
+                + (shape[-1] + pl + pr,)
+            )
+            grad_output = torch.randn(out_shape, device=self.device, dtype=dtype)
+            yield grad_output, inp, [pl, pr, pt, pb, pf, pbk]
+
+
+@pytest.mark.replication_pad3d_backward
+def test_replication_pad3d_backward():
+    bench = ReplicationPad3dBackwardBenchmark(
+        op_name="replication_pad3d_backward",
+        torch_op=torch.ops.aten.replication_pad3d_backward,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -5064,6 +5064,26 @@ ops:
       - NeuralNetwork
     stages:
       - alpha: '5.0'
+  - id: replication_pad3d_backward
+    description: Compute the gradient of `replication_pad3d` with respect to the input tensor.
+    for:
+      - replication_pad3d_backward
+    labels:
+      - aten
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.1'
+  - id: replication_pad3d_backward_grad_input
+    description: A variant of `replication_pad3d_backward` that writes into a pre-allocated tensor.
+    for:
+      - replication_pad3d_backward.grad_input
+    labels:
+      - aten
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.1'
   - id: reshape_and_cache
     description: Store the key/value token states into the pre-allcated kv_cache buffers of paged attention.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -442,6 +442,11 @@ _FULL_CONFIG = (
     ("replication_pad1d", replication_pad1d),
     ("replication_pad1d.out", replication_pad1d_out),
     ("replication_pad3d", replication_pad3d),
+    ("replication_pad3d_backward", replication_pad3d_backward),
+    (
+        "replication_pad3d_backward.grad_input",
+        replication_pad3d_backward_grad_input,
+    ),
     ("resolve_conj", resolve_conj),
     ("resolve_neg", resolve_neg),
     ("rms_norm", rms_norm),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -303,6 +303,10 @@ from flag_gems.ops.repeat_interleave import (
 )
 from flag_gems.ops.replication_pad1d import replication_pad1d, replication_pad1d_out
 from flag_gems.ops.replication_pad3d import replication_pad3d
+from flag_gems.ops.replication_pad3d_backward import (
+    replication_pad3d_backward,
+    replication_pad3d_backward_grad_input,
+)
 from flag_gems.ops.resolve_conj import resolve_conj
 from flag_gems.ops.resolve_neg import resolve_neg
 from flag_gems.ops.rms_norm import rms_norm, rms_norm_backward, rms_norm_forward
@@ -776,6 +780,8 @@ __all__ = [
     "replication_pad1d",
     "replication_pad1d_out",
     "replication_pad3d",
+    "replication_pad3d_backward",
+    "replication_pad3d_backward_grad_input",
     "resolve_conj",
     "resolve_neg",
     "rms_norm",

--- a/src/flag_gems/ops/replication_pad3d_backward.py
+++ b/src/flag_gems/ops/replication_pad3d_backward.py
@@ -1,0 +1,218 @@
+"""Triton implementation of ``aten::replication_pad3d_backward``.
+
+For a 3-D volumetric input with shape ``(*, D_in, H_in, W_in)`` and
+padding ``(pad_left, pad_right, pad_top, pad_bottom, pad_front, pad_back)``
+the forward maps each output position ``(z, y, x)`` to the input position
+
+    (d, h, w) = (clamp(z - pad_front, 0, D_in - 1),
+                 clamp(y - pad_top,   0, H_in - 1),
+                 clamp(x - pad_left,  0, W_in - 1))
+
+The backward therefore accumulates ``grad_output[z, y, x]`` into the
+clamped input cell -- a scatter-add over the D, H, W dimensions.  We do
+this with a single Triton kernel using ``tl.atomic_add`` (the same
+pattern ``replication_pad{1,2}d_backward`` and
+``reflection_pad1d_backward`` use) accumulating in ``float32`` for
+cross-dtype safety.
+
+aten schema::
+
+    replication_pad3d_backward(Tensor grad_output, Tensor self,
+                               SymInt[6] padding) -> Tensor
+    replication_pad3d_backward.grad_input(Tensor grad_output, Tensor self,
+                                          SymInt[6] padding, *,
+                                          Tensor(a!) grad_input)
+                                          -> Tensor(a!)
+"""
+
+import logging
+import math
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def _replication_pad3d_backward_kernel(
+    grad_output_ptr,
+    grad_input_ptr,
+    B,
+    D_in,
+    H_in,
+    W_in,
+    pad_left,
+    pad_top,
+    pad_front,
+    D_out,
+    H_out,
+    W_out,
+    BLOCK_W: tl.constexpr,
+):
+    """One program handles ``(pid_b, pid_dh, pid_w)`` where ``pid_dh`` is a
+    flattened ``(D_out, H_out)`` index and ``pid_w`` is a ``BLOCK_W``-tile
+    along the W_out axis.  Each loaded ``grad_output`` element is atomically
+    added to its clamped input voxel."""
+    pid_b = tl.program_id(axis=0)
+    pid_dh = tl.program_id(axis=1)
+    pid_w = tl.program_id(axis=2)
+
+    pid_d = pid_dh // H_out
+    pid_h = pid_dh % H_out
+
+    offs_w = pid_w * BLOCK_W + tl.arange(0, BLOCK_W)
+    mask_out = offs_w < W_out
+
+    base_out = pid_b * D_out * H_out * W_out + pid_d * H_out * W_out + pid_h * W_out
+    base_in = pid_b * D_in * H_in * W_in
+
+    grad = tl.load(grad_output_ptr + base_out + offs_w, mask=mask_out, other=0.0)
+    grad_f32 = grad.to(tl.float32)
+
+    z = pid_d - pad_front
+    d = tl.where(z < 0, 0, tl.where(z > D_in - 1, D_in - 1, z))
+
+    y = pid_h - pad_top
+    h = tl.where(y < 0, 0, tl.where(y > H_in - 1, H_in - 1, y))
+
+    x = offs_w.to(tl.int32) - pad_left
+    w = tl.where(x < 0, 0, tl.where(x > W_in - 1, W_in - 1, x))
+
+    tl.atomic_add(
+        grad_input_ptr + base_in + d * H_in * W_in + h * W_in + w,
+        grad_f32,
+        mask=mask_out,
+    )
+
+
+@triton.jit
+def _copy_rows_kernel(in_ptr, out_ptr, B, N, BLOCK_W: tl.constexpr):
+    """Generic ``BLOCK_W``-tile row copy used both for the ``pad == 0`` fast
+    path and for the final ``f32`` -> input-dtype cast."""
+    pid_b = tl.program_id(axis=0)
+    pid_w = tl.program_id(axis=1)
+
+    offs_w = pid_w * BLOCK_W + tl.arange(0, BLOCK_W)
+    mask = (offs_w < N) & (pid_b < B)
+
+    base = pid_b * N
+    vals = tl.load(in_ptr + base + offs_w, mask=mask, other=0)
+    tl.store(out_ptr + base + offs_w, vals, mask=mask)
+
+
+def _launch(grad_output: torch.Tensor, self: torch.Tensor, padding, grad_input=None):
+    if not isinstance(padding, (list, tuple)) or len(padding) != 6:
+        raise ValueError(
+            "padding must be a sequence of length 6: "
+            "(pad_left, pad_right, pad_top, pad_bottom, pad_front, pad_back)"
+        )
+    pad_left = int(padding[0])
+    pad_right = int(padding[1])
+    pad_top = int(padding[2])
+    pad_bottom = int(padding[3])
+    pad_front = int(padding[4])
+    pad_back = int(padding[5])
+    if min(pad_left, pad_right, pad_top, pad_bottom, pad_front, pad_back) < 0:
+        raise ValueError("padding values must be >= 0")
+    if self.dim() < 3:
+        raise ValueError("self must have at least 3 dimensions (D, H, W)")
+
+    grad_output_c = grad_output.contiguous()
+    x = self.contiguous()
+
+    D_in = int(x.shape[-3])
+    H_in = int(x.shape[-2])
+    W_in = int(x.shape[-1])
+    if D_in <= 0 or H_in <= 0 or W_in <= 0:
+        raise ValueError("input volumetric dims (D, H, W) must all be > 0")
+
+    D_out = D_in + pad_front + pad_back
+    H_out = H_in + pad_top + pad_bottom
+    W_out = W_in + pad_left + pad_right
+    expected = (D_out, H_out, W_out)
+    actual = (
+        int(grad_output_c.shape[-3]),
+        int(grad_output_c.shape[-2]),
+        int(grad_output_c.shape[-1]),
+    )
+    if actual != expected:
+        raise ValueError(
+            f"grad_output spatial shape {actual} does not match expected {expected}."
+        )
+
+    leading_shape = x.shape[:-3]
+    B = int(math.prod(leading_shape)) if len(leading_shape) > 0 else 1
+
+    # Accumulate in float32 for safe atomic adds across dtypes.
+    grad_input_f32 = torch.zeros_like(x, dtype=torch.float32)
+
+    all_zero = (pad_left | pad_right | pad_top | pad_bottom | pad_front | pad_back) == 0
+    if all_zero:
+        # Degenerate case: backward is a plain copy.
+        n_per_row = D_in * H_in * W_in
+        grid = (B, triton.cdiv(n_per_row, 256))
+        with torch_device_fn.device(x.device):
+            _copy_rows_kernel[grid](
+                grad_output_c, grad_input_f32, B, n_per_row, BLOCK_W=256
+            )
+    else:
+        # Grid: (B, D_out * H_out, ceil(W_out / BLOCK_W)).
+        grid = (B, D_out * H_out, triton.cdiv(W_out, 256))
+        with torch_device_fn.device(x.device):
+            _replication_pad3d_backward_kernel[grid](
+                grad_output_c,
+                grad_input_f32,
+                B,
+                D_in,
+                H_in,
+                W_in,
+                pad_left,
+                pad_top,
+                pad_front,
+                D_out,
+                H_out,
+                W_out,
+                BLOCK_W=256,
+            )
+
+    target_dtype = x.dtype if grad_input is None else grad_input.dtype
+    if target_dtype == torch.float32:
+        casted = grad_input_f32
+    else:
+        casted = torch.empty(x.shape, device=x.device, dtype=target_dtype)
+        n_per_row = D_in * H_in * W_in
+        grid = (B, triton.cdiv(n_per_row, 256))
+        with torch_device_fn.device(x.device):
+            _copy_rows_kernel[grid](grad_input_f32, casted, B, n_per_row, BLOCK_W=256)
+
+    if grad_input is None:
+        return casted
+
+    if tuple(grad_input.shape) != tuple(x.shape):
+        grad_input.resize_(x.shape)
+    grad_input.copy_(casted)
+    return grad_input
+
+
+def replication_pad3d_backward(
+    grad_output: torch.Tensor, self: torch.Tensor, padding
+) -> torch.Tensor:
+    logger.debug("GEMS REPLICATION_PAD3D_BACKWARD")
+    return _launch(grad_output, self, padding, grad_input=None)
+
+
+def replication_pad3d_backward_grad_input(
+    grad_output: torch.Tensor,
+    self: torch.Tensor,
+    padding,
+    *,
+    grad_input: torch.Tensor,
+) -> torch.Tensor:
+    """``replication_pad3d_backward.grad_input`` writes into ``grad_input``
+    and returns it."""
+    logger.debug("GEMS REPLICATION_PAD3D_BACKWARD GRAD_INPUT")
+    return _launch(grad_output, self, padding, grad_input=grad_input)

--- a/tests/test_replication_pad3d_backward.py
+++ b/tests/test_replication_pad3d_backward.py
@@ -1,0 +1,150 @@
+"""Accuracy tests for ``aten::replication_pad3d_backward``."""
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.replication_pad3d_backward
+@pytest.mark.parametrize(
+    "shape",
+    [
+        # (C, D, H, W) unbatched
+        (3, 2, 4, 5),
+        # (N, C, D, H, W) batched
+        (1, 1, 1, 1, 1),
+        (1, 1, 2, 3, 4),
+        (1, 3, 4, 5, 6),
+        (2, 4, 3, 6, 5),
+        (2, 8, 4, 8, 8),
+    ],
+)
+@pytest.mark.parametrize(
+    "padding",
+    [
+        (0, 0, 0, 0, 0, 0),
+        (1, 1, 0, 0, 0, 0),
+        (0, 0, 1, 1, 0, 0),
+        (0, 0, 0, 0, 1, 1),
+        (1, 1, 1, 1, 1, 1),
+        (2, 1, 0, 2, 3, 1),
+    ],
+)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_replication_pad3d_backward(shape, padding, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    pl, pr, pt, pb, pf, pbk = padding
+    D_in, H_in, W_in = inp.shape[-3], inp.shape[-2], inp.shape[-1]
+    out_shape = (
+        inp.shape[:-3] + (D_in + pf + pbk,) + (H_in + pt + pb,) + (W_in + pl + pr,)
+    )
+    grad_output = torch.randn(out_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+    ref_grad_output = utils.to_reference(grad_output).to(torch.float32)
+    ref_out = torch.ops.aten.replication_pad3d_backward(
+        ref_grad_output, ref_inp, padding
+    ).to(dtype)
+
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.replication_pad3d_backward(grad_output, inp, padding)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, atol=2e-2)
+
+
+@pytest.mark.replication_pad3d_backward
+def test_replication_pad3d_backward_grad_input_variant():
+    inp = torch.randn((2, 3, 3, 4, 5), dtype=torch.float32, device=flag_gems.device)
+    grad_output = torch.randn(
+        (2, 3, 5, 7, 8), dtype=torch.float32, device=flag_gems.device
+    )
+    out_buf = torch.empty_like(inp)
+    ref_buf = torch.empty_like(inp)
+
+    torch.ops.aten.replication_pad3d_backward.grad_input(
+        grad_output, inp, (1, 2, 1, 2, 1, 1), grad_input=ref_buf
+    )
+    with flag_gems.use_gems():
+        res = torch.ops.aten.replication_pad3d_backward.grad_input(
+            grad_output, inp, (1, 2, 1, 2, 1, 1), grad_input=out_buf
+        )
+
+    assert res is out_buf
+    utils.gems_assert_close(out_buf, ref_buf, torch.float32)
+
+
+@pytest.mark.replication_pad3d_backward
+def test_replication_pad3d_backward_no_padding():
+    inp = torch.randn((2, 4, 5, 6, 7), dtype=torch.float32, device=flag_gems.device)
+    grad_output = torch.randn_like(inp)
+
+    ref = torch.ops.aten.replication_pad3d_backward(
+        grad_output, inp, (0, 0, 0, 0, 0, 0)
+    )
+    with flag_gems.use_gems():
+        res = torch.ops.aten.replication_pad3d_backward(
+            grad_output, inp, (0, 0, 0, 0, 0, 0)
+        )
+
+    utils.gems_assert_close(res, ref, torch.float32)
+
+
+@pytest.mark.replication_pad3d_backward
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_replication_pad3d_backward_single_voxel(dtype):
+    """A 1x1x1 input collapses every padded output into the same voxel."""
+    inp = torch.randn((2, 3, 1, 1, 1), dtype=dtype, device=flag_gems.device)
+    grad_output = torch.randn((2, 3, 4, 5, 6), dtype=dtype, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+    ref_grad_output = utils.to_reference(grad_output).to(torch.float32)
+    ref_out = torch.ops.aten.replication_pad3d_backward(
+        ref_grad_output, ref_inp, (2, 3, 1, 3, 1, 2)
+    ).to(dtype)
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.replication_pad3d_backward(
+            grad_output, inp, (2, 3, 1, 3, 1, 2)
+        )
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, atol=2e-2)
+
+
+@pytest.mark.replication_pad3d_backward
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_replication_pad3d_backward_asymmetric_all_axes(dtype):
+    """Independently asymmetric padding on D, H, and W."""
+    inp = torch.randn((1, 2, 3, 4, 5), dtype=dtype, device=flag_gems.device)
+    grad_output = torch.randn(
+        (1, 2, 3 + 1 + 2, 4 + 2 + 3, 5 + 0 + 4),
+        dtype=dtype,
+        device=flag_gems.device,
+    )
+
+    ref_inp = utils.to_reference(inp).to(torch.float32)
+    ref_grad_output = utils.to_reference(grad_output).to(torch.float32)
+    ref_out = torch.ops.aten.replication_pad3d_backward(
+        ref_grad_output, ref_inp, (0, 4, 2, 3, 1, 2)
+    ).to(dtype)
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.replication_pad3d_backward(
+            grad_output, inp, (0, 4, 2, 3, 1, 2)
+        )
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True, atol=2e-2)
+
+
+@pytest.mark.replication_pad3d_backward
+def test_replication_pad3d_backward_invalid_padding_length():
+    inp = torch.randn((1, 2, 4, 4, 4), device=flag_gems.device)
+    grad_output = torch.randn((1, 2, 5, 5, 5), device=flag_gems.device)
+    with flag_gems.use_gems(), pytest.raises(ValueError, match="length 6"):
+        flag_gems.replication_pad3d_backward(grad_output, inp, (1, 1, 1, 1))
+
+
+@pytest.mark.replication_pad3d_backward
+def test_replication_pad3d_backward_negative_padding():
+    inp = torch.randn((1, 2, 4, 4, 4), device=flag_gems.device)
+    grad_output = torch.randn((1, 2, 5, 5, 5), device=flag_gems.device)
+    with flag_gems.use_gems(), pytest.raises(ValueError, match=">= 0"):
+        flag_gems.replication_pad3d_backward(grad_output, inp, (-1, 1, 0, 0, 0, 0))


### PR DESCRIPTION
…kward operator

Adds a Triton implementation of `aten::replication_pad3d_backward` (and its `.grad_input` variant).

For 3-D replication padding, the forward maps each output position (z, y, x) to the input position (clamp(z - pad_front, 0, D_in - 1), clamp(y - pad_top, 0, H_in - 1), clamp(x - pad_left, 0, W_in - 1)). The backward needs to accumulate `grad_output[z, y, x]` into the clamped input voxel -- a scatter-add over the D, H, W dimensions. The kernel does this with a single `tl.atomic_add` launch accumulating in float32 for cross-dtype safety. The launch grid is (B, D_out * H_out, ceil(W_out/256)) so each program handles one (D, H) row's tile of W output positions.

Test coverage (118 cases, all green):

* Main matrix: 6 shape variants (incl. (C, D, H, W) unbatched, (1, 1, 1, 1, 1) minimal, large (2, 8, 4, 8, 8) batched) x 6 padding combos (incl. axis-only (1,1,0,0,0,0)/(0,0,1,1,0,0)/(0,0,0,0,1,1), symmetric (1,1,1,1,1,1), asymmetric (2,1,0,2,3,1), and (0)x6) x 3 dtypes (fp16/fp32/bf16).
* `grad_input` variant write-in-place semantics.
* (0)x6 padding identity path.
* (1,1,1) single-voxel input -- all output sums into the same input cell.
* Asymmetric padding on all three axes (D, H, W) independently.
* Negative padding -> ValueError.
* Wrong-length padding sequence -> ValueError.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
