### PR TITLE
Fix PyYAML version in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ classifiers = [
 
 dependencies = [
     "packaging==26.0",
-    "PyYAML==6.0.3",
+    "PyYAML==6.0.1",
     "sqlalchemy==2.0.48",
     "numpy==1.26.4",
 ]


### PR DESCRIPTION
### PR Category

Other

### Type of Change

Bug Fix

### Description

The PyYAML 6.0.3 requirement conflicts with the Enflame backend. Have to downgrade it to 6.0.1.