### PR TITLE
Standardize Sunrise backend debug log format

### DIFF
--- a/src/flag_gems/runtime/backend/_sunrise/ops/_safe_softmax.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/_safe_softmax.py
@@ -34,7 +34,7 @@ def _safe_softmax_kernel(
 
 
 def _safe_softmax(x: torch.Tensor, dim: int = -1, dtype: torch.dtype = None):
-    logger.debug("GEMS _SAFE_SOFTMAX")
+    logger.debug("GEMS_SUNRISE _SAFE_SOFTMAX")
     assert x.is_ptpu, "Input tensor must be on PTPU device"
     assert x.ndim >= 1, "Input tensor must have at least 1 dimension"
 

--- a/src/flag_gems/runtime/backend/_sunrise/ops/_upsample_nearest_exact1d.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/_upsample_nearest_exact1d.py
@@ -202,7 +202,7 @@ def _prepare_out_tensor(in_t, out_w, scale_w, dtype=None, device=None):
 
 
 def _upsample_nearest_exact1d(*args, **kwargs):
-    logger.debug("GEMS _UPSAMPLE_NEAREST_EXACT1D")
+    logger.debug("GEMS_SUNRISE _UPSAMPLE_NEAREST_EXACT1D")
     in_t, _, out_w, scale_w = _extract_io_and_params(args, kwargs, expect_out=False)
     out_t = _prepare_out_tensor(in_t, out_w, scale_w)
     if out_t.numel() == 0:
@@ -213,7 +213,7 @@ def _upsample_nearest_exact1d(*args, **kwargs):
 
 
 def _upsample_nearest_exact1d_out(*args, **kwargs):
-    logger.debug("GEMS _UPSAMPLE_NEAREST_EXACT1D_OUT")
+    logger.debug("GEMS_SUNRISE _UPSAMPLE_NEAREST_EXACT1D_OUT")
     in_t, out_t, out_w, scale_w = _extract_io_and_params(args, kwargs, expect_out=True)
     if out_t.ndim != 3:
         raise ValueError(
@@ -233,7 +233,7 @@ def _upsample_nearest_exact1d_out(*args, **kwargs):
 
 
 def _upsample_nearest_exact1d_vec(*args, **kwargs):
-    logger.debug("GEMS _UPSAMPLE_NEAREST_EXACT1D_VEC")
+    logger.debug("GEMS_SUNRISE _UPSAMPLE_NEAREST_EXACT1D_VEC")
     # Treat vec the same as base variant, allowing list-like output_size/scales
     in_t, _, out_w, scale_w = _extract_io_and_params(args, kwargs, expect_out=False)
     out_t = _prepare_out_tensor(in_t, out_w, scale_w)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/abs.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/abs.py
@@ -26,11 +26,11 @@ def abs_func(x):
 
 
 def abs(A):
-    logger.debug("GEMS ABS")
+    logger.debug("GEMS_SUNRISE ABS")
     return abs_func(A)
 
 
 def abs_(A):
-    logger.debug("GEMS ABS_")
+    logger.debug("GEMS_SUNRISE ABS_")
     abs_func(A, out0=A)
     return A

--- a/src/flag_gems/runtime/backend/_sunrise/ops/add.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/add.py
@@ -103,7 +103,7 @@ def should_use_broadcast_configs(A, B):
 
 
 def add(A, B, *, alpha=1):
-    logger.debug("GEMS ADD")
+    logger.debug("GEMS_SUNRISE ADD")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         if B.device != A.device:
             B = B.to(A.device)
@@ -122,7 +122,7 @@ def add(A, B, *, alpha=1):
 
 
 def add_(A, B, *, alpha=1):
-    logger.debug("GEMS ADD_")
+    logger.debug("GEMS_SUNRISE ADD_")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         if B.device != A.device:
             B = B.to(A.device)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/angle.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/angle.py
@@ -35,7 +35,7 @@ def angle_float_and_int(real):
 
 
 def angle(input_tensor: torch.Tensor) -> torch.Tensor:
-    logger.debug("GEMS ANGLE")
+    logger.debug("GEMS_SUNRISE ANGLE")
     if input_tensor.dtype == torch.complex32 or input_tensor.dtype == torch.complex64:
         device = input_tensor.device
         input_tensor = input_tensor.to(device="cpu")

--- a/src/flag_gems/runtime/backend/_sunrise/ops/arcsinh.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/arcsinh.py
@@ -82,10 +82,10 @@ def _arcsinh_impl(input_tensor: torch.Tensor, out_tensor: torch.Tensor = None):
 
 
 def arcsinh(input_tensor: torch.Tensor):
-    logger.debug("GEMS ARCSINH")
+    logger.debug("GEMS_SUNRISE ARCSINH")
     return _arcsinh_impl(input_tensor)
 
 
 def arcsinh_out(input_tensor: torch.Tensor, out: torch.Tensor):
-    logger.debug("GEMS ARCSINH_OUT")
+    logger.debug("GEMS_SUNRISE ARCSINH_OUT")
     return _arcsinh_impl(input_tensor, out)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/attention.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/attention.py
@@ -768,7 +768,7 @@ def scaled_dot_product_attention_forward(
     scale=None,
     enable_gqa=False,
 ):
-    logger.debug("GEMS_SUNRISE SCALED DOT PRODUCT ATTENTION FORWARD")
+    logger.debug("GEMS_SUNRISE SCALED_DOT_PRODUCT_ATTENTION_FORWARD")
     # shape constraints
     HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
     # when v is in float8_e5m2 it is transposed.

--- a/src/flag_gems/runtime/backend/_sunrise/ops/attention.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/attention.py
@@ -875,7 +875,7 @@ def scaled_dot_product_attention_backward(
     scale=None,
     enable_gqa=False,
 ):
-    logger.debug("GEMS_SUNRISE SCALED DOT PRODUCT ATTENTION BACKWARD")
+    logger.debug("GEMS_SUNRISE SCALED_DOT_PRODUCT_ATTENTION_BACKWARD")
     # shape constraints
     HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
     # when v is in float8_e5m2 it is transposed.

--- a/src/flag_gems/runtime/backend/_sunrise/ops/attention.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/attention.py
@@ -768,7 +768,7 @@ def scaled_dot_product_attention_forward(
     scale=None,
     enable_gqa=False,
 ):
-    logger.debug("GEMS SCALED DOT PRODUCT ATTENTION FORWARD")
+    logger.debug("GEMS_SUNRISE SCALED DOT PRODUCT ATTENTION FORWARD")
     # shape constraints
     HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
     # when v is in float8_e5m2 it is transposed.
@@ -875,7 +875,7 @@ def scaled_dot_product_attention_backward(
     scale=None,
     enable_gqa=False,
 ):
-    logger.debug("GEMS SCALED DOT PRODUCT ATTENTION BACKWARD")
+    logger.debug("GEMS_SUNRISE SCALED DOT PRODUCT ATTENTION BACKWARD")
     # shape constraints
     HEAD_DIM_Q, HEAD_DIM_K = query.shape[-1], key.shape[-1]
     # when v is in float8_e5m2 it is transposed.
@@ -1113,7 +1113,7 @@ def flash_attention_forward(
     alibi_slopes=None,
     disable_splitkv=False,
 ):
-    logger.debug("GEMS FLASH_ATTENTION_FORWARD")
+    logger.debug("GEMS_SUNRISE FLASH_ATTENTION_FORWARD")
     assert (
         cumulative_sequence_length_q is None and cumulative_sequence_length_k is None
     ), "varlen is not supported yet."
@@ -1293,7 +1293,7 @@ def flash_attn_varlen_func(
     if num_splits > 0:
         raise RuntimeError("num_splits > 0 is not implemented in GEMS.")
     if use_c_extension:
-        logger.debug("GEMS FLASH_ATTN_VARLEN_FUNC(C EXTENSION)")
+        logger.debug("GEMS_SUNRISE FLASH_ATTN_VARLEN_FUNC(C EXTENSION)")
         with torch_device_fn.device(q.device):
             out_cpp, softmax_lse = torch.ops.flag_gems.flash_attn_varlen_func(
                 q,
@@ -1329,7 +1329,7 @@ def flash_attn_varlen_func(
             )
         return (out_cpp, softmax_lse) if return_softmax_lse else out_cpp
     else:
-        logger.debug("GEMS FLASH_ATTN_VARLEN_FUNC")
+        logger.debug("GEMS_SUNRISE FLASH_ATTN_VARLEN_FUNC")
         assert (
             cu_seqlens_k is not None or seqused_k is not None
         ), "cu_seqlens_k or seqused_k must be provided"

--- a/src/flag_gems/runtime/backend/_sunrise/ops/bitwise_and.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/bitwise_and.py
@@ -25,12 +25,12 @@ def bitwise_and_func(x, y):
 
 
 def bitwise_and_tensor(A, B):
-    logger.debug("GEMS BITWISE AND")
+    logger.debug("GEMS_SUNRISE BITWISE AND")
     return bitwise_and_func(A, B)
 
 
 def bitwise_and_tensor_(A, B):
-    logger.debug("GEMS BITWISE AND_")
+    logger.debug("GEMS_SUNRISE BITWISE AND_")
     return bitwise_and_func(A, B, out0=A)
 
 
@@ -43,15 +43,15 @@ def bitwise_and_func_scalar(x, y):
 
 
 def bitwise_and_scalar(A, B):
-    logger.debug("GEMS BITWISE AND SCALAR")
+    logger.debug("GEMS_SUNRISE BITWISE AND SCALAR")
     return bitwise_and_func_scalar(A, B)
 
 
 def bitwise_and_scalar_(A, B):
-    logger.debug("GEMS BITWISE AND_ SCALAR")
+    logger.debug("GEMS_SUNRISE BITWISE AND_ SCALAR")
     return bitwise_and_func_scalar(A, B, out0=A)
 
 
 def bitwise_and_scalar_tensor(A, B):
-    logger.debug("GEMS BITWISE AND SCALAR TENSOR")
+    logger.debug("GEMS_SUNRISE BITWISE AND SCALAR TENSOR")
     return bitwise_and_func_scalar(B, A)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/bitwise_left_shift.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/bitwise_left_shift.py
@@ -21,7 +21,7 @@ def bitwise_left_shift_func_scalar(x, y):
 
 
 def bitwise_left_shift(A, B):
-    logger.debug("GEMS BITWISE_LEFT_SHIFT")
+    logger.debug("GEMS_SUNRISE BITWISE_LEFT_SHIFT")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return bitwise_left_shift_func(A, B)
     elif isinstance(A, torch.Tensor):
@@ -32,7 +32,7 @@ def bitwise_left_shift(A, B):
 
 
 def bitwise_left_shift_out(A, B, out):
-    logger.debug("GEMS BITWISE_LEFT_SHIFT OUT")
+    logger.debug("GEMS_SUNRISE BITWISE_LEFT_SHIFT OUT")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return bitwise_left_shift_func(A, B, out0=out)
     elif isinstance(A, torch.Tensor):
@@ -43,7 +43,7 @@ def bitwise_left_shift_out(A, B, out):
 
 
 def bitwise_left_shift_(A, B):
-    logger.debug("GEMS BITWISE_LEFT_SHIFT_")
+    logger.debug("GEMS_SUNRISE BITWISE_LEFT_SHIFT_")
     if isinstance(B, torch.Tensor):
         return bitwise_left_shift_func(A, B, out0=A)
     return bitwise_left_shift_func_scalar(A, B, out0=A)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/bitwise_right_shift.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/bitwise_right_shift.py
@@ -21,7 +21,7 @@ def bitwise_right_shift_func_scalar(x, y):
 
 
 def bitwise_right_shift(A, B):
-    logger.debug("GEMS BITWISE_RIGHT_SHIFT")
+    logger.debug("GEMS_SUNRISE BITWISE_RIGHT_SHIFT")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return bitwise_right_shift_func(A, B)
     elif isinstance(A, torch.Tensor):
@@ -32,7 +32,7 @@ def bitwise_right_shift(A, B):
 
 
 def bitwise_right_shift_out(A, B, out):
-    logger.debug("GEMS BITWISE_RIGHT_SHIFT OUT")
+    logger.debug("GEMS_SUNRISE BITWISE_RIGHT_SHIFT OUT")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return bitwise_right_shift_func(A, B, out0=out)
     elif isinstance(A, torch.Tensor):
@@ -43,7 +43,7 @@ def bitwise_right_shift_out(A, B, out):
 
 
 def bitwise_right_shift_(A, B):
-    logger.debug("GEMS BITWISE_RIGHT_SHIFT_")
+    logger.debug("GEMS_SUNRISE BITWISE_RIGHT_SHIFT_")
     if isinstance(B, torch.Tensor):
         return bitwise_right_shift_func(A, B, out0=A)
     return bitwise_right_shift_func_scalar(A, B, out0=A)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/clamp.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/clamp.py
@@ -78,7 +78,7 @@ def clamp_tensor(A, mini=None, maxi=None):
 
 
 def clamp_tensor_(A, mini=None, maxi=None):
-    logger.debug("GEMS CLAMP_ TENSOR")
+    logger.debug("GEMS_SUNRISE CLAMP_ TENSOR")
     if A.dtype == torch.half:
         if mini is None and maxi is None:
             raise ValueError("At least one of mini or maxi must not be None")
@@ -146,21 +146,21 @@ def clamp_func_max_f16(x, maxi):
 
 
 def clamp_min(A, mini):
-    logger.debug("GEMS CLAMP MIN")
+    logger.debug("GEMS_SUNRISE CLAMP MIN")
     if mini is None:
         raise ValueError("Mini must not be None")
     return clamp_func_min(A, mini)
 
 
 def clamp_min_(A, mini):
-    logger.debug("GEMS CLAMP_ MIN")
+    logger.debug("GEMS_SUNRISE CLAMP_ MIN")
     if mini is None:
         raise ValueError("Mini must not be None")
     return clamp_func_min(A, mini, out0=A)
 
 
 def clamp(A, mini=None, maxi=None):
-    logger.debug("GEMS CLAMP")
+    logger.debug("GEMS_SUNRISE CLAMP")
     if A.dtype == torch.half:
         if mini is None and maxi is None:
             raise ValueError("At least one of mini or maxi must not be None")
@@ -182,7 +182,7 @@ def clamp(A, mini=None, maxi=None):
 
 
 def clamp_(A, mini=None, maxi=None):
-    logger.debug("GEMS CLAMP")
+    logger.debug("GEMS_SUNRISE CLAMP")
     if A.dtype == torch.half:
         if mini is None and maxi is None:
             raise ValueError("At least one of mini or maxi must not be None")

--- a/src/flag_gems/runtime/backend/_sunrise/ops/conv2d.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/conv2d.py
@@ -340,7 +340,7 @@ def conv2d_backward_kernel_weight(
 class Conv2d(torch.autograd.Function):
     @staticmethod
     def forward(ctx, input, weight, bias, stride, padding, dilation, groups):
-        logger.debug("GEMS CONV2D")
+        logger.debug("GEMS_SUNRISE CONV2D")
         assert weight.ndim == 4, "Weights must be 4D, received shape {weight.shape}"
         assert (
             bias is None or bias.ndim == 1
@@ -440,7 +440,7 @@ class Conv2d(torch.autograd.Function):
 
     @staticmethod
     def backward(ctx, out_grad):
-        logger.debug("GEMS CONV2D VJP")
+        logger.debug("GEMS_SUNRISE CONV2D VJP")
         (weight, input, bias) = ctx.saved_tensors
         # (out_c equals origin cout divide groups)
         out_c, weight_c, weight_height, weight_width = ctx.weight_info

--- a/src/flag_gems/runtime/backend/_sunrise/ops/cos.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/cos.py
@@ -25,11 +25,11 @@ def cos_func(x):
 
 
 def cos(A):
-    logger.debug("GEMS COS")
+    logger.debug("GEMS_SUNRISE COS")
     return cos_func(A)
 
 
 def cos_(A):
-    logger.debug("GEMS COS_")
+    logger.debug("GEMS_SUNRISE COS_")
     cos_func(A, out0=A)
     return A

--- a/src/flag_gems/runtime/backend/_sunrise/ops/count_nonzero.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/count_nonzero.py
@@ -74,7 +74,7 @@ def count_nonzero_combin_kernel(
 
 
 def count_nonzero(x, dim=None):
-    logger.debug("GEMS COUNT NONZERO")
+    logger.debug("GEMS_SUNRISE COUNT NONZERO")
     if dim is not None:
         assert dim >= -x.ndim and dim < x.ndim, "Invalid dim"
         shape = x.shape

--- a/src/flag_gems/runtime/backend/_sunrise/ops/cumsum.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/cumsum.py
@@ -366,12 +366,12 @@ def reduce_then_scan_block_scan_kernel_row(
 
 
 def cumsum(inp, dim=1, *, dtype=None):
-    logger.debug("GEMS CUMSUM")
+    logger.debug("GEMS_SUNRISE CUMSUM")
     return cumsum_wrapper(inp, dim, dtype)
 
 
 def cumsum_out(inp, dim=1, *, dtype=None, out):
-    logger.debug("GEMS CUMSUM_OUT")
+    logger.debug("GEMS_SUNRISE CUMSUM_OUT")
     return cumsum_wrapper(inp, dim, dtype, out)
 
 
@@ -519,7 +519,7 @@ GRID_Y_LIMIT = 65535
 
 
 def normed_cumsum(inp, dim=-1):
-    logger.debug("GEMS NORMED_CUMSUM")
+    logger.debug("GEMS_SUNRISE NORMED_CUMSUM")
     assert inp.dtype in (torch.float16, torch.bfloat16, torch.float32, torch.float64)
     dim = dim % inp.ndim
     N = inp.numel()

--- a/src/flag_gems/runtime/backend/_sunrise/ops/div.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/div.py
@@ -44,7 +44,7 @@ def true_div_func_scalar_tensor(x, y):
 
 
 def true_divide(A, B):
-    logger.debug("GEMS TRUE_DIVIDE")
+    logger.debug("GEMS_SUNRISE TRUE_DIVIDE")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return true_div_func(A, B)
     elif isinstance(A, torch.Tensor):
@@ -57,7 +57,7 @@ def true_divide(A, B):
 
 
 def true_divide_out(A, B, out):
-    logger.debug("GEMS TRUE_DIVIDE OUT")
+    logger.debug("GEMS_SUNRISE TRUE_DIVIDE OUT")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return true_div_func(A, B, out0=out)
     elif isinstance(A, torch.Tensor):
@@ -70,7 +70,7 @@ def true_divide_out(A, B, out):
 
 
 def true_divide_(A, B):
-    logger.debug("GEMS TRUE_DIVIDE_")
+    logger.debug("GEMS_SUNRISE TRUE_DIVIDE_")
     if isinstance(B, torch.Tensor):
         return true_div_func(A, B, out0=A)
     else:
@@ -100,7 +100,7 @@ def trunc_div_func_scalar_tensor(x, y):
 
 
 def trunc_divide(A, B):
-    logger.debug("GEMS TRUNC_DIVIDE")
+    logger.debug("GEMS_SUNRISE TRUNC_DIVIDE")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return trunc_div_func(A, B)
     elif isinstance(A, torch.Tensor):
@@ -113,7 +113,7 @@ def trunc_divide(A, B):
 
 
 def trunc_divide_(A, B):
-    logger.debug("GEMS TRUNC_DIVIDE_")
+    logger.debug("GEMS_SUNRISE TRUNC_DIVIDE_")
     if isinstance(B, torch.Tensor):
         return trunc_div_func(A, B, out0=A)
     else:
@@ -205,7 +205,7 @@ def floor_div_func_scalar_tensor(x, y):
 
 
 def floor_divide(A, B):
-    logger.debug("GEMS FLOOR_DIVIDE")
+    logger.debug("GEMS_SUNRISE FLOOR_DIVIDE")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return floor_div_func(A, B)
     elif isinstance(A, torch.Tensor):
@@ -218,7 +218,7 @@ def floor_divide(A, B):
 
 
 def floor_divide_(A, B):
-    logger.debug("GEMS FLOOR_DIVIDE_")
+    logger.debug("GEMS_SUNRISE FLOOR_DIVIDE_")
     if isinstance(B, torch.Tensor):
         return floor_div_func(A, B, out0=A)
     else:
@@ -280,7 +280,7 @@ def rem_st(x, y):
 
 
 def remainder(A, B):
-    logger.debug("GEMS REMAINDER")
+    logger.debug("GEMS_SUNRISE REMAINDER")
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return rem_tt(A, B)
     elif isinstance(A, torch.Tensor):
@@ -293,7 +293,7 @@ def remainder(A, B):
 
 
 def remainder_(A, B):
-    logger.debug("GEMS REMAINDER_")
+    logger.debug("GEMS_SUNRISE REMAINDER_")
     if isinstance(B, torch.Tensor):
         return rem_tt(A, B, out0=A)
     else:

--- a/src/flag_gems/runtime/backend/_sunrise/ops/dropout.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/dropout.py
@@ -116,7 +116,7 @@ UNROLL = 4
 
 
 def dropout(input, p, train=True):
-    logger.debug("GEMS NATIVE DROPOUT FORWARD")
+    logger.debug("GEMS_SUNRISE NATIVE DROPOUT FORWARD")
     if not train or p == 0:
         out = input.clone()
         mask = torch.ones_like(input, dtype=torch.bool)
@@ -145,7 +145,7 @@ def dropout(input, p, train=True):
 
 
 def dropout_backward(grad_output, mask, scale):
-    logger.debug("GEMS NATIVE DROPOUT BACKWARD")
+    logger.debug("GEMS_SUNRISE NATIVE DROPOUT BACKWARD")
     grad_output = grad_output.contiguous()
     grad_input = torch.empty_like(grad_output)
     N = grad_output.numel()

--- a/src/flag_gems/runtime/backend/_sunrise/ops/embedding.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/embedding.py
@@ -116,7 +116,7 @@ def embedding_grad_scale_kernel(
 
 
 def embedding(weight, indices, padding_idx=-1, scale_grad_by_freq=False, sparse=False):
-    logger.debug("GEMS EMBEDDING FORWARD")
+    logger.debug("GEMS_SUNRISE EMBEDDING FORWARD")
     assert not sparse, "Currently do not support sparse format"
 
     M = indices.numel()
@@ -142,7 +142,7 @@ def embedding_backward(
     scale_grad_by_freq=False,
     sparse=False,
 ):
-    logger.debug("GEMS EMBEDDING BACKWARD")
+    logger.debug("GEMS_SUNRISE EMBEDDING BACKWARD")
     assert not sparse, "Currently do not support sparse format"
 
     M = indices.numel()

--- a/src/flag_gems/runtime/backend/_sunrise/ops/eq.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/eq.py
@@ -34,7 +34,7 @@ def eq(A, B):
             B = B.to(A.device)
         else:
             A = A.to(B.device)
-    logger.debug("GEMS EQ")
+    logger.debug("GEMS_SUNRISE EQ")
     return eq_func(A, B)
 
 
@@ -47,12 +47,12 @@ def eq_func_scalar(x, y):
 
 
 def eq_scalar(A, B):
-    logger.debug("GEMS EQ SCALAR")
+    logger.debug("GEMS_SUNRISE EQ SCALAR")
     return eq_func_scalar(A, B)
 
 
 def equal(x: torch.Tensor, y: torch.Tensor) -> bool:
-    logger.debug("GEMS EQUAL")
+    logger.debug("GEMS_SUNRISE EQUAL")
     if x.shape != y.shape:
         return False
     eq_tensor = eq(x, y)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/exponential_.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/exponential_.py
@@ -160,7 +160,7 @@ def fused_exponential_kernel_f64(
 
 
 def exponential_(x, lambd: float = 1.0, *, generator=None):
-    logger.debug("GEMS EXPONENTIAL_")
+    logger.debug("GEMS_SUNRISE EXPONENTIAL_")
 
     dtype = x.dtype
     device = x.device

--- a/src/flag_gems/runtime/backend/_sunrise/ops/fill.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/fill.py
@@ -44,14 +44,14 @@ def fill_tensor_func(inp, value):
 
 
 def fill_scalar(input, value):
-    logger.debug("GEMS FILL (Dynamic)")
+    logger.debug("GEMS_SUNRISE FILL (Dynamic)")
     out = torch.empty_like(input)
     with torch_device_fn.device(input.device):
         return fill_scalar_func(input, value, out0=out)
 
 
 def fill_scalar_out(input, value, *, out=None):
-    logger.debug("GEMS FILL_SCALAR_OUT")
+    logger.debug("GEMS_SUNRISE FILL_SCALAR_OUT")
     if out is None:
         return fill_scalar(input, value)
     with torch_device_fn.device(input.device):
@@ -62,7 +62,7 @@ def fill_scalar_out(input, value, *, out=None):
 def fill_tensor(input, value):
     if not value.is_cuda:
         return fill_scalar(input, value.item())
-    logger.debug("GEMS FILL (Dynamic)")
+    logger.debug("GEMS_SUNRISE FILL (Dynamic)")
     if value.ndim != 0:
         raise RuntimeError(
             f"fill_ only supports 0-dimension value tensor but got tensor with {value.ndim} dimensions."
@@ -73,7 +73,7 @@ def fill_tensor(input, value):
 
 
 def fill_tensor_out(input, value, *, out=None):
-    logger.debug("GEMS FILL_TENSOR_OUT")
+    logger.debug("GEMS_SUNRISE FILL_TENSOR_OUT")
     if out is None:
         return fill_tensor(input, value)
     if not value.is_cuda:
@@ -90,7 +90,7 @@ def fill_tensor_out(input, value, *, out=None):
 def fill_tensor_(self, value):
     if not value.is_cuda:
         return fill_scalar_(self, value.item())
-    logger.debug("GEMS FILL_TENSOR_")
+    logger.debug("GEMS_SUNRISE FILL_TENSOR_")
     if value.ndim != 0:
         raise RuntimeError(
             f"fill_ only supports 0-dimension value tensor but got tensor with {value.ndim} dimensions."
@@ -101,7 +101,7 @@ def fill_tensor_(self, value):
 
 
 def fill_scalar_(self, value):
-    logger.debug("GEMS FILL_SCALAR_")
+    logger.debug("GEMS_SUNRISE FILL_SCALAR_")
     with torch_device_fn.device(self.device):
         fill_scalar_func(self, value, out0=self)
     return self

--- a/src/flag_gems/runtime/backend/_sunrise/ops/gather.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/gather.py
@@ -187,7 +187,7 @@ _gather_func = GatherFunction()
 
 
 def gather(inp, dim, index, out=None, sparse_grad=False):
-    logger.debug("GEMS GATHER")
+    logger.debug("GEMS_SUNRISE GATHER")
     if out is None:
         out = torch.empty_like(index, dtype=inp.dtype, device=inp.device)
     dim_stride = inp.stride(dim)
@@ -198,6 +198,6 @@ def gather(inp, dim, index, out=None, sparse_grad=False):
 
 
 def gather_backward(grad, self, dim, index, sparse_grad):
-    logger.debug("GEMS GATHER BACKWARD")
+    logger.debug("GEMS_SUNRISE GATHER BACKWARD")
     result = grad.new_zeros(self.shape)
     return scatter_(result, dim, index, grad, reduce="add")

--- a/src/flag_gems/runtime/backend/_sunrise/ops/ge.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/ge.py
@@ -25,7 +25,7 @@ def ge_func(x, y):
 
 
 def ge(A, B):
-    logger.debug("GEMS GE")
+    logger.debug("GEMS_SUNRISE GE")
     return ge_func(A, B)
 
 
@@ -38,5 +38,5 @@ def ge_func_scalar(x, y):
 
 
 def ge_scalar(A, B):
-    logger.debug("GEMS GE SCALAR")
+    logger.debug("GEMS_SUNRISE GE SCALAR")
     return ge_func_scalar(A, B)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/gelu.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/gelu.py
@@ -71,7 +71,7 @@ def gelu_backward_tanh(x, dy):
 
 
 def gelu(self, *, approximate="none"):
-    logger.debug("GEMS GELU FORWARD")
+    logger.debug("GEMS_SUNRISE GELU FORWARD")
     if approximate == "tanh":
         out = gelu_tanh(self)
     else:
@@ -80,7 +80,7 @@ def gelu(self, *, approximate="none"):
 
 
 def gelu_backward(grad_output, self, *, approximate="none"):
-    logger.debug("GEMS GELU BACKWARD")
+    logger.debug("GEMS_SUNRISE GELU BACKWARD")
     if approximate == "tanh":
         in_grad = gelu_backward_tanh(self, grad_output)
     else:
@@ -89,7 +89,7 @@ def gelu_backward(grad_output, self, *, approximate="none"):
 
 
 def gelu_(A, *, approximate="none"):
-    logger.debug("GEMS GELU_ FORWARD")
+    logger.debug("GEMS_SUNRISE GELU_ FORWARD")
     if approximate == "tanh":
         out = gelu_tanh(A, out0=A)
     else:

--- a/src/flag_gems/runtime/backend/_sunrise/ops/i0.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/i0.py
@@ -98,7 +98,7 @@ def _launch_i0(out: torch.Tensor, x: torch.Tensor):
 
 
 def i0(x: torch.Tensor):
-    logger.debug("GEMS I0")
+    logger.debug("GEMS_SUNRISE I0")
     if not x.is_ptpu:
         raise ValueError("i0: input tensor must be on PTPU device")
     # Result dtype follows PyTorch's floating type behavior
@@ -109,7 +109,7 @@ def i0(x: torch.Tensor):
 
 
 def i0_out(x: torch.Tensor, out: torch.Tensor):
-    logger.debug("GEMS I0_OUT")
+    logger.debug("GEMS_SUNRISE I0_OUT")
     if not (x.is_ptpu and out.is_ptpu):
         raise ValueError("i0_out: input and output tensors must be on PTPU device")
     if not out.is_floating_point():

--- a/src/flag_gems/runtime/backend/_sunrise/ops/i0_.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/i0_.py
@@ -65,7 +65,7 @@ def i0_kernel_(x_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
 
 
 def i0_(*args, **kwargs):
-    logger.debug("GEMS I0_")
+    logger.debug("GEMS_SUNRISE I0_")
     x = None
     if len(args) > 0:
         x = args[0]

--- a/src/flag_gems/runtime/backend/_sunrise/ops/index_add.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/index_add.py
@@ -220,7 +220,7 @@ _index_add_func = IndexAddFunction()
 
 
 def index_add(inp, dim, index, src, alpha=1):
-    logger.debug("GEMS INDEX ADD")
+    logger.debug("GEMS_SUNRISE INDEX ADD")
     assert ((0 <= index) * (index < inp.size(dim))).equal(
         torch.ones(tuple(index.shape), dtype=torch.bool, device=inp.device)
     ), "0 <= index < self.size(dim)"
@@ -261,7 +261,7 @@ def index_add(inp, dim, index, src, alpha=1):
 
 
 def index_add_(inp, dim, index, src, alpha=1):
-    logger.debug("GEMS INDEX ADD_")
+    logger.debug("GEMS_SUNRISE INDEX ADD_")
     assert ((0 <= index) * (index < inp.size(dim))).equal(
         torch.ones(tuple(index.shape), dtype=torch.bool, device=inp.device)
     ), "0 <= index < self.size(dim)"

--- a/src/flag_gems/runtime/backend/_sunrise/ops/index_put.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/index_put.py
@@ -264,14 +264,14 @@ _index_put_func = IndexPutFunction()
 
 
 def index_put(inp, indices, values, accumulate=False):
-    logger.debug("GEMS INDEX PUT")
+    logger.debug("GEMS_SUNRISE INDEX PUT")
 
     out = inp.clone()
     return index_put_(out, indices, values, accumulate)
 
 
 def index_put_(inp, indices, values, accumulate=False):
-    logger.debug("GEMS INDEX PUT_")
+    logger.debug("GEMS_SUNRISE INDEX PUT_")
 
     indices = list(indices)
 

--- a/src/flag_gems/runtime/backend/_sunrise/ops/index_select.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/index_select.py
@@ -93,7 +93,7 @@ def index_select_dim0(inp, dim, index):
 
 
 def index_select(inp, dim, index):
-    logger.debug("GEMS INDEX SELECT")
+    logger.debug("GEMS_SUNRISE INDEX SELECT")
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
     assert index.ndim <= 1, "Index should have dimension 1 or 0"
 

--- a/src/flag_gems/runtime/backend/_sunrise/ops/isin.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/isin.py
@@ -255,7 +255,7 @@ def isin(
     assume_unique: bool = False,
     invert: bool = False,
 ) -> torch.Tensor:
-    logger.debug("GEMS ISIN")
+    logger.debug("GEMS_SUNRISE ISIN")
     if not torch.is_tensor(in0):
         assert torch.is_tensor(in1)
         in0 = torch.tensor(in0, device=in1.device)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/isnan.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/isnan.py
@@ -27,5 +27,5 @@ def isnan_func(x):
 
 
 def isnan(A):
-    logger.debug("GEMS ISNAN")
+    logger.debug("GEMS_SUNRISE ISNAN")
     return isnan_func(A)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/layernorm.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/layernorm.py
@@ -336,7 +336,7 @@ def weight_bias_backward_kernel(
 
 
 def layer_norm(input, normalized_shape, weight=None, bias=None, eps=1e-5):
-    logger.debug("GEMS LAYERNORM FORWARD")
+    logger.debug("GEMS_SUNRISE LAYERNORM FORWARD")
 
     N = math.prod(normalized_shape)
     M = input.numel() // N
@@ -410,7 +410,7 @@ def layer_norm_backward(
     bias=None,
     output_mask=None,
 ):
-    logger.debug("GEMS LAYERNORM BACKWARD")
+    logger.debug("GEMS_SUNRISE LAYERNORM BACKWARD")
 
     grad_out = grad_out.contiguous()
     input = input.contiguous()

--- a/src/flag_gems/runtime/backend/_sunrise/ops/lift_fresh_copy.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/lift_fresh_copy.py
@@ -19,7 +19,7 @@ def _copy_kernel(in_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
 
 
 def lift_fresh_copy(*args, **kwargs):
-    logger.debug("GEMS LIFT_FRESH_COPY")
+    logger.debug("GEMS_SUNRISE LIFT_FRESH_COPY")
     # Attempt to find the input tensor from args/kwargs
     x = None
     if len(args) > 0 and isinstance(args[0], torch.Tensor):
@@ -48,7 +48,7 @@ def lift_fresh_copy(*args, **kwargs):
 
 
 def lift_fresh_copy_out(x: torch.Tensor, out: torch.Tensor = None):
-    logger.debug("GEMS LIFT_FRESH_COPY_OUT")
+    logger.debug("GEMS_SUNRISE LIFT_FRESH_COPY_OUT")
     if x is None or not isinstance(x, torch.Tensor):
         raise ValueError("lift_fresh_copy_out expects 'x' to be a Tensor")
     if not x.is_ptpu:

--- a/src/flag_gems/runtime/backend/_sunrise/ops/linspace.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/linspace.py
@@ -36,7 +36,7 @@ def linspace_kernel(
 def linspace(
     start, end, steps, *, dtype=None, layout=None, device=None, pin_memory=None
 ) -> torch.Tensor:
-    logger.debug("GEMS LINSPACE")
+    logger.debug("GEMS_SUNRISE LINSPACE")
     assert steps >= 1, "steps must be >= 1"
 
     out = torch.empty(

--- a/src/flag_gems/runtime/backend/_sunrise/ops/log_softmax.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/log_softmax.py
@@ -227,7 +227,7 @@ def log_softmax_backward_kernel_opt(
 
 
 def log_softmax(self, dim, half_to_float=False):
-    logger.debug("GEMS LOG_SOFTMAX")
+    logger.debug("GEMS_SUNRISE LOG_SOFTMAX")
 
     assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
     dim = dim % self.ndim
@@ -264,7 +264,7 @@ def log_softmax(self, dim, half_to_float=False):
 
 
 def log_softmax_backward(grad_output, output, dim, input_dtype):
-    logger.debug("GEMS LOG_SOFTMAX VJP")
+    logger.debug("GEMS_SUNRISE LOG_SOFTMAX VJP")
 
     assert dim >= -output.ndim and dim < output.ndim, "Invalid dim"
     dim = dim % output.ndim

--- a/src/flag_gems/runtime/backend/_sunrise/ops/logaddexp.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/logaddexp.py
@@ -66,7 +66,7 @@ def _launch_logaddexp_kernel(x: torch.Tensor, y: torch.Tensor, out: torch.Tensor
 
 
 def logaddexp(x, y):
-    logger.debug("GEMS LOGADDEXP")
+    logger.debug("GEMS_SUNRISE LOGADDEXP")
     # Determine device
     device = None
     if torch.is_tensor(x) and x.is_ptpu:
@@ -96,7 +96,7 @@ def logaddexp(x, y):
 
 
 def logaddexp_out(x, y, out):
-    logger.debug("GEMS LOGADDEXP_OUT")
+    logger.debug("GEMS_SUNRISE LOGADDEXP_OUT")
     if not torch.is_tensor(out):
         raise ValueError("out must be a tensor")
 

--- a/src/flag_gems/runtime/backend/_sunrise/ops/logical_and.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/logical_and.py
@@ -26,5 +26,5 @@ def logical_and_func(x, y):
 
 
 def logical_and(A, B):
-    logger.debug("GEMS LOGICAL_AND")
+    logger.debug("GEMS_SUNRISE LOGICAL_AND")
     return logical_and_func(A, B)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/logical_or.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/logical_or.py
@@ -25,11 +25,11 @@ def logical_or_func(x, y):
 
 
 def logical_or(A, B):
-    logger.debug("GEMS LOGICAL_OR")
+    logger.debug("GEMS_SUNRISE LOGICAL_OR")
     return logical_or_func(A, B)
 
 
 def logical_or_(A, B):
-    logger.debug("GEMS LOGICAL_OR_")
+    logger.debug("GEMS_SUNRISE LOGICAL_OR_")
     logical_or_func(A, B, out0=A)
     return A

--- a/src/flag_gems/runtime/backend/_sunrise/ops/margin_ranking_loss.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/margin_ranking_loss.py
@@ -31,7 +31,7 @@ def _margin_ranking_loss_kernel(
 
 
 def margin_ranking_loss(*args, **kwargs):
-    logger.debug("GEMS MARGIN_RANKING_LOSS")
+    logger.debug("GEMS_SUNRISE MARGIN_RANKING_LOSS")
     # Parse inputs: (input1, input2, target, margin=0.0, reduction='mean')
     if len(args) < 3 and not all(k in kwargs for k in ("self", "other", "target")):
         raise TypeError(

--- a/src/flag_gems/runtime/backend/_sunrise/ops/masked_select.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/masked_select.py
@@ -126,7 +126,7 @@ def write_back_kernel(
 
 
 def masked_select(inp, mask):
-    logger.debug("GEMS MASKED SELECT")
+    logger.debug("GEMS_SUNRISE MASKED SELECT")
 
     inp_shape = tuple(inp.shape)
     mask_shape = tuple(mask.shape)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/mean.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/mean.py
@@ -62,7 +62,7 @@ def mean_kernel_2(mid, out, M, MID_SIZE, BLOCK_MID: tl.constexpr):
 
 
 def mean(inp, *, dtype=None):
-    logger.debug("GEMS MEAN")
+    logger.debug("GEMS_SUNRISE MEAN")
     M = inp.numel()
     if dtype is None:
         dtype = inp.dtype
@@ -224,7 +224,7 @@ def mean_dim_kernel(
 
 
 def mean_dim_comm(inp, dim=None, keepdim=False, *, dtype=None, out=None):
-    logger.debug("GEMS MEAN_DIM")
+    logger.debug("GEMS_SUNRISE MEAN_DIM")
     if dtype is None:
         dtype = inp.dtype
         if dtype is torch.bool:
@@ -306,6 +306,6 @@ def mean_dim_comm(inp, dim=None, keepdim=False, *, dtype=None, out=None):
 
 
 def mean_dim(inp, dim=None, keepdim=False, *, dtype=None):
-    logger.debug("GEMS MEAN_DIM (wrapper)")
+    logger.debug("GEMS_SUNRISE MEAN_DIM (wrapper)")
 
     return mean_dim_comm(inp, dim, keepdim, dtype=dtype)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/mul.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/mul.py
@@ -48,7 +48,7 @@ def mul_complex_kernel(ar, ai, br, bi):
 
 
 def mul(A, B):
-    logger.debug("GEMS MUL")
+    logger.debug("GEMS_SUNRISE MUL")
     A_is_complex = (isinstance(A, torch.Tensor) and A.is_complex()) or isinstance(
         A, complex
     )
@@ -124,7 +124,7 @@ def mul(A, B):
 
 
 def mul_(A, B):
-    logger.debug("GEMS MUL_")
+    logger.debug("GEMS_SUNRISE MUL_")
     if isinstance(B, torch.Tensor):
         return mul_func(A, B, out0=A)
     else:

--- a/src/flag_gems/runtime/backend/_sunrise/ops/mv.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/mv.py
@@ -52,7 +52,7 @@ def mv_kernel(
 
 
 def mv(inp, vec):
-    logger.debug("GEMS MV")
+    logger.debug("GEMS_SUNRISE MV")
     assert inp.shape[1] == vec.shape[0], "incompatible dimensions"
     N, M = inp.shape
     out = torch.empty((N,), dtype=inp.dtype).to(device=inp.device)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/neg.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/neg.py
@@ -24,10 +24,10 @@ def neg_func(x):
 
 
 def neg(A):
-    logger.debug("GEMS NEG")
+    logger.debug("GEMS_SUNRISE NEG")
     return neg_func(A)
 
 
 def neg_(A):
-    logger.debug("GEMS NEG_")
+    logger.debug("GEMS_SUNRISE NEG_")
     return neg_func(A, out0=A)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/nonzero.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/nonzero.py
@@ -43,7 +43,7 @@ def nonzero_kernel(
 
 
 def nonzero(inp, *, as_tuple=False):
-    logger.debug("GEMS NONZERO")
+    logger.debug("GEMS_SUNRISE NONZERO")
 
     inp_ndim = inp.ndim
 

--- a/src/flag_gems/runtime/backend/_sunrise/ops/pad.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/pad.py
@@ -453,7 +453,7 @@ _pad_func = PadFunction()
 
 
 def pad(self, pad, mode="constant", value=None):
-    logger.debug("GEMS CONSTANT PAD ND")
+    logger.debug("GEMS_SUNRISE CONSTANT PAD ND")
 
     ndim = self.ndim
 

--- a/src/flag_gems/runtime/backend/_sunrise/ops/polar.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/polar.py
@@ -24,7 +24,7 @@ def polar_kernel(abs, angle):
 
 
 def polar(abs, angle):
-    logger.debug("GEMS POLAR")
+    logger.debug("GEMS_SUNRISE POLAR")
     output = torch.empty((*abs.shape, 2), dtype=abs.dtype, device=abs.device)
 
     polar_kernel(abs, angle, out0=output[..., 0], out1=output[..., 1])

--- a/src/flag_gems/runtime/backend/_sunrise/ops/pow.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/pow.py
@@ -26,12 +26,12 @@ def pow_func(x, exponent):
 
 
 def pow_tensor_tensor(A, exponent):
-    logger.debug("GEMS POW_TENSOR_TENSOR")
+    logger.debug("GEMS_SUNRISE POW_TENSOR_TENSOR")
     return pow_func(A, exponent)
 
 
 def pow_tensor_tensor_(A, exponent):
-    logger.debug("GEMS POW_TENSOR_TENSOR_")
+    logger.debug("GEMS_SUNRISE POW_TENSOR_TENSOR_")
     return pow_func(A, exponent, out0=A)
 
 
@@ -44,12 +44,12 @@ def pow_func_tensor_scalar(x, exponent):
 
 
 def pow_tensor_scalar(A, exponent):
-    logger.debug("GEMS POW_TENSOR_SCALAR")
+    logger.debug("GEMS_SUNRISE POW_TENSOR_SCALAR")
     return pow_func_tensor_scalar(A, exponent)
 
 
 def pow_tensor_scalar_(A, exponent):
-    logger.debug("GEMS POW_TENSOR_SCALAR_")
+    logger.debug("GEMS_SUNRISE POW_TENSOR_SCALAR_")
     return pow_func_tensor_scalar(A, exponent, out0=A)
 
 
@@ -62,5 +62,5 @@ def pow_func_scalar_tensor(x, exponent):
 
 
 def pow_scalar(A, exponent):
-    logger.debug("GEMS POW_SCALAR")
+    logger.debug("GEMS_SUNRISE POW_SCALAR")
     return pow_func_scalar_tensor(A, exponent)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/prelu.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/prelu.py
@@ -38,7 +38,7 @@ def prelu_kernel(
 
 
 def prelu(*args, **kwargs):
-    logger.debug("GEMS PRELU")
+    logger.debug("GEMS_SUNRISE PRELU")
     # Extract inputs
     if len(args) >= 2:
         x, weight = args[0], args[1]

--- a/src/flag_gems/runtime/backend/_sunrise/ops/quantile.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/quantile.py
@@ -92,7 +92,7 @@ def quantile_kernel(
 def quantile(
     inp, q, dim=None, keepdim=False, interpolation="linear", out=None
 ) -> Tensor:
-    logger.debug("GEMS QUANTILE DIM")
+    logger.debug("GEMS_SUNRISE QUANTILE DIM")
     assert torch.is_floating_point(inp)
     assert dim is None or isinstance(dim, int)
     assert isinstance(q, (float, torch.Tensor))

--- a/src/flag_gems/runtime/backend/_sunrise/ops/randperm.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/randperm.py
@@ -421,7 +421,7 @@ def randperm(
     requires_grad=False,
     pin_memory=False,
 ):
-    logger.debug("GEMS RANDPERM")
+    logger.debug("GEMS_SUNRISE RANDPERM")
     assert dtype == torch.int16 or dtype == torch.int32 or dtype == torch.int64
     assert n <= _MAX_INT64_VAL, "n exceeds maximum int64"
 

--- a/src/flag_gems/runtime/backend/_sunrise/ops/reflection_pad2d.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/reflection_pad2d.py
@@ -148,10 +148,10 @@ def launch_reflection_pad2d(input: torch.Tensor, padding, out: torch.Tensor = No
 
 
 def reflection_pad2d(input: torch.Tensor, padding):
-    logger.debug("GEMS REFLECTION_PAD2D")
+    logger.debug("GEMS_SUNRISE REFLECTION_PAD2D")
     return launch_reflection_pad2d(input, padding, out=None)
 
 
 def reflection_pad2d_out(input: torch.Tensor, padding, out: torch.Tensor):
-    logger.debug("GEMS REFLECTION_PAD2D_OUT")
+    logger.debug("GEMS_SUNRISE REFLECTION_PAD2D_OUT")
     return launch_reflection_pad2d(input, padding, out=out)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/repeat.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/repeat.py
@@ -441,7 +441,7 @@ _repeat_func = RepeatFunction()
 
 
 def repeat(inp: torch.Tensor, sizes) -> torch.Tensor:
-    logger.debug("GEMS REPEAT")
+    logger.debug("GEMS_SUNRISE REPEAT")
 
     out = _repeat_func(inp, sizes)
     return out

--- a/src/flag_gems/runtime/backend/_sunrise/ops/repeat_interleave.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/repeat_interleave.py
@@ -20,7 +20,7 @@ def copy_func(x):
 
 
 def repeat_interleave_self_int(inp, repeats, dim=None, *, output_size=None):
-    logger.debug("GEMS REPEAT_INTERLEAVE_SELF_INT")
+    logger.debug("GEMS_SUNRISE REPEAT_INTERLEAVE_SELF_INT")
     if dim is None:
         inp = inp.flatten()
         dim = 0
@@ -83,7 +83,7 @@ def repeat_interleave_tensor_kernel(
 
 
 def repeat_interleave_tensor(repeats, *, output_size=None):
-    logger.debug("GEMS REPEAT_INTERLEAVE_TENSOR")
+    logger.debug("GEMS_SUNRISE REPEAT_INTERLEAVE_TENSOR")
 
     assert repeats.ndim == 1, "repeat_interleave only accept 1D vector as repeat"
 
@@ -109,7 +109,7 @@ def repeat_interleave_tensor(repeats, *, output_size=None):
 
 
 def repeat_interleave_self_tensor(inp, repeats, dim=None, *, output_size=None):
-    logger.debug("GEMS REPEAT_INTERLEAVE_SELF_TENSOR")
+    logger.debug("GEMS_SUNRISE REPEAT_INTERLEAVE_SELF_TENSOR")
 
     if dim is None:
         inp = inp.flatten()

--- a/src/flag_gems/runtime/backend/_sunrise/ops/rms_norm.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/rms_norm.py
@@ -241,7 +241,7 @@ def rms_norm_grad_dw_kernel(
 
 
 def rms_norm_forward(x, normalized_shape, weight, eps=1e-5):
-    logger.debug("GEMS RMS_NORM FORWARD")
+    logger.debug("GEMS_SUNRISE RMS_NORM FORWARD")
     dim = x.ndim - len(normalized_shape)
     M = math.prod(x.shape[:dim])
     N = math.prod(normalized_shape)
@@ -270,7 +270,7 @@ def rms_norm_forward(x, normalized_shape, weight, eps=1e-5):
 
 
 def rms_norm_backward(dy, x, inv_rms, normalized_shape, weight, eps=1e-5):
-    logger.debug("GEMS RMS_NORM BACKWARD")
+    logger.debug("GEMS_SUNRISE RMS_NORM BACKWARD")
     dim = x.ndim - len(normalized_shape)
     M = math.prod(x.shape[:dim])
     N = math.prod(normalized_shape)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/scatter.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/scatter.py
@@ -333,7 +333,7 @@ _scatter_func = ScatterFunction()
 
 # 由于atomic不支持fp16相关操作，所以需要进行转换之后再运算，恢复成fp16;
 def scatter(inp, dim, index, src, reduce=None):
-    logger.debug("GEMS SCATTER")
+    logger.debug("GEMS_SUNRISE SCATTER")
     is_fp16 = inp.dtype == torch.float16 and (reduce is not None)
     if is_fp16:
         inp = inp.float()
@@ -373,7 +373,7 @@ def scatter(inp, dim, index, src, reduce=None):
 
 
 def scatter_(inp, dim, index, src, reduce=None):
-    logger.debug("GEMS SCATTER_")
+    logger.debug("GEMS_SUNRISE SCATTER_")
     base_inp = inp
     is_fp16 = inp.dtype == torch.float16 and (reduce is not None)
     if is_fp16:

--- a/src/flag_gems/runtime/backend/_sunrise/ops/sigmoid.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/sigmoid.py
@@ -39,18 +39,18 @@ def sigmoid_backward_kernel(dy, y):
 
 
 def sigmoid(self):
-    logger.debug("GEMS SIGMOID FORWARD")
+    logger.debug("GEMS_SUNRISE SIGMOID FORWARD")
     output = sigmoid_forward(self)
     return output
 
 
 def sigmoid_backward(grad_output, output):
-    logger.debug("GEMS SIGMOID BACKWARD")
+    logger.debug("GEMS_SUNRISE SIGMOID BACKWARD")
     grad_input = sigmoid_backward_kernel(grad_output, output)
     return grad_input
 
 
 def sigmoid_(A):
-    logger.debug("GEMS SIGMOID_ FORWARD")
+    logger.debug("GEMS_SUNRISE SIGMOID_ FORWARD")
     out = sigmoid_forward(A, out0=A)
     return out

--- a/src/flag_gems/runtime/backend/_sunrise/ops/soft_margin_loss.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/soft_margin_loss.py
@@ -91,7 +91,7 @@ def _check_tensors(input: torch.Tensor, target: torch.Tensor):
 
 
 def soft_margin_loss(input: torch.Tensor, target: torch.Tensor, reduction="mean"):
-    logger.debug("GEMS SOFT_MARGIN_LOSS")
+    logger.debug("GEMS_SUNRISE SOFT_MARGIN_LOSS")
     input, target = _check_tensors(input, target)
     red = _normalize_reduction(reduction)
     n_elements = input.numel()
@@ -138,7 +138,7 @@ def soft_margin_loss_out(
     reduction="mean",
     out: torch.Tensor = None,
 ):
-    logger.debug("GEMS SOFT_MARGIN_LOSS_OUT")
+    logger.debug("GEMS_SUNRISE SOFT_MARGIN_LOSS_OUT")
     input, target = _check_tensors(input, target)
     red = _normalize_reduction(reduction)
     n_elements = input.numel()

--- a/src/flag_gems/runtime/backend/_sunrise/ops/softmax.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/softmax.py
@@ -282,7 +282,7 @@ def softmax_backward_kernel_inner(
 
 
 def softmax(self, dim, half_to_float=False):
-    logger.debug("GEMS SOFTMAX")
+    logger.debug("GEMS_SUNRISE SOFTMAX")
 
     assert dim >= -self.ndim and dim < self.ndim, "Invalid dim"
 
@@ -329,7 +329,7 @@ def softmax(self, dim, half_to_float=False):
 
 
 def softmax_backward(grad_output, output, dim, input_dtype):
-    logger.debug("GEMS SOFTMAX VJP")
+    logger.debug("GEMS_SUNRISE SOFTMAX VJP")
 
     assert dim >= -output.ndim and dim < output.ndim, "Invalid dim"
     dim = dim % output.ndim

--- a/src/flag_gems/runtime/backend/_sunrise/ops/softmax.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/softmax.py
@@ -329,7 +329,7 @@ def softmax(self, dim, half_to_float=False):
 
 
 def softmax_backward(grad_output, output, dim, input_dtype):
-    logger.debug("GEMS_SUNRISE SOFTMAX VJP")
+    logger.debug("GEMS_SUNRISE SOFTMAX_BACKWARD")
 
     assert dim >= -output.ndim and dim < output.ndim, "Invalid dim"
     dim = dim % output.ndim

--- a/src/flag_gems/runtime/backend/_sunrise/ops/sort.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/sort.py
@@ -410,13 +410,13 @@ def sort_kernel(
 
 def sort(inp, dim=-1, descending=False):
     # We only implement stable radix sort here
-    logger.debug("GEMS SORT")
+    logger.debug("GEMS_SUNRISE SORT")
     return sort_stable(inp, stable=False, dim=dim, descending=descending)
 
 
 def sort_stable(inp, *, stable, dim=-1, descending=False):
     device = inp.device
-    logger.debug("GEMS SORT.STABLE")
+    logger.debug("GEMS_SUNRISE SORT.STABLE")
     # We only implement stable radix sort here
     _ = stable
     sort_elem_cnt = inp.shape[dim]

--- a/src/flag_gems/runtime/backend/_sunrise/ops/special_i1.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/special_i1.py
@@ -77,7 +77,7 @@ def _launch_special_i1(x: torch.Tensor, out: torch.Tensor):
 
 
 def special_i1(self: torch.Tensor):
-    logger.debug("GEMS SPECIAL_I1")
+    logger.debug("GEMS_SUNRISE SPECIAL_I1")
     x = self
     x_c = x.contiguous()
     out = torch.empty_like(x_c)
@@ -89,7 +89,7 @@ def special_i1(self: torch.Tensor):
 
 
 def special_i1_out(self: torch.Tensor, out: torch.Tensor):
-    logger.debug("GEMS SPECIAL_I1_OUT")
+    logger.debug("GEMS_SUNRISE SPECIAL_I1_OUT")
     x = self
     if out.dtype != x.dtype:
         raise TypeError("out dtype must match input dtype")

--- a/src/flag_gems/runtime/backend/_sunrise/ops/sum.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/sum.py
@@ -96,7 +96,7 @@ def sum_kernel_dim0(
 
 
 def sum(inp, *, dtype=None):
-    logger.debug("GEMS SUM")
+    logger.debug("GEMS_SUNRISE SUM")
     inp = inp.contiguous()
     M = inp.numel()
     if dtype is None:
@@ -118,7 +118,7 @@ def sum(inp, *, dtype=None):
 
 
 def sum_out(inp, *, dtype=None, out):
-    logger.debug("GEMS SUM_OUT")
+    logger.debug("GEMS_SUNRISE SUM_OUT")
     M = inp.numel()
     if dtype is None:
         dtype = inp.dtype
@@ -380,7 +380,7 @@ def sum_dim0(inp, dim, keepdim, dtype):
 
 
 def sum_dim(inp, dim=None, keepdim=False, *, dtype=None):
-    logger.debug("GEMS SUM_DIM")
+    logger.debug("GEMS_SUNRISE SUM_DIM")
     # support dim = 0, which are consistent with PyTorch
     if inp.numel() == 0:
         if dtype is None:
@@ -418,5 +418,5 @@ def sum_dim(inp, dim=None, keepdim=False, *, dtype=None):
 
 
 def sum_dim_out(inp, dim=None, keepdim=False, *, dtype=None, out):
-    logger.debug("GEMS SUM_DIM_OUT")
+    logger.debug("GEMS_SUNRISE SUM_DIM_OUT")
     return sum_dim_comm(inp, dim, keepdim, dtype=dtype, out=out)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/t_copy.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/t_copy.py
@@ -125,13 +125,13 @@ def t_copy_out(
     out: torch.Tensor,
     memory_format: torch.memory_format | None = None,
 ):
-    logger.debug("GEMS T_COPY_OUT")
+    logger.debug("GEMS_SUNRISE T_COPY_OUT")
     _launch_t_copy_kernel(input, out)
     return out
 
 
 def t_copy(input: torch.Tensor, memory_format: torch.memory_format | None = None):
-    logger.debug("GEMS T_COPY")
+    logger.debug("GEMS_SUNRISE T_COPY")
     dim = input.dim()
     if dim == 0:
         out = torch.empty((), dtype=input.dtype, device=input.device)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/tile.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/tile.py
@@ -441,7 +441,7 @@ _tile_func = TileFunction()
 
 
 def tile(inp: torch.Tensor, dims) -> torch.Tensor:
-    logger.debug("GEMS TILE")
+    logger.debug("GEMS_SUNRISE TILE")
 
     out = _tile_func(inp, dims)
     return out

--- a/src/flag_gems/runtime/backend/_sunrise/ops/topk.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/topk.py
@@ -250,7 +250,7 @@ def topk_stage2_kernel(
 
 
 def topk(x, k, dim=-1, largest=True, sorted=True):
-    logger.debug("GEMS TOPK")
+    logger.debug("GEMS_SUNRISE TOPK")
     # If dim equals to last dim, we set it to -1.
     if dim < 0:
         dim = dim + x.ndim

--- a/src/flag_gems/runtime/backend/_sunrise/ops/triu.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/triu.py
@@ -77,7 +77,7 @@ INT32_MAX = torch.iinfo(torch.int32).max
 
 
 def triu(A, diagonal=0):
-    logger.debug("GEMS TRIU")
+    logger.debug("GEMS_SUNRISE TRIU")
     A = A.contiguous()
     ori_type = A.dtype
     out = torch.empty(A.shape, device="ptpu").as_strided(A.shape, A.stride())

--- a/src/flag_gems/runtime/backend/_sunrise/ops/upsample_bicubic2d.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/upsample_bicubic2d.py
@@ -161,7 +161,7 @@ def upsample_bicubic2d(
     scales_h: float | None = None,
     scales_w: float | None = None,
 ) -> torch.Tensor:
-    logger.debug("GEMS_SUNRISE UPSAMPLE BICUBIC2D")
+    logger.debug("GEMS_SUNRISE UPSAMPLE_BICUBIC2D")
     scale_factors = (scales_h, scales_w)
 
     if input.dim() != 4:

--- a/src/flag_gems/runtime/backend/_sunrise/ops/upsample_bicubic2d.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/upsample_bicubic2d.py
@@ -161,7 +161,7 @@ def upsample_bicubic2d(
     scales_h: float | None = None,
     scales_w: float | None = None,
 ) -> torch.Tensor:
-    logger.debug("GEMS UPSAMPLE BICUBIC2D")
+    logger.debug("GEMS_SUNRISE UPSAMPLE BICUBIC2D")
     scale_factors = (scales_h, scales_w)
 
     if input.dim() != 4:

--- a/src/flag_gems/runtime/backend/_sunrise/ops/upsample_linear1d.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/upsample_linear1d.py
@@ -59,7 +59,7 @@ def upsample_linear1d(
     align_corners: bool,
     scales: float = None,
 ):
-    logger.debug("GEMS_SUNRISE UPSAMPLE LINEAR1D OPTIMIZED")
+    logger.debug("GEMS_SUNRISE UPSAMPLE_LINEAR1D")
     assert self.ndim == 3, "Input must be [N, C, W]"
     assert self.is_ptpu
 

--- a/src/flag_gems/runtime/backend/_sunrise/ops/upsample_linear1d.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/upsample_linear1d.py
@@ -59,7 +59,7 @@ def upsample_linear1d(
     align_corners: bool,
     scales: float = None,
 ):
-    logger.debug("GEMS UPSAMPLE LINEAR1D OPTIMIZED")
+    logger.debug("GEMS_SUNRISE UPSAMPLE LINEAR1D OPTIMIZED")
     assert self.ndim == 3, "Input must be [N, C, W]"
     assert self.is_ptpu
 

--- a/src/flag_gems/runtime/backend/_sunrise/ops/where.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/where.py
@@ -28,7 +28,7 @@ def where_inner(condition, self, other):
 
 
 def where_self_out(condition, self, other, out=None):
-    logger.debug("GEMS WHERE_SELF_OUT")
+    logger.debug("GEMS_SUNRISE WHERE_SELF_OUT")
     result_type = torch.result_type(self, other)
     if out is not None:
         assert (
@@ -78,15 +78,15 @@ def where_self_out(condition, self, other, out=None):
 
 
 def where_self(condition, self, other):
-    logger.debug("GEMS WHERE_SELF")
+    logger.debug("GEMS_SUNRISE WHERE_SELF")
     return where_self_out(condition, self, other)
 
 
 def where_scalar_self(condition, self, other):
-    logger.debug("GEMS WHERE_SCALAR_SELF")
+    logger.debug("GEMS_SUNRISE WHERE_SCALAR_SELF")
     return where_self_out(condition, self, other)
 
 
 def where_scalar_other(condition, self, other):
-    logger.debug("GEMS WHERE_SCALAR_OTHER")
+    logger.debug("GEMS_SUNRISE WHERE_SCALAR_OTHER")
     return where_self_out(condition, self, other)

--- a/src/flag_gems/runtime/backend/_sunrise/ops/zero.py
+++ b/src/flag_gems/runtime/backend/_sunrise/ops/zero.py
@@ -38,7 +38,7 @@ def _launch_zero_kernel(tensor: torch.Tensor):
 
 
 def zero(*args, **kwargs):
-    logger.debug("GEMS ZERO")
+    logger.debug("GEMS_SUNRISE ZERO")
     # Accept common conventions: first positional as target, or 'self'/'input'/'out' in kwargs
     target = None
     if len(args) >= 1 and isinstance(args[0], torch.Tensor):
@@ -57,7 +57,7 @@ def zero(*args, **kwargs):
 
 
 def zero_out(*args, **kwargs):
-    logger.debug("GEMS ZERO_OUT")
+    logger.debug("GEMS_SUNRISE ZERO_OUT")
     # Out variant: prefer 'out' kwarg; else first positional
     out = None
     if "out" in kwargs and isinstance(kwargs["out"], torch.Tensor):


### PR DESCRIPTION
## Summary
Unify Sunrise backend debug log format to match the standard pattern GEMS_VENDOR OP_NAME.

## Changes
- GEMS {OP_NAME} -> GEMS_SUNRISE {OP_NAME} (70 files, 151 occurrences)

Note: Runtime debug messages in flash_api.py are left unchanged.

## Motivation
Standardize debug log format for consistency across all backends.