### PR TITLE
Enable backend tests for enflame, spacemit and sunrise

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -161,6 +161,19 @@ jobs:
     secrets:
       RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}
 
+  backend-enflame:
+    needs: preprocess
+    if: contains(needs.preprocess.outputs.labels, 'vendor/Enflame')
+    uses: ./.github/workflows/backend-test.yaml
+    with:
+      vendor: enflame
+      runner_label: enflame
+      # gpu_check_script: tools/gpu_check_hygon.sh
+      changed_files: ${{ join(needs.preprocess.outputs.changed_files, ' ') }}
+      pr_id: ${{ needs.preprocess.outputs.pr_id }}
+    secrets:
+      RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}
+
   backend-hygon:
     needs: preprocess
     if: contains(needs.preprocess.outputs.labels, 'vendor/Hygon')
@@ -241,14 +254,27 @@ jobs:
     secrets:
       RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}
 
-  backend-tsingmicro:
+  backend-spacemit:
     needs: preprocess
-    if: contains(needs.preprocess.outputs.labels, 'vendor/TsingMicro')
+    if: contains(needs.preprocess.outputs.labels, 'vendor/SpaceMit')
     uses: ./.github/workflows/backend-test.yaml
     with:
-      vendor: tsingmicro
-      runner_label: tsingmicro
-      gpu_check_script: tools/gpu_check_tsingmicro.sh
+      vendor: spacemit
+      runner_label: spacemit
+      # gpu_check_script: tools/gpu_check_thead.sh
+      changed_files: ${{ join(needs.preprocess.outputs.changed_files, ' ') }}
+      pr_id: ${{ needs.preprocess.outputs.pr_id }}
+    secrets:
+      RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}
+
+  backend-sunrise:
+    needs: preprocess
+    if: contains(needs.preprocess.outputs.labels, 'vendor/Sunrise')
+    uses: ./.github/workflows/backend-test.yaml
+    with:
+      vendor: sunrise
+      runner_label: sunrise
+      # gpu_check_script: tools/gpu_check_thead.sh
       changed_files: ${{ join(needs.preprocess.outputs.changed_files, ' ') }}
       pr_id: ${{ needs.preprocess.outputs.pr_id }}
     secrets:
@@ -262,6 +288,20 @@ jobs:
       vendor: thead
       runner_label: thead
       gpu_check_script: tools/gpu_check_thead.sh
+      changed_files: ${{ join(needs.preprocess.outputs.changed_files, ' ') }}
+      pr_id: ${{ needs.preprocess.outputs.pr_id }}
+    secrets:
+      RUNNER_SSH_KEY: ${{ secrets.RUNNER_SSH_KEY }}
+
+
+  backend-tsingmicro:
+    needs: preprocess
+    if: contains(needs.preprocess.outputs.labels, 'vendor/TsingMicro')
+    uses: ./.github/workflows/backend-test.yaml
+    with:
+      vendor: tsingmicro
+      runner_label: tsingmicro
+      gpu_check_script: tools/gpu_check_tsingmicro.sh
       changed_files: ${{ join(needs.preprocess.outputs.changed_files, ' ') }}
       pr_id: ${{ needs.preprocess.outputs.pr_id }}
     secrets:


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

We previously added some runners for spacemit, enflame, sunrise but haven't hook them into the CI pipeline. This PR fixes this issue.