### PR TITLE
Fix environment setting for iluvatar backend

### DIFF
--- a/tools/set-env.sh
+++ b/tools/set-env.sh
@@ -15,7 +15,9 @@ case $VENDOR in
     echo "PATH=$PATH"
     ;;
   iluvatar)
-    export LD_LIBRARY_PATH=/usr/local/corex/lib:$LD_LIBRARY_PATH
+    export COREX_ROOT=/usr/local/corex
+    export PATH=$COREX_ROOT/bin:$PATH
+    export LD_LIBRARY_PATH=$COREX_ROOT/lib:$LD_LIBRARY_PATH
     ;;
   kunlunxin)
     export LD_LIBRARY_PATH=/xcudart/lib:/usr/local/cuda/lib64


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The corex/iluvatar nodes have been refreshed recently. The environment settings are no longer defaulted. This PR adds PATH and LD_LIBRARY_PATH manually.