### PR TITLE
Fix any_dim accuracy failure on Iluvatar BI-V150 (float16 input)

### DIFF
--- a/src/flag_gems/ops/any.py
+++ b/src/flag_gems/ops/any.py
@@ -118,6 +118,7 @@ def any_dim(inp, dim=None, keepdim=False):
         M = inp.numel() // N
 
         out = torch.empty(shape, dtype=torch.bool, device=inp.device)
+        inp = inp.to(torch.bool)
 
         grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
         with torch_device_fn.device(inp.device):
@@ -144,6 +145,7 @@ def any_dims(inp, dim=None, keepdim=False):
     M = inp.numel() // N
 
     out = torch.empty(shape, dtype=torch.bool, device=inp.device)
+    inp = inp.to(torch.bool)
 
     grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
     with torch_device_fn.device(inp.device):


### PR DESCRIPTION
## Summary
- **Operator:** any_dim
- **Error type:** accuracy_fail
- **Root cause:** When any_kernel_dim receives a non-bool input (e.g. float16), Triton's autotuner JIT specialization causes a pointer type mismatch: the output bool pointer (1 byte) gets written with a 2-byte stride inferred from the float16 input pointer, producing alternating [1,0,1,0,...] bytes in the output. This only manifests when the autotuner cache is populated by prior kernel invocations with different M,N values.
- **Fix:** Cast the compressed input tensor to torch.bool before passing it to any_kernel_dim in both any_dim() and any_dims(). Since torch.any only checks for non-zero values, bool conversion is semantically equivalent and ensures both input and output pointers use 1-byte elements, preventing the stride mismatch.
- **Files modified:**
  - `src/flag_gems/ops/any.py`

## Verification
- Accuracy test: 144/144 passed
- Benchmark: passed
- Format check: N/A

## Test Plan
- [ ] `pytest -m 'any_dim' tests/ --ref cpu -vs`
- [ ] `pytest -m 'any_dim' benchmark/ --level core --record log`

## Issue
- WEEKTEST-432
