### PR TITLE
Fix per-channel INT8 W8A16 fused_moe: in-kernel dequant instead of ho…

### DIFF
--- a/src/flag_gems/fused/fused_moe.py
+++ b/src/flag_gems/fused/fused_moe.py
@@ -1184,6 +1184,16 @@ def fused_moe_kernel(
             offs_k[:, None] * stride_bk + offs_bn_up[None, :] * stride_bn
         )
 
+        if use_int8_w8a16:
+            # Per-channel weight scales for the gate and up halves; applied once
+            # on the fp32 accumulators after each K-loop.
+            b_scale_gate = tl.load(
+                b_scale_ptr + off_experts * stride_bse + offs_bn_gate[None, :] * stride_bsn
+            )
+            b_scale_up = tl.load(
+                b_scale_ptr + off_experts * stride_bse + offs_bn_up[None, :] * stride_bsn
+            )
+
         if use_fp8_w8a8 or use_int8_w8a8:
             if group_k > 0 and group_n > 0:  # block-wise
                 a_scale_ptrs = a_scale_ptr + (offs_token // top_k) * stride_asm
@@ -1266,13 +1276,17 @@ def fused_moe_kernel(
                         acc_gate = tl.dot(a, b_gate, acc=acc_gate)
                     else:
                         acc_gate += tl.dot(a, b_gate)
+            elif use_int8_w8a16:
+                acc_gate = tl.dot(a, b_gate.to(compute_type), acc=acc_gate)
             else:
                 acc_gate += tl.dot(a, b_gate)
 
             a_ptrs += BLOCK_SIZE_K * stride_ak
             b_ptrs_gate += BLOCK_SIZE_K * stride_bk
 
-        if use_fp8_w8a8 or use_int8_w8a8:
+        if use_int8_w8a16:
+            acc_gate = acc_gate * b_scale_gate
+        elif use_fp8_w8a8 or use_int8_w8a8:
             if group_k > 0 and group_n > 0:
                 pass
             elif per_channel_quant:
@@ -1318,13 +1332,17 @@ def fused_moe_kernel(
                         acc_up = tl.dot(a, b_up, acc=acc_up)
                     else:
                         acc_up += tl.dot(a, b_up)
+            elif use_int8_w8a16:
+                acc_up = tl.dot(a, b_up.to(compute_type), acc=acc_up)
             else:
                 acc_up += tl.dot(a, b_up)
 
             a_ptrs += BLOCK_SIZE_K * stride_ak
             b_ptrs_up += BLOCK_SIZE_K * stride_bk
 
-        if use_fp8_w8a8 or use_int8_w8a8:
+        if use_int8_w8a16:
+            acc_up = acc_up * b_scale_up
+        elif use_fp8_w8a8 or use_int8_w8a8:
             if group_k > 0 and group_n > 0:
                 pass
             elif per_channel_quant:
@@ -1663,6 +1681,10 @@ def invoke_fused_moe_triton_kernel(
     # Force disable SWAP_AB in fusion mode
     if FUSE_SILU:
         swap_AB = False
+    # The paired gate/up dot has no int8 conversion or scale handling; use the
+    # two-pass fused path for W8A16.
+    if use_int8_w8a16:
+        pair_gate_up_dot = False
 
     fused_moe_kernel[grid](
         A,
@@ -1962,8 +1984,19 @@ def fused_experts_impl(
         else:
             raise NotImplementedError(f"Unsupported ocp_mx_scheme={ocp_mx_scheme}")
 
-    # Dequant INT8/INT4 weights (Triton can't do mixed-dtype dot)
-    if use_int8_w8a16 or use_int4_w4a16:
+    # Per-channel INT8 W8A16 is handled in-kernel: fused_moe_kernel loads the
+    # int8 tile, converts with b.to(compute_type) inside the K-loop (mixed-dtype
+    # dot is NOT a Triton limitation), and applies the per-N scale once on the
+    # fp32 accumulator. Host-side dequant of the full expert tensors moved
+    # ~10 GB per call on Mixtral-8x7B shapes (a flat ~8.5 ms on H100,
+    # 6-22x slower than the bf16 path at every token count).
+    #
+    # INT4 (and grouped-scale INT8) still fall back to host dequant here:
+    # the WNA16/GPTQ kernel path expects offset-binary packed layouts that
+    # this entry point does not prepare.
+    if use_int4_w4a16 or (
+        use_int8_w8a16 and block_shape is not None and block_shape[1] > 0
+    ):
         w1 = w1.to(hidden_states.dtype) * w1_scale.unsqueeze(-1).to(hidden_states.dtype)
         w1_scale = None
         w2 = w2.to(hidden_states.dtype) * w2_scale.unsqueeze(-1).to(hidden_states.dtype)

--- a/src/flag_gems/fused/fused_moe.py
+++ b/src/flag_gems/fused/fused_moe.py
@@ -1188,10 +1188,14 @@ def fused_moe_kernel(
             # Per-channel weight scales for the gate and up halves; applied once
             # on the fp32 accumulators after each K-loop.
             b_scale_gate = tl.load(
-                b_scale_ptr + off_experts * stride_bse + offs_bn_gate[None, :] * stride_bsn
+                b_scale_ptr
+                + off_experts * stride_bse
+                + offs_bn_gate[None, :] * stride_bsn
             )
             b_scale_up = tl.load(
-                b_scale_ptr + off_experts * stride_bse + offs_bn_up[None, :] * stride_bsn
+                b_scale_ptr
+                + off_experts * stride_bse
+                + offs_bn_up[None, :] * stride_bsn
             )
 
         if use_fp8_w8a8 or use_int8_w8a8:


### PR DESCRIPTION
…st-side

The use_int8_w8a16 path host-dequantized ALL expert weights on every call (w1.to(dtype) * scale), moving ~10 GB per call on Mixtral-8x7B shapes -- a flat ~8.5 ms overhead on H100 that made W8A16 6-22x slower than bf16 at every token count.

The non-fused fused_moe_kernel already supports in-kernel W8A16 (b.to(compute_type) in the K-loop, per-N scale applied once on the fp32 accumulator); only the FUSE_SILU fused gate/up path was missing that support, which is why the host fallback existed. This change:

- adds W8A16 handling to the FUSE_SILU two-pass path (int8 tile conversion in both K-loops, per-channel gate/up scales applied on the accumulators)
- disables PAIR_GATE_UP_DOT for W8A16 (the paired dot has no conversion/scale handling) in favor of the two-pass path
- routes per-channel INT8 W8A16 through the kernel, keeping the host dequant fallback only for INT4 and grouped-scale INT8 (the WNA16 path expects offset-binary packed layouts not prepared here)

Measured on H100 (Mixtral-8x7B shapes, E=8 H=4096 I=14336 top-k=2, fp16), W8A16 vs bf16: 1.07x at T=1, 1.70x at T=16-64, 1.20x at T=128, 1.03x at T=256, 2.63x at T=512 -- previously 0.05-0.16x (always slower). Output rel err vs fp16 reference ~0.012, consistent with per-channel INT8 weight quantization error.

### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
