### PR TITLE
Clarify operator stages

### DIFF
--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -37,6 +37,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: acos
     description: Returns a new tensor with the arccosine (in radians) of each element in `input`.
     for:
@@ -71,6 +72,7 @@ ops:
       - NeuralNetwork
     stages:
       - alpha: '5.0'
+      - beta: '5.3'
   - id: adaptive_avg_pool3d_out
     description: |
       A variant of `_adaptive_avg_pool3d` that assigns the output to the `out` tensor.
@@ -84,6 +86,7 @@ ops:
       - NeuralNetwork
     stages:
       - alpha: '5.0'
+      - beta: '5.3'
   - id: add
     description: |
       Add a scalar or tensor to `self` tensor. If both `alpha` and `other` are specified,
@@ -121,7 +124,7 @@ ops:
     kind:
       - NeuralNetwork
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: addcdiv
     description: |
       Performs the element-wise division of `tensor1` by `tensor2`, multiplies the result
@@ -175,6 +178,7 @@ ops:
       - LinearAlg
     stages:
       - alpha: '5.0'
+      - beta: '5.3'
   - id: addmm
     description: |
       Performs a matrix multiplication of the matrices `mat1` and `mat2`.
@@ -284,6 +288,7 @@ ops:
       - Tensor
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: alias_copy_out
     description: A variant of `alias_copy()` that assigns the output to the `out` tensor.
     for:
@@ -295,6 +300,7 @@ ops:
       - Tensor
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: all
     description: Tests if all elements in input evaluate to True.
     for:
@@ -478,6 +484,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.4'
   - id: arcsinh_
     description: The in-place version of `arcsinh()`.
     for:
@@ -489,6 +496,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.4'
   - id: arcsinh_out
     description: A variant of `arcsinh` that allows the output to be assigned to the `out` tensor.
     for:
@@ -500,6 +508,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.4'
   - id: arctanh_
     description: |
       Computes the element-wise inverse hyperbolic tangent of a given input tensor.
@@ -513,6 +522,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.4'
   - id: argmax
     description: Returns the indices of the maximum value of all elements in the `input` tensor.
     for:
@@ -546,7 +556,7 @@ ops:
     kind:
       - Tensor
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: as_strided_copy
     description: |
       Creates a contiguous copy of an `as_strided` view of the input tensor.
@@ -580,7 +590,7 @@ ops:
     kind:
       - Math
     stages:
-      - beta: '5.3'
+      - alpha: '5.3'
   - id: asinh_
     description: Computes the inverse hyperbolic sine for each element of a tensor in-place.
     for:
@@ -592,6 +602,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: assert_async
     description: |
       A utility used to perform data-dependent assertions on GPU tensors
@@ -661,7 +672,7 @@ ops:
     kind:
       - Math
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: atanh_
     description: The in-place version of `atanh()`.
     for:
@@ -672,7 +683,7 @@ ops:
     kind:
       - Math
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: avg_pool2d
     description: |
       Applies 2D average-pooling operation in `kH \mul kW` regions by step size `sH \mul sW` steps.
@@ -1089,6 +1100,7 @@ ops:
       - Attention
     stages:
       - alpha: '5.0'
+      - beta: '5.3'
   - id: clamp
     description: Clamps all elements in `input` into the range `[min, max]`.
     for:
@@ -1123,7 +1135,7 @@ ops:
     kind:
       - Math
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: clamp_max_
     description: |
       The in-place version of `clamp_max()`.
@@ -1136,7 +1148,7 @@ ops:
     kind:
       - Math
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: clamp_min
     description: A variant of `clamp()` with `min` set to `min`.
     for:
@@ -1379,6 +1391,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '2.2'
+      - stable: '5.3'
   - id: conv_transpose1d
     description: |
       Applies a 1D transposed convolution operator over an input image composed of several input planes.
@@ -1416,6 +1429,7 @@ ops:
       - Tensor
     stages:
       - beta: '4.2'
+      - stable: '5.3'
   - id: copy_
     description: Copies the elements from `src` into `self` tensor and returns `self`.
     for:
@@ -1736,6 +1750,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: dispatch_fused_moe_kernel
     description: |
       Accelerates neural network training by combining token routing (dispatch/all-to-all communication),
@@ -1750,6 +1765,7 @@ ops:
       - MoE
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: div_out
     description: This is an variant of `div()` with an `out` argument.
     for:
@@ -1887,6 +1903,7 @@ ops:
       - NeuralNetwork
     stages:
       - alpha: '4.2'
+      - beta: '5.3'
   - id: dropout
     description: An internal IR for implementing `torch.nn.functional.dropout`.
     for:
@@ -1922,6 +1939,7 @@ ops:
       - NeuralNetwork
     stages:
       - alpha: '5.0'
+      - beta: '5.3'
   - id: dunder_ior_scalar
     description: The scalar version of `dunder_ior_tensor`.
     for:
@@ -2418,6 +2436,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: floor_
     description: |
       Performs an in-place element-wise floor operation, rounding each element of a tensor
@@ -2431,6 +2450,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: floor_divide_scalar
     description: Computes `input` divided by `other`, elementwise, and floors the result.
     for:
@@ -2484,6 +2504,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: fmin
     description: |
       Computes the element-wise minimum of two tensors, specially handling NaN values
@@ -2498,6 +2519,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: fmin_out
     description: A variant of `fmin()` that assigns the output to the `out` tensor.
     for:
@@ -2509,6 +2531,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: fmod_
     description: In-place remainder of division (fmod_), computes element-wise remainder with truncation toward zero.
     for:
@@ -2519,7 +2542,7 @@ ops:
     kind:
       - Math
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: fmod_scalar
     description: |
       Computes the element-wise remainder of division of input by a scalar divisor.
@@ -2695,6 +2718,7 @@ ops:
       - Attention
     stages:
       - alpha: '5.0'
+      - beta: '5.3'
   - id: gather
     description: Gathers values along an axis specified by `dim`.
     for:
@@ -2771,6 +2795,7 @@ ops:
       - NeuralNetwork
     stages:
       - alpha: '4.2'
+      - beta: '5.3'
   - id: gelu
     description: |
       Apply Cumulative Distribution Function for Gaussian Distribution function element-wise.
@@ -3054,6 +3079,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.2'
+      - stable: '5.3'
   - id: hc_split_sinkhorn_forward
     description: |
       Computes a differentiable approximation of the Wasserstein distance (Optimal Transport)
@@ -3103,6 +3129,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: hypot_out
     description: |
       Given the legs of a right triangle, return its hypotenuse.
@@ -3117,6 +3144,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: i0
     description: |
       Computes the modified Bessel function of the first kind of order zero element-wise for a given input tensor.
@@ -3129,6 +3157,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: i0_
     description: The inplace version of `i0`.
     for:
@@ -3140,6 +3169,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: i0_out
     description: A variant of `i0` that assigns the output to the `out` tensor.
     for:
@@ -3151,6 +3181,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: index
     description: |
       Extract, access or modify specific elements, slices, or subsets of data within a tensor.
@@ -3255,7 +3286,7 @@ ops:
     kind:
       - Tensor
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: index_select
     description: |
       Returns a new tensor which indexes the `input` tensor along dimension `dim`
@@ -3291,6 +3322,7 @@ ops:
       - MoE
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: instance_norm
     description: |
       Apply Instance Normalization independently for each channel in every data sample within a batch.
@@ -3559,6 +3591,7 @@ ops:
       - Tensor
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: linspace
     description: |
       Creates a one-dimensional tensor of size `steps` whose values are evenly spaced from `start` to `end`, inclusive.
@@ -3626,6 +3659,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: log1p_
     description: |
       Computes the natural logarithm of `1+x(y_i=log_e(x_i+1))` for each element in the input tensor in-place.
@@ -3638,6 +3672,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: log_sigmoid
     description: Applies the Logsigmoid function element-wise.
     for:
@@ -3675,6 +3710,7 @@ ops:
       - NeuralNetwork
     stages:
       - alpha: '5.0'
+      - beta: '5.3'
   - id: log_softmax_backward_data_out
     description: |
       A variant of `_log_softmax_backward_data` that assigns the output to the `out` tensor.
@@ -3687,6 +3723,7 @@ ops:
       - NeuralNetwork
     stages:
       - alpha: '5.0'
+      - beta: '5.3'
   - id: log_softmax_out
     description: An internal IR for applying a softmax followed by a logarithm.
     for:
@@ -3711,6 +3748,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: logaddexp_out
     description: A variant of `logaddexp` that allows the output to be assigned to an `out` tensor.
     for:
@@ -3723,6 +3761,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: logical_and
     description: |
       Computes the element-wise logical AND of the given `input` tensors.
@@ -3806,6 +3845,7 @@ ops:
       - LinearAlg
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: logit_
     description: The in-place version of `logit()`.
     for:
@@ -3818,6 +3858,7 @@ ops:
       - LinearAlg
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: logit_out
     description: |
       A variant of `logit` that allows the output to be assigned to another tensor.
@@ -3831,6 +3872,7 @@ ops:
       - LinearAlg
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: logspace
     description: |
       Creates a one-dimensional tensor of size `steps` whose values are evenly spaced
@@ -4283,7 +4325,7 @@ ops:
     kind:
       - LinearAlg
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: nanmedian_dim
     description: |
       Returns a namedtuple `(values, indices)` where `values` contains the median
@@ -4297,7 +4339,7 @@ ops:
     kind:
       - LinearAlg
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: nanmedian_dim_values
     description: A variant of `nanmedian_dim()` with the `out` argument.
     for:
@@ -4308,7 +4350,7 @@ ops:
     kind:
       - LinearAlg
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: nanmedian_out
     description: A variant of `nanmedian()` with the `out` argument.
     for:
@@ -4319,7 +4361,7 @@ ops:
     kind:
       - LinearAlg
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: ne
     description: Computes that `input` is not equal to `other` element-wise.
     for:
@@ -4479,16 +4521,6 @@ ops:
       - Tensor
     stages:
       - alpha: '5.3'
-  - id: normal_
-    description: Random sampling operator (normal_).
-    for:
-      - normal_
-    labels:
-      - skip_precision_check
-    kind:
-      - Tensor
-    stages:
-      - alpha: '5.3'
   - id: normal_float_float_
     description: |
       Returns a tensor of random numbers drawn from separate normal distributions
@@ -4622,6 +4654,7 @@ ops:
       - MoE
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: pack_seq_triton
     description: Pack variable-length token sequences into a padded batched tensor.
     for:
@@ -4660,6 +4693,7 @@ ops:
       - Quantization
     stages:
       - alpha: '4.2'
+      - beta: '5.3'
   - id: pixel_shuffle
     description: Rearranges elements in a tensor to a new tensor of different shape.
     for:
@@ -4671,6 +4705,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: pixel_unshuffle
     description: |
       Rearranges elements from a low-resolution feature map with many channels
@@ -4684,6 +4719,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: pixel_unshuffle_out
     description: A variant of `pixel_unshuffle` that assigns the output to the `out` tensor.
     for:
@@ -4799,6 +4835,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: prod
     description: Returns the product of all elements in the `input` tensor.
     for:
@@ -4888,7 +4925,7 @@ ops:
     kind:
       - Distribution
     stages:
-      - stable: '2.1'
+      - stable: '5.1'
   - id: randint_like
     description: |
       Returns a tensor with the same size as `input` that is filled with random integers
@@ -4901,7 +4938,7 @@ ops:
     kind:
       - Distribution
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: randn
     description: |
       Returns a tensor filled with random numbers from a normal distribution with mean 0
@@ -4973,6 +5010,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: reflection_pad1d_backward
     description: Computes the gradient of reflection_pad1d with respect to the input tensor.
     for:
@@ -4996,6 +5034,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: reflection_pad2d
     description: |
       Pads the input 3D or 2D tensor (typically representing signals or sequences)
@@ -5010,6 +5049,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: reflection_pad2d_out
     description: A variant of `reflection_pad2d` that assigns the output to `out` tensor.
     for:
@@ -5022,6 +5062,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: reglu
     description: |
       Rectified Gated Linear Unit is a variant of GLU that uses ReLU instead of the sigmoid function for gating.
@@ -5034,6 +5075,7 @@ ops:
       - NeuralNetwork
     stages:
       - alpha: '4.2'
+      - beta: '5.3'
   - id: relu
     description: Apply the RELU (Rectified Linear Unit) activation function element-wise.
     for:
@@ -5063,6 +5105,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: relu_
     description: This is the in-place version of `relu()`.
     for:
@@ -5087,7 +5130,7 @@ ops:
     kind:
       - Math
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: remainder_scalar
     description: |
       Computes Python's modulus operation entrywise. The result has the same sign
@@ -5156,7 +5199,7 @@ ops:
     kind:
       - Math
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: renorm_
     description: The in-place version of `renorm()`.
     for:
@@ -5167,7 +5210,7 @@ ops:
     kind:
       - Math
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: repeat
     description: Repeats this tensor along the specified dimensions.
     for:
@@ -5224,6 +5267,7 @@ ops:
       - Tensor
     stages:
       - beta: '5.0'
+      - stable: '5.4'
   - id: replication_pad1d_out
     description: A variant of `replication_pad1d` that assigns the output to the `out` tensor.
     for:
@@ -5235,6 +5279,7 @@ ops:
       - Tensor
     stages:
       - beta: '5.0'
+      - stable: '5.4'
   - id: replication_pad3d
     description: Pads the edge of a 3D input tensor by repeating the boundary values.
     for:
@@ -5245,6 +5290,7 @@ ops:
       - NeuralNetwork
     stages:
       - alpha: '5.0'
+      - beta: '5.3'
   - id: reshape_and_cache
     description: Store the key/value token states into the pre-allcated kv_cache buffers of paged attention.
     for:
@@ -5328,7 +5374,7 @@ ops:
     kind:
       - Math
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: round
     description: Rounds elements of input to the nearest integer.
     for:
@@ -5505,7 +5551,7 @@ ops:
     kind:
       - BLAS
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: scaled_mm_out
     description: A variant of `_scaled_mm` that writes the result into `out`.
     for:
@@ -5515,7 +5561,7 @@ ops:
     kind:
       - BLAS
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: scaled_softmax_backward
     description: |
       The backward pass for a scaled softmax function, commonly used in Scaled Dot-Product Attention (SDPA)
@@ -5636,7 +5682,7 @@ ops:
     kind:
       - Tensor
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: searchsorted_out
     description: A variant of `searchsorted.Tensor` that assigns the result to `out`.
     for:
@@ -5647,7 +5693,7 @@ ops:
     kind:
       - Tensor
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: searchsorted_scalar
     description: |
       Finds insertion indices for a scalar value in one-dimensional sorted boundaries.
@@ -5659,7 +5705,7 @@ ops:
     kind:
       - Tensor
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: searchsorted_scalar_out
     description: A variant of `searchsorted.Scalar` that assigns the result to `out`.
     for:
@@ -5670,7 +5716,7 @@ ops:
     kind:
       - Tensor
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: segment_reduce
     description: |
       Reduces contiguous segments of a tensor along the specified axis. Segments are described
@@ -5682,7 +5728,7 @@ ops:
     kind:
       - Reduction
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: segment_reduce_backward
     description: Computes gradients for `segment_reduce` with lengths or offsets based segment definitions.
     for:
@@ -5692,7 +5738,7 @@ ops:
     kind:
       - Reduction
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: segment_reduce_backward_out
     description: |
       A variant of `_segment_reduce_backward` that assigns the gradient input to the `out` tensor.
@@ -5703,7 +5749,7 @@ ops:
     kind:
       - Reduction
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: segment_reduce_out
     description: |
       A variant of `segment_reduce` that assigns the reduced segments to the `out` tensor.
@@ -5714,7 +5760,7 @@ ops:
     kind:
       - Reduction
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: select_backward
     description: Calculate the gradient during the backward pass in the neural network.
     for:
@@ -5753,6 +5799,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: selu_
     description: |
       This is the in-place version of `selu`.
@@ -5767,6 +5814,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: sgn_
     description: |
       Computes the sign of each element in the `self` tensor, element-wise.
@@ -5781,6 +5829,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: sigmoid
     description: Computes the expit (also known as the logistic sigmoid function) of the elements of `input`.
     for:
@@ -5958,6 +6007,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: skip_layer_norm
     description: |
       An optimized operation used in Transformer models to improve performance
@@ -6104,6 +6154,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: softshrink_out
     description: |
       This is a variant of `softshrink` that supports an output tensor.
@@ -6118,6 +6169,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: sort
     description: Sorts the elements of the `input` tensor along a given dimension in ascending order by value.
     for:
@@ -6165,6 +6217,7 @@ ops:
       - DSA
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: special_i0e
     description: |
       Computes the exponentially scaled zeroth order modified Bessel function
@@ -6179,6 +6232,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: special_i0e_out
     description: |
       A variant of `special_i0e()` with output saved to provided `out`..
@@ -6192,6 +6246,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: special_i1
     description: |
       Computes the modified Bessel function of the first kind of order 1 (I_1(x)) for each element
@@ -6206,6 +6261,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: special_i1_out
     description: A variant of `special_i1` that allows the output to be assigned to another tensor.
     for:
@@ -6218,6 +6274,7 @@ ops:
       - Math
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: split_with_sizes_copy
     description: |
       Splits a tensor into sub-tensors along a given dimension,
@@ -6230,7 +6287,7 @@ ops:
     kind:
       - Math
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: sqrt
     description: Returns a new tensor with the square-root of the elements of `input`.
     for:
@@ -6405,6 +6462,7 @@ ops:
       - Tensor
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: t_copy_out
     description: A variant of `t_copy()` that allows the output to be assigned to the `out` tensor.
     for:
@@ -6416,6 +6474,7 @@ ops:
       - Tensor
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: tan
     description: |
       Returns a new tensor with the tangent of the elements in the `input` tensor,
@@ -6483,7 +6542,7 @@ ops:
     kind:
       - Math
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: threshold
     description: Apply a threshold to each element of the input Tensor.
     for:
@@ -6535,6 +6594,7 @@ ops:
       - Tensor
     stages:
       - beta: '4.1'
+      - stable: '5.3'
   - id: top_k_per_row_decode
     description: |
       Triton top-K per row for DeepSeek V4 decode-phase token selection.
@@ -6627,6 +6687,7 @@ ops:
       - BLAS
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: tril_
     description: |
       The in-place version of `tril()`.
@@ -6692,7 +6753,7 @@ ops:
     kind:
       - Math
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: trunc_
     description: The in-place version of `trunc()`.
     for:
@@ -6703,7 +6764,7 @@ ops:
     kind:
       - Math
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: trunc_divide
     description: The `div` function with rounding_mode set to `trunc`.
     for:
@@ -6779,7 +6840,7 @@ ops:
     kind:
       - Tensor
     stages:
-      - beta: '5.3'
+      - beta: '5.4'
   - id: unpack_seq_triton
     description: Unpack a packed sequence tensor back to its original variable-length form.
     for:
@@ -6837,6 +6898,7 @@ ops:
       - NeuralNetwork
     stages:
       - alpha: '5.0'
+      - beta: '5.3'
   - id: upsample_linear1d_backward
     description: A backward case for `upsample_linear1d()`.
     for:
@@ -6847,7 +6909,7 @@ ops:
     kind:
       - NeuralNetwork
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: upsample_nearest1d
     description: |
       Upsamples the `input`, using nearest neighbours' pixel values.
@@ -6898,6 +6960,7 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: upsample_trilinear3d
     description: Upsamples the input (NCDHW) using trilinear interpolation.
     for:
@@ -6908,7 +6971,7 @@ ops:
     kind:
       - Math
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: var
     description: Calculates the variance over all dimensions.
     for:
@@ -6989,7 +7052,7 @@ ops:
     kind:
       - Tensor
     stages:
-      - alpha: '5.3'
+      - alpha: '5.4'
   - id: vstack
     description: Stack tensors in sequence vertically (row wise).
     for:
@@ -7087,6 +7150,7 @@ ops:
       - Tensor
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: zero_
     description: Fills `self` tensor with zeros.
     for:
@@ -7108,6 +7172,7 @@ ops:
       - Tensor
     stages:
       - beta: '5.0'
+      - stable: '5.3'
   - id: zeros
     description: |
       Returns a tensor filled with the scalar value 0, with the shape defined by


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Update

### Description

This PR updates the operator inventory to accurately record the history/stages of each operator.

- The 5.3 release branch (`5.3.0-rc2`) for FlagOS v2.1 was cut early this week. Some operators failed to get merged into `main` branch before the release branch was cut. The earliest release of FlagGems that will include these operators would be `5.4`. This PR fixes up the operators that were merged after the the release branch was cut.
- There have been some operators staying on `beta` for at least one release cycle (from `5.0` to `5.3`), these operators are supposed to be promoted to `stable` in `5.3.0` release if there is no open issues related to them.
- Similarly, there are some operators that were in the `alpha` stage before `5.3.0`. If there are no open issues related to them (they have proved to be trustworthy for at least one release cycle), they are supposed to be promoted to `beta` in `5.3.0`.

This PR fixes the operator inventory for the above cases.