### PR TITLE
Add setup support for CANN9.0.0 for Ascend backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,13 @@ ascend = [
     "flagtree==0.5.0+ascend3.2",
 ]
 
+ascend-cann9 = [
+    "torch==2.10.0+cpu",
+    "torch-npu==2.10.0",
+    "triton==3.5.0",
+    "triton-ascend==3.2.1",
+]
+
 enflame = [
     "pyefml==1.9.10",
     "torch==2.10.0+cpu",

--- a/setup.sh
+++ b/setup.sh
@@ -2,6 +2,7 @@
 
 SUPPORTED_VENDORS=(
   "ascend"
+  "ascend-cann9"
   "enflame"
   "hygon"
   "iluvatar"
@@ -18,6 +19,7 @@ SUPPORTED_VENDORS=(
 # TODO: Add thead PPU
 declare -A PYTHON_SUPPORTED=(
   ["ascend"]="3.11"
+  ["ascend-cann9"]="3.11"
   ["enflame"]="3.12"
   ["hygon"]="3.10"
   ["iluvatar"]="3.10"
@@ -109,7 +111,11 @@ else
 fi
 
 # Install FlagGems
-export FLAGOS_PYPI="https://resource.flagos.net/repository/flagos-pypi-${VENDOR}/simple"
+PYPI_VENDOR=${VENDOR}
+if [ "$VENDOR" = "ascend-cann9" ]; then
+  PYPI_VENDOR="ascend"
+fi
+export FLAGOS_PYPI="https://resource.flagos.net/repository/flagos-pypi-${PYPI_VENDOR}/simple"
 printf "Install build tools ... "
 uv pip install \
   "setuptools>=64.0" \
@@ -130,8 +136,14 @@ fi
 ## Vendor-specific installation steps
 source tools/env.sh ${VENDOR}
 # source tools/vendor.sh ${VENDOR}
-uv pip install ".[${VENDOR}]" --default-index ${FLAGOS_PYPI} \
-  --index https://mirrors.aliyun.com/pypi/simple
+if [ "$VENDOR" = "ascend-cann9" ]; then
+    uv pip install triton==3.5.0
+    uv pip install triton-ascend==3.2.1 --index ${FLAGOS_PYPI}
+fi
+
+uv pip install ".[${VENDOR}]" --default-index ${FLAGOS_PYPI}
+    --index https://mirrors.aliyun.com/pypi/simple \
+
 uv pip install ".[test]"
 
 [ "$?" == 0 ] || { echo "Failed to setup FlagGems" ; exit 1; }

--- a/tools/env.sh
+++ b/tools/env.sh
@@ -2,7 +2,7 @@ VENDOR=$1
 echo "Setting up environment variable for vendor $VENDOR"
 
 case $VENDOR in
-  ascend)
+  ascend|ascend-cann9)
     # This script is provided by the Huawei Ascend CANN toolkit installation.
     if [ -f /usr/local/Ascend/ascend-toolkit/set_env.sh ]; then
       source /usr/local/Ascend/ascend-toolkit/set_env.sh


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

New Feature

### Description

On runner hw25, we have provisioned CANN 9.0.0 for testing Ascend backend. This PR adds a special extra config for this platform.