### PR TITLE
[KMCompiler] Reimplement top_k_per_row_prefill and top_k_per_row_decode

### DIFF
--- a/benchmark/test_top_k_per_row_decode.py
+++ b/benchmark/test_top_k_per_row_decode.py
@@ -47,43 +47,42 @@ except (ImportError, AttributeError):
     _vllm_top_k_per_row_decode = None
 
 
-def _torch_topk_ref(
-    logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k
-):
-    """Pure-PyTorch fallback reference using torch.topk."""
-    seq_len = seq_lens[0].item()
-    valid_logits = logits[:, :seq_len]
-    _, top_idx = torch.topk(valid_logits, top_k, dim=1, largest=True, sorted=False)
-    indices.copy_(top_idx.to(torch.int32))
-
-
-_baseline_op = _vllm_top_k_per_row_decode if HAS_VLLM else _torch_topk_ref
-
-
 class TopKPerRowDecodeBenchmark(base.Benchmark):
-    DEFAULT_SHAPE_DESC = "vocab_size, top_k"
+    DEFAULT_SHAPE_DESC = "num_rows, vocab_size, next_n, top_k, stride0, stride1"
 
     def set_shapes(self, shape_file_path=None):
         self.shapes = [
-            (129280, 1024),
-            (32768, 512),
-            (16384, 256),
-            (8192, 128),
-            (4096, 64),
+            # DeepSeek-V4-Flash
+            (1, 262144, 1, 512, 262144, 1),
+            (496, 262144, 1, 512, 262144, 1),
+            (512, 262144, 1, 512, 262144, 1),
+            (16, 262144, 1, 512, 262144, 1),
+            (32, 262144, 1, 512, 262144, 1),
+            (48, 262144, 1, 512, 262144, 1),
+            (40, 262144, 1, 512, 262144, 1),
+            (56, 262144, 1, 512, 262144, 1),
+            (4, 262144, 1, 512, 262144, 1),
+            (8, 262144, 1, 512, 262144, 1),
+            (24, 262144, 1, 512, 262144, 1),
         ]
 
     def get_input_iter(self, dtype):
-        for vocab_size, top_k in self.shapes:
+        for num_rows, vocab_size, next_n, top_k, stride0, stride1 in self.shapes:
             torch.manual_seed(42)
-            logits = torch.randn(
-                (1, vocab_size), dtype=torch.float32, device=self.device
+            buf = torch.randn(
+                (num_rows - 1) * stride0 + (vocab_size - 1) * stride1 + 1,
+                device=self.device,
+                dtype=torch.float32,
             )
-            seq_lens = torch.tensor([vocab_size], dtype=torch.int32, device=self.device)
-            indices = torch.zeros((1, top_k), dtype=torch.int32, device=self.device)
-            num_rows = 1
-            next_n = 1
-            stride0 = logits.stride(0)
-            stride1 = logits.stride(1)
+            logits = torch.as_strided(buf, (num_rows, vocab_size), (stride0, stride1))
+
+            batch_size = num_rows // next_n
+            seq_lens = torch.full(
+                (batch_size,), vocab_size, dtype=torch.int32, device=self.device
+            )
+            indices = torch.zeros(
+                (num_rows, top_k), dtype=torch.int32, device=self.device
+            )
 
             yield (
                 logits,
@@ -98,10 +97,11 @@ class TopKPerRowDecodeBenchmark(base.Benchmark):
 
 
 @pytest.mark.top_k_per_row_decode
+@pytest.mark.skipif(not HAS_VLLM, reason="vLLM not installed")
 def test_top_k_per_row_decode():
     bench = TopKPerRowDecodeBenchmark(
         op_name="top_k_per_row_decode",
-        torch_op=_baseline_op,
+        torch_op=_vllm_top_k_per_row_decode,
         gems_op=top_k_per_row_decode,
         dtypes=[torch.float32],
     )

--- a/benchmark/test_top_k_per_row_prefill.py
+++ b/benchmark/test_top_k_per_row_prefill.py
@@ -8,9 +8,8 @@ Shapes match DeepSeek V4 production config:
     - num_rows=64: larger prefill batch
     - num_rows=2048: max prefill sequence length
 
-The torch reference uses torch.topk directly (no masking), representing the
-theoretical minimum for selection-only. The Triton kernel additionally handles
-masking and index adjustment.
+The baseline uses vLLM's persistent_topk CUDA kernel when available,
+falling back to torch.topk for the selection-only theoretical minimum.
 """
 
 import pytest
@@ -28,16 +27,38 @@ pytestmark = pytest.mark.skipif(
     reason="CUDA device required",
 )
 
+# --- vLLM CUDA baseline (preferred) with PyTorch fallback ---
+try:
+    import vllm._custom_ops  # noqa: F401 — loads torch.ops._C
+
+    def _vllm_top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+    ):
+        torch.ops._C.top_k_per_row_prefill(
+            logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+        )
+
+    HAS_VLLM = True
+except (ImportError, AttributeError):
+    HAS_VLLM = False
+    _vllm_top_k_per_row_prefill = None
+
+
+def _torch_topk_ref(
+    logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+):
+    """Pure-PyTorch fallback: torch.topk on full vocab (no masking)."""
+    _, top_idx = torch.topk(logits, top_k, dim=1, largest=True, sorted=False)
+    indices.copy_(top_idx.to(torch.int32))
+
+
+_baseline_op = _vllm_top_k_per_row_prefill if HAS_VLLM else _torch_topk_ref
+
 
 class TopKPerRowPrefillBenchmark(base.Benchmark):
     DEFAULT_SHAPE_DESC = "num_rows, vocab_size, top_k"
 
     def set_shapes(self, shape_file_path=None):
-        # DeepSeek V4 production shapes:
-        # - (1, 129280, 1024): decode path, single token, latency-critical
-        # - (32, 129280, 1024): typical prefill micro-batch
-        # - (64, 129280, 1024): larger prefill batch
-        # - (2048, 129280, 1024): max sequence length prefill
         self.shapes = [
             (1, 129280, 1024),
             (32, 129280, 1024),
@@ -50,31 +71,22 @@ class TopKPerRowPrefillBenchmark(base.Benchmark):
             logits = torch.randn(
                 num_rows, vocab_size, device=device, dtype=torch.float32
             )
-            # Full vocab range: row_starts=0, row_ends=vocab_size (common case)
             row_starts = torch.zeros(num_rows, dtype=torch.int32, device=device)
             row_ends = torch.full(
                 (num_rows,), vocab_size, dtype=torch.int32, device=device
             )
-            # Pre-allocated output buffer (matches vLLM calling convention)
             indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
-            stride0 = logits.stride(0)  # = vocab_size for contiguous
-            stride1 = logits.stride(1)  # = 1 for contiguous
+            stride0 = logits.stride(0)
+            stride1 = logits.stride(1)
 
             yield logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
-
-
-def _torch_topk_ref(
-    logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
-):
-    _, top_idx = torch.topk(logits, top_k, dim=1, largest=True, sorted=False)
-    indices.copy_(top_idx.to(torch.int32))
 
 
 @pytest.mark.top_k_per_row_prefill
 def test_top_k_per_row_prefill():
     bench = TopKPerRowPrefillBenchmark(
         op_name="top_k_per_row_prefill",
-        torch_op=_torch_topk_ref,
+        torch_op=_baseline_op,
         gems_op=top_k_per_row_prefill,
         dtypes=[torch.float32],
     )

--- a/benchmark/test_top_k_per_row_prefill.py
+++ b/benchmark/test_top_k_per_row_prefill.py
@@ -44,49 +44,44 @@ except (ImportError, AttributeError):
     _vllm_top_k_per_row_prefill = None
 
 
-def _torch_topk_ref(
-    logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
-):
-    """Pure-PyTorch fallback: torch.topk on full vocab (no masking)."""
-    _, top_idx = torch.topk(logits, top_k, dim=1, largest=True, sorted=False)
-    indices.copy_(top_idx.to(torch.int32))
-
-
-_baseline_op = _vllm_top_k_per_row_prefill if HAS_VLLM else _torch_topk_ref
-
-
 class TopKPerRowPrefillBenchmark(base.Benchmark):
-    DEFAULT_SHAPE_DESC = "num_rows, vocab_size, top_k"
+    DEFAULT_SHAPE_DESC = "num_rows, vocab_size, top_k, stride0, stride1"
 
     def set_shapes(self, shape_file_path=None):
         self.shapes = [
-            (1, 129280, 1024),
-            (32, 129280, 1024),
-            (64, 129280, 1024),
-            (2048, 129280, 1024),
+            # DeepSeek-V4-Flash
+            (4, 8193, 512, 8456, 1),
+            (16383, 4095, 512, 4352, 1),
+            (4, 16385, 512, 16648, 1),
+            (12961, 4100, 512, 4360, 1),
+            (16380, 5115, 512, 5376, 1),
+            (4100, 1025, 512, 1288, 1),
         ]
 
     def get_input_iter(self, dtype):
-        for num_rows, vocab_size, top_k in self.shapes:
-            logits = torch.randn(
-                num_rows, vocab_size, device=device, dtype=torch.float32
+        for num_rows, vocab_size, top_k, stride0, stride1 in self.shapes:
+            torch.manual_seed(42)
+            buf = torch.randn(
+                (num_rows - 1) * stride0 + (vocab_size - 1) * stride1 + 1,
+                device=device,
+                dtype=torch.float32,
             )
+            logits = torch.as_strided(buf, (num_rows, vocab_size), (stride0, stride1))
             row_starts = torch.zeros(num_rows, dtype=torch.int32, device=device)
             row_ends = torch.full(
                 (num_rows,), vocab_size, dtype=torch.int32, device=device
             )
             indices = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
-            stride0 = logits.stride(0)
-            stride1 = logits.stride(1)
 
             yield logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
 
 
 @pytest.mark.top_k_per_row_prefill
+@pytest.mark.skipif(not HAS_VLLM, reason="vLLM not installed")
 def test_top_k_per_row_prefill():
     bench = TopKPerRowPrefillBenchmark(
         op_name="top_k_per_row_prefill",
-        torch_op=_baseline_op,
+        torch_op=_vllm_top_k_per_row_prefill,
         gems_op=top_k_per_row_prefill,
         dtypes=[torch.float32],
     )

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -7955,6 +7955,7 @@ ops:
       - None
     labels:
       - fused
+      - KernelGen
     kind:
       - NeuralNetwork
     stages:

--- a/src/flag_gems/fused/top_k_per_row_decode.py
+++ b/src/flag_gems/fused/top_k_per_row_decode.py
@@ -1,31 +1,8 @@
-"""Triton top_k_per_row_decode for DeepSeek V4 decode-phase token selection.
+"""Triton top_k_per_row_decode for DeepSeek V4 decode-phase topk selection.
 
-Replaces vLLM's top_k_per_row_decode CUDA kernel with a pure Triton
-implementation using radix-select (4-iteration 8-bit histogram radix).
+   Implement based on file python/tutorials/tle/deepseek_v32/01-topk_selector.py from repo
+   https://github.com/flagos-ai/FlagTree.git, align with vLLM implementation.
 
-Background:
-    In DeepSeek V4 decode, each step selects the top-K token indices from a
-    single row of logits [1, vocab_size]. The vLLM CUDA kernel uses a
-    radix-based approach; this Triton kernel matches that strategy with
-    three dispatch tiers optimized for different vocab sizes.
-
-Strategy:
-    1. Single-block path (vocab_size <= 8192): All data fits in one thread
-       block's registers. Four radix iterations with tl.histogram, no
-       inter-block synchronization, no global memory scratch.
-    2. Medium multi-block path (8192 < vocab_size <= 32768): All blocks
-       participate in all 4 radix iterations. Double-buffered per-block
-       histograms with 4 barriers (1 per iteration). Eliminates serial
-       block-0 bottleneck seen in buffer-based approaches.
-    3. Large multi-block path (vocab_size > 32768): First radix iteration
-       runs across all blocks with per-block histograms + barrier. Remaining
-       3 iterations run on block-0 only using a compacted buffer, avoiding
-       barrier overhead for high block counts.
-
-Performance (DeepSeek V4 config, H20 GPU):
-    - vocab=129280, k=1024: 1.82x faster than vLLM CUDA
-    - vocab=32768,  k=512:  0.78x vs vLLM CUDA
-    - vocab=8192,   k=128:  0.50x vs vLLM CUDA
 """
 
 import logging
@@ -34,453 +11,1194 @@ import torch
 import triton
 import triton.language as tl
 
+from flag_gems.utils.triton_version_utils import has_triton_tle
+
+if has_triton_tle(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle
+
+        HAS_TLE = True
+    except ImportError:
+        tle = None
+        HAS_TLE = False
+else:
+    tle = None
+    HAS_TLE = False
+
+
 logger = logging.getLogger(__name__)
 
-_SIGN_BIT = tl.constexpr(-(1 << 31))
+# Start of shared implementation code for top_k_per_row_decode and top_k_per_row_prefill
+
+SORTING_ALGORITHM_THRESHOLD = 12288
+SPLIT_WORK_THRESHOLD = 200 * 1000
+NUM_THREADS_PER_BLOCK = 512
+MULTIPLE_BLOCKS_PER_ROW_CONFIG = 10
+NUM_THREADS_PER_BLOCK_MERGE = 1024
+NUM_FILNAL_ITEMS = 2048
+NUM_BINS = 2048
+RADIX_BITS_FINAL = 8
+RADIX_SIZE_FINAL = 1 << RADIX_BITS_FINAL
 
 
 @triton.jit
-def _float_to_sortable(val):
-    """Convert IEEE 754 float to order-preserving unsigned integer.
-
-    XOR with sign-dependent mask so that sorted int order == sorted float order.
-    """
-    bits = val.to(tl.int32, bitcast=True)
-    sign_ext = bits >> 31
-    mask = sign_ext | tl.full(bits.shape, _SIGN_BIT, dtype=tl.int32)
-    return bits ^ mask
+def _convert_to_uint32(x):
+    bits = x.to(tl.uint32, bitcast=True)
+    sign_mask = tl.full(bits.shape, 0x80000000, tl.uint32)
+    sign_set = (bits & sign_mask) != 0
+    inv = (~bits) & tl.full(bits.shape, 0x7FFFFFFF, tl.uint32)
+    return tl.where(sign_set, bits, inv)
 
 
 @triton.jit
-def _topk_single_block(
-    logits_ptr,
-    seq_len_ptr,
-    indices_ptr,
-    stride1,
-    N: tl.constexpr,
-    BLOCK: tl.constexpr,
-    TOP_K: tl.constexpr,
+def _extract_bin_idx(x, in_range, pattern, STEP: tl.constexpr):
+    is_partial_match = in_range
+    if STEP == 0:
+        h = x.to(tl.float16)
+        bits = h.to(tl.uint16, bitcast=True)
+        sign_mask = tl.full(bits.shape, 0x8000, tl.uint16)
+        sign_set = (bits & sign_mask) != 0
+        inv = (~bits) & tl.full(bits.shape, 0x7FFF, tl.uint16)
+        mapped = tl.where(sign_set, bits, inv)
+        bin_idx = (mapped >> 5).to(tl.uint32)
+    else:
+        bits = _convert_to_uint32(x)
+        if STEP == 1:
+            bin_idx = bits >> 21
+        elif STEP == 2:
+            bin_idx = (bits >> 10) & 0x7FF
+            is_partial_match &= ((bits ^ pattern) >> 21) == 0
+        elif STEP == 3:
+            bin_idx = bits & 0x3FF
+            is_partial_match &= ((bits ^ pattern) >> 10) == 0
+    return bin_idx, is_partial_match
+
+
+@triton.jit
+def _convert_to_trt_uint16_hi11(x):
+    h = x.to(tl.float16)
+    bits = h.to(tl.uint16, bitcast=True)
+    sign_mask = tl.full(bits.shape, 0x8000, tl.uint16)
+    sign_set = (bits & sign_mask) != 0
+    inv = (~bits) & tl.full(bits.shape, 0x7FFF, tl.uint16)
+    mapped = tl.where(sign_set, bits, inv)
+    return (mapped >> 5).to(tl.int32)
+
+
+@triton.jit
+def _distribute_to_bins(
+    logits,
+    in_range,
+    ones,
+    logit_pattern,
+    s_histogram_ptr,
+    STEP: tl.constexpr,
 ):
-    """Single-block radix select: all 4 iterations in-register, no barriers."""
-    offs = tl.arange(0, BLOCK)
-    seq_len = tl.load(seq_len_ptr)
-    valid = (offs < N) & (offs < seq_len)
-
-    vals = tl.load(logits_ptr + offs * stride1, mask=valid, other=float("-inf"))
-    sortable = _float_to_sortable(vals)
-
-    bins = tl.arange(0, 256)
-
-    # Radix iteration 0: byte 3 (MSB)
-    bucket_0 = (sortable >> 24) & 0xFF
-    counts_0 = tl.histogram(bucket_0, 256, mask=valid)
-    total_0 = tl.sum(counts_0)
-    ps_0 = tl.cumsum(counts_0, axis=0)
-    ss_0 = total_0 - ps_0 + counts_0
-    pivot_0 = tl.max(tl.where(ss_0 >= TOP_K, bins, -1))
-    ca_0 = tl.sum(tl.where(bins > pivot_0, counts_0, 0))
-    remaining_k = TOP_K - ca_0
-    match_0 = (bucket_0 == pivot_0) & valid
-
-    # Radix iteration 1: byte 2
-    bucket_1 = (sortable >> 16) & 0xFF
-    counts_1 = tl.histogram(bucket_1, 256, mask=match_0)
-    total_1 = tl.sum(counts_1)
-    ps_1 = tl.cumsum(counts_1, axis=0)
-    ss_1 = total_1 - ps_1 + counts_1
-    pivot_1 = tl.max(tl.where(ss_1 >= remaining_k, bins, -1))
-    ca_1 = tl.sum(tl.where(bins > pivot_1, counts_1, 0))
-    remaining_k = remaining_k - ca_1
-    match_1 = match_0 & (bucket_1 == pivot_1)
-
-    # Radix iteration 2: byte 1
-    bucket_2 = (sortable >> 8) & 0xFF
-    counts_2 = tl.histogram(bucket_2, 256, mask=match_1)
-    total_2 = tl.sum(counts_2)
-    ps_2 = tl.cumsum(counts_2, axis=0)
-    ss_2 = total_2 - ps_2 + counts_2
-    pivot_2 = tl.max(tl.where(ss_2 >= remaining_k, bins, -1))
-    ca_2 = tl.sum(tl.where(bins > pivot_2, counts_2, 0))
-    remaining_k = remaining_k - ca_2
-    match_2 = match_1 & (bucket_2 == pivot_2)
-
-    # Radix iteration 3: byte 0 (LSB)
-    bucket_3 = sortable & 0xFF
-    counts_3 = tl.histogram(bucket_3, 256, mask=match_2)
-    total_3 = tl.sum(counts_3)
-    ps_3 = tl.cumsum(counts_3, axis=0)
-    ss_3 = total_3 - ps_3 + counts_3
-    pivot_3 = tl.max(tl.where(ss_3 >= remaining_k, bins, -1))
-    ca_3 = tl.sum(tl.where(bins > pivot_3, counts_3, 0))
-    remaining_k = remaining_k - ca_3
-
-    # Selection: write indices for elements above threshold, then equal
-    threshold = (pivot_0 << 24) | (pivot_1 << 16) | (pivot_2 << 8) | pivot_3
-    above_total = TOP_K - remaining_k
-
-    s_shifted = sortable ^ tl.full(sortable.shape, _SIGN_BIT, dtype=tl.int32)
-    t_shifted = threshold ^ _SIGN_BIT
-
-    above = (s_shifted > t_shifted) & valid
-    equal = (sortable == threshold) & valid
-
-    pa = tl.cumsum(above.to(tl.int32), axis=0)
-    tl.store(
-        indices_ptr + pa - 1,
-        offs.to(tl.int32),
-        mask=above & (pa - 1 >= 0) & (pa - 1 < TOP_K),
+    bin_idx, is_partial_match = _extract_bin_idx(
+        logits,
+        in_range,
+        logit_pattern,
+        STEP=STEP,
     )
-
-    pe = tl.cumsum(equal.to(tl.int32), axis=0)
-    wpe = above_total + pe - 1
-    tl.store(
-        indices_ptr + wpe,
-        offs.to(tl.int32),
-        mask=equal & ((pe - 1) < remaining_k) & (wpe >= 0) & (wpe < TOP_K),
+    tl.atomic_add(
+        s_histogram_ptr + bin_idx,
+        ones,
+        mask=is_partial_match,
+        sem="relaxed",
+        scope="cta",
     )
 
 
 @triton.jit
-def _topk_medium_block(
-    logits_ptr,
-    seq_len_ptr,
-    pb_hist_a_ptr,
-    pb_hist_b_ptr,
-    sync_ptr,
-    counter_ptr,
+def _process_bins(
+    logits,
+    in_range,
+    ones,
+    offs,  # row_start based
+    found_topk_values_ptrs,
+    final_cnt_ptrs,
+    logit_pattern,
+    threshold_bin_idx,
+    write_directly,
+    use_final,
+    row_start,
     indices_ptr,
-    stride1,
-    N: tl.constexpr,
-    NUM_BLOCKS: tl.constexpr,
-    BLOCK: tl.constexpr,
-    TOP_K: tl.constexpr,
+    s_histogram_ptr,
+    s_final_logits_ptr,
+    s_out_indices_ptr,
+    s_out_logits_ptr,
+    STEP: tl.constexpr,
+    TOPK: tl.constexpr,
+    MULTIPLE_BLOCKS_PER_ROW: tl.constexpr,
+    MERGE_BLOCKS: tl.constexpr,
 ):
-    """Multi-block radix select for medium vocab (8K-32K).
+    NUM_FINAL_ITEMS: tl.constexpr = 2048
 
-    All blocks participate in all 4 radix iterations using double-buffered
-    per-block histograms. 4 barriers total (1 per iteration).
-    """
-    pid = tl.program_id(0)
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
-    seq_len = tl.load(seq_len_ptr)
-    valid = (offs < N) & (offs < seq_len)
-
-    vals = tl.load(logits_ptr + offs * stride1, mask=valid, other=float("-inf"))
-    sortable = _float_to_sortable(vals)
-
-    bins = tl.arange(0, 256)
-    ha_base = pb_hist_a_ptr + pid * 256
-    hb_base = pb_hist_b_ptr + pid * 256
-
-    # Iteration 0: byte 3 (MSB), write to buf_A
-    bucket_0 = (sortable >> 24) & 0xFF
-    local_hist_0 = tl.histogram(bucket_0, 256, mask=valid)
-    tl.store(ha_base + bins, local_hist_0)
-
-    tl.debug_barrier()
-    tl.atomic_add(sync_ptr, 1)
-    while tl.atomic_add(sync_ptr, 0) < NUM_BLOCKS:
-        pass
-
-    counts = tl.zeros([256], dtype=tl.int32)
-    for i in tl.static_range(NUM_BLOCKS):
-        counts += tl.load(pb_hist_a_ptr + i * 256 + bins)
-
-    total_0 = tl.sum(counts)
-    ps_0 = tl.cumsum(counts, axis=0)
-    ss_0 = total_0 - ps_0 + counts
-    pivot_0 = tl.max(tl.where(ss_0 >= TOP_K, bins, -1))
-    ca_0 = tl.sum(tl.where(bins > pivot_0, counts, 0))
-    remaining_k = TOP_K - ca_0
-    match = (bucket_0 == pivot_0) & valid
-
-    # Iteration 1: byte 2, write to buf_B
-    bucket_1 = (sortable >> 16) & 0xFF
-    local_hist_1 = tl.histogram(bucket_1, 256, mask=match)
-    tl.store(hb_base + bins, local_hist_1)
-
-    tl.debug_barrier()
-    tl.atomic_add(sync_ptr + 1, 1)
-    while tl.atomic_add(sync_ptr + 1, 0) < NUM_BLOCKS:
-        pass
-
-    counts = tl.zeros([256], dtype=tl.int32)
-    for i in tl.static_range(NUM_BLOCKS):
-        counts += tl.load(pb_hist_b_ptr + i * 256 + bins)
-
-    total_1 = tl.sum(counts)
-    ps_1 = tl.cumsum(counts, axis=0)
-    ss_1 = total_1 - ps_1 + counts
-    pivot_1 = tl.max(tl.where(ss_1 >= remaining_k, bins, -1))
-    ca_1 = tl.sum(tl.where(bins > pivot_1, counts, 0))
-    remaining_k = remaining_k - ca_1
-    match = match & (bucket_1 == pivot_1)
-
-    # Iteration 2: byte 1, write to buf_A
-    bucket_2 = (sortable >> 8) & 0xFF
-    local_hist_2 = tl.histogram(bucket_2, 256, mask=match)
-    tl.store(ha_base + bins, local_hist_2)
-
-    tl.debug_barrier()
-    tl.atomic_add(sync_ptr + 2, 1)
-    while tl.atomic_add(sync_ptr + 2, 0) < NUM_BLOCKS:
-        pass
-
-    counts = tl.zeros([256], dtype=tl.int32)
-    for i in tl.static_range(NUM_BLOCKS):
-        counts += tl.load(pb_hist_a_ptr + i * 256 + bins)
-
-    total_2 = tl.sum(counts)
-    ps_2 = tl.cumsum(counts, axis=0)
-    ss_2 = total_2 - ps_2 + counts
-    pivot_2 = tl.max(tl.where(ss_2 >= remaining_k, bins, -1))
-    ca_2 = tl.sum(tl.where(bins > pivot_2, counts, 0))
-    remaining_k = remaining_k - ca_2
-    match = match & (bucket_2 == pivot_2)
-
-    # Iteration 3: byte 0 (LSB), write to buf_B
-    bucket_3 = sortable & 0xFF
-    local_hist_3 = tl.histogram(bucket_3, 256, mask=match)
-    tl.store(hb_base + bins, local_hist_3)
-
-    tl.debug_barrier()
-    tl.atomic_add(sync_ptr + 3, 1)
-    while tl.atomic_add(sync_ptr + 3, 0) < NUM_BLOCKS:
-        pass
-
-    counts = tl.zeros([256], dtype=tl.int32)
-    for i in tl.static_range(NUM_BLOCKS):
-        counts += tl.load(pb_hist_b_ptr + i * 256 + bins)
-
-    total_3 = tl.sum(counts)
-    ps_3 = tl.cumsum(counts, axis=0)
-    ss_3 = total_3 - ps_3 + counts
-    pivot_3 = tl.max(tl.where(ss_3 >= remaining_k, bins, -1))
-    ca_3 = tl.sum(tl.where(bins > pivot_3, counts, 0))
-    remaining_k = remaining_k - ca_3
-
-    # Selection phase
-    threshold = (pivot_0 << 24) | (pivot_1 << 16) | (pivot_2 << 8) | pivot_3
-    above_total = TOP_K - remaining_k
-
-    s_shifted = sortable ^ tl.full(sortable.shape, _SIGN_BIT, dtype=tl.int32)
-    t_shifted = threshold ^ _SIGN_BIT
-
-    above = (s_shifted > t_shifted) & valid
-    equal = (sortable == threshold) & valid
-
-    n_above = tl.sum(above.to(tl.int32))
-    if n_above > 0:
-        pa = tl.cumsum(above.to(tl.int32), axis=0)
-        base_a = tl.atomic_add(counter_ptr, n_above)
-        wp = base_a + pa - 1
+    bin_idx, is_partial_match = _extract_bin_idx(
+        logits,
+        in_range,
+        logit_pattern,
+        STEP=STEP,
+    )
+    take_lt = is_partial_match & (bin_idx < threshold_bin_idx) & write_directly
+    out_pos_lt = tl.atomic_add(
+        found_topk_values_ptrs,
+        ones,
+        mask=take_lt,
+        sem="relaxed",
+        scope="cta",
+    )
+    if MERGE_BLOCKS:
+        indices = tl.load(
+            indices_ptr + offs,
+            mask=take_lt,
+        )
         tl.store(
-            indices_ptr + wp,
+            s_out_indices_ptr + out_pos_lt,
+            indices,
+            mask=take_lt,
+        )
+    elif MULTIPLE_BLOCKS_PER_ROW:
+        tl.store(
+            s_out_indices_ptr + out_pos_lt,
+            (offs + row_start).to(tl.int32),
+            mask=take_lt,
+        )
+        tl.store(
+            s_out_logits_ptr + out_pos_lt,
+            logits,
+            mask=take_lt,
+        )
+    else:
+        tl.store(
+            s_out_indices_ptr + out_pos_lt,
             offs.to(tl.int32),
-            mask=above & (wp >= 0) & (wp < TOP_K),
+            mask=take_lt,
         )
 
-    n_equal = tl.sum(equal.to(tl.int32))
-    if n_equal > 0:
-        pe = tl.cumsum(equal.to(tl.int32), axis=0)
-        base_e = tl.atomic_add(counter_ptr + 1, n_equal)
-        wpe = above_total + base_e + pe - 1
-        tl.store(
-            indices_ptr + wpe,
-            offs.to(tl.int32),
-            mask=equal & ((base_e + pe - 1) < remaining_k) & (wpe >= 0) & (wpe < TOP_K),
+    if STEP < 3:
+        if use_final:
+            take_eq_final = is_partial_match & (bin_idx == threshold_bin_idx)
+            final_pos = tl.atomic_add(
+                final_cnt_ptrs,
+                ones,
+                mask=take_eq_final,
+                sem="relaxed",
+                scope="cta",
+            )
+            tl.store(
+                s_final_logits_ptr + final_pos,
+                logits,
+                mask=take_eq_final & (final_pos < NUM_FINAL_ITEMS),
+            )
+            # s_histogram_ptr being used for indices in final sort
+            if MERGE_BLOCKS:
+                indices = tl.load(
+                    indices_ptr + offs,
+                    mask=take_eq_final & (final_pos < NUM_FINAL_ITEMS),
+                )
+                tl.store(
+                    s_histogram_ptr + final_pos,
+                    indices,
+                    mask=take_eq_final & (final_pos < NUM_FINAL_ITEMS),
+                )
+            elif MULTIPLE_BLOCKS_PER_ROW:
+                tl.store(
+                    s_histogram_ptr + final_pos,
+                    (offs + row_start).to(tl.int32),
+                    mask=take_eq_final & (final_pos < NUM_FINAL_ITEMS),
+                )
+            else:
+                tl.store(
+                    s_histogram_ptr + final_pos,
+                    offs.to(tl.int32),
+                    mask=take_eq_final & (final_pos < NUM_FINAL_ITEMS),
+                )
+    else:
+        take_eq = is_partial_match & (bin_idx == threshold_bin_idx)
+        # s_histogram_ptr being used for exclude prefix sum
+        out_pos_eq = tl.atomic_add(
+            s_histogram_ptr + bin_idx,
+            ones,
+            mask=take_eq,
+            sem="relaxed",
+            scope="cta",
         )
-
-    # Zero shared state for next call
-    if pid == 0:
-        tl.store(sync_ptr + tl.arange(0, 4), tl.zeros([4], dtype=tl.int32))
-        tl.store(counter_ptr, 0)
-        tl.store(counter_ptr + 1, 0)
+        if MERGE_BLOCKS:
+            indices = tl.load(
+                indices_ptr + offs,
+                mask=take_eq & (out_pos_eq < TOPK),
+            )
+            tl.store(
+                s_out_indices_ptr + out_pos_eq,
+                indices,
+                mask=take_eq & (out_pos_eq < TOPK),
+            )
+        elif MULTIPLE_BLOCKS_PER_ROW:
+            tl.store(
+                s_out_indices_ptr + out_pos_eq,
+                (offs + row_start).to(tl.int32),
+                mask=take_eq & (out_pos_eq < TOPK),
+            )
+            tl.store(
+                s_out_logits_ptr + out_pos_eq,
+                logits,
+                mask=take_eq & (out_pos_eq < TOPK),
+            )
+        else:
+            tl.store(
+                s_out_indices_ptr + out_pos_eq,
+                offs.to(tl.int32),
+                mask=take_eq & (out_pos_eq < TOPK),
+            )
 
 
 @triton.jit
-def _topk_multi_block(
+def _process_histogram_step(
     logits_ptr,
-    seq_len_ptr,
-    pb_hist_ptr,
-    sync_ptr,
-    buf_val_ptr,
-    buf_idx_ptr,
-    counter_ptr,
-    indices_ptr,
+    row_start,
+    row_end,
     stride1,
-    N: tl.constexpr,
-    NUM_BLOCKS: tl.constexpr,
-    BLOCK: tl.constexpr,
-    TOP_K: tl.constexpr,
-    BUF_SIZE: tl.constexpr,
+    vocab_size,
+    skip_elems,
+    indices_ptr,
+    logit_pattern,
+    threshold_bin_idx,
+    assume_aligned,
+    s_histogram_ptr,
+    s_final_logits_ptr,
+    s_final_cnt_ptr,
+    s_threshold_bin_idx_ptr,
+    s_final_bin_size_ptr,
+    s_found_topk_values_ptr,
+    s_out_indices_ptr,
+    s_out_logits_ptr,
+    STEP: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    HAS_TLE: tl.constexpr,
+    MULTIPLE_BLOCKS_PER_ROW: tl.constexpr,
+    MERGE_BLOCKS: tl.constexpr,
 ):
-    """Multi-block radix select for large vocab (>32K).
+    VEC: tl.constexpr = 4
+    NUM_FINAL_ITEMS: tl.constexpr = 2048
+    RADIX11_SIZE: tl.constexpr = 2048
+    RADIX11_MASK: tl.constexpr = 0x7FF
+    RADIX10_SIZE: tl.constexpr = 1024
 
-    Iteration 0: all blocks compute byte-3 histograms + barrier + reduce.
-    Iterations 1-3: block-0 only, operating on a compacted buffer of
-    elements matching the byte-3 pivot.  Avoids barrier overhead for
-    high block counts (e.g. 32 blocks for vocab=129280).
-    """
-    pid = tl.program_id(0)
-    offs = pid * BLOCK + tl.arange(0, BLOCK)
-    seq_len = tl.load(seq_len_ptr)
-    valid = (offs < N) & (offs < seq_len)
+    lane = tl.arange(0, BLOCK_SIZE)
+    vec = tl.arange(0, VEC)
+    ones = tl.full([BLOCK_SIZE], 1, tl.int32)
+    ones_vec_2d = tl.full([BLOCK_SIZE, VEC], 1, tl.int32)
+    zeros = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+    zeros_vec_2d = tl.zeros([BLOCK_SIZE, VEC], dtype=tl.int32)
 
-    vals = tl.load(logits_ptr + offs * stride1, mask=valid, other=float("-inf"))
-    sortable = _float_to_sortable(vals)
+    threshold_rounds: tl.constexpr = (
+        RADIX10_SIZE // BLOCK_SIZE if STEP == 3 else RADIX11_SIZE // BLOCK_SIZE
+    )
+    for clear_round in tl.static_range(0, threshold_rounds):
+        clear_bins = clear_round * BLOCK_SIZE + lane
+        tl.store(s_histogram_ptr + clear_bins, 0)
+    tl.debug_barrier()
 
-    # Iteration 0: all blocks compute byte-3 histogram
-    bucket = (sortable >> 24) & 0xFF
-    local_hist = tl.histogram(bucket, 256, mask=valid)
+    if STEP == 2:
+        logit_pattern = (threshold_bin_idx.to(tl.uint32) & RADIX11_MASK) << 21
+    elif STEP == 3:
+        logit_pattern |= (threshold_bin_idx.to(tl.uint32) & RADIX11_MASK) << 10
 
-    bins = tl.arange(0, 256)
-    h_base = pb_hist_ptr + pid * 256
-    tl.store(h_base + bins, local_hist)
+    if assume_aligned:
+        n_tiles = tl.cdiv(vocab_size, BLOCK_SIZE)
+        n_vec_full = vocab_size // (BLOCK_SIZE * VEC)
+        rem_tiles = (vocab_size - n_vec_full * BLOCK_SIZE * VEC) // BLOCK_SIZE
+        for t in tl.range(0, n_vec_full):
+            base = t * BLOCK_SIZE * VEC + lane * VEC
+            offs = base[:, None] + vec[None, :]
+            x_vec = tl.load(logits_ptr + offs)
+            _distribute_to_bins(
+                x_vec,
+                True,
+                ones_vec_2d,
+                logit_pattern,
+                s_histogram_ptr,
+                STEP=STEP,
+            )
+        for t in tl.range(0, rem_tiles):
+            offs = (n_vec_full * VEC + t) * BLOCK_SIZE + lane
+            x = tl.load(logits_ptr + offs)
+            _distribute_to_bins(
+                x,
+                True,
+                ones,
+                logit_pattern,
+                s_histogram_ptr,
+                STEP=STEP,
+            )
+    elif stride1 == 1:
+        aligned_row_ptr = tl.multiple_of(logits_ptr + row_start + skip_elems, VEC * 4)
+        row_len = row_end - row_start - skip_elems
+        n_vec_full = row_len // (BLOCK_SIZE * VEC)
+        rem_tiles = (row_len - n_vec_full * BLOCK_SIZE * VEC) // BLOCK_SIZE
+        rem_elems = row_len % BLOCK_SIZE
+        for t in tl.range(0, n_vec_full):
+            base = t * BLOCK_SIZE * VEC + lane * VEC
+            offs = base[:, None] + vec[None, :]
+            x_vec = tl.load(aligned_row_ptr + offs)
+            _distribute_to_bins(
+                x_vec,
+                True,
+                ones_vec_2d,
+                logit_pattern,
+                s_histogram_ptr,
+                STEP=STEP,
+            )
+        for t in tl.range(0, rem_tiles):
+            offs = (n_vec_full * VEC + t) * BLOCK_SIZE + lane
+            x = tl.load(aligned_row_ptr + offs)
+            _distribute_to_bins(
+                x,
+                True,
+                ones,
+                logit_pattern,
+                s_histogram_ptr,
+                STEP=STEP,
+            )
+        if skip_elems > 0:
+            offs = lane
+            in_range = lane < skip_elems
+            x = tl.load(
+                logits_ptr + row_start + offs, mask=in_range, other=float("-inf")
+            )
+            _distribute_to_bins(
+                x,
+                in_range,
+                ones,
+                logit_pattern,
+                s_histogram_ptr,
+                STEP=STEP,
+            )
+        if rem_elems > 0:
+            offs = (n_vec_full * VEC + rem_tiles) * BLOCK_SIZE + lane
+            in_range = lane < rem_elems
+            x = tl.load(aligned_row_ptr + offs, mask=in_range, other=float("-inf"))
+            _distribute_to_bins(
+                x,
+                in_range,
+                ones,
+                logit_pattern,
+                s_histogram_ptr,
+                STEP=STEP,
+            )
+    else:
+        row_len = row_end - row_start
+        n_tiles = tl.cdiv(row_len, BLOCK_SIZE)
+        for t in tl.range(0, n_tiles):
+            offs = t * BLOCK_SIZE + lane
+            in_range = offs < row_len
+            x = tl.load(
+                logits_ptr + row_start + offs * stride1,
+                mask=in_range,
+                other=float("-inf"),
+            )
+            _distribute_to_bins(
+                x,
+                in_range,
+                ones,
+                logit_pattern,
+                s_histogram_ptr,
+                STEP=STEP,
+            )
+    last_value = tl.load(s_found_topk_values_ptr)
+    tl.debug_barrier()
+
+    threshold_bin_ptrs = s_threshold_bin_idx_ptr + zeros
+    final_bin_size_ptrs = s_final_bin_size_ptr + zeros
+    threshold_found = tl.full((), False, dtype=tl.int1)
+    for round_idx in tl.static_range(0, threshold_rounds):
+        if not threshold_found:
+            bins = round_idx * BLOCK_SIZE + lane
+            counts = tl.load(s_histogram_ptr + bins)
+            if HAS_TLE:
+                prefix_sum, counts_total = tle.cumsum(counts, axis=0, reverse=False)
+            else:
+                counts_total = tl.sum(counts)
+                prefix_sum = counts_total - tl.cumsum(counts, axis=0, reverse=True)
+            prefix_sum = prefix_sum + last_value
+            total_sum = last_value + counts_total
+            next_prefix_sum = prefix_sum + counts
+            threshold_mask = (prefix_sum < TOPK) & (next_prefix_sum >= TOPK)
+            threshold_bin = bins
+            threshold_bin_size = next_prefix_sum - prefix_sum
+            if STEP == 3:
+                tl.store(s_histogram_ptr + bins, prefix_sum)
+            tl.store(threshold_bin_ptrs, threshold_bin, mask=threshold_mask)
+            tl.store(final_bin_size_ptrs, threshold_bin_size, mask=threshold_mask)
+            found_round = tl.reduce_or(threshold_mask, axis=0)
+            threshold_found = found_round
+            last_value = total_sum
 
     tl.debug_barrier()
-    tl.atomic_add(sync_ptr, 1)
-    while tl.atomic_add(sync_ptr, 0) < NUM_BLOCKS:
-        pass
+    threshold_bin_idx = tl.load(s_threshold_bin_idx_ptr)
+    final_bin_size = tl.load(s_final_bin_size_ptr)
+    use_final = final_bin_size <= NUM_FINAL_ITEMS
+    write_directly = ((STEP == 0) & (final_bin_size <= NUM_FINAL_ITEMS)) | (STEP >= 1)
 
-    counts = tl.zeros([256], dtype=tl.int32)
-    for i in tl.static_range(NUM_BLOCKS):
-        counts += tl.load(pb_hist_ptr + i * 256 + bins)
-
-    total = tl.sum(counts)
-    ps = tl.cumsum(counts, axis=0)
-    ss = total - ps + counts
-    pivot_0 = tl.max(tl.where(ss >= TOP_K, bins, -1))
-    count_above_0 = tl.sum(tl.where(bins > pivot_0, counts, 0))
-    remaining_k = TOP_K - count_above_0
-
-    above = (bucket > pivot_0) & valid
-    match = (bucket == pivot_0) & valid
-
-    # Write above-threshold indices directly to output
-    n_above = tl.sum(above.to(tl.int32))
-    if n_above > 0:
-        pa = tl.cumsum(above.to(tl.int32), axis=0)
-        base_a = tl.atomic_add(counter_ptr, n_above)
-        wp = base_a + pa - 1
-        tl.store(
-            indices_ptr + wp,
-            offs.to(tl.int32),
-            mask=above & (wp >= 0) & (wp < TOP_K),
-        )
-
-    # Compact matching elements into buffer for block-0
-    n_match = tl.sum(match.to(tl.int32))
-    if n_match > 0:
-        pm = tl.cumsum(match.to(tl.int32), axis=0)
-        base_m = tl.atomic_add(counter_ptr + 1, n_match)
-        bp = base_m + pm - 1
-        tl.store(
-            buf_val_ptr + bp,
-            sortable,
-            mask=match & (bp >= 0) & (bp < BUF_SIZE),
-        )
-        tl.store(
-            buf_idx_ptr + bp,
-            offs.to(tl.int32),
-            mask=match & (bp >= 0) & (bp < BUF_SIZE),
-        )
-
-    # Iterations 1-3: block-0 processes compacted buffer
+    found_ptrs = s_found_topk_values_ptr + zeros
+    final_cnt_ptrs = s_final_cnt_ptr + zeros
+    if assume_aligned:
+        found_ptrs_vec_2d = s_found_topk_values_ptr + zeros_vec_2d
+        final_cnt_ptrs_vec_2d = s_final_cnt_ptr + zeros_vec_2d
+        n_tiles = tl.cdiv(vocab_size, BLOCK_SIZE)
+        n_vec_full = vocab_size // (BLOCK_SIZE * VEC)
+        rem_tiles = (vocab_size - n_vec_full * BLOCK_SIZE * VEC) // BLOCK_SIZE
+        for t in tl.range(0, n_vec_full):
+            base = t * BLOCK_SIZE * VEC + lane * VEC
+            offs = base[:, None] + vec[None, :]
+            x_vec = tl.load(logits_ptr + offs)
+            _process_bins(
+                x_vec,
+                True,
+                ones_vec_2d,
+                offs,
+                found_ptrs_vec_2d,
+                final_cnt_ptrs_vec_2d,
+                logit_pattern,
+                threshold_bin_idx,
+                write_directly,
+                use_final,
+                row_start,
+                indices_ptr,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=STEP,
+                TOPK=TOPK,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
+        for t in tl.range(0, rem_tiles):
+            offs = (n_vec_full * VEC + t) * BLOCK_SIZE + lane
+            x = tl.load(logits_ptr + offs)
+            _process_bins(
+                x,
+                True,
+                ones,
+                offs,
+                found_ptrs,
+                final_cnt_ptrs,
+                logit_pattern,
+                threshold_bin_idx,
+                write_directly,
+                use_final,
+                row_start,
+                indices_ptr,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=STEP,
+                TOPK=TOPK,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
+    elif stride1 == 1:
+        found_ptrs_vec_2d = s_found_topk_values_ptr + zeros_vec_2d
+        final_cnt_ptrs_vec_2d = s_final_cnt_ptr + zeros_vec_2d
+        aligned_row_ptr = tl.multiple_of(logits_ptr + row_start + skip_elems, VEC * 4)
+        row_len = row_end - row_start - skip_elems
+        n_vec_full = row_len // (BLOCK_SIZE * VEC)
+        rem_tiles = (row_len - n_vec_full * BLOCK_SIZE * VEC) // BLOCK_SIZE
+        rem_elems = row_len % BLOCK_SIZE
+        for t in tl.range(0, n_vec_full):
+            base = t * BLOCK_SIZE * VEC + lane * VEC
+            offs = base[:, None] + vec[None, :]
+            x_vec = tl.load(aligned_row_ptr + offs)
+            _process_bins(
+                x_vec,
+                True,
+                ones_vec_2d,
+                offs + skip_elems,
+                found_ptrs_vec_2d,
+                final_cnt_ptrs_vec_2d,
+                logit_pattern,
+                threshold_bin_idx,
+                write_directly,
+                use_final,
+                row_start,
+                indices_ptr,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=STEP,
+                TOPK=TOPK,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
+        for t in tl.range(0, rem_tiles):
+            offs = (n_vec_full * VEC + t) * BLOCK_SIZE + lane
+            x = tl.load(aligned_row_ptr + offs)
+            _process_bins(
+                x,
+                True,
+                ones,
+                offs + skip_elems,
+                found_ptrs,
+                final_cnt_ptrs,
+                logit_pattern,
+                threshold_bin_idx,
+                write_directly,
+                use_final,
+                row_start,
+                indices_ptr,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=STEP,
+                TOPK=TOPK,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
+        if skip_elems > 0:
+            offs = lane
+            in_range = lane < skip_elems
+            x = tl.load(
+                logits_ptr + row_start + offs, mask=in_range, other=float("-inf")
+            )
+            _process_bins(
+                x,
+                in_range,
+                ones,
+                offs,
+                found_ptrs,
+                final_cnt_ptrs,
+                logit_pattern,
+                threshold_bin_idx,
+                write_directly,
+                use_final,
+                row_start,
+                indices_ptr,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=STEP,
+                TOPK=TOPK,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
+        if rem_elems > 0:
+            offs = (n_vec_full * VEC + rem_tiles) * BLOCK_SIZE + lane
+            in_range = lane < rem_elems
+            x = tl.load(aligned_row_ptr + offs, mask=in_range, other=float("-inf"))
+            _process_bins(
+                x,
+                in_range,
+                ones,
+                offs + skip_elems,
+                found_ptrs,
+                final_cnt_ptrs,
+                logit_pattern,
+                threshold_bin_idx,
+                write_directly,
+                use_final,
+                row_start,
+                indices_ptr,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=STEP,
+                TOPK=TOPK,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
+    else:
+        row_len = row_end - row_start
+        n_tiles = tl.cdiv(row_len, BLOCK_SIZE)
+        for t in tl.range(0, n_tiles):
+            offs = t * BLOCK_SIZE + lane
+            in_range = offs < row_len
+            x = tl.load(
+                logits_ptr + row_start + offs * stride1,
+                mask=in_range,
+                other=float("-inf"),
+            )
+            _process_bins(
+                x,
+                in_range,
+                ones,
+                offs,
+                found_ptrs,
+                final_cnt_ptrs,
+                logit_pattern,
+                threshold_bin_idx,
+                write_directly,
+                use_final,
+                row_start,
+                indices_ptr,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=STEP,
+                TOPK=TOPK,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
     tl.debug_barrier()
-    tl.atomic_add(sync_ptr + 1, 1)
-    if pid == 0:
-        while tl.atomic_add(sync_ptr + 1, 0) < NUM_BLOCKS:
-            pass
+    return final_bin_size > NUM_FINAL_ITEMS, logit_pattern, threshold_bin_idx
 
-        buf_count = tl.atomic_add(counter_ptr + 1, 0)
 
-        b_offs = tl.arange(0, BUF_SIZE)
-        b_valid = b_offs < buf_count
-        b_vals = tl.load(buf_val_ptr + b_offs, mask=b_valid, other=0)
-        b_idxs = tl.load(buf_idx_ptr + b_offs, mask=b_valid, other=0)
+@triton.jit
+def _final_select_radix(
+    s_histogram_ptr,
+    s_final_logits_ptr,
+    s_final_cnt_ptr,
+    s_found_topk_values_ptr,
+    s_out_indices_ptr,
+    s_out_logits_ptr,
+    TOPK: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    MULTIPLE_BLOCKS_PER_ROW: tl.constexpr,
+):
+    NUM_FINAL_ITEMS: tl.constexpr = 2048
+    RADIX_BITS_FINAL: tl.constexpr = 8
+    RADIX_SIZE_FINAL: tl.constexpr = 1 << RADIX_BITS_FINAL
+    RADIX_MASK_FINAL: tl.constexpr = RADIX_SIZE_FINAL - 1
+    DIGIT_START: tl.constexpr = 32 - RADIX_BITS_FINAL
 
-        # Iteration 1: byte 2
-        b_byte_1 = (b_vals >> 16) & 0xFF
-        counts_1 = tl.histogram(b_byte_1, 256, mask=b_valid)
-        total_1 = tl.sum(counts_1)
-        ps_1 = tl.cumsum(counts_1, axis=0)
-        ss_1 = total_1 - ps_1 + counts_1
-        pivot_1 = tl.max(tl.where(ss_1 >= remaining_k, bins, -1))
-        ca_1 = tl.sum(tl.where(bins > pivot_1, counts_1, 0))
-        remaining_k = remaining_k - ca_1
+    lane = tl.arange(0, BLOCK_SIZE)
+    ones = tl.full([BLOCK_SIZE], 1, tl.int32)
+    zeros = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+    bins = tl.arange(0, RADIX_SIZE_FINAL)
 
-        # Iteration 2: byte 1
-        prefix_hi16 = (pivot_0 << 8) | pivot_1
-        upper16 = (b_vals >> 16) & 0xFFFF
-        b_match_2 = (upper16 == prefix_hi16) & b_valid
-        b_bucket_2 = (b_vals >> 8) & 0xFF
-        counts_2 = tl.histogram(b_bucket_2, 256, mask=b_match_2)
-        total_2 = tl.sum(counts_2)
-        ps_2 = tl.cumsum(counts_2, axis=0)
-        ss_2 = total_2 - ps_2 + counts_2
-        pivot_2 = tl.max(tl.where(ss_2 >= remaining_k, bins, -1))
-        ca_2 = tl.sum(tl.where(bins > pivot_2, counts_2, 0))
-        remaining_k = remaining_k - ca_2
+    s_radix_counts = tle.gpu.alloc(
+        [RADIX_SIZE_FINAL],
+        dtype=tl.int32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_radix_count_ptr = tle.gpu.local_ptr(s_radix_counts, (0,))
+    radix_count_vec_ptr = s_radix_count_ptr + bins
+    base_idx = tl.load(s_found_topk_values_ptr)
+    final_cnt = tl.minimum(tl.load(s_final_cnt_ptr), NUM_FINAL_ITEMS)
+    remain = tl.minimum(TOPK - base_idx, final_cnt)
+    tl.debug_barrier()
 
-        # Iteration 3: byte 0 (LSB)
-        prefix_hi24 = (prefix_hi16 << 8) | pivot_2
-        upper24 = (b_vals >> 8) & 0xFFFFFF
-        b_match_3 = (upper24 == prefix_hi24) & b_valid
-        b_bucket_3 = b_vals & 0xFF
-        counts_3 = tl.histogram(b_bucket_3, 256, mask=b_match_3)
-        total_3 = tl.sum(counts_3)
-        ps_3 = tl.cumsum(counts_3, axis=0)
-        ss_3 = total_3 - ps_3 + counts_3
-        pivot_3 = tl.max(tl.where(ss_3 >= remaining_k, bins, -1))
-        ca_3 = tl.sum(tl.where(bins > pivot_3, counts_3, 0))
-        remaining_k = remaining_k - ca_3
+    if remain > 0:
+        desired = tl.zeros((), dtype=tl.uint32)
+        desired_mask = tl.zeros((), dtype=tl.uint32)
+        k_to_find = remain + 1
 
-        # Final selection from buffer
-        threshold = (prefix_hi24 << 8) | pivot_3
-        above_total = TOP_K - remaining_k
+        for digit_pos in tl.static_range(DIGIT_START, -1, -RADIX_BITS_FINAL):
+            if k_to_find > 1:
+                tl.store(s_radix_count_ptr + lane, 0, mask=lane < RADIX_SIZE_FINAL)
+                tl.debug_barrier()
 
-        s_sh = b_vals ^ tl.full(b_vals.shape, _SIGN_BIT, dtype=tl.int32)
-        t_sh = threshold ^ _SIGN_BIT
+                cnt_tiles = tl.cdiv(final_cnt, BLOCK_SIZE)
+                for t in tl.range(0, cnt_tiles):
+                    pos = t * BLOCK_SIZE + lane
+                    valid = pos < final_cnt
+                    x = tl.load(
+                        s_final_logits_ptr + pos,
+                        mask=valid,
+                        other=0,
+                    )
+                    key = _convert_to_uint32(x)
+                    matches = (key & desired_mask) == desired
+                    digit = ((key >> digit_pos) & RADIX_MASK_FINAL).to(tl.int32)
+                    take = valid & matches
+                    tl.atomic_add(
+                        s_radix_count_ptr + digit,
+                        ones,
+                        mask=take,
+                        sem="relaxed",
+                        scope="cta",
+                    )
 
-        above_buf = (s_sh > t_sh) & b_valid
-        equal_buf = (b_vals == threshold) & b_valid
+                tl.debug_barrier()
+                counts = tl.load(radix_count_vec_ptr)
+                prefix_sum, _ = tle.cumsum(counts, axis=0, reverse=False)
+                next_prefix_sum = prefix_sum + counts
+                threshold_mask = (prefix_sum < k_to_find) & (
+                    next_prefix_sum >= k_to_find
+                )
+                threshold_init = tl.full((), RADIX_SIZE_FINAL, dtype=tl.int32)
+                threshold_bin = tl.min(
+                    tl.where(threshold_mask, bins, threshold_init), axis=0
+                ).to(tl.int32)
+                threshold_bin = tl.where(
+                    threshold_bin == RADIX_SIZE_FINAL,
+                    RADIX_SIZE_FINAL - 1,
+                    threshold_bin,
+                )
+                counts_lt = tl.max(
+                    tl.where(bins == threshold_bin, prefix_sum, 0), axis=0
+                ).to(tl.int32)
 
-        pa_b = tl.cumsum(above_buf.to(tl.int32), axis=0)
-        wp_b = count_above_0 + pa_b - 1
-        tl.store(
-            indices_ptr + wp_b,
-            b_idxs,
-            mask=above_buf & (wp_b >= 0) & (wp_b < TOP_K),
+                desired = desired | (threshold_bin.to(tl.uint32) << digit_pos)
+                desired_mask = desired_mask | (
+                    tl.full((), RADIX_MASK_FINAL, dtype=tl.uint32) << digit_pos
+                )
+                k_to_find = k_to_find - counts_lt
+
+        thr_key = desired
+        found_ptrs = s_found_topk_values_ptr + zeros
+        cnt_tiles = tl.cdiv(final_cnt, BLOCK_SIZE)
+        for t in tl.range(0, cnt_tiles):
+            pos = t * BLOCK_SIZE + lane
+            valid = pos < final_cnt
+            idx = tl.load(s_histogram_ptr + pos, mask=valid, other=0)
+            x = tl.load(
+                s_final_logits_ptr + pos,
+                mask=valid,
+                other=0,
+            )
+            key = _convert_to_uint32(x)
+            take_lt = valid & (key < thr_key)
+            out_pos_gt = tl.atomic_add(
+                found_ptrs,
+                ones,
+                mask=take_lt,
+                sem="relaxed",
+                scope="cta",
+            )
+            tl.store(
+                s_out_indices_ptr + out_pos_gt,
+                idx,
+                mask=take_lt & (out_pos_gt < TOPK),
+            )
+            if MULTIPLE_BLOCKS_PER_ROW:
+                tl.store(
+                    s_out_logits_ptr + out_pos_gt,
+                    x,
+                    mask=take_lt & (out_pos_gt < TOPK),
+                )
+
+        tl.debug_barrier()
+        cur = tl.load(s_found_topk_values_ptr)
+        if cur < TOPK:
+            for t in tl.range(0, cnt_tiles):
+                cur = tl.load(s_found_topk_values_ptr)
+                if cur < TOPK:
+                    pos = t * BLOCK_SIZE + lane
+                    valid = pos < final_cnt
+                    idx = tl.load(s_histogram_ptr + pos, mask=valid, other=0)
+                    x = tl.load(
+                        s_final_logits_ptr + pos,
+                        mask=valid,
+                        other=0,
+                    )
+                    key = _convert_to_uint32(x)
+                    take_eq = valid & (key == thr_key)
+                    out_pos_eq = tl.atomic_add(
+                        found_ptrs,
+                        ones,
+                        mask=take_eq,
+                        sem="relaxed",
+                        scope="cta",
+                    )
+                    tl.store(
+                        s_out_indices_ptr + out_pos_eq,
+                        idx,
+                        mask=take_eq & (out_pos_eq < TOPK),
+                    )
+                    if MULTIPLE_BLOCKS_PER_ROW:
+                        tl.store(
+                            s_out_logits_ptr + out_pos_eq,
+                            x,
+                            mask=take_eq & (out_pos_eq < TOPK),
+                        )
+        tl.debug_barrier()
+
+
+@triton.jit
+def _top_k_per_row_job(
+    logits_ptr,
+    out_indices_ptr,
+    row_start,
+    row_end,
+    stride1,
+    vocab_size,
+    skip_elems,
+    out_logits_ptr,
+    indices_ptr,
+    s_histogram_ptr,
+    s_final_logits_ptr,
+    s_final_cnt_ptr,
+    s_threshold_bin_idx_ptr,
+    s_final_bin_size_ptr,
+    s_found_topk_values_ptr,
+    s_out_indices_ptr,
+    s_out_logits_ptr,
+    TOPK: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    USE_RADIX_FINAL: tl.constexpr,
+    HAS_TLE: tl.constexpr,
+    MULTIPLE_BLOCKS_PER_ROW: tl.constexpr,
+    MERGE_BLOCKS: tl.constexpr,
+):
+    NUM_FINAL_ITEMS: tl.constexpr = 2048
+
+    assume_aligned = (
+        (row_start == 0)
+        & (row_end == vocab_size)
+        & (stride1 == 1)
+        & ((vocab_size % BLOCK_SIZE) == 0)
+    )
+    if assume_aligned:
+        tl.assume(row_start == 0)
+        tl.assume(row_end == vocab_size)
+        tl.assume(stride1 == 1)
+        vocab_size = tl.multiple_of(vocab_size, BLOCK_SIZE)
+    elif stride1 == 1:
+        tl.assume(stride1 == 1)
+
+    lane = tl.arange(0, BLOCK_SIZE)
+    row_len = row_end - row_start
+    if row_len <= TOPK:
+        chunks: tl.constexpr = (TOPK + BLOCK_SIZE - 1) // BLOCK_SIZE
+        for chunk_idx in tl.range(0, chunks):
+            pos = chunk_idx * BLOCK_SIZE + lane
+            take_row = pos < row_len
+            if MULTIPLE_BLOCKS_PER_ROW:
+                tl.store(
+                    out_indices_ptr + pos,
+                    (pos + row_start).to(tl.int32),
+                    mask=take_row,
+                )
+                logits = tl.load(logits_ptr + pos + row_start, mask=take_row)
+                tl.store(out_logits_ptr + pos, logits, mask=take_row)
+            else:
+                tl.store(
+                    out_indices_ptr + pos,
+                    pos.to(tl.int32),
+                    mask=take_row,
+                )
+            take_pad = (pos >= row_len) & (pos < TOPK)
+            tl.store(out_indices_ptr + pos, -1, mask=take_pad)
+            if MULTIPLE_BLOCKS_PER_ROW:
+                tl.store(out_logits_ptr + pos, float("-inf"), mask=take_pad)
+        return
+    tl.store(s_final_cnt_ptr, 0)
+    tl.store(s_found_topk_values_ptr, 0)
+    tl.debug_barrier()
+    logit_pattern = tl.zeros((), dtype=tl.uint32)
+    continue_to_next_step = tl.full((), True, dtype=tl.int1)
+    threshold_bin_idx = tl.full((), -1, dtype=tl.int32)
+    for step_idx in tl.static_range(0, 4):
+        if continue_to_next_step:
+            (
+                continue_to_next_step,
+                logit_pattern,
+                threshold_bin_idx,
+            ) = _process_histogram_step(
+                logits_ptr,
+                row_start,
+                row_end,
+                stride1,
+                vocab_size,
+                skip_elems,
+                indices_ptr,
+                logit_pattern,
+                threshold_bin_idx,
+                assume_aligned,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_final_cnt_ptr,
+                s_threshold_bin_idx_ptr,
+                s_final_bin_size_ptr,
+                s_found_topk_values_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=step_idx,
+                TOPK=TOPK,
+                BLOCK_SIZE=BLOCK_SIZE,
+                HAS_TLE=HAS_TLE,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
+
+    if not continue_to_next_step:
+        if USE_RADIX_FINAL and HAS_TLE:
+            _final_select_radix(
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_final_cnt_ptr,
+                s_found_topk_values_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                TOPK=TOPK,
+                BLOCK_SIZE=BLOCK_SIZE,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+            )
+        else:
+            base_idx = tl.load(s_found_topk_values_ptr)
+            # Guard against stale/oversized counts to avoid out-of-bounds accesses
+            # in the shared-memory final buffers.
+            final_cnt = tl.minimum(tl.load(s_final_cnt_ptr), NUM_FINAL_ITEMS)
+            sort_chunks = tl.cdiv(final_cnt, BLOCK_SIZE)
+            for sort_chunk in tl.range(0, sort_chunks):
+                pos = sort_chunk * BLOCK_SIZE + lane
+                valid = pos < final_cnt
+                logit_i = tl.load(
+                    s_final_logits_ptr + pos,
+                    mask=valid,
+                    other=0,
+                )
+                out_rank = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+                for j in tl.range(0, final_cnt):
+                    logit_j = tl.load(s_final_logits_ptr + j)
+                    better = (logit_i < logit_j) | ((logit_i == logit_j) & (pos < j))
+                    out_rank = out_rank + (valid & better).to(tl.int32)
+                dst_pos = base_idx + out_rank
+                take = valid & (dst_pos < TOPK)
+                idx_i = tl.load(
+                    s_histogram_ptr + pos,
+                    mask=take,
+                    other=0,
+                )
+                tl.store(s_out_indices_ptr + dst_pos, idx_i, mask=take)
+                if MULTIPLE_BLOCKS_PER_ROW:
+                    tl.store(s_out_logits_ptr + dst_pos, logit_i, mask=take)
+            tl.debug_barrier()
+
+    # out_indices_ptr is identical to s_out_indices_ptr for non-tle
+    if HAS_TLE:
+        flush_chunks: tl.constexpr = (TOPK + BLOCK_SIZE - 1) // BLOCK_SIZE
+        for flush_chunk in tl.static_range(flush_chunks):
+            pos = flush_chunk * BLOCK_SIZE + lane
+            mask = pos < TOPK
+            out_vals = tl.load(s_out_indices_ptr + pos, mask=mask, other=-1)
+            tl.store(out_indices_ptr + pos, out_vals, mask=mask)
+            if MULTIPLE_BLOCKS_PER_ROW:
+                split_logits = tl.load(
+                    s_out_logits_ptr + pos, mask=mask, other=float("-inf")
+                )
+                tl.store(out_logits_ptr + pos, split_logits, mask=mask)
+
+
+# End of shared implementation code for top_k_per_row_decode and top_k_per_row_prefill
+
+
+@triton.jit
+def tle_top_k_per_row_decode(
+    logits_ptr,
+    out_indices_ptr,
+    seq_lens_ptr,
+    next_n,
+    stride0,
+    stride1,
+    vocab_size,
+    out_logits_ptr,
+    indices_ptr,
+    TOPK: tl.constexpr,
+    TOPKP: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    USE_RADIX_FINAL: tl.constexpr,
+    MULTIPLE_BLOCKS_PER_ROW: tl.constexpr,
+    MULTIPLE_BLOCKS_NUM: tl.constexpr,
+    MERGE_BLOCKS: tl.constexpr,
+):
+    NUM_FILNAL_ITEMS: tl.constexpr = 2048
+    NUM_BINS: tl.constexpr = 2048
+    VEC: tl.constexpr = 4
+
+    row_id = tl.program_id(0)
+    batch_id = row_id // next_n
+    batch_offset = row_id % next_n
+    seq_len = tl.load(seq_lens_ptr + batch_id)
+    row_start = 0
+    row_len = seq_len - next_n + batch_offset + 1
+    row_end = row_len
+
+    if (not MULTIPLE_BLOCKS_PER_ROW) & (not MERGE_BLOCKS):
+        out_indices_ptr += row_id * TOPK
+    elif MULTIPLE_BLOCKS_PER_ROW:
+        blk_id = tl.program_id(1)
+        row_blk_size = row_end // MULTIPLE_BLOCKS_NUM
+        row_start = row_blk_size * blk_id
+        row_end = (
+            row_end if blk_id == MULTIPLE_BLOCKS_NUM - 1 else row_start + row_blk_size
         )
+        out_indices_ptr += row_id * MULTIPLE_BLOCKS_NUM * TOPK + blk_id * TOPK
+        out_logits_ptr += row_id * MULTIPLE_BLOCKS_NUM * TOPK + blk_id * TOPK
+    elif MERGE_BLOCKS:
+        row_end = MULTIPLE_BLOCKS_NUM * TOPK
+        indices_ptr += row_id * MULTIPLE_BLOCKS_NUM * TOPK
+        out_indices_ptr += row_id * TOPK
+    logits_ptr += row_id * stride0
+    # float4 align
+    x_off_mod = (row_id * stride0 + row_start) % VEC
+    skip_elems = 0 if x_off_mod == 0 else VEC - x_off_mod
 
-        pe_b = tl.cumsum(equal_buf.to(tl.int32), axis=0)
-        wpe_b = above_total + pe_b - 1
-        tl.store(
-            indices_ptr + wpe_b,
-            b_idxs,
-            mask=equal_buf
-            & ((pe_b - 1) < remaining_k)
-            & (wpe_b >= 0)
-            & (wpe_b < TOP_K),
+    # used for histogram, indices in final sort and exclude prefix_sum
+    s_histogram = tle.gpu.alloc(
+        [NUM_BINS],
+        dtype=tl.int32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_final_logits = tle.gpu.alloc(
+        [NUM_FILNAL_ITEMS],
+        dtype=tl.float32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_out_indices = tle.gpu.alloc(
+        [TOPKP],
+        dtype=tl.int32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_final_cnt = tle.gpu.alloc(
+        [1],
+        dtype=tl.int32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_threshold_bin_idx = tle.gpu.alloc(
+        [1],
+        dtype=tl.int32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_final_bin_size = tle.gpu.alloc(
+        [1],
+        dtype=tl.int32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_found_topk_values = tle.gpu.alloc(
+        [1],
+        dtype=tl.int32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_histogram_ptr = tle.gpu.local_ptr(s_histogram, (0,))
+    s_final_logits_ptr = tle.gpu.local_ptr(s_final_logits, (0,))
+    s_out_indices_ptr = tle.gpu.local_ptr(s_out_indices, (0,))
+    s_final_cnt_ptr = tle.gpu.local_ptr(s_final_cnt, (0,))
+    s_threshold_bin_idx_ptr = tle.gpu.local_ptr(s_threshold_bin_idx, (0,))
+    s_final_bin_size_ptr = tle.gpu.local_ptr(s_final_bin_size, (0,))
+    s_found_topk_values_ptr = tle.gpu.local_ptr(s_found_topk_values, (0,))
+    if MULTIPLE_BLOCKS_PER_ROW:
+        s_out_logits = tle.gpu.alloc(
+            [TOPKP],
+            dtype=tl.float32,
+            layout=None,
+            scope=tle.gpu.smem,
+            nv_mma_shared_layout=False,
         )
+        s_out_logits_ptr = tle.gpu.local_ptr(s_out_logits, (0,))
+    else:
+        s_out_logits_ptr = None
 
-        tl.store(sync_ptr, 0)
-        tl.store(sync_ptr + 1, 0)
-        tl.store(counter_ptr, 0)
-        tl.store(counter_ptr + 1, 0)
+    _top_k_per_row_job(
+        logits_ptr,
+        out_indices_ptr,
+        row_start,
+        row_end,
+        stride1,
+        vocab_size,
+        skip_elems,
+        out_logits_ptr,
+        indices_ptr,
+        s_histogram_ptr,
+        s_final_logits_ptr,
+        s_final_cnt_ptr,
+        s_threshold_bin_idx_ptr,
+        s_final_bin_size_ptr,
+        s_found_topk_values_ptr,
+        s_out_indices_ptr,
+        s_out_logits_ptr,
+        TOPK=TOPK,
+        BLOCK_SIZE=BLOCK_SIZE,
+        USE_RADIX_FINAL=USE_RADIX_FINAL,
+        HAS_TLE=True,
+        MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+        MERGE_BLOCKS=MERGE_BLOCKS,
+    )
 
 
-# Persistent scratch buffers, keyed by (device_index, dispatch_tier).
-# Allocated once per device and reused across calls to avoid cudaMalloc overhead.
-_cache = {}
+@triton.jit
+def non_tle_top_k_per_row_decode(
+    logits_ptr,
+    out_indices_ptr,
+    seq_lens_ptr,
+    next_n,
+    stride0,
+    stride1,
+    vocab_size,
+    s_histogram_ptr,
+    s_final_logits_ptr,
+    s_final_cnt_ptr,
+    s_threshold_bin_idx_ptr,
+    s_final_bin_size_ptr,
+    s_found_topk_values_ptr,
+    TOPK: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+):
+    VEC: tl.constexpr = 4
+    NUM_BINS: tl.constexpr = 2048
+    NUM_FILNAL_ITEMS: tl.constexpr = 2048
 
-# Dispatch thresholds for the three kernel tiers
-_SINGLE_BLOCK_LIMIT = 8192
-_MEDIUM_BLOCK_LIMIT = 32768
-_MEDIUM_BLOCK_SIZE = 4096
-_LARGE_BLOCK_SIZE = 4096
-_LARGE_BUF_SIZE = 4096
+    row_id = tl.program_id(0)
+    batch_id = row_id // next_n
+    batch_offset = row_id % next_n
+    seq_len = tl.load(seq_lens_ptr + batch_id)
+    row_start = 0
+    row_len = seq_len - next_n + batch_offset + 1
+    row_end = row_len
+
+    out_indices_ptr += row_id * TOPK
+    logits_ptr += row_id * stride0
+    # float4 align
+    x_off_mod = (row_id * stride0 + row_start) % VEC
+    skip_elems = 0 if x_off_mod == 0 else VEC - x_off_mod
+
+    s_histogram_ptr += row_id * NUM_BINS
+    s_final_logits_ptr += row_id * NUM_FILNAL_ITEMS
+    s_final_cnt_ptr += row_id
+    s_threshold_bin_idx_ptr += row_id
+    s_final_bin_size_ptr += row_id
+    s_found_topk_values_ptr += row_id
+
+    _top_k_per_row_job(
+        logits_ptr,
+        out_indices_ptr,
+        row_start,
+        row_end,
+        stride1,
+        vocab_size,
+        skip_elems,
+        None,
+        None,
+        s_histogram_ptr,
+        s_final_logits_ptr,
+        s_final_cnt_ptr,
+        s_threshold_bin_idx_ptr,
+        s_final_bin_size_ptr,
+        s_found_topk_values_ptr,
+        out_indices_ptr,
+        None,
+        TOPK=TOPK,
+        BLOCK_SIZE=BLOCK_SIZE,
+        USE_RADIX_FINAL=False,
+        HAS_TLE=False,
+        MULTIPLE_BLOCKS_PER_ROW=False,
+        MERGE_BLOCKS=False,
+    )
 
 
 def top_k_per_row_decode(
@@ -492,10 +1210,10 @@ def top_k_per_row_decode(
     selection. Only valid elements within [0, seq_lens[0]) are considered.
 
     Args:
-        logits: [1, vocab_size] float32 tensor.
+        logits: [num_rows, vocab_size] float32 tensor.
         next_n: number of next tokens (unused, kept for API compatibility).
-        seq_lens: [1] int32 — valid range [0, seq_lens[0]).
-        indices: [1, top_k] int32 — output buffer, filled with selected indices.
+        seq_lens: [B,] int32 — valid range [0, seq_lens[0]).
+        indices: [num_rows, top_k] int32 — output buffer, filled with selected indices.
         num_rows: must be 1 (decode processes one row at a time).
         stride0: logits.stride(0).
         stride1: logits.stride(1).
@@ -503,102 +1221,120 @@ def top_k_per_row_decode(
     """
     logger.debug("GEMS TOP_K_PER_ROW_DECODE")
 
-    assert num_rows == 1, "Only num_rows=1 supported in decode path"
-
+    assert num_rows == logits.shape[0]
     vocab_size = logits.shape[1]
-    device = logits.device
-    ind = indices.view(-1)
-
-    if vocab_size <= _SINGLE_BLOCK_LIMIT // 2:
-        # Small vocab: single block with BLOCK=4096
-        _topk_single_block[(1,)](
-            logits,
-            seq_lens,
-            ind,
-            stride1,
-            N=vocab_size,
-            BLOCK=_SINGLE_BLOCK_LIMIT // 2,
-            TOP_K=top_k,
-            num_warps=8,
-        )
-    elif vocab_size <= _SINGLE_BLOCK_LIMIT:
-        # Medium-small vocab: single block with BLOCK=8192
-        _topk_single_block[(1,)](
-            logits,
-            seq_lens,
-            ind,
-            stride1,
-            N=vocab_size,
-            BLOCK=_SINGLE_BLOCK_LIMIT,
-            TOP_K=top_k,
-            num_warps=16,
-        )
-    elif vocab_size <= _MEDIUM_BLOCK_LIMIT:
-        # Medium vocab: double-buffered all-blocks radix
-        n_blocks = (vocab_size + _MEDIUM_BLOCK_SIZE - 1) // _MEDIUM_BLOCK_SIZE
-        dev_idx = device.index if device.index is not None else 0
-        key = (dev_idx, "med")
-        if key not in _cache:
-            max_nb = (
-                _MEDIUM_BLOCK_LIMIT + _MEDIUM_BLOCK_SIZE - 1
-            ) // _MEDIUM_BLOCK_SIZE
-            pb_size = max_nb * 256
-            pb_hist_a = torch.zeros(pb_size, dtype=torch.int32, device=device)
-            pb_hist_b = torch.zeros(pb_size, dtype=torch.int32, device=device)
-            sync = torch.zeros(4, dtype=torch.int32, device=device)
-            counter = torch.zeros(2, dtype=torch.int32, device=device)
-            _cache[key] = (pb_hist_a, pb_hist_b, sync, counter)
-        pb_hist_a, pb_hist_b, sync, counter = _cache[key]
-
-        _topk_medium_block[(n_blocks,)](
-            logits,
-            seq_lens,
-            pb_hist_a,
-            pb_hist_b,
-            sync,
-            counter,
-            ind,
-            stride1,
-            N=vocab_size,
-            NUM_BLOCKS=n_blocks,
-            BLOCK=_MEDIUM_BLOCK_SIZE,
-            TOP_K=top_k,
-            num_warps=8,
-        )
-    else:
-        # Large vocab: buffer-based multi-block radix
-        n_blocks = (vocab_size + _LARGE_BLOCK_SIZE - 1) // _LARGE_BLOCK_SIZE
-        dev_idx = device.index if device.index is not None else 0
-        key = (dev_idx, "large")
-        if key not in _cache:
-            max_nb = 64
-            pb_size = max_nb * 256
-            total_sz = pb_size + 4
-            scratch = torch.zeros(total_sz, dtype=torch.int32, device=device)
-            buf = torch.empty(_LARGE_BUF_SIZE * 2, dtype=torch.int32, device=device)
-            _cache[key] = (
-                scratch[:pb_size],
-                scratch[pb_size : pb_size + 2],
-                buf[:_LARGE_BUF_SIZE],
-                buf[_LARGE_BUF_SIZE:],
-                scratch[pb_size + 2 : pb_size + 4],
+    use_radix_final = vocab_size >= SORTING_ALGORITHM_THRESHOLD
+    if HAS_TLE:
+        topkp = triton.next_power_of_2(top_k)
+        if vocab_size < SPLIT_WORK_THRESHOLD:
+            tle_top_k_per_row_decode[(num_rows,)](
+                logits,
+                indices,
+                seq_lens,
+                next_n,
+                stride0,
+                stride1,
+                vocab_size,
+                None,
+                None,
+                TOPK=top_k,
+                TOPKP=topkp,
+                BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
+                USE_RADIX_FINAL=use_radix_final,
+                MULTIPLE_BLOCKS_PER_ROW=False,
+                MULTIPLE_BLOCKS_NUM=1,
+                MERGE_BLOCKS=False,
+                num_warps=NUM_THREADS_PER_BLOCK // 32,
             )
-        pb_hist, sync, buf_val, buf_idx, counter = _cache[key]
-
-        _topk_multi_block[(n_blocks,)](
+        else:
+            device = logits.device
+            out_indices_aux = torch.empty(
+                (num_rows, MULTIPLE_BLOCKS_PER_ROW_CONFIG, top_k),
+                device=device,
+                dtype=torch.int32,
+            )
+            out_logits_aux = torch.empty(
+                (num_rows, MULTIPLE_BLOCKS_PER_ROW_CONFIG, top_k),
+                device=device,
+                dtype=torch.float32,
+            )
+            tle_top_k_per_row_decode[
+                (
+                    num_rows,
+                    MULTIPLE_BLOCKS_PER_ROW_CONFIG,
+                )
+            ](
+                logits,
+                out_indices_aux,
+                seq_lens,
+                next_n,
+                stride0,
+                stride1,
+                vocab_size,
+                out_logits_aux,
+                None,
+                TOPK=top_k,
+                TOPKP=topkp,
+                BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
+                USE_RADIX_FINAL=use_radix_final,
+                MULTIPLE_BLOCKS_PER_ROW=True,
+                MULTIPLE_BLOCKS_NUM=MULTIPLE_BLOCKS_PER_ROW_CONFIG,
+                MERGE_BLOCKS=False,
+                num_warps=NUM_THREADS_PER_BLOCK // 32,
+            )
+            tle_top_k_per_row_decode[(num_rows,)](
+                out_logits_aux,
+                indices,
+                seq_lens,
+                next_n,
+                MULTIPLE_BLOCKS_PER_ROW_CONFIG * top_k,
+                1,
+                MULTIPLE_BLOCKS_PER_ROW_CONFIG * top_k,
+                None,
+                out_indices_aux,
+                TOPK=top_k,
+                TOPKP=topkp,
+                BLOCK_SIZE=NUM_THREADS_PER_BLOCK_MERGE,
+                USE_RADIX_FINAL=use_radix_final,
+                MULTIPLE_BLOCKS_PER_ROW=False,
+                MULTIPLE_BLOCKS_NUM=MULTIPLE_BLOCKS_PER_ROW_CONFIG,
+                MERGE_BLOCKS=True,
+                num_warps=NUM_THREADS_PER_BLOCK_MERGE // 32,
+            )
+    else:
+        # based on tle version
+        device = logits.device
+        s_histogram_ptr = torch.empty(
+            (num_rows, NUM_BINS), device=device, dtype=torch.int32
+        )
+        s_final_logits_ptr = torch.empty(
+            (num_rows, NUM_FILNAL_ITEMS), device=device, dtype=torch.float32
+        )
+        s_final_cnt_ptr = torch.empty((num_rows,), device=device, dtype=torch.int32)
+        s_threshold_bin_idx_ptr = torch.empty(
+            (num_rows,), device=device, dtype=torch.int32
+        )
+        s_final_bin_size_ptr = torch.empty(
+            (num_rows,), device=device, dtype=torch.int32
+        )
+        s_found_topk_values_ptr = torch.empty(
+            (num_rows,), device=device, dtype=torch.int32
+        )
+        non_tle_top_k_per_row_decode[(num_rows,)](
             logits,
+            indices,
             seq_lens,
-            pb_hist,
-            sync,
-            buf_val,
-            buf_idx,
-            counter,
-            ind,
+            next_n,
+            stride0,
             stride1,
-            N=vocab_size,
-            NUM_BLOCKS=n_blocks,
-            BLOCK=_LARGE_BLOCK_SIZE,
-            TOP_K=top_k,
-            BUF_SIZE=_LARGE_BUF_SIZE,
-            num_warps=8,
+            vocab_size,
+            s_histogram_ptr,
+            s_final_logits_ptr,
+            s_final_cnt_ptr,
+            s_threshold_bin_idx_ptr,
+            s_final_bin_size_ptr,
+            s_found_topk_values_ptr,
+            TOPK=top_k,
+            BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
+            num_warps=NUM_THREADS_PER_BLOCK // 32,
         )

--- a/src/flag_gems/fused/top_k_per_row_prefill.py
+++ b/src/flag_gems/fused/top_k_per_row_prefill.py
@@ -25,19 +25,33 @@ Performance (DeepSeek V4 config, vocab=129280, top_k=1024):
     - num_rows=32: 0.38x vs vLLM CUDA (bounded by torch.topk on large vocab)
 """
 
+import logging
+
 import torch
 import triton
 import triton.language as tl
 
+logger = logging.getLogger(__name__)
 
+
+@triton.autotune(
+    configs=[
+        triton.Config({"BLOCK_SIZE": 4096}, num_warps=2),
+        triton.Config({"BLOCK_SIZE": 8192}, num_warps=2),
+        triton.Config({"BLOCK_SIZE": 8192}, num_warps=4),
+        triton.Config({"BLOCK_SIZE": 16384}, num_warps=4),
+    ],
+    key=["vocab_size"],
+)
 @triton.jit
 def _mask_invalid_kernel(
     logits_ptr,
     row_starts_ptr,
     row_ends_ptr,
-    stride0,  # logits row stride (= vocab_size for contiguous tensor)
-    BLOCK_SIZE: tl.constexpr,  # 8192: tuned for 129280 vocab (16 blocks/row)
-    VOCAB_SIZE: tl.constexpr,  # total vocabulary size (e.g. 129280)
+    stride0,
+    num_rows,
+    vocab_size,
+    BLOCK_SIZE: tl.constexpr,
 ):
     """Mask logits outside [row_starts[i], row_ends[i]) to -inf, in-place.
 
@@ -46,7 +60,7 @@ def _mask_invalid_kernel(
     Early exits when the row uses full vocab to avoid unnecessary stores.
     """
     pid = tl.program_id(0)
-    num_blocks_per_row = tl.cdiv(VOCAB_SIZE, BLOCK_SIZE)
+    num_blocks_per_row = tl.cdiv(vocab_size, BLOCK_SIZE)
     row_id = pid // num_blocks_per_row
     block_id = pid % num_blocks_per_row
 
@@ -55,27 +69,27 @@ def _mask_invalid_kernel(
 
     # Early exit: most rows in inference use full vocab (start=0, end=vocab_size).
     # Skipping these avoids ~90% of memory writes in typical workloads.
-    if start == 0 and end >= VOCAB_SIZE:
+    if start == 0 and end >= vocab_size:
         return
 
     # Compute which positions in this block are outside the valid range
     offs = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
     out_of_range = (offs < start) | (offs >= end)
     # Only write to positions that are both within vocab bounds AND out of valid range
-    mask = (offs < VOCAB_SIZE) & out_of_range
+    mask = (offs < vocab_size) & out_of_range
 
     tl.store(logits_ptr + row_id * stride0 + offs, float("-inf"), mask=mask)
 
 
 @triton.jit
 def _fused_postprocess_kernel(
-    src_ptr,  # source indices (from argsort or topk)
-    dst_ptr,  # destination: output indices buffer [num_rows, top_k]
-    row_starts_ptr,  # per-row start offsets for index adjustment
+    src_ptr,
+    dst_ptr,
+    row_starts_ptr,
     num_rows: tl.constexpr,
-    top_k: tl.constexpr,  # 1024 in DeepSeek V4
-    src_stride0: tl.constexpr,  # row stride of src (vocab_size for argsort, top_k for topk)
-    BLOCK_SIZE: tl.constexpr,  # next_power_of_2(top_k), e.g. 1024
+    top_k: tl.constexpr,
+    src_stride0: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
 ):
     """Fused slice + cast + subtract: convert absolute indices to row-relative.
 
@@ -122,31 +136,28 @@ def top_k_per_row_prefill(
         stride1: logits.stride(1), typically == 1 for contiguous tensor.
         top_k: number of top elements per row (1024 in DeepSeek V4).
     """
+    logger.debug("GEMS TOP_K_PER_ROW_PREFILL")
+
     vocab_size = logits.shape[1]
 
     if top_k > vocab_size:
         raise ValueError(f"top_k ({top_k}) must not exceed vocab_size ({vocab_size})")
 
     # --- Phase 1: Mask invalid ranges to -inf ---
-    # BLOCK_SIZE=8192 chosen to balance occupancy vs. grid size:
-    # For vocab=129280, this gives ceil(129280/8192)=16 blocks per row.
-    # num_warps=2 is sufficient since masking is memory-bound (simple store).
-    MASK_BS = 8192
-    num_mask_blocks = (vocab_size + MASK_BS - 1) // MASK_BS
-    _mask_invalid_kernel[(num_rows * num_mask_blocks,)](
+    grid = lambda META: (num_rows * triton.cdiv(vocab_size, META["BLOCK_SIZE"]),)
+    _mask_invalid_kernel[grid](
         logits,
         row_starts,
         row_ends,
         stride0,
-        BLOCK_SIZE=MASK_BS,
-        VOCAB_SIZE=vocab_size,
-        num_warps=2,
+        num_rows,
+        vocab_size,
     )
 
     # --- Phase 2: Select top-K indices ---
     # POSTPROC_BLOCK must be power-of-2 >= top_k for tl.arange.
-    # For top_k=1024, this is exactly 1024 (no waste).
     POSTPROC_BLOCK = triton.next_power_of_2(top_k)
+    num_warps_post = min(max(POSTPROC_BLOCK // 256, 1), 8)
 
     if num_rows == 1:
         # Single row path: torch.argsort uses CUB radix sort under the hood.
@@ -154,7 +165,6 @@ def top_k_per_row_prefill(
         # than torch.topk's heap-based O(N log k) because it fully utilizes GPU
         # parallelism without the sequential heap maintenance bottleneck.
         sorted_idx = torch.argsort(logits, dim=1, descending=True, stable=False)
-        # src_stride0=vocab_size because argsort returns full-width sorted indices
         _fused_postprocess_kernel[(1,)](
             sorted_idx,
             indices,
@@ -163,7 +173,7 @@ def top_k_per_row_prefill(
             top_k=top_k,
             src_stride0=vocab_size,
             BLOCK_SIZE=POSTPROC_BLOCK,
-            num_warps=4,
+            num_warps=num_warps_post,
         )
     else:
         # Multi-row path: torch.topk with sorted=False.
@@ -171,7 +181,6 @@ def top_k_per_row_prefill(
         # than argsort (which serializes the full sort per row).
         # sorted=False avoids an unnecessary final sort pass.
         _, top_idx = torch.topk(logits, top_k, dim=1, largest=True, sorted=False)
-        # src_stride0=top_k because topk output shape is [num_rows, top_k]
         _fused_postprocess_kernel[(num_rows,)](
             top_idx,
             indices,
@@ -180,5 +189,5 @@ def top_k_per_row_prefill(
             top_k=top_k,
             src_stride0=top_k,
             BLOCK_SIZE=POSTPROC_BLOCK,
-            num_warps=4,
+            num_warps=num_warps_post,
         )

--- a/src/flag_gems/fused/top_k_per_row_prefill.py
+++ b/src/flag_gems/fused/top_k_per_row_prefill.py
@@ -1,28 +1,8 @@
-"""Triton top_k_per_row_prefill for DeepSeek V4 sparse attention.
+"""Triton top_k_per_row_prefill for DeepSeek V4 prefill-phase topk selection.
 
-Replaces vLLM's persistent_topk CUDA kernel with a Triton implementation.
+   Implement based on file python/tutorials/tle/deepseek_v32/01-topk_selector.py from repo
+   https://github.com/flagos-ai/FlagTree.git, align with vLLM implementation.
 
-Background:
-    In DeepSeek V4 prefill, each token computes attention logits over a subset of
-    the vocabulary [row_starts[i], row_ends[i]) and selects the top-K indices.
-    Typical config: vocab_size=129280, top_k=1024, num_rows=1 (decode) or 32+ (prefill).
-
-Strategy:
-    1. In-place masking kernel: set logits outside [row_starts, row_ends) to -inf.
-       Early exit when the row uses full vocab (start==0, end>=vocab_size), which is
-       the common case during inference and avoids unnecessary memory writes.
-    2. Adaptive top-K selection:
-       - num_rows=1: torch.argsort (backed by CUB radix sort, O(N) for single row,
-         ~2x faster than torch.topk for large vocab on a single row)
-       - num_rows>1: torch.topk with sorted=False (heap-based O(N log k), better
-         parallelism across rows than argsort)
-    3. Fused postprocess kernel: single Triton kernel performs slice + cast + subtract
-       in one pass, converting absolute vocab indices to 0-based indices relative to
-       row_starts[i]. Saves one kernel launch vs separate slice/subtract ops.
-
-Performance (DeepSeek V4 config, vocab=129280, top_k=1024):
-    - num_rows=1:  0.89x vs vLLM CUDA (competitive, bounded by argsort)
-    - num_rows=32: 0.38x vs vLLM CUDA (bounded by torch.topk on large vocab)
 """
 
 import logging
@@ -31,89 +11,1156 @@ import torch
 import triton
 import triton.language as tl
 
+from flag_gems.utils.triton_version_utils import has_triton_tle
+
+if has_triton_tle(3, 6, 0):
+    try:
+        import triton.experimental.tle.language as tle
+
+        HAS_TLE = True
+    except ImportError:
+        tle = None
+        HAS_TLE = False
+else:
+    tle = None
+    HAS_TLE = False
+
+
 logger = logging.getLogger(__name__)
 
+# Start of shared implementation code for top_k_per_row_decode and top_k_per_row_prefill
 
-@triton.autotune(
-    configs=[
-        triton.Config({"BLOCK_SIZE": 4096}, num_warps=2),
-        triton.Config({"BLOCK_SIZE": 8192}, num_warps=2),
-        triton.Config({"BLOCK_SIZE": 8192}, num_warps=4),
-        triton.Config({"BLOCK_SIZE": 16384}, num_warps=4),
-    ],
-    key=["vocab_size"],
-)
+SORTING_ALGORITHM_THRESHOLD = 12288
+SPLIT_WORK_THRESHOLD = 200 * 1000
+NUM_THREADS_PER_BLOCK = 512
+MULTIPLE_BLOCKS_PER_ROW_CONFIG = 10
+NUM_THREADS_PER_BLOCK_MERGE = 1024
+NUM_FILNAL_ITEMS = 2048
+NUM_BINS = 2048
+RADIX_BITS_FINAL = 8
+RADIX_SIZE_FINAL = 1 << RADIX_BITS_FINAL
+
+
 @triton.jit
-def _mask_invalid_kernel(
+def _convert_to_uint32(x):
+    bits = x.to(tl.uint32, bitcast=True)
+    sign_mask = tl.full(bits.shape, 0x80000000, tl.uint32)
+    sign_set = (bits & sign_mask) != 0
+    inv = (~bits) & tl.full(bits.shape, 0x7FFFFFFF, tl.uint32)
+    return tl.where(sign_set, bits, inv)
+
+
+@triton.jit
+def _extract_bin_idx(x, in_range, pattern, STEP: tl.constexpr):
+    is_partial_match = in_range
+    if STEP == 0:
+        h = x.to(tl.float16)
+        bits = h.to(tl.uint16, bitcast=True)
+        sign_mask = tl.full(bits.shape, 0x8000, tl.uint16)
+        sign_set = (bits & sign_mask) != 0
+        inv = (~bits) & tl.full(bits.shape, 0x7FFF, tl.uint16)
+        mapped = tl.where(sign_set, bits, inv)
+        bin_idx = (mapped >> 5).to(tl.uint32)
+    else:
+        bits = _convert_to_uint32(x)
+        if STEP == 1:
+            bin_idx = bits >> 21
+        elif STEP == 2:
+            bin_idx = (bits >> 10) & 0x7FF
+            is_partial_match &= ((bits ^ pattern) >> 21) == 0
+        elif STEP == 3:
+            bin_idx = bits & 0x3FF
+            is_partial_match &= ((bits ^ pattern) >> 10) == 0
+    return bin_idx, is_partial_match
+
+
+@triton.jit
+def _convert_to_trt_uint16_hi11(x):
+    h = x.to(tl.float16)
+    bits = h.to(tl.uint16, bitcast=True)
+    sign_mask = tl.full(bits.shape, 0x8000, tl.uint16)
+    sign_set = (bits & sign_mask) != 0
+    inv = (~bits) & tl.full(bits.shape, 0x7FFF, tl.uint16)
+    mapped = tl.where(sign_set, bits, inv)
+    return (mapped >> 5).to(tl.int32)
+
+
+@triton.jit
+def _distribute_to_bins(
+    logits,
+    in_range,
+    ones,
+    logit_pattern,
+    s_histogram_ptr,
+    STEP: tl.constexpr,
+):
+    bin_idx, is_partial_match = _extract_bin_idx(
+        logits,
+        in_range,
+        logit_pattern,
+        STEP=STEP,
+    )
+    tl.atomic_add(
+        s_histogram_ptr + bin_idx,
+        ones,
+        mask=is_partial_match,
+        sem="relaxed",
+        scope="cta",
+    )
+
+
+@triton.jit
+def _process_bins(
+    logits,
+    in_range,
+    ones,
+    offs,  # row_start based
+    found_topk_values_ptrs,
+    final_cnt_ptrs,
+    logit_pattern,
+    threshold_bin_idx,
+    write_directly,
+    use_final,
+    row_start,
+    indices_ptr,
+    s_histogram_ptr,
+    s_final_logits_ptr,
+    s_out_indices_ptr,
+    s_out_logits_ptr,
+    STEP: tl.constexpr,
+    TOPK: tl.constexpr,
+    MULTIPLE_BLOCKS_PER_ROW: tl.constexpr,
+    MERGE_BLOCKS: tl.constexpr,
+):
+    NUM_FINAL_ITEMS: tl.constexpr = 2048
+
+    bin_idx, is_partial_match = _extract_bin_idx(
+        logits,
+        in_range,
+        logit_pattern,
+        STEP=STEP,
+    )
+    take_lt = is_partial_match & (bin_idx < threshold_bin_idx) & write_directly
+    out_pos_lt = tl.atomic_add(
+        found_topk_values_ptrs,
+        ones,
+        mask=take_lt,
+        sem="relaxed",
+        scope="cta",
+    )
+    if MERGE_BLOCKS:
+        indices = tl.load(
+            indices_ptr + offs,
+            mask=take_lt,
+        )
+        tl.store(
+            s_out_indices_ptr + out_pos_lt,
+            indices,
+            mask=take_lt,
+        )
+    elif MULTIPLE_BLOCKS_PER_ROW:
+        tl.store(
+            s_out_indices_ptr + out_pos_lt,
+            (offs + row_start).to(tl.int32),
+            mask=take_lt,
+        )
+        tl.store(
+            s_out_logits_ptr + out_pos_lt,
+            logits,
+            mask=take_lt,
+        )
+    else:
+        tl.store(
+            s_out_indices_ptr + out_pos_lt,
+            offs.to(tl.int32),
+            mask=take_lt,
+        )
+
+    if STEP < 3:
+        if use_final:
+            take_eq_final = is_partial_match & (bin_idx == threshold_bin_idx)
+            final_pos = tl.atomic_add(
+                final_cnt_ptrs,
+                ones,
+                mask=take_eq_final,
+                sem="relaxed",
+                scope="cta",
+            )
+            tl.store(
+                s_final_logits_ptr + final_pos,
+                logits,
+                mask=take_eq_final & (final_pos < NUM_FINAL_ITEMS),
+            )
+            # s_histogram_ptr being used for indices in final sort
+            if MERGE_BLOCKS:
+                indices = tl.load(
+                    indices_ptr + offs,
+                    mask=take_eq_final & (final_pos < NUM_FINAL_ITEMS),
+                )
+                tl.store(
+                    s_histogram_ptr + final_pos,
+                    indices,
+                    mask=take_eq_final & (final_pos < NUM_FINAL_ITEMS),
+                )
+            elif MULTIPLE_BLOCKS_PER_ROW:
+                tl.store(
+                    s_histogram_ptr + final_pos,
+                    (offs + row_start).to(tl.int32),
+                    mask=take_eq_final & (final_pos < NUM_FINAL_ITEMS),
+                )
+            else:
+                tl.store(
+                    s_histogram_ptr + final_pos,
+                    offs.to(tl.int32),
+                    mask=take_eq_final & (final_pos < NUM_FINAL_ITEMS),
+                )
+    else:
+        take_eq = is_partial_match & (bin_idx == threshold_bin_idx)
+        # s_histogram_ptr being used for exclude prefix sum
+        out_pos_eq = tl.atomic_add(
+            s_histogram_ptr + bin_idx,
+            ones,
+            mask=take_eq,
+            sem="relaxed",
+            scope="cta",
+        )
+        if MERGE_BLOCKS:
+            indices = tl.load(
+                indices_ptr + offs,
+                mask=take_eq & (out_pos_eq < TOPK),
+            )
+            tl.store(
+                s_out_indices_ptr + out_pos_eq,
+                indices,
+                mask=take_eq & (out_pos_eq < TOPK),
+            )
+        elif MULTIPLE_BLOCKS_PER_ROW:
+            tl.store(
+                s_out_indices_ptr + out_pos_eq,
+                (offs + row_start).to(tl.int32),
+                mask=take_eq & (out_pos_eq < TOPK),
+            )
+            tl.store(
+                s_out_logits_ptr + out_pos_eq,
+                logits,
+                mask=take_eq & (out_pos_eq < TOPK),
+            )
+        else:
+            tl.store(
+                s_out_indices_ptr + out_pos_eq,
+                offs.to(tl.int32),
+                mask=take_eq & (out_pos_eq < TOPK),
+            )
+
+
+@triton.jit
+def _process_histogram_step(
     logits_ptr,
-    row_starts_ptr,
-    row_ends_ptr,
-    stride0,
-    num_rows,
+    row_start,
+    row_end,
+    stride1,
     vocab_size,
+    skip_elems,
+    indices_ptr,
+    logit_pattern,
+    threshold_bin_idx,
+    assume_aligned,
+    s_histogram_ptr,
+    s_final_logits_ptr,
+    s_final_cnt_ptr,
+    s_threshold_bin_idx_ptr,
+    s_final_bin_size_ptr,
+    s_found_topk_values_ptr,
+    s_out_indices_ptr,
+    s_out_logits_ptr,
+    STEP: tl.constexpr,
+    TOPK: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    HAS_TLE: tl.constexpr,
+    MULTIPLE_BLOCKS_PER_ROW: tl.constexpr,
+    MERGE_BLOCKS: tl.constexpr,
 ):
-    """Mask logits outside [row_starts[i], row_ends[i]) to -inf, in-place.
+    VEC: tl.constexpr = 4
+    NUM_FINAL_ITEMS: tl.constexpr = 2048
+    RADIX11_SIZE: tl.constexpr = 2048
+    RADIX11_MASK: tl.constexpr = 0x7FF
+    RADIX10_SIZE: tl.constexpr = 1024
 
-    Grid: (num_rows * num_blocks_per_row,) — 1D flat grid.
-    Each program handles one BLOCK_SIZE chunk of one row.
-    Early exits when the row uses full vocab to avoid unnecessary stores.
-    """
-    pid = tl.program_id(0)
-    num_blocks_per_row = tl.cdiv(vocab_size, BLOCK_SIZE)
-    row_id = pid // num_blocks_per_row
-    block_id = pid % num_blocks_per_row
+    lane = tl.arange(0, BLOCK_SIZE)
+    vec = tl.arange(0, VEC)
+    ones = tl.full([BLOCK_SIZE], 1, tl.int32)
+    ones_vec_2d = tl.full([BLOCK_SIZE, VEC], 1, tl.int32)
+    zeros = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+    zeros_vec_2d = tl.zeros([BLOCK_SIZE, VEC], dtype=tl.int32)
 
-    start = tl.load(row_starts_ptr + row_id)
-    end = tl.load(row_ends_ptr + row_id)
+    threshold_rounds: tl.constexpr = (
+        RADIX10_SIZE // BLOCK_SIZE if STEP == 3 else RADIX11_SIZE // BLOCK_SIZE
+    )
+    for clear_round in tl.static_range(0, threshold_rounds):
+        clear_bins = clear_round * BLOCK_SIZE + lane
+        tl.store(s_histogram_ptr + clear_bins, 0)
+    tl.debug_barrier()
 
-    # Early exit: most rows in inference use full vocab (start=0, end=vocab_size).
-    # Skipping these avoids ~90% of memory writes in typical workloads.
-    if start == 0 and end >= vocab_size:
-        return
+    if STEP == 2:
+        logit_pattern = (threshold_bin_idx.to(tl.uint32) & RADIX11_MASK) << 21
+    elif STEP == 3:
+        logit_pattern |= (threshold_bin_idx.to(tl.uint32) & RADIX11_MASK) << 10
 
-    # Compute which positions in this block are outside the valid range
-    offs = block_id * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
-    out_of_range = (offs < start) | (offs >= end)
-    # Only write to positions that are both within vocab bounds AND out of valid range
-    mask = (offs < vocab_size) & out_of_range
+    if assume_aligned:
+        n_tiles = tl.cdiv(vocab_size, BLOCK_SIZE)
+        n_vec_full = vocab_size // (BLOCK_SIZE * VEC)
+        rem_tiles = (vocab_size - n_vec_full * BLOCK_SIZE * VEC) // BLOCK_SIZE
+        for t in tl.range(0, n_vec_full):
+            base = t * BLOCK_SIZE * VEC + lane * VEC
+            offs = base[:, None] + vec[None, :]
+            x_vec = tl.load(logits_ptr + offs)
+            _distribute_to_bins(
+                x_vec,
+                True,
+                ones_vec_2d,
+                logit_pattern,
+                s_histogram_ptr,
+                STEP=STEP,
+            )
+        for t in tl.range(0, rem_tiles):
+            offs = (n_vec_full * VEC + t) * BLOCK_SIZE + lane
+            x = tl.load(logits_ptr + offs)
+            _distribute_to_bins(
+                x,
+                True,
+                ones,
+                logit_pattern,
+                s_histogram_ptr,
+                STEP=STEP,
+            )
+    elif stride1 == 1:
+        aligned_row_ptr = tl.multiple_of(logits_ptr + row_start + skip_elems, VEC * 4)
+        row_len = row_end - row_start - skip_elems
+        n_vec_full = row_len // (BLOCK_SIZE * VEC)
+        rem_tiles = (row_len - n_vec_full * BLOCK_SIZE * VEC) // BLOCK_SIZE
+        rem_elems = row_len % BLOCK_SIZE
+        for t in tl.range(0, n_vec_full):
+            base = t * BLOCK_SIZE * VEC + lane * VEC
+            offs = base[:, None] + vec[None, :]
+            x_vec = tl.load(aligned_row_ptr + offs)
+            _distribute_to_bins(
+                x_vec,
+                True,
+                ones_vec_2d,
+                logit_pattern,
+                s_histogram_ptr,
+                STEP=STEP,
+            )
+        for t in tl.range(0, rem_tiles):
+            offs = (n_vec_full * VEC + t) * BLOCK_SIZE + lane
+            x = tl.load(aligned_row_ptr + offs)
+            _distribute_to_bins(
+                x,
+                True,
+                ones,
+                logit_pattern,
+                s_histogram_ptr,
+                STEP=STEP,
+            )
+        if skip_elems > 0:
+            offs = lane
+            in_range = lane < skip_elems
+            x = tl.load(
+                logits_ptr + row_start + offs, mask=in_range, other=float("-inf")
+            )
+            _distribute_to_bins(
+                x,
+                in_range,
+                ones,
+                logit_pattern,
+                s_histogram_ptr,
+                STEP=STEP,
+            )
+        if rem_elems > 0:
+            offs = (n_vec_full * VEC + rem_tiles) * BLOCK_SIZE + lane
+            in_range = lane < rem_elems
+            x = tl.load(aligned_row_ptr + offs, mask=in_range, other=float("-inf"))
+            _distribute_to_bins(
+                x,
+                in_range,
+                ones,
+                logit_pattern,
+                s_histogram_ptr,
+                STEP=STEP,
+            )
+    else:
+        row_len = row_end - row_start
+        n_tiles = tl.cdiv(row_len, BLOCK_SIZE)
+        for t in tl.range(0, n_tiles):
+            offs = t * BLOCK_SIZE + lane
+            in_range = offs < row_len
+            x = tl.load(
+                logits_ptr + row_start + offs * stride1,
+                mask=in_range,
+                other=float("-inf"),
+            )
+            _distribute_to_bins(
+                x,
+                in_range,
+                ones,
+                logit_pattern,
+                s_histogram_ptr,
+                STEP=STEP,
+            )
+    last_value = tl.load(s_found_topk_values_ptr)
+    tl.debug_barrier()
 
-    tl.store(logits_ptr + row_id * stride0 + offs, float("-inf"), mask=mask)
+    threshold_bin_ptrs = s_threshold_bin_idx_ptr + zeros
+    final_bin_size_ptrs = s_final_bin_size_ptr + zeros
+    threshold_found = tl.full((), False, dtype=tl.int1)
+    for round_idx in tl.static_range(0, threshold_rounds):
+        if not threshold_found:
+            bins = round_idx * BLOCK_SIZE + lane
+            counts = tl.load(s_histogram_ptr + bins)
+            if HAS_TLE:
+                prefix_sum, counts_total = tle.cumsum(counts, axis=0, reverse=False)
+            else:
+                counts_total = tl.sum(counts)
+                prefix_sum = counts_total - tl.cumsum(counts, axis=0, reverse=True)
+            prefix_sum = prefix_sum + last_value
+            total_sum = last_value + counts_total
+            next_prefix_sum = prefix_sum + counts
+            threshold_mask = (prefix_sum < TOPK) & (next_prefix_sum >= TOPK)
+            threshold_bin = bins
+            threshold_bin_size = next_prefix_sum - prefix_sum
+            if STEP == 3:
+                tl.store(s_histogram_ptr + bins, prefix_sum)
+            tl.store(threshold_bin_ptrs, threshold_bin, mask=threshold_mask)
+            tl.store(final_bin_size_ptrs, threshold_bin_size, mask=threshold_mask)
+            found_round = tl.reduce_or(threshold_mask, axis=0)
+            threshold_found = found_round
+            last_value = total_sum
+
+    tl.debug_barrier()
+    threshold_bin_idx = tl.load(s_threshold_bin_idx_ptr)
+    final_bin_size = tl.load(s_final_bin_size_ptr)
+    use_final = final_bin_size <= NUM_FINAL_ITEMS
+    write_directly = ((STEP == 0) & (final_bin_size <= NUM_FINAL_ITEMS)) | (STEP >= 1)
+
+    found_ptrs = s_found_topk_values_ptr + zeros
+    final_cnt_ptrs = s_final_cnt_ptr + zeros
+    if assume_aligned:
+        found_ptrs_vec_2d = s_found_topk_values_ptr + zeros_vec_2d
+        final_cnt_ptrs_vec_2d = s_final_cnt_ptr + zeros_vec_2d
+        n_tiles = tl.cdiv(vocab_size, BLOCK_SIZE)
+        n_vec_full = vocab_size // (BLOCK_SIZE * VEC)
+        rem_tiles = (vocab_size - n_vec_full * BLOCK_SIZE * VEC) // BLOCK_SIZE
+        for t in tl.range(0, n_vec_full):
+            base = t * BLOCK_SIZE * VEC + lane * VEC
+            offs = base[:, None] + vec[None, :]
+            x_vec = tl.load(logits_ptr + offs)
+            _process_bins(
+                x_vec,
+                True,
+                ones_vec_2d,
+                offs,
+                found_ptrs_vec_2d,
+                final_cnt_ptrs_vec_2d,
+                logit_pattern,
+                threshold_bin_idx,
+                write_directly,
+                use_final,
+                row_start,
+                indices_ptr,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=STEP,
+                TOPK=TOPK,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
+        for t in tl.range(0, rem_tiles):
+            offs = (n_vec_full * VEC + t) * BLOCK_SIZE + lane
+            x = tl.load(logits_ptr + offs)
+            _process_bins(
+                x,
+                True,
+                ones,
+                offs,
+                found_ptrs,
+                final_cnt_ptrs,
+                logit_pattern,
+                threshold_bin_idx,
+                write_directly,
+                use_final,
+                row_start,
+                indices_ptr,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=STEP,
+                TOPK=TOPK,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
+    elif stride1 == 1:
+        found_ptrs_vec_2d = s_found_topk_values_ptr + zeros_vec_2d
+        final_cnt_ptrs_vec_2d = s_final_cnt_ptr + zeros_vec_2d
+        aligned_row_ptr = tl.multiple_of(logits_ptr + row_start + skip_elems, VEC * 4)
+        row_len = row_end - row_start - skip_elems
+        n_vec_full = row_len // (BLOCK_SIZE * VEC)
+        rem_tiles = (row_len - n_vec_full * BLOCK_SIZE * VEC) // BLOCK_SIZE
+        rem_elems = row_len % BLOCK_SIZE
+        for t in tl.range(0, n_vec_full):
+            base = t * BLOCK_SIZE * VEC + lane * VEC
+            offs = base[:, None] + vec[None, :]
+            x_vec = tl.load(aligned_row_ptr + offs)
+            _process_bins(
+                x_vec,
+                True,
+                ones_vec_2d,
+                offs + skip_elems,
+                found_ptrs_vec_2d,
+                final_cnt_ptrs_vec_2d,
+                logit_pattern,
+                threshold_bin_idx,
+                write_directly,
+                use_final,
+                row_start,
+                indices_ptr,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=STEP,
+                TOPK=TOPK,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
+        for t in tl.range(0, rem_tiles):
+            offs = (n_vec_full * VEC + t) * BLOCK_SIZE + lane
+            x = tl.load(aligned_row_ptr + offs)
+            _process_bins(
+                x,
+                True,
+                ones,
+                offs + skip_elems,
+                found_ptrs,
+                final_cnt_ptrs,
+                logit_pattern,
+                threshold_bin_idx,
+                write_directly,
+                use_final,
+                row_start,
+                indices_ptr,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=STEP,
+                TOPK=TOPK,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
+        if skip_elems > 0:
+            offs = lane
+            in_range = lane < skip_elems
+            x = tl.load(
+                logits_ptr + row_start + offs, mask=in_range, other=float("-inf")
+            )
+            _process_bins(
+                x,
+                in_range,
+                ones,
+                offs,
+                found_ptrs,
+                final_cnt_ptrs,
+                logit_pattern,
+                threshold_bin_idx,
+                write_directly,
+                use_final,
+                row_start,
+                indices_ptr,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=STEP,
+                TOPK=TOPK,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
+        if rem_elems > 0:
+            offs = (n_vec_full * VEC + rem_tiles) * BLOCK_SIZE + lane
+            in_range = lane < rem_elems
+            x = tl.load(aligned_row_ptr + offs, mask=in_range, other=float("-inf"))
+            _process_bins(
+                x,
+                in_range,
+                ones,
+                offs + skip_elems,
+                found_ptrs,
+                final_cnt_ptrs,
+                logit_pattern,
+                threshold_bin_idx,
+                write_directly,
+                use_final,
+                row_start,
+                indices_ptr,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=STEP,
+                TOPK=TOPK,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
+    else:
+        row_len = row_end - row_start
+        n_tiles = tl.cdiv(row_len, BLOCK_SIZE)
+        for t in tl.range(0, n_tiles):
+            offs = t * BLOCK_SIZE + lane
+            in_range = offs < row_len
+            x = tl.load(
+                logits_ptr + row_start + offs * stride1,
+                mask=in_range,
+                other=float("-inf"),
+            )
+            _process_bins(
+                x,
+                in_range,
+                ones,
+                offs,
+                found_ptrs,
+                final_cnt_ptrs,
+                logit_pattern,
+                threshold_bin_idx,
+                write_directly,
+                use_final,
+                row_start,
+                indices_ptr,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=STEP,
+                TOPK=TOPK,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
+    tl.debug_barrier()
+    return final_bin_size > NUM_FINAL_ITEMS, logit_pattern, threshold_bin_idx
 
 
 @triton.jit
-def _fused_postprocess_kernel(
-    src_ptr,
-    dst_ptr,
-    row_starts_ptr,
-    num_rows: tl.constexpr,
-    top_k: tl.constexpr,
-    src_stride0: tl.constexpr,
+def _final_select_radix(
+    s_histogram_ptr,
+    s_final_logits_ptr,
+    s_final_cnt_ptr,
+    s_found_topk_values_ptr,
+    s_out_indices_ptr,
+    s_out_logits_ptr,
+    TOPK: tl.constexpr,
     BLOCK_SIZE: tl.constexpr,
+    MULTIPLE_BLOCKS_PER_ROW: tl.constexpr,
 ):
-    """Fused slice + cast + subtract: convert absolute indices to row-relative.
+    NUM_FINAL_ITEMS: tl.constexpr = 2048
+    RADIX_BITS_FINAL: tl.constexpr = 8
+    RADIX_SIZE_FINAL: tl.constexpr = 1 << RADIX_BITS_FINAL
+    RADIX_MASK_FINAL: tl.constexpr = RADIX_SIZE_FINAL - 1
+    DIGIT_START: tl.constexpr = 32 - RADIX_BITS_FINAL
 
-    For each row i, computes: dst[i, :top_k] = src[i, :top_k] - row_starts[i]
-    This converts absolute vocab indices to 0-based indices within the valid range.
-    Grid: (num_rows,) — one program per row.
-    """
-    row_id = tl.program_id(0)
-    if row_id >= num_rows:
+    lane = tl.arange(0, BLOCK_SIZE)
+    ones = tl.full([BLOCK_SIZE], 1, tl.int32)
+    zeros = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+    bins = tl.arange(0, RADIX_SIZE_FINAL)
+
+    s_radix_counts = tle.gpu.alloc(
+        [RADIX_SIZE_FINAL],
+        dtype=tl.int32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_radix_count_ptr = tle.gpu.local_ptr(s_radix_counts, (0,))
+    radix_count_vec_ptr = s_radix_count_ptr + bins
+    base_idx = tl.load(s_found_topk_values_ptr)
+    final_cnt = tl.minimum(tl.load(s_final_cnt_ptr), NUM_FINAL_ITEMS)
+    remain = tl.minimum(TOPK - base_idx, final_cnt)
+    tl.debug_barrier()
+
+    if remain > 0:
+        desired = tl.zeros((), dtype=tl.uint32)
+        desired_mask = tl.zeros((), dtype=tl.uint32)
+        k_to_find = remain + 1
+
+        for digit_pos in tl.static_range(DIGIT_START, -1, -RADIX_BITS_FINAL):
+            if k_to_find > 1:
+                tl.store(s_radix_count_ptr + lane, 0, mask=lane < RADIX_SIZE_FINAL)
+                tl.debug_barrier()
+
+                cnt_tiles = tl.cdiv(final_cnt, BLOCK_SIZE)
+                for t in tl.range(0, cnt_tiles):
+                    pos = t * BLOCK_SIZE + lane
+                    valid = pos < final_cnt
+                    x = tl.load(
+                        s_final_logits_ptr + pos,
+                        mask=valid,
+                        other=0,
+                    )
+                    key = _convert_to_uint32(x)
+                    matches = (key & desired_mask) == desired
+                    digit = ((key >> digit_pos) & RADIX_MASK_FINAL).to(tl.int32)
+                    take = valid & matches
+                    tl.atomic_add(
+                        s_radix_count_ptr + digit,
+                        ones,
+                        mask=take,
+                        sem="relaxed",
+                        scope="cta",
+                    )
+
+                tl.debug_barrier()
+                counts = tl.load(radix_count_vec_ptr)
+                prefix_sum, _ = tle.cumsum(counts, axis=0, reverse=False)
+                next_prefix_sum = prefix_sum + counts
+                threshold_mask = (prefix_sum < k_to_find) & (
+                    next_prefix_sum >= k_to_find
+                )
+                threshold_init = tl.full((), RADIX_SIZE_FINAL, dtype=tl.int32)
+                threshold_bin = tl.min(
+                    tl.where(threshold_mask, bins, threshold_init), axis=0
+                ).to(tl.int32)
+                threshold_bin = tl.where(
+                    threshold_bin == RADIX_SIZE_FINAL,
+                    RADIX_SIZE_FINAL - 1,
+                    threshold_bin,
+                )
+                counts_lt = tl.max(
+                    tl.where(bins == threshold_bin, prefix_sum, 0), axis=0
+                ).to(tl.int32)
+
+                desired = desired | (threshold_bin.to(tl.uint32) << digit_pos)
+                desired_mask = desired_mask | (
+                    tl.full((), RADIX_MASK_FINAL, dtype=tl.uint32) << digit_pos
+                )
+                k_to_find = k_to_find - counts_lt
+
+        thr_key = desired
+        found_ptrs = s_found_topk_values_ptr + zeros
+        cnt_tiles = tl.cdiv(final_cnt, BLOCK_SIZE)
+        for t in tl.range(0, cnt_tiles):
+            pos = t * BLOCK_SIZE + lane
+            valid = pos < final_cnt
+            idx = tl.load(s_histogram_ptr + pos, mask=valid, other=0)
+            x = tl.load(
+                s_final_logits_ptr + pos,
+                mask=valid,
+                other=0,
+            )
+            key = _convert_to_uint32(x)
+            take_lt = valid & (key < thr_key)
+            out_pos_gt = tl.atomic_add(
+                found_ptrs,
+                ones,
+                mask=take_lt,
+                sem="relaxed",
+                scope="cta",
+            )
+            tl.store(
+                s_out_indices_ptr + out_pos_gt,
+                idx,
+                mask=take_lt & (out_pos_gt < TOPK),
+            )
+            if MULTIPLE_BLOCKS_PER_ROW:
+                tl.store(
+                    s_out_logits_ptr + out_pos_gt,
+                    x,
+                    mask=take_lt & (out_pos_gt < TOPK),
+                )
+
+        tl.debug_barrier()
+        cur = tl.load(s_found_topk_values_ptr)
+        if cur < TOPK:
+            for t in tl.range(0, cnt_tiles):
+                cur = tl.load(s_found_topk_values_ptr)
+                if cur < TOPK:
+                    pos = t * BLOCK_SIZE + lane
+                    valid = pos < final_cnt
+                    idx = tl.load(s_histogram_ptr + pos, mask=valid, other=0)
+                    x = tl.load(
+                        s_final_logits_ptr + pos,
+                        mask=valid,
+                        other=0,
+                    )
+                    key = _convert_to_uint32(x)
+                    take_eq = valid & (key == thr_key)
+                    out_pos_eq = tl.atomic_add(
+                        found_ptrs,
+                        ones,
+                        mask=take_eq,
+                        sem="relaxed",
+                        scope="cta",
+                    )
+                    tl.store(
+                        s_out_indices_ptr + out_pos_eq,
+                        idx,
+                        mask=take_eq & (out_pos_eq < TOPK),
+                    )
+                    if MULTIPLE_BLOCKS_PER_ROW:
+                        tl.store(
+                            s_out_logits_ptr + out_pos_eq,
+                            x,
+                            mask=take_eq & (out_pos_eq < TOPK),
+                        )
+        tl.debug_barrier()
+
+
+@triton.jit
+def _top_k_per_row_job(
+    logits_ptr,
+    out_indices_ptr,
+    row_start,
+    row_end,
+    stride1,
+    vocab_size,
+    skip_elems,
+    out_logits_ptr,
+    indices_ptr,
+    s_histogram_ptr,
+    s_final_logits_ptr,
+    s_final_cnt_ptr,
+    s_threshold_bin_idx_ptr,
+    s_final_bin_size_ptr,
+    s_found_topk_values_ptr,
+    s_out_indices_ptr,
+    s_out_logits_ptr,
+    TOPK: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    USE_RADIX_FINAL: tl.constexpr,
+    HAS_TLE: tl.constexpr,
+    MULTIPLE_BLOCKS_PER_ROW: tl.constexpr,
+    MERGE_BLOCKS: tl.constexpr,
+):
+    NUM_FINAL_ITEMS: tl.constexpr = 2048
+
+    assume_aligned = (
+        (row_start == 0)
+        & (row_end == vocab_size)
+        & (stride1 == 1)
+        & ((vocab_size % BLOCK_SIZE) == 0)
+    )
+    if assume_aligned:
+        tl.assume(row_start == 0)
+        tl.assume(row_end == vocab_size)
+        tl.assume(stride1 == 1)
+        vocab_size = tl.multiple_of(vocab_size, BLOCK_SIZE)
+    elif stride1 == 1:
+        tl.assume(stride1 == 1)
+
+    lane = tl.arange(0, BLOCK_SIZE)
+    row_len = row_end - row_start
+    if row_len <= TOPK:
+        chunks: tl.constexpr = (TOPK + BLOCK_SIZE - 1) // BLOCK_SIZE
+        for chunk_idx in tl.range(0, chunks):
+            pos = chunk_idx * BLOCK_SIZE + lane
+            take_row = pos < row_len
+            if MULTIPLE_BLOCKS_PER_ROW:
+                tl.store(
+                    out_indices_ptr + pos,
+                    (pos + row_start).to(tl.int32),
+                    mask=take_row,
+                )
+                logits = tl.load(logits_ptr + pos + row_start, mask=take_row)
+                tl.store(out_logits_ptr + pos, logits, mask=take_row)
+            else:
+                tl.store(
+                    out_indices_ptr + pos,
+                    pos.to(tl.int32),
+                    mask=take_row,
+                )
+            take_pad = (pos >= row_len) & (pos < TOPK)
+            tl.store(out_indices_ptr + pos, -1, mask=take_pad)
+            if MULTIPLE_BLOCKS_PER_ROW:
+                tl.store(out_logits_ptr + pos, float("-inf"), mask=take_pad)
         return
+    tl.store(s_final_cnt_ptr, 0)
+    tl.store(s_found_topk_values_ptr, 0)
+    tl.debug_barrier()
+    logit_pattern = tl.zeros((), dtype=tl.uint32)
+    continue_to_next_step = tl.full((), True, dtype=tl.int1)
+    threshold_bin_idx = tl.full((), -1, dtype=tl.int32)
+    for step_idx in tl.static_range(0, 4):
+        if continue_to_next_step:
+            (
+                continue_to_next_step,
+                logit_pattern,
+                threshold_bin_idx,
+            ) = _process_histogram_step(
+                logits_ptr,
+                row_start,
+                row_end,
+                stride1,
+                vocab_size,
+                skip_elems,
+                indices_ptr,
+                logit_pattern,
+                threshold_bin_idx,
+                assume_aligned,
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_final_cnt_ptr,
+                s_threshold_bin_idx_ptr,
+                s_final_bin_size_ptr,
+                s_found_topk_values_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                STEP=step_idx,
+                TOPK=TOPK,
+                BLOCK_SIZE=BLOCK_SIZE,
+                HAS_TLE=HAS_TLE,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+                MERGE_BLOCKS=MERGE_BLOCKS,
+            )
 
-    row_start = tl.load(row_starts_ptr + row_id)
+    if not continue_to_next_step:
+        if USE_RADIX_FINAL and HAS_TLE:
+            _final_select_radix(
+                s_histogram_ptr,
+                s_final_logits_ptr,
+                s_final_cnt_ptr,
+                s_found_topk_values_ptr,
+                s_out_indices_ptr,
+                s_out_logits_ptr,
+                TOPK=TOPK,
+                BLOCK_SIZE=BLOCK_SIZE,
+                MULTIPLE_BLOCKS_PER_ROW=MULTIPLE_BLOCKS_PER_ROW,
+            )
+        else:
+            base_idx = tl.load(s_found_topk_values_ptr)
+            # Guard against stale/oversized counts to avoid out-of-bounds accesses
+            # in the shared-memory final buffers.
+            final_cnt = tl.minimum(tl.load(s_final_cnt_ptr), NUM_FINAL_ITEMS)
+            sort_chunks = tl.cdiv(final_cnt, BLOCK_SIZE)
+            for sort_chunk in tl.range(0, sort_chunks):
+                pos = sort_chunk * BLOCK_SIZE + lane
+                valid = pos < final_cnt
+                logit_i = tl.load(
+                    s_final_logits_ptr + pos,
+                    mask=valid,
+                    other=0,
+                )
+                out_rank = tl.zeros([BLOCK_SIZE], dtype=tl.int32)
+                for j in tl.range(0, final_cnt):
+                    logit_j = tl.load(s_final_logits_ptr + j)
+                    better = (logit_i < logit_j) | ((logit_i == logit_j) & (pos < j))
+                    out_rank = out_rank + (valid & better).to(tl.int32)
+                dst_pos = base_idx + out_rank
+                take = valid & (dst_pos < TOPK)
+                idx_i = tl.load(
+                    s_histogram_ptr + pos,
+                    mask=take,
+                    other=0,
+                )
+                tl.store(s_out_indices_ptr + dst_pos, idx_i, mask=take)
+                if MULTIPLE_BLOCKS_PER_ROW:
+                    tl.store(s_out_logits_ptr + dst_pos, logit_i, mask=take)
+            tl.debug_barrier()
 
-    offs = tl.arange(0, BLOCK_SIZE)
-    mask = offs < top_k
+    # out_indices_ptr is identical to s_out_indices_ptr for non-tle
+    if HAS_TLE:
+        flush_chunks: tl.constexpr = (TOPK + BLOCK_SIZE - 1) // BLOCK_SIZE
+        for flush_chunk in tl.static_range(flush_chunks):
+            pos = flush_chunk * BLOCK_SIZE + lane
+            mask = pos < TOPK
+            out_vals = tl.load(s_out_indices_ptr + pos, mask=mask, other=-1)
+            tl.store(out_indices_ptr + pos, out_vals, mask=mask)
+            if MULTIPLE_BLOCKS_PER_ROW:
+                split_logits = tl.load(
+                    s_out_logits_ptr + pos, mask=mask, other=float("-inf")
+                )
+                tl.store(out_logits_ptr + pos, split_logits, mask=mask)
 
-    src_idx = row_id * src_stride0 + offs
-    src_vals = tl.load(src_ptr + src_idx, mask=mask, other=0)
 
-    # Subtract row_start to get 0-based index within [row_start, row_end)
-    dst_vals = (src_vals - row_start).to(tl.int32)
+# End of shared implementation code for top_k_per_row_decode and top_k_per_row_prefill
 
-    dst_idx = row_id * top_k + offs
-    tl.store(dst_ptr + dst_idx, dst_vals, mask=mask)
+
+@triton.jit
+def tle_top_k_per_row_prefill(
+    logits_ptr,
+    out_indices_ptr,
+    row_starts,
+    row_ends,
+    stride0,
+    stride1,
+    vocab_size,
+    TOPK: tl.constexpr,
+    TOPKP: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    USE_RADIX_FINAL: tl.constexpr,
+    ROW_OFFSET: tl.constexpr,
+):
+    NUM_FILNAL_ITEMS: tl.constexpr = 2048
+    NUM_BINS: tl.constexpr = 2048
+    VEC: tl.constexpr = 4
+
+    row_id = tl.program_id(0) + ROW_OFFSET
+    row_start = tl.load(row_starts + row_id)
+    row_end = tl.load(row_ends + row_id)
+    logits_ptr += row_id * stride0
+    # float4 align
+    x_off_mod = (row_id * stride0 + row_start) % VEC
+    skip_elems = 0 if x_off_mod == 0 else VEC - x_off_mod
+    out_indices_ptr += row_id * TOPK
+
+    # used for histogram, indices in final sort and exclude prefix_sum
+    s_histogram = tle.gpu.alloc(
+        [NUM_BINS],
+        dtype=tl.int32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_final_logits = tle.gpu.alloc(
+        [NUM_FILNAL_ITEMS],
+        dtype=tl.float32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_out_indices = tle.gpu.alloc(
+        [TOPKP],
+        dtype=tl.int32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_final_cnt = tle.gpu.alloc(
+        [1],
+        dtype=tl.int32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_threshold_bin_idx = tle.gpu.alloc(
+        [1],
+        dtype=tl.int32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_final_bin_size = tle.gpu.alloc(
+        [1],
+        dtype=tl.int32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_found_topk_values = tle.gpu.alloc(
+        [1],
+        dtype=tl.int32,
+        layout=None,
+        scope=tle.gpu.smem,
+        nv_mma_shared_layout=False,
+    )
+    s_histogram_ptr = tle.gpu.local_ptr(s_histogram, (0,))
+    s_final_logits_ptr = tle.gpu.local_ptr(s_final_logits, (0,))
+    s_out_indices_ptr = tle.gpu.local_ptr(s_out_indices, (0,))
+    s_final_cnt_ptr = tle.gpu.local_ptr(s_final_cnt, (0,))
+    s_threshold_bin_idx_ptr = tle.gpu.local_ptr(s_threshold_bin_idx, (0,))
+    s_final_bin_size_ptr = tle.gpu.local_ptr(s_final_bin_size, (0,))
+    s_found_topk_values_ptr = tle.gpu.local_ptr(s_found_topk_values, (0,))
+
+    _top_k_per_row_job(
+        logits_ptr,
+        out_indices_ptr,
+        row_start,
+        row_end,
+        stride1,
+        vocab_size,
+        skip_elems,
+        None,
+        None,
+        s_histogram_ptr,
+        s_final_logits_ptr,
+        s_final_cnt_ptr,
+        s_threshold_bin_idx_ptr,
+        s_final_bin_size_ptr,
+        s_found_topk_values_ptr,
+        s_out_indices_ptr,
+        None,
+        TOPK=TOPK,
+        BLOCK_SIZE=BLOCK_SIZE,
+        USE_RADIX_FINAL=USE_RADIX_FINAL,
+        HAS_TLE=True,
+        MULTIPLE_BLOCKS_PER_ROW=False,
+        MERGE_BLOCKS=False,
+    )
+
+
+@triton.jit
+def non_tle_top_k_per_row_prefill(
+    logits_ptr,
+    out_indices_ptr,
+    row_starts,
+    row_ends,
+    stride0,
+    stride1,
+    vocab_size,
+    s_histogram_ptr,
+    s_final_logits_ptr,
+    s_final_cnt_ptr,
+    s_threshold_bin_idx_ptr,
+    s_final_bin_size_ptr,
+    s_found_topk_values_ptr,
+    TOPK: tl.constexpr,
+    BLOCK_SIZE: tl.constexpr,
+    ROW_OFFSET: tl.constexpr,
+):
+    VEC: tl.constexpr = 4
+    NUM_BINS: tl.constexpr = 2048
+    NUM_FILNAL_ITEMS: tl.constexpr = 2048
+
+    row_id = tl.program_id(0) + ROW_OFFSET
+    row_start = tl.load(row_starts + row_id)
+    row_end = tl.load(row_ends + row_id)
+    logits_ptr += row_id * stride0
+    # float4 align
+    x_off_mod = (row_id * stride0 + row_start) % VEC
+    skip_elems = 0 if x_off_mod == 0 else VEC - x_off_mod
+    out_indices_ptr += row_id * TOPK
+
+    s_histogram_ptr += row_id * NUM_BINS
+    s_final_logits_ptr += row_id * NUM_FILNAL_ITEMS
+    s_final_cnt_ptr += row_id
+    s_threshold_bin_idx_ptr += row_id
+    s_final_bin_size_ptr += row_id
+    s_found_topk_values_ptr += row_id
+
+    _top_k_per_row_job(
+        logits_ptr,
+        out_indices_ptr,
+        row_start,
+        row_end,
+        stride1,
+        vocab_size,
+        skip_elems,
+        None,
+        None,
+        s_histogram_ptr,
+        s_final_logits_ptr,
+        s_final_cnt_ptr,
+        s_threshold_bin_idx_ptr,
+        s_final_bin_size_ptr,
+        s_found_topk_values_ptr,
+        out_indices_ptr,
+        None,
+        TOPK=TOPK,
+        BLOCK_SIZE=BLOCK_SIZE,
+        USE_RADIX_FINAL=False,
+        HAS_TLE=False,
+        MULTIPLE_BLOCKS_PER_ROW=False,
+        MERGE_BLOCKS=False,
+    )
 
 
 def top_k_per_row_prefill(
@@ -121,73 +1168,94 @@ def top_k_per_row_prefill(
 ):
     """Top-K per row for prefill phase of DeepSeek V4 sparse attention.
 
-    Masks invalid ranges in-place, then selects top-K indices per row.
-    Output indices are 0-based relative to row_starts[i].
+    Selects top_k indices from a single row of logits using radix-based
+    selection. Only valid elements within [row_start, row_end) are considered.
 
     Args:
-        logits: [num_rows, vocab_size] float32 tensor, modified in-place (masked to -inf).
-                In DeepSeek V4: vocab_size=129280.
+        logits: [num_rows, vocab_size] float32 tensor.
         row_starts: [num_rows] int32 — start of valid range per row (inclusive).
         row_ends: [num_rows] int32 — end of valid range per row (exclusive).
         indices: [num_rows, top_k] int32 — output buffer, filled with 0-based indices
                  relative to row_starts[i]. Caller pre-allocates this.
-        num_rows: number of rows (1 for decode, 32/64/2048 for prefill batches).
+        num_rows: number of rows.
         stride0: logits.stride(0), typically == vocab_size for contiguous tensor.
         stride1: logits.stride(1), typically == 1 for contiguous tensor.
-        top_k: number of top elements per row (1024 in DeepSeek V4).
+        top_k: number of top elements per row.
     """
     logger.debug("GEMS TOP_K_PER_ROW_PREFILL")
 
     vocab_size = logits.shape[1]
-
-    if top_k > vocab_size:
-        raise ValueError(f"top_k ({top_k}) must not exceed vocab_size ({vocab_size})")
-
-    # --- Phase 1: Mask invalid ranges to -inf ---
-    grid = lambda META: (num_rows * triton.cdiv(vocab_size, META["BLOCK_SIZE"]),)
-    _mask_invalid_kernel[grid](
-        logits,
-        row_starts,
-        row_ends,
-        stride0,
-        num_rows,
-        vocab_size,
-    )
-
-    # --- Phase 2: Select top-K indices ---
-    # POSTPROC_BLOCK must be power-of-2 >= top_k for tl.arange.
-    POSTPROC_BLOCK = triton.next_power_of_2(top_k)
-    num_warps_post = min(max(POSTPROC_BLOCK // 256, 1), 8)
-
-    if num_rows == 1:
-        # Single row path: torch.argsort uses CUB radix sort under the hood.
-        # For large vocab (129280) with a single row, radix sort O(N) is ~2x faster
-        # than torch.topk's heap-based O(N log k) because it fully utilizes GPU
-        # parallelism without the sequential heap maintenance bottleneck.
-        sorted_idx = torch.argsort(logits, dim=1, descending=True, stable=False)
-        _fused_postprocess_kernel[(1,)](
-            sorted_idx,
+    assert num_rows == logits.shape[0]
+    if HAS_TLE:
+        topkp = triton.next_power_of_2(top_k)
+        num_insert_sort_blocks = min(num_rows, SORTING_ALGORITHM_THRESHOLD)
+        tle_top_k_per_row_prefill[(num_insert_sort_blocks,)](
+            logits,
             indices,
             row_starts,
-            num_rows=1,
-            top_k=top_k,
-            src_stride0=vocab_size,
-            BLOCK_SIZE=POSTPROC_BLOCK,
-            num_warps=num_warps_post,
+            row_ends,
+            stride0,
+            stride1,
+            vocab_size,
+            TOPK=top_k,
+            TOPKP=topkp,
+            BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
+            USE_RADIX_FINAL=False,
+            ROW_OFFSET=0,
+            num_warps=NUM_THREADS_PER_BLOCK // 32,
         )
+        if num_rows > SORTING_ALGORITHM_THRESHOLD:
+            num_radix_sort_blocks = num_rows - SORTING_ALGORITHM_THRESHOLD
+            tle_top_k_per_row_prefill[(num_radix_sort_blocks,)](
+                logits,
+                indices,
+                row_starts,
+                row_ends,
+                stride0,
+                stride1,
+                vocab_size,
+                TOPK=top_k,
+                TOPKP=topkp,
+                BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
+                USE_RADIX_FINAL=True,
+                ROW_OFFSET=SORTING_ALGORITHM_THRESHOLD,
+                num_warps=NUM_THREADS_PER_BLOCK // 32,
+            )
     else:
-        # Multi-row path: torch.topk with sorted=False.
-        # For batched rows, topk's heap approach has better parallelism across rows
-        # than argsort (which serializes the full sort per row).
-        # sorted=False avoids an unnecessary final sort pass.
-        _, top_idx = torch.topk(logits, top_k, dim=1, largest=True, sorted=False)
-        _fused_postprocess_kernel[(num_rows,)](
-            top_idx,
+        # based on tle version
+        device = logits.device
+        s_histogram_ptr = torch.empty(
+            (num_rows, NUM_BINS), device=device, dtype=torch.int32
+        )
+        s_final_logits_ptr = torch.empty(
+            (num_rows, NUM_FILNAL_ITEMS), device=device, dtype=torch.float32
+        )
+        s_final_cnt_ptr = torch.empty((num_rows,), device=device, dtype=torch.int32)
+        s_threshold_bin_idx_ptr = torch.empty(
+            (num_rows,), device=device, dtype=torch.int32
+        )
+        s_final_bin_size_ptr = torch.empty(
+            (num_rows,), device=device, dtype=torch.int32
+        )
+        s_found_topk_values_ptr = torch.empty(
+            (num_rows,), device=device, dtype=torch.int32
+        )
+        non_tle_top_k_per_row_prefill[(num_rows,)](
+            logits,
             indices,
             row_starts,
-            num_rows=num_rows,
-            top_k=top_k,
-            src_stride0=top_k,
-            BLOCK_SIZE=POSTPROC_BLOCK,
-            num_warps=num_warps_post,
+            row_ends,
+            stride0,
+            stride1,
+            vocab_size,
+            s_histogram_ptr,
+            s_final_logits_ptr,
+            s_final_cnt_ptr,
+            s_threshold_bin_idx_ptr,
+            s_final_bin_size_ptr,
+            s_found_topk_values_ptr,
+            TOPK=top_k,
+            BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
+            ROW_OFFSET=0,
+            num_warps=NUM_THREADS_PER_BLOCK // 32,
         )

--- a/tests/test_top_k_per_row_decode.py
+++ b/tests/test_top_k_per_row_decode.py
@@ -5,11 +5,8 @@ Uses value-based comparison (sorted selected values must match) to handle
 non-deterministic tie-breaking between implementations.
 """
 
-import inspect
-
 import pytest
 import torch
-import triton.language as tl
 
 import flag_gems
 from flag_gems.fused import top_k_per_row_decode
@@ -18,27 +15,20 @@ from . import conftest as cfg
 
 device = flag_gems.device
 
-
-def _has_histogram_mask():
-    if not hasattr(tl, "histogram"):
-        return False
-    try:
-        return "mask" in inspect.signature(tl.histogram).parameters
-    except (ValueError, TypeError):
-        return False
-
-
 pytestmark = pytest.mark.skipif(
-    not _has_histogram_mask(),
-    reason="tl.histogram with mask parameter not available",
+    not torch.cuda.is_available(),
+    reason="CUDA device required",
 )
+
 
 # --- Shape configuration with QUICK_MODE support ---
 if cfg.QUICK_MODE:
-    VOCAB_SIZE_LIST = [129280]
-    TOP_K_LIST = [1024]
+    BATCH_SIZE_LIST = [1]
+    VOCAB_SIZE_LIST = [262144]
+    TOP_K_LIST = [512]
 else:
-    VOCAB_SIZE_LIST = [4096, 8192, 16384, 32768, 129280]
+    BATCH_SIZE_LIST = [1, 496]
+    VOCAB_SIZE_LIST = [4096, 8192, 16384, 32768, 129280, 262144]
     TOP_K_LIST = [64, 128, 256, 512, 1024]
 
 # --- vLLM CUDA reference (optional) ---
@@ -58,20 +48,35 @@ except (ImportError, AttributeError):
     _vllm_top_k_per_row_decode = None
 
 
-def _selected_values(logits, indices):
-    """Gather values at selected indices, sort for order-independent comparison."""
-    return logits.gather(1, indices.long()).sort(dim=1).values
+def check_topk_values_match(logits, indices_test, indices_ref, top_k):
+    num_rows = logits.shape[0]
+    for i in range(num_rows):
+        abs_test = indices_test[i].long()
+        abs_ref = indices_ref[i].long()
+
+        valid_test = abs_test[abs_test >= 0]
+        valid_ref = abs_ref[abs_ref >= 0]
+
+        vals_test = logits[i].gather(0, valid_test)
+        vals_ref = logits[i].gather(0, valid_ref)
+
+        vals_test_sorted, _ = vals_test.sort(descending=True)
+        vals_ref_sorted, _ = vals_ref.sort(descending=True)
+
+        if not torch.allclose(vals_test_sorted, vals_ref_sorted, atol=1e-6, rtol=1e-6):
+            return False
+    return True
 
 
-def _make_inputs(vocab_size, top_k, seq_len=None):
+def _make_inputs(batch_size, vocab_size, top_k, seq_len=None):
     """Generate test inputs matching DeepSeek V4 decode config."""
     if seq_len is None:
         seq_len = vocab_size
-    logits = torch.randn(1, vocab_size, dtype=torch.float32, device=device)
-    seq_lens = torch.tensor([seq_len], dtype=torch.int32, device=device)
-    indices = torch.zeros(1, top_k, dtype=torch.int32, device=device)
-    num_rows = 1
     next_n = 1
+    num_rows = batch_size * next_n
+    logits = torch.randn(num_rows, vocab_size, dtype=torch.float32, device=device)
+    seq_lens = torch.full((num_rows,), seq_len, dtype=torch.int32, device=device)
+    indices = torch.zeros(num_rows, top_k, dtype=torch.int32, device=device)
     stride0 = logits.stride(0)
     stride1 = logits.stride(1)
     return logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k
@@ -81,25 +86,35 @@ def _torch_topk_ref(
     logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k
 ):
     """Pure-PyTorch fallback reference using torch.topk."""
-    seq_len = seq_lens[0].item()
-    valid_logits = logits[:, :seq_len]
-    _, top_idx = torch.topk(valid_logits, top_k, dim=1, largest=True, sorted=False)
-    indices.copy_(top_idx.to(torch.int32))
+    for i in range(num_rows):
+        batch_id = i // next_n
+        batch_offset = i % next_n
+        seq_len = seq_lens[batch_id]
+        row_len = seq_len - next_n + batch_offset + 1
+        row_slice = logits[i, :row_len]
+        k = min(top_k, row_len)
+        _, topk_idx = torch.topk(row_slice, k, largest=True, sorted=False)
+        indices[i, :k] = topk_idx.to(torch.int32)
+        if k < top_k:
+            indices[i, k:] = -1
 
 
 @pytest.mark.top_k_per_row_decode
 @pytest.mark.parametrize(
-    "vocab_size, top_k",
-    [(v, k) for v, k in zip(VOCAB_SIZE_LIST, TOP_K_LIST)],
-    ids=[f"V{v}_K{k}" for v, k in zip(VOCAB_SIZE_LIST, TOP_K_LIST)],
+    "batch_size, vocab_size, top_k",
+    [(b, v, k) for b, v, k in zip(BATCH_SIZE_LIST, VOCAB_SIZE_LIST, TOP_K_LIST)],
+    ids=[
+        f"B{b}_V{v}_K{k}"
+        for b, v, k in zip(BATCH_SIZE_LIST, VOCAB_SIZE_LIST, TOP_K_LIST)
+    ],
 )
-def test_top_k_per_row_decode(vocab_size, top_k):
+def test_top_k_per_row_decode(batch_size, vocab_size, top_k):
     """Test top-k correctness: selected values must match reference."""
     torch.manual_seed(42)
     ref_fn = _vllm_top_k_per_row_decode if HAS_VLLM else _torch_topk_ref
 
     logits, next_n, seq_lens, indices, num_rows, s0, s1, k = _make_inputs(
-        vocab_size, top_k
+        batch_size, vocab_size, top_k
     )
     logits_ref = logits.clone()
     indices_ref = torch.zeros_like(indices)
@@ -107,9 +122,7 @@ def test_top_k_per_row_decode(vocab_size, top_k):
     top_k_per_row_decode(logits, next_n, seq_lens, indices, num_rows, s0, s1, k)
     ref_fn(logits_ref, next_n, seq_lens, indices_ref, num_rows, s0, s1, k)
 
-    vals_tri = _selected_values(logits, indices)
-    vals_ref = _selected_values(logits_ref, indices_ref)
-    torch.testing.assert_close(vals_tri, vals_ref, rtol=1e-5, atol=1e-5)
+    assert check_topk_values_match(logits, indices, indices_ref, top_k)
 
 
 @pytest.mark.top_k_per_row_decode
@@ -125,10 +138,11 @@ def test_top_k_per_row_decode(vocab_size, top_k):
 def test_top_k_per_row_decode_partial_seqlen(vocab_size, top_k, seq_len):
     """Test with seq_len < vocab_size (partial valid range)."""
     torch.manual_seed(123)
+    batch_size = 1
     ref_fn = _vllm_top_k_per_row_decode if HAS_VLLM else _torch_topk_ref
 
     logits, next_n, seq_lens, indices, num_rows, s0, s1, k = _make_inputs(
-        vocab_size, top_k, seq_len=seq_len
+        batch_size, vocab_size, top_k, seq_len=seq_len
     )
     logits_ref = logits.clone()
     indices_ref = torch.zeros_like(indices)
@@ -136,45 +150,57 @@ def test_top_k_per_row_decode_partial_seqlen(vocab_size, top_k, seq_len):
     top_k_per_row_decode(logits, next_n, seq_lens, indices, num_rows, s0, s1, k)
     ref_fn(logits_ref, next_n, seq_lens, indices_ref, num_rows, s0, s1, k)
 
-    vals_tri = _selected_values(logits, indices)
-    vals_ref = _selected_values(logits_ref, indices_ref)
-    torch.testing.assert_close(vals_tri, vals_ref, rtol=1e-5, atol=1e-5)
+    assert check_topk_values_match(logits, indices, indices_ref, top_k)
 
 
 @pytest.mark.top_k_per_row_decode
-def test_top_k_per_row_decode_indices_in_range():
-    """Verify all selected indices are within [0, seq_len)."""
-    torch.manual_seed(7)
-    vocab_size, top_k, seq_len = 129280, 1024, 100000
-    logits, next_n, seq_lens, indices, num_rows, s0, s1, k = _make_inputs(
-        vocab_size, top_k, seq_len=seq_len
-    )
-    top_k_per_row_decode(logits, next_n, seq_lens, indices, num_rows, s0, s1, k)
-    assert indices.min().item() >= 0
-    assert indices.max().item() < seq_len
+def test_topk_greater_than_row_len():
+    torch.manual_seed(456)
+    batch_size = 1
+    vocab_size = 262144
+    top_k = 512
+    seq_len = 496
+    ref_fn = _vllm_top_k_per_row_decode if HAS_VLLM else _torch_topk_ref
 
-
-@pytest.mark.top_k_per_row_decode
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
-@pytest.mark.parametrize(
-    "vocab_size, top_k",
-    [(129280, 1024), (32768, 512), (4096, 64)],
-    ids=["V129280_K1024", "V32768_K512", "V4096_K64"],
-)
-def test_top_k_per_row_decode_vs_vllm(vocab_size, top_k):
-    """Test against vLLM CUDA kernel."""
-    torch.manual_seed(42)
     logits, next_n, seq_lens, indices, num_rows, s0, s1, k = _make_inputs(
-        vocab_size, top_k
+        batch_size, vocab_size, top_k, seq_len=seq_len
     )
     logits_ref = logits.clone()
     indices_ref = torch.zeros_like(indices)
 
     top_k_per_row_decode(logits, next_n, seq_lens, indices, num_rows, s0, s1, k)
-    _vllm_top_k_per_row_decode(
-        logits_ref, next_n, seq_lens, indices_ref, num_rows, s0, s1, k
-    )
+    ref_fn(logits_ref, next_n, seq_lens, indices_ref, num_rows, s0, s1, k)
 
-    vals_tri = _selected_values(logits, indices)
-    vals_ref = _selected_values(logits_ref, indices_ref)
-    torch.testing.assert_close(vals_tri, vals_ref, rtol=1e-5, atol=1e-5)
+    assert check_topk_values_match(logits, indices, indices_ref, top_k)
+
+
+@pytest.mark.top_k_per_row_decode
+def test_logits_diff_in_8LSBits():
+    num_rows = 1
+    next_n = 1
+    vocab_size = 262144
+    top_k = 512
+    seq_len = vocab_size
+    ref_fn = _vllm_top_k_per_row_decode if HAS_VLLM else _torch_topk_ref
+
+    random_8bit = torch.randint(
+        0,
+        2**8,
+        (num_rows, vocab_size),
+        dtype=torch.int32,
+        device=device,
+    )
+    logits_bits = 0x3F900000 | (random_8bit & 0xFF)
+    logits = logits_bits.view(torch.float32)
+    seq_lens = torch.full((num_rows,), seq_len, dtype=torch.int32, device=device)
+    indices = torch.zeros(num_rows, top_k, dtype=torch.int32, device=device)
+    s0 = logits.stride(0)
+    s1 = logits.stride(1)
+
+    logits_ref = logits.clone()
+    indices_ref = torch.zeros_like(indices)
+
+    top_k_per_row_decode(logits, next_n, seq_lens, indices, num_rows, s0, s1, top_k)
+    ref_fn(logits_ref, next_n, seq_lens, indices_ref, num_rows, s0, s1, top_k)
+
+    assert check_topk_values_match(logits, indices, indices_ref, top_k)

--- a/tests/test_top_k_per_row_prefill.py
+++ b/tests/test_top_k_per_row_prefill.py
@@ -1,7 +1,8 @@
 """Accuracy tests for top_k_per_row_prefill (DeepSeek V4 sparse attention).
 
-Tests the Triton kernel against a pure-PyTorch reference implementation.
-Verifies that the selected top-K values match (set comparison, order-independent).
+Tests the Triton kernel against vLLM CUDA reference (when available) and a
+pure-PyTorch fallback. Verifies that the selected top-K values match
+(set comparison, order-independent).
 
 Test shapes match DeepSeek V4 production config:
     - vocab_size=129280: DeepSeek V4 vocabulary size
@@ -35,6 +36,22 @@ pytestmark = pytest.mark.skipif(
     reason="CUDA device required",
 )
 
+# --- vLLM CUDA reference (optional) ---
+try:
+    import vllm._custom_ops  # noqa: F401 — loads torch.ops._C
+
+    def _vllm_top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+    ):
+        torch.ops._C.top_k_per_row_prefill(
+            logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+        )
+
+    HAS_VLLM = True
+except (ImportError, AttributeError):
+    HAS_VLLM = False
+    _vllm_top_k_per_row_prefill = None
+
 
 def reference_top_k_per_row(logits, row_starts, row_ends, top_k):
     """Pure-PyTorch reference: per-row torch.topk on valid range [start, end).
@@ -51,7 +68,6 @@ def reference_top_k_per_row(logits, row_starts, row_ends, top_k):
         row_slice = logits[i, start:end]
         k = min(top_k, end - start)
         _, topk_idx = torch.topk(row_slice, k, largest=True, sorted=False)
-        # topk_idx is already 0-based relative to start (since we sliced)
         indices[i, :k] = topk_idx.to(torch.int32)
         if k < top_k:
             indices[i, k:] = -1
@@ -63,26 +79,21 @@ def check_topk_values_match(logits, indices_test, indices_ref, row_starts, top_k
     """Value-based set comparison: verify that the actual logit values selected
     by test indices match those selected by reference indices.
 
-    This is order-independent — we only care that the same top-K values are found,
-    not that they appear in the same order. This is important because argsort and
-    topk may break ties differently.
+    Order-independent — we only care that the same top-K values are found,
+    not that they appear in the same order (argsort and topk break ties differently).
     """
     num_rows = logits.shape[0]
     for i in range(num_rows):
         offset = row_starts[i].item()
-        # Convert 0-based row-relative indices back to absolute vocab indices
         abs_test = indices_test[i].long() + offset
         abs_ref = indices_ref[i].long() + offset
 
-        # Filter out padding (-1 + offset could be invalid)
         valid_test = abs_test[abs_test >= offset]
         valid_ref = abs_ref[abs_ref >= offset]
 
         vals_test = logits[i].gather(0, valid_test)
         vals_ref = logits[i].gather(0, valid_ref)
 
-        # Sort values descending and compare — if same top-K values are selected,
-        # sorted arrays must match regardless of index order
         vals_test_sorted, _ = vals_test.sort(descending=True)
         vals_ref_sorted, _ = vals_ref.sort(descending=True)
 
@@ -101,6 +112,9 @@ def test_top_k_per_row_prefill_full_vocab(num_rows, vocab_size, top_k):
     This is the most common case in inference: every token sees the full vocabulary.
     The masking kernel should early-exit for all rows.
     """
+    if top_k > vocab_size:
+        return
+
     torch.manual_seed(42)
 
     logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
@@ -109,7 +123,6 @@ def test_top_k_per_row_prefill_full_vocab(num_rows, vocab_size, top_k):
     stride0 = logits.stride(0)
     stride1 = logits.stride(1)
 
-    # Reference uses a clone because the Triton kernel modifies logits in-place
     indices_ref = reference_top_k_per_row(logits.clone(), row_starts, row_ends, top_k)
 
     indices_test = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
@@ -137,11 +150,13 @@ def test_top_k_per_row_prefill_variable_lengths(num_rows, vocab_size, top_k):
     KV ranges (e.g., due to causal masking or sequence packing).
     row_ends is randomized in [top_k, vocab_size] to ensure enough valid elements.
     """
+    if top_k > vocab_size:
+        return
+
     torch.manual_seed(123)
 
     logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
     row_starts = torch.zeros(num_rows, dtype=torch.int32, device=device)
-    # Ensure row_ends >= top_k so there are enough valid elements to select
     row_ends = torch.randint(
         top_k, vocab_size + 1, (num_rows,), dtype=torch.int32, device=device
     )
@@ -166,17 +181,14 @@ def test_top_k_per_row_prefill_nonzero_starts(num_rows):
     """Test with non-zero row_starts.
 
     Verifies the index subtraction logic: output indices must be 0-based relative
-    to row_starts[i], not absolute vocab positions. This catches off-by-one errors
-    in the _fused_postprocess_kernel.
+    to row_starts[i], not absolute vocab positions.
     """
     torch.manual_seed(456)
     vocab_size = 50000
     top_k = 1024
 
     logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
-    # row_starts in [0, 1000): simulates offset within a packed sequence
     row_starts = torch.randint(0, 1000, (num_rows,), dtype=torch.int32, device=device)
-    # row_ends in [top_k+1000, vocab_size]: ensures enough valid range after start
     row_ends = torch.randint(
         top_k + 1000, vocab_size + 1, (num_rows,), dtype=torch.int32, device=device
     )
@@ -193,3 +205,43 @@ def test_top_k_per_row_prefill_nonzero_starts(num_rows):
     assert check_topk_values_match(
         logits, indices_test, indices_ref, row_starts, top_k
     ), f"FAIL: num_rows={num_rows}, nonzero starts"
+
+
+@pytest.mark.top_k_per_row_prefill
+@pytest.mark.skipif(not HAS_VLLM, reason="vLLM is not installed")
+@pytest.mark.parametrize("num_rows", [1, 32, 64])
+def test_top_k_per_row_prefill_vs_vllm(num_rows):
+    """Test against vLLM CUDA kernel (persistent_topk)."""
+    torch.manual_seed(789)
+    vocab_size = 129280
+    top_k = 1024
+
+    logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
+    row_starts = torch.zeros(num_rows, dtype=torch.int32, device=device)
+    row_ends = torch.full((num_rows,), vocab_size, dtype=torch.int32, device=device)
+    stride0 = logits.stride(0)
+    stride1 = logits.stride(1)
+
+    # vLLM CUDA reference
+    logits_vllm = logits.clone()
+    indices_vllm = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
+    _vllm_top_k_per_row_prefill(
+        logits_vllm,
+        row_starts,
+        row_ends,
+        indices_vllm,
+        num_rows,
+        stride0,
+        stride1,
+        top_k,
+    )
+
+    # FlagGems Triton kernel
+    indices_test = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
+    top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices_test, num_rows, stride0, stride1, top_k
+    )
+
+    assert check_topk_values_match(
+        logits, indices_test, indices_vllm, row_starts, top_k
+    ), f"FAIL vs vLLM: num_rows={num_rows}"

--- a/tests/test_top_k_per_row_prefill.py
+++ b/tests/test_top_k_per_row_prefill.py
@@ -24,11 +24,11 @@ device = flag_gems.device
 # Shape configs for QUICK_MODE
 if cfg.QUICK_MODE:
     NUM_ROWS_FULL_VOCAB = [1, 64]
-    NUM_ROWS_VARIABLE = [1, 32]
+    NUM_ROWS_VARIABLE = [4, 16383]
     NUM_ROWS_NONZERO = [1]
 else:
     NUM_ROWS_FULL_VOCAB = [1, 32, 64, 2048]
-    NUM_ROWS_VARIABLE = [1, 32]
+    NUM_ROWS_VARIABLE = [4, 16383]
     NUM_ROWS_NONZERO = [1, 16]
 
 pytestmark = pytest.mark.skipif(
@@ -137,12 +137,8 @@ def test_top_k_per_row_prefill_full_vocab(num_rows, vocab_size, top_k):
 
 @pytest.mark.top_k_per_row_prefill
 @pytest.mark.parametrize("num_rows", NUM_ROWS_VARIABLE)
-@pytest.mark.parametrize(
-    "vocab_size", [20000, 129280]  # 20000: smaller vocab for edge case coverage
-)
-@pytest.mark.parametrize(
-    "top_k", [1024, 2048]  # 2048: tests larger top_k (used in some configs)
-)
+@pytest.mark.parametrize("vocab_size", [4095, 8193])
+@pytest.mark.parametrize("top_k", [512])
 def test_top_k_per_row_prefill_variable_lengths(num_rows, vocab_size, top_k):
     """Test with variable row lengths (partial vocab per row).
 
@@ -245,3 +241,28 @@ def test_top_k_per_row_prefill_vs_vllm(num_rows):
     assert check_topk_values_match(
         logits, indices_test, indices_vllm, row_starts, top_k
     ), f"FAIL vs vLLM: num_rows={num_rows}"
+
+
+@pytest.mark.top_k_per_row_prefill
+def test_topk_greater_than_row_len():
+    torch.manual_seed(456)
+    num_rows = 4
+    vocab_size = 257
+    top_k = 512
+
+    logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
+    row_starts = torch.randint(
+        0, vocab_size // 2, (num_rows,), dtype=torch.int32, device=device
+    )
+    row_ends = torch.full((num_rows,), vocab_size, dtype=torch.int32, device=device)
+    stride0 = logits.stride(0)
+    stride1 = logits.stride(1)
+
+    indices_ref = reference_top_k_per_row(logits.clone(), row_starts, row_ends, top_k)
+
+    indices_test = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
+    top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices_test, num_rows, stride0, stride1, top_k
+    )
+
+    assert check_topk_values_match(logits, indices_test, indices_ref, row_starts, top_k)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix | Performance Optimization | Refactor

### Description
The new implement is based on file python/tutorials/tle/deepseek_v32/01-topk_selector.py
from repo https://github.com/flagos-ai/FlagTree.git, align with vLLM implementation.

Reimplement reasons:
1. top_k_per_row_prefill previously relied on torch.argsort or
   torch.topk, and mutate the input `logits`
2. top_k_per_row_decode previously used a global cache keyed by
   device_id, only supported single-row input, and the kernel
   `_topk_multi_block` faced cache overflow risks when all logits
   were extremely close.

Main works:
1. add barrier to fix correctness issue
2. fix vectorization issue
3. align the implement from flagtree with vLLM
4. add non-tle variant
5. replace benchmark test shapes with those from DeepSeek-V4-Flash, and
   skip the test when vLLM not installed
6. add serveral most common shapes from DeepSeek-V4-Flash to correctness
   tests
7. add edge test cases where `top_k > vocab_size` to correctness tests

Also pick the commit in PR #3425 to modify test file of `top_k_per_row_prefill`

### Performance
perf test comand:
```
pytest benchmark/test_top_k_per_row_decode.py --record log --level core
pytest benchmark/test_top_k_per_row_prefill.py --record log --level core
```
GPU: H20

**top_k_per_row_prefill performance(tle version) vs vllm:** 
| num_rows | vocab_size | top_k | stride0 | stride1 | speedup |
| --- | --- | --- | --- | --- | --- |
| 4 | 8193 | 512 | 8456 | 1 | 0.98 |
| 16383 | 4095 | 512 | 4352 | 1 | 1.29 |
| 4 | 16385 | 512 | 16648 | 1 | 0.99 |
| 12961 | 4100 | 512 | 4360 | 1 | 0.97 |
| 16380 | 5115 | 512 | 5376 | 1 | 1.37 |
| 4100 | 1025 | 512 | 1288 | 1 | 1.00 |

**top_k_per_row_decode performance(tle version) vs vllm:** 
| num_rows | vocab_size | top_k | stride0 | stride1 | speedup |
| --- | --- | --- | --- | --- | --- |
| 1 | 262144 | 512 | 262144 | 1 | 1.52 |
| 496 | 262144 | 512 | 262144 | 1 | 1.82 |
| 512 | 262144 | 512 | 262144 | 1 | 1.82 |
| 16 | 262144 | 512 | 262144 | 1 | 1.67 |
| 32 | 262144 | 512 | 262144 | 1 | 1.57 |
| 48 | 262144 | 512 | 262144 | 1 | 1.58 |
| 40 | 262144 | 512 | 262144 | 1 | 1.60 |
| 56 | 262144 | 512 | 262144 | 1 | 1.61 |
| 4 | 262144 | 512 | 262144 | 1 | 1.47 |
| 8 | 262144 | 512 | 262144 | 1 | 1.46 |
| 24 | 262144 | 512 | 262144 | 1 | 1.49 |

**top_k_per_row_prefill performance(non-tle version) vs vllm:** 
| num_rows | vocab_size | top_k | stride0 | stride1 | speedup |
| --- | --- | --- | --- | --- | --- |
| 4 | 8193 | 512 | 8456 | 1 | 0.57|
| 16383 | 4095 | 512 | 4352 | 1 | 0.52 |
| 4 | 16385 | 512 | 16648 | 1 | 0.52 |
| 12961 | 4100 | 512 | 4360 | 1 | 0.35 |
| 16380 | 5115 | 512 | 5376 | 1 | 0.50 |
| 4100 | 1025 | 512 | 1288 | 1 | 0.45 |

**top_k_per_row_decode performance(non-tle version) vs vllm:** 
| num_rows | vocab_size | top_k | stride0 | stride1 | speedup |
| --- | --- | --- | --- | --- | --- |
| 1 | 262144 | 512 | 262144 | 1 | 0.21 |
| 496 | 262144 | 512 | 262144 | 1 | 0.60 |
| 512 | 262144 | 512 | 262144 | 1 | 0.59 |
| 16 | 262144 | 512 | 262144 | 1 | 0.34 |
| 32 | 262144 | 512 | 262144 | 1 | 0.39 |
| 48 | 262144 | 512 | 262144 | 1 | 0.37 |
| 40 | 262144 | 512 | 262144 | 1 | 0.34 |
| 56 | 262144 | 512 | 262144 | 1 | 0.38 |
| 4 | 262144 | 512 | 262144 | 1 | 0.21 |
| 8 | 262144 | 512 | 262144 | 1 | 0.25 |
| 24 | 262144 | 512 | 262144 | 1 | 0.34 |
