### PR TITLE
Standardize Mthreads backend debug log format

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/dropout.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/dropout.py
@@ -131,7 +131,7 @@ def dropout(input, p, train=True):
 
 
 def dropout_backward(grad_output, mask, scale):
-    logger.debug("GEMS_MTHREADS NATIVE DROPOUT BACKWARD")
+    logger.debug("GEMS_MTHREADS NATIVE_DROPOUT_BACKWARD")
     grad_output = grad_output.contiguous()
     grad_input = torch.empty_like(grad_output)
     N = grad_output.numel()

--- a/src/flag_gems/runtime/backend/_mthreads/ops/dropout.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/dropout.py
@@ -131,7 +131,7 @@ def dropout(input, p, train=True):
 
 
 def dropout_backward(grad_output, mask, scale):
-    logger.debug("GEMS NATIVE DROPOUT BACKWARD")
+    logger.debug("GEMS_MTHREADS NATIVE DROPOUT BACKWARD")
     grad_output = grad_output.contiguous()
     grad_input = torch.empty_like(grad_output)
     N = grad_output.numel()

--- a/src/flag_gems/runtime/backend/_mthreads/ops/tile.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/tile.py
@@ -346,7 +346,7 @@ def tile_kernel_nd_flat(
 
 
 def tile(inp: torch.Tensor, dims) -> torch.Tensor:
-    logger.debug("GEMS TILE")
+    logger.debug("GEMS_MTHREADS TILE")
     in0_rank = inp.dim()
     dims_rank = len(dims)
     in0_shape = list(inp.shape)


### PR DESCRIPTION
## Summary
Fix two debug logs missing the vendor identifier.

## Changes
- GEMS NATIVE DROPOUT BACKWARD -> GEMS_MTHREADS NATIVE DROPOUT BACKWARD
- GEMS TILE -> GEMS_MTHREADS TILE

## Motivation
Standardize debug log format to GEMS_VENDOR OP_NAME pattern for consistency across all backends.