### PR TITLE
Standardize Aipu backend debug log format

### DIFF
--- a/src/flag_gems/runtime/backend/_aipu/ops/cumsum.py
+++ b/src/flag_gems/runtime/backend/_aipu/ops/cumsum.py
@@ -222,12 +222,12 @@ def cumsum_wrapper(inp, dim=1, dtype=None, out=None):
 
 
 def cumsum(inp, dim=1, *, dtype=None):
-    logger.debug("GEMS CUMSUM")
+    logger.debug("GEMS_AIPU CUMSUM")
     return cumsum_wrapper(inp, dim, dtype)
 
 
 def cumsum_out(inp, dim=1, *, dtype=None, out):
-    logger.debug("GEMS CUMSUM_OUT")
+    logger.debug("GEMS_AIPU CUMSUM_OUT")
     return cumsum_wrapper(inp, dim, dtype, out)
 
 
@@ -375,7 +375,7 @@ GRID_Y_LIMIT = 65535
 
 
 def normed_cumsum(inp, dim=-1):
-    logger.debug("GEMS NORMED_CUMSUM")
+    logger.debug("GEMS_AIPU NORMED_CUMSUM")
     assert inp.dtype in (torch.float16, torch.bfloat16, torch.float32, torch.float64)
     dim = dim % inp.ndim
     N = inp.numel()

--- a/src/flag_gems/runtime/backend/_aipu/ops/multinomial.py
+++ b/src/flag_gems/runtime/backend/_aipu/ops/multinomial.py
@@ -52,7 +52,7 @@ def multinomial_with_replacement(
 
 
 def multinomial(prob, n_samples, with_replacement=False, *, gen=None):
-    logger.debug("GEMS MULTINOMIAL")
+    logger.debug("GEMS_AIPU MULTINOMIAL")
     assert prob.dtype in (torch.float16, torch.float32, torch.bfloat16, torch.float64)
     assert 0 < prob.dim() <= 2, "prob_dist must be 1 or 2 dim"
     n_categories = prob.size(-1)


### PR DESCRIPTION
## Summary
Unify Aipu backend debug log format to match the standard pattern GEMS_VENDOR OP_NAME.

## Changes
- GEMS CUMSUM -> GEMS_AIPU CUMSUM
- GEMS CUMSUM_OUT -> GEMS_AIPU CUMSUM_OUT
- GEMS NORMED_CUMSUM -> GEMS_AIPU NORMED_CUMSUM
- GEMS MULTINOMIAL -> GEMS_AIPU MULTINOMIAL

## Motivation
Standardize debug log format for consistency across all backends.