### PR TITLE
Unskip conv_depthwise2d accuracy test

### DIFF
--- a/tests/test_conv_depthwise2d.py
+++ b/tests/test_conv_depthwise2d.py
@@ -21,7 +21,6 @@ SHAPE_DEPTHWISE = [
 ]
 
 
-@pytest.mark.skip(reason="Issue #3021: This operator currently fails the test.")
 @pytest.mark.conv_depthwise2d
 @pytest.mark.parametrize("shape_input, shape_weight, kernel", SHAPE_DEPTHWISE)
 @pytest.mark.parametrize("stride", [[1, 1], [2, 2]])


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Other

### Description

The `conv_depthwise2d` operator is passing the accuracy test. Unskip it now.
The issue #3021 can be reopened if the operator fails again.

### Issue

Closes: #3021