### PR TITLE
[Ascend] fix: fill_ ZeroDivisionError on empty tensor

### DIFF
--- a/src/flag_gems/runtime/backend/_ascend/ops/fill.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/fill.py
@@ -91,6 +91,8 @@ def fill_tensor_(self, value):
             f"fill_ only supports 0-dimension value tensor but got tensor with {value.ndim} dimensions."
         )
     N = self.numel()
+    if N == 0:
+        return self
     # FIXME: 910B3&910B4 have 40 AIV cores while 910B1 has 50, 910B2 has 48.
     grid = min(40, N)
     BLOCK_SIZE = (N + grid - 1) // grid
@@ -104,6 +106,8 @@ def fill_tensor_(self, value):
 def fill_scalar_(self, value):
     logger.debug("GEMS_ASCEND FILL_SCALAR_")
     N = self.numel()
+    if N == 0:
+        return self
     # FIXME: 910B3&910B4 have 40 AIV cores while 910B1 has 50, 910B2 has 48.
     grid = min(40, N)
     BLOCK_SIZE = (N + grid - 1) // grid


### PR DESCRIPTION
## Fix

`fill_tensor_()` and `fill_scalar_()` in `_ascend/ops/fill.py` crash with `ZeroDivisionError: integer division or modulo by zero` when `numel() == 0` because `grid = min(40, N)` returns 0, then `BLOCK_SIZE = (N + grid - 1) // grid` divides by zero.

PyTorch native `fill_` on empty tensor is a legal no-op — this fix adds early return for `N == 0`.

## Reproduction

```python
import torch
import flag_gems
flag_gems.enable()
torch.zeros(0, device="npu").fill_(0)  # ZeroDivisionError
```

Discovered during FlagOS 2.1 P0-1 Ascend SVT: SGLang weight loading calls `param[num_loaded:].data.fill_(0)` on `VocabParallelEmbedding`, hitting the empty-slice path.

## Changes

Only 4 lines added, Ascend backend only:

```diff
+    if N == 0:
+        return self
```

## Verification

- ✅ Ascend 910B4-1 x8, CANN 9.0.0, FlagGems 5.3.0rc2
- ✅ SGLang 0.5.11 + Qwen3.6-27B TP=2 loads weights without crash
- ✅ No impact on other vendors (CUDA/MUSA/etc unaffected)

## Related

Closes: #4019