### PR TITLE
Bump metax versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,11 +99,12 @@ kunlunxin = [
 ]
 
 metax = [
-    "torch==2.8.0+metax3.5.3.9",
-    "torchaudio==2.4.1+metax3.5.3.9",
-    "torchvision==0.15.1+metax3.5.3.9",
-    "flagtree==3.1.0+metax3.5.3.9",
-    # "triton==3.0.0+metax3.5.3.9",
+    "torch==2.8.0+metax3.7.2.0",
+    "torchaudio==2.4.1+metax3.7.2.0",
+    "torchvision==0.15.1+metax3.7.2.0",
+    "flagtree==3.1.0+metax3.7.2.0",
+    "flash_attn==2.6.3+metax3.7.2.0torch2.8",
+    # "triton==3.0.0+metax3.7.2.0",
 ]
 
 mthreads = [

--- a/tools/vendor.sh
+++ b/tools/vendor.sh
@@ -107,16 +107,17 @@ case $VENDOR in
 
   metax)
     uv pip install --index ${FLAGOS_PYPI} \
-        "torch==2.8.0+metax3.5.3.9" \
-        "torchaudio==2.4.1+metax3.5.3.9" \
-        "torchvision==0.15.1+metax3.5.3.9" \
-        "flagtree==3.1.0+metax3.5.3.9"
+        "torch==2.8.0+metax3.7.2.0" \
+        "torchaudio==2.4.1+metax3.7.2.0" \
+        "torchvision==0.15.1+metax3.7.2.0" \
+        "flagtree==3.1.0+metax3.7.2.0" \
+        "flash_attn==2.6.3+metax3.7.2.0torch2.8"
 
-    if [ -n "${USE_TRITON}" ]; then
-      uv pip uninstall flagtree
-      uv pip install --index ${FLAGOS_PYPI} \
-        "triton==3.0.0+metax3.5.3.9"
-    fi
+    # if [ -n "${USE_TRITON}" ]; then
+    #   uv pip uninstall flagtree
+    #   uv pip install --index ${FLAGOS_PYPI} \
+    #     "triton==3.0.0+metax3.7.2.0"
+    # fi
 
     uv pip install -e  .
     uv pip install ".[test]"


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

Bump MetaX package versions for the newer 3.7.2.0 runtime. The new runtime has been deployed on the CI runner. The new runtime version is to be used as the basis for container building.