### PR TITLE
Update pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -143,8 +143,8 @@ tsingmicro = [
     "torchaudio==2.7.0+cpu",
     "torch_txda==0.1.0+20260416.b8f53e8a",
     "txops==0.1.0+20260508.60287151",
-    "flagtree==0.5.0+tsingmicro3.3",
-    # "triton==3.3.0+git2e9c1195",
+    # "flagtree==0.5.0+tsingmicro3.3",
+    "triton==3.3.0+git2e9c1195",
 ]
 
 # Test packages


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

Looks like FlagTree has more environment variable setting requirements than Triton.
Let's try Triton again.