### PR TITLE
[KMCompiler]Optimize unpack_seq

### DIFF
--- a/src/flag_gems/fused/unpack_seq.py
+++ b/src/flag_gems/fused/unpack_seq.py
@@ -7,6 +7,17 @@ import triton.language as tl
 logger = logging.getLogger(__name__)
 
 
+def _select_unpack_seq_config(
+    B: int,
+    Lmax: int,
+    D: int,
+    element_size: int,
+) -> tuple[int, int, int, int]:
+    if element_size <= 4 and B >= 512 and Lmax <= 16 and D >= 512:
+        return 128, 256, 4, 2
+    return 64, 64, 4, 2
+
+
 @triton.jit
 def _unpack_seq_triton_kernel(
     packed_ptr,  # [B, Lmax, D]
@@ -15,6 +26,7 @@ def _unpack_seq_triton_kernel(
     B: tl.constexpr,
     Lmax: tl.constexpr,
     D: tl.constexpr,
+    BLOCK_B: tl.constexpr,
     BLOCK_T: tl.constexpr,  # timesteps per program
     BLOCK_D: tl.constexpr,  # features per program
 ):
@@ -25,9 +37,9 @@ def _unpack_seq_triton_kernel(
     off_d = pid_d * BLOCK_D + tl.arange(0, BLOCK_D)  # [BLOCK_D]
 
     # bounds: compute start from cumulative lengths
-    in_start = 0
-    for i in range(pid_b):
-        in_start += tl.load(lengths_ptr + i)
+    off_b = tl.arange(0, BLOCK_B)
+    prev_lengths = tl.load(lengths_ptr + off_b, mask=off_b < pid_b, other=0)
+    in_start = tl.sum(prev_lengths, axis=0)
     seq_len = tl.load(lengths_ptr + pid_b)
 
     # valid time positions for this block
@@ -69,6 +81,12 @@ def unpack_seq_triton(
     N = int(lengths.sum().item())
 
     out = torch.empty((N, D), device=packed_tensor.device, dtype=packed_tensor.dtype)
+    num_warps = 4
+    num_stages = 2
+    if block_t == 64 and block_d == 64:
+        block_t, block_d, num_warps, num_stages = _select_unpack_seq_config(
+            B, Lmax, D, packed_reshaped.element_size()
+        )
 
     grid = (B, triton.cdiv(Lmax, block_t), triton.cdiv(D, block_d))
     _unpack_seq_triton_kernel[grid](
@@ -78,10 +96,11 @@ def unpack_seq_triton(
         B,
         Lmax,
         D,
+        BLOCK_B=triton.next_power_of_2(B),
         BLOCK_T=block_t,
         BLOCK_D=block_d,
-        num_warps=4,
-        num_stages=2,
+        num_warps=num_warps,
+        num_stages=num_stages,
     )
 
     if len(original_shape) > 3:


### PR DESCRIPTION
## Summary

Tune `unpack_seq` for CUDA Graph replay in sparse decode-like shapes.

This PR only changes `src/flag_gems/fused/unpack_seq.py`.

Changes:
- Add shape-based launch config selection for short-sequence, large-batch cases.
- Replace scalar prefix-sum loop over previous sequence lengths with vectorized `BLOCK_B` accumulation.

## Performance

Measured with CUDA Graph replay, bf16, `--warmup 10 --iter 100`.

Baseline: vLLM + CUDA Graph  
Candidate: FlagGems + CUDA Graph

| output_token | hidden_size | batch | lmax | vLLM + CUDA Graph ms | FlagGems + CUDA Graph ms | Speedup |
|---:|---:|---:|---:|---:|---:|---:|
| 512 | 64 | 5 | 128 | 0.003539 | 0.003531 | 1.002 |
| 4096 | 128 | 4 | 1024 | 0.003633 | 0.003485 | 1.043 |
| 8192 | 256 | 5 | 2048 | 0.003706 | 0.003574 | 1.037 |
| 2048 | 512 | 4 | 512 | 0.003472 | 0.003486 | 0.996 |
| 16384 | 64 | 8 | 2048 | 0.003330 | 0.003426 | 0.972 |
| 1024 | 1024 | 4 | 256 | 0.003346 | 0.003499 | 0.956 |
| 2048 | 2048 | 512 | 4 | 0.134372 | 0.006196 | 21.689 |
| 4096 | 2048 | 512 | 8 | 0.134606 | 0.008367 | 16.088 |
| 8192 | 2048 | 512 | 16 | 0.135907 | 0.020076 | 6.770 |
| 4096 | 1024 | 1024 | 4 | 0.256597 | 0.007135 | 35.963 |
| 8192 | 1024 | 1024 | 8 | 0.256905 | 0.009040 | 28.420 |
| 16384 | 1024 | 1024 | 16 | 0.257765 | 0.020242 | 12.734 |
| 2048 | 4096 | 256 | 16 | 0.072924 | 0.012613 | 5.782 |
| 4096 | 2048 | 512 | 16 | 0.135213 | 0.008808 | 15.351 |
| 8192 | 1024 | 1024 | 16 | 0.256851 | 0.009534 | 26.940 |
