### PR TITLE
Standardize Cambricon backend debug log format

### DIFF
--- a/src/flag_gems/runtime/backend/_cambricon/ops/elu.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/elu.py
@@ -58,7 +58,7 @@ def elu_(A, alpha=1.0, scale=1.0, input_scale=1.0):
 
 
 def elu_backward(grad_output, alpha, scale, input_scale, is_result, self_or_result):
-    logger.debug("GEMS_CAMBRICON ELU BACKWARD")
+    logger.debug("GEMS_CAMBRICON ELU_BACKWARD")
     if is_result:
         return elu_backward_kernel_with_result(
             grad_output, alpha, scale, input_scale, self_or_result

--- a/src/flag_gems/runtime/backend/_cambricon/ops/elu.py
+++ b/src/flag_gems/runtime/backend/_cambricon/ops/elu.py
@@ -58,7 +58,7 @@ def elu_(A, alpha=1.0, scale=1.0, input_scale=1.0):
 
 
 def elu_backward(grad_output, alpha, scale, input_scale, is_result, self_or_result):
-    logger.debug("GEMS ELU BACKWARD")
+    logger.debug("GEMS_CAMBRICON ELU BACKWARD")
     if is_result:
         return elu_backward_kernel_with_result(
             grad_output, alpha, scale, input_scale, self_or_result


### PR DESCRIPTION
## Summary
Fix one debug log in elu.py that was missing the vendor identifier.

## Changes
- GEMS ELU BACKWARD -> GEMS_CAMBRICON ELU BACKWARD

## Motivation
Standardize debug log format to GEMS_VENDOR OP_NAME pattern for consistency across all backends.