### PR TITLE
add fused_indexer_q_rope_quant op

### DIFF
--- a/benchmark/test_fused_indexer_q_rope_quant.py
+++ b/benchmark/test_fused_indexer_q_rope_quant.py
@@ -16,6 +16,13 @@ HAS_NATIVE_FP8 = hasattr(torch, "float8_e4m3fn") and (
 )
 
 
+def _supports_mxfp4_ptx():
+    if flag_gems.device != "cuda" or not torch.cuda.is_available():
+        return False
+    major, _ = torch.cuda.get_device_capability()
+    return major >= 10
+
+
 def _make_cos_sin_cache(max_pos, rope_dim, device, dtype):
     half = rope_dim // 2
     inv_freq = 1.0 / (
@@ -126,6 +133,10 @@ class FusedIndexerQRopeQuantBenchmark(base.GenericBenchmark):
         super().init_user_config()
         if any(len(shape) != 3 for shape in self.shapes):
             self.shapes = self.DEFAULT_SHAPES
+        if not _supports_mxfp4_ptx():
+            self.shapes = [shape for shape in self.shapes if not shape[2]]
+        if not self.shapes:
+            self.shapes = [(1, NUM_HEADS, False)]
 
 
 @pytest.mark.fused_indexer_q_rope_quant

--- a/benchmark/test_fused_indexer_q_rope_quant.py
+++ b/benchmark/test_fused_indexer_q_rope_quant.py
@@ -1,0 +1,142 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import base
+
+HEAD_DIM = 128
+ROPE_DIM = 64
+NUM_HEADS = 8
+MAX_POS = 4096
+MXFP4_BLOCK_SIZE = 32
+
+HAS_NATIVE_FP8 = hasattr(torch, "float8_e4m3fn") and (
+    flag_gems.SUPPORTED_FP8_DTYPE == torch.float8_e4m3fn
+)
+
+
+def _make_cos_sin_cache(max_pos, rope_dim, device, dtype):
+    half = rope_dim // 2
+    inv_freq = 1.0 / (
+        10000.0 ** (torch.arange(0, half, device=device, dtype=torch.float32) / half)
+    )
+    t = torch.arange(max_pos, device=device, dtype=torch.float32)
+    freqs = torch.outer(t, inv_freq)
+    return torch.cat((freqs.cos(), freqs.sin()), dim=-1).to(dtype)
+
+
+def _rotate_tail_gptj(q, positions, cos_sin_cache):
+    nope_dim = HEAD_DIM - ROPE_DIM
+    half = ROPE_DIM // 2
+    cos_sin = cos_sin_cache.index_select(0, positions).float()
+    cos = cos_sin[:, :half].unsqueeze(1)
+    sin = cos_sin[:, half:].unsqueeze(1)
+
+    q_rot = q.float()
+    tail = q_rot[..., nope_dim:]
+    even = tail[..., 0::2]
+    odd = tail[..., 1::2]
+    q_rot[..., nope_dim::2] = (even * cos - odd * sin).to(torch.bfloat16).float()
+    q_rot[..., nope_dim + 1 :: 2] = (odd * cos + even * sin).to(torch.bfloat16).float()
+    return q_rot
+
+
+def _quantize_to_mxfp4(x):
+    orig_shape = x.shape
+    head_dim = orig_shape[-1]
+    n_blocks = head_dim // MXFP4_BLOCK_SIZE
+    x_f32 = x.float().reshape(-1, n_blocks, MXFP4_BLOCK_SIZE)
+
+    amax = x_f32.abs().amax(dim=-1, keepdim=True).clamp(min=6 * (2**-126))
+    log2_ratio = (amax / 6.0).log2().ceil().clamp(-127.0, 127.0)
+    scale = log2_ratio.exp2()
+    ue8m0 = (log2_ratio + 127.0).to(torch.uint8)
+
+    x_scaled = (x_f32 / scale).clamp(-6.0, 6.0)
+    abs_x = x_scaled.abs()
+    code = torch.zeros_like(abs_x, dtype=torch.int32)
+    code = torch.where(abs_x > 0.25, 1, code)
+    code = torch.where(abs_x >= 0.75, 2, code)
+    code = torch.where(abs_x > 1.25, 3, code)
+    code = torch.where(abs_x >= 1.75, 4, code)
+    code = torch.where(abs_x > 2.5, 5, code)
+    code = torch.where(abs_x >= 3.5, 6, code)
+    code = torch.where(abs_x > 5.0, 7, code)
+    sign = ((x_scaled.view(torch.int32) >> 31) & 1).to(torch.uint8)
+    nibble = code.to(torch.uint8) | (sign << 3)
+
+    nibble_flat = nibble.reshape(-1, head_dim)
+    packed = (nibble_flat[:, 0::2] | (nibble_flat[:, 1::2] << 4)).contiguous()
+    packed = packed.reshape(*orig_shape[:-1], head_dim // 2)
+    scales = ue8m0.view(*orig_shape[:-1], n_blocks)
+    return packed, scales
+
+
+def _reference_op(
+    positions,
+    q,
+    cos_sin_cache,
+    weights,
+    softmax_scale,
+    head_scale,
+    use_fp4,
+):
+    q_rot = _rotate_tail_gptj(q, positions, cos_sin_cache)
+    if use_fp4:
+        q_packed, q_scale = _quantize_to_mxfp4(q_rot)
+        weights_out = weights.float() * softmax_scale * head_scale
+        return (q_packed, q_scale.view(torch.int32).squeeze(-1)), weights_out
+
+    amax = q_rot.abs().amax(dim=-1)
+    q_scale = torch.exp2(torch.ceil(torch.log2(amax.clamp(min=1e-4) / 448.0)))
+    q_fp8 = (q_rot / q_scale.unsqueeze(-1)).to(torch.float8_e4m3fn)
+    weights_out = weights.float() * q_scale * softmax_scale * head_scale
+    return q_fp8, weights_out
+
+
+def _input_fn(shape, dtype, device):
+    num_tokens, num_heads, use_fp4 = shape
+    q = torch.randn(num_tokens, num_heads, HEAD_DIM, dtype=dtype, device=device)
+    positions = torch.randint(
+        0, MAX_POS, (num_tokens,), dtype=torch.int64, device=device
+    )
+    cos_sin_cache = _make_cos_sin_cache(MAX_POS, ROPE_DIM, device, torch.bfloat16)
+    weights = torch.randn(num_tokens, num_heads, dtype=dtype, device=device)
+    yield (
+        positions,
+        q,
+        cos_sin_cache,
+        weights,
+        HEAD_DIM**-0.5,
+        num_heads**-0.5,
+        use_fp4,
+    )
+
+
+class FusedIndexerQRopeQuantBenchmark(base.GenericBenchmark):
+    DEFAULT_SHAPES = [
+        (1, NUM_HEADS, False),
+        (32, NUM_HEADS, False),
+        (32, NUM_HEADS, True),
+    ]
+    DEFAULT_SHAPE_DESC = "num_tokens, num_heads, use_fp4"
+
+    def init_user_config(self):
+        super().init_user_config()
+        if any(len(shape) != 3 for shape in self.shapes):
+            self.shapes = self.DEFAULT_SHAPES
+
+
+@pytest.mark.fused_indexer_q_rope_quant
+@pytest.mark.skipif(flag_gems.device != "cuda", reason="requires CUDA")
+@pytest.mark.skipif(not HAS_NATIVE_FP8, reason="requires native float8_e4m3fn support")
+def test_fused_indexer_q_rope_quant():
+    bench = FusedIndexerQRopeQuantBenchmark(
+        op_name="fused_indexer_q_rope_quant",
+        input_fn=_input_fn,
+        torch_op=_reference_op,
+        dtypes=[torch.bfloat16],
+    )
+    bench.set_gems(flag_gems.fused_indexer_q_rope_quant)
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -2727,6 +2727,21 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.3'
+  - id: fused_indexer_q_rope_quant
+    description: |
+      Applies RoPE to sparse indexer Q, quantizes it to FP8 or MXFP4, and folds
+      indexer weights for DeepSeekV4 attention.
+    for:
+      - vllm.v1.attention.ops.deepseek_v4_ops.fused_indexer_q_rope_quant
+    labels:
+      - fused
+      - Attention
+      - vLLM
+      - DeepSeekV4
+    kind:
+      - NeuralNetwork
+    stages:
+      - beta: '5.4'
   - id: fused_moe
     description: The generic interface for fused MoE.
     for:
@@ -2753,21 +2768,6 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.3'
-  - id: fused_indexer_q_rope_quant
-    description: |
-      Applies RoPE to sparse indexer Q, quantizes it to FP8 or MXFP4, and folds
-      indexer weights for DeepSeekV4 attention.
-    for:
-      - vllm.v1.attention.ops.deepseek_v4_ops.fused_indexer_q_rope_quant
-    labels:
-      - fused
-      - Attention
-      - vLLM
-      - DeepSeekV4
-    kind:
-      - NeuralNetwork
-    stages:
-      - beta: '5.4'
   - id: fused_recurrent_gated_delta_rule_fwd
     description: |
       The forward case for `fused_recurrent_gated_delta_rule` used in Flash Linear Attention (FLA).

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -2753,6 +2753,21 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.3'
+  - id: fused_indexer_q_rope_quant
+    description: |
+      Applies RoPE to sparse indexer Q, quantizes it to FP8 or MXFP4, and folds
+      indexer weights for DeepSeekV4 attention.
+    for:
+      - vllm.v1.attention.ops.deepseek_v4_ops.fused_indexer_q_rope_quant
+    labels:
+      - fused
+      - Attention
+      - vLLM
+      - DeepSeekV4
+    kind:
+      - NeuralNetwork
+    stages:
+      - beta: '5.4'
   - id: fused_recurrent_gated_delta_rule_fwd
     description: |
       The forward case for `fused_recurrent_gated_delta_rule` used in Flash Linear Attention (FLA).

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -31,6 +31,7 @@ from flag_gems.fused.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert import (
     fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert,
 )
 from flag_gems.fused.fused_inv_rope_fp8_quant import fused_inv_rope_fp8_quant
+from flag_gems.fused.fused_indexer_q_rope_quant import fused_indexer_q_rope_quant
 from flag_gems.fused.fused_moe import (
     dispatch_fused_moe_kernel,
     fused_experts_impl,
@@ -106,6 +107,7 @@ __all__ = [
     "fused_add_rms_norm",
     "fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert",
     "fused_experts_impl",
+    "fused_indexer_q_rope_quant",
     "fused_inv_rope_fp8_quant",
     "fused_q_kv_rmsnorm",
     "fused_recurrent_gated_delta_rule_fwd",

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -30,8 +30,8 @@ from flag_gems.fused.fused_add_rms_norm import fused_add_rms_norm
 from flag_gems.fused.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert import (
     fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert,
 )
-from flag_gems.fused.fused_inv_rope_fp8_quant import fused_inv_rope_fp8_quant
 from flag_gems.fused.fused_indexer_q_rope_quant import fused_indexer_q_rope_quant
+from flag_gems.fused.fused_inv_rope_fp8_quant import fused_inv_rope_fp8_quant
 from flag_gems.fused.fused_moe import (
     dispatch_fused_moe_kernel,
     fused_experts_impl,

--- a/src/flag_gems/fused/fused_indexer_q_rope_quant.py
+++ b/src/flag_gems/fused/fused_indexer_q_rope_quant.py
@@ -1,0 +1,403 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+
+import torch
+
+import triton
+import triton.language as tl
+
+# MXFP4: 32 elements per block, packed 2 nibbles per byte, ue8m0 block scale.
+MXFP4_BLOCK_SIZE = 32
+
+
+@triton.jit
+def _get_cos_sin(
+    cos_sin_cache_ptr,
+    cos_sin_cache_stride,
+    pos,
+    HALF_ROT_DIM: tl.constexpr,
+):
+    block = tl.arange(0, HALF_ROT_DIM)
+    cos = tl.load(cos_sin_cache_ptr + pos * cos_sin_cache_stride + block)
+    cos = cos.to(tl.float32)
+    sin = tl.load(cos_sin_cache_ptr + pos * cos_sin_cache_stride + block + HALF_ROT_DIM)
+    sin = sin.to(tl.float32)
+    return cos, sin
+
+
+@triton.jit
+def _fp32x2_to_fp4x2(x_lo, x_hi):
+    # NOTE: $1 is high nibble, $2 is low nibble
+    return tl.inline_asm_elementwise(
+        """
+        {
+            .reg .b8 tmp;
+            cvt.rn.satfinite.e2m1x2.f32 tmp, $1, $2;
+            cvt.u32.u8 $0, tmp;
+        }
+        """,
+        constraints="=r,f,f",
+        args=[x_hi, x_lo],
+        dtype=tl.uint32,
+        is_pure=True,
+        pack=1,
+    ).to(tl.uint8)
+
+
+@triton.jit
+def _quantize_mxfp4_pair(x_lo, x_hi):
+    """Quantize a block of MXFP4_BLOCK_SIZE fp32 values given as two
+    interleaved halves (x_lo = values at even positions in the block,
+    x_hi = values at odd positions). Returns:
+        - packed : uint8[BLOCK/2]  (low nibble = quant(x_lo), high = quant(x_hi))
+        - ue8m0  : scalar uint8    (block scale = 2^(ue8m0 - 127))
+    """
+    amax = tl.maximum(tl.max(tl.abs(x_lo)), tl.max(tl.abs(x_hi)))
+    # 6 * 2^-126 is from https://huggingface.co/deepseek-ai/DeepSeek-V4-Pro/blob/main/inference/kernel.py#L163
+    amax = tl.maximum(amax, 6.0 * (2**-126))
+    # ue8m0 block scale: 2^ceil(log2(amax/6.0)).
+    log2_ratio = tl.math.ceil(tl.math.log2(amax * (1.0 / 6.0)))
+    log2_ratio = tl.minimum(tl.maximum(log2_ratio, -127.0), 127.0)
+    scale = tl.math.exp2(log2_ratio)
+    ue8m0 = (log2_ratio + 127.0).to(tl.uint8)
+
+    inv_scale = 1.0 / scale
+    packed = _fp32x2_to_fp4x2(x_lo * inv_scale, x_hi * inv_scale)
+    return packed, ue8m0
+
+
+@triton.jit
+def _fused_indexer_q_rope_quant_kernel(
+    pos_ptr,
+    # Index Q RoPE
+    index_q_ptr,
+    index_q_stride0,
+    index_q_stride1,
+    index_q_cos_sin_ptr,
+    index_q_cos_sin_stride,
+    INDEX_Q_HALF_ROT_DIM: tl.constexpr,
+    # Index Q Quantize
+    index_q_fp8_ptr,
+    index_q_fp8_stride0,
+    index_q_fp8_stride1,
+    INDEX_Q_HEAD_DIM: tl.constexpr,
+    # Index weights
+    index_weights_ptr,
+    index_weights_stride,
+    index_weights_softmax_scale,
+    index_weights_head_scale,
+    index_weights_out_ptr,
+    index_weights_out_stride,
+):
+    # Layout matches the unfused reference (DeepseekV4ScalingRotaryEmbedding
+    # + per_token_group_quant_fp8): GPT-J interleaved RoPE applied to the
+    # LAST rope_dim dims of each head; the leading [0, NOPE_DIM) is passed
+    # through unchanged.
+    INDEX_Q_ROT_DIM: tl.constexpr = 2 * INDEX_Q_HALF_ROT_DIM
+    INDEX_Q_NOPE_DIM: tl.constexpr = INDEX_Q_HEAD_DIM - INDEX_Q_ROT_DIM
+    tl.static_assert(INDEX_Q_NOPE_DIM >= 0)
+
+    tok_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+
+    pos = tl.load(pos_ptr + tok_idx)
+    cos, sin = _get_cos_sin(
+        index_q_cos_sin_ptr,
+        index_q_cos_sin_stride,
+        pos,
+        INDEX_Q_HALF_ROT_DIM,
+    )
+    half_offset = tl.arange(0, INDEX_Q_HALF_ROT_DIM)
+    base_ptr = index_q_ptr + tok_idx * index_q_stride0 + head_idx * index_q_stride1
+
+    # Interleaved (GPT-J) RoPE on dims [NOPE_DIM, HEAD_DIM):
+    #   even = q[NOPE_DIM + 2*i],  odd = q[NOPE_DIM + 2*i + 1]
+    rot_base = base_ptr + INDEX_Q_NOPE_DIM
+    x_even = tl.load(rot_base + half_offset * 2).to(tl.float32)
+    x_odd = tl.load(rot_base + half_offset * 2 + 1).to(tl.float32)
+    r_even = x_even * cos - x_odd * sin
+    r_odd = x_odd * cos + x_even * sin
+
+    # Match reference numerics: fp32 → bf16 → fp32 before the ue8m0 absmax.
+    # Same pattern as the K-side compressor kernel (fused_compress_quant_cache.py).
+    r_even = r_even.to(tl.bfloat16).to(tl.float32)
+    r_odd = r_odd.to(tl.bfloat16).to(tl.float32)
+
+    amax = tl.maximum(tl.max(tl.abs(r_even)), tl.max(tl.abs(r_odd)))
+    if INDEX_Q_NOPE_DIM > 0:
+        nope_offset = tl.arange(0, INDEX_Q_NOPE_DIM)
+        x_nope = tl.load(base_ptr + nope_offset).to(tl.float32)
+        amax = tl.maximum(amax, tl.max(tl.abs(x_nope)))
+    index_q_scale = tl.div_rn(tl.maximum(amax, 1e-4), 448.0)
+    index_q_scale = tl.math.exp2(tl.math.ceil(tl.math.log2(index_q_scale)))
+
+    # Store quantized values to index_q_fp8
+    fp8_base_ptr = (
+        index_q_fp8_ptr + tok_idx * index_q_fp8_stride0 + head_idx * index_q_fp8_stride1
+    )
+    if INDEX_Q_NOPE_DIM > 0:
+        tl.store(
+            fp8_base_ptr + nope_offset,
+            tl.div_rn(x_nope, index_q_scale).to(tl.float8e4nv),
+        )
+    fp8_rot_base = fp8_base_ptr + INDEX_Q_NOPE_DIM
+    tl.store(
+        fp8_rot_base + half_offset * 2,
+        tl.div_rn(r_even, index_q_scale).to(tl.float8e4nv),
+    )
+    tl.store(
+        fp8_rot_base + half_offset * 2 + 1,
+        tl.div_rn(r_odd, index_q_scale).to(tl.float8e4nv),
+    )
+
+    # FP8 weight-fold contract:
+    #   index_weights_out = index_weights * q_scale * softmax_scale * head_scale
+    # The per-token-per-head q_scale (fp32) IS folded into the output weights
+    # here because FP8 Q is stored WITHOUT a companion scale tensor — the
+    # downstream fp8_fp4_mqa_logits/fp8_fp4_paged_mqa_logits kernels use `weights` to
+    # apply per-token Q scale inline. See the MXFP4 kernel below for the
+    # contrasting convention (scales live with the Q values, weights are NOT
+    # q-scaled).
+    index_weights = tl.load(
+        index_weights_ptr + tok_idx * index_weights_stride + head_idx
+    )
+    index_weights = index_weights.to(tl.float32)
+    index_weights *= index_q_scale
+    index_weights *= index_weights_softmax_scale
+    index_weights *= index_weights_head_scale
+    tl.store(
+        index_weights_out_ptr + tok_idx * index_weights_out_stride + head_idx,
+        index_weights,
+    )
+
+
+@triton.jit
+def _fused_indexer_q_rope_mxfp4_kernel(
+    pos_ptr,
+    # Index Q RoPE input (fp/bf16)
+    index_q_ptr,
+    index_q_stride0,
+    index_q_stride1,
+    index_q_cos_sin_ptr,
+    index_q_cos_sin_stride,
+    INDEX_Q_HALF_ROT_DIM: tl.constexpr,
+    # MXFP4 Q outputs
+    index_q_mxfp4_ptr,  # uint8, (T, H, HEAD_DIM // 2)
+    index_q_mxfp4_stride0,
+    index_q_mxfp4_stride1,
+    index_q_scale_ptr,  # uint8 ue8m0, (T, H, HEAD_DIM // BLOCK)
+    index_q_scale_stride0,
+    index_q_scale_stride1,
+    INDEX_Q_HEAD_DIM: tl.constexpr,
+    MXFP4_BLOCK: tl.constexpr,
+    # Weights (NO per-token q_scale fold for MXFP4; per-block scales stay
+    # with the Q values in the output scale tensor).
+    index_weights_ptr,
+    index_weights_stride,
+    index_weights_softmax_scale,
+    index_weights_head_scale,
+    index_weights_out_ptr,
+    index_weights_out_stride,
+):
+    INDEX_Q_ROT_DIM: tl.constexpr = 2 * INDEX_Q_HALF_ROT_DIM
+    INDEX_Q_NOPE_DIM: tl.constexpr = INDEX_Q_HEAD_DIM - INDEX_Q_ROT_DIM
+    NUM_NOPE_BLOCKS: tl.constexpr = INDEX_Q_NOPE_DIM // MXFP4_BLOCK
+    NUM_ROPE_BLOCKS: tl.constexpr = INDEX_Q_ROT_DIM // MXFP4_BLOCK
+    HALF_BLOCK: tl.constexpr = MXFP4_BLOCK // 2
+    tl.static_assert(INDEX_Q_NOPE_DIM >= 0)
+    tl.static_assert(INDEX_Q_NOPE_DIM % MXFP4_BLOCK == 0)
+    tl.static_assert(INDEX_Q_ROT_DIM % MXFP4_BLOCK == 0)
+    tl.static_assert(MXFP4_BLOCK % 2 == 0)
+
+    tok_idx = tl.program_id(0)
+    head_idx = tl.program_id(1)
+
+    pos = tl.load(pos_ptr + tok_idx)
+
+    q_base = index_q_ptr + tok_idx * index_q_stride0 + head_idx * index_q_stride1
+    out_base = (
+        index_q_mxfp4_ptr
+        + tok_idx * index_q_mxfp4_stride0
+        + head_idx * index_q_mxfp4_stride1
+    )
+    scale_base = (
+        index_q_scale_ptr
+        + tok_idx * index_q_scale_stride0
+        + head_idx * index_q_scale_stride1
+    )
+
+    half_off = tl.arange(0, HALF_BLOCK)
+
+    # ---- NoPE blocks: direct load, pair as (even-index, odd-index) values ----
+    for b in tl.static_range(NUM_NOPE_BLOCKS):
+        base = b * MXFP4_BLOCK
+        x_lo = tl.load(q_base + base + half_off * 2).to(tl.float32)
+        x_hi = tl.load(q_base + base + half_off * 2 + 1).to(tl.float32)
+        packed, ue8m0 = _quantize_mxfp4_pair(x_lo, x_hi)
+        tl.store(out_base + base // 2 + half_off, packed)
+        tl.store(scale_base + b, ue8m0)
+
+    # ---- RoPE blocks: apply GPT-J interleaved RoPE to the block's 16 pairs,
+    # then quantize. Each block covers HALF_BLOCK (=16) cos/sin pairs. ----
+    rot_q_base = q_base + INDEX_Q_NOPE_DIM
+    for b in tl.static_range(NUM_ROPE_BLOCKS):
+        pair_off = b * HALF_BLOCK + half_off  # indices in [0, HALF_ROT_DIM)
+        cos_b = tl.load(
+            index_q_cos_sin_ptr + pos * index_q_cos_sin_stride + pair_off
+        ).to(tl.float32)
+        sin_b = tl.load(
+            index_q_cos_sin_ptr
+            + pos * index_q_cos_sin_stride
+            + pair_off
+            + INDEX_Q_HALF_ROT_DIM
+        ).to(tl.float32)
+        x_even = tl.load(rot_q_base + pair_off * 2).to(tl.float32)
+        x_odd = tl.load(rot_q_base + pair_off * 2 + 1).to(tl.float32)
+        r_even = x_even * cos_b - x_odd * sin_b
+        r_odd = x_odd * cos_b + x_even * sin_b
+        # bf16 roundtrip for parity with the FP8 kernel / reference numerics.
+        r_even = r_even.to(tl.bfloat16).to(tl.float32)
+        r_odd = r_odd.to(tl.bfloat16).to(tl.float32)
+        packed, ue8m0 = _quantize_mxfp4_pair(r_even, r_odd)
+        rope_byte_off = (INDEX_Q_NOPE_DIM + b * MXFP4_BLOCK) // 2
+        tl.store(out_base + rope_byte_off + half_off, packed)
+        tl.store(scale_base + NUM_NOPE_BLOCKS + b, ue8m0)
+
+    # MXFP4 weight-fold contract:
+    #   index_weights_out = index_weights * softmax_scale * head_scale
+    # NOTE: q_scale is NOT folded here (contrast with the FP8 kernel above).
+    # MXFP4 Q emits a separate ue8m0 scale tensor of shape
+    # (T, H, HEAD_DIM // MXFP4_BLOCK) alongside the packed values, so each
+    # per-block scale is applied by the downstream MXFP4 logits kernel when
+    # dequantizing Q — there is no per-token scalar to fold into `weights`.
+    index_weights = tl.load(
+        index_weights_ptr + tok_idx * index_weights_stride + head_idx
+    ).to(tl.float32)
+    index_weights *= index_weights_softmax_scale
+    index_weights *= index_weights_head_scale
+    tl.store(
+        index_weights_out_ptr + tok_idx * index_weights_out_stride + head_idx,
+        index_weights,
+    )
+
+
+def fused_indexer_q_rope_quant(
+    positions: torch.Tensor,
+    index_q: torch.Tensor,
+    index_q_cos_sin_cache: torch.Tensor,
+    # Index weights
+    index_weights: torch.Tensor,
+    index_weights_softmax_scale: float,
+    index_weights_head_scale: float,
+    use_fp4: bool = False,
+) -> tuple[
+    torch.Tensor | tuple[torch.Tensor, torch.Tensor],
+    torch.Tensor,
+]:
+    """Fused RoPE + quantize Q for the sparse indexer.
+
+    Weight-fold semantics (important — the two paths differ):
+
+    FP8 path (use_fp4=False, default):
+        q_fp8      : (T, H, HEAD_DIM) float8_e4m3fn, per-token-per-head
+                     scalar scale (NOT stored — folded into weights below)
+        weights_out = weights * q_scale * softmax_scale * head_scale
+        Rationale: a single per-token q_scale is a scalar the downstream FP8
+        logits kernel would otherwise multiply in. Folding it into `weights`
+        avoids emitting a separate tensor and is free for the logits kernel.
+
+    MXFP4 path (use_fp4=True):
+        q_packed   : (T, H, HEAD_DIM // 2) uint8 (2 E2M1 nibbles per byte)
+        q_scale    : (T, H, HEAD_DIM // MXFP4_BLOCK_SIZE) uint8 ue8m0 bytes
+        weights_out = weights * softmax_scale * head_scale
+        Rationale: MXFP4 has PER-BLOCK (32-element) scales that live with
+        the Q values — they cannot be folded into a per-token weight
+        scalar, so `weights` carries only the softmax and head scales.
+
+    Returns (q_quant, weights_out) where q_quant is either a Tensor (FP8) or
+    a (values, scales) tuple (MXFP4). This matches the union type accepted
+    by `SparseAttnIndexer.forward_*`.
+    """
+    assert positions.ndim == 1
+    assert index_q.ndim == 3
+    assert index_q_cos_sin_cache.ndim == 2
+
+    num_tokens = positions.shape[0]
+    num_index_q_heads = index_q.shape[1]
+    index_q_head_dim = index_q.shape[2]
+
+    index_weights_out = torch.empty_like(index_weights, dtype=torch.float32)
+
+    if use_fp4:
+        assert index_q_head_dim % MXFP4_BLOCK_SIZE == 0, (
+            f"head_dim={index_q_head_dim} must be a multiple of MXFP4 block "
+            f"size {MXFP4_BLOCK_SIZE}"
+        )
+        num_scale_blocks = index_q_head_dim // MXFP4_BLOCK_SIZE
+        index_q_packed = torch.empty(
+            (num_tokens, num_index_q_heads, index_q_head_dim // 2),
+            dtype=torch.uint8,
+            device=index_q.device,
+        )
+        index_q_scale = torch.empty(
+            (num_tokens, num_index_q_heads, num_scale_blocks),
+            dtype=torch.uint8,
+            device=index_q.device,
+        )
+        _fused_indexer_q_rope_mxfp4_kernel[(num_tokens, num_index_q_heads)](
+            positions,
+            index_q,
+            index_q.stride(0),
+            index_q.stride(1),
+            index_q_cos_sin_cache,
+            index_q_cos_sin_cache.stride(0),
+            index_q_cos_sin_cache.shape[-1] // 2,
+            index_q_packed,
+            index_q_packed.stride(0),
+            index_q_packed.stride(1),
+            index_q_scale,
+            index_q_scale.stride(0),
+            index_q_scale.stride(1),
+            index_q_head_dim,
+            MXFP4_BLOCK_SIZE,
+            index_weights,
+            index_weights.stride(0),
+            index_weights_softmax_scale,
+            index_weights_head_scale,
+            index_weights_out,
+            index_weights_out.stride(0),
+            num_warps=1,  # TODO: Tune this
+        )
+
+        # Values stay uint8 (2 E2M1 nibbles per byte). Scales are 4 ue8m0
+        # bytes per (token, head) reinterpreted as one int32, then squeezed
+        # from (T, H, 1) to (T, H) to match DeepGEMM's expected q_sf rank
+        # (prefill wants 2-D (seq_len, num_heads); decode reshapes this to
+        # 3-D (batch, next_n, num_heads)).
+        return (
+            index_q_packed,
+            index_q_scale.view(torch.int32).squeeze(-1),
+        ), index_weights_out
+
+    index_q_fp8 = torch.empty_like(index_q, dtype=torch.float8_e4m3fn)
+    _fused_indexer_q_rope_quant_kernel[(num_tokens, num_index_q_heads)](
+        positions,
+        index_q,
+        index_q.stride(0),
+        index_q.stride(1),
+        index_q_cos_sin_cache,
+        index_q_cos_sin_cache.stride(0),
+        index_q_cos_sin_cache.shape[-1] // 2,
+        index_q_fp8,
+        index_q_fp8.stride(0),
+        index_q_fp8.stride(1),
+        index_q_head_dim,
+        index_weights,
+        index_weights.stride(0),
+        index_weights_softmax_scale,
+        index_weights_head_scale,
+        index_weights_out,
+        index_weights_out.stride(0),
+        num_warps=1,  # TODO: Tune this
+    )
+    return index_q_fp8, index_weights_out

--- a/src/flag_gems/fused/fused_indexer_q_rope_quant.py
+++ b/src/flag_gems/fused/fused_indexer_q_rope_quant.py
@@ -2,7 +2,6 @@
 # SPDX-FileCopyrightText: Copyright contributors to the vLLM project
 
 import torch
-
 import triton
 import triton.language as tl
 
@@ -290,10 +289,7 @@ def fused_indexer_q_rope_quant(
     index_weights_softmax_scale: float,
     index_weights_head_scale: float,
     use_fp4: bool = False,
-) -> tuple[
-    torch.Tensor | tuple[torch.Tensor, torch.Tensor],
-    torch.Tensor,
-]:
+) -> tuple[torch.Tensor | tuple[torch.Tensor, torch.Tensor], torch.Tensor,]:
     """Fused RoPE + quantize Q for the sparse indexer.
 
     Weight-fold semantics (important — the two paths differ):

--- a/src/flag_gems/fused/fused_indexer_q_rope_quant.py
+++ b/src/flag_gems/fused/fused_indexer_q_rope_quant.py
@@ -329,6 +329,14 @@ def fused_indexer_q_rope_quant(
     index_weights_out = torch.empty_like(index_weights, dtype=torch.float32)
 
     if use_fp4:
+        if not index_q.is_cuda:
+            raise RuntimeError("MXFP4 fused_indexer_q_rope_quant requires CUDA")
+        major, _ = torch.cuda.get_device_capability(index_q.device)
+        if major < 10:
+            raise RuntimeError(
+                "MXFP4 fused_indexer_q_rope_quant requires sm100 or newer; "
+                f"got sm{major}x"
+            )
         assert index_q_head_dim % MXFP4_BLOCK_SIZE == 0, (
             f"head_dim={index_q_head_dim} must be a multiple of MXFP4 block "
             f"size {MXFP4_BLOCK_SIZE}"

--- a/tests/test_fused_indexer_q_rope_quant.py
+++ b/tests/test_fused_indexer_q_rope_quant.py
@@ -1,0 +1,137 @@
+import pytest
+import torch
+
+import flag_gems
+
+HEAD_DIM = 128
+ROPE_DIM = 64
+NUM_HEADS = 8
+MAX_POS = 4096
+MXFP4_BLOCK_SIZE = 32
+
+HAS_NATIVE_FP8 = hasattr(torch, "float8_e4m3fn") and (
+    flag_gems.SUPPORTED_FP8_DTYPE == torch.float8_e4m3fn
+)
+
+
+def _make_cos_sin_cache(max_pos, rope_dim, device, dtype):
+    half = rope_dim // 2
+    inv_freq = 1.0 / (
+        10000.0 ** (torch.arange(0, half, device=device, dtype=torch.float32) / half)
+    )
+    t = torch.arange(max_pos, device=device, dtype=torch.float32)
+    freqs = torch.outer(t, inv_freq)
+    return torch.cat((freqs.cos(), freqs.sin()), dim=-1).to(dtype)
+
+
+def _rotate_tail_gptj(q, positions, cos_sin_cache):
+    nope_dim = HEAD_DIM - ROPE_DIM
+    half = ROPE_DIM // 2
+    cos_sin = cos_sin_cache.index_select(0, positions).float()
+    cos = cos_sin[:, :half].unsqueeze(1)
+    sin = cos_sin[:, half:].unsqueeze(1)
+
+    q_rot = q.float()
+    tail = q_rot[..., nope_dim:]
+    even = tail[..., 0::2]
+    odd = tail[..., 1::2]
+    rot_even = (even * cos - odd * sin).to(torch.bfloat16).float()
+    rot_odd = (odd * cos + even * sin).to(torch.bfloat16).float()
+    q_rot[..., nope_dim::2] = rot_even
+    q_rot[..., nope_dim + 1 :: 2] = rot_odd
+    return q_rot
+
+
+def _reference_fp8(q_rot, weights, softmax_scale, head_scale):
+    amax = q_rot.abs().amax(dim=-1)
+    q_scale = torch.exp2(torch.ceil(torch.log2(amax.clamp(min=1e-4) / 448.0)))
+    q_fp8 = (q_rot / q_scale.unsqueeze(-1)).to(torch.float8_e4m3fn)
+    weights_out = weights.float() * q_scale * softmax_scale * head_scale
+    return q_fp8, weights_out
+
+
+def _quantize_to_mxfp4(x):
+    orig_shape = x.shape
+    head_dim = orig_shape[-1]
+    n_blocks = head_dim // MXFP4_BLOCK_SIZE
+    x_f32 = x.float().reshape(-1, n_blocks, MXFP4_BLOCK_SIZE)
+
+    amax = x_f32.abs().amax(dim=-1, keepdim=True).clamp(min=6 * (2**-126))
+    log2_ratio = (amax / 6.0).log2().ceil().clamp(-127.0, 127.0)
+    scale = log2_ratio.exp2()
+    ue8m0 = (log2_ratio + 127.0).to(torch.uint8)
+
+    x_scaled = (x_f32 / scale).clamp(-6.0, 6.0)
+    abs_x = x_scaled.abs()
+    code = torch.zeros_like(abs_x, dtype=torch.int32)
+    code = torch.where(abs_x > 0.25, 1, code)
+    code = torch.where(abs_x >= 0.75, 2, code)
+    code = torch.where(abs_x > 1.25, 3, code)
+    code = torch.where(abs_x >= 1.75, 4, code)
+    code = torch.where(abs_x > 2.5, 5, code)
+    code = torch.where(abs_x >= 3.5, 6, code)
+    code = torch.where(abs_x > 5.0, 7, code)
+    sign = ((x_scaled.view(torch.int32) >> 31) & 1).to(torch.uint8)
+    nibble = code.to(torch.uint8) | (sign << 3)
+
+    nibble_flat = nibble.reshape(-1, head_dim)
+    packed = (nibble_flat[:, 0::2] | (nibble_flat[:, 1::2] << 4)).contiguous()
+    packed = packed.reshape(*orig_shape[:-1], head_dim // 2)
+    scales = ue8m0.view(*orig_shape[:-1], n_blocks)
+    return packed, scales
+
+
+def _reference_mxfp4(q_rot, weights, softmax_scale, head_scale):
+    q_packed, q_scale = _quantize_to_mxfp4(q_rot)
+    weights_out = weights.float() * softmax_scale * head_scale
+    return (q_packed, q_scale.view(torch.int32).squeeze(-1)), weights_out
+
+
+@pytest.mark.fused_indexer_q_rope_quant
+@pytest.mark.skipif(flag_gems.device != "cuda", reason="requires CUDA")
+@pytest.mark.skipif(not HAS_NATIVE_FP8, reason="requires native float8_e4m3fn support")
+@pytest.mark.parametrize("num_tokens", [1, 7, 32])
+@pytest.mark.parametrize("cache_dtype", [torch.float32, torch.bfloat16])
+@pytest.mark.parametrize("use_fp4", [False, True])
+@torch.inference_mode()
+def test_fused_indexer_q_rope_quant(num_tokens, cache_dtype, use_fp4):
+    device = flag_gems.device
+    torch.manual_seed(0)
+
+    q = torch.randn(
+        num_tokens, NUM_HEADS, HEAD_DIM, dtype=torch.bfloat16, device=device
+    )
+    positions = torch.randint(
+        0, MAX_POS, (num_tokens,), dtype=torch.int64, device=device
+    )
+    cos_sin_cache = _make_cos_sin_cache(MAX_POS, ROPE_DIM, device, cache_dtype)
+    weights = torch.randn(num_tokens, NUM_HEADS, dtype=torch.bfloat16, device=device)
+    softmax_scale = HEAD_DIM**-0.5
+    head_scale = NUM_HEADS**-0.5
+
+    q_rot = _rotate_tail_gptj(q, positions, cos_sin_cache)
+    if use_fp4:
+        q_ref, weights_ref = _reference_mxfp4(q_rot, weights, softmax_scale, head_scale)
+    else:
+        q_ref, weights_ref = _reference_fp8(q_rot, weights, softmax_scale, head_scale)
+
+    q_out, weights_out = flag_gems.fused_indexer_q_rope_quant(
+        positions,
+        q,
+        cos_sin_cache,
+        weights,
+        softmax_scale,
+        head_scale,
+        use_fp4=use_fp4,
+    )
+
+    if use_fp4:
+        q_ref_values, q_ref_scales = q_ref
+        q_out_values, q_out_scales = q_out
+        assert torch.equal(q_ref_scales, q_out_scales)
+        assert torch.equal(q_ref_values, q_out_values)
+    else:
+        assert torch.equal(q_ref.view(torch.int8), q_out.view(torch.int8))
+
+    assert weights_out.dtype == torch.float32
+    torch.testing.assert_close(weights_out, weights_ref, rtol=0, atol=0)

--- a/tests/test_fused_indexer_q_rope_quant.py
+++ b/tests/test_fused_indexer_q_rope_quant.py
@@ -14,6 +14,13 @@ HAS_NATIVE_FP8 = hasattr(torch, "float8_e4m3fn") and (
 )
 
 
+def _supports_mxfp4_ptx():
+    if flag_gems.device != "cuda" or not torch.cuda.is_available():
+        return False
+    major, _ = torch.cuda.get_device_capability()
+    return major >= 10
+
+
 def _make_cos_sin_cache(max_pos, rope_dim, device, dtype):
     half = rope_dim // 2
     inv_freq = 1.0 / (
@@ -95,6 +102,9 @@ def _reference_mxfp4(q_rot, weights, softmax_scale, head_scale):
 @pytest.mark.parametrize("use_fp4", [False, True])
 @torch.inference_mode()
 def test_fused_indexer_q_rope_quant(num_tokens, cache_dtype, use_fp4):
+    if use_fp4 and not _supports_mxfp4_ptx():
+        pytest.skip("MXFP4 E2M1 PTX conversion requires sm100 or newer")
+
     device = flag_gems.device
     torch.manual_seed(0)
 


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
New Feature

### Description
add fused_indexer_q_rope_quant op

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
```
FlagGems/benchmark# pytest -s test_fused_indexer_q_rope_quant.py 
==================================== test session starts ====================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.13.0, xdoctest-1.0.2, rerunfailures-15.1, hypothesis-6.130.8, xdist-3.6.1, flakefinder-1.1.0, shard-0.1.2
collected 1 item                                                                            
Running 1 items in this shard

test_fused_indexer_q_rope_quant.py 
Operator: fused_indexer_q_rope_quant  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.176288            0.006240              28.251          [torch.Size([1]), torch.Size([1, 8, 128]), torch.Size([4096, 64]), torch.Size([1, 8]), 0.08838834764831845, 0.3535533905932738, False]
SUCCESS               0.180832            0.006432              28.114          [torch.Size([32]), torch.Size([32, 8, 128]), torch.Size([4096, 64]), torch.Size([32, 8]), 0.08838834764831845, 0.3535533905932738, False]

.

===================================== 1 passed in 4.13s =====================================
```
