### PR TITLE
[SPACEMIT] Update Triton to 3.6.0+spacemit.a5 and fix mm, argmax, gel…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,7 +119,7 @@ nvidia = [
 
 spacemit = [
     "torch==2.8.0+spacemit.0",
-    "triton==3.6.0+spacemit.a4",
+    "triton==3.6.0+spacemit.a5",
 ]
 
 sunrise = [

--- a/src/flag_gems/runtime/backend/_spacemit/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_spacemit/ops/__init__.py
@@ -1,17 +1,17 @@
 # from .addmm import addmm
 from .argmax import argmax
 from .argmin import argmin
-from .bmm import bmm
+from .bmm import bmm, bmm_out
 
 # from .conv1d import conv1d
 # from .conv2d import conv2d
 # from .thnn_conv2d import thnn_conv2d
 # from .conv_depthwise2d import _conv_depthwise2d
 # from .flash_attention import flash_attention, scaled_dot_product_attention
-from .gelu import gelu
+from .gelu import gelu, gelu_, gelu_backward
 from .layernorm import layer_norm
 from .mean import global_avg_pool, mean_dim
-from .mm import mm
+from .mm import mm, mm_out
 from .mv import mv
 from .pow import (
     pow_scalar,
@@ -31,15 +31,19 @@ __all__ = [
     "argmax",
     "argmin",
     "bmm",
+    "bmm_out",
     # "conv1d",
     # "conv2d",
     # "_conv_depthwise2d",
     # "flash_attention",
     "gelu",
+    "gelu_",
+    "gelu_backward",
     "global_avg_pool",
     "layer_norm",
     "mean_dim",
     "mm",
+    "mm_out",
     "mv",
     "pow_scalar",
     "pow_tensor_scalar",

--- a/src/flag_gems/runtime/backend/_spacemit/ops/argmax.py
+++ b/src/flag_gems/runtime/backend/_spacemit/ops/argmax.py
@@ -136,6 +136,14 @@ def argmax(inp, dim=None, keepdim=False, *, dtype=None):
             )
         shape = inp.shape
         dim = dim % inp.ndim
+        if inp.numel() == 0:
+            out_shape = list(shape)
+            if keepdim:
+                out_shape[dim] = 1
+            else:
+                del out_shape[dim]
+            return torch.empty(out_shape, dtype=torch.int64, device=inp.device)
+
         N = shape[dim]
         M = math.prod(shape[:dim])
         K = inp.numel() // M // N

--- a/src/flag_gems/runtime/backend/_spacemit/ops/bmm.py
+++ b/src/flag_gems/runtime/backend/_spacemit/ops/bmm.py
@@ -167,3 +167,55 @@ def bmm(A, B):
         SUB_BLK_K=SUB_BLK_K,
     )
     return out
+
+
+def bmm_out(A, B, out):
+    logger.debug("GEMS_SPACEMIT BMM_OUT")
+    batch, M, K = A.shape
+    _, _, N = B.shape
+    if A.stride(0) > 1 and A.stride(1) > 1:
+        A = A.contiguous()
+    if B.stride(0) > 1 and B.stride(1) > 1:
+        B = B.contiguous()
+
+    if K == 1 and batch == 1:
+        vec_a = A[0, :, 0]
+        vec_b = B[0, 0, :]
+        result = outer(vec_a, vec_b)
+        out.copy_(result.unsqueeze(0))
+        return out
+
+    if K == 1:
+        out.copy_(mul(A, B))
+        return out
+
+    def grid_fn(meta):
+        return (
+            triton.cdiv(meta["M"], meta["TILE_M"]),
+            triton.cdiv(meta["N"], meta["TILE_N"]),
+            batch,
+        )
+
+    TILE_K = triton.next_power_of_2(K)
+    SUB_BLK_K = min(1024, TILE_K)
+
+    bmm_kernel[grid_fn](
+        A,
+        B,
+        out,
+        M,
+        N,
+        K,
+        A.stride(0),
+        A.stride(1),
+        A.stride(2),
+        B.stride(0),
+        B.stride(1),
+        B.stride(2),
+        out.stride(0),
+        out.stride(1),
+        out.stride(2),
+        TILE_K=TILE_K,
+        SUB_BLK_K=SUB_BLK_K,
+    )
+    return out

--- a/src/flag_gems/runtime/backend/_spacemit/ops/gelu.py
+++ b/src/flag_gems/runtime/backend/_spacemit/ops/gelu.py
@@ -1,6 +1,5 @@
 import logging
 
-import torch
 import triton
 import triton.language as tl
 
@@ -54,38 +53,36 @@ def gelu_backward_none(x, dy):
 def gelu_backward_tanh(x, dy):
     x_fp32 = x.to(tl.float32)
     # 0.79788456 = math.sqrt(2 / math.pi)
-    tanh_out = tanh(0.79788456 * x * (1 + 0.044715 * pow(x_fp32, 2)))
-    dydx = 0.5 * x * (
+    tanh_out = tanh(0.79788456 * x_fp32 * (1 + 0.044715 * pow(x_fp32, 2)))
+    dydx = 0.5 * x_fp32 * (
         (1 - pow(tanh_out, 2)) * (0.79788456 + 0.1070322243 * pow(x_fp32, 2))
     ) + 0.5 * (1 + tanh_out)
     dx = dydx * dy
     return dx
 
 
-class Gelu(torch.autograd.Function):
-    @staticmethod
-    def forward(ctx, A, approximate):
-        logging.debug("GEMS_SPACEMIT GELU_FORWARD")
-        if approximate == "tanh":
-            out = gelu_tanh(A)
-        else:
-            out = gelu_none(A)
-        ctx.save_for_backward(A)
-        ctx.approximate = approximate
-        return out
-
-    @staticmethod
-    def backward(ctx, out_grad):
-        logging.debug("GEMS_SPACEMIT GELU_BACKWARD")
-        (inp,) = ctx.saved_tensors
-        approximate = ctx.approximate
-        if approximate == "tanh":
-            in_grad = gelu_backward_tanh(inp, out_grad)
-        else:
-            in_grad = gelu_backward_none(inp, out_grad)
-        return in_grad, None
-
-
 def gelu(A, *, approximate="none"):
-    # print("\n.......test for mutibackend specific gelu........\n")
-    return Gelu.apply(A, approximate)
+    logging.debug("GEMS_SPACEMIT GELU FORWARD")
+    if approximate == "tanh":
+        out = gelu_tanh(A)
+    else:
+        out = gelu_none(A)
+    return out
+
+
+def gelu_backward(grad_output, self, *, approximate="none"):
+    logging.debug("GEMS_SPACEMIT GELU_BACKWARD")
+    if approximate == "tanh":
+        in_grad = gelu_backward_tanh(self, grad_output)
+    else:
+        in_grad = gelu_backward_none(self, grad_output)
+    return in_grad
+
+
+def gelu_(A, *, approximate="none"):
+    logging.debug("GEMS_SPACEMIT GELU_ FORWARD")
+    if approximate == "tanh":
+        out = gelu_tanh(A, out0=A)
+    else:
+        out = gelu_none(A, out0=A)
+    return out

--- a/src/flag_gems/runtime/backend/_spacemit/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_spacemit/ops/mm.py
@@ -214,7 +214,7 @@ def mm_kernel(
 def mm(a, b):
     if not a.is_contiguous():
         a = a.contiguous()
-    if not b.is_contiguous():
+    if b.stride(0) > 1 and b.stride(1) > 1:
         b = b.contiguous()
     # checks constraints
     assert a.shape[1] == b.shape[0], "incompatible dimensions"
@@ -247,3 +247,41 @@ def mm(a, b):
         SUB_BLK_K=SUB_BLK_K,
     )
     return c
+
+
+def mm_out(a, b, *, out):
+    if not a.is_contiguous():
+        a = a.contiguous()
+    if b.stride(0) > 1 and b.stride(1) > 1:
+        b = b.contiguous()
+
+    # checks constraints
+    assert a.shape[1] == b.shape[0], "incompatible dimensions"
+    M, K = a.shape
+    _, N = b.shape
+
+    # launch kernel
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_SIZE_M"]),
+        triton.cdiv(N, META["BLOCK_SIZE_N"]),
+    )
+    BLOCK_SIZE_K = triton.next_power_of_2(K)
+    SUB_BLK_K = min(512, BLOCK_SIZE_K)
+
+    mm_kernel[grid](
+        a,
+        b,
+        out,
+        M,
+        N,
+        K,
+        a.stride(0),
+        a.stride(1),
+        b.stride(0),
+        b.stride(1),
+        out.stride(0),
+        out.stride(1),
+        BLOCK_SIZE_K=BLOCK_SIZE_K,
+        SUB_BLK_K=SUB_BLK_K,
+    )
+    return out

--- a/tools/setup_vendor.sh
+++ b/tools/setup_vendor.sh
@@ -184,7 +184,7 @@ case $VENDOR in
     uv pip install ".[spacemit]"
     uv pip install --index ${FLAGOS_PYPI} \
         "torch==2.8.0+spacemit.0" \
-        "triton==3.6.0+spacemit.a4"
+        "triton==3.6.0+spacemit.a5"
     uv pip install ".[test]"
     ;;
 


### PR DESCRIPTION
cherry pick from https://github.com/flagos-ai/FlagGems/pull/3793

* fix(spacemit): update triton version to 3.6.0+spacemit.a5, fixed mm、argmax、gelu、bmm

* fix(mm): remove debug print statement for tensor b

* refactor(setup_triton_config): format get_tuned_config assignment

* chore(gelu): remove unused import of torch



### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
