### PR TITLE
[KMCompiler]Optimize pack_seq

### DIFF
--- a/src/flag_gems/fused/pack_seq.py
+++ b/src/flag_gems/fused/pack_seq.py
@@ -7,6 +7,19 @@ import triton.language as tl
 logger = logging.getLogger(__name__)
 
 
+def _select_pack_seq_config(
+    B: int,
+    Lmax: int,
+    D: int,
+    element_size: int,
+) -> tuple[int, int, int, int]:
+    # Use larger tiles only for the real sparse decode-like shapes where it was
+    # measured to help: compact dtype, large serving batch, small Lmax, large D.
+    if element_size <= 2 and B >= 512 and Lmax <= 16 and D >= 1024:
+        return 128, 256, 4, 2
+    return 64, 64, 4, 2
+
+
 @triton.jit
 def _pack_seq_kernel(
     x_ptr,  # [N, D]
@@ -17,6 +30,7 @@ def _pack_seq_kernel(
     Lmax: tl.constexpr,
     PAD_VALUE: tl.constexpr,
     PAD_IS_UINT8: tl.constexpr,
+    BLOCK_B: tl.constexpr,  # rounded-up batch entries for prefix sum
     BLOCK_T: tl.constexpr,  # timesteps per program
     BLOCK_D: tl.constexpr,  # features per program
 ):
@@ -26,10 +40,10 @@ def _pack_seq_kernel(
     off_t = pid_t * BLOCK_T + tl.arange(0, BLOCK_T)  # [BLOCK_T]
     off_d = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)  # [BLOCK_D]
 
-    # Compute start index and sequence length from cumulative lengths
-    in_start = 0
-    for i in range(pid_b):
-        in_start += tl.load(lengths_ptr + i)
+    # Compute start index and sequence length from cumulative lengths.
+    off_b = tl.arange(0, BLOCK_B)
+    prev_lengths = tl.load(lengths_ptr + off_b, mask=off_b < pid_b, other=0)
+    in_start = tl.sum(prev_lengths, axis=0)
     seq_len = tl.load(lengths_ptr + pid_b)
 
     # valid time positions for this block
@@ -48,7 +62,7 @@ def _pack_seq_kernel(
 
     # Initialize with PAD. PAD_IS_UINT8 selects the pad tensor's dtype so
     # integer-typed outputs (e.g. MXFP4 packed nibbles, ue8m0 scale bytes)
-    # get an exact-byte pad rather than going through an fp32→uint8 cast
+    # get an exact-byte pad rather than going through an fp32->uint8 cast
     # that's implementation-defined outside of value 0.
     d_mask = off_d[None, :] < D
     if PAD_IS_UINT8:
@@ -92,6 +106,12 @@ def pack_seq_triton(
     Lmax = int(lengths.max().item())
 
     out = torch.empty((B, Lmax, D), device=x.device, dtype=x.dtype)
+    num_warps = 4
+    num_stages = 2
+    if block_t == 64 and block_d == 64:
+        block_t, block_d, num_warps, num_stages = _select_pack_seq_config(
+            B, Lmax, D, x_reshaped.element_size()
+        )
 
     grid = (B, triton.cdiv(Lmax, block_t), triton.cdiv(D, block_d))
     _pack_seq_kernel[grid](
@@ -103,10 +123,11 @@ def pack_seq_triton(
         Lmax,
         PAD_VALUE=pad_constexpr,
         PAD_IS_UINT8=is_uint8,
+        BLOCK_B=triton.next_power_of_2(B),
         BLOCK_T=block_t,
         BLOCK_D=block_d,
-        num_warps=4,
-        num_stages=2,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
 
     if len(original_shape) > 2:


### PR DESCRIPTION
## Summary

Tune `pack_seq` for CUDA Graph replay in sparse decode-like shapes.

This PR only changes `src/flag_gems/fused/pack_seq.py`.

Changes:
- Add shape-based launch config selection for short-sequence, large-batch cases.
- Replace scalar prefix-sum loop over previous sequence lengths with vectorized `BLOCK_B` accumulation.
- Keep the default config for non-target shapes.

## Performance

Measured with CUDA Graph replay, bf16, `--warmup 10 --iter 100`.

Baseline: vLLM + CUDA Graph  
Candidate: FlagGems + CUDA Graph

| input_token | hidden_size | batch | lmax | vLLM + CUDA Graph ms | FlagGems + CUDA Graph ms | Speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 512 | 64 | 5 | 128 | 0.003142 | 0.003177 | 0.989 |
| 4096 | 128 | 4 | 1024 | 0.003100 | 0.003127 | 0.991 |
| 8192 | 256 | 5 | 2048 | 0.004785 | 0.004822 | 0.992 |
| 2048 | 512 | 4 | 512 | 0.003304 | 0.003385 | 0.976 |
| 16384 | 64 | 8 | 2048 | 0.003414 | 0.003416 | 0.999 |
| 1024 | 1024 | 4 | 256 | 0.003391 | 0.003340 | 1.015 |
| 2048 | 2048 | 512 | 4 | 0.134823 | 0.007332 | 18.388 |
| 4096 | 2048 | 512 | 8 | 0.135256 | 0.011323 | 11.946 |
| 8192 | 2048 | 512 | 16 | 0.136405 | 0.024466 | 5.575 |
| 4096 | 1024 | 1024 | 4 | 0.257762 | 0.008008 | 32.187 |
| 8192 | 1024 | 1024 | 8 | 0.257143 | 0.011559 | 22.246 |
| 16384 | 1024 | 1024 | 16 | 0.258522 | 0.024464 | 10.568 |
| 2048 | 4096 | 256 | 16 | 0.074163 | 0.018402 | 4.030 |
| 4096 | 2048 | 512 | 16 | 0.136082 | 0.017471 | 7.789 |
| 8192 | 1024 | 1024 | 16 | 0.258733 | 0.017636 | 14.671 |
| 16384 | 1024 | 256 | 64 | 0.030267 | 0.023875 | 1.268 |
| 16384 | 1024 | 256 | 128 | 0.048626 | 0.032618 | 1.491 |
