### PR TITLE
Downgrade torch from 2.12 to 2.11 for Nvidia

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,8 +116,8 @@ mthreads = [
 ]
 
 nvidia = [
-    "torch==2.12.0+cu132",
-    "torchvision==0.27.0+cu132",
+    "torch==2.11.0+cu130",
+    "torchvision==0.26.0+cu130",
     "triton==3.6.0",
     # "flagtree==0.5.1+3.6",
 ]

--- a/tools/vendor.sh
+++ b/tools/vendor.sh
@@ -149,8 +149,8 @@ case $VENDOR in
   nvidia)
     # We need pytorch first for building C++ wrapped operators
     uv pip install --index ${FLAGOS_PYPI} \
-        "torch==2.12.0+cu132" \
-        "torchvision==0.27.0+cu132" \
+        "torch==2.11.0+cu130" \
+        "torchvision==0.26.0+cu130" \
         "triton==3.6.0"
 
     # The follow environments are for C++ wrapped operators


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The previous version bump for torch on Nvidia was proved to be too aggressive. Torch 2.12 requires triton 3.7.0 which is not yet supported by FlagGems. There are some issues to be fixed. After downgrading Triton to 3.6.0, we have to downgrade Torch to at most 2.11.