### PR TITLE
Allowing for specifying all GPUs when testing

### DIFF
--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -941,12 +941,18 @@ def main():
     ensure_dir(output_dir)
     CFG.output_dir = output_dir
 
-    gpu_list = OPTS.gpus.strip().split(",")
-    if len(gpu_list) == 0:
-        pwarn("Empty GPU list specified.")
-        sys.exit(1)
-
-    gpu_ids = [int(x) for x in gpu_list if x.strip()]
+    if OPTS.gpus.strip().lower() == "all":
+        dev_count = ENV_INFO.get("torch", {}).get("device_count", 0)
+        if dev_count == 0:
+            perror("--gpus all specified but no devices detected.")
+            sys.exit(1)
+        gpu_ids = list(range(dev_count))
+    else:
+        gpu_list = OPTS.gpus.strip().split(",")
+        if len(gpu_list) == 0:
+            pwarn("Empty GPU list specified.")
+            sys.exit(1)
+        gpu_ids = [int(x) for x in gpu_list if x.strip()]
     gpu_count = len(gpu_ids)
 
     op_width = min(max(len(op) for op in ops), 40) if ops else 20


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

New Feature

### Description

Adding a `--gpus all` option for specifying all GPUs for testing. This is a convenience if we have, say, 32 GPUs to use.