### PR TITLE
[SiliconFlow] Skip segment_reduce benchmark on MUSA

### DIFF
--- a/benchmark/test_segment_reduce.py
+++ b/benchmark/test_segment_reduce.py
@@ -5,6 +5,11 @@ import flag_gems
 
 from . import base, consts
 
+pytestmark = pytest.mark.skipif(
+    flag_gems.vendor_name in ["mthreads"],
+    reason="Issue #4114: Not supported on Moore Threads MUSA",
+)
+
 REDUCTIONS = ("sum", "mean", "max", "min", "prod")
 
 


### PR DESCRIPTION
## Summary
- Skip the `segment_reduce` benchmark on Moore Threads / MUSA with a file-level `pytest.mark.skipif`.
- The underlying failure is internal issue 576 and GitHub Issue #4114: MUSA does not provide the native PyTorch `segment_reduce` baseline used by the benchmark.
- Leave the operator implementation, accuracy tests, registry, and non-MUSA benchmark behavior unchanged.

## Test plan
- [x] `pre-commit run flake8 --files benchmark/test_segment_reduce.py`
- [x] `pre-commit run isort --files benchmark/test_segment_reduce.py`
- [x] `pre-commit run black --files benchmark/test_segment_reduce.py`
- [x] `git diff --check`
- [ ] Not run: `pytest` / benchmark tests, per request; this is a benchmark-only backend skip.

## Issue
- WEEKTEST-123
- WEEKTEST-188
