### PR TITLE
[Performance Optimization] Improve any_dims parallel reduction

### DIFF
--- a/src/flag_gems/ops/any.py
+++ b/src/flag_gems/ops/any.py
@@ -376,6 +376,13 @@ def any_dims(
                 out = out.squeeze(dim=d)
         return out
 
+    if layout.num_outputs == 1:
+        out = any(inp).reshape(layout.out_shape)
+        if not keepdim:
+            for d in reversed(reduce_dims):
+                out = out.squeeze(dim=d)
+        return out
+
     block_height, block_width, num_warps = _select_reduction_config(
         layout.num_outputs,
         layout.inputs_per_output,

--- a/src/flag_gems/ops/any.py
+++ b/src/flag_gems/ops/any.py
@@ -1,5 +1,7 @@
+import importlib.util
 import logging
 import math
+from typing import Sequence
 
 import torch
 import triton
@@ -9,6 +11,8 @@ from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import dim_compress, libentry, libtuner
 from flag_gems.utils import triton_lang_extension as ext
+from flag_gems.utils.code_cache import code_cache_dir
+from flag_gems.utils.code_utils import IndentedBuffer, write_atomic
 
 logger = logging.getLogger(__name__)
 
@@ -128,28 +132,275 @@ def any_dim(inp, dim=None, keepdim=False):
     return out
 
 
-def any_dims(inp, dim=None, keepdim=False):
-    logger.debug("GEMS ANY DIMS")
+class _TensorReduceLayout:
+    """Logical keepdim layout for strided reductions."""
 
+    @staticmethod
+    def _coalesce_dims(
+        dims: Sequence[tuple[int, tuple[int, ...]]],
+    ) -> tuple[tuple[int, tuple[int, ...]], ...]:
+        # Match TensorIterator's rule for adjacent dimensions in fastest-first
+        # order: size-1 dims are free, otherwise every tracked stride must be
+        # contiguous.
+        coalesced: list[tuple[int, tuple[int, ...]]] = []
+        for shape, strides in dims:
+            if not coalesced:
+                coalesced.append((shape, strides))
+                continue
+
+            prev_shape, prev_strides = coalesced[-1]
+            can_merge = (
+                prev_shape == 1
+                or shape == 1
+                or all(
+                    prev_shape * prev_stride == stride
+                    for prev_stride, stride in zip(prev_strides, strides)
+                )
+            )
+            if not can_merge:
+                coalesced.append((shape, strides))
+                continue
+
+            merged_strides = strides if prev_shape == 1 else prev_strides
+            coalesced[-1] = (prev_shape * shape, merged_strides)
+        return tuple(coalesced)
+
+    def __init__(self, inp: torch.Tensor, reduce_dims: Sequence[int]):
+        self.shape = tuple(inp.shape)
+        self.input_strides = tuple(inp.stride())
+        self.reduce_dims = tuple(reduce_dims)
+        reduce_dim_set = set(self.reduce_dims)
+        self.out_shape = tuple(
+            1 if dim in reduce_dim_set else size for dim, size in enumerate(self.shape)
+        )
+
+    def finalize(self, out: torch.Tensor):
+        output_strides_full = tuple(out.stride())
+        output_dims = tuple(
+            dim for dim in range(len(self.shape)) if dim not in self.reduce_dims
+        )
+
+        # Keep reduce and output spaces separate so the kernel can split
+        # reduce_linear and output_linear independently.
+        reduce_order = tuple(
+            sorted(self.reduce_dims, key=lambda dim: abs(self.input_strides[dim]))
+        )
+        output_order = tuple(
+            sorted(output_dims, key=lambda dim: abs(output_strides_full[dim]))
+        )
+
+        reduce_items = self._coalesce_dims(
+            tuple((self.shape[dim], (self.input_strides[dim],)) for dim in reduce_order)
+        )
+        output_items = self._coalesce_dims(
+            tuple(
+                (
+                    self.shape[dim],
+                    (self.input_strides[dim], output_strides_full[dim]),
+                )
+                for dim in output_order
+            )
+        )
+
+        self.reduce_shapes = tuple(shape for shape, _ in reduce_items)
+        self.input_reduce_strides = tuple(strides[0] for _, strides in reduce_items)
+        self.output_shapes = tuple(shape for shape, _ in output_items)
+        self.input_output_strides = tuple(strides[0] for _, strides in output_items)
+        self.output_strides = tuple(strides[1] for _, strides in output_items)
+        self.inputs_per_output = math.prod(self.reduce_shapes)
+        self.num_outputs = math.prod(self.output_shapes)
+
+    def kernel_args(self) -> tuple[int, ...]:
+        return (
+            *self.output_shapes,
+            *self.input_output_strides,
+            *self.output_strides,
+            *self.reduce_shapes,
+            *self.input_reduce_strides,
+        )
+
+
+def _generate_any_dims_kernel_source(
+    num_output_dims: int, num_reduce_dims: int
+) -> tuple[str, str]:
+    kernel_name = f"_any_dims_kernel_o{num_output_dims}_r{num_reduce_dims}"
+    metadata_args = (
+        [f"output_shape{i}" for i in range(num_output_dims)]
+        + [f"input_output_stride{i}" for i in range(num_output_dims)]
+        + [f"output_stride{i}" for i in range(num_output_dims)]
+        + [f"reduce_shape{i}" for i in range(num_reduce_dims)]
+        + [f"input_reduce_stride{i}" for i in range(num_reduce_dims)]
+    )
+    code = IndentedBuffer()
+    code.writeline("import triton")
+    code.writeline("import triton.language as tl")
+    code.newline()
+    code.writeline("@triton.jit(do_not_specialize=[")
+    with code.indent():
+        for arg_name in metadata_args:
+            code.writeline(f"{arg_name!r},")
+    code.writeline("])")
+    code.writeline(f"def {kernel_name}(")
+    with code.indent():
+        code.writeline("inp,")
+        code.writeline("out,")
+        for arg_name in metadata_args:
+            code.writeline(f"{arg_name},")
+        code.writeline("BLOCK_M: tl.constexpr,")
+        code.writeline("BLOCK_N: tl.constexpr,")
+    code.writeline("):")
+    with code.indent():
+        output = " * ".join(f"output_shape{i}" for i in range(num_output_dims))
+        input_per_output = " * ".join(
+            f"reduce_shape{i}" for i in range(num_reduce_dims)
+        )
+        code.writeline(f"output = {output or '1'}")
+        code.writeline(f"input_per_output = {input_per_output or '1'}")
+        code.writeline("output_tiles = tl.cdiv(output, BLOCK_M)")
+        code.writeline("pid = tl.program_id(0)")
+        code.writeline("pid_y = pid % output_tiles")
+        code.writeline("pid_x = pid // output_tiles")
+        code.newline()
+        code.writeline(
+            "output_offsets_linear = (pid_y * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)"
+        )
+        code.writeline(
+            "reduce_offsets_linear = (pid_x * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)"
+        )
+        code.writeline("output_mask = output_offsets_linear < output")
+        code.writeline("reduce_mask = reduce_offsets_linear < input_per_output")
+        code.newline()
+        code.writeline("input_output_offsets = tl.zeros((BLOCK_M,), dtype=tl.int64)")
+        code.writeline("output_offsets = tl.zeros((BLOCK_M,), dtype=tl.int64)")
+        code.writeline("output_linear = output_offsets_linear")
+        code.writeline("# Expand output_linear into input/output base offsets.")
+        for i in range(num_output_dims):
+            code.writeline(f"out_idx{i} = output_linear % output_shape{i}")
+            code.writeline(
+                f"input_output_offsets += out_idx{i} * input_output_stride{i}"
+            )
+            code.writeline(f"output_offsets += out_idx{i} * output_stride{i}")
+            if i != num_output_dims - 1:
+                code.writeline(f"output_linear = output_linear // output_shape{i}")
+        code.newline()
+        code.writeline("input_reduce_offsets = tl.zeros((BLOCK_N,), dtype=tl.int64)")
+        code.writeline("reduce_linear = reduce_offsets_linear")
+        code.writeline("# Expand reduce_linear into the input reduce offset.")
+        for i in range(num_reduce_dims):
+            code.writeline(f"red_idx{i} = reduce_linear % reduce_shape{i}")
+            code.writeline(
+                f"input_reduce_offsets += red_idx{i} * input_reduce_stride{i}"
+            )
+            if i != num_reduce_dims - 1:
+                code.writeline(f"reduce_linear = reduce_linear // reduce_shape{i}")
+        code.newline()
+        code.writeline(
+            "input_offsets = input_output_offsets[:, None] + input_reduce_offsets[None, :]"
+        )
+        code.writeline(
+            "active = tl.load(out + output_offsets, mask=output_mask, other=1) == 0"
+        )
+        code.writeline(
+            "mask = output_mask[:, None] & reduce_mask[None, :] & active[:, None]"
+        )
+        code.writeline("vals = tl.load(inp + input_offsets, mask=mask, other=0.0)")
+        code.writeline("local_any = tl.max(vals != 0, axis=1).to(tl.int32)")
+        # int32 atomic avoids backend issues with bool or 8-bit atomics.
+        code.writeline(
+            "tl.atomic_max(out + output_offsets, local_any, mask=output_mask & active & (local_any != 0))"
+        )
+    return kernel_name, code.getvalue()
+
+
+def _any_dims_kernel_for_rank(num_output_dims: int, num_reduce_dims: int):
+    key = f"{num_output_dims}_{num_reduce_dims}"
+    if not hasattr(_any_dims_kernel_for_rank, "overloads"):
+        _any_dims_kernel_for_rank.overloads = {}
+
+    overloads = _any_dims_kernel_for_rank.overloads
+    if key in overloads:
+        return overloads[key]
+
+    kernel_name, source = _generate_any_dims_kernel_source(
+        num_output_dims, num_reduce_dims
+    )
+    file_name = f"any_dims_rank_{key}.py"
+    file_path = code_cache_dir() / file_name
+    write_atomic(file_path, source)
+
+    spec = importlib.util.spec_from_file_location(
+        f"_any_dims_gen_module_rank_{key}",
+        file_path,
+    )
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    kernel = getattr(module, kernel_name)
+    overloads[key] = kernel
+    return kernel
+
+
+def _select_reduction_config(
+    num_outputs,
+    inputs_per_output,
+):
+    block_width = min(256, triton.next_power_of_2(inputs_per_output))
+    block_height = min(32, triton.next_power_of_2(num_outputs))
+    num_warps = 8 if block_width >= 256 else 4
+
+    return block_height, block_width, num_warps
+
+
+def any_dims(
+    inp,
+    dim=None,
+    keepdim=False,
+):
+    logger.debug("GEMS ANY DIMS")
     if dim is None or isinstance(dim, int):
         return any_dim(inp, dim=dim, keepdim=keepdim)
-    assert ((i >= -inp.ndim and i < inp.ndim) for i in dim), "Invalid dim"
 
-    shape = list(inp.shape)
-    dim = [d % inp.ndim for d in dim]
-    inp = dim_compress(inp, dim)
-    N = 1
-    for i in dim:
-        N *= shape[i]
-        shape[i] = 1
-    M = inp.numel() // N
+    dims = list(dim)
+    assert all(-inp.ndim <= d < inp.ndim for d in dims), "Invalid dim"
+    reduce_dims = sorted(set(d % inp.ndim for d in dims))
+    layout = _TensorReduceLayout(inp, reduce_dims)
+    # Partial reductions from different reduce blocks are merged with atomic_max.
+    # Use int32 for broad backend support, then cast to the public bool result.
+    out_i32 = torch.zeros(layout.out_shape, dtype=torch.int32, device=inp.device)
+    layout.finalize(out_i32)
 
-    out = torch.empty(shape, dtype=torch.bool, device=inp.device)
-    inp = inp.to(torch.bool)
+    if layout.num_outputs == 0 or layout.inputs_per_output == 0:
+        out = out_i32.to(torch.bool)
+        if not keepdim:
+            for d in reversed(reduce_dims):
+                out = out.squeeze(dim=d)
+        return out
 
-    grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
+    block_height, block_width, num_warps = _select_reduction_config(
+        layout.num_outputs,
+        layout.inputs_per_output,
+    )
+    grid = (
+        triton.cdiv(layout.num_outputs, block_height)
+        * triton.cdiv(layout.inputs_per_output, block_width),
+    )
+    kernel = _any_dims_kernel_for_rank(
+        len(layout.output_shapes), len(layout.reduce_shapes)
+    )
+
     with torch_device_fn.device(inp.device):
-        any_kernel_dim[grid](inp, out, M, N)
+        kernel[grid](
+            inp,
+            out_i32,
+            *layout.kernel_args(),
+            BLOCK_M=block_height,
+            BLOCK_N=block_width,
+            num_warps=num_warps,
+            num_stages=2,
+        )
+
+    out = out_i32.to(torch.bool)
     if not keepdim:
-        out = out.squeeze(dim=dim)
+        for d in reversed(reduce_dims):
+            out = out.squeeze(dim=d)
     return out


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Performance Optimization

### Description
- Rework `any_dims` with a TensorIterator-style strided reduce layout to avoid `contiguous()` copies for non-contiguous reductions.
- Generate rank-specialized Triton kernels from coalesced shape/stride metadata with `flag_gems.utils.code_utils`.
- Merge split partial reductions with `int32 atomic_max` to preserve correctness across arbitrary input strides.
- Route to `any` when reduce full tensor.

### Issue
N/A

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
#### iluvatar
- GPU: `Iluvatar BI-V150`
- OS: `Ubuntu 24.04`
- Python: `3.12.11`
- Torch: `2.10.0`
- Triton: `3.1.0`
- FlagTree: `0.6.0+iluvatar.git19bc3194`
- FlagGems: `5.4.0dev+git29358a51`
- Vendor: `iluvatar`
- Device: `cuda`

`any_dims` average speedup improves from x0.47 to x4.1:

shape | dim | dtype | latency_base | latency | speedup
-- | -- | -- | -- | -- | --
(64,64) | (0,1) | torch.float16 | 0.01 | 0.01 | 1.00
(1024,1024) | (0,1) | torch.float16 | 0.16 | 0.02 | 9.33
(4096,4096) | (0,1) | torch.float16 | 0.11 | 0.09 | 1.22
(64,512,512) | (0,1) | torch.float16 | 0.32 | 0.07 | 4.80
(1024,1024,1024) | (0,1) | torch.float16 | 5.45 | 2.55 | 2.14
(64,64) | (0,1) | torch.float32 | 0.01 | 0.01 | 1.06
(1024,1024) | (0,1) | torch.float32 | 0.23 | 0.02 | 9.41
(4096,4096) | (0,1) | torch.float32 | 0.23 | 0.14 | 1.63
(64,512,512) | (0,1) | torch.float32 | 0.34 | 0.07 | 4.56
(1024,1024,1024) | (0,1) | torch.float32 | 6.57 | 2.55 | 2.57
(64,64) | (0,1) | torch.bfloat16 | 0.01 | 0.01 | 1.01
(1024,1024) | (0,1) | torch.bfloat16 | 0.16 | 0.02 | 9.36
(4096,4096) | (0,1) | torch.bfloat16 | 0.11 | 0.09 | 1.22
(64,512,512) | (0,1) | torch.bfloat16 | 0.32 | 0.07 | 4.79
(1024,1024,1024) | (0,1) | torch.bfloat16 | 5.45 | 2.55 | 2.14
(64,64) | (0,1) | torch.bool | 0.01 | 0.01 | 1.08
(1024,1024) | (0,1) | torch.bool | 0.13 | 0.01 | 9.54
(4096,4096) | (0,1) | torch.bool | 0.08 | 0.07 | 1.20
(64,512,512) | (0,1) | torch.bool | 0.67 | 0.06 | 10.87
(1024,1024,1024) | (0,1) | torch.bool | 9.20 | 2.52 | 3.64

#### nvidia
- GPU: `Nvidia-A100`
- Architecture: `x86_64`
- OS: `ubuntu 22.04`
- Python: `3.10.12`
- Torch: `2.4.0a0+3bcc3cddb5.nv24.07`
- FlagTree: `0.4.0`
- Triton: `3.1.0`
- FlagGems: `5.4.0dev+git8d1d3f70`
- Vendor: `nvidia`
- Device: `cuda`

`any_dims` average speedup improves from x0.24 to x0.43:

| shape            | dim   | dtype          | latency_base | latency | speedup |
| ---------------- | ----- | -------------- | -----------: | ------: | ------: |
| (64,64)          | (0,1) | torch.float16  |        0.011 |   0.080 |   0.141 |
| (1024,1024)      | (0,1) | torch.float16  |        0.019 |   0.080 |   0.244 |
| (4096,4096)      | (0,1) | torch.float16  |        0.048 |   0.083 |   0.580 |
| (64,512,512)     | (0,1) | torch.float16  |        0.081 |   0.091 |   0.888 |
| (1024,1024,1024) | (0,1) | torch.float16  |        1.398 |   4.289 |   0.326 |
| (64,64)          | (0,1) | torch.float32  |        0.009 |   0.075 |   0.123 |
| (1024,1024)      | (0,1) | torch.float32  |        0.017 |   0.080 |   0.218 |
| (4096,4096)      | (0,1) | torch.float32  |        0.067 |   0.084 |   0.793 |
| (64,512,512)     | (0,1) | torch.float32  |        0.101 |   0.094 |   1.076 |
| (1024,1024,1024) | (0,1) | torch.float32  |        2.577 |   4.233 |   0.609 |
| (64,64)          | (0,1) | torch.bfloat16 |        0.010 |   0.080 |   0.128 |
| (1024,1024)      | (0,1) | torch.bfloat16 |        0.017 |   0.081 |   0.215 |
| (4096,4096)      | (0,1) | torch.bfloat16 |        0.049 |   0.084 |   0.585 |
| (64,512,512)     | (0,1) | torch.bfloat16 |        0.080 |   0.097 |   0.821 |
| (1024,1024,1024) | (0,1) | torch.bfloat16 |        1.402 |   4.564 |   0.307 |
| (64,64)          | (0,1) | torch.bool     |        0.009 |   0.074 |   0.125 |
| (1024,1024)      | (0,1) | torch.bool     |        0.016 |   0.081 |   0.203 |
| (4096,4096)      | (0,1) | torch.bool     |        0.034 |   0.082 |   0.413 |
| (64,512,512)     | (0,1) | torch.bool     |        0.060 |   0.094 |   0.641 |
| (1024,1024,1024) | (0,1) | torch.bool     |        0.855 |   4.385 |   0.195 |
