### PR TITLE
Fix cpp test

### DIFF
--- a/.github/workflows/cpp-op-test.yaml
+++ b/.github/workflows/cpp-op-test.yaml
@@ -32,13 +32,13 @@ jobs:
         uses: actions/checkout@v6
       - shell: bash
         run: |
-          export PATH="/home/secure/.pyenv/bin:/usr/local/cuda-12.8/bin:$PATH"
+          export PATH="/home/secure/.pyenv/bin:/usr/local/cuda/bin:$PATH"
           eval "$(pyenv init -)"
           export CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DCMAKE_BUILD_TYPE=Release"
           pip install -v -e . --no-build-isolation
       - shell: bash
         run: |
-          export PATH="/home/secure/.pyenv/bin:/usr/local/cuda-12.8/bin:$PATH"
+          export PATH="/home/secure/.pyenv/bin:/usr/local/cuda/bin:$PATH"
           eval "$(pyenv init -)"
           cd build/cpython-*/ctests
           export FLAGGEMS_SOURCE_DIR=$(python -c "import os;import flag_gems;print(os.path.dirname(flag_gems.__file__))")


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The current workflow pins the CPP tests to a specific CUDA version. This is not good. By convention, when CUDA toolkit is installed/updated, there will be a symbol link `/usr/local/cuda` pointing to the currently active CUDA distribution.

This PR fixes the hardcoded CUDA version string.