### PR TITLE
Skip the fused_marlin_moe accuracy test due to assertion failures

### DIFF
--- a/tests/test_fused_marlin_moe.py
+++ b/tests/test_fused_marlin_moe.py
@@ -386,6 +386,7 @@ def test_fused_marlin_moe_vs_ref(config, dtype):
     torch.testing.assert_close(result, ref, rtol=rtol, atol=atol)
 
 
+@pytest.mark.skip(reason="Issue #3733: assertion failure.")
 @pytest.mark.parametrize("config", QUICK_CONFIGS)
 @pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
 def test_fused_marlin_moe_vs_ref_int8(config, dtype):


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

The `fused_marlin_moe` operator is not stable. We have to skip it to unblock batch/daily tests. Issues have been filed (#3733).