### PR TITLE
Install vllm=0.21.0 on H20 for operator testing

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -75,6 +75,10 @@ jobs:
         run: |
           source tools/env.sh ${{ inputs.vendor }}
           ./setup.sh ${{ inputs.vendor }}
+          if [ "${RUNNER_LABEL}" == "h20" ]; then
+             source .venv/bin/activate
+             uv pip install --no-cache-dir vllm==0.21.0 --torch-backend=cu130
+          fi
       - id: check-gpu
         if: ${{ inputs.gpu_check_script != '' }}
         shell: bash

--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -102,6 +102,11 @@ jobs:
           echo "VENDOR=${VENDOR}" >> $GITHUB_ENV
 
           ./setup.sh ${VENDOR}
+          # Install vllm for testing
+          if [ "${VENDOR}" == "nvidia" ]; then
+             source .venv/bin/activate
+             uv pip install --no-cache-dir vllm==0.21.0 --torch-backend=cu130
+          fi
 
       - name: Check GPU availability
         shell: bash

--- a/.github/workflows/random-test.yaml
+++ b/.github/workflows/random-test.yaml
@@ -89,6 +89,12 @@ jobs:
 
           ./setup.sh ${VENDOR}
 
+          # Install vllm for testing
+          if [ "${VENDOR}" == "nvidia" ]; then
+             source .venv/bin/activate
+             uv pip install --no-cache-dir vllm==0.21.0 --torch-backend=cu130
+          fi
+
       - name: Check GPU availability
         shell: bash
         run: |


### PR DESCRIPTION
### PR Category

OP Test | CI/CD

### Type of Change

New Feature

### Description

We don't have vllm installed on the H20 backend. However, 'vllm' installation should not be part of the FlagGems normal setup process, i.e. it should not be part of the pyproject.toml at the moment, and it should not be part of the `setup.sh` script. The workaround is to make sure that for CI's purpose, we have 'vllm' readily installed. In other words, we amend the CI workflow to get it set up.