### PR TITLE
Fix TsingMicro CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,8 +147,9 @@ tsingmicro = [
     "torchaudio==2.7.0+cpu",
     "torch_txda==0.1.0+20260610.3968e515",
     "txops==0.1.0+20260508.60287151",
-    "flagtree==0.5.0+tsingmicro3.3",
-    # "triton==3.3.0+git2e9c1195",
+    "triton==3.3.0+git2e9c1195",
+    # Some dependencies need to be resolved for flagtree
+    # "flagtree==0.5.0+tsingmicro3.3",
 ]
 
 # Test packages

--- a/tools/vendor.sh
+++ b/tools/vendor.sh
@@ -209,14 +209,14 @@ case $VENDOR in
         "torchaudio==2.7.0+cpu" \
         "torch_txda==0.1.0+20260610.3968e515" \
         "txops==0.1.0+20260508.60287151" \
-        "flagtree==0.5.0+tsingmicro3.3"
+        "triton==3.3.0+git2e9c1195"
 
     # Replace flagtree with Triton if requested
-    if [ -n "${USE_TRITON}" ]; then
-      uv pip uninstall flagtree
-      uv pip install --index ${FLAGOS_PYPI} \
-        "triton==3.3.0+git2e9c1195"
-    fi
+    # if [ -z "${USE_TRITON}" ]; then
+    #   uv pip uninstall flagtree
+    #   uv pip install --index ${FLAGOS_PYPI} \
+    #     "flagtree==0.5.0+tsingmicro3.3"
+    # fi
 
     uv pip install -e .
     uv pip install ".[test]"


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

FlagTree on TsingMicro has too many runtime dependencies. Fall back to Triton to unblock CI.