### PR TITLE
fix: bump version to 5.3.0rc2 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 name = "flag_gems"
 
-version = "5.0.2"
+version = "5.3.0rc2"
 
 description = "FlagGems is a function library written in Triton language."
 


### PR DESCRIPTION
## Summary

The package version in pyproject.toml is inconsistent with the current 5.3.0-rc2 branch, still showing 5.0.2. Updated the version field to match the current release version.

## Root Cause

When the 5.3.0-rc2 branch was created, the `version` field in pyproject.toml was not updated, causing the built and installed package to still report version 5.0.2.

## Changes

* Updated `version = "5.0.2"` to `version = "5.3.0rc2"` in pyproject.toml

## Tests

* Install the built package
* Run `pip show flag_gems`
* Confirm the displayed version is 5.3.0rc2

## Risk

Low.

Only updates version metadata — no functional logic, build process, or runtime behavior changes.