### PR TITLE
Fix github CI for script rename

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -73,13 +73,13 @@ jobs:
         env:
           RUNNER_LABEL: ${{ inputs.runner_label }}
         run: |
-          source tools/set-env.sh ${{ inputs.vendor }}
+          source tools/env.sh ${{ inputs.vendor }}
           ./setup.sh ${{ inputs.vendor }}
       - id: check-gpu
         if: ${{ inputs.gpu_check_script != '' }}
         shell: bash
         run: |
-          source tools/set-env.sh ${{ inputs.vendor }}
+          source tools/env.sh ${{ inputs.vendor }}
           bash ${{ inputs.gpu_check_script }}
       - name: Test alpha ops
         if: ${{ inputs.test_script != '' }}
@@ -95,5 +95,5 @@ jobs:
           CHANGED_FILES: ${{ inputs.changed_files }}
         run: |
           source .venv/bin/activate
-          source tools/set-env.sh ${{ inputs.vendor }}
+          source tools/env.sh ${{ inputs.vendor }}
           tools/test-op.sh ${{ inputs.pr_id }}

--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -114,7 +114,7 @@ jobs:
           EXISTING_OP: ${{ needs.preprocess.outputs.existing }}
         run: |
           source .venv/bin/activate
-          source tools/set-env.sh ${VENDOR}
+          source tools/env.sh ${VENDOR}
           tools/run_tests.py --ops ${{ needs.preprocess.outputs.op }} \
             --dump-output \
             --output-dir results_new

--- a/.github/workflows/random-test.yaml
+++ b/.github/workflows/random-test.yaml
@@ -98,7 +98,7 @@ jobs:
         shell: bash
         run: |
           source .venv/bin/activate
-          source tools/set-env.sh ${VENDOR}
+          source tools/env.sh ${VENDOR}
           tools/run_tests.py --ops ${{ inputs.operators }} --gpus ${{ inputs.gpus }}
 
       - name: Upload results


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The renaming of 'set-env.sh` broke some github workflows. This PR fixes them.