### PR TITLE
Fix Kunlunxin setup

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -133,16 +133,21 @@ fi
 
 # export USE_TRITON=0
 
-## Vendor-specific installation steps
+#---- Vendor-specific installation steps -------------
 source tools/env.sh ${VENDOR}
-# source tools/vendor.sh ${VENDOR}
+
 if [ "$VENDOR" = "ascend-cann9" ]; then
-    uv pip install triton==3.5.0
-    uv pip install triton-ascend==3.2.1 --index ${FLAGOS_PYPI}
+  uv pip install triton==3.5.0
+  uv pip install "triton-ascend==3.2.1" --index ${FLAGOS_PYPI}
 fi
 
 uv pip install ".[${VENDOR}]" --default-index ${FLAGOS_PYPI} \
     --index https://mirrors.aliyun.com/pypi/simple \
+
+# Kunlunxin needs an override of the default Triton installed (3.5.0)
+if [ "$VENDOR" = "kunlunxin" ]; then
+  uv pip install "triton==3.0.0+a48aedef" --index ${FLAGOS_PYPI}
+fi
 
 uv pip install ".[test]"
 


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The Kunlunxin backend has a specialized triton that needs to be installed **AFTER** the default Triton==3.5.0 is dragged in. This is a special step that was previously captured in the `tools/vendor.sh` script. While we are gradually eliminating the `vendor.sh` script, this steps has to be included in the main `setup.sh` file.