### PR TITLE
Prefer Triton over FlagTree on Iluvatar

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,7 +75,8 @@ iluvatar = [
     "torch==2.7.1+corex.4.4.0",
     "torchaudio==2.7.1+corex.4.4.0",
     "torchvision==0.22.1+corex.4.4.0",
-    "flagtree==0.5.1+iluvatar3.1"
+    "triton==3.1.0+corex.4.4.0",
+    # "flagtree==0.5.1+iluvatar3.1"
 ]
 
 kunlunxin = [

--- a/tools/setup_vendor.sh
+++ b/tools/setup_vendor.sh
@@ -65,14 +65,14 @@ case $VENDOR in
         "torch==2.7.1+corex.4.4.0" \
         "torchaudio==2.7.1+corex.4.4.0" \
         "torchvision==0.22.1+corex.4.4.0" \
-        "flagtree==0.5.1+iluvatar3.1"
-
-    # Replace flagtree by Triton if requested
-    if [ -n "${USE_TRITON}" ]; then
-      uv pip uninstall flagtree
-      uv pip install --index $FLAGOS_PYPI \
         "triton==3.1.0+corex.4.4.0"
-    fi
+
+    # Replace Triton by FlagTree when FlagTree doesn't coredump
+    # if [ -z "${USE_TRITON}" ]; then
+    #   uv pip uninstall triton
+    #   uv pip install --index $FLAGOS_PYPI \
+    #     "flagtree==0.5.1+iluvatar3.1"
+    # fi
 
     uv pip install -e .
     uv pip install ".[test]"


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

FlagTree cannot run on Ubuntu 20.04 because the gcc/g++/libstdc++ verisons cannot match its requirement. We only get 20.04 nodes for CI. Manually upgrade gcc-toolchain and glibc was a success. However, during runtime, we still get either `.so` not found or core dump.

We have to switch back to Triton for CI's purpose.