### PR TITLE
Standardize Iluvatar backend debug log format

### DIFF
--- a/src/flag_gems/runtime/backend/_iluvatar/ops/div.py
+++ b/src/flag_gems/runtime/backend/_iluvatar/ops/div.py
@@ -33,7 +33,7 @@ def true_div_func_scalar_tensor(x, y):
 
 
 def true_divide(A, B):
-    logger.debug("GEMS TRUE_DIVIDE")
+    logger.debug("GEMS_ILUVATAR TRUE_DIVIDE")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return true_div_func(A, B)
     elif isinstance(A, torch.Tensor):
@@ -46,7 +46,7 @@ def true_divide(A, B):
 
 
 def true_divide_(A, B):
-    logger.debug("GEMS TRUE_DIVIDE_")
+    logger.debug("GEMS_ILUVATAR TRUE_DIVIDE_")
     if isinstance(B, torch.Tensor):
         return true_div_func(A, B, out0=A)
     else:
@@ -91,7 +91,7 @@ def trunc_div_int_func_scalar_tensor(x, y):
 
 
 def trunc_divide(A, B):
-    logger.debug("GEMS TRUNC_DIVIDE")
+    logger.debug("GEMS_ILUVATAR TRUNC_DIVIDE")
     # Integer types: use dedicated int kernels (Triton // is C-style truncation)
     if isinstance(A, torch.Tensor) and not A.is_floating_point():
         if isinstance(B, torch.Tensor):
@@ -112,7 +112,7 @@ def trunc_divide(A, B):
 
 
 def trunc_divide_(A, B):
-    logger.debug("GEMS TRUNC_DIVIDE_")
+    logger.debug("GEMS_ILUVATAR TRUNC_DIVIDE_")
     # Integer types: use dedicated int kernels (Triton // is C-style truncation)
     if not A.is_floating_point():
         if isinstance(B, torch.Tensor):
@@ -206,7 +206,7 @@ def floor_div_func_scalar_tensor(x, y):
 
 
 def floor_divide(A, B):
-    logger.debug("GEMS FLOOR_DIVIDE")
+    logger.debug("GEMS_ILUVATAR FLOOR_DIVIDE")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return floor_div_func(A, B)
     elif isinstance(A, torch.Tensor):
@@ -219,7 +219,7 @@ def floor_divide(A, B):
 
 
 def floor_divide_(A, B):
-    logger.debug("GEMS FLOOR_DIVIDE_")
+    logger.debug("GEMS_ILUVATAR FLOOR_DIVIDE_")
     if isinstance(B, torch.Tensor):
         return floor_div_func(A, B, out0=A)
     else:
@@ -277,7 +277,7 @@ def rem_st(x, y):
 
 
 def remainder(A, B):
-    logger.debug("GEMS FLOOR_DIVIDE")
+    logger.debug("GEMS_ILUVATAR REMAINDER")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return rem_tt(A, B)
     elif isinstance(A, torch.Tensor):
@@ -290,7 +290,7 @@ def remainder(A, B):
 
 
 def remainder_(A, B):
-    logger.debug("GEMS REMAINDER_")
+    logger.debug("GEMS_ILUVATAR REMAINDER_")
     if isinstance(B, torch.Tensor):
         return rem_tt(A, B, out0=A)
     else:


### PR DESCRIPTION
## Summary
Unify Iluvatar backend debug log format to match the standard pattern GEMS_VENDOR OP_NAME used by other backends (Ascend, Kunlunxin, Cambricon, Mthreads).

## Changes
- GEMS TRUE_DIVIDE -> GEMS_ILUVATAR TRUE_DIVIDE
- GEMS TRUE_DIVIDE_ -> GEMS_ILUVATAR TRUE_DIVIDE_
- GEMS TRUNC_DIVIDE -> GEMS_ILUVATAR TRUNC_DIVIDE
- GEMS TRUNC_DIVIDE_ -> GEMS_ILUVATAR TRUNC_DIVIDE_
- GEMS FLOOR_DIVIDE -> GEMS_ILUVATAR FLOOR_DIVIDE
- GEMS FLOOR_DIVIDE_ -> GEMS_ILUVATAR FLOOR_DIVIDE_
- GEMS REMAINDER_ -> GEMS_ILUVATAR REMAINDER_

## Bug Fix
- Fixed remainder() function which was incorrectly logging FLOOR_DIVIDE instead of REMAINDER

## Motivation
Before this change, Iluvatar backend logs lacked the vendor identifier, making it difficult to distinguish which backend was being used when debugging. This standardization improves log clarity and consistency across all non-NVIDIA backends.