### PR TITLE
Fix parameters used for benchmarking kunlunxin

### DIFF
--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -590,6 +590,8 @@ def run_benchmark_q(gpu_id, op):
 
     dur = time.time()
     cmd = f'pytest -m "{op}" --level core --record json --output benchmark_{op}.json'
+    if ENV_INFO["flag_gems"]["vendor"] == "kunlunxin":
+        cmd += " --fg_mode operator"
     code = run_cmd(op, cmd, cwd=benchmark_dir, env=env, flavor="performance")
     dur = time.time() - dur
 


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

The benchmark timing code is `triton.testing.do_bench`, which uses `torch.cuda.Event` internally. Kunlunxin's CUDA compatibility layer apparently doesn't support event timing.
This PR fixes the problem by using OPERATOR mode instead — it uses `time.time()` with `torch_device_fn.synchronize()`, which works on any backend.

A follow-up may be needed for all other backends. This patch is only a workaround for unblocking batch testing on Kunlunxin backend.