### PR TITLE
[KernelGen] Fix addmm_dtype and addmm_dtype_out accuracy tests for --ref cpu mode

### DIFF
--- a/tests/test_addmm.py
+++ b/tests/test_addmm.py
@@ -113,8 +113,12 @@ def test_addmm_dtype_fp32_accum(M, N, K):
             bias, mat1, mat2, torch.float32, beta=1.0, alpha=1.0
         )
 
+    if utils.TO_CPU:
+        res_out = res_out.to("cpu")
+    else:
+        ref_out = ref_out.to(flag_gems.device)
     utils.gems_assert_close(
-        res_out, ref_out.to(flag_gems.device), torch.float32, reduce_dim=K
+        res_out, ref_out, torch.float32, reduce_dim=K
     )
 
 
@@ -144,6 +148,10 @@ def test_addmm_dtype_out_fp32_accum(M, N, K):
             bias, mat1, mat2, torch.float32, beta=1.0, alpha=1.0, out=out
         )
 
+    if utils.TO_CPU:
+        out = out.to("cpu")
+    else:
+        ref_out = ref_out.to(flag_gems.device)
     utils.gems_assert_close(
-        out, ref_out.to(flag_gems.device), torch.float32, reduce_dim=K
+        out, ref_out, torch.float32, reduce_dim=K
     )

--- a/tests/test_addmm.py
+++ b/tests/test_addmm.py
@@ -117,9 +117,7 @@ def test_addmm_dtype_fp32_accum(M, N, K):
         res_out = res_out.to("cpu")
     else:
         ref_out = ref_out.to(flag_gems.device)
-    utils.gems_assert_close(
-        res_out, ref_out, torch.float32, reduce_dim=K
-    )
+    utils.gems_assert_close(res_out, ref_out, torch.float32, reduce_dim=K)
 
 
 @pytest.mark.addmm_dtype_out
@@ -152,6 +150,4 @@ def test_addmm_dtype_out_fp32_accum(M, N, K):
         out = out.to("cpu")
     else:
         ref_out = ref_out.to(flag_gems.device)
-    utils.gems_assert_close(
-        out, ref_out, torch.float32, reduce_dim=K
-    )
+    utils.gems_assert_close(out, ref_out, torch.float32, reduce_dim=K)


### PR DESCRIPTION
## Summary
- Fix `test_addmm_dtype_fp32_accum` and `test_addmm_dtype_out_fp32_accum` to handle `--ref cpu` mode correctly
- These tests compute reference on CPU then move it to device with `.to(flag_gems.device)`, which breaks the `to_cpu()` assertion. Now conditionally keep ref on CPU and move res to CPU instead.

Fixes internal issues #412 (`addmm_dtype`) and #413 (`addmm_dtype_out`) accuracy test failures under `--ref cpu` mode.

## Test plan
- [x] `pytest -m "addmm_dtype or addmm_dtype_out" tests/ --ref cpu` — 6 passed
- [x] `pytest -m "addmm_dtype or addmm_dtype_out" tests/` — 6 passed (no regression)

## Issue
- WEEKTEST-412
- WEEKTEST-413