### PR TITLE
Remove buggy plugin dragged in by Triton on kunlunxin

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -147,6 +147,8 @@ uv pip install ".[${VENDOR}]" --default-index ${FLAGOS_PYPI} \
 # Kunlunxin needs an override of the default Triton installed (3.5.0)
 if [ "$VENDOR" = "kunlunxin" ]; then
   uv pip install "triton==3.0.0+a48aedef" --index ${FLAGOS_PYPI}
+  # Kunlunxin triton drags in a buggy pytest plugin which has to be uninstalled
+  uv pip uninstall pytest-repeat
 fi
 
 uv pip install ".[test]"


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The Kunlunxin customized Triton package has a builtin dependency over pytest-repeat which is buggy. It has to be removed.