### PR TITLE
[KernelGen][Nvidia] Add fp8_fp4_mqa_logits Triton kernel

### DIFF
--- a/benchmark/test_fp8_fp4_mqa_logits.py
+++ b/benchmark/test_fp8_fp4_mqa_logits.py
@@ -1,0 +1,105 @@
+import pytest
+import torch
+
+try:
+    from vllm.platforms import current_platform
+    from vllm.third_party.deep_gemm.utils import per_custom_dims_cast_to_fp8
+    from vllm.utils.deep_gemm import fp8_fp4_mqa_logits as vllm_fp8_fp4_mqa_logits
+
+    VLLM_AVAILABLE = True
+    SM90_AVAILABLE = current_platform.has_device_capability(90)
+except ImportError:
+    VLLM_AVAILABLE = False
+    SM90_AVAILABLE = False
+
+from . import base
+
+# DeepSeek V4 production config
+H = 64
+D = 128
+
+
+def _build_case(M, N, dtype, device):
+    """Build FP8 quantized inputs for benchmarking."""
+    q_bf16 = torch.randn(M, H, D, device=device, dtype=dtype)
+    k_bf16 = torch.randn(N, D, device=device, dtype=dtype)
+    weights = torch.randn(M, H, device=device, dtype=torch.float32).abs()
+
+    q_fp8 = q_bf16.clamp(
+        min=torch.finfo(torch.float8_e4m3fn).min,
+        max=torch.finfo(torch.float8_e4m3fn).max,
+    ).to(torch.float8_e4m3fn)
+    k_fp8, k_scale = per_custom_dims_cast_to_fp8(k_bf16, (0,), False)
+
+    ks = torch.zeros(M, dtype=torch.int32, device=device)
+    ke = torch.full((M,), N, dtype=torch.int32, device=device)
+
+    return q_fp8, k_fp8, k_scale, weights, ks, ke
+
+
+class FP8FP4MQALogitsBenchmark(base.Benchmark):
+    """Benchmark for fp8_fp4_mqa_logits: FlagGems Triton vs vLLM DeepGEMM."""
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = [
+            (1, 1024),
+            (1, 2048),
+            (1, 4096),
+            (4, 2048),
+            (4, 4096),
+            (64, 4096),
+            (256, 4096),
+            (1024, 4096),
+            (2048, 4096),
+            (4096, 8192),
+            (1024, 8192),
+        ]
+
+    def get_input_iter(self, dtype):
+        for M, N in self.shapes:
+            case = _build_case(M, N, dtype, self.device)
+            q_fp8, k_fp8, k_scale, weights, ks, ke = case
+            yield (q_fp8, k_fp8, k_scale, weights, ks, ke, dtype)
+
+
+def _vllm_wrapper(q_fp8, k_fp8, k_scale, weights, ks, ke, dtype):
+    return vllm_fp8_fp4_mqa_logits(
+        q=(q_fp8, None),
+        kv=(k_fp8, k_scale),
+        weights=weights,
+        cu_seqlen_ks=ks,
+        cu_seqlen_ke=ke,
+        clean_logits=True,
+    )
+
+
+def _gems_wrapper(q_fp8, k_fp8, k_scale, weights, ks, ke, dtype):
+    from flag_gems.fused import fp8_fp4_mqa_logits
+
+    return fp8_fp4_mqa_logits(
+        q=(q_fp8, None),
+        kv=(k_fp8, k_scale),
+        weights=weights,
+        cu_seqlen_ks=ks,
+        cu_seqlen_ke=ke,
+        clean_logits=True,
+    )
+
+
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() and SM90_AVAILABLE),
+    reason="requires CUDA with Hopper architecture (SM90+)",
+)
+@pytest.mark.skipif(
+    not VLLM_AVAILABLE,
+    reason="requires vLLM with DeepGEMM and FP8 quantization support",
+)
+@pytest.mark.fp8_fp4_mqa_logits
+def test_fp8_fp4_mqa_logits():
+    bench = FP8FP4MQALogitsBenchmark(
+        op_name="fp8_fp4_mqa_logits",
+        torch_op=_vllm_wrapper,
+        gems_op=_gems_wrapper,
+        dtypes=[torch.bfloat16],
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -2674,6 +2674,21 @@ ops:
       - Math
     stages:
       - alpha: '5.3'
+  - id: fp8_fp4_mqa_logits
+    description: |
+      Compute weighted MQA logits with FP8 quantized Q and K tensors.
+      Uses head-batched tiled dot products with K reuse for high throughput
+      on DeepSeek V4 sparse attention indexer workloads.
+    for:
+      - vllm.utils.deep_gemm.fp8_fp4_mqa_logits
+    labels:
+      - fused
+      - vLLM
+      - KernelGen
+    kind:
+      - NeuralNetwork
+    stages:
+      - alpha: '5.1'
   - id: fp8_mqa_logits
     description: |
       For each token in the given E4M3 tensor, iterate all tokens from two other given tensors,

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -27,6 +27,7 @@ from flag_gems.fused.FLA import (
 from flag_gems.fused.flash_mla import flash_mla
 from flag_gems.fused.flash_mla_with_kvcache import flash_mla_with_kvcache
 from flag_gems.fused.flashmla_sparse import flash_mla_sparse_fwd
+from flag_gems.fused.fp8_fp4_mqa_logits import fp8_fp4_mqa_logits
 from flag_gems.fused.fused_add_rms_norm import fused_add_rms_norm
 from flag_gems.fused.fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert import (
     fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert,
@@ -105,6 +106,7 @@ __all__ = [
     "flash_mla",
     "flash_mla_sparse_fwd",
     "flash_mla_with_kvcache",
+    "fp8_fp4_mqa_logits",
     "fused_add_rms_norm",
     "fused_deepseek_v4_qnorm_rope_kv_rope_quant_insert",
     "fused_experts_impl",

--- a/src/flag_gems/fused/fp8_fp4_mqa_logits.py
+++ b/src/flag_gems/fused/fp8_fp4_mqa_logits.py
@@ -1,0 +1,236 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems import runtime
+from flag_gems.utils import libentry, libtuner
+
+logger = logging.getLogger(__name__)
+
+
+@libentry()
+@libtuner(
+    configs=runtime.get_tuned_config("fp8_fp4_mqa_logits"),
+    key=["M", "N", "H", "D"],
+)
+@triton.jit
+def _fp8_fp4_mqa_logits_kernel(
+    Q_ptr,
+    K_ptr,
+    K_scale_ptr,
+    W_ptr,
+    O_ptr,
+    M,
+    N,
+    H: tl.constexpr,
+    D: tl.constexpr,
+    stride_qm,
+    stride_qh,
+    stride_qd,
+    stride_kn,
+    stride_kd,
+    stride_om,
+    stride_on,
+    stride_wm,
+    stride_wh,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_BLOCK: tl.constexpr,
+):
+    """Fused FP8 MQA logits with head-batched tiled dot products.
+
+    Computes logits[m, n] = sum_h(ReLU(sum_d(q[m,h,d]*k[n,d]) * k_scale[n])
+                                  * weights[m, h])
+
+    K is loaded once per (BLOCK_M, BLOCK_N) tile and reused across HEAD_BLOCK
+    heads to minimize global memory traffic.
+    """
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    m_offs = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    n_offs = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    d_offs = tl.arange(0, D)
+
+    m_mask = m_offs < M
+    n_mask = n_offs < N
+
+    # Load K tile once — reused across all head batches
+    k = tl.load(
+        K_ptr + n_offs[:, None] * stride_kn + d_offs[None, :] * stride_kd,
+        mask=n_mask[:, None] & (d_offs[None, :] < D),
+        other=0.0,
+    )
+
+    k_scale = tl.load(K_scale_ptr + n_offs, mask=n_mask, other=0.0)
+
+    # Accumulator for output: [BLOCK_M, BLOCK_N] in fp32
+    acc = tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32)
+
+    for hb in range(0, H, HEAD_BLOCK):
+        hb_offs = hb + tl.arange(0, HEAD_BLOCK)
+
+        # Load Q for this head batch: [BLOCK_M, HEAD_BLOCK, D]
+        q = tl.load(
+            Q_ptr
+            + m_offs[:, None, None] * stride_qm
+            + hb_offs[None, :, None] * stride_qh
+            + d_offs[None, None, :] * stride_qd,
+            mask=m_mask[:, None, None]
+            & (hb_offs[None, :, None] < H)
+            & (d_offs[None, None, :] < D),
+            other=0.0,
+        )
+
+        # Flatten to 2D for MMA: [BLOCK_M * HEAD_BLOCK, D]
+        q_2d = tl.reshape(q, [BLOCK_M * HEAD_BLOCK, D])
+
+        # Dot product: [BLOCK_M * HEAD_BLOCK, BLOCK_N]
+        dot = tl.dot(q_2d, tl.trans(k))
+
+        # Fused k_scale + ReLU activation
+        dot = tl.maximum(dot * k_scale[None, :], 0.0)
+
+        # Load weights for this head batch: [BLOCK_M, HEAD_BLOCK]
+        w = tl.load(
+            W_ptr + m_offs[:, None] * stride_wm + hb_offs[None, :] * stride_wh,
+            mask=m_mask[:, None] & (hb_offs[None, :] < H),
+            other=0.0,
+        )
+
+        # Weight each head's contribution
+        w_flat = tl.reshape(w, [BLOCK_M * HEAD_BLOCK])
+        dot = dot * w_flat[:, None]
+
+        # Reduce over head dimension: [BLOCK_M, HEAD_BLOCK, BLOCK_N] -> sum
+        dot_3d = tl.reshape(dot, [BLOCK_M, HEAD_BLOCK, BLOCK_N])
+        dot_reduced = tl.sum(dot_3d, axis=1)
+
+        acc += dot_reduced
+
+    # Store output tile
+    write_mask = m_mask[:, None] & n_mask[None, :]
+    out_ptrs = O_ptr + m_offs[:, None] * stride_om + n_offs[None, :] * stride_on
+    tl.store(out_ptrs, acc, mask=write_mask)
+
+
+@libentry()
+@triton.jit
+def _clean_logits_kernel(
+    O_ptr,
+    KS_ptr,
+    KE_ptr,
+    M,
+    N,
+    stride_om,
+    stride_on,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    """Fill invalid positions with -inf based on per-row [ks, ke) ranges."""
+    pid_m = tl.program_id(0)
+    pid_n = tl.program_id(1)
+
+    m_offs = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    n_offs = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    m_mask = m_offs < M
+    n_mask = n_offs < N
+
+    ks = tl.load(KS_ptr + m_offs, mask=m_mask, other=0)
+    ke = tl.load(KE_ptr + m_offs, mask=m_mask, other=0)
+
+    invalid_mask = (n_offs[None, :] < ks[:, None]) | (n_offs[None, :] >= ke[:, None])
+    write_mask = m_mask[:, None] & n_mask[None, :] & invalid_mask
+
+    neg_inf = float("-inf")
+    out_ptrs = O_ptr + m_offs[:, None] * stride_om + n_offs[None, :] * stride_on
+    tl.store(
+        out_ptrs,
+        neg_inf + tl.zeros([BLOCK_M, BLOCK_N], dtype=tl.float32),
+        mask=write_mask,
+    )
+
+
+def fp8_fp4_mqa_logits(
+    q: tuple,
+    kv: tuple,
+    weights: torch.Tensor,
+    cu_seqlen_ks: torch.Tensor,
+    cu_seqlen_ke: torch.Tensor,
+    clean_logits: bool = True,
+) -> torch.Tensor:
+    """Triton implementation of fp8_fp4_mqa_logits.
+
+    Computes weighted MQA logits with FP8 quantized Q and K tensors.
+    Uses head-batched tiled dot products with K reuse for high throughput.
+
+    Args:
+        q: Tuple of (q_values [M, H, D] fp8, q_scale or None).
+        kv: Tuple of (k_values [N, D] fp8, k_scales [N] fp32).
+        weights: [M, H] fp32 per-head weights.
+        cu_seqlen_ks: [M] int32 start indices for valid K range.
+        cu_seqlen_ke: [M] int32 end indices for valid K range.
+        clean_logits: Whether to fill invalid positions with -inf.
+
+    Returns:
+        logits: [M, N] fp32 output tensor.
+    """
+    logger.debug("GEMS FP8_FP4_MQA_LOGITS")
+
+    q_values, _ = q
+    k_values, k_scales = kv
+
+    M, H, D = q_values.shape
+    N = k_values.shape[0]
+
+    logits = torch.empty((M, N), dtype=torch.float32, device=q_values.device)
+
+    grid = lambda META: (
+        triton.cdiv(M, META["BLOCK_M"]),
+        triton.cdiv(N, META["BLOCK_N"]),
+    )
+
+    _fp8_fp4_mqa_logits_kernel[grid](
+        q_values,
+        k_values,
+        k_scales,
+        weights,
+        logits,
+        M,
+        N,
+        H,
+        D,
+        q_values.stride(0),
+        q_values.stride(1),
+        q_values.stride(2),
+        k_values.stride(0),
+        k_values.stride(1),
+        logits.stride(0),
+        logits.stride(1),
+        weights.stride(0),
+        weights.stride(1),
+    )
+
+    if clean_logits:
+        CLEAN_BLOCK_M = 8
+        CLEAN_BLOCK_N = 128
+        clean_grid = (
+            triton.cdiv(M, CLEAN_BLOCK_M),
+            triton.cdiv(N, CLEAN_BLOCK_N),
+        )
+        _clean_logits_kernel[clean_grid](
+            logits,
+            cu_seqlen_ks,
+            cu_seqlen_ke,
+            M,
+            N,
+            logits.stride(0),
+            logits.stride(1),
+            BLOCK_M=CLEAN_BLOCK_M,
+            BLOCK_N=CLEAN_BLOCK_N,
+        )
+
+    return logits

--- a/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
@@ -1741,6 +1741,35 @@ fp8_mqa_logits:
     stages:
       - 2
       - 3
+fp8_fp4_mqa_logits:
+  - gen: true
+    param_map:
+      META:
+        BLOCK_M: block_m
+        BLOCK_N: block_n
+        HEAD_BLOCK: head_block
+      num_warps: warps
+      num_stages: stages
+    block_m:
+      - 1
+      - 2
+      - 4
+      - 8
+    block_n:
+      - 64
+      - 128
+    head_block:
+      - 16
+      - 32
+      - 64
+    warps:
+      - 4
+      - 8
+    stages:
+      - 1
+      - 2
+      - 3
+
 # Shared memory tiling kernel for large tensors
 # Optimized for memory bandwidth by caching input tiles# Grid sample operator configurations
 grid_sample_2d_nearest:

--- a/tests/test_fp8_fp4_mqa_logits.py
+++ b/tests/test_fp8_fp4_mqa_logits.py
@@ -1,0 +1,94 @@
+import pytest
+import torch
+
+try:
+    from vllm.platforms import current_platform
+    from vllm.third_party.deep_gemm.utils import per_custom_dims_cast_to_fp8
+    from vllm.utils.deep_gemm import fp8_fp4_mqa_logits as vllm_fp8_fp4_mqa_logits
+
+    VLLM_AVAILABLE = True
+    SM90_AVAILABLE = current_platform.has_device_capability(90)
+except ImportError:
+    VLLM_AVAILABLE = False
+    SM90_AVAILABLE = False
+
+import flag_gems
+from flag_gems.fused.fp8_fp4_mqa_logits import fp8_fp4_mqa_logits
+
+from .accuracy_utils import gems_assert_close, to_reference
+
+device = flag_gems.device
+
+# DeepSeek V4 production config
+H = 64
+D = 128
+
+# Test shapes: (M, N) covering decode and prefill workloads
+DECODE_SHAPES = [(1, 1024), (1, 2048), (1, 4096), (4, 2048), (4, 4096)]
+PREFILL_SHAPES = [
+    (64, 4096),
+    (256, 4096),
+    (1024, 4096),
+    (2048, 4096),
+    (1024, 8192),
+]
+
+
+def _build_inputs(M, N, device):
+    """Build FP8 quantized inputs matching vLLM DeepGEMM conventions."""
+    torch.manual_seed(42)
+
+    q_bf16 = torch.randn(M, H, D, device=device, dtype=torch.bfloat16)
+    k_bf16 = torch.randn(N, D, device=device, dtype=torch.bfloat16)
+    weights = torch.randn(M, H, device=device, dtype=torch.float32).abs()
+
+    q_fp8 = q_bf16.to(torch.float8_e4m3fn)
+    k_fp8, k_scale = per_custom_dims_cast_to_fp8(k_bf16, (0,), False)
+
+    ks = torch.zeros(M, dtype=torch.int32, device=device)
+    ke = torch.full((M,), N, dtype=torch.int32, device=device)
+
+    return q_fp8, k_fp8, k_scale, weights, ks, ke
+
+
+@pytest.mark.fp8_fp4_mqa_logits
+@pytest.mark.skipif(
+    not (torch.cuda.is_available() and SM90_AVAILABLE),
+    reason="requires CUDA with Hopper architecture (SM90+)",
+)
+@pytest.mark.skipif(
+    not VLLM_AVAILABLE,
+    reason="requires vLLM with DeepGEMM and FP8 quantization support",
+)
+@pytest.mark.parametrize(
+    "M, N",
+    DECODE_SHAPES + PREFILL_SHAPES,
+    ids=[f"{m}x{n}" for m, n in DECODE_SHAPES + PREFILL_SHAPES],
+)
+@pytest.mark.parametrize("clean_logits", [True, False])
+def test_fp8_fp4_mqa_logits(M, N, clean_logits):
+    q_fp8, k_fp8, k_scale, weights, ks, ke = _build_inputs(M, N, device)
+
+    ref_out = vllm_fp8_fp4_mqa_logits(
+        q=(q_fp8, None),
+        kv=(k_fp8, k_scale),
+        weights=weights,
+        cu_seqlen_ks=ks,
+        cu_seqlen_ke=ke,
+        clean_logits=clean_logits,
+    )
+    ref_out = to_reference(ref_out)
+
+    with flag_gems.use_gems():
+        res_out = fp8_fp4_mqa_logits(
+            q=(q_fp8, None),
+            kv=(k_fp8, k_scale),
+            weights=weights,
+            cu_seqlen_ks=ks,
+            cu_seqlen_ke=ke,
+            clean_logits=clean_logits,
+        )
+
+    gems_assert_close(
+        res_out, ref_out, res_out.dtype, equal_nan=True, atol=5e-2, reduce_dim=1
+    )


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

New Feature

### Description

Add a Triton implementation of `fp8_fp4_mqa_logits` — the weighted FP8 MQA logits computation used by DeepSeek V4's sparse attention indexer.

The kernel replaces the vLLM DeepGEMM CUDA implementation (`vllm.utils.deep_gemm.fp8_fp4_mqa_logits`) with a portable Triton version that uses head-batched tiled dot products with K-tile reuse to minimize global memory traffic.

### Performance

Hardware: NVIDIA H20 | H=64, D=128 (DeepSeek V4 config)

Reference: `vllm.utils.deep_gemm.fp8_fp4_mqa_logits` (DeepGEMM CUDA kernel)

| Shape (M, N) | Label | Triton (us) | CUDA (us) | Speedup |
|---|---|---|---|---|
| (1, 1024) | decode-1-1k | 51.1 | 35.7 | 0.70x |
| (1, 2048) | decode-1-2k | 51.1 | 69.3 | 1.36x |
| (1, 4096) | decode-1-4k | 51.2 | 87.8 | 1.71x |
| (4, 2048) | decode-4-2k | 29.4 | 69.4 | 2.36x |
| (4, 4096) | decode-4-4k | 31.2 | 87.9 | 2.81x |
| (64, 4096) | prefill-64-4k | 73.1 | 87.8 | 1.20x |
| (256, 4096) | prefill-256-4k | 213.1 | 175.8 | 0.82x |
| (1024, 4096) | prefill-1024-4k | 766.1 | 585.9 | 0.76x |
| (2048, 4096) | prefill-2048-4k | 1527.0 | 1151.4 | 0.75x |
| (4096, 8192) | prefill-4096-8k | 6131.9 | 4411.8 | 0.72x |
| (1024, 8192) | prefill-1024-8k | 1526.6 | 1164.4 | 0.76x |
| **Geometric Mean** | — | — | — | **1.12x** |

**Notes:**
- Decode shapes (M<=4) show 1.36x-2.81x speedup over DeepGEMM CUDA due to better SM utilization with head-batched tiling
- Prefill shapes (M>=256) are 0.72x-0.82x vs CUDA; the DeepGEMM kernel uses hardware-specific WGMMA instructions not available in Triton
- The single M=1, N=1024 case (0.70x) is kernel-launch-latency dominated

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Files Changed

- **New**: `src/flag_gems/fused/fp8_fp4_mqa_logits.py` — Triton kernel + Python wrapper
- **New**: `tests/test_fp8_fp4_mqa_logits.py` — Correctness tests vs vLLM DeepGEMM reference
- **New**: `benchmark/test_fp8_fp4_mqa_logits.py` — Performance benchmark framework
- **Modified**: `src/flag_gems/fused/__init__.py` — Register operator
- **Modified**: `conf/operators.yaml` — Add operator metadata
- **Modified**: `src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml` — Add autotune search space

### Testing

Requires NVIDIA Hopper (SM90+) with vLLM DeepGEMM:
```bash
pytest tests/test_fp8_fp4_mqa_logits.py -m fp8_fp4_mqa_logits -v
```
