### PR TITLE
[FlagGems Operator Development Competition] Add fmax operator

### DIFF
--- a/benchmark/test_fmax.py
+++ b/benchmark/test_fmax.py
@@ -1,0 +1,32 @@
+import pytest
+import torch
+
+from . import base, consts
+
+
+@pytest.mark.fmax
+def test_fmax():
+    bench = base.BinaryPointwiseBenchmark(
+        op_name="fmax",
+        torch_op=torch.fmax,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()
+
+
+def fmax_out_input_fn(shape, dtype, device):
+    inp1 = torch.randn(shape, dtype=dtype, device=device)
+    inp2 = torch.randn(shape, dtype=dtype, device=device)
+    out = torch.empty(shape, dtype=dtype, device=device)
+    yield inp1, inp2, {"out": out}
+
+
+@pytest.mark.fmax_out
+def test_fmax_out():
+    bench = base.GenericBenchmark(
+        op_name="fmax_out",
+        torch_op=torch.fmax,
+        input_fn=fmax_out_input_fn,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -2412,6 +2412,31 @@ ops:
       - Math
     stages:
       - stable: '2.2'
+  - id: fmax
+    description: |
+      Computes the element-wise maximum of two tensors with IEEE-754 NaN handling:
+      if one input is NaN and the other is a number, `fmax()` returns the number.
+      Both NaN inputs propagate NaN. Supports broadcasting and type promotion.
+    for:
+      - fmax
+    labels:
+      - aten
+      - pointwise
+    kind:
+      - Math
+    stages:
+      - beta: '5.0'
+  - id: fmax_out
+    description: A variant of `fmax()` that writes its result into a pre-allocated `out` tensor.
+    for:
+      - fmax.out
+    labels:
+      - aten
+      - pointwise
+    kind:
+      - Math
+    stages:
+      - beta: '5.0'
   - id: fmin
     description: |
       Computes the element-wise minimum of two tensors, specially handling NaN values

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -249,6 +249,8 @@ _FULL_CONFIG = (
     ("floor_divide.Scalar", floor_divide),
     ("floor_divide_.Scalar", floor_divide_),
     ("floor_divide_.Tensor", floor_divide_),
+    ("fmax", fmax),
+    ("fmax.out", fmax_out),
     ("fmin", fmin),
     ("fmin.out", fmin_out),
     ("fmod.Scalar", fmod_scalar),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -141,6 +141,7 @@ from flag_gems.ops.fill import (
 from flag_gems.ops.flip import flip
 from flag_gems.ops.floor import floor, floor_out
 from flag_gems.ops.floor_ import floor_
+from flag_gems.ops.fmax import fmax, fmax_out
 from flag_gems.ops.fmin import fmin, fmin_out
 from flag_gems.ops.fmod import fmod_scalar, fmod_scalar_, fmod_tensor, fmod_tensor_
 from flag_gems.ops.fp8_matmul import fp8_matmul
@@ -577,6 +578,8 @@ __all__ = [
     "floor_out",
     "floor_divide",
     "floor_divide_",
+    "fmax",
+    "fmax_out",
     "fmin",
     "fmin_out",
     "fmod_scalar",

--- a/src/flag_gems/ops/fmax.py
+++ b/src/flag_gems/ops/fmax.py
@@ -1,0 +1,42 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(__name__)
+
+
+# fmax(x, y) returns the element-wise maximum with IEEE NaN handling:
+#   * If exactly one input is NaN, return the other (non-NaN) value.
+#   * If both inputs are NaN, return NaN.
+# This is in contrast to torch.maximum which propagates NaN if *either* input
+# is NaN. We compute in float32 for fp16/bf16 to ensure comparisons remain
+# well-defined; pointwise_dynamic handles the final type promotion.
+@pointwise_dynamic(is_tensor=[True, True], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def fmax_func(x, y):
+    x_f32 = x.to(tl.float32)
+    y_f32 = y.to(tl.float32)
+    x_nan = x_f32 != x_f32
+    y_nan = y_f32 != y_f32
+    both_nan = x_nan & y_nan
+    # tl.maximum on NaN inputs is implementation-defined; choose explicitly.
+    base = tl.where(x_f32 > y_f32, x_f32, y_f32)
+    # Override one-sided NaN cases.
+    base = tl.where(x_nan, y_f32, base)
+    base = tl.where(y_nan, x_f32, base)
+    base = tl.where(both_nan, float("nan"), base)
+    return base
+
+
+def fmax(self, other):
+    logger.debug("GEMS FMAX")
+    return fmax_func(self, other)
+
+
+def fmax_out(self, other, out):
+    logger.debug("GEMS FMAX_OUT")
+    fmax_func(self, other, out0=out)
+    return out

--- a/tests/test_fmax.py
+++ b/tests/test_fmax.py
@@ -1,0 +1,91 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+
+
+@pytest.mark.fmax
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_fmax(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    y = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = utils.to_reference(x, True)
+    ref_y = utils.to_reference(y, True)
+    ref_out = torch.fmax(ref_x, ref_y)
+
+    with flag_gems.use_gems():
+        res_out = torch.fmax(x, y)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.fmax
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_fmax_with_nan(shape, dtype):
+    # Inject NaNs into both tensors to exercise the asymmetric NaN handling:
+    # if exactly one input is NaN, fmax returns the other; both NaN -> NaN.
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    y = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    if x.numel() >= 4:
+        x_flat = x.flatten()
+        y_flat = y.flatten()
+        x_flat[0] = float("nan")
+        y_flat[1] = float("nan")
+        x_flat[2] = float("nan")
+        y_flat[2] = float("nan")
+
+    ref_x = utils.to_reference(x, True)
+    ref_y = utils.to_reference(y, True)
+    ref_out = torch.fmax(ref_x, ref_y)
+
+    with flag_gems.use_gems():
+        res_out = torch.fmax(x, y)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True)
+
+
+@pytest.mark.fmax
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_fmax_broadcast(shape, dtype):
+    if len(shape) < 2:
+        pytest.skip("broadcast variant needs >=2D shapes")
+    x_shape = list(shape)
+    y_shape = list(shape)
+    y_shape[0] = 1
+
+    x = torch.randn(x_shape, dtype=dtype, device=flag_gems.device)
+    y = torch.randn(y_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = utils.to_reference(x, True)
+    ref_y = utils.to_reference(y, True)
+    ref_out = torch.fmax(ref_x, ref_y)
+
+    with flag_gems.use_gems():
+        res_out = torch.fmax(x, y)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.fmax
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_fmax_out(shape, dtype):
+    x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    y = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+
+    ref_x = utils.to_reference(x, True)
+    ref_y = utils.to_reference(y, True)
+    ref_out_buf = torch.empty(shape, dtype=ref_x.dtype, device=ref_x.device)
+    ref_out = torch.ops.aten.fmax.out(ref_x, ref_y, out=ref_out_buf)
+
+    res_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
+    with flag_gems.use_gems():
+        res_out = torch.ops.aten.fmax.out(x, y, out=res_out_buf)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)


### PR DESCRIPTION
## Summary

Implement `fmax` operator for the FlagGems Operator Development Competition.

`fmax(x, y)` is the element-wise maximum with **IEEE-754 NaN handling**: if exactly one input is NaN, return the other (non-NaN) value; if both inputs are NaN, return NaN. This is the asymmetric counterpart to `torch.maximum`, which propagates NaN if either input is NaN. The new op mirrors the structure of the existing `fmin` implementation.

## Implementation

- Kernel: `@pointwise_dynamic` decorator for automatic type promotion, broadcasting, and non-contiguous tensor support.
- Computation is performed in float32 even for fp16/bf16 inputs to ensure comparisons remain well-defined under reduced precision.
- One-sided NaN cases are handled explicitly with `tl.where` overrides (since `tl.maximum` on NaN inputs is implementation-defined).

## Files Added

- `src/flag_gems/ops/fmax.py` — operator implementation
- `tests/test_fmax.py` — accuracy tests
- `benchmark/test_fmax.py` — performance benchmark

## Files Modified

- `src/flag_gems/ops/__init__.py` — import + `__all__`
- `src/flag_gems/__init__.py` — `aten` dispatch table (`fmax`, `fmax.out`)
- `conf/operators.yaml` — operator inventory entries

## Testing

- `float32` / `float16` / `bfloat16` dtypes
- `POINTWISE_SHAPES` shape coverage (small, regular, large)
- Broadcast variant (single-axis expansion)
- `out=` variant via `torch.ops.aten.fmax.out`
- Explicit NaN corner cases: `fmax(NaN, x) = x`, `fmax(x, NaN) = x`, `fmax(NaN, NaN) = NaN`

All cases verified numerically against the upcast reference under the FlagGems tolerance.

---

FlagGems Operator Development Competition
