### PR TITLE
Fix operator inventory

### DIFF
--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -1,14 +1,4 @@
 ops:
-  - id: _to_copy
-    description: Layout/memory operation (to_copy).
-    for:
-      - _to_copy
-    labels:
-      - skip_precision_check
-    kind:
-      - Tensor
-    stages:
-      - alpha: '5.1'
   - id: abs
     description: |
       Computes the absolute value of each element in `input`.
@@ -1251,16 +1241,6 @@ ops:
       - Math
     stages:
       - beta: '5.3'
-  - id: clone
-    description: Pure layout/memory operation (clone).
-    for:
-      - clone
-    labels:
-      - skip_precision_check
-    kind:
-      - Tensor
-    stages:
-      - alpha: '5.1'
   - id: col2im
     description: |
       Rearranges column blocks back into a multidimensional tensor (inverse of im2col).
@@ -2123,16 +2103,6 @@ ops:
       - NeuralNetwork
     stages:
       - stable: '5.0'
-  - id: empty
-    description: Tensor factory operation (empty).
-    for:
-      - empty
-    labels:
-      - skip_precision_check
-    kind:
-      - Tensor
-    stages:
-      - alpha: '5.1'
   - id: eq
     description: Computes element-wise equality.
     for:
@@ -2256,16 +2226,6 @@ ops:
       - Math
     stages:
       - stable: '4.1'
-  - id: expand
-    description: Pure layout operation (expand).
-    for:
-      - expand
-    labels:
-      - skip_precision_check
-    kind:
-      - Tensor
-    stages:
-      - alpha: '5.1'
   - id: expm1
     description: Computes the exponential of the elements minus 1 of `input`.
     for:
@@ -4929,16 +4889,6 @@ ops:
     stages:
       - alpha: '4.2'
       - beta: '5.3'
-  - id: permute
-    description: Pure layout operation (permute).
-    for:
-      - permute
-    labels:
-      - skip_precision_check
-    kind:
-      - Tensor
-    stages:
-      - alpha: '5.1'
   - id: pixel_shuffle
     description: Rearranges elements in a tensor to a new tensor of different shape.
     for:
@@ -5546,16 +5496,6 @@ ops:
     stages:
       - alpha: '5.0'
       - beta: '5.3'
-  - id: reshape
-    description: Pure layout operation (reshape).
-    for:
-      - reshape
-    labels:
-      - skip_precision_check
-    kind:
-      - Tensor
-    stages:
-      - alpha: '5.1'
   - id: reshape_and_cache
     description: Store the key/value token states into the pre-allcated kv_cache buffers of paged attention.
     for:
@@ -6850,16 +6790,6 @@ ops:
       - Tensor
     stages:
       - stable: '2.1'
-  - id: to
-    description: Device/dtype cast operation (to).
-    for:
-      - to
-    labels:
-      - skip_precision_check
-    kind:
-      - Tensor
-    stages:
-      - alpha: '5.1'
   - id: to_copy
     for:
       - _to_copy
@@ -6955,16 +6885,6 @@ ops:
       - Reduction
     stages:
       - stable: '4.0'
-  - id: transpose
-    description: Pure layout operation (transpose).
-    for:
-      - transpose
-    labels:
-      - skip_precision_check
-    kind:
-      - Tensor
-    stages:
-      - alpha: '5.1'
   - id: tril
     description: |
       Returns the lower triangular part of an input matrix (or a batch of matrices) and
@@ -7355,16 +7275,6 @@ ops:
       - NeuralNetwork
     stages:
       - stable: '2.0'
-  - id: view
-    description: Pure layout operation (view).
-    for:
-      - view
-    labels:
-      - skip_precision_check
-    kind:
-      - Tensor
-    stages:
-      - alpha: '5.1'
   - id: view_copy
     description: |
       Returns a copy of the tensor with the specified shape.


### PR DESCRIPTION
### PR Category

OP Test

### Type of Change

Bug Fix

### Description

There were some operators that are not customized/implemented in FlagGems, but added into the operator inventory due to misunderstanding of the inventory. These operators were removed previously but got sneaking into the yaml file again in #3766.