### PR TITLE
Standardize MetaX backend debug log format

### DIFF
--- a/src/flag_gems/runtime/backend/_metax/ops/addmm.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/addmm.py
@@ -92,7 +92,7 @@ def addmm_kernel(
 
 
 def addmm(bias, mat1, mat2, *, beta=1, alpha=1):
-    logger.debug("METAX GEMS ADDMM")
+    logger.debug("GEMS_METAX ADDMM")
     assert mat1.shape[1] == mat2.shape[0], "Incompatible dimensions"
     assert broadcastable_to(
         bias.shape, (mat1.shape[0], mat2.shape[1])

--- a/src/flag_gems/runtime/backend/_metax/ops/amax.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/amax.py
@@ -80,7 +80,7 @@ def amax_kernel(
 
 
 def amax(inp, dim=None, keepdim=False):
-    logger.debug("METAX GEMS AMAX")
+    logger.debug("GEMS_METAX AMAX")
     if dim is None or len(dim) == 0:
         M = inp.numel()
         block_size = triton.next_power_of_2(math.ceil(math.sqrt(M)))

--- a/src/flag_gems/runtime/backend/_metax/ops/arange.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/arange.py
@@ -27,7 +27,7 @@ def arange_func(y_ptr, start, end, step, size, BLOCK_SIZE: tl.constexpr):
 def arange_start(
     start, end, step=1, *, dtype=None, layout=None, device=None, pin_memory=None
 ):
-    logger.debug("METAX GEMS ARANGE")
+    logger.debug("GEMS_METAX ARANGE")
     if dtype is torch.int64:
         sgn = (step > 0) - (step < 0)
         size = (end - start + step - sgn) // step

--- a/src/flag_gems/runtime/backend/_metax/ops/bmm.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/bmm.py
@@ -137,7 +137,7 @@ def bmm_kernel(
 
 
 def bmm(A, B):
-    logger.debug("METAX GEMS BMM")
+    logger.debug("GEMS_METAX BMM")
     batch, M, K = A.shape
     _, _, N = B.shape
     logger.debug(

--- a/src/flag_gems/runtime/backend/_metax/ops/exponential_.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/exponential_.py
@@ -226,7 +226,7 @@ def transform_exponential_bfloat16(u):
 
 
 def exponential_(x, lambd: float = 1.0, *, generator=None):
-    logger.debug("METAX GEMS EXPONENTIAL_")
+    logger.debug("GEMS_METAX EXPONENTIAL_")
     dtype = x.dtype
     device = x.device
     inplace = x.is_contiguous()

--- a/src/flag_gems/runtime/backend/_metax/ops/full.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/full.py
@@ -110,7 +110,7 @@ def full_(out, N, dtype, device, fill_value):
 
 
 def full(size, fill_value, *, dtype=None, layout=None, device=None, pin_memory=None):
-    logger.debug("METAX GEMS FULL")
+    logger.debug("GEMS_METAX FULL")
     if device is None:
         device = torch.device("cpu")
     if dtype is None:

--- a/src/flag_gems/runtime/backend/_metax/ops/full_like.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/full_like.py
@@ -17,7 +17,7 @@ def full_like(
     pin_memory=None,
     memory_format=None,
 ):
-    logger.debug("METAX GEMS FULL_LIKE")
+    logger.debug("GEMS_METAX FULL_LIKE")
     if device is None:
         device = x.device
     if dtype is None:

--- a/src/flag_gems/runtime/backend/_metax/ops/groupnorm.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/groupnorm.py
@@ -178,7 +178,7 @@ def weight_bias_backward_kernel(
 class GroupNorm(torch.autograd.Function):
     @staticmethod
     def forward(ctx, x, N, C, HW, num_groups, weight=None, bias=None, eps=1e-05):
-        logger.debug("METAX GEMS GROUPNORM FORWARD")
+        logger.debug("GEMS_METAX GROUPNORM FORWARD")
         group_size = C // num_groups
         x = x.contiguous()
         if weight is not None:
@@ -217,7 +217,7 @@ class GroupNorm(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, y_grad, mean_grad, rstd_grad):
-        logger.debug("METAX GEMS GROUPNORM BACKWARD")
+        logger.debug("GEMS_METAX GROUPNORM BACKWARD")
         y_grad = y_grad.contiguous()
         (x, weight, bias, mean, rstd) = ctx.saved_tensors
         num_groups = ctx.num_groups

--- a/src/flag_gems/runtime/backend/_metax/ops/index.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/index.py
@@ -262,7 +262,7 @@ _index_func = IndexFunction()
 
 
 def index(inp, indices):
-    logger.debug("GEMS INDEX")
+    logger.debug("GEMS_METAX INDEX")
     original_indices = list(indices)  # Save original indices for later checks
     indices = list(indices)
 

--- a/src/flag_gems/runtime/backend/_metax/ops/index_put.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/index_put.py
@@ -264,7 +264,7 @@ _index_put_func = IndexPutFunction()
 
 
 def index_put(inp, indices, values, accumulate=False):
-    logger.debug("GEMS INDEX PUT")
+    logger.debug("GEMS_METAX INDEX PUT")
 
     indices = list(indices)
     if len(indices) == 1 and indices[0].dtype == torch.bool:
@@ -311,7 +311,7 @@ def index_put(inp, indices, values, accumulate=False):
 
 
 def index_put_(inp, indices, values, accumulate=False):
-    logger.debug("GEMS INDEX PUT_")
+    logger.debug("GEMS_METAX INDEX PUT_")
 
     indices = list(indices)
     if len(indices) == 1 and indices[0].dtype == torch.bool:

--- a/src/flag_gems/runtime/backend/_metax/ops/index_select.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/index_select.py
@@ -57,7 +57,7 @@ def dim_transpose(inp):
 
 
 def index_select(inp, dim, index):
-    logger.debug("METAX GEMS INDEX SELECT")
+    logger.debug("GEMS_METAX INDEX SELECT")
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
     assert index.ndim <= 1, "Index should have dimension 1 or 0"
     assert ((i >= 0 and i < inp.size(dim)) for i in index), "Index out of range"

--- a/src/flag_gems/runtime/backend/_metax/ops/log_softmax.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/log_softmax.py
@@ -113,7 +113,7 @@ def log_softmax_backward_kernel(
 
 
 def log_softmax(self, dim, half_to_float=False):
-    logger.debug("METAX GEMS LOG_SOFTMAX")
+    logger.debug("GEMS_METAX LOG_SOFTMAX")
 
     assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
     dim = dim % self.ndim
@@ -147,7 +147,7 @@ def log_softmax(self, dim, half_to_float=False):
 
 
 def log_softmax_backward(grad_output, output, dim, input_dtype):
-    logger.debug("METAX GEMS LOG_SOFTMAX VJP")
+    logger.debug("GEMS_METAX LOG_SOFTMAX VJP")
 
     assert dim >= -output.ndim and dim < output.ndim, "Invalid dim"
     dim = dim % output.ndim

--- a/src/flag_gems/runtime/backend/_metax/ops/masked_fill.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/masked_fill.py
@@ -38,7 +38,7 @@ def masked_fill_kernel_self(inp, expand_mask, value, N, BLOCK_SIZE: tl.constexpr
 
 
 def masked_fill(inp, mask, value):
-    logger.debug("METAX GEMS MASKED FILL")
+    logger.debug("GEMS_METAX MASKED FILL")
     assert (
         (torch.is_tensor(value) and value.ndim == 0)
         or isinstance(value, int)
@@ -73,7 +73,7 @@ def masked_fill(inp, mask, value):
 
 
 def masked_fill_(inp, mask, value):
-    logger.debug("METAX GEMS MASKED FILL")
+    logger.debug("GEMS_METAX MASKED FILL")
     assert (
         (torch.is_tensor(value) and value.ndim == 0)
         or isinstance(value, int)

--- a/src/flag_gems/runtime/backend/_metax/ops/min.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/min.py
@@ -107,7 +107,7 @@ def min_kernel(
 
 
 def min(inp):
-    logger.debug("METAX GEMS MIN")
+    logger.debug("GEMS_METAX MIN")
     M = inp.numel()
     block_size = triton.next_power_of_2(math.ceil(math.sqrt(M)))
     mid_size = triton.cdiv(M, block_size)
@@ -124,7 +124,7 @@ def min(inp):
 
 
 def min_dim(inp, dim=None, keepdim=False):
-    logger.debug("METAX GEMS MIN DIM")
+    logger.debug("GEMS_METAX MIN DIM")
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
     shape = inp.shape
     dim = dim % inp.ndim

--- a/src/flag_gems/runtime/backend/_metax/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/mm.py
@@ -156,7 +156,7 @@ def get_higher_dtype(a, b):
 
 
 def mm(a, b):
-    logger.debug("METAX GEMS MM")
+    logger.debug("GEMS_METAX MM")
     device = a.device
     # handle non-contiguous inputs if necessary
     if a.stride(0) > 1 and a.stride(1) > 1:
@@ -206,7 +206,7 @@ def mm(a, b):
 
 
 def mm_out(a, b, *, out):
-    logger.debug("METAX GEMS MM_OUT")
+    logger.debug("GEMS_METAX MM_OUT")
     # handle non-contiguous inputs if necessary
     if a.stride(0) > 1 and a.stride(1) > 1:
         a = a.contiguous()

--- a/src/flag_gems/runtime/backend/_metax/ops/nonzero.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/nonzero.py
@@ -181,7 +181,7 @@ _nonzero_func = NonzeroFunction()
 
 
 def nonzero(inp, *, as_tuple=False):
-    logger.debug("METAX GEMS NONZERO")
+    logger.debug("GEMS_METAX NONZERO")
 
     assert len(inp.shape) > 0, "Invalid input shape, input dimension must > 0"
     inp_ndim = inp.ndim

--- a/src/flag_gems/runtime/backend/_metax/ops/ones.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/ones.py
@@ -30,7 +30,7 @@ def ones_kernel(
 
 
 def ones(size, *, dtype=None, layout=None, device=None, pin_memory=None):
-    logger.debug("METAX GEMS ONES")
+    logger.debug("GEMS_METAX ONES")
     if dtype is None:
         dtype = torch.get_default_dtype()
     if device is None:

--- a/src/flag_gems/runtime/backend/_metax/ops/ones_like.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/ones_like.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("flag_gems." + __name__)
 def ones_like(
     x, *, dtype=None, layout=None, device=None, pin_memory=None, memory_format=None
 ):
-    logger.debug("METAX GEMS ONES_LIKE")
+    logger.debug("GEMS_METAX ONES_LIKE")
     if device is None:
         device = x.device
     if dtype is None:

--- a/src/flag_gems/runtime/backend/_metax/ops/outer.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/outer.py
@@ -69,7 +69,7 @@ def mul(inp, weight):
 class Outer(torch.autograd.Function):
     @staticmethod
     def forward(ctx, inp, weight):
-        logger.debug("METAX GEMS OUTER")
+        logger.debug("GEMS_METAX OUTER")
         assert inp.ndim == 1 and weight.ndim == 1, "Invalid input"
         inp1 = inp[:, None]
         weight1 = weight[None, :]
@@ -81,7 +81,7 @@ class Outer(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, out_grad):
-        logger.debug("METAX GEMS OUTER VJP")
+        logger.debug("GEMS_METAX OUTER VJP")
         assert out_grad.ndim == 2, "invalide out_grad shape"
 
         inp, weight = ctx.saved_tensors

--- a/src/flag_gems/runtime/backend/_metax/ops/polar.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/polar.py
@@ -39,7 +39,7 @@ def polar_kernel_kernel(
 
 
 def polar(abs, angle):
-    logger.debug("METAX GEMS polar")
+    logger.debug("GEMS_METAX polar")
     output = torch.empty((*abs.shape, 2), dtype=abs.dtype, device=abs.device)
     n_input = abs.numel()
     n_output = output.numel()

--- a/src/flag_gems/runtime/backend/_metax/ops/prod.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/prod.py
@@ -48,7 +48,7 @@ def prod_kernel_result(mid, out, mid_size, BLOCK_MID: tl.constexpr):
 
 
 def prod(inp, *, dtype=None):
-    logger.debug("METAX GEMS PROD")
+    logger.debug("GEMS_METAX PROD")
     if dtype is None:
         dtype = inp.dtype
 
@@ -117,7 +117,7 @@ def prod_kernel(
 
 
 def prod_dim(inp, dim=None, keepdim=False, *, dtype=None):
-    logger.debug("METAX GEMS PROD DIM")
+    logger.debug("GEMS_METAX PROD DIM")
 
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
     shape = inp.shape

--- a/src/flag_gems/runtime/backend/_metax/ops/repeat_interleave.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/repeat_interleave.py
@@ -19,7 +19,7 @@ def copy_func(x):
 
 
 def repeat_interleave_self_int(inp, repeats, dim=None, *, output_size=None):
-    logger.debug("METAX GEMS REPEAT_INTERLEAVE_SELF_INT")
+    logger.debug("GEMS_METAX REPEAT_INTERLEAVE_SELF_INT")
     if dim is None:
         inp = inp.flatten()
         dim = 0
@@ -107,7 +107,7 @@ def fused_repeat_and_index_select_kernel(
 
 
 def repeat_interleave_tensor(repeats, *, output_size=None):
-    logger.debug("METAX GEMS REPEAT_INTERLEAVE_TENSOR")
+    logger.debug("GEMS_METAX REPEAT_INTERLEAVE_TENSOR")
 
     assert repeats.ndim == 1, "repeat_interleave only accept 1D vector as repeat"
 
@@ -133,7 +133,7 @@ def repeat_interleave_tensor(repeats, *, output_size=None):
 
 
 def fused_repeat_and_index_select(inp, repeats, dim):
-    logger.debug("METAX GEMS FUSED_REPEAT_AND_INDEX_SELECT")
+    logger.debug("GEMS_METAX FUSED_REPEAT_AND_INDEX_SELECT")
 
     assert repeats.ndim == 1, "repeat_interleave only accept 1D vector as repeat"
 
@@ -157,7 +157,7 @@ def fused_repeat_and_index_select(inp, repeats, dim):
 
 
 def repeat_interleave_self_tensor(inp, repeats, dim=None, *, output_size=None):
-    logger.debug("METAX GEMS REPEAT_INTERLEAVE_SELF_TENSOR")
+    logger.debug("GEMS_METAX REPEAT_INTERLEAVE_SELF_TENSOR")
 
     if dim is None:
         inp = inp.flatten()

--- a/src/flag_gems/runtime/backend/_metax/ops/resolve_conj.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/resolve_conj.py
@@ -8,5 +8,5 @@ logger = logging.getLogger("flag_gems." + __name__)
 
 
 def resolve_conj(A: torch.Tensor):
-    logger.debug("METAX GEMS RESOLVE_CONJ")
+    logger.debug("GEMS_METAX RESOLVE_CONJ")
     return torch.complex(A.real, neg_func(A.imag)) if A.is_conj() else A

--- a/src/flag_gems/runtime/backend/_metax/ops/sigmoid.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/sigmoid.py
@@ -71,7 +71,7 @@ def sigmoid_backward_custom(x: torch.Tensor, y: torch.Tensor):
 class Sigmoid(torch.autograd.Function):
     @staticmethod
     def forward(ctx, A):
-        logger.debug("METAX GEMS SIGMOID FORWARD")
+        logger.debug("GEMS_METAX SIGMOID FORWARD")
         if A.requires_grad is True:
             out = sigmoid_forward(A.to(torch.float32))
             ctx.save_for_backward(out)
@@ -82,7 +82,7 @@ class Sigmoid(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, out_grad):
-        logger.debug("METAX GEMS SIGMOID BACKWARD")
+        logger.debug("GEMS_METAX SIGMOID BACKWARD")
         (out,) = ctx.saved_tensors
 
         is_grad_stride_0 = True

--- a/src/flag_gems/runtime/backend/_metax/ops/tanh.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/tanh.py
@@ -66,7 +66,7 @@ def tanh_backward_custom(x: torch.Tensor, y: torch.Tensor):
 class Tanh(torch.autograd.Function):
     @staticmethod
     def forward(ctx, A):
-        logger.debug("METAX GEMS TANH FORWARD")
+        logger.debug("GEMS_METAX TANH FORWARD")
         if A.requires_grad is True:
             out = tanh_forward(A.to(torch.float32))
             ctx.save_for_backward(out)
@@ -77,7 +77,7 @@ class Tanh(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, out_grad):
-        logger.debug("METAX GEMS TANH BACKWARD")
+        logger.debug("GEMS_METAX TANH BACKWARD")
         (out,) = ctx.saved_tensors
 
         is_grad_stride_0 = True

--- a/src/flag_gems/runtime/backend/_metax/ops/upsample_nearest2d.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/upsample_nearest2d.py
@@ -64,7 +64,7 @@ def upsample_nearest2d(
     scales_h: Optional[float] = None,
     scales_w: Optional[float] = None,
 ) -> torch.Tensor:
-    logger.debug("METAX GEMS UPSAMPLE NEAREST2D")
+    logger.debug("GEMS_METAX UPSAMPLE NEAREST2D")
     assert input.device.type == device
     assert input.ndim == 4, "The ndim of input must be 4"
     assert len(output_size) == 2, "The len of output_size must be 2"

--- a/src/flag_gems/runtime/backend/_metax/ops/zeros.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/zeros.py
@@ -30,7 +30,7 @@ def zeros_kernel(
 
 
 def zeros(size, *, dtype=None, layout=None, device=None, pin_memory=None):
-    logger.debug("METAX GEMS ZEROS")
+    logger.debug("GEMS_METAX ZEROS")
     if dtype is None:
         dtype = torch.get_default_dtype()
     if device is None:

--- a/src/flag_gems/runtime/backend/_metax/ops/zeros_like.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/zeros_like.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("flag_gems." + __name__)
 def zeros_like(
     x, *, dtype=None, layout=None, device=None, pin_memory=None, memory_format=None
 ):
-    logger.debug("METAX GEMS ZEROS_LIKE")
+    logger.debug("GEMS_METAX ZEROS_LIKE")
     if device is None:
         device = x.device
     if dtype is None:


### PR DESCRIPTION
## Summary
Unify MetaX backend debug log format to match the standard pattern GEMS_VENDOR OP_NAME used by other backends.

## Changes
- METAX GEMS {OP_NAME} -> GEMS_METAX {OP_NAME} (39 occurrences)
- GEMS INDEX PUT -> GEMS_METAX INDEX PUT
- GEMS INDEX PUT_ -> GEMS_METAX INDEX PUT_

## Affected Files
28 operator implementations across MetaX backend including:
- addmm, amax, arange, bmm, exponential_
- full, full_like, groupnorm, index, index_put
- index_select, log_softmax, masked_fill, min, mm
- nonzero, ones, ones_like, outer, polar
- prod, repeat_interleave, resolve_conj, sigmoid
- tanh, upsample_nearest2d, zeros, zeros_like

## Motivation
Before this change, MetaX backend used inconsistent log format (METAX GEMS instead of GEMS_METAX), and some operators lacked the vendor identifier entirely. This standardization improves log clarity and consistency across all non-NVIDIA backends (Ascend, Kunlunxin, Cambricon, Mthreads, Iluvatar).