### PR TITLE
Standardize Tsingmicro backend debug log format

### DIFF
--- a/src/flag_gems/runtime/backend/_tsingmicro/ops/attention.py
+++ b/src/flag_gems/runtime/backend/_tsingmicro/ops/attention.py
@@ -1271,7 +1271,7 @@ def flash_attn_varlen_func(
     if num_splits > 0:
         raise RuntimeError("num_splits > 0 is not implemented in GEMS.")
     if use_c_extension:
-        logger.debug("GEMS_TSINGMICRO FLASH_ATTN_VARLEN_FUNC_C_EXTENSION")
+        logger.debug("GEMS_TSINGMICRO FLASH_ATTN_VARLEN_FUNC (C Extension)")
         with torch_device_fn.device(q.device):
             out_cpp, softmax_lse = torch.ops.flag_gems.flash_attn_varlen_func(
                 q,

--- a/src/flag_gems/runtime/backend/_tsingmicro/ops/attention.py
+++ b/src/flag_gems/runtime/backend/_tsingmicro/ops/attention.py
@@ -876,7 +876,7 @@ def scaled_dot_product_attention_backward(
     scale=None,
     enable_gqa=False,
 ):
-    logger.debug("GEMS_TSINGMICRO SCALED DOT PRODUCT ATTENTION BACKWARD")
+    logger.debug("GEMS_TSINGMICRO SCALED_DOT_PRODUCT_ATTENTION_BACKWARD")
     # shape constraints
     HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
     # when v is in float8_e5m2 it is transposed.
@@ -1271,7 +1271,7 @@ def flash_attn_varlen_func(
     if num_splits > 0:
         raise RuntimeError("num_splits > 0 is not implemented in GEMS.")
     if use_c_extension:
-        logger.debug("GEMS_TSINGMICRO FLASH_ATTN_VARLEN_FUNC(C EXTENSION)")
+        logger.debug("GEMS_TSINGMICRO FLASH_ATTN_VARLEN_FUNC_C_EXTENSION")
         with torch_device_fn.device(q.device):
             out_cpp, softmax_lse = torch.ops.flag_gems.flash_attn_varlen_func(
                 q,

--- a/src/flag_gems/runtime/backend/_tsingmicro/ops/attention.py
+++ b/src/flag_gems/runtime/backend/_tsingmicro/ops/attention.py
@@ -769,7 +769,7 @@ def scaled_dot_product_attention_forward(
     scale=None,
     enable_gqa=False,
 ):
-    logger.debug("GEMS_TSINGMICRO SCALED DOT PRODUCT ATTENTION FORWARD")
+    logger.debug("GEMS_TSINGMICRO SCALED_DOT_PRODUCT_ATTENTION_FORWARD")
     # shape constraints
     HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
     # when v is in float8_e5m2 it is transposed.

--- a/src/flag_gems/runtime/backend/_tsingmicro/ops/attention.py
+++ b/src/flag_gems/runtime/backend/_tsingmicro/ops/attention.py
@@ -769,7 +769,7 @@ def scaled_dot_product_attention_forward(
     scale=None,
     enable_gqa=False,
 ):
-    logger.debug("GEMS_TSINGMICRO SCALED_DOT_PRODUCT_ATTENTION_FORWARD")
+    logger.debug("GEMS_TSINGMICRO SCALED_DOT_PRODUCT_ATTENTION")
     # shape constraints
     HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
     # when v is in float8_e5m2 it is transposed.

--- a/src/flag_gems/runtime/backend/_tsingmicro/ops/attention.py
+++ b/src/flag_gems/runtime/backend/_tsingmicro/ops/attention.py
@@ -769,7 +769,7 @@ def scaled_dot_product_attention_forward(
     scale=None,
     enable_gqa=False,
 ):
-    logger.debug("GEMS SCALED DOT PRODUCT ATTENTION FORWARD")
+    logger.debug("GEMS_TSINGMICRO SCALED DOT PRODUCT ATTENTION FORWARD")
     # shape constraints
     HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
     # when v is in float8_e5m2 it is transposed.
@@ -876,7 +876,7 @@ def scaled_dot_product_attention_backward(
     scale=None,
     enable_gqa=False,
 ):
-    logger.debug("GEMS SCALED DOT PRODUCT ATTENTION BACKWARD")
+    logger.debug("GEMS_TSINGMICRO SCALED DOT PRODUCT ATTENTION BACKWARD")
     # shape constraints
     HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
     # when v is in float8_e5m2 it is transposed.
@@ -1094,7 +1094,7 @@ def flash_attention_forward(
     alibi_slopes=None,
     disable_splitkv=False,
 ):
-    logger.debug("GEMS FLASH_ATTENTION_FORWARD")
+    logger.debug("GEMS_TSINGMICRO FLASH_ATTENTION_FORWARD")
     assert (
         cumulative_sequence_length_q is None and cumulative_sequence_length_k is None
     ), "varlen is not supported yet."
@@ -1271,7 +1271,7 @@ def flash_attn_varlen_func(
     if num_splits > 0:
         raise RuntimeError("num_splits > 0 is not implemented in GEMS.")
     if use_c_extension:
-        logger.debug("GEMS FLASH_ATTN_VARLEN_FUNC(C EXTENSION)")
+        logger.debug("GEMS_TSINGMICRO FLASH_ATTN_VARLEN_FUNC(C EXTENSION)")
         with torch_device_fn.device(q.device):
             out_cpp, softmax_lse = torch.ops.flag_gems.flash_attn_varlen_func(
                 q,
@@ -1307,7 +1307,7 @@ def flash_attn_varlen_func(
             )
         return (out_cpp, softmax_lse) if return_softmax_lse else out_cpp
     else:
-        logger.debug("GEMS FLASH_ATTN_VARLEN_FUNC")
+        logger.debug("GEMS_TSINGMICRO FLASH_ATTN_VARLEN_FUNC")
         assert (
             cu_seqlens_k is not None or seqused_k is not None
         ), "cu_seqlens_k or seqused_k must be provided"

--- a/src/flag_gems/runtime/backend/_tsingmicro/ops/count_nonzero.py
+++ b/src/flag_gems/runtime/backend/_tsingmicro/ops/count_nonzero.py
@@ -107,8 +107,8 @@ def count_nonzero_combin_kernel(
 
 
 def count_nonzero(x, dim=None):
-    logger.debug("GEMS_TSINGMICRO COUNT NONZERO")
-    print("GEMS_TSINGMICRO COUNT NONZERO")
+    logger.debug("GEMS_TSINGMICRO COUNT_NONZERO")
+    print("GEMS_TSINGMICRO COUNT_NONZERO")
     if dim is not None:
         assert dim >= -x.ndim and dim < x.ndim, "Invalid dim"
         shape = x.shape

--- a/src/flag_gems/runtime/backend/_tsingmicro/ops/index.py
+++ b/src/flag_gems/runtime/backend/_tsingmicro/ops/index.py
@@ -262,7 +262,7 @@ _index_func = IndexFunction()
 
 
 def index(inp, indices):
-    logger.debug("GEMS INDEX")
+    logger.debug("GEMS_TSINGMICRO INDEX")
     original_indices = list(indices)  # Save original indices for later checks
     indices = list(indices)
 

--- a/src/flag_gems/runtime/backend/_tsingmicro/ops/masked_select.py
+++ b/src/flag_gems/runtime/backend/_tsingmicro/ops/masked_select.py
@@ -39,7 +39,7 @@ def masked_select_kernel(
 
 
 def masked_select(inp, mask):
-    logger.debug("GEMS_TSINGMICRO MASKED SELECT")
+    logger.debug("GEMS_TSINGMICRO MASKED_SELECT")
 
     inp_shape = tuple(inp.shape)
     mask_shape = tuple(mask.shape)

--- a/src/flag_gems/runtime/backend/_tsingmicro/ops/pow.py
+++ b/src/flag_gems/runtime/backend/_tsingmicro/ops/pow.py
@@ -18,12 +18,12 @@ def pow_func(x, exponent):
 
 
 def pow_tensor_tensor(A, exponent):
-    logger.debug("GEMS POW_TENSOR_TENSOR")
+    logger.debug("GEMS_TSINGMICRO POW_TENSOR_TENSOR")
     return pow_func(A, exponent)
 
 
 def pow_tensor_tensor_(A, exponent):
-    logger.debug("GEMS POW_TENSOR_TENSOR_")
+    logger.debug("GEMS_TSINGMICRO POW_TENSOR_TENSOR_")
     return pow_func(A, exponent, out0=A)
 
 
@@ -34,12 +34,12 @@ def pow_func_tensor_scalar(x, exponent):
 
 
 def pow_tensor_scalar(A, exponent):
-    logger.debug("GEMS POW_TENSOR_SCALAR")
+    logger.debug("GEMS_TSINGMICRO POW_TENSOR_SCALAR")
     return pow_func_tensor_scalar(A, exponent)
 
 
 def pow_tensor_scalar_(A, exponent):
-    logger.debug("GEMS POW_TENSOR_SCALAR_")
+    logger.debug("GEMS_TSINGMICRO POW_TENSOR_SCALAR_")
     return pow_func_tensor_scalar(A, exponent, out0=A)
 
 
@@ -50,5 +50,5 @@ def pow_func_scalar_tensor(x, exponent):
 
 
 def pow_scalar(A, exponent):
-    logger.debug("GEMS POW_SCALAR")
+    logger.debug("GEMS_TSINGMICRO POW_SCALAR")
     return pow_func_scalar_tensor(A, exponent)

--- a/src/flag_gems/runtime/backend/_tsingmicro/ops/rms_norm.py
+++ b/src/flag_gems/runtime/backend/_tsingmicro/ops/rms_norm.py
@@ -149,7 +149,7 @@ def rms_norm_grad_dw_kernel(
 
 
 def rms_norm_forward(x, normalized_shape, weight, eps=1e-5):
-    logger.debug("GEMS_TSINGMICRO RMS_NORM FORWARD")
+    logger.debug("GEMS_TSINGMICRO RMS_NORM_FORWARD")
     dim = x.ndim - len(normalized_shape)
     M = math.prod(x.shape[:dim])
     N = math.prod(normalized_shape)
@@ -167,7 +167,7 @@ def rms_norm_forward(x, normalized_shape, weight, eps=1e-5):
 
 
 def rms_norm_backward(dy, x, inv_rms, normalized_shape, weight, eps=1e-5):
-    logger.debug("GEMS_TSINGMICRO RMS_NORM BACKWARD")
+    logger.debug("GEMS_TSINGMICRO RMS_NORM_BACKWARD")
     dim = x.ndim - len(normalized_shape)
     M = math.prod(x.shape[:dim])
     N = math.prod(normalized_shape)

--- a/src/flag_gems/runtime/backend/_tsingmicro/ops/rsqrt.py
+++ b/src/flag_gems/runtime/backend/_tsingmicro/ops/rsqrt.py
@@ -15,10 +15,10 @@ def rsqrt_func(x):
 
 
 def rsqrt(A):
-    logger.debug("GEMS RSQRT")
+    logger.debug("GEMS_TSINGMICRO RSQRT")
     return rsqrt_func(A)
 
 
 def rsqrt_(A):
-    logger.debug("GEMS RSQRT_")
+    logger.debug("GEMS_TSINGMICRO RSQRT_")
     return rsqrt_func(A, out0=A)

--- a/src/flag_gems/runtime/backend/_tsingmicro/ops/silu_and_mul.py
+++ b/src/flag_gems/runtime/backend/_tsingmicro/ops/silu_and_mul.py
@@ -35,7 +35,7 @@ class SiluAndMul(torch.autograd.Function):
     @staticmethod
     def forward(ctx, A, B):
         ctx.save_for_backward(A, B)
-        logger.debug("GEMS_TSINGMICRO SILU_AND_MUL_FORWARD")
+        logger.debug("GEMS_TSINGMICRO SILU_AND_MUL")
         return silu_and_mul_kernel(A, B)
 
     def backward(ctx, grad_output):

--- a/src/flag_gems/runtime/backend/_tsingmicro/ops/silu_and_mul.py
+++ b/src/flag_gems/runtime/backend/_tsingmicro/ops/silu_and_mul.py
@@ -35,7 +35,7 @@ class SiluAndMul(torch.autograd.Function):
     @staticmethod
     def forward(ctx, A, B):
         ctx.save_for_backward(A, B)
-        logger.debug("GEMS SILU AND MUL FORWARD")
+        logger.debug("GEMS_TSINGMICRO SILU AND MUL FORWARD")
         return silu_and_mul_kernel(A, B)
 
     def backward(ctx, grad_output):

--- a/src/flag_gems/runtime/backend/_tsingmicro/ops/silu_and_mul.py
+++ b/src/flag_gems/runtime/backend/_tsingmicro/ops/silu_and_mul.py
@@ -35,7 +35,7 @@ class SiluAndMul(torch.autograd.Function):
     @staticmethod
     def forward(ctx, A, B):
         ctx.save_for_backward(A, B)
-        logger.debug("GEMS_TSINGMICRO SILU AND MUL FORWARD")
+        logger.debug("GEMS_TSINGMICRO SILU_AND_MUL_FORWARD")
         return silu_and_mul_kernel(A, B)
 
     def backward(ctx, grad_output):


### PR DESCRIPTION
## Summary
Unify Tsingmicro backend debug log format to match the standard pattern GEMS_VENDOR OP_NAME.

## Changes
- GEMS {OP_NAME} -> GEMS_TSINGMICRO {OP_NAME} (5 files, 14 occurrences)

Note: Runtime debug messages in flash_api.py are left unchanged.

## Motivation
Standardize debug log format for consistency across all backends.