### PR TITLE
Standardize Kunlunxin backend debug log format

### DIFF
--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/addmv.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/addmv.py
@@ -108,7 +108,7 @@ def addmv(self, mat, vec, *, beta=1, alpha=1):
 
 
 def addmv_out(self, mat, vec, *, beta=1, alpha=1, out=None):
-    logger.debug("GEMS_KUNLUNXIN ADDMV OUT")
+    logger.debug("GEMS_KUNLUNXIN ADDMV_OUT")
     assert mat.shape[1] == vec.shape[0], "incompatible dimensions"
     assert broadcastable_to(self.shape, (mat.shape[0],)), "Incompatible self shape"
     N, M = mat.shape

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/addr.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/addr.py
@@ -63,7 +63,7 @@ def addr_kernel(
 
 
 def addr(input, vec1, vec2, *, beta=1, alpha=1):
-    logger.debug("GEMS ADDR")
+    logger.debug("GEMS_KUNLUNXIN ADDR")
     if vec1.dim() != 1 or vec2.dim() != 1:
         raise ValueError("addr: expected 1-D vectors")
 

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/all.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/all.py
@@ -90,7 +90,7 @@ def all_kernel_dim(
 
 
 def all(inp):
-    logger.debug("GEMS ALL")
+    logger.debug("GEMS_KUNLUNXIN ALL")
     n_elements = inp.numel()
     # BLOCK_SIZE must fit in XPU per-core local buffer so the Triton fallback
     # kernel always compiles.  The C++ handler (api::all<T,bool>) ignores this
@@ -105,7 +105,7 @@ def all(inp):
 
 
 def all_dim(inp, dim=None, keepdim=False):
-    logger.debug("GEMS ALL DIM")
+    logger.debug("GEMS_KUNLUNXIN ALL DIM")
     shape = list(inp.shape)
     if dim is None:
         out = all(inp)
@@ -135,7 +135,7 @@ def all_dim(inp, dim=None, keepdim=False):
 
 
 def all_dims(inp, dim=None, keepdim=False):
-    logger.debug("GEMS ALL DIMS")
+    logger.debug("GEMS_KUNLUNXIN ALL DIMS")
 
     if dim is None or isinstance(dim, int):
         return all_dim(inp, dim=dim, keepdim=keepdim)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/all.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/all.py
@@ -105,7 +105,7 @@ def all(inp):
 
 
 def all_dim(inp, dim=None, keepdim=False):
-    logger.debug("GEMS_KUNLUNXIN ALL DIM")
+    logger.debug("GEMS_KUNLUNXIN ALL_DIM")
     shape = list(inp.shape)
     if dim is None:
         out = all(inp)
@@ -135,7 +135,7 @@ def all_dim(inp, dim=None, keepdim=False):
 
 
 def all_dims(inp, dim=None, keepdim=False):
-    logger.debug("GEMS_KUNLUNXIN ALL DIMS")
+    logger.debug("GEMS_KUNLUNXIN ALL_DIMS")
 
     if dim is None or isinstance(dim, int):
         return all_dim(inp, dim=dim, keepdim=keepdim)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/amax.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/amax.py
@@ -92,7 +92,7 @@ def amax_kernel(
 
 
 def amax(inp, dim=None, keepdim=False):
-    logger.debug("GEMS AMAX")
+    logger.debug("GEMS_KUNLUNXIN AMAX")
     if dim is None or len(dim) == 0:
         M = inp.numel()
         # block_size = triton.next_power_of_2(math.ceil(math.sqrt(M)))

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/any.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/any.py
@@ -183,7 +183,7 @@ def any(inp):
 
 
 def any_dim(inp, dim=None, keepdim=False):
-    logger.debug("GEMS_KUNLUNXIN ANY DIM")
+    logger.debug("GEMS_KUNLUNXIN ANY_DIM")
     shape = list(inp.shape)
     if dim is None:
         out = any(inp)
@@ -218,7 +218,7 @@ def any_dim(inp, dim=None, keepdim=False):
 
 
 def any_dims(inp, dim=None, keepdim=False):
-    logger.debug("GEMS_KUNLUNXIN ANY DIMS")
+    logger.debug("GEMS_KUNLUNXIN ANY_DIMS")
 
     if dim is None or isinstance(dim, int):
         return any_dim(inp, dim=dim, keepdim=keepdim)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/any.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/any.py
@@ -142,7 +142,7 @@ def any_kernel_2(mid, out, MID_SIZE, BLOCK_MID: tl.constexpr):
 
 
 def any(inp):
-    logger.debug("GEMS ANY")
+    logger.debug("GEMS_KUNLUNXIN ANY")
     n_elements = inp.numel()
     block_size = max(
         triton.cdiv(get_block(n_elements), cluster_num),
@@ -183,7 +183,7 @@ def any(inp):
 
 
 def any_dim(inp, dim=None, keepdim=False):
-    logger.debug("GEMS ANY DIM")
+    logger.debug("GEMS_KUNLUNXIN ANY DIM")
     shape = list(inp.shape)
     if dim is None:
         out = any(inp)
@@ -218,7 +218,7 @@ def any_dim(inp, dim=None, keepdim=False):
 
 
 def any_dims(inp, dim=None, keepdim=False):
-    logger.debug("GEMS ANY DIMS")
+    logger.debug("GEMS_KUNLUNXIN ANY DIMS")
 
     if dim is None or isinstance(dim, int):
         return any_dim(inp, dim=dim, keepdim=keepdim)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/apply_repetition_penalties.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/apply_repetition_penalties.py
@@ -45,7 +45,7 @@ def _repetition_penalty_kernel(
 
 
 def apply_repetition_penalties(logits, prompt_mask, output_mask, repetition_penalties):
-    logger.debug("GEMS APPLY REPETITION PENALTIES")
+    logger.debug("GEMS_KUNLUNXIN APPLY REPETITION PENALTIES")
     assert logits.is_contiguous(), "logits must be contiguous"
     assert (
         prompt_mask.is_contiguous() and prompt_mask.dtype == torch.bool

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/apply_repetition_penalties.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/apply_repetition_penalties.py
@@ -45,7 +45,7 @@ def _repetition_penalty_kernel(
 
 
 def apply_repetition_penalties(logits, prompt_mask, output_mask, repetition_penalties):
-    logger.debug("GEMS_KUNLUNXIN APPLY REPETITION PENALTIES")
+    logger.debug("GEMS_KUNLUNXIN APPLY_REPETITION_PENALTIES")
     assert logits.is_contiguous(), "logits must be contiguous"
     assert (
         prompt_mask.is_contiguous() and prompt_mask.dtype == torch.bool

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/argmax.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/argmax.py
@@ -154,7 +154,7 @@ def argmax_kernel_small_n(
 
 
 def argmax(inp, dim=None, keepdim=False, *, dtype=None):
-    logger.debug("GEMS ARGMAX")
+    logger.debug("GEMS_KUNLUNXIN ARGMAX")
     if dim is None:
         M = inp.numel()
         if dtype is None:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/argmin.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/argmin.py
@@ -106,7 +106,7 @@ def argmin_kernel(
 
 
 def argmin(inp, dim=None, keepdim=False, *, dtype=None):
-    logger.debug("GEMS_KUNLUNXIN argmin")
+    logger.debug("GEMS_KUNLUNXIN ARGMIN")
     if dim is None:
         M = inp.numel()
         if dtype is None:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/argmin.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/argmin.py
@@ -106,7 +106,7 @@ def argmin_kernel(
 
 
 def argmin(inp, dim=None, keepdim=False, *, dtype=None):
-    logger.debug("GEMS argmin")
+    logger.debug("GEMS_KUNLUNXIN argmin")
     if dim is None:
         M = inp.numel()
         if dtype is None:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/atan.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/atan.py
@@ -18,12 +18,12 @@ def atan_kernel(x):
 
 
 def atan(A):
-    logger.debug("GEMS ATAN")
+    logger.debug("GEMS_KUNLUNXIN ATAN")
     out = atan_kernel(A)
     return out
 
 
 def atan_(A):
-    logger.debug("GEMS ATAN_")
+    logger.debug("GEMS_KUNLUNXIN ATAN_")
     atan_kernel(A, out0=A)
     return A

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/attention.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/attention.py
@@ -784,7 +784,7 @@ def scaled_dot_product_attention_backward(
     scale=None,
     enable_gqa=False,
 ):
-    logger.debug("GEMS SCALED DOT PRODUCT ATTENTION BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN SCALED DOT PRODUCT ATTENTION BACKWARD")
     # shape constraints
     HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
     # when v is in float8_e5m2 it is transposed.
@@ -906,7 +906,7 @@ class ScaleDotProductAttention(torch.autograd.Function):
         scale=None,
         enable_gqa=False,
     ):
-        logger.debug("GEMS SCALED DOT PRODUCT ATTENTION")
+        logger.debug("GEMS_KUNLUNXIN SCALED DOT PRODUCT ATTENTION")
         # shape constraints
         HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
         # when v is in float8_e5m2 it is transposed.
@@ -1070,7 +1070,7 @@ def flash_attention_forward(
     alibi_slopes=None,
     disable_splitkv=False,
 ):
-    logger.debug("GEMS FLASH_ATTENTION_FORWARD")
+    logger.debug("GEMS_KUNLUNXIN FLASH_ATTENTION_FORWARD")
     assert (
         cumulative_sequence_length_q is None and cumulative_sequence_length_k is None
     ), "varlen is not supported yet."
@@ -1222,7 +1222,7 @@ def flash_attn_varlen_func(
             normalization factor).
     """
     if use_c_extension:
-        logger.debug("GEMS FLASH_ATTN_VARLEN_FUNC(C EXTENSION)")
+        logger.debug("GEMS_KUNLUNXIN FLASH_ATTN_VARLEN_FUNC(C EXTENSION)")
         with torch_device_fn.device(q.device):
             out_cpp, softmax_lse = torch.ops.flag_gems.flash_attn_varlen_func(
                 q,
@@ -1253,7 +1253,7 @@ def flash_attn_varlen_func(
             )
         return (out_cpp, softmax_lse) if return_softmax_lse else out_cpp
     else:
-        logger.debug("GEMS FLASH_ATTN_VARLEN_FUNC")
+        logger.debug("GEMS_KUNLUNXIN FLASH_ATTN_VARLEN_FUNC")
         assert (
             cu_seqlens_k is not None or seqused_k is not None
         ), "cu_seqlens_k or seqused_k must be provided"

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/attention.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/attention.py
@@ -784,7 +784,7 @@ def scaled_dot_product_attention_backward(
     scale=None,
     enable_gqa=False,
 ):
-    logger.debug("GEMS_KUNLUNXIN SCALED DOT PRODUCT ATTENTION BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN SCALED_DOT_PRODUCT_ATTENTION_BACKWARD")
     # shape constraints
     HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
     # when v is in float8_e5m2 it is transposed.
@@ -906,7 +906,7 @@ class ScaleDotProductAttention(torch.autograd.Function):
         scale=None,
         enable_gqa=False,
     ):
-        logger.debug("GEMS_KUNLUNXIN SCALED DOT PRODUCT ATTENTION")
+        logger.debug("GEMS_KUNLUNXIN SCALED_DOT_PRODUCT_ATTENTION")
         # shape constraints
         HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
         # when v is in float8_e5m2 it is transposed.
@@ -1222,7 +1222,7 @@ def flash_attn_varlen_func(
             normalization factor).
     """
     if use_c_extension:
-        logger.debug("GEMS_KUNLUNXIN FLASH_ATTN_VARLEN_FUNC(C EXTENSION)")
+        logger.debug("GEMS_KUNLUNXIN FLASH_ATTN_VARLEN_FUNC_C_EXTENSION")
         with torch_device_fn.device(q.device):
             out_cpp, softmax_lse = torch.ops.flag_gems.flash_attn_varlen_func(
                 q,

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/attention.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/attention.py
@@ -1222,7 +1222,7 @@ def flash_attn_varlen_func(
             normalization factor).
     """
     if use_c_extension:
-        logger.debug("GEMS_KUNLUNXIN FLASH_ATTN_VARLEN_FUNC_C_EXTENSION")
+        logger.debug("GEMS_KUNLUNXIN FLASH_ATTN_VARLEN_FUNC (C Extension)")
         with torch_device_fn.device(q.device):
             out_cpp, softmax_lse = torch.ops.flag_gems.flash_attn_varlen_func(
                 q,

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/avg_pool2d.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/avg_pool2d.py
@@ -290,7 +290,7 @@ def avg_pool2d(
     count_include_pad=True,
     divisor_override=None,
 ):
-    logger.debug("GEMS_KUNLUNXIN AVG_POOL2D FORWARD")
+    logger.debug("GEMS_KUNLUNXIN AVG_POOL2D_FORWARD")
 
     if divisor_override is not None and divisor_override == 0:
         raise ValueError("divisor_override cannot be zero")
@@ -360,7 +360,7 @@ def avg_pool2d_backward(
     count_include_pad,
     divisor_override,
 ):
-    logger.debug("GEMS_KUNLUNXIN AVG_POOL2D BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN AVG_POOL2D_BACKWARD")
 
     if divisor_override is not None and divisor_override == 0:
         raise ValueError("divisor_override cannot be zero")

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/avg_pool2d.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/avg_pool2d.py
@@ -290,7 +290,7 @@ def avg_pool2d(
     count_include_pad=True,
     divisor_override=None,
 ):
-    logger.debug("GEMS AVG_POOL2D FORWARD")
+    logger.debug("GEMS_KUNLUNXIN AVG_POOL2D FORWARD")
 
     if divisor_override is not None and divisor_override == 0:
         raise ValueError("divisor_override cannot be zero")
@@ -360,7 +360,7 @@ def avg_pool2d_backward(
     count_include_pad,
     divisor_override,
 ):
-    logger.debug("GEMS AVG_POOL2D BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN AVG_POOL2D BACKWARD")
 
     if divisor_override is not None and divisor_override == 0:
         raise ValueError("divisor_override cannot be zero")

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/baddbmm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/baddbmm.py
@@ -137,7 +137,7 @@ def baddbmm_kernel(
 class BaddbmmFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, bias, A, B, beta, alpha):
-        logger.debug("GEMS BADDBMM FORWARD")
+        logger.debug("GEMS_KUNLUNXIN BADDBMM FORWARD")
 
         ctx.save_for_backward(A, B, bias)
         ctx.alpha = alpha
@@ -178,7 +178,7 @@ class BaddbmmFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        logger.debug("GEMS BADDBMM BACKWARD")
+        logger.debug("GEMS_KUNLUNXIN BADDBMM BACKWARD")
         A, B, bias = ctx.saved_tensors
 
         grad_A = None

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/baddbmm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/baddbmm.py
@@ -137,7 +137,7 @@ def baddbmm_kernel(
 class BaddbmmFunction(torch.autograd.Function):
     @staticmethod
     def forward(ctx, bias, A, B, beta, alpha):
-        logger.debug("GEMS_KUNLUNXIN BADDBMM FORWARD")
+        logger.debug("GEMS_KUNLUNXIN BADDBMM_FORWARD")
 
         ctx.save_for_backward(A, B, bias)
         ctx.alpha = alpha
@@ -178,7 +178,7 @@ class BaddbmmFunction(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad_output):
-        logger.debug("GEMS_KUNLUNXIN BADDBMM BACKWARD")
+        logger.debug("GEMS_KUNLUNXIN BADDBMM_BACKWARD")
         A, B, bias = ctx.saved_tensors
 
         grad_A = None

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/batch_norm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/batch_norm.py
@@ -331,7 +331,7 @@ def batch_norm(
     momentum=0.1,
     eps=1e-05,
 ):
-    logger.debug("GEMS_KUNLUNXIN BATCHNORM FORWARD")
+    logger.debug("GEMS_KUNLUNXIN BATCHNORM_FORWARD")
 
     input_3d_i = make_3d_for_bn(input)
     m, n, k = input_3d_i.shape
@@ -383,7 +383,7 @@ def batch_norm_backward(
     eps=1e-05,
     output_mask=None,
 ):
-    logger.debug("GEMS_KUNLUNXIN BATCHNORM BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN BATCHNORM_BACKWARD")
     input_3d_i = make_3d_for_bn(input)
     m, n, k = input_3d_i.shape
     input_3d_f = input_3d_i.permute(0, 2, 1).reshape(-1, n)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/batch_norm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/batch_norm.py
@@ -331,7 +331,7 @@ def batch_norm(
     momentum=0.1,
     eps=1e-05,
 ):
-    logger.debug("GEMS_KUNLUNXIN BATCHNORM_FORWARD")
+    logger.debug("GEMS_KUNLUNXIN BATCH_NORM")
 
     input_3d_i = make_3d_for_bn(input)
     m, n, k = input_3d_i.shape
@@ -383,7 +383,7 @@ def batch_norm_backward(
     eps=1e-05,
     output_mask=None,
 ):
-    logger.debug("GEMS_KUNLUNXIN BATCHNORM_BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN BATCH_NORM_BACKWARD")
     input_3d_i = make_3d_for_bn(input)
     m, n, k = input_3d_i.shape
     input_3d_f = input_3d_i.permute(0, 2, 1).reshape(-1, n)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_and.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_and.py
@@ -26,12 +26,12 @@ def bitwise_and_func(x, y):
 
 
 def bitwise_and_tensor(A, B):
-    logger.debug("GEMS BITWISE AND")
+    logger.debug("GEMS_KUNLUNXIN BITWISE AND")
     return bitwise_and_func(A, B)
 
 
 def bitwise_and_tensor_(A, B):
-    logger.debug("GEMS BITWISE AND_")
+    logger.debug("GEMS_KUNLUNXIN BITWISE AND_")
     return bitwise_and_func(A, B, out0=A)
 
 
@@ -42,15 +42,15 @@ def bitwise_and_func_scalar(x, y):
 
 
 def bitwise_and_scalar(A, B):
-    logger.debug("GEMS BITWISE AND SCALAR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE AND SCALAR")
     return bitwise_and_func_scalar(A, B)
 
 
 def bitwise_and_scalar_(A, B):
-    logger.debug("GEMS BITWISE AND_ SCALAR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE AND_ SCALAR")
     return bitwise_and_func_scalar(A, B, out0=A)
 
 
 def bitwise_and_scalar_tensor(A, B):
-    logger.debug("GEMS BITWISE AND SCALAR TENSOR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE AND SCALAR TENSOR")
     return bitwise_and_func_scalar(B, A)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_and.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_and.py
@@ -47,7 +47,7 @@ def bitwise_and_scalar(A, B):
 
 
 def bitwise_and_scalar_(A, B):
-    logger.debug("GEMS_KUNLUNXIN BITWISE_AND__SCALAR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE_AND_SCALAR_")
     return bitwise_and_func_scalar(A, B, out0=A)
 
 

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_and.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_and.py
@@ -26,12 +26,12 @@ def bitwise_and_func(x, y):
 
 
 def bitwise_and_tensor(A, B):
-    logger.debug("GEMS_KUNLUNXIN BITWISE AND")
+    logger.debug("GEMS_KUNLUNXIN BITWISE_AND")
     return bitwise_and_func(A, B)
 
 
 def bitwise_and_tensor_(A, B):
-    logger.debug("GEMS_KUNLUNXIN BITWISE AND_")
+    logger.debug("GEMS_KUNLUNXIN BITWISE_AND_")
     return bitwise_and_func(A, B, out0=A)
 
 
@@ -42,15 +42,15 @@ def bitwise_and_func_scalar(x, y):
 
 
 def bitwise_and_scalar(A, B):
-    logger.debug("GEMS_KUNLUNXIN BITWISE AND SCALAR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE_AND_SCALAR")
     return bitwise_and_func_scalar(A, B)
 
 
 def bitwise_and_scalar_(A, B):
-    logger.debug("GEMS_KUNLUNXIN BITWISE AND_ SCALAR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE_AND__SCALAR")
     return bitwise_and_func_scalar(A, B, out0=A)
 
 
 def bitwise_and_scalar_tensor(A, B):
-    logger.debug("GEMS_KUNLUNXIN BITWISE AND SCALAR TENSOR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE_AND_SCALAR_TENSOR")
     return bitwise_and_func_scalar(B, A)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_left_shift.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_left_shift.py
@@ -14,5 +14,5 @@ def bitwise_left_shift_kernel(a, b):
 
 
 def bitwise_left_shift(self, other, *, out=None):
-    logger.debug("GEMS BITWISE_LEFT_SHIFT")
+    logger.debug("GEMS_KUNLUNXIN BITWISE_LEFT_SHIFT")
     return bitwise_left_shift_kernel(self, other, out=out)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_not.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_not.py
@@ -26,11 +26,11 @@ def bitwise_not_func(x):
 
 
 def bitwise_not(A):
-    logger.debug("GEMS_KUNLUNXIN BITWISE NOT")
+    logger.debug("GEMS_KUNLUNXIN BITWISE_NOT")
     return bitwise_not_func(A)
 
 
 def bitwise_not_(A):
-    logger.debug("GEMS_KUNLUNXIN BITWISE NOT_")
+    logger.debug("GEMS_KUNLUNXIN BITWISE_NOT_")
     bitwise_not_func(A, out0=A)
     return A

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_not.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_not.py
@@ -26,11 +26,11 @@ def bitwise_not_func(x):
 
 
 def bitwise_not(A):
-    logger.debug("GEMS BITWISE NOT")
+    logger.debug("GEMS_KUNLUNXIN BITWISE NOT")
     return bitwise_not_func(A)
 
 
 def bitwise_not_(A):
-    logger.debug("GEMS BITWISE NOT_")
+    logger.debug("GEMS_KUNLUNXIN BITWISE NOT_")
     bitwise_not_func(A, out0=A)
     return A

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_or.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_or.py
@@ -26,12 +26,12 @@ def bitwise_or_func(x, y):
 
 
 def bitwise_or_tensor(A, B):
-    logger.debug("GEMS BITWISE OR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE OR")
     return bitwise_or_func(A, B)
 
 
 def bitwise_or_tensor_(A, B):
-    logger.debug("GEMS BITWISE OR_")
+    logger.debug("GEMS_KUNLUNXIN BITWISE OR_")
     return bitwise_or_func(A, B, out0=A)
 
 
@@ -42,15 +42,15 @@ def bitwise_or_func_scalar(x, y):
 
 
 def bitwise_or_scalar(A, B):
-    logger.debug("GEMS BITWISE OR SCALAR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE OR SCALAR")
     return bitwise_or_func_scalar(A, B)
 
 
 def bitwise_or_scalar_(A, B):
-    logger.debug("GEMS BITWISE OR_ SCALAR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE OR_ SCALAR")
     return bitwise_or_func_scalar(A, B, out0=A)
 
 
 def bitwise_or_scalar_tensor(A, B):
-    logger.debug("GEMS BITWISE OR SCALAR TENSOR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE OR SCALAR TENSOR")
     return bitwise_or_func_scalar(B, A)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_or.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_or.py
@@ -26,12 +26,12 @@ def bitwise_or_func(x, y):
 
 
 def bitwise_or_tensor(A, B):
-    logger.debug("GEMS_KUNLUNXIN BITWISE OR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE_OR")
     return bitwise_or_func(A, B)
 
 
 def bitwise_or_tensor_(A, B):
-    logger.debug("GEMS_KUNLUNXIN BITWISE OR_")
+    logger.debug("GEMS_KUNLUNXIN BITWISE_OR_")
     return bitwise_or_func(A, B, out0=A)
 
 
@@ -42,15 +42,15 @@ def bitwise_or_func_scalar(x, y):
 
 
 def bitwise_or_scalar(A, B):
-    logger.debug("GEMS_KUNLUNXIN BITWISE OR SCALAR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE_OR_SCALAR")
     return bitwise_or_func_scalar(A, B)
 
 
 def bitwise_or_scalar_(A, B):
-    logger.debug("GEMS_KUNLUNXIN BITWISE OR_ SCALAR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE_OR__SCALAR")
     return bitwise_or_func_scalar(A, B, out0=A)
 
 
 def bitwise_or_scalar_tensor(A, B):
-    logger.debug("GEMS_KUNLUNXIN BITWISE OR SCALAR TENSOR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE_OR_SCALAR_TENSOR")
     return bitwise_or_func_scalar(B, A)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_or.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/bitwise_or.py
@@ -47,7 +47,7 @@ def bitwise_or_scalar(A, B):
 
 
 def bitwise_or_scalar_(A, B):
-    logger.debug("GEMS_KUNLUNXIN BITWISE_OR__SCALAR")
+    logger.debug("GEMS_KUNLUNXIN BITWISE_OR_SCALAR_")
     return bitwise_or_func_scalar(A, B, out0=A)
 
 

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/bmm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/bmm.py
@@ -145,7 +145,7 @@ def bmm_kernel(
 
 
 def bmm(A, B):
-    logger.debug("GEMS BMM")
+    logger.debug("GEMS_KUNLUNXIN BMM")
     batch, M, K = A.shape
     _, _, N = B.shape
     A = A.contiguous()
@@ -163,7 +163,7 @@ def bmm(A, B):
 
 
 def bmm_out(A, B, out):
-    logger.debug("GEMS BMM_OUT")
+    logger.debug("GEMS_KUNLUNXIN BMM_OUT")
     assert A.shape[0] == B.shape[0] == out.shape[0], "Batch dim mismatch"
     assert A.shape[2] == B.shape[1], "K dim mismatch"
     batch, M, K = A.shape

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/cat.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/cat.py
@@ -29,7 +29,7 @@ def copy_func(x):
 def cat(
     A: Union[Tuple[torch.Tensor, ...], List[torch.Tensor]], dim: int = 0
 ) -> torch.Tensor:
-    logger.debug("GEMS CAT")
+    logger.debug("GEMS_KUNLUNXIN CAT")
 
     if len(A) == 0:
         raise RuntimeError("torch.cat(): expected a non-empty list of Tensors")

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/celu.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/celu.py
@@ -33,10 +33,10 @@ def celu_forward_kernel(x, alpha):
 
 
 def celu(A, alpha=1.0):
-    logger.debug("GEMS CELU")
+    logger.debug("GEMS_KUNLUNXIN CELU")
     return celu_forward_kernel(A, alpha)
 
 
 def celu_(A, alpha=1.0):
-    logger.debug("GEMS CELU_")
+    logger.debug("GEMS_KUNLUNXIN CELU_")
     return celu_forward_kernel(A, alpha, out0=A)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/clamp.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/clamp.py
@@ -39,7 +39,7 @@ def clamp_tensor(A, mini=None, maxi=None):
 
 
 def clamp_tensor_(A, mini=None, maxi=None):
-    logger.debug("GEMS_KUNLUNXIN CLAMP__TENSOR")
+    logger.debug("GEMS_KUNLUNXIN CLAMP_TENSOR_")
     if mini is None and maxi is None:
         raise ValueError("At least one of mini or maxi must not be None")
     elif mini is None:
@@ -78,7 +78,7 @@ def clamp_min(A, mini):
 
 
 def clamp_min_(A, mini):
-    logger.debug("GEMS_KUNLUNXIN CLAMP__MIN")
+    logger.debug("GEMS_KUNLUNXIN CLAMP_MIN_")
     if mini is None:
         raise ValueError("Mini must not be None")
     return clamp_func_min(A, mini, out0=A)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/clamp.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/clamp.py
@@ -27,7 +27,7 @@ def clamp_func_max_tensor(x, maxi):
 
 
 def clamp_tensor(A, mini=None, maxi=None):
-    logger.debug("GEMS_KUNLUNXIN CLAMP TENSOR")
+    logger.debug("GEMS_KUNLUNXIN CLAMP_TENSOR")
     if mini is None and maxi is None:
         raise ValueError("At least one of mini or maxi must not be None")
     elif mini is None:
@@ -39,7 +39,7 @@ def clamp_tensor(A, mini=None, maxi=None):
 
 
 def clamp_tensor_(A, mini=None, maxi=None):
-    logger.debug("GEMS_KUNLUNXIN CLAMP_ TENSOR")
+    logger.debug("GEMS_KUNLUNXIN CLAMP__TENSOR")
     if mini is None and maxi is None:
         raise ValueError("At least one of mini or maxi must not be None")
     elif mini is None:
@@ -71,14 +71,14 @@ def clamp_func_max(x, maxi):
 
 
 def clamp_min(A, mini):
-    logger.debug("GEMS_KUNLUNXIN CLAMP MIN")
+    logger.debug("GEMS_KUNLUNXIN CLAMP_MIN")
     if mini is None:
         raise ValueError("Mini must not be None")
     return clamp_func_min(A, mini)
 
 
 def clamp_min_(A, mini):
-    logger.debug("GEMS_KUNLUNXIN CLAMP_ MIN")
+    logger.debug("GEMS_KUNLUNXIN CLAMP__MIN")
     if mini is None:
         raise ValueError("Mini must not be None")
     return clamp_func_min(A, mini, out0=A)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/contiguous.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/contiguous.py
@@ -9,7 +9,7 @@ logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 
 def contiguous(inp, memory_format=torch.contiguous_format):
     assert memory_format == torch.contiguous_format
-    logger.debug("GEMS CONTIGUOUS")
+    logger.debug("GEMS_KUNLUNXIN CONTIGUOUS")
     if inp.is_contiguous(memory_format=memory_format):
         return inp
     out = torch.empty_like(inp, memory_format=memory_format)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/conv1d.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/conv1d.py
@@ -7,7 +7,7 @@ logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 
 
 def conv1d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
-    logger.debug("GEMS CONV1D")
+    logger.debug("GEMS_KUNLUNXIN CONV1D")
     if isinstance(stride, (list, tuple)):
         stride_width = stride[0]
     else:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/conv2d.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/conv2d.py
@@ -507,7 +507,7 @@ class Conv2d(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, out_grad):
-        logger.debug("GEMS_KUNLUNXIN CONV2D VJP")
+        logger.debug("GEMS_KUNLUNXIN CONV2D_VJP")
         (weight, input, bias) = ctx.saved_tensors
         # (out_c equals origin cout divide groups)
         out_c, weight_c, weight_height, weight_width = ctx.weight_info

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/conv2d.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/conv2d.py
@@ -356,7 +356,7 @@ def conv2d_backward_kernel_weight(
 class Conv2d(torch.autograd.Function):
     @staticmethod
     def forward(ctx, input, weight, bias, stride, padding, dilation, groups):
-        logger.debug("GEMS CONV2D")
+        logger.debug("GEMS_KUNLUNXIN CONV2D")
         assert weight.ndim == 4, "Weights must be 4D, received shape {weight.shape}"
         assert (
             bias is None or bias.ndim == 1
@@ -507,7 +507,7 @@ class Conv2d(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, out_grad):
-        logger.debug("GEMS CONV2D VJP")
+        logger.debug("GEMS_KUNLUNXIN CONV2D VJP")
         (weight, input, bias) = ctx.saved_tensors
         # (out_c equals origin cout divide groups)
         out_c, weight_c, weight_height, weight_width = ctx.weight_info

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/conv2d.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/conv2d.py
@@ -507,7 +507,7 @@ class Conv2d(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, out_grad):
-        logger.debug("GEMS_KUNLUNXIN CONV2D_VJP")
+        logger.debug("GEMS_KUNLUNXIN CONV2D")
         (weight, input, bias) = ctx.saved_tensors
         # (out_c equals origin cout divide groups)
         out_c, weight_c, weight_height, weight_width = ctx.weight_info

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/conv3d.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/conv3d.py
@@ -221,7 +221,7 @@ def conv3d_forward_kernel(
 
 
 def conv3d(input, weight, bias=None, stride=1, padding=0, dilation=1, groups=1):
-    logger.debug("GEMS CONV3D")
+    logger.debug("GEMS_KUNLUNXIN CONV3D")
     assert weight.ndim == 5, "Weights must be 5D, received shape {weight.shape}"
     assert (
         bias is None or bias.ndim == 1

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/conv_depthwise2d.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/conv_depthwise2d.py
@@ -6,7 +6,7 @@ logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 
 
 def _conv_depthwise2d(input, weight, kernel_size, bias, stride, padding, dilation):
-    logger.debug("GEMS DEPTHWISE")
+    logger.debug("GEMS_KUNLUNXIN DEPTHWISE")
     assert (
         input.ndim == 4
     ), "Invalid input tensor must be 4D, recevied shape {input.shape}"

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/conv_depthwise2d.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/conv_depthwise2d.py
@@ -6,7 +6,7 @@ logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 
 
 def _conv_depthwise2d(input, weight, kernel_size, bias, stride, padding, dilation):
-    logger.debug("GEMS_KUNLUNXIN DEPTHWISE")
+    logger.debug("GEMS_KUNLUNXIN CONV_DEPTHWISE2D")
     assert (
         input.ndim == 4
     ), "Invalid input tensor must be 4D, recevied shape {input.shape}"

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/copy.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/copy.py
@@ -67,7 +67,7 @@ def _expand_like(src: torch.Tensor, target_shape: torch.Size) -> torch.Tensor:
 def copy(
     template: torch.Tensor, src: torch.Tensor, *, non_blocking: Optional[bool] = False
 ):
-    logger.debug("GEMS_KUNLUNXIN COPY (functional)")
+    logger.debug("GEMS_KUNLUNXIN COPY_FUNCTIONAL")
     out = torch.empty_strided(
         template.size(), template.stride(), dtype=template.dtype, device=template.device
     )

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/copy.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/copy.py
@@ -67,7 +67,7 @@ def _expand_like(src: torch.Tensor, target_shape: torch.Size) -> torch.Tensor:
 def copy(
     template: torch.Tensor, src: torch.Tensor, *, non_blocking: Optional[bool] = False
 ):
-    logger.debug("GEMS_KUNLUNXIN COPY_FUNCTIONAL")
+    logger.debug("GEMS_KUNLUNXIN COPY")
     out = torch.empty_strided(
         template.size(), template.stride(), dtype=template.dtype, device=template.device
     )

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/copy.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/copy.py
@@ -67,7 +67,7 @@ def _expand_like(src: torch.Tensor, target_shape: torch.Size) -> torch.Tensor:
 def copy(
     template: torch.Tensor, src: torch.Tensor, *, non_blocking: Optional[bool] = False
 ):
-    logger.debug("GEMS COPY (functional)")
+    logger.debug("GEMS_KUNLUNXIN COPY (functional)")
     out = torch.empty_strided(
         template.size(), template.stride(), dtype=template.dtype, device=template.device
     )
@@ -113,7 +113,7 @@ def copy_(dst: torch.Tensor, src: torch.Tensor, non_blocking: bool = False):
             _FALLBACK_KEYSET, dst, src, non_blocking
         )
 
-    logger.debug("GEMS COPY_")
+    logger.debug("GEMS_KUNLUNXIN COPY_")
 
     try:
         broadcast_shape = torch.broadcast_shapes(dst.shape, src.shape)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/count_nonzero.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/count_nonzero.py
@@ -104,7 +104,7 @@ def reduce_partial_counts(
 
 
 def count_nonzero(x, dim=None):
-    logger.debug("GEMS_KUNLUNXIN COUNT NONZERO")
+    logger.debug("GEMS_KUNLUNXIN COUNT_NONZERO")
 
     if dim is not None:
         assert dim >= -x.ndim and dim < x.ndim, "Invalid dim"

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/cummax.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/cummax.py
@@ -446,7 +446,7 @@ def cummax(
     *,
     out: Union[Tensor, Tuple[Tensor, ...], List[Tensor], None] = None,
 ) -> torch.return_types.cummax:
-    logger.debug("GEMS cummax")
+    logger.debug("GEMS_KUNLUNXIN cummax")
     assert dim >= -input.ndim and dim < input.ndim, "Invalid dim"
     shape = input.shape
     dim = dim % input.ndim

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/cummax.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/cummax.py
@@ -446,7 +446,7 @@ def cummax(
     *,
     out: Union[Tensor, Tuple[Tensor, ...], List[Tensor], None] = None,
 ) -> torch.return_types.cummax:
-    logger.debug("GEMS_KUNLUNXIN cummax")
+    logger.debug("GEMS_KUNLUNXIN CUMMAX")
     assert dim >= -input.ndim and dim < input.ndim, "Invalid dim"
     shape = input.shape
     dim = dim % input.ndim

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/cummin.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/cummin.py
@@ -431,7 +431,7 @@ def cummin(
     *,
     out: Union[Tensor, Tuple[Tensor, ...], List[Tensor], None] = None,
 ) -> torch.return_types.cummin:
-    logger.debug("GEMS_KUNLUNXIN cummin")
+    logger.debug("GEMS_KUNLUNXIN CUMMIN")
     assert dim >= -input.ndim and dim < input.ndim, "Invalid dim"
     shape = input.shape
     dim = dim % input.ndim

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/cumsum.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/cumsum.py
@@ -239,12 +239,12 @@ def cumsum_wrapper(inp, dim=1, dtype=None, out=None):
 
 
 def cumsum(inp, dim=1, *, dtype=None):
-    logger.debug("GEMS CUMSUM")
+    logger.debug("GEMS_KUNLUNXIN CUMSUM")
     return cumsum_wrapper(inp, dim, dtype)
 
 
 def cumsum_out(inp, dim=1, *, dtype=None, out):
-    logger.debug("GEMS CUMSUM_OUT")
+    logger.debug("GEMS_KUNLUNXIN CUMSUM_OUT")
     return cumsum_wrapper(inp, dim, dtype, out)
 
 
@@ -392,7 +392,7 @@ GRID_Y_LIMIT = 65535
 
 
 def normed_cumsum(inp, dim=-1):
-    logger.debug("GEMS NORMED_CUMSUM")
+    logger.debug("GEMS_KUNLUNXIN NORMED_CUMSUM")
     assert inp.dtype in (torch.float16, torch.bfloat16, torch.float32, torch.float64)
     dim = dim % inp.ndim
     N = inp.numel()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/diagonal.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/diagonal.py
@@ -15,7 +15,7 @@ def copy_func(x):
 
 
 def diagonal_backward(grad_output, input_sizes, offset, dim1, dim2):
-    logger.debug("GEMS_KUNLUNXIN diagonal backward")
+    logger.debug("GEMS_KUNLUNXIN DIAGONAL_BACKWARD")
     grad_input = torch.zeros(
         input_sizes, dtype=grad_output.dtype, device=grad_output.device
     )

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/diagonal.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/diagonal.py
@@ -15,7 +15,7 @@ def copy_func(x):
 
 
 def diagonal_backward(grad_output, input_sizes, offset, dim1, dim2):
-    logger.debug("GEMS diagonal backward")
+    logger.debug("GEMS_KUNLUNXIN diagonal backward")
     grad_input = torch.zeros(
         input_sizes, dtype=grad_output.dtype, device=grad_output.device
     )

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/div.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/div.py
@@ -47,7 +47,7 @@ def true_div_func_scalar_tensor(x, y):
 
 
 def true_divide(A, B):
-    logger.debug("GEMS TRUE_DIVIDE")
+    logger.debug("GEMS_KUNLUNXIN TRUE_DIVIDE")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return true_div_func(A, B)
     elif isinstance(A, torch.Tensor):
@@ -60,7 +60,7 @@ def true_divide(A, B):
 
 
 def true_divide_out(A, B, out):
-    logger.debug("GEMS TRUE_DIVIDE OUT")
+    logger.debug("GEMS_KUNLUNXIN TRUE_DIVIDE OUT")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return true_div_func(A, B, out0=out)
     elif isinstance(A, torch.Tensor):
@@ -73,7 +73,7 @@ def true_divide_out(A, B, out):
 
 
 def true_divide_(A, B):
-    logger.debug("GEMS TRUE_DIVIDE_")
+    logger.debug("GEMS_KUNLUNXIN TRUE_DIVIDE_")
     if isinstance(B, torch.Tensor):
         return true_div_func(A, B, out0=A)
     else:
@@ -233,7 +233,7 @@ def floor_div_func_scalar_tensor(x, y):
 
 
 def floor_divide(A, B):
-    logger.debug("GEMS FLOOR_DIVIDE")
+    logger.debug("GEMS_KUNLUNXIN FLOOR_DIVIDE")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return floor_div_func(A, B)
     elif isinstance(A, torch.Tensor):
@@ -246,7 +246,7 @@ def floor_divide(A, B):
 
 
 def floor_divide_(A, B):
-    logger.debug("GEMS FLOOR_DIVIDE_")
+    logger.debug("GEMS_KUNLUNXIN FLOOR_DIVIDE_")
     if isinstance(B, torch.Tensor):
         return floor_div_func(A, B, out0=A)
     else:
@@ -304,7 +304,7 @@ def rem_st(x, y):
 
 
 def remainder(A, B):
-    logger.debug("GEMS FLOOR_DIVIDE")
+    logger.debug("GEMS_KUNLUNXIN FLOOR_DIVIDE")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return rem_tt(A, B)
     elif isinstance(A, torch.Tensor):
@@ -317,7 +317,7 @@ def remainder(A, B):
 
 
 def remainder_(A, B):
-    logger.debug("GEMS REMAINDER_")
+    logger.debug("GEMS_KUNLUNXIN REMAINDER_")
     if isinstance(B, torch.Tensor):
         return rem_tt(A, B, out0=A)
     else:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/div.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/div.py
@@ -60,7 +60,7 @@ def true_divide(A, B):
 
 
 def true_divide_out(A, B, out):
-    logger.debug("GEMS_KUNLUNXIN TRUE_DIVIDE OUT")
+    logger.debug("GEMS_KUNLUNXIN TRUE_DIVIDE_OUT")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return true_div_func(A, B, out0=out)
     elif isinstance(A, torch.Tensor):

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/dropout.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/dropout.py
@@ -129,7 +129,7 @@ UNROLL = 8
 
 
 def dropout(input, p, train=True):
-    logger.debug("GEMS_KUNLUNXIN NATIVE DROPOUT FORWARD")
+    logger.debug("GEMS_KUNLUNXIN NATIVE_DROPOUT_FORWARD")
     if not train or p == 0:
         out = input.clone()
         mask = torch.ones_like(input, dtype=torch.bool)
@@ -155,7 +155,7 @@ def dropout(input, p, train=True):
 
 
 def dropout_backward(grad_output, mask, scale):
-    logger.debug("GEMS_KUNLUNXIN NATIVE DROPOUT BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN NATIVE_DROPOUT_BACKWARD")
     grad_output = grad_output.contiguous()
     grad_input = torch.empty_like(grad_output)
     N = grad_output.numel()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/elu.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/elu.py
@@ -50,7 +50,7 @@ def elu_(A, alpha=1.0, scale=1.0, input_scale=1.0):
 
 
 def elu_backward(grad_output, alpha, scale, input_scale, is_result, self_or_result):
-    logger.debug("GEMS_KUNLUNXIN ELU BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN ELU_BACKWARD")
     grad_input = elu_backward_kernel(
         grad_output, self_or_result, alpha, scale, input_scale, is_result
     )

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/embedding.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/embedding.py
@@ -111,7 +111,7 @@ def embedding_grad_scale_kernel(
 
 
 def embedding(weight, indices, padding_idx=-1, scale_grad_by_freq=False, sparse=False):
-    logger.debug("GEMS_KUNLUNXIN EMBEDDING FORWARD")
+    logger.debug("GEMS_KUNLUNXIN EMBEDDING_FORWARD")
     assert not sparse, "Currently do not support sparse format"
 
     M = indices.numel()
@@ -137,7 +137,7 @@ def embedding_backward(
     scale_grad_by_freq=False,
     sparse=False,
 ):
-    logger.debug("GEMS_KUNLUNXIN EMBEDDING BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN EMBEDDING_BACKWARD")
     assert not sparse, "Currently do not support sparse format"
 
     M = indices.numel()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/embedding.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/embedding.py
@@ -111,7 +111,7 @@ def embedding_grad_scale_kernel(
 
 
 def embedding(weight, indices, padding_idx=-1, scale_grad_by_freq=False, sparse=False):
-    logger.debug("GEMS EMBEDDING FORWARD")
+    logger.debug("GEMS_KUNLUNXIN EMBEDDING FORWARD")
     assert not sparse, "Currently do not support sparse format"
 
     M = indices.numel()
@@ -137,7 +137,7 @@ def embedding_backward(
     scale_grad_by_freq=False,
     sparse=False,
 ):
-    logger.debug("GEMS EMBEDDING BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN EMBEDDING BACKWARD")
     assert not sparse, "Currently do not support sparse format"
 
     M = indices.numel()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/eq.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/eq.py
@@ -55,5 +55,5 @@ def eq_func_scalar(x, y):
 
 
 def eq_scalar(A, B):
-    logger.debug("GEMS_KUNLUNXIN EQ SCALAR")
+    logger.debug("GEMS_KUNLUNXIN EQ_SCALAR")
     return eq_func_scalar(A, B)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/erf.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/erf.py
@@ -17,10 +17,10 @@ def erf_func(x):
 
 
 def erf(x):
-    logger.debug("GEMS ERF")
+    logger.debug("GEMS_KUNLUNXIN ERF")
     return erf_func(x)
 
 
 def erf_(x):
-    logger.debug("GEMS ERF_")
+    logger.debug("GEMS_KUNLUNXIN ERF_")
     return erf_func(x, out0=x)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/exp.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/exp.py
@@ -28,16 +28,16 @@ def exp_func(x):
 
 
 def exp(A):
-    logger.debug("GEMS EXP")
+    logger.debug("GEMS_KUNLUNXIN EXP")
     return exp_func(A)
 
 
 def exp_(A):
-    logger.debug("GEMS EXP_")
+    logger.debug("GEMS_KUNLUNXIN EXP_")
     return exp_func(A, out0=A)
 
 
 # exp.out(Tensor self, *, Tensor(a!) out) -> Tensor(a!)
 def exp_out(A, out):
-    logger.debug("GEMS EXP_OUT")
+    logger.debug("GEMS_KUNLUNXIN EXP_OUT")
     return exp_func(A, out0=out)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/exp2.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/exp2.py
@@ -27,10 +27,10 @@ def exp2_func(x):
 
 
 def exp2(A):
-    logger.debug("GEMS EXP")
+    logger.debug("GEMS_KUNLUNXIN EXP")
     return exp2_func(A)
 
 
 def exp2_(A):
-    logger.debug("GEMS EXP_")
+    logger.debug("GEMS_KUNLUNXIN EXP_")
     return exp2_func(A, out0=A)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/eye.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/eye.py
@@ -15,7 +15,7 @@ def eye(size, *, dtype=None, layout=torch.strided, device=None, pin_memory=None)
     """
     Triton-based implementation of torch.eye(n, n), using 2D tiles to split the matrix into blocks.
     """
-    logger.debug("GEMS EYE")
+    logger.debug("GEMS_KUNLUNXIN EYE")
 
     if dtype is None:
         dtype = torch.get_default_dtype()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/eye_m.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/eye_m.py
@@ -39,7 +39,7 @@ def eye_m(n, m, *, dtype=None, layout=torch.strided, device=None, pin_memory=Non
     """
     Triton-based implementation of torch.eye_m(n, m), using 2D tiles to split the matrix into blocks.
     """
-    logger.debug("GEMS EYE_M")
+    logger.debug("GEMS_KUNLUNXIN EYE_M")
     if dtype is None:
         dtype = torch.get_default_dtype()
     if device is None:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/fill.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/fill.py
@@ -44,7 +44,7 @@ def fill_tensor_func(inp, value):
 
 
 def fill_scalar(input, value):
-    logger.debug("GEMS FILL (Dynamic)")
+    logger.debug("GEMS_KUNLUNXIN FILL (Dynamic)")
     out = torch.empty_like(input)
     with torch_device_fn.device(input.device):
         return fill_scalar_func(input, value, out0=out)
@@ -53,7 +53,7 @@ def fill_scalar(input, value):
 def fill_tensor(input, value):
     if not value.is_cuda:
         return fill_scalar(input, value.item())
-    logger.debug("GEMS FILL (Dynamic)")
+    logger.debug("GEMS_KUNLUNXIN FILL (Dynamic)")
     if value.ndim != 0:
         raise RuntimeError(
             f"fill_ only supports 0-dimension value tensor but got tensor with {value.ndim} dimensions."
@@ -66,7 +66,7 @@ def fill_tensor(input, value):
 def fill_tensor_(self, value):
     if not value.is_cuda:
         return fill_scalar_(self, value.item())
-    logger.debug("GEMS FILL_TENSOR_")
+    logger.debug("GEMS_KUNLUNXIN FILL_TENSOR_")
     if value.ndim != 0:
         raise RuntimeError(
             f"fill_ only supports 0-dimension value tensor but got tensor with {value.ndim} dimensions."
@@ -77,7 +77,7 @@ def fill_tensor_(self, value):
 
 
 def fill_scalar_(self, value):
-    logger.debug("GEMS FILL_SCALAR_")
+    logger.debug("GEMS_KUNLUNXIN FILL_SCALAR_")
     with torch_device_fn.device(self.device):
         fill_scalar_func(self, value, out0=self)
     return self

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/flip.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/flip.py
@@ -17,7 +17,7 @@ def copy_func(x):
 
 
 def flip(A: torch.Tensor, dims) -> torch.Tensor:
-    logger.debug("GEMS FLIP")
+    logger.debug("GEMS_KUNLUNXIN FLIP")
     strides = list(A.stride())
     flip_dims_b = [False for _ in A.stride()]
     for dim in dims:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/full.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/full.py
@@ -59,7 +59,7 @@ def check_dtype(fill_value, dtype, device):
 
 
 def full(size, fill_value, *, dtype=None, layout=None, device=None, pin_memory=None):
-    logger.debug("GEMS FULL")
+    logger.debug("GEMS_KUNLUNXIN FULL")
     if size == [0]:
         out = torch.empty(size, device=device, dtype=dtype)
         return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/full_like.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/full_like.py
@@ -20,7 +20,7 @@ def full_like(
     pin_memory=None,
     memory_format=None,
 ):
-    logger.debug("GEMS FULL_LIKE")
+    logger.debug("GEMS_KUNLUNXIN FULL_LIKE")
     if device is None:
         device = x.device
     if dtype is None:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/gather.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/gather.py
@@ -277,7 +277,7 @@ _gather_func = GatherFunction()
 
 
 def gather(inp, dim, index, out=None, sparse_grad=False):
-    logger.debug("GEMS GATHER")
+    logger.debug("GEMS_KUNLUNXIN GATHER")
     if dim < 0:
         dim += inp.ndim
     if inp.ndim != index.ndim:
@@ -303,6 +303,6 @@ def gather(inp, dim, index, out=None, sparse_grad=False):
 
 
 def gather_backward(grad, self, dim, index, sparse_grad):
-    logger.debug("GEMS GATHER BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN GATHER BACKWARD")
     result = grad.new_zeros(self.shape)
     return scatter_(result, dim, index, grad, reduce="add")

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/gather.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/gather.py
@@ -303,6 +303,6 @@ def gather(inp, dim, index, out=None, sparse_grad=False):
 
 
 def gather_backward(grad, self, dim, index, sparse_grad):
-    logger.debug("GEMS_KUNLUNXIN GATHER BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN GATHER_BACKWARD")
     result = grad.new_zeros(self.shape)
     return scatter_(result, dim, index, grad, reduce="add")

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/ge.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/ge.py
@@ -31,7 +31,7 @@ def ge_func(x, y):
 
 
 def ge(A, B):
-    logger.debug("GEMS GE")
+    logger.debug("GEMS_KUNLUNXIN GE")
     os.environ["TRITONXPU_COMPARE_FUSION"] = "1"
     os.environ["TRITONXPU_FP16_FAST"] = "1"
     res = ge_func(A, B)
@@ -51,6 +51,6 @@ def ge_func_scalar(x, y):
 
 
 def ge_scalar(A, B):
-    logger.debug("GEMS GE SCALAR")
+    logger.debug("GEMS_KUNLUNXIN GE SCALAR")
     res = ge_func_scalar(A, B)
     return res

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/ge.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/ge.py
@@ -51,6 +51,6 @@ def ge_func_scalar(x, y):
 
 
 def ge_scalar(A, B):
-    logger.debug("GEMS_KUNLUNXIN GE SCALAR")
+    logger.debug("GEMS_KUNLUNXIN GE_SCALAR")
     res = ge_func_scalar(A, B)
     return res

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/gelu.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/gelu.py
@@ -57,7 +57,7 @@ def gelu_backward_tanh(x, dy):
 
 
 def gelu(self, *, approximate="none"):
-    logger.debug("GEMS_KUNLUNXIN GELU FORWARD")
+    logger.debug("GEMS_KUNLUNXIN GELU_FORWARD")
     if approximate == "tanh":
         out = gelu_tanh(self)
     else:
@@ -66,7 +66,7 @@ def gelu(self, *, approximate="none"):
 
 
 def gelu_backward(grad_output, self, *, approximate="none"):
-    logger.debug("GEMS_KUNLUNXIN GELU BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN GELU_BACKWARD")
     if approximate == "tanh":
         in_grad = gelu_backward_tanh(self, grad_output)
     else:
@@ -75,7 +75,7 @@ def gelu_backward(grad_output, self, *, approximate="none"):
 
 
 def gelu_(A, *, approximate="none"):
-    logger.debug("GEMS_KUNLUNXIN GELU_ FORWARD")
+    logger.debug("GEMS_KUNLUNXIN GELU__FORWARD")
     if approximate == "tanh":
         out = gelu_tanh(A, out0=A)
     else:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/gelu.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/gelu.py
@@ -57,7 +57,7 @@ def gelu_backward_tanh(x, dy):
 
 
 def gelu(self, *, approximate="none"):
-    logger.debug("GEMS_KUNLUNXIN GELU_FORWARD")
+    logger.debug("GEMS_KUNLUNXIN GELU")
     if approximate == "tanh":
         out = gelu_tanh(self)
     else:
@@ -75,7 +75,7 @@ def gelu_backward(grad_output, self, *, approximate="none"):
 
 
 def gelu_(A, *, approximate="none"):
-    logger.debug("GEMS_KUNLUNXIN GELU__FORWARD")
+    logger.debug("GEMS_KUNLUNXIN GELU_")
     if approximate == "tanh":
         out = gelu_tanh(A, out0=A)
     else:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/glu.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/glu.py
@@ -38,7 +38,7 @@ def glu_backward_kernel(grad_output, a, b):
 
 def glu(self, dim=-1):
     assert self.shape[dim] % 2 == 0, "Split dimension must be even"
-    logger.debug("GLU FORWARD")
+    logger.debug("GEMS_KUNLUNXIN GLU FORWARD")
     # Split into a and b
     a, b = torch.chunk(self, 2, dim=dim)
     out = glu_kernel(a, b)
@@ -48,7 +48,7 @@ def glu(self, dim=-1):
 
 def glu_backward(grad_output, self, dim=-1):
     assert self.shape[dim] % 2 == 0, "Split dimension must be even"
-    logger.debug("GEMS GLU BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN GLU BACKWARD")
     # Recreate a and b
     a, b = torch.chunk(self, 2, dim=dim)
     grad_input = torch.empty_like(self, memory_format=torch.contiguous_format)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/glu.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/glu.py
@@ -38,7 +38,7 @@ def glu_backward_kernel(grad_output, a, b):
 
 def glu(self, dim=-1):
     assert self.shape[dim] % 2 == 0, "Split dimension must be even"
-    logger.debug("GEMS_KUNLUNXIN GLU_FORWARD")
+    logger.debug("GEMS_KUNLUNXIN GLU")
     # Split into a and b
     a, b = torch.chunk(self, 2, dim=dim)
     out = glu_kernel(a, b)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/glu.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/glu.py
@@ -38,7 +38,7 @@ def glu_backward_kernel(grad_output, a, b):
 
 def glu(self, dim=-1):
     assert self.shape[dim] % 2 == 0, "Split dimension must be even"
-    logger.debug("GEMS_KUNLUNXIN GLU FORWARD")
+    logger.debug("GEMS_KUNLUNXIN GLU_FORWARD")
     # Split into a and b
     a, b = torch.chunk(self, 2, dim=dim)
     out = glu_kernel(a, b)
@@ -48,7 +48,7 @@ def glu(self, dim=-1):
 
 def glu_backward(grad_output, self, dim=-1):
     assert self.shape[dim] % 2 == 0, "Split dimension must be even"
-    logger.debug("GEMS_KUNLUNXIN GLU BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN GLU_BACKWARD")
     # Recreate a and b
     a, b = torch.chunk(self, 2, dim=dim)
     grad_input = torch.empty_like(self, memory_format=torch.contiguous_format)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/groupnorm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/groupnorm.py
@@ -233,7 +233,7 @@ def weight_bias_backward_kernel_loop(
 
 
 def group_norm(input, weight, bias, N, C, HxW, group, eps=1e-05):
-    logger.debug("GEMS_KUNLUNXIN GROUPNORM_FORWARD")
+    logger.debug("GEMS_KUNLUNXIN GROUP_NORM")
 
     group_size = triton.cdiv(C, group)
     input = input.contiguous()
@@ -275,7 +275,7 @@ def group_norm(input, weight, bias, N, C, HxW, group, eps=1e-05):
 def group_norm_backward(
     grad_out, input, mean, rstd, weight, N, C, HxW, group, output_mask
 ):
-    logger.debug("GEMS_KUNLUNXIN GROUPNORM_BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN GROUP_NORM_BACKWARD")
 
     grad_out = grad_out.contiguous()
     input = input.contiguous()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/groupnorm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/groupnorm.py
@@ -233,7 +233,7 @@ def weight_bias_backward_kernel_loop(
 
 
 def group_norm(input, weight, bias, N, C, HxW, group, eps=1e-05):
-    logger.debug("GEMS GROUPNORM FORWARD")
+    logger.debug("GEMS_KUNLUNXIN GROUPNORM FORWARD")
 
     group_size = triton.cdiv(C, group)
     input = input.contiguous()
@@ -275,7 +275,7 @@ def group_norm(input, weight, bias, N, C, HxW, group, eps=1e-05):
 def group_norm_backward(
     grad_out, input, mean, rstd, weight, N, C, HxW, group, output_mask
 ):
-    logger.debug("GEMS GROUPNORM BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN GROUPNORM BACKWARD")
 
     grad_out = grad_out.contiguous()
     input = input.contiguous()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/groupnorm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/groupnorm.py
@@ -233,7 +233,7 @@ def weight_bias_backward_kernel_loop(
 
 
 def group_norm(input, weight, bias, N, C, HxW, group, eps=1e-05):
-    logger.debug("GEMS_KUNLUNXIN GROUPNORM FORWARD")
+    logger.debug("GEMS_KUNLUNXIN GROUPNORM_FORWARD")
 
     group_size = triton.cdiv(C, group)
     input = input.contiguous()
@@ -275,7 +275,7 @@ def group_norm(input, weight, bias, N, C, HxW, group, eps=1e-05):
 def group_norm_backward(
     grad_out, input, mean, rstd, weight, N, C, HxW, group, output_mask
 ):
-    logger.debug("GEMS_KUNLUNXIN GROUPNORM BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN GROUPNORM_BACKWARD")
 
     grad_out = grad_out.contiguous()
     input = input.contiguous()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/gt.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/gt.py
@@ -32,7 +32,7 @@ def gt_func(x, y):
 
 
 def gt(A, B):
-    logger.debug("GEMS GT")
+    logger.debug("GEMS_KUNLUNXIN GT")
     os.environ["TRITONXPU_COMPARE_FUSION"] = "1"
     os.environ["TRITONXPU_FP16_FAST"] = "1"
     res = gt_func(A, B)
@@ -52,6 +52,6 @@ def gt_func_scalar(x, y):
 
 
 def gt_scalar(A, B):
-    logger.debug("GEMS GT SCALAR")
+    logger.debug("GEMS_KUNLUNXIN GT SCALAR")
     res = gt_func_scalar(A, B)
     return res

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/gt.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/gt.py
@@ -52,6 +52,6 @@ def gt_func_scalar(x, y):
 
 
 def gt_scalar(A, B):
-    logger.debug("GEMS_KUNLUNXIN GT SCALAR")
+    logger.debug("GEMS_KUNLUNXIN GT_SCALAR")
     res = gt_func_scalar(A, B)
     return res

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/hstack.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/hstack.py
@@ -21,7 +21,7 @@ def copy_func(x):
 def hstack(
     tensors: Union[Tuple[torch.Tensor, ...], List[torch.Tensor]]
 ) -> torch.Tensor:
-    logger.debug("GEMS HSTACK")
+    logger.debug("GEMS_KUNLUNXIN HSTACK")
 
     if len(tensors) == 0:
         raise RuntimeError("hstack expected a non-empty TensorList")

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/index.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/index.py
@@ -292,7 +292,7 @@ _index_func = IndexFunction()
 
 
 def index(inp, indices):
-    logger.debug("GEMS INDEX")
+    logger.debug("GEMS_KUNLUNXIN INDEX")
     original_indices = list(indices)  # Save original indices for later checks
     indices = list(indices)
 

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/index_add.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/index_add.py
@@ -77,7 +77,7 @@ def index_add_kernel(
 
 
 def index_add(inp, dim, index, src, alpha=1):
-    logger.debug("GEMS INDEX ADD")
+    logger.debug("GEMS_KUNLUNXIN INDEX ADD")
     assert ((0 <= index) * (index < inp.size(dim))).equal(
         torch.ones(tuple(index.shape), dtype=torch.bool, device="cuda")
     ), "0 <= index < self.size(dim)"
@@ -120,7 +120,7 @@ def index_add(inp, dim, index, src, alpha=1):
 
 
 def index_add_(inp, dim, index, src, alpha=1):
-    logger.debug("GEMS INDEX ADD_")
+    logger.debug("GEMS_KUNLUNXIN INDEX ADD_")
     assert ((0 <= index) * (index < inp.size(dim))).equal(
         torch.ones(tuple(index.shape), dtype=torch.bool, device="cuda")
     ), "0 <= index < self.size(dim)"

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/index_add.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/index_add.py
@@ -77,7 +77,7 @@ def index_add_kernel(
 
 
 def index_add(inp, dim, index, src, alpha=1):
-    logger.debug("GEMS_KUNLUNXIN INDEX ADD")
+    logger.debug("GEMS_KUNLUNXIN INDEX_ADD")
     assert ((0 <= index) * (index < inp.size(dim))).equal(
         torch.ones(tuple(index.shape), dtype=torch.bool, device="cuda")
     ), "0 <= index < self.size(dim)"
@@ -120,7 +120,7 @@ def index_add(inp, dim, index, src, alpha=1):
 
 
 def index_add_(inp, dim, index, src, alpha=1):
-    logger.debug("GEMS_KUNLUNXIN INDEX ADD_")
+    logger.debug("GEMS_KUNLUNXIN INDEX_ADD_")
     assert ((0 <= index) * (index < inp.size(dim))).equal(
         torch.ones(tuple(index.shape), dtype=torch.bool, device="cuda")
     ), "0 <= index < self.size(dim)"

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/index_add_.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/index_add_.py
@@ -77,7 +77,7 @@ def index_add_kernel(
 
 
 def index_add(inp, dim, index, src, alpha=1):
-    logger.debug("GEMS_KUNLUNXIN INDEX ADD")
+    logger.debug("GEMS_KUNLUNXIN INDEX_ADD")
     assert ((0 <= index) * (index < inp.size(dim))).equal(
         torch.ones(tuple(index.shape), dtype=torch.bool, device="cuda")
     ), "0 <= index < self.size(dim)"
@@ -120,7 +120,7 @@ def index_add(inp, dim, index, src, alpha=1):
 
 
 def index_add_(inp, dim, index, src, alpha=1):
-    logger.debug("GEMS_KUNLUNXIN INDEX ADD_")
+    logger.debug("GEMS_KUNLUNXIN INDEX_ADD_")
     assert ((0 <= index) * (index < inp.size(dim))).equal(
         torch.ones(tuple(index.shape), dtype=torch.bool, device="cuda")
     ), "0 <= index < self.size(dim)"

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/index_put.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/index_put.py
@@ -292,7 +292,7 @@ _index_put_func = IndexPutFunction()
 
 
 def index_put(inp, indices, values, accumulate=False):
-    logger.debug("GEMS INDEX PUT")
+    logger.debug("GEMS_KUNLUNXIN INDEX PUT")
 
     indices = list(indices)
     if len(indices) == 1 and indices[0].dtype == torch.bool:
@@ -390,7 +390,7 @@ def index_put(inp, indices, values, accumulate=False):
 
 
 def index_put_(inp, indices, values, accumulate=False):
-    logger.debug("GEMS INDEX PUT_")
+    logger.debug("GEMS_KUNLUNXIN INDEX PUT_")
 
     indices = list(indices)
     if len(indices) == 1 and indices[0].dtype == torch.bool:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/index_put.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/index_put.py
@@ -292,7 +292,7 @@ _index_put_func = IndexPutFunction()
 
 
 def index_put(inp, indices, values, accumulate=False):
-    logger.debug("GEMS_KUNLUNXIN INDEX PUT")
+    logger.debug("GEMS_KUNLUNXIN INDEX_PUT")
 
     indices = list(indices)
     if len(indices) == 1 and indices[0].dtype == torch.bool:
@@ -390,7 +390,7 @@ def index_put(inp, indices, values, accumulate=False):
 
 
 def index_put_(inp, indices, values, accumulate=False):
-    logger.debug("GEMS_KUNLUNXIN INDEX PUT_")
+    logger.debug("GEMS_KUNLUNXIN INDEX_PUT_")
 
     indices = list(indices)
     if len(indices) == 1 and indices[0].dtype == torch.bool:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/index_select.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/index_select.py
@@ -41,7 +41,7 @@ def index_select_kernel(
 
 
 def index_select(inp, dim, index):
-    logger.debug("GEMS INDEX SELECT")
+    logger.debug("GEMS_KUNLUNXIN INDEX SELECT")
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
     assert index.ndim <= 1, "Index should have dimension 1 or 0"
     assert ((i >= 0 and i < inp.size(dim)) for i in index), "Index out of range"

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/index_select.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/index_select.py
@@ -41,7 +41,7 @@ def index_select_kernel(
 
 
 def index_select(inp, dim, index):
-    logger.debug("GEMS_KUNLUNXIN INDEX SELECT")
+    logger.debug("GEMS_KUNLUNXIN INDEX_SELECT")
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
     assert index.ndim <= 1, "Index should have dimension 1 or 0"
     assert ((i >= 0 and i < inp.size(dim)) for i in index), "Index out of range"

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/instance_norm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/instance_norm.py
@@ -546,7 +546,7 @@ class InstanceNorm(torch.autograd.Function):
         eps=1e-05,
         cudnn_enable=False,
     ):
-        logger.debug("GEMS_KUNLUNXIN INSTANCENORM_FORWARD")
+        logger.debug("GEMS_KUNLUNXIN INSTANCE_NORM")
         assert len(x.shape) in [
             3,
             4,
@@ -658,7 +658,7 @@ class InstanceNorm(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, out_grad):
-        logger.debug("GEMS_KUNLUNXIN INSTANCENORM_BACKWARD")
+        logger.debug("GEMS_KUNLUNXIN INSTANCE_NORM_BACKWARD")
         out_grad = out_grad.contiguous()
         x, weight, mean, rstd = ctx.saved_tensors
         M = ctx.M

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/instance_norm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/instance_norm.py
@@ -546,7 +546,7 @@ class InstanceNorm(torch.autograd.Function):
         eps=1e-05,
         cudnn_enable=False,
     ):
-        logger.debug("GEMS_KUNLUNXIN INSTANCENORM FORWARD")
+        logger.debug("GEMS_KUNLUNXIN INSTANCENORM_FORWARD")
         assert len(x.shape) in [
             3,
             4,
@@ -658,7 +658,7 @@ class InstanceNorm(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, out_grad):
-        logger.debug("GEMS_KUNLUNXIN INSTANCENORM BACKWARD")
+        logger.debug("GEMS_KUNLUNXIN INSTANCENORM_BACKWARD")
         out_grad = out_grad.contiguous()
         x, weight, mean, rstd = ctx.saved_tensors
         M = ctx.M

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/isclose.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/isclose.py
@@ -51,7 +51,7 @@ def isclose(
     atol=1e-08,
     equal_nan: bool = False,
 ) -> torch.Tensor:
-    logger.debug("GEMS ISCLOSE")
+    logger.debug("GEMS_KUNLUNXIN ISCLOSE")
     if not equal_nan:
         os.environ["XPU_cmp_nan"] = "1"
     else:
@@ -84,5 +84,5 @@ def allclose(
     atol=1e-08,
     equal_nan: bool = False,
 ) -> bool:
-    logger.debug("GEMS ALLCLOSE")
+    logger.debug("GEMS_KUNLUNXIN ALLCLOSE")
     return all(isclose(A, B, rtol, atol, equal_nan)).item()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/isinf.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/isinf.py
@@ -18,5 +18,5 @@ def isinf_func(x):
 
 
 def isinf(A):
-    logger.debug("GEMS ISINF")
+    logger.debug("GEMS_KUNLUNXIN ISINF")
     return isinf_func(A)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/layernorm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/layernorm.py
@@ -434,7 +434,7 @@ def weight_bias_backward_kernel(
 
 
 def layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-5):
-    logger.debug("GEMS_KUNLUNXIN LAYERNORM_FORWARD")
+    logger.debug("GEMS_KUNLUNXIN LAYER_NORM")
 
     N = math.prod(normalized_shape)
     M = input.numel() // N
@@ -497,7 +497,7 @@ def layer_norm_backward(
     bias=None,
     output_mask=None,
 ):
-    logger.debug("GEMS_KUNLUNXIN LAYERNORM_BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN LAYER_NORM_BACKWARD")
 
     grad_out = grad_out.contiguous()
     input = input.contiguous()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/layernorm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/layernorm.py
@@ -434,7 +434,7 @@ def weight_bias_backward_kernel(
 
 
 def layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-5):
-    logger.debug("GEMS LAYERNORM FORWARD")
+    logger.debug("GEMS_KUNLUNXIN LAYERNORM FORWARD")
 
     N = math.prod(normalized_shape)
     M = input.numel() // N
@@ -497,7 +497,7 @@ def layer_norm_backward(
     bias=None,
     output_mask=None,
 ):
-    logger.debug("GEMS LAYERNORM BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN LAYERNORM BACKWARD")
 
     grad_out = grad_out.contiguous()
     input = input.contiguous()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/layernorm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/layernorm.py
@@ -434,7 +434,7 @@ def weight_bias_backward_kernel(
 
 
 def layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-5):
-    logger.debug("GEMS_KUNLUNXIN LAYERNORM FORWARD")
+    logger.debug("GEMS_KUNLUNXIN LAYERNORM_FORWARD")
 
     N = math.prod(normalized_shape)
     M = input.numel() // N
@@ -497,7 +497,7 @@ def layer_norm_backward(
     bias=None,
     output_mask=None,
 ):
-    logger.debug("GEMS_KUNLUNXIN LAYERNORM BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN LAYERNORM_BACKWARD")
 
     grad_out = grad_out.contiguous()
     input = input.contiguous()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/le.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/le.py
@@ -52,6 +52,6 @@ def le_func_scalar(x, y):
 
 
 def le_scalar(A, B):
-    logger.debug("GEMS_KUNLUNXIN LE SCALAR")
+    logger.debug("GEMS_KUNLUNXIN LE_SCALAR")
     res = le_func_scalar(A, B)
     return res

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/lerp.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/lerp.py
@@ -55,12 +55,12 @@ def lerp_tensor(input, end, weight):
 
 
 def lerp_tensor_(input, end, weight):
-    logger.debug("GEMS_KUNLUNXIN LERP_INPLACE_TENSOR")
+    logger.debug("GEMS_KUNLUNXIN LERP_TENSOR_")
     return lerp_tensor_kernel(input, end, weight, out0=input)
 
 
 def lerp_scalar(input, end, weight):
-    logger.debug("GEMS_KUNLUNXIN LERP_TENSOR")
+    logger.debug("GEMS_KUNLUNXIN LERP_SCALAR")
     if weight < 0.5:
         out = lerp_scalar_kernel_head(input, end, weight)
     else:
@@ -69,7 +69,7 @@ def lerp_scalar(input, end, weight):
 
 
 def lerp_scalar_(input, end, weight):
-    logger.debug("GEMS_KUNLUNXIN LERP_INPLACE_TENSOR")
+    logger.debug("GEMS_KUNLUNXIN LERP_SCALAR_")
     if weight < 0.5:
         return lerp_scalar_kernel_head(input, end, weight, out0=input)
     else:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/lerp.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/lerp.py
@@ -49,18 +49,18 @@ def lerp_scalar_kernel_tail(input, end, weight):
 
 
 def lerp_tensor(input, end, weight):
-    logger.debug("GEMS_KUNLUNXIN LERP TENSOR")
+    logger.debug("GEMS_KUNLUNXIN LERP_TENSOR")
     out = lerp_tensor_kernel(input, end, weight)
     return out
 
 
 def lerp_tensor_(input, end, weight):
-    logger.debug("GEMS_KUNLUNXIN LERP INPLACE TENSOR")
+    logger.debug("GEMS_KUNLUNXIN LERP_INPLACE_TENSOR")
     return lerp_tensor_kernel(input, end, weight, out0=input)
 
 
 def lerp_scalar(input, end, weight):
-    logger.debug("GEMS_KUNLUNXIN LERP TENSOR")
+    logger.debug("GEMS_KUNLUNXIN LERP_TENSOR")
     if weight < 0.5:
         out = lerp_scalar_kernel_head(input, end, weight)
     else:
@@ -69,7 +69,7 @@ def lerp_scalar(input, end, weight):
 
 
 def lerp_scalar_(input, end, weight):
-    logger.debug("GEMS_KUNLUNXIN LERP INPLACE TENSOR")
+    logger.debug("GEMS_KUNLUNXIN LERP_INPLACE_TENSOR")
     if weight < 0.5:
         return lerp_scalar_kernel_head(input, end, weight, out0=input)
     else:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/lerp.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/lerp.py
@@ -49,18 +49,18 @@ def lerp_scalar_kernel_tail(input, end, weight):
 
 
 def lerp_tensor(input, end, weight):
-    logger.debug("GEMS LERP TENSOR")
+    logger.debug("GEMS_KUNLUNXIN LERP TENSOR")
     out = lerp_tensor_kernel(input, end, weight)
     return out
 
 
 def lerp_tensor_(input, end, weight):
-    logger.debug("GEMS LERP INPLACE TENSOR")
+    logger.debug("GEMS_KUNLUNXIN LERP INPLACE TENSOR")
     return lerp_tensor_kernel(input, end, weight, out0=input)
 
 
 def lerp_scalar(input, end, weight):
-    logger.debug("GEMS LERP TENSOR")
+    logger.debug("GEMS_KUNLUNXIN LERP TENSOR")
     if weight < 0.5:
         out = lerp_scalar_kernel_head(input, end, weight)
     else:
@@ -69,7 +69,7 @@ def lerp_scalar(input, end, weight):
 
 
 def lerp_scalar_(input, end, weight):
-    logger.debug("GEMS LERP INPLACE TENSOR")
+    logger.debug("GEMS_KUNLUNXIN LERP INPLACE TENSOR")
     if weight < 0.5:
         return lerp_scalar_kernel_head(input, end, weight, out0=input)
     else:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/linspace.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/linspace.py
@@ -36,7 +36,7 @@ def linspace_kernel(
 def linspace(
     start, end, steps, *, dtype=None, layout=None, device=None, pin_memory=None
 ) -> torch.Tensor:
-    logger.debug("GEMS LINSPACE")
+    logger.debug("GEMS_KUNLUNXIN LINSPACE")
     assert steps >= 1, "steps must be >= 1"
 
     out = torch.empty(

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/log.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/log.py
@@ -15,5 +15,5 @@ def log_func(x):
 
 
 def log(A):
-    logger.debug("GEMS LOG")
+    logger.debug("GEMS_KUNLUNXIN LOG")
     return log_func(A)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/log_sigmoid.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/log_sigmoid.py
@@ -15,6 +15,6 @@ def log_sigmoid_forward(x):
 
 
 def log_sigmoid(x):
-    logger.debug("GEMS_KUNLUNXIN LOG_SIGMOID FORWARD")
+    logger.debug("GEMS_KUNLUNXIN LOG_SIGMOID_FORWARD")
 
     return log_sigmoid_forward(x)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/log_sigmoid.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/log_sigmoid.py
@@ -15,6 +15,6 @@ def log_sigmoid_forward(x):
 
 
 def log_sigmoid(x):
-    logger.debug("GEMS LOG_SIGMOID FORWARD")
+    logger.debug("GEMS_KUNLUNXIN LOG_SIGMOID FORWARD")
 
     return log_sigmoid_forward(x)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/log_sigmoid.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/log_sigmoid.py
@@ -15,6 +15,6 @@ def log_sigmoid_forward(x):
 
 
 def log_sigmoid(x):
-    logger.debug("GEMS_KUNLUNXIN LOG_SIGMOID_FORWARD")
+    logger.debug("GEMS_KUNLUNXIN LOG_SIGMOID")
 
     return log_sigmoid_forward(x)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/log_softmax.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/log_softmax.py
@@ -120,7 +120,7 @@ def log_softmax_backward_kernel(
 
 
 def log_softmax(self, dim, half_to_float=False):
-    logger.debug("GEMS LOG_SOFTMAX")
+    logger.debug("GEMS_KUNLUNXIN LOG_SOFTMAX")
 
     assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
     dim = dim % self.ndim
@@ -154,7 +154,7 @@ def log_softmax(self, dim, half_to_float=False):
 
 
 def log_softmax_backward(grad_output, output, dim, input_dtype):
-    logger.debug("GEMS LOG_SOFTMAX VJP")
+    logger.debug("GEMS_KUNLUNXIN LOG_SOFTMAX VJP")
 
     assert dim >= -output.ndim and dim < output.ndim, "Invalid dim"
     dim = dim % output.ndim

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/log_softmax.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/log_softmax.py
@@ -154,7 +154,7 @@ def log_softmax(self, dim, half_to_float=False):
 
 
 def log_softmax_backward(grad_output, output, dim, input_dtype):
-    logger.debug("GEMS_KUNLUNXIN LOG_SOFTMAX VJP")
+    logger.debug("GEMS_KUNLUNXIN LOG_SOFTMAX_VJP")
 
     assert dim >= -output.ndim and dim < output.ndim, "Invalid dim"
     dim = dim % output.ndim

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/log_softmax.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/log_softmax.py
@@ -154,7 +154,7 @@ def log_softmax(self, dim, half_to_float=False):
 
 
 def log_softmax_backward(grad_output, output, dim, input_dtype):
-    logger.debug("GEMS_KUNLUNXIN LOG_SOFTMAX_VJP")
+    logger.debug("GEMS_KUNLUNXIN LOG_SOFTMAX_BACKWARD")
 
     assert dim >= -output.ndim and dim < output.ndim, "Invalid dim"
     dim = dim % output.ndim

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/logical_and.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/logical_and.py
@@ -15,5 +15,5 @@ def logical_and_func(x, y):
 
 
 def logical_and(A, B):
-    logger.debug("GEMS LOGICAL_AND")
+    logger.debug("GEMS_KUNLUNXIN LOGICAL_AND")
     return logical_and_func(A, B)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/logical_not.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/logical_not.py
@@ -15,5 +15,5 @@ def logical_not_func(x):
 
 
 def logical_not(A):
-    logger.debug("GEMS LOGICAL_NOT")
+    logger.debug("GEMS_KUNLUNXIN LOGICAL_NOT")
     return logical_not_func(A)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/logical_xor.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/logical_xor.py
@@ -15,5 +15,5 @@ def logical_xor_func(x, y):
 
 
 def logical_xor(A, B):
-    logger.debug("GEMS LOGICAL_XOR")
+    logger.debug("GEMS_KUNLUNXIN LOGICAL_XOR")
     return logical_xor_func(A, B)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/logspace.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/logspace.py
@@ -49,7 +49,7 @@ def logspace(
     device=None,
     pin_memory=None,
 ) -> torch.Tensor:
-    logger.debug("GEMS LOGSPACE")
+    logger.debug("GEMS_KUNLUNXIN LOGSPACE")
     assert steps >= 0, "number of steps must be non-negative"
     out_dtype = dtype if dtype is not None else torch.get_default_dtype()
     out = torch.empty(

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/lt.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/lt.py
@@ -31,7 +31,7 @@ def lt_func(x, y):
 
 
 def lt(A, B):
-    logger.debug("GEMS LT")
+    logger.debug("GEMS_KUNLUNXIN LT")
     os.environ["TRITONXPU_COMPARE_FUSION"] = "1"
     os.environ["TRITONXPU_FP16_FAST"] = "1"
     res = lt_func(A, B)
@@ -51,6 +51,6 @@ def lt_func_scalar(x, y):
 
 
 def lt_scalar(A, B):
-    logger.debug("GEMS LT SCALAR")
+    logger.debug("GEMS_KUNLUNXIN LT SCALAR")
     res = lt_func_scalar(A, B)
     return res

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/lt.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/lt.py
@@ -51,6 +51,6 @@ def lt_func_scalar(x, y):
 
 
 def lt_scalar(A, B):
-    logger.debug("GEMS_KUNLUNXIN LT SCALAR")
+    logger.debug("GEMS_KUNLUNXIN LT_SCALAR")
     res = lt_func_scalar(A, B)
     return res

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/masked_fill.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/masked_fill.py
@@ -114,7 +114,7 @@ def masked_fill(inp, mask, value):
 
 
 def masked_fill_(inp, mask, value):
-    logger.debug("GEMS_KUNLUNXIN MASKED_FILL")
+    logger.debug("GEMS_KUNLUNXIN MASKED_FILL_")
     assert (
         (torch.is_tensor(value) and value.ndim == 0)
         or isinstance(value, int)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/masked_fill.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/masked_fill.py
@@ -59,7 +59,7 @@ def masked_fill_kernel_self(inp, expand_mask, value, N, BLOCK_SIZE: tl.constexpr
 
 
 def masked_fill(inp, mask, value):
-    logger.debug("GEMS MASKED FILL")
+    logger.debug("GEMS_KUNLUNXIN MASKED FILL")
     assert (
         (torch.is_tensor(value) and value.ndim == 0)
         or isinstance(value, int)
@@ -114,7 +114,7 @@ def masked_fill(inp, mask, value):
 
 
 def masked_fill_(inp, mask, value):
-    logger.debug("GEMS MASKED FILL")
+    logger.debug("GEMS_KUNLUNXIN MASKED FILL")
     assert (
         (torch.is_tensor(value) and value.ndim == 0)
         or isinstance(value, int)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/masked_fill.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/masked_fill.py
@@ -59,7 +59,7 @@ def masked_fill_kernel_self(inp, expand_mask, value, N, BLOCK_SIZE: tl.constexpr
 
 
 def masked_fill(inp, mask, value):
-    logger.debug("GEMS_KUNLUNXIN MASKED FILL")
+    logger.debug("GEMS_KUNLUNXIN MASKED_FILL")
     assert (
         (torch.is_tensor(value) and value.ndim == 0)
         or isinstance(value, int)
@@ -114,7 +114,7 @@ def masked_fill(inp, mask, value):
 
 
 def masked_fill_(inp, mask, value):
-    logger.debug("GEMS_KUNLUNXIN MASKED FILL")
+    logger.debug("GEMS_KUNLUNXIN MASKED_FILL")
     assert (
         (torch.is_tensor(value) and value.ndim == 0)
         or isinstance(value, int)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/masked_scatter.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/masked_scatter.py
@@ -181,7 +181,7 @@ def masked_scatter_impl(inp, mask, source, N):
 
 
 def masked_scatter(inp, mask, source):
-    logger.debug("GEMS MASKED SCATTER")
+    logger.debug("GEMS_KUNLUNXIN MASKED SCATTER")
 
     assert broadcastable(
         inp.shape, mask.shape
@@ -205,7 +205,7 @@ def masked_scatter(inp, mask, source):
 
 
 def masked_scatter_(inp, mask, source):
-    logger.debug("GEMS MASKED SCATTER_")
+    logger.debug("GEMS_KUNLUNXIN MASKED SCATTER_")
 
     assert broadcastable(inp.shape, mask.shape)
     _, mask = torch.broadcast_tensors(inp, mask)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/masked_scatter.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/masked_scatter.py
@@ -181,7 +181,7 @@ def masked_scatter_impl(inp, mask, source, N):
 
 
 def masked_scatter(inp, mask, source):
-    logger.debug("GEMS_KUNLUNXIN MASKED SCATTER")
+    logger.debug("GEMS_KUNLUNXIN MASKED_SCATTER")
 
     assert broadcastable(
         inp.shape, mask.shape
@@ -205,7 +205,7 @@ def masked_scatter(inp, mask, source):
 
 
 def masked_scatter_(inp, mask, source):
-    logger.debug("GEMS_KUNLUNXIN MASKED SCATTER_")
+    logger.debug("GEMS_KUNLUNXIN MASKED_SCATTER_")
 
     assert broadcastable(inp.shape, mask.shape)
     _, mask = torch.broadcast_tensors(inp, mask)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/masked_select.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/masked_select.py
@@ -36,7 +36,7 @@ def masked_select_kernel(
 
 
 def masked_select(inp, mask):
-    logger.debug("GEMS_KUNLUNXIN MASKED SELECT")
+    logger.debug("GEMS_KUNLUNXIN MASKED_SELECT")
 
     inp_shape = tuple(inp.shape)
     mask_shape = tuple(mask.shape)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/max.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/max.py
@@ -130,7 +130,7 @@ def max_kernel(
 
 
 def max(inp):
-    logger.debug("GEMS MAX")
+    logger.debug("GEMS_KUNLUNXIN MAX")
     os.environ["TRITONXPU_IS_SCATTER_SLICE"] = "1"
     inp = inp.contiguous()
     M = inp.numel()
@@ -165,7 +165,7 @@ def max(inp):
 
 
 def max_dim(inp, dim=None, keepdim=False):
-    logger.debug("GEMS MAX DIM")
+    logger.debug("GEMS_KUNLUNXIN MAX DIM")
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
     shape = inp.shape
     dim = dim % inp.ndim

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/max.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/max.py
@@ -165,7 +165,7 @@ def max(inp):
 
 
 def max_dim(inp, dim=None, keepdim=False):
-    logger.debug("GEMS_KUNLUNXIN MAX DIM")
+    logger.debug("GEMS_KUNLUNXIN MAX_DIM")
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
     shape = inp.shape
     dim = dim % inp.ndim

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/max_pool2d_with_indices.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/max_pool2d_with_indices.py
@@ -251,7 +251,7 @@ def max_pool2d_with_indices(
     dilation=1,
     ceil_mode=False,
 ):
-    logger.debug("GEMS_KUNLUNXIN MAX_POOL2D_WITH_INDICES_FORWARD")
+    logger.debug("GEMS_KUNLUNXIN MAX_POOL2D_WITH_INDICES")
     input = input.contiguous()
 
     params = _parse_pool_params(kernel_size, stride, padding, dilation)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/max_pool2d_with_indices.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/max_pool2d_with_indices.py
@@ -251,7 +251,7 @@ def max_pool2d_with_indices(
     dilation=1,
     ceil_mode=False,
 ):
-    logger.debug("GEMS MAX_POOL2D_WITH_INDICES FORWARD")
+    logger.debug("GEMS_KUNLUNXIN MAX_POOL2D_WITH_INDICES FORWARD")
     input = input.contiguous()
 
     params = _parse_pool_params(kernel_size, stride, padding, dilation)
@@ -326,7 +326,7 @@ def max_pool2d_backward(
     dilation,
     ceil_mode,
 ):
-    logger.debug("GEMS MAX_POOL2D BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN MAX_POOL2D BACKWARD")
     original_dtype = grad_output.dtype
     grad_output = grad_output.to(torch.float32).contiguous()
     indices = indices.to(torch.int32).contiguous()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/max_pool2d_with_indices.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/max_pool2d_with_indices.py
@@ -251,7 +251,7 @@ def max_pool2d_with_indices(
     dilation=1,
     ceil_mode=False,
 ):
-    logger.debug("GEMS_KUNLUNXIN MAX_POOL2D_WITH_INDICES FORWARD")
+    logger.debug("GEMS_KUNLUNXIN MAX_POOL2D_WITH_INDICES_FORWARD")
     input = input.contiguous()
 
     params = _parse_pool_params(kernel_size, stride, padding, dilation)
@@ -326,7 +326,7 @@ def max_pool2d_backward(
     dilation,
     ceil_mode,
 ):
-    logger.debug("GEMS_KUNLUNXIN MAX_POOL2D BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN MAX_POOL2D_BACKWARD")
     original_dtype = grad_output.dtype
     grad_output = grad_output.to(torch.float32).contiguous()
     indices = indices.to(torch.int32).contiguous()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/maximum.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/maximum.py
@@ -22,6 +22,6 @@ def maximum_kernel(X, Y):
 
 
 def maximum(X, Y):
-    logger.debug("GEMS MAXIMUM")
+    logger.debug("GEMS_KUNLUNXIN MAXIMUM")
     assert X.device.type == device and Y.device.type == device
     return maximum_kernel(X, Y)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/mean.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/mean.py
@@ -36,7 +36,7 @@ def mean_scalar_kernel(inp, out, M, BLOCK_SIZE: tl.constexpr):
 
 
 def mean(inp, *, dtype=None):
-    logger.debug("GEMS MEAN")
+    logger.debug("GEMS_KUNLUNXIN MEAN")
     M = inp.numel()
     if dtype is None:
         dtype = inp.dtype
@@ -97,7 +97,7 @@ def mean_dim_kernel(X, Mean, M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr)
 
 
 def mean_dim(x, dim, keepdim=False, *, dtype=None):
-    logger.debug("GEMS MEAN DIM")
+    logger.debug("GEMS_KUNLUNXIN MEAN DIM")
 
     if dtype is None:
         dtype = x.dtype

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/mean.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/mean.py
@@ -97,7 +97,7 @@ def mean_dim_kernel(X, Mean, M, N, BLOCK_M: tl.constexpr, BLOCK_N: tl.constexpr)
 
 
 def mean_dim(x, dim, keepdim=False, *, dtype=None):
-    logger.debug("GEMS_KUNLUNXIN MEAN DIM")
+    logger.debug("GEMS_KUNLUNXIN MEAN_DIM")
 
     if dtype is None:
         dtype = x.dtype

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/min.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/min.py
@@ -116,7 +116,7 @@ def min_kernel(
 
 
 def min(inp):
-    logger.debug("GEMS MIN")
+    logger.debug("GEMS_KUNLUNXIN MIN")
     M = inp.numel()
     # block_size = triton.next_power_of_2(math.ceil(math.sqrt(M)))
     block_size = get_block_size_1d(M, inp.element_size())
@@ -147,7 +147,7 @@ def min(inp):
 
 
 def min_dim(inp, dim=None, keepdim=False):
-    logger.debug("GEMS MIN DIM")
+    logger.debug("GEMS_KUNLUNXIN MIN DIM")
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
     shape = inp.shape
     dim = dim % inp.ndim

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/min.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/min.py
@@ -147,7 +147,7 @@ def min(inp):
 
 
 def min_dim(inp, dim=None, keepdim=False):
-    logger.debug("GEMS_KUNLUNXIN MIN DIM")
+    logger.debug("GEMS_KUNLUNXIN MIN_DIM")
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
     shape = inp.shape
     dim = dim % inp.ndim

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/minimum.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/minimum.py
@@ -21,6 +21,6 @@ def minimum_kernel(X, Y):
 
 
 def minimum(X, Y):
-    logger.debug("GEMS MINIMUM")
+    logger.debug("GEMS_KUNLUNXIN MINIMUM")
     assert X.device.type == device and Y.device.type == device
     return minimum_kernel(X, Y)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/mm.py
@@ -144,7 +144,7 @@ def get_higher_dtype(a, b):
 
 
 def mm(a, b):
-    logger.debug("GEMS MM")
+    logger.debug("GEMS_KUNLUNXIN MM")
     device = a.device
     # handle non-contiguous inputs if necessary
     if a.stride(0) > 1 and a.stride(1) > 1:
@@ -184,7 +184,7 @@ def mm(a, b):
 
 
 def mm_out(a, b, *, out):
-    logger.debug("GEMS MM_OUT")
+    logger.debug("GEMS_KUNLUNXIN MM_OUT")
     # handle non-contiguous inputs if necessary
     if a.stride(0) > 1 and a.stride(1) > 1:
         a = a.contiguous()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/mse_loss.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/mse_loss.py
@@ -61,7 +61,7 @@ class Reduction(Enum):
 
 
 def mse_loss(inp, target, reduction=Reduction.MEAN.value):
-    logger.debug("GEMS_KUNLUNXIN MSE LOSS")
+    logger.debug("GEMS_KUNLUNXIN MSE_LOSS")
     if reduction == Reduction.NONE.value:
         return func(inp, target)
 

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/mul.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/mul.py
@@ -33,7 +33,7 @@ def mul_complex_kernel(ar, ai, br, bi):
 
 
 def mul(A, B):
-    logger.debug("GEMS MUL")
+    logger.debug("GEMS_KUNLUNXIN MUL")
     A_is_complex = isinstance(A, torch.Tensor) and A.is_complex()
     B_is_complex = isinstance(B, torch.Tensor) and B.is_complex()
 
@@ -84,7 +84,7 @@ def mul(A, B):
 
 
 def mul_(A, B):
-    logger.debug("GEMS MUL_")
+    logger.debug("GEMS_KUNLUNXIN MUL_")
     if isinstance(B, torch.Tensor):
         return mul_func(A, B, out0=A)
     else:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/multinomial.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/multinomial.py
@@ -51,7 +51,7 @@ def multinomial_with_replacement(
 
 
 def multinomial(prob, n_samples, with_replacement=False, *, gen=None):
-    logger.debug("GEMS MULTINOMIAL")
+    logger.debug("GEMS_KUNLUNXIN MULTINOMIAL")
     assert prob.dtype in (torch.float16, torch.float32, torch.bfloat16, torch.float64)
     assert 0 < prob.dim() <= 2, "prob_dist must be 1 or 2 dim"
     n_categories = prob.size(-1)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/mv.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/mv.py
@@ -72,7 +72,7 @@ def mv_kernel(
 
 
 def mv(inp, vec):
-    logger.debug("GEMS MV")
+    logger.debug("GEMS_KUNLUNXIN MV")
     assert inp.shape[1] == vec.shape[0], "incompatible dimensions"
     N, M = inp.shape
     # TODO: fix autotune config has no item
@@ -105,7 +105,7 @@ def mv(inp, vec):
 
 
 def mv_cluster(inp, vec):
-    logger.debug("GEMS MV")
+    logger.debug("GEMS_KUNLUNXIN MV")
     assert inp.shape[1] == vec.shape[0], "incompatible dimensions"
     N, M = inp.shape
     out = torch.empty((N,), device=inp.device, dtype=inp.dtype)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/nan_to_num.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/nan_to_num.py
@@ -28,7 +28,7 @@ def nan_to_num_func(x, nan, posinf, neginf):
 
 # nan_to_num(Tensor self, float? nan=None, float? posinf=None, float? neginf=None) -> Tensor
 def nan_to_num(A, nan=None, posinf=None, neginf=None):
-    logger.debug("GEMS_KUNLUNXIN NAN_TO_NUM TENSOR")
+    logger.debug("GEMS_KUNLUNXIN NAN_TO_NUM_TENSOR")
     if posinf is None:
         posinf = torch.finfo(A.dtype).max
     if neginf is None:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/nan_to_num.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/nan_to_num.py
@@ -28,7 +28,7 @@ def nan_to_num_func(x, nan, posinf, neginf):
 
 # nan_to_num(Tensor self, float? nan=None, float? posinf=None, float? neginf=None) -> Tensor
 def nan_to_num(A, nan=None, posinf=None, neginf=None):
-    logger.debug("GEMS NAN_TO_NUM TENSOR")
+    logger.debug("GEMS_KUNLUNXIN NAN_TO_NUM TENSOR")
     if posinf is None:
         posinf = torch.finfo(A.dtype).max
     if neginf is None:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/ne.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/ne.py
@@ -50,6 +50,6 @@ def ne_func_scalar(x, y):
 
 
 def ne_scalar(A, B):
-    logger.debug("GEMS_KUNLUNXIN NE SCALAR")
+    logger.debug("GEMS_KUNLUNXIN NE_SCALAR")
     res = ne_func_scalar(A, B)
     return res

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/ne.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/ne.py
@@ -30,7 +30,7 @@ def ne_func(x, y):
 
 
 def ne(A, B):
-    logger.debug("GEMS NE")
+    logger.debug("GEMS_KUNLUNXIN NE")
     os.environ["TRITONXPU_COMPARE_FUSION"] = "1"
     os.environ["TRITONXPU_FP16_FAST"] = "1"
     res = ne_func(A, B)
@@ -50,6 +50,6 @@ def ne_func_scalar(x, y):
 
 
 def ne_scalar(A, B):
-    logger.debug("GEMS NE SCALAR")
+    logger.debug("GEMS_KUNLUNXIN NE SCALAR")
     res = ne_func_scalar(A, B)
     return res

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/neg.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/neg.py
@@ -26,10 +26,10 @@ def neg_func(x):
 
 
 def neg(A):
-    logger.debug("GEMS NEG")
+    logger.debug("GEMS_KUNLUNXIN NEG")
     return neg_func(A)
 
 
 def neg_(A):
-    logger.debug("GEMS NEG_")
+    logger.debug("GEMS_KUNLUNXIN NEG_")
     return neg_func(A, out0=A)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/nllloss.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/nllloss.py
@@ -213,7 +213,7 @@ def nll_loss2d_backward_kernel(
 
 # 1d & 2d tensor
 def nll_loss_forward(self, target, weight=None, reduction=1, ignore_index=-100):
-    logger.debug("GEMS NLL Loss FWD")
+    logger.debug("GEMS_KUNLUNXIN NLL Loss FWD")
     assert self.ndim <= 2, "Invalid input ndim"
     shape = list(target.shape)
     N = 1 if self.ndim == 1 else self.shape[0]
@@ -271,7 +271,7 @@ def nll_loss_backward(
     ignore_index=-100,
     total_weight=None,
 ):
-    logger.debug("GEMS NLL Loss BWD")
+    logger.debug("GEMS_KUNLUNXIN NLL Loss BWD")
     N = 1 if self.ndim == 1 else self.shape[0]
     C = self.shape[-1]
 
@@ -300,7 +300,7 @@ def nll_loss_backward(
 
 # 3d+ tensor
 def nll_loss2d_forward(self, target, weight=None, reduction=1, ignore_index=-100):
-    logger.debug("GEMS NLL Loss2d FWD")
+    logger.debug("GEMS_KUNLUNXIN NLL Loss2d FWD")
     assert self.ndim >= 3, "Invalid input ndim"
 
     N, C = self.shape[0], self.shape[1]
@@ -358,7 +358,7 @@ def nll_loss2d_backward(
     ignore_index=-100,
     total_weight=None,
 ):
-    logger.debug("GEMS NLL Loss2d BWD")
+    logger.debug("GEMS_KUNLUNXIN NLL Loss2d BWD")
     N, C = self.shape[0], self.shape[1]
     D = self.numel() // (N * C)
 

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/nllloss.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/nllloss.py
@@ -213,7 +213,7 @@ def nll_loss2d_backward_kernel(
 
 # 1d & 2d tensor
 def nll_loss_forward(self, target, weight=None, reduction=1, ignore_index=-100):
-    logger.debug("GEMS_KUNLUNXIN NLL Loss FWD")
+    logger.debug("GEMS_KUNLUNXIN NLL_LOSS_FWD")
     assert self.ndim <= 2, "Invalid input ndim"
     shape = list(target.shape)
     N = 1 if self.ndim == 1 else self.shape[0]
@@ -271,7 +271,7 @@ def nll_loss_backward(
     ignore_index=-100,
     total_weight=None,
 ):
-    logger.debug("GEMS_KUNLUNXIN NLL Loss BWD")
+    logger.debug("GEMS_KUNLUNXIN NLL_LOSS_BWD")
     N = 1 if self.ndim == 1 else self.shape[0]
     C = self.shape[-1]
 
@@ -300,7 +300,7 @@ def nll_loss_backward(
 
 # 3d+ tensor
 def nll_loss2d_forward(self, target, weight=None, reduction=1, ignore_index=-100):
-    logger.debug("GEMS_KUNLUNXIN NLL Loss2d FWD")
+    logger.debug("GEMS_KUNLUNXIN NLL_LOSS2D_FWD")
     assert self.ndim >= 3, "Invalid input ndim"
 
     N, C = self.shape[0], self.shape[1]
@@ -358,7 +358,7 @@ def nll_loss2d_backward(
     ignore_index=-100,
     total_weight=None,
 ):
-    logger.debug("GEMS_KUNLUNXIN NLL Loss2d BWD")
+    logger.debug("GEMS_KUNLUNXIN NLL_LOSS2D_BWD")
     N, C = self.shape[0], self.shape[1]
     D = self.numel() // (N * C)
 

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/nonzero.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/nonzero.py
@@ -57,7 +57,7 @@ def nonzero_kernel(
 
 
 def nonzero(inp, *, as_tuple=False):
-    logger.debug("GEMS NONZERO")
+    logger.debug("GEMS_KUNLUNXIN NONZERO")
 
     inp_ndim = inp.ndim
 

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/normal.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/normal.py
@@ -68,7 +68,7 @@ def normal_distribution(shape, device, *, generator=None, out=None):
 
 
 def normal_tensor_tensor(mean, std, *, generator=None):
-    logger.debug("GEMS NORMAL_TENSOR_TENSOR")
+    logger.debug("GEMS_KUNLUNXIN NORMAL_TENSOR_TENSOR")
     shape = broadcast_shapes([mean.shape, std.shape])
     device = mean.device
     out = normal_distribution(shape, device)
@@ -76,7 +76,7 @@ def normal_tensor_tensor(mean, std, *, generator=None):
 
 
 def normal_tensor_float(mean, std, *, generator=None):
-    logger.debug("GEMS NORMAL_TENSOR_FLOAT")
+    logger.debug("GEMS_KUNLUNXIN NORMAL_TENSOR_FLOAT")
     shape = mean.shape
     device = mean.device
     out = normal_distribution(shape, device)
@@ -84,7 +84,7 @@ def normal_tensor_float(mean, std, *, generator=None):
 
 
 def normal_float_tensor(mean, std, *, generator=None):
-    logger.debug("GEMS NORMAL_FLOAT_TENSOR")
+    logger.debug("GEMS_KUNLUNXIN NORMAL_FLOAT_TENSOR")
     shape = std.shape
     device = std.device
     out = normal_distribution(shape, device)
@@ -92,7 +92,7 @@ def normal_float_tensor(mean, std, *, generator=None):
 
 
 def normal_(self, mean=0, std=1, *, generator=None):
-    logger.debug("GEMS NORMAL_")
+    logger.debug("GEMS_KUNLUNXIN NORMAL_")
     shape = self.shape
     device = self.device
     self = normal_distribution(shape, device, generator=None, out=self)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/ones.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/ones.py
@@ -29,7 +29,7 @@ def ones_kernel(
 
 
 def ones(size, *, dtype=None, layout=None, device=None, pin_memory=None):
-    logger.debug("GEMS ONES")
+    logger.debug("GEMS_KUNLUNXIN ONES")
     if dtype is None:
         dtype = torch.get_default_dtype()
     if device is None:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/ones_like.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/ones_like.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 def ones_like(
     x, *, dtype=None, layout=None, device=None, pin_memory=None, memory_format=None
 ):
-    logger.debug("GEMS ONES_LIKE")
+    logger.debug("GEMS_KUNLUNXIN ONES_LIKE")
     if device is None:
         device = x.device
     if dtype is None:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/pad.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/pad.py
@@ -460,7 +460,7 @@ _pad_func = PadFunction()
 
 
 def pad(self, pad, mode="constant", value=None):
-    logger.debug("GEMS_KUNLUNXIN CONSTANT PAD ND")
+    logger.debug("GEMS_KUNLUNXIN CONSTANT_PAD_ND")
 
     ndim = self.ndim
 

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/pad.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/pad.py
@@ -460,7 +460,7 @@ _pad_func = PadFunction()
 
 
 def pad(self, pad, mode="constant", value=None):
-    logger.debug("GEMS CONSTANT PAD ND")
+    logger.debug("GEMS_KUNLUNXIN CONSTANT PAD ND")
 
     ndim = self.ndim
 

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/prod.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/prod.py
@@ -49,7 +49,7 @@ def prod_kernel_result(mid, out, mid_size, BLOCK_MID: tl.constexpr):
 
 
 def prod(inp, *, dtype=None):
-    logger.debug("GEMS PROD")
+    logger.debug("GEMS_KUNLUNXIN PROD")
     if dtype is None:
         dtype = inp.dtype
 
@@ -123,7 +123,7 @@ def prod_kernel(
 
 
 def prod_dim(inp, dim=None, keepdim=False, *, dtype=None):
-    logger.debug("GEMS PROD DIM")
+    logger.debug("GEMS_KUNLUNXIN PROD DIM")
 
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
     shape = list(inp.shape)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/prod.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/prod.py
@@ -123,7 +123,7 @@ def prod_kernel(
 
 
 def prod_dim(inp, dim=None, keepdim=False, *, dtype=None):
-    logger.debug("GEMS_KUNLUNXIN PROD DIM")
+    logger.debug("GEMS_KUNLUNXIN PROD_DIM")
 
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
     shape = list(inp.shape)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/quantile.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/quantile.py
@@ -103,7 +103,7 @@ def quantile_kernel(
 def quantile(
     inp, q, dim=None, keepdim=False, interpolation="linear", out=None
 ) -> Tensor:
-    logger.debug("GEMS QUANTILE DIM")
+    logger.debug("GEMS_KUNLUNXIN QUANTILE DIM")
     assert torch.is_floating_point(inp)
     assert dim is None or isinstance(dim, int)
     assert isinstance(q, (float, torch.Tensor))

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/quantile.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/quantile.py
@@ -103,7 +103,7 @@ def quantile_kernel(
 def quantile(
     inp, q, dim=None, keepdim=False, interpolation="linear", out=None
 ) -> Tensor:
-    logger.debug("GEMS_KUNLUNXIN QUANTILE DIM")
+    logger.debug("GEMS_KUNLUNXIN QUANTILE_DIM")
     assert torch.is_floating_point(inp)
     assert dim is None or isinstance(dim, int)
     assert isinstance(q, (float, torch.Tensor))

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/rand.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/rand.py
@@ -148,7 +148,7 @@ def rand_kernel_2(
 
 
 def rand(size, *, dtype=None, layout=None, device=None, pin_memory=None):
-    logger.debug("GEMS RAND")
+    logger.debug("GEMS_KUNLUNXIN RAND")
     if dtype is None:
         dtype = torch.get_default_dtype()
     if device is None:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/rand_like.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/rand_like.py
@@ -15,7 +15,7 @@ logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 def rand_like(
     x, *, dtype=None, layout=None, device=None, pin_memory=None, memory_format=None
 ):
-    logger.debug("GEMS RAND_LIKE")
+    logger.debug("GEMS_KUNLUNXIN RAND_LIKE")
     if device is None:
         device = x.device
     if dtype is None:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/randn.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/randn.py
@@ -64,7 +64,7 @@ UNROLL = 4
 
 
 def randn(size, *, dtype=None, layout=None, device=None, pin_memory=None):
-    logger.debug("GEMS RANDN")
+    logger.debug("GEMS_KUNLUNXIN RANDN")
     if dtype is None:
         dtype = torch.get_default_dtype()
     if device is None:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/randn_like.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/randn_like.py
@@ -15,7 +15,7 @@ UNROLL = 4
 def randn_like(
     x, *, dtype=None, layout=None, device=None, pin_memory=None, memory_format=None
 ):
-    logger.debug("GEMS RANDN_LIKE")
+    logger.debug("GEMS_KUNLUNXIN RANDN_LIKE")
     if device is None:
         device = x.device.index
     if dtype is None:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/randperm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/randperm.py
@@ -422,7 +422,7 @@ def randperm(
     requires_grad=False,
     pin_memory=False,
 ):
-    logger.debug("GEMS RANDPERM")
+    logger.debug("GEMS_KUNLUNXIN RANDPERM")
     assert dtype == torch.int16 or dtype == torch.int32 or dtype == torch.int64
     assert n <= _MAX_INT64_VAL, "n exceeds maximum int64"
 

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/reciprocal.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/reciprocal.py
@@ -27,10 +27,10 @@ def reciprocal_func(x):
 
 
 def reciprocal(A):
-    logger.debug("GEMS RECIPROCAL")
+    logger.debug("GEMS_KUNLUNXIN RECIPROCAL")
     return reciprocal_func(A)
 
 
 def reciprocal_(A):
-    logger.debug("GEMS RECIPROCAL_")
+    logger.debug("GEMS_KUNLUNXIN RECIPROCAL_")
     return reciprocal_func(A, out0=A)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/relu.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/relu.py
@@ -23,12 +23,12 @@ def relu_backward(x, dy):
 
 
 def relu(self):
-    logger.debug("GEMS RELU FORWARD")
+    logger.debug("GEMS_KUNLUNXIN RELU FORWARD")
     output = relu_forward(self)
     return output
 
 
 def relu_(A):
-    logger.debug("GEMS RELU_ FORWARD")
+    logger.debug("GEMS_KUNLUNXIN RELU_ FORWARD")
     out = relu_forward(A, out0=A)
     return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/relu.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/relu.py
@@ -23,12 +23,12 @@ def relu_backward(x, dy):
 
 
 def relu(self):
-    logger.debug("GEMS_KUNLUNXIN RELU FORWARD")
+    logger.debug("GEMS_KUNLUNXIN RELU_FORWARD")
     output = relu_forward(self)
     return output
 
 
 def relu_(A):
-    logger.debug("GEMS_KUNLUNXIN RELU_ FORWARD")
+    logger.debug("GEMS_KUNLUNXIN RELU__FORWARD")
     out = relu_forward(A, out0=A)
     return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/repeat.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/repeat.py
@@ -442,7 +442,7 @@ _repeat_func = RepeatFunction()
 
 
 def repeat(inp: torch.Tensor, sizes) -> torch.Tensor:
-    logger.debug("GEMS REPEAT")
+    logger.debug("GEMS_KUNLUNXIN REPEAT")
 
     out = _repeat_func(inp, sizes)
     return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/repeat_interleave.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/repeat_interleave.py
@@ -20,7 +20,7 @@ def copy_func(x):
 
 
 def repeat_interleave_self_int(inp, repeats, dim=None, *, output_size=None):
-    logger.debug("GEMS REPEAT_INTERLEAVE_SELF_INT")
+    logger.debug("GEMS_KUNLUNXIN REPEAT_INTERLEAVE_SELF_INT")
     if dim is None:
         inp = inp.flatten()
         dim = 0
@@ -83,7 +83,7 @@ def repeat_interleave_tensor_kernel(
 
 
 def repeat_interleave_tensor(repeats, *, output_size=None):
-    logger.debug("GEMS REPEAT_INTERLEAVE_TENSOR")
+    logger.debug("GEMS_KUNLUNXIN REPEAT_INTERLEAVE_TENSOR")
 
     assert repeats.ndim == 1, "repeat_interleave only accept 1D vector as repeat"
 
@@ -109,7 +109,7 @@ def repeat_interleave_tensor(repeats, *, output_size=None):
 
 
 def repeat_interleave_self_tensor(inp, repeats, dim=None, *, output_size=None):
-    logger.debug("GEMS REPEAT_INTERLEAVE_SELF_TENSOR")
+    logger.debug("GEMS_KUNLUNXIN REPEAT_INTERLEAVE_SELF_TENSOR")
 
     if dim is None:
         inp = inp.flatten()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/resolve_conj.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/resolve_conj.py
@@ -6,5 +6,5 @@ logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 
 
 def resolve_conj(A: torch.Tensor):
-    logger.debug("GEMS RESOLVE_CONJ")
+    logger.debug("GEMS_KUNLUNXIN RESOLVE_CONJ")
     return torch.complex(A.real, A.imag.neg()) if A.is_conj() else A

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/resolve_neg.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/resolve_neg.py
@@ -8,5 +8,5 @@ logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 
 
 def resolve_neg(A: torch.Tensor):
-    logger.debug("GEMS RESOLVE_NEG")
+    logger.debug("GEMS_KUNLUNXIN RESOLVE_NEG")
     return neg_func(A) if A.is_neg() else A

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/rms_norm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/rms_norm.py
@@ -302,7 +302,7 @@ def rms_norm_grad_kernel(
 
 
 def rms_norm_forward(x, normalized_shape, weight, eps=1e-5):
-    logger.debug("GEMS_KUNLUNXIN RMS_NORM FORWARD")
+    logger.debug("GEMS_KUNLUNXIN RMS_NORM_FORWARD")
     dim = x.ndim - len(normalized_shape)
     M = math.prod(x.shape[:dim])
     N = math.prod(normalized_shape)
@@ -331,7 +331,7 @@ def rms_norm_forward(x, normalized_shape, weight, eps=1e-5):
 
 
 def rms_norm_backward(dy, x, inv_rms, normalized_shape, weight, eps=1e-5):
-    logger.debug("GEMS_KUNLUNXIN RMS_NORM BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN RMS_NORM_BACKWARD")
 
     dim = x.ndim - len(normalized_shape)
     M = math.prod(x.shape[:dim])
@@ -410,7 +410,7 @@ def rms_norm_backward(dy, x, inv_rms, normalized_shape, weight, eps=1e-5):
 
 
 def rms_norm_backward_fusion(dy, x, inv_rms, normalized_shape, weight, eps=1e-5):
-    logger.debug("GEMS_KUNLUNXIN RMS_NORM BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN RMS_NORM_BACKWARD")
 
     dim = x.ndim - len(normalized_shape)
     M = math.prod(x.shape[:dim])  # Batch dimension

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/rms_norm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/rms_norm.py
@@ -302,7 +302,7 @@ def rms_norm_grad_kernel(
 
 
 def rms_norm_forward(x, normalized_shape, weight, eps=1e-5):
-    logger.debug("GEMS RMS_NORM FORWARD")
+    logger.debug("GEMS_KUNLUNXIN RMS_NORM FORWARD")
     dim = x.ndim - len(normalized_shape)
     M = math.prod(x.shape[:dim])
     N = math.prod(normalized_shape)
@@ -331,7 +331,7 @@ def rms_norm_forward(x, normalized_shape, weight, eps=1e-5):
 
 
 def rms_norm_backward(dy, x, inv_rms, normalized_shape, weight, eps=1e-5):
-    logger.debug("GEMS RMS_NORM BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN RMS_NORM BACKWARD")
 
     dim = x.ndim - len(normalized_shape)
     M = math.prod(x.shape[:dim])
@@ -410,7 +410,7 @@ def rms_norm_backward(dy, x, inv_rms, normalized_shape, weight, eps=1e-5):
 
 
 def rms_norm_backward_fusion(dy, x, inv_rms, normalized_shape, weight, eps=1e-5):
-    logger.debug("GEMS RMS_NORM BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN RMS_NORM BACKWARD")
 
     dim = x.ndim - len(normalized_shape)
     M = math.prod(x.shape[:dim])  # Batch dimension

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/rsqrt.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/rsqrt.py
@@ -16,10 +16,10 @@ def rsqrt_func(x):
 
 
 def rsqrt(A):
-    logger.debug("GEMS RSQRT")
+    logger.debug("GEMS_KUNLUNXIN RSQRT")
     return rsqrt_func(A)
 
 
 def rsqrt_(A):
-    logger.debug("GEMS RSQRT_")
+    logger.debug("GEMS_KUNLUNXIN RSQRT_")
     return rsqrt_func(A, out0=A)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/rsub.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/rsub.py
@@ -31,7 +31,7 @@ def rsub_func_scalar_tensor(x, y, alpha):
 
 
 def rsub(A, B, *, alpha=1):
-    logger.debug("GEMS SUB")
+    logger.debug("GEMS_KUNLUNXIN SUB")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return rsub_func(A, B, alpha)
     elif isinstance(A, torch.Tensor):

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/scatter.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/scatter.py
@@ -319,7 +319,7 @@ _scatter_func = ScatterFunction()
 
 
 def scatter(inp, dim, index, src, reduce=None):
-    logger.debug("GEMS SCATTER")
+    logger.debug("GEMS_KUNLUNXIN SCATTER")
     if dim < 0:
         dim += inp.ndim
     out = inp.clone()
@@ -356,7 +356,7 @@ def scatter(inp, dim, index, src, reduce=None):
 
 
 def scatter_(inp, dim, index, src, reduce=None):
-    logger.debug("GEMS SCATTER_")
+    logger.debug("GEMS_KUNLUNXIN SCATTER_")
     if dim < 0:
         dim += inp.ndim
     out = inp

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/scatter_add_.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/scatter_add_.py
@@ -292,7 +292,7 @@ _scatter_func = ScatterFunction()
 
 
 def scatter_add_0(inp, dim, index, src):
-    logger.debug("GEMS SCATTER_ADD_0")
+    logger.debug("GEMS_KUNLUNXIN SCATTER_ADD_0")
     dtype_convert = False
     if inp.dtype == torch.float16 or inp.dtype == torch.bfloat16:
         out = inp.to(torch.float32)
@@ -330,7 +330,7 @@ def clip_tensor_to_shape(b, a):
 
 
 def scatter_add_1(x, dim, index, src):
-    logger.debug("GEMS SCATTER_ADD_1")
+    logger.debug("GEMS_KUNLUNXIN SCATTER_ADD_1")
     index_dim_n = index.size(dim)
     inp_dim_n = x.size(dim)
     origin = x

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/sigmoid.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/sigmoid.py
@@ -44,7 +44,7 @@ def sigmoid_backward_kernel(dy, y):
 
 
 def sigmoid(self):
-    logger.debug("GEMS_KUNLUNXIN SIGMOID_FORWARD")
+    logger.debug("GEMS_KUNLUNXIN SIGMOID")
     output = sigmoid_forward(self)
     return output
 
@@ -56,6 +56,6 @@ def sigmoid_backward(grad_output, output):
 
 
 def sigmoid_(A):
-    logger.debug("GEMS_KUNLUNXIN SIGMOID__FORWARD")
+    logger.debug("GEMS_KUNLUNXIN SIGMOID_")
     out = sigmoid_forward(A, out0=A)
     return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/sigmoid.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/sigmoid.py
@@ -44,18 +44,18 @@ def sigmoid_backward_kernel(dy, y):
 
 
 def sigmoid(self):
-    logger.debug("GEMS_KUNLUNXIN SIGMOID FORWARD")
+    logger.debug("GEMS_KUNLUNXIN SIGMOID_FORWARD")
     output = sigmoid_forward(self)
     return output
 
 
 def sigmoid_backward(grad_output, output):
-    logger.debug("GEMS_KUNLUNXIN SIGMOID BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN SIGMOID_BACKWARD")
     grad_input = sigmoid_backward_kernel(grad_output, output)
     return grad_input
 
 
 def sigmoid_(A):
-    logger.debug("GEMS_KUNLUNXIN SIGMOID_ FORWARD")
+    logger.debug("GEMS_KUNLUNXIN SIGMOID__FORWARD")
     out = sigmoid_forward(A, out0=A)
     return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/sigmoid.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/sigmoid.py
@@ -44,18 +44,18 @@ def sigmoid_backward_kernel(dy, y):
 
 
 def sigmoid(self):
-    logger.debug("GEMS SIGMOID FORWARD")
+    logger.debug("GEMS_KUNLUNXIN SIGMOID FORWARD")
     output = sigmoid_forward(self)
     return output
 
 
 def sigmoid_backward(grad_output, output):
-    logger.debug("GEMS SIGMOID BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN SIGMOID BACKWARD")
     grad_input = sigmoid_backward_kernel(grad_output, output)
     return grad_input
 
 
 def sigmoid_(A):
-    logger.debug("GEMS SIGMOID_ FORWARD")
+    logger.debug("GEMS_KUNLUNXIN SIGMOID_ FORWARD")
     out = sigmoid_forward(A, out0=A)
     return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/silu.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/silu.py
@@ -42,7 +42,7 @@ def silu_backward_kernel(x, dy):
 
 
 def silu(self):
-    logger.debug("GEMS_KUNLUNXIN SILU_FORWARD")
+    logger.debug("GEMS_KUNLUNXIN SILU")
     output = silu_forward(self)
     return output
 
@@ -54,6 +54,6 @@ def silu_backward(grad_output, self):
 
 
 def silu_(A):
-    logger.debug("GEMS_KUNLUNXIN SILU__FORWARD")
+    logger.debug("GEMS_KUNLUNXIN SILU_")
     out = silu_forward(A, out0=A)
     return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/silu.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/silu.py
@@ -42,18 +42,18 @@ def silu_backward_kernel(x, dy):
 
 
 def silu(self):
-    logger.debug("GEMS_KUNLUNXIN SILU FORWARD")
+    logger.debug("GEMS_KUNLUNXIN SILU_FORWARD")
     output = silu_forward(self)
     return output
 
 
 def silu_backward(grad_output, self):
-    logger.debug("GEMS_KUNLUNXIN SILU BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN SILU_BACKWARD")
     grad_input = silu_backward_kernel(self, grad_output)
     return grad_input
 
 
 def silu_(A):
-    logger.debug("GEMS_KUNLUNXIN SILU_ FORWARD")
+    logger.debug("GEMS_KUNLUNXIN SILU__FORWARD")
     out = silu_forward(A, out0=A)
     return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/silu.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/silu.py
@@ -42,18 +42,18 @@ def silu_backward_kernel(x, dy):
 
 
 def silu(self):
-    logger.debug("GEMS SILU FORWARD")
+    logger.debug("GEMS_KUNLUNXIN SILU FORWARD")
     output = silu_forward(self)
     return output
 
 
 def silu_backward(grad_output, self):
-    logger.debug("GEMS SILU BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN SILU BACKWARD")
     grad_input = silu_backward_kernel(self, grad_output)
     return grad_input
 
 
 def silu_(A):
-    logger.debug("GEMS SILU_ FORWARD")
+    logger.debug("GEMS_KUNLUNXIN SILU_ FORWARD")
     out = silu_forward(A, out0=A)
     return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/sin.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/sin.py
@@ -15,11 +15,11 @@ def sin_func(x):
 
 
 def sin(A):
-    logger.debug("GEMS SIN")
+    logger.debug("GEMS_KUNLUNXIN SIN")
     return sin_func(A)
 
 
 def sin_(A):
-    logger.debug("GEMS SIN_")
+    logger.debug("GEMS_KUNLUNXIN SIN_")
     sin_func(A, out0=A)
     return A

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/slice_scatter.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/slice_scatter.py
@@ -10,7 +10,7 @@ logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 
 
 def slice_scatter(inp, src, dim=0, start=None, end=None, step=1):
-    logger.debug("GEMS SLICE_SCATTER")
+    logger.debug("GEMS_KUNLUNXIN SLICE_SCATTER")
     assert src.device == inp.device, "inp and src reside on different devices."
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
     assert step > 0, "slice step must be positive"

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/softmax.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/softmax.py
@@ -187,7 +187,7 @@ def softmax_backward_kernel_inner(
 
 
 def softmax(self, dim, half_to_float=False):
-    logger.debug("GEMS SOFTMAX")
+    logger.debug("GEMS_KUNLUNXIN SOFTMAX")
 
     assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
 
@@ -263,7 +263,7 @@ def softmax(self, dim, half_to_float=False):
 
 
 def softmax_backward(grad_output, output, dim, input_dtype):
-    logger.debug("GEMS SOFTMAX VJP")
+    logger.debug("GEMS_KUNLUNXIN SOFTMAX VJP")
 
     assert dim >= -output.ndim and dim < output.ndim, "Invalid dim"
     dim = dim % output.ndim

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/softmax.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/softmax.py
@@ -263,7 +263,7 @@ def softmax(self, dim, half_to_float=False):
 
 
 def softmax_backward(grad_output, output, dim, input_dtype):
-    logger.debug("GEMS_KUNLUNXIN SOFTMAX VJP")
+    logger.debug("GEMS_KUNLUNXIN SOFTMAX_VJP")
 
     assert dim >= -output.ndim and dim < output.ndim, "Invalid dim"
     dim = dim % output.ndim

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/softplus.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/softplus.py
@@ -19,6 +19,6 @@ def softplus_forward(x, beta, threshold):
 
 
 def softplus(self, beta=1.0, threshold=20.0):
-    logger.debug("GEMS_KUNLUNXIN SOFTPLUS FORWARD")
+    logger.debug("GEMS_KUNLUNXIN SOFTPLUS_FORWARD")
     output = softplus_forward(self, beta, threshold)
     return output

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/softplus.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/softplus.py
@@ -19,6 +19,6 @@ def softplus_forward(x, beta, threshold):
 
 
 def softplus(self, beta=1.0, threshold=20.0):
-    logger.debug("GEMS SOFTPLUS FORWARD")
+    logger.debug("GEMS_KUNLUNXIN SOFTPLUS FORWARD")
     output = softplus_forward(self, beta, threshold)
     return output

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/sort.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/sort.py
@@ -531,7 +531,7 @@ def sort_kernel(
 
 
 def sort(inp, dim=-1, descending=False):
-    logger.debug("GEMS SORT")
+    logger.debug("GEMS_KUNLUNXIN SORT")
     sort_elem_cnt = inp.shape[dim]
     if sort_elem_cnt == 1:
         return inp, torch.zeros_like(inp, dtype=torch.int64)
@@ -569,7 +569,7 @@ def sort(inp, dim=-1, descending=False):
 
 
 def sort_stable(inp, *, stable, dim=-1, descending=False):
-    logger.debug("GEMS SORT.STABLE")
+    logger.debug("GEMS_KUNLUNXIN SORT.STABLE")
     # We only implement stable radix sort here
     _ = stable
     sort_elem_cnt = inp.shape[dim]

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/sqrt.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/sqrt.py
@@ -27,11 +27,11 @@ def sqrt_func(x):
 
 
 def sqrt(A):
-    logger.debug("GEMS SQRT")
+    logger.debug("GEMS_KUNLUNXIN SQRT")
     return sqrt_func(A)
 
 
 def sqrt_(A):
-    logger.debug("GEMS SQRT_")
+    logger.debug("GEMS_KUNLUNXIN SQRT_")
     sqrt_func(A, out0=A)
     return A

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/stack.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/stack.py
@@ -21,7 +21,7 @@ def copy_func(x):
 def stack(
     tensors: Union[Tuple[torch.Tensor, ...], List[torch.Tensor]], dim: int = 0
 ) -> torch.Tensor:
-    logger.debug("GEMS STACK")
+    logger.debug("GEMS_KUNLUNXIN STACK")
 
     if len(tensors) == 0:
         raise RuntimeError("stack expected a non-empty TensorList")

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/std.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/std.py
@@ -122,7 +122,7 @@ def std(x, dim=None, *, correction=None, keepdim=False):
     input_ndim = x.ndim
 
     if dim is None:
-        logger.debug("GEMS STD (Global Simple Map-Reduce Path)")
+        logger.debug("GEMS_KUNLUNXIN STD (Global Simple Map-Reduce Path)")
         N = x.numel()
         if N == 0 or N - effective_correction <= 0:
             return torch.full([], float("nan"), device=x.device, dtype=x.dtype)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/sub.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/sub.py
@@ -31,7 +31,7 @@ def sub_func_scalar_tensor(x, y, alpha):
 
 
 def sub(A, B, *, alpha=1.0):
-    logger.debug("GEMS SUB")
+    logger.debug("GEMS_KUNLUNXIN SUB")
     A_is_complex = (isinstance(A, torch.Tensor) and A.is_complex()) or isinstance(
         A, complex
     )
@@ -88,7 +88,7 @@ def sub(A, B, *, alpha=1.0):
 
 
 def sub_(A, B, *, alpha=1):
-    logger.debug("GEMS SUB_")
+    logger.debug("GEMS_KUNLUNXIN SUB_")
     if isinstance(B, torch.Tensor):
         return sub_func(A, B, alpha, out0=A)
     else:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/sum.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/sum.py
@@ -111,7 +111,7 @@ def sum_kernel(
 
 
 def sum(inp, *, dtype=None):
-    logger.debug("GEMS SUM")
+    logger.debug("GEMS_KUNLUNXIN SUM")
     M = inp.numel()
     if dtype is None:
         dtype = inp.dtype
@@ -134,7 +134,7 @@ def sum(inp, *, dtype=None):
 
 
 def sum_out(inp, *, dtype=None, out):
-    logger.debug("GEMS SUM_OUT")
+    logger.debug("GEMS_KUNLUNXIN SUM_OUT")
     M = inp.numel()
     if dtype is None:
         dtype = inp.dtype
@@ -155,7 +155,7 @@ def sum_out(inp, *, dtype=None, out):
 
 
 def sum_dim(inp, dim=None, keepdim=False, *, dtype=None):
-    logger.debug("GEMS SUM DIM")
+    logger.debug("GEMS_KUNLUNXIN SUM DIM")
     if dtype is None:
         dtype = inp.dtype
         if dtype is torch.bool:
@@ -204,7 +204,7 @@ def sum_dim(inp, dim=None, keepdim=False, *, dtype=None):
 
 
 def sum_dim_out(inp, dim=None, keepdim=False, *, dtype=None, out):
-    logger.debug("GEMS SUM_DIM_OUT")
+    logger.debug("GEMS_KUNLUNXIN SUM_DIM_OUT")
     if dtype is None:
         dtype = inp.dtype
         if dtype is torch.bool:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/sum.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/sum.py
@@ -155,7 +155,7 @@ def sum_out(inp, *, dtype=None, out):
 
 
 def sum_dim(inp, dim=None, keepdim=False, *, dtype=None):
-    logger.debug("GEMS_KUNLUNXIN SUM DIM")
+    logger.debug("GEMS_KUNLUNXIN SUM_DIM")
     if dtype is None:
         dtype = inp.dtype
         if dtype is torch.bool:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/tan.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/tan.py
@@ -29,11 +29,11 @@ def tan_func(x):
 
 
 def tan(A):
-    logger.debug("GEMS TAN")
+    logger.debug("GEMS_KUNLUNXIN TAN")
     return tan_func(A)
 
 
 def tan_(A):
-    logger.debug("GEMS TAN_")
+    logger.debug("GEMS_KUNLUNXIN TAN_")
     tan_func(A, out0=A)
     return A

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/tanh.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/tanh.py
@@ -26,18 +26,18 @@ def tanh_backward_kernel(y, dy):
 
 
 def tanh(self):
-    logger.debug("GEMS_KUNLUNXIN TANH FORWARD")
+    logger.debug("GEMS_KUNLUNXIN TANH_FORWARD")
     out = tanh_kernel(self)
     return out
 
 
 def tanh_backward(grad_output, output):
-    logger.debug("GEMS_KUNLUNXIN TANH BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN TANH_BACKWARD")
     in_grad = tanh_backward_kernel(output, grad_output)
     return in_grad
 
 
 def tanh_(A):
-    logger.debug("GEMS_KUNLUNXIN TANH_ FORWARD")
+    logger.debug("GEMS_KUNLUNXIN TANH__FORWARD")
     out = tanh_kernel(A, out0=A)
     return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/tanh.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/tanh.py
@@ -26,18 +26,18 @@ def tanh_backward_kernel(y, dy):
 
 
 def tanh(self):
-    logger.debug("GEMS TANH FORWARD")
+    logger.debug("GEMS_KUNLUNXIN TANH FORWARD")
     out = tanh_kernel(self)
     return out
 
 
 def tanh_backward(grad_output, output):
-    logger.debug("GEMS TANH BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN TANH BACKWARD")
     in_grad = tanh_backward_kernel(output, grad_output)
     return in_grad
 
 
 def tanh_(A):
-    logger.debug("GEMS TANH_ FORWARD")
+    logger.debug("GEMS_KUNLUNXIN TANH_ FORWARD")
     out = tanh_kernel(A, out0=A)
     return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/tanh.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/tanh.py
@@ -26,7 +26,7 @@ def tanh_backward_kernel(y, dy):
 
 
 def tanh(self):
-    logger.debug("GEMS_KUNLUNXIN TANH_FORWARD")
+    logger.debug("GEMS_KUNLUNXIN TANH")
     out = tanh_kernel(self)
     return out
 
@@ -38,6 +38,6 @@ def tanh_backward(grad_output, output):
 
 
 def tanh_(A):
-    logger.debug("GEMS_KUNLUNXIN TANH__FORWARD")
+    logger.debug("GEMS_KUNLUNXIN TANH_")
     out = tanh_kernel(A, out0=A)
     return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/threshold.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/threshold.py
@@ -21,12 +21,12 @@ def threshold_backward_kernel(grad_output, self, threshold):
 
 
 def threshold(self, threshold, value):
-    logger.debug("GEMS_KUNLUNXIN THRESHOLD FORWARD")
+    logger.debug("GEMS_KUNLUNXIN THRESHOLD_FORWARD")
     output = threshold_kernel(self, threshold, value)
     return output
 
 
 def threshold_backward(grad_output, self, threshold):
-    logger.debug("GEMS_KUNLUNXIN THRESHOLD BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN THRESHOLD_BACKWARD")
     grad_input = threshold_backward_kernel(grad_output, self, threshold)
     return grad_input

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/threshold.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/threshold.py
@@ -21,12 +21,12 @@ def threshold_backward_kernel(grad_output, self, threshold):
 
 
 def threshold(self, threshold, value):
-    logger.debug("GEMS THRESHOLD FORWARD")
+    logger.debug("GEMS_KUNLUNXIN THRESHOLD FORWARD")
     output = threshold_kernel(self, threshold, value)
     return output
 
 
 def threshold_backward(grad_output, self, threshold):
-    logger.debug("GEMS THRESHOLD BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN THRESHOLD BACKWARD")
     grad_input = threshold_backward_kernel(grad_output, self, threshold)
     return grad_input

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/tile.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/tile.py
@@ -442,7 +442,7 @@ _tile_func = TileFunction()
 
 
 def tile(inp: torch.Tensor, dims) -> torch.Tensor:
-    logger.debug("GEMS TILE")
+    logger.debug("GEMS_KUNLUNXIN TILE")
 
     out = _tile_func(inp, dims)
     return out

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/to.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/to.py
@@ -141,7 +141,7 @@ def to_copy(
             memory_format=target_memory_format,
         )
 
-    logger.debug("GEMS _TO_COPY")
+    logger.debug("GEMS_KUNLUNXIN _TO_COPY")
     empty_kwargs = {"dtype": target_dtype, "device": target_device}
 
     if target_memory_format is torch.preserve_format:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/topk.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/topk.py
@@ -275,7 +275,7 @@ def topk_stage2_kernel(
 
 
 def topk(x, k, dim=-1, largest=True, sorted=True):
-    logger.debug("GEMS TOPK")
+    logger.debug("GEMS_KUNLUNXIN TOPK")
     # If dim equals to last dim, we set it to -1.
     if dim < 0:
         dim = dim + x.ndim

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/trace.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/trace.py
@@ -53,7 +53,7 @@ def trace_kernel(
 
 
 def trace(self):
-    logger.debug("GEMS TRACE")
+    logger.debug("GEMS_KUNLUNXIN TRACE")
 
     if self.ndim != 2:
         raise RuntimeError(

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/triu.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/triu.py
@@ -106,7 +106,7 @@ INT32_MAX = torch.iinfo(torch.int32).max
 
 
 def triu(A, diagonal=0):
-    logger.debug("GEMS TRIU")
+    logger.debug("GEMS_KUNLUNXIN TRIU")
     A = A.contiguous()
     out = torch.empty_like(A)
     assert len(A.shape) > 1, "Input tensor must have at least 2 dimensions"

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/uniform.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/uniform.py
@@ -51,7 +51,7 @@ UNROLL = 4
 
 
 def uniform_(self, from_=0.0, to=1.0, *, generator=None):
-    logger.debug("GEMS UNIFORM")
+    logger.debug("GEMS_KUNLUNXIN UNIFORM")
     N = volume(self.shape)
     grid_fn = lambda meta: (triton.cdiv(N, meta["BLOCK"] * UNROLL),)
 

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/upsample_bicubic2d_aa.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/upsample_bicubic2d_aa.py
@@ -533,7 +533,7 @@ def _upsample_bicubic2d_aa(
     scales_h: Optional[float] = None,
     scales_w: Optional[float] = None,
 ):
-    logger.debug("GEMS_KUNLUNXIN UPSAMPLE BICUBIC2D AA")
+    logger.debug("GEMS_KUNLUNXIN UPSAMPLE_BICUBIC2D_AA")
     assert input.device.type == device
     assert input.ndim == 4, "The ndim of input must be 4"
     assert len(output_size) == 2, "The len of output_size must be 2"

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/upsample_bicubic2d_aa.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/upsample_bicubic2d_aa.py
@@ -533,7 +533,7 @@ def _upsample_bicubic2d_aa(
     scales_h: Optional[float] = None,
     scales_w: Optional[float] = None,
 ):
-    logger.debug("GEMS UPSAMPLE BICUBIC2D AA")
+    logger.debug("GEMS_KUNLUNXIN UPSAMPLE BICUBIC2D AA")
     assert input.device.type == device
     assert input.ndim == 4, "The ndim of input must be 4"
     assert len(output_size) == 2, "The len of output_size must be 2"

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/upsample_nearest1d.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/upsample_nearest1d.py
@@ -64,7 +64,7 @@ def upsample_nearest1d(
     output_size: Optional[Tuple[int]] = None,
     scales: Optional[float] = None,
 ) -> torch.Tensor:
-    logger.debug("GEMS UPSAMPLE NEAREST1D")
+    logger.debug("GEMS_KUNLUNXIN UPSAMPLE NEAREST1D")
     assert input.device.type == device
     assert input.ndim == 3, "The ndim of input must be 3"
     assert (

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/upsample_nearest1d.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/upsample_nearest1d.py
@@ -64,7 +64,7 @@ def upsample_nearest1d(
     output_size: Optional[Tuple[int]] = None,
     scales: Optional[float] = None,
 ) -> torch.Tensor:
-    logger.debug("GEMS_KUNLUNXIN UPSAMPLE NEAREST1D")
+    logger.debug("GEMS_KUNLUNXIN UPSAMPLE_NEAREST1D")
     assert input.device.type == device
     assert input.ndim == 3, "The ndim of input must be 3"
     assert (

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/upsample_nearest2d.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/upsample_nearest2d.py
@@ -72,7 +72,7 @@ def upsample_nearest2d(
     scales_h: Optional[float] = None,
     scales_w: Optional[float] = None,
 ) -> torch.Tensor:
-    logger.debug("GEMS UPSAMPLE NEAREST2D")
+    logger.debug("GEMS_KUNLUNXIN UPSAMPLE NEAREST2D")
     assert input.device.type == device
     assert input.ndim == 4, "The ndim of input must be 4"
     assert len(output_size) == 2, "The len of output_size must be 2"

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/upsample_nearest2d.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/upsample_nearest2d.py
@@ -72,7 +72,7 @@ def upsample_nearest2d(
     scales_h: Optional[float] = None,
     scales_w: Optional[float] = None,
 ) -> torch.Tensor:
-    logger.debug("GEMS_KUNLUNXIN UPSAMPLE NEAREST2D")
+    logger.debug("GEMS_KUNLUNXIN UPSAMPLE_NEAREST2D")
     assert input.device.type == device
     assert input.ndim == 4, "The ndim of input must be 4"
     assert len(output_size) == 2, "The len of output_size must be 2"

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/var_mean.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/var_mean.py
@@ -154,7 +154,7 @@ def var_mean_kernel_2(
 
 
 def var_mean(x, dim=None, *, correction=None, keepdim=False):
-    logger.debug("GEMS VAR MEAN")
+    logger.debug("GEMS_KUNLUNXIN VAR MEAN")
     if correction is None:
         correction = 1.0
 

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/var_mean.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/var_mean.py
@@ -154,7 +154,7 @@ def var_mean_kernel_2(
 
 
 def var_mean(x, dim=None, *, correction=None, keepdim=False):
-    logger.debug("GEMS_KUNLUNXIN VAR MEAN")
+    logger.debug("GEMS_KUNLUNXIN VAR_MEAN")
     if correction is None:
         correction = 1.0
 

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/vdot.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/vdot.py
@@ -149,7 +149,7 @@ def dot_kernel(
 
 
 def vdot(input: Tensor, other: Tensor):
-    logger.debug("GEMS VDOT")
+    logger.debug("GEMS_KUNLUNXIN VDOT")
 
     assert (
         input.dtype == other.dtype

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/vector_norm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/vector_norm.py
@@ -315,7 +315,7 @@ def l1_norm_kernel_2(
 
 
 def vector_norm(x, ord=2, dim=None, keepdim=False, dtype=None):
-    logger.debug("GEMS_KUNLUNXIN VECTOR NORM")
+    logger.debug("GEMS_KUNLUNXIN VECTOR_NORM")
     if dtype is not None:
         dtype = torch.dtype(dtype)
     else:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/vector_norm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/vector_norm.py
@@ -315,7 +315,7 @@ def l1_norm_kernel_2(
 
 
 def vector_norm(x, ord=2, dim=None, keepdim=False, dtype=None):
-    logger.debug("GEMS VECTOR NORM")
+    logger.debug("GEMS_KUNLUNXIN VECTOR NORM")
     if dtype is not None:
         dtype = torch.dtype(dtype)
     else:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/vstack.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/vstack.py
@@ -75,7 +75,7 @@ def vstack_kernel(
 
 
 def vstack(tensors: list):
-    logger.debug("GEMS VSTACK")
+    logger.debug("GEMS_KUNLUNXIN VSTACK")
 
     tensors = torch.atleast_2d(tensors)
     num_tensors = len(tensors)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/weight_norm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/weight_norm.py
@@ -156,7 +156,7 @@ def weight_norm_except_dim_bwd_kernel(
 
 
 def weight_norm_except_dim(v, g, dim):
-    logger.debug("GEMS_KUNLUNXIN WEIGHT NORM EXCEPT DIM FORWARD")
+    logger.debug("GEMS_KUNLUNXIN WEIGHT_NORM_EXCEPT_DIM_FORWARD")
     v = v.contiguous()
     output = torch.empty_like(v)
     norm = torch.empty_like(g, dtype=torch.float32)
@@ -183,7 +183,7 @@ def weight_norm_except_dim(v, g, dim):
 
 
 def weight_norm_except_dim_backward(grad, v, g, norm, dim):
-    logger.debug("GEMS_KUNLUNXIN WEIGHT NORM EXCEPT DIM BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN WEIGHT_NORM_EXCEPT_DIM_BACKWARD")
     grad = grad.contiguous()
     v_grad = torch.empty_like(v)
     g_grad = torch.empty_like(g)
@@ -211,7 +211,7 @@ def weight_norm_except_dim_backward(grad, v, g, norm, dim):
 class WeightNorm(torch.autograd.Function):
     @staticmethod
     def forward(ctx, v, g, dim=0):
-        logger.debug("GEMS_KUNLUNXIN WEIGHT NORM")
+        logger.debug("GEMS_KUNLUNXIN WEIGHT_NORM")
         dim = dim % v.ndim
         can_use_fused = dim == 0 or dim == v.ndim - 1
         if can_use_fused:
@@ -225,7 +225,7 @@ class WeightNorm(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, grad):
-        logger.debug("GEMS_KUNLUNXIN WEIGHT NORM BACKWARD")
+        logger.debug("GEMS_KUNLUNXIN WEIGHT_NORM_BACKWARD")
         v, g, norm = ctx.saved_tensors
         dim = ctx.dim
         if ctx.can_use_fused:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/weightnorm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/weightnorm.py
@@ -262,7 +262,7 @@ def weight_norm_bwd_kernel_first(
 
 
 def weight_norm_interface(v, g, dim=0):
-    logger.debug("GEMS WEIGHT NORM INTERFACE FORWARD")
+    logger.debug("GEMS_KUNLUNXIN WEIGHT NORM INTERFACE FORWARD")
     v = v.contiguous()
     g = g.contiguous()
     output = torch.empty_like(v)
@@ -287,7 +287,7 @@ def weight_norm_interface(v, g, dim=0):
 
 
 def weight_norm_interface_backward(w_grad, saved_v, saved_g, saved_norms, dim):
-    logger.debug("GEMS WEIGHT NORM INTERFACE BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN WEIGHT NORM INTERFACE BACKWARD")
     w_grad = w_grad.contiguous()
     saved_v = saved_v.contiguous()
     saved_g = saved_g.contiguous()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/weightnorm.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/weightnorm.py
@@ -262,7 +262,7 @@ def weight_norm_bwd_kernel_first(
 
 
 def weight_norm_interface(v, g, dim=0):
-    logger.debug("GEMS_KUNLUNXIN WEIGHT NORM INTERFACE FORWARD")
+    logger.debug("GEMS_KUNLUNXIN WEIGHT_NORM_INTERFACE_FORWARD")
     v = v.contiguous()
     g = g.contiguous()
     output = torch.empty_like(v)
@@ -287,7 +287,7 @@ def weight_norm_interface(v, g, dim=0):
 
 
 def weight_norm_interface_backward(w_grad, saved_v, saved_g, saved_norms, dim):
-    logger.debug("GEMS_KUNLUNXIN WEIGHT NORM INTERFACE BACKWARD")
+    logger.debug("GEMS_KUNLUNXIN WEIGHT_NORM_INTERFACE_BACKWARD")
     w_grad = w_grad.contiguous()
     saved_v = saved_v.contiguous()
     saved_g = saved_g.contiguous()

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/where.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/where.py
@@ -19,7 +19,7 @@ def where_inner(condition, self, other):
 
 
 def where_self_out(condition, self, other, out=None):
-    logger.debug("GEMS WHERE_SELF_OUT")
+    logger.debug("GEMS_KUNLUNXIN WHERE_SELF_OUT")
     result_type = torch.result_type(self, other)
     if out is not None:
         assert (
@@ -69,15 +69,15 @@ def where_self_out(condition, self, other, out=None):
 
 
 def where_self(condition, self, other):
-    logger.debug("GEMS WHERE_SELF")
+    logger.debug("GEMS_KUNLUNXIN WHERE_SELF")
     return where_self_out(condition, self, other)
 
 
 def where_scalar_self(condition, self, other):
-    logger.debug("GEMS WHERE_SCALAR_SELF")
+    logger.debug("GEMS_KUNLUNXIN WHERE_SCALAR_SELF")
     return where_self_out(condition, self, other)
 
 
 def where_scalar_other(condition, self, other):
-    logger.debug("GEMS WHERE_SCALAR_OTHER")
+    logger.debug("GEMS_KUNLUNXIN WHERE_SCALAR_OTHER")
     return where_self_out(condition, self, other)

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/zeros.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/zeros.py
@@ -28,7 +28,7 @@ def zeros_kernel(
 
 
 def zeros(size, *, dtype=None, layout=None, device=None, pin_memory=None):
-    logger.debug("GEMS ZEROS")
+    logger.debug("GEMS_KUNLUNXIN ZEROS")
     if dtype is None:
         dtype = torch.get_default_dtype()
     if device is None:

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/zeros_like.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/zeros_like.py
@@ -13,7 +13,7 @@ logger = logging.getLogger("flag_gems").getChild(__name__.lstrip("."))
 def zeros_like(
     x, *, dtype=None, layout=None, device=None, pin_memory=None, memory_format=None
 ):
-    logger.debug("GEMS ZEROS_LIKE")
+    logger.debug("GEMS_KUNLUNXIN ZEROS_LIKE")
     if device is None:
         device = x.device
     if dtype is None:


### PR DESCRIPTION
## Summary
Unify Kunlunxin backend debug log format to match the standard pattern GEMS_VENDOR OP_NAME used by other backends.

## Changes
- GEMS {OP_NAME} -> GEMS_KUNLUNXIN {OP_NAME} (all op entry logs)
- GLU FORWARD -> GEMS_KUNLUNXIN GLU FORWARD (was missing GEMS prefix entirely)

Note: Runtime debug messages in flash_api.py (kernel selection, config logging) are left unchanged as they are not op entry markers.

## Scope
132 operator implementation files across the Kunlunxin backend.

## Motivation
Before this change, Kunlunxin backend logs lacked the vendor identifier, making it difficult to distinguish which backend produced a given log line. This standardization improves log clarity and consistency across all backends (Ascend, Cambricon, Mthreads, MetaX, Iluvatar, Spacemit).