### PR TITLE
Update project setting for CANN 9.0.0

### DIFF
--- a/container/flaggems-ascend-9.0.0
+++ b/container/flaggems-ascend-9.0.0
@@ -1,0 +1,86 @@
+# ============================================================
+# FlagGems development image for Ascend CANN 8.5.0
+# ============================================================
+# History:
+# - 2026/06/18: Initial version
+
+# ── Build arguments ────────────────────────────────────────────
+ARG BASE_IMAGE=ascend-cann:9.0.0
+ARG PYTHON_VERSION=3.11.15
+ARG FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-ascend/simple
+ARG EXTRA_PYPI=https://mirrors.aliyun.com/pypi/simple
+ARG INCLUDE_TESTS=true
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS builder
+
+ARG PYTHON_VERSION
+ARG FLAGOS_PYPI
+ARG EXTRA_PYPI
+ARG INCLUDE_TESTS
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── Prepare uv and virtual environment ─────────────────────────
+# Install 'uv' to /usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+RUN uv venv /flagos --python ${PYTHON_VERSION} --relocatable
+ENV VIRTUAL_ENV=/flagos \
+    PATH="/flagos/bin:${PATH}"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+RUN uv pip install --no-cache-dir --index ${EXTRA_PYPI} \
+  "setuptools>=64.0,<80.0" \
+  "scikit-build-core==0.12.2" \
+  "pybind11==3.0.3" \
+  "cmake>=3.20,<4.0" \
+  "ninja==1.13.0" \
+  "pip"
+
+# TODO: Add support to C++ wrapper operators
+# ENV CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=METAX"
+# ENV CMAKE_PREFIX_PATH="$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')"
+RUN uv pip install --no-cache-dir ".[ascend-cann9]" \
+      --default-index ${FLAGOS_PYPI} \
+      --index ${EXTRA_PYPI} \
+      --trusted-host resource.flagos.net \
+      --trusted-host mirrors.aliyun.com \
+  && uv pip install --no-cache-dir --index ${FLAGOS_PYPI} \
+      "triton_ascend==3.2.1"
+RUN uv pip install --no-cache-dir ".[test]" \
+      --index ${EXTRA_PYPI} \
+      --trusted-host mirrors.aliyun.com
+
+RUN mkdir /app
+RUN if [ "$INCLUDE_TESTS" = "true" ]; then \
+      cp -r /build/FlagGems/tests /app/tests && \
+      cp -r /build/FlagGems/benchmark /app/benchmark && \
+      cp /build/FlagGems/pytest.ini /app; \
+    fi
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── Copy uv and Python from builder ────────────────────────────
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /root/.local/share/uv /root/.local/share/uv
+COPY --from=builder /flagos /flagos
+
+# ── Copy tests and benchmarks into container if required ───────
+COPY --from=builder /app /app
+WORKDIR /app
+
+# Note: VIRTUAL_ENV and PATH are not sharable between stages
+ENV VIRTUAL_ENV=/flagos \
+   PATH="/flagos/bin:${PATH}"
+
+ENTRYPOINT ["bash"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,7 @@ ascend-cann9 = [
     "torch==2.10.0+cpu",
     "torch-npu==2.10.0",
     "triton==3.5.0",
-    "triton-ascend==3.2.1",
+    # "triton-ascend==3.2.1",
 ]
 
 enflame = [

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -234,17 +234,30 @@ def _probe_torch():
         ENV_INFO["torch"]["device_count"] = 0
         dev_count = 0
 
-    if dev_count == 0:
-        try:
-            # Is this a TsingMicro chip?
-            import torch_txda
+    if dev_count > 0:
+        return
 
-            dev_count = torch_txda.device_count()
+    try:
+        # Is this a TsingMicro chip?
+        import torch_txda
 
-            ENV_INFO["torch"]["device_count"] = dev_count
-            pinfo(f"TorchTXDA device count ... {dev_count}")
-        except Exception:
-            pass
+        dev_count = torch_txda.device_count()
+
+        ENV_INFO["torch"]["device_count"] = dev_count
+        pinfo(f"TorchTXDA device count ... {dev_count}")
+    except Exception:
+        pass
+
+    try:
+        # Is this a Ascend chip?
+        import torch.npu
+
+        dev_count = torch.npu.device_count()
+
+        ENV_INFO["torch"]["device_count"] = dev_count
+        pinfo(f"Torch NPU device count ... {dev_count}")
+    except Exception:
+        pass
 
 
 def _probe_triton():


### PR DESCRIPTION
### PR Category

Other

### Type of Change

New Feature

### Description

This PR

- adapts the `pyproject.toml` to intentionally remove `triton_ascend` from `ascend-cann9` extra. The `triton_ascend` package has to be separately installed.
- adapts the `runt_tests.py` script for detecting device count on Ascend.
- adds container file for Ascend CANN 9.0.0 platform.