### PR TITLE
Fix int32 offset overflow in index/index_put for large tensors

### DIFF
--- a/src/flag_gems/ops/index.py
+++ b/src/flag_gems/ops/index.py
@@ -41,6 +41,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("from flag_gems.utils import libentry, libtuner")
     code.writeline("from flag_gems import runtime")
     code.writeline("from flag_gems.utils.shape_utils import volume")
+    code.writeline("from flag_gems.utils.shape_utils import can_use_int32_index")
     code.writeline("from flag_gems.utils import triton_lang_extension as ext")
 
     code.newline()
@@ -76,6 +77,7 @@ def generate_index_kernel(
         args += [
             "M,",
             "N,",
+            "INT32_OFFSET: tl.constexpr,",
             "BLOCK_SIZE0: tl.constexpr,",
             "BLOCK_SIZE1: tl.constexpr,",
         ]
@@ -111,6 +113,18 @@ def generate_index_kernel(
             code.writeline(
                 f"cur_index{i} = tl.load(indices{i}_ptr + {' + '.join(comp)}, mask=mask0, other=0)"
             )
+        code.newline()
+
+        # Promote to int64 when INT32_OFFSET is False to prevent overflow
+        code.writeline("if not INT32_OFFSET:")
+        with code.indent():
+            for i in range(indices_len):
+                code.writeline(f"cur_index{i} = cur_index{i}.to(tl.int64)")
+            for i in range(index_rank):
+                code.writeline(f"indices_idx{i} = indices_idx{i}.to(tl.int64)")
+            for i in range(indices_len, inp_rank):
+                code.writeline(f"input_idx{i} = input_idx{i}.to(tl.int64)")
+
         code.newline()
         index_mask = [
             f"(cur_index{i} >= 0) & (cur_index{i} < input_shape{i})"
@@ -160,6 +174,15 @@ def generate_index_wrapper(
         code.writeline("M = indices[0].numel()")
         code.writeline(f"N = volume(input_shape[{indices_len}: ])")
         code.newline()
+        # Determine if int32 offsets are safe for all tensors
+        code.writeline(
+            "int32_offset = can_use_int32_index(input) and can_use_int32_index(out)"
+        )
+        for i in range(indices_len):
+            code.writeline(
+                f"int32_offset = int32_offset and can_use_int32_index(indices[{i}])"
+            )
+        code.newline()
         code.writeline("grid = lambda meta: (")
         with code.indent():
             code.writeline("triton.cdiv(M, meta['BLOCK_SIZE0']), ")
@@ -180,7 +203,7 @@ def generate_index_wrapper(
             args += [
                 f"out_stride[{i}]," for i in range(index_rank + inp_rank - indices_len)
             ]
-            args += ["M,", "N,"]
+            args += ["M,", "N,", "int32_offset,"]
             code.writelines(args)
         code.writeline(")")
         code.writeline("return input")

--- a/src/flag_gems/ops/index_put.py
+++ b/src/flag_gems/ops/index_put.py
@@ -41,6 +41,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("from flag_gems.utils import libentry")
     code.writeline("from flag_gems import runtime")
     code.writeline("from flag_gems.utils.shape_utils import volume")
+    code.writeline("from flag_gems.utils.shape_utils import can_use_int32_index")
     code.writeline("from flag_gems.utils import triton_lang_extension as ext")
 
     code.newline()
@@ -71,6 +72,7 @@ def generate_index_put_kernel(
             "M,",
             "N,",
             "IS_ACCUMULATE: tl.constexpr,",
+            "INT32_OFFSET: tl.constexpr,",
             "BLOCK_SIZE0: tl.constexpr = 2,",
             "BLOCK_SIZE1: tl.constexpr = 2048,",
         ]
@@ -106,6 +108,18 @@ def generate_index_put_kernel(
             code.writeline(
                 f"cur_index{i} = tl.load(indices{i}_ptr + {' + '.join(comp)}, mask=mask0, other=0)"
             )
+        code.newline()
+
+        # Promote to int64 when INT32_OFFSET is False to prevent overflow
+        code.writeline("if not INT32_OFFSET:")
+        with code.indent():
+            for i in range(indices_len):
+                code.writeline(f"cur_index{i} = cur_index{i}.to(tl.int64)")
+            for i in range(index_rank):
+                code.writeline(f"indices_idx{i} = indices_idx{i}.to(tl.int64)")
+            for i in range(indices_len, inp_rank):
+                code.writeline(f"input_idx{i} = input_idx{i}.to(tl.int64)")
+
         code.newline()
         index_mask = [
             f"(cur_index{i} >= 0) & (cur_index{i} < input_shape{i})"
@@ -162,6 +176,15 @@ def generate_index_put_wrapper(
         code.writeline("M = indices[0].numel()")
         code.writeline(f"N = volume(input_shape[{indices_len}: ])")
         code.newline()
+        # Determine if int32 offsets are safe for all tensors
+        code.writeline(
+            "int32_offset = can_use_int32_index(input) and can_use_int32_index(values)"
+        )
+        for i in range(indices_len):
+            code.writeline(
+                f"int32_offset = int32_offset and can_use_int32_index(indices[{i}])"
+            )
+        code.newline()
         code.writeline("grid = lambda meta: (")
         with code.indent():
             code.writeline("triton.cdiv(M, meta['BLOCK_SIZE0']), ")
@@ -183,7 +206,7 @@ def generate_index_put_wrapper(
                 f"values_stride[{i}],"
                 for i in range(index_rank + inp_rank - indices_len)
             ]
-            args += ["M,", "N,", "accumulate==True,"]
+            args += ["M,", "N,", "accumulate==True,", "int32_offset,"]
             code.writelines(args)
         code.writeline(")")
         code.writeline("return input")

--- a/src/flag_gems/runtime/backend/_ascend/ops/index.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/index.py
@@ -23,8 +23,8 @@ def index_kernel_func(
         offset = pid0 * BLOCK_SIZE + i
 
         if offset < index_len:
-            in_start_index = tl.load(index_ptr + offset) * stride
-            out_start_offset = offset * stride
+            in_start_index = tl.load(index_ptr + offset).to(tl.int64) * stride
+            out_start_offset = offset.to(tl.int64) * stride
             loop_num = (stride - 1) // MAX_DATA_SIZE + 1
 
             for loop_idx in range(0, loop_num):

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/index.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/index.py
@@ -42,6 +42,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("from flag_gems.utils import libentry")
     code.writeline("from flag_gems import runtime")
     code.writeline("from flag_gems.utils.shape_utils import volume")
+    code.writeline("from flag_gems.utils.shape_utils import can_use_int32_index")
     code.writeline("from flag_gems.utils import triton_lang_extension as ext")
 
     code.newline()
@@ -106,6 +107,7 @@ def generate_index_kernel(
         args += [
             "M,",
             "N,",
+            "INT32_OFFSET: tl.constexpr,",
             "BLOCK_SIZE0: tl.constexpr,",
             "BLOCK_SIZE1: tl.constexpr,",
         ]
@@ -141,6 +143,18 @@ def generate_index_kernel(
             code.writeline(
                 f"cur_index{i} = tl.load(indices{i}_ptr + {' + '.join(comp)}, mask=mask0, other=0)"
             )
+        code.newline()
+
+        # Promote to int64 when INT32_OFFSET is False to prevent overflow
+        code.writeline("if not INT32_OFFSET:")
+        with code.indent():
+            for i in range(indices_len):
+                code.writeline(f"cur_index{i} = cur_index{i}.to(tl.int64)")
+            for i in range(index_rank):
+                code.writeline(f"indices_idx{i} = indices_idx{i}.to(tl.int64)")
+            for i in range(indices_len, inp_rank):
+                code.writeline(f"input_idx{i} = input_idx{i}.to(tl.int64)")
+
         code.newline()
         index_mask = [
             f"(cur_index{i} >= 0) & (cur_index{i} < input_shape{i})"
@@ -190,6 +204,15 @@ def generate_index_wrapper(
         code.writeline("M = indices[0].numel()")
         code.writeline(f"N = volume(input_shape[{indices_len}: ])")
         code.newline()
+        # Determine if int32 offsets are safe for all tensors
+        code.writeline(
+            "int32_offset = can_use_int32_index(input) and can_use_int32_index(out)"
+        )
+        for i in range(indices_len):
+            code.writeline(
+                f"int32_offset = int32_offset and can_use_int32_index(indices[{i}])"
+            )
+        code.newline()
         code.writeline("grid = lambda meta: (")
         with code.indent():
             code.writeline("triton.cdiv(M, meta['BLOCK_SIZE0']), ")
@@ -210,7 +233,7 @@ def generate_index_wrapper(
             args += [
                 f"out_stride[{i}]," for i in range(index_rank + inp_rank - indices_len)
             ]
-            args += ["M,", "N,"]
+            args += ["M,", "N,", "int32_offset,"]
             code.writelines(args)
         code.writeline(")")
         code.writeline("return input")

--- a/src/flag_gems/runtime/backend/_kunlunxin/ops/index_put.py
+++ b/src/flag_gems/runtime/backend/_kunlunxin/ops/index_put.py
@@ -42,6 +42,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("from flag_gems.utils import libentry")
     code.writeline("from flag_gems import runtime")
     code.writeline("from flag_gems.utils.shape_utils import volume")
+    code.writeline("from flag_gems.utils.shape_utils import can_use_int32_index")
 
     code.newline()
     code.newline()
@@ -99,6 +100,7 @@ def generate_index_put_kernel(
             "M: tl.constexpr,",
             "N: tl.constexpr,",
             "IS_ACCUMULATE: tl.constexpr,",
+            "INT32_OFFSET: tl.constexpr,",
             "BLOCK_SIZE0: tl.constexpr,",
             "BLOCK_SIZE1: tl.constexpr,",
         ]
@@ -134,6 +136,18 @@ def generate_index_put_kernel(
             code.writeline(
                 f"cur_index{i} = tl.load(indices{i}_ptr + {' + '.join(comp)}, mask=mask0, other=0)"
             )
+        code.newline()
+
+        # Promote to int64 when INT32_OFFSET is False to prevent overflow
+        code.writeline("if not INT32_OFFSET:")
+        with code.indent():
+            for i in range(indices_len):
+                code.writeline(f"cur_index{i} = cur_index{i}.to(tl.int64)")
+            for i in range(index_rank):
+                code.writeline(f"indices_idx{i} = indices_idx{i}.to(tl.int64)")
+            for i in range(indices_len, inp_rank):
+                code.writeline(f"input_idx{i} = input_idx{i}.to(tl.int64)")
+
         code.newline()
         index_mask = [
             f"(cur_index{i} >= 0) & (cur_index{i} < input_shape{i})"
@@ -190,6 +204,15 @@ def generate_index_put_wrapper(
         code.writeline("M = indices[0].numel()")
         code.writeline(f"N = volume(input_shape[{indices_len}: ])")
         code.newline()
+        # Determine if int32 offsets are safe for all tensors
+        code.writeline(
+            "int32_offset = can_use_int32_index(input) and can_use_int32_index(values)"
+        )
+        for i in range(indices_len):
+            code.writeline(
+                f"int32_offset = int32_offset and can_use_int32_index(indices[{i}])"
+            )
+        code.newline()
         code.writeline("grid = lambda meta: (")
         with code.indent():
             code.writeline("triton.cdiv(M, meta['BLOCK_SIZE0']), ")
@@ -211,7 +234,7 @@ def generate_index_put_wrapper(
                 f"values_stride[{i}],"
                 for i in range(index_rank + inp_rank - indices_len)
             ]
-            args += ["M,", "N,", "accumulate==True,"]
+            args += ["M,", "N,", "accumulate==True,", "int32_offset,"]
             code.writelines(args)
         code.writeline(")")
         code.writeline("return input")

--- a/src/flag_gems/runtime/backend/_metax/ops/index.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/index.py
@@ -41,6 +41,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("from flag_gems.utils import libentry, libtuner")
     code.writeline("from flag_gems import runtime")
     code.writeline("from flag_gems.utils.shape_utils import volume")
+    code.writeline("from flag_gems.utils.shape_utils import can_use_int32_index")
     code.writeline("from flag_gems.utils import triton_lang_extension as ext")
 
     code.newline()
@@ -76,6 +77,7 @@ def generate_index_kernel(
         args += [
             "M,",
             "N,",
+            "INT32_OFFSET: tl.constexpr,",
             "BLOCK_SIZE0: tl.constexpr,",
             "BLOCK_SIZE1: tl.constexpr,",
         ]
@@ -111,6 +113,18 @@ def generate_index_kernel(
             code.writeline(
                 f"cur_index{i} = tl.load(indices{i}_ptr + {' + '.join(comp)}, mask=mask0, other=0)"
             )
+        code.newline()
+
+        # Promote to int64 when INT32_OFFSET is False to prevent overflow
+        code.writeline("if not INT32_OFFSET:")
+        with code.indent():
+            for i in range(indices_len):
+                code.writeline(f"cur_index{i} = cur_index{i}.to(tl.int64)")
+            for i in range(index_rank):
+                code.writeline(f"indices_idx{i} = indices_idx{i}.to(tl.int64)")
+            for i in range(indices_len, inp_rank):
+                code.writeline(f"input_idx{i} = input_idx{i}.to(tl.int64)")
+
         code.newline()
         index_mask = [
             f"(cur_index{i} >= 0) & (cur_index{i} < input_shape{i})"
@@ -160,6 +174,15 @@ def generate_index_wrapper(
         code.writeline("M = indices[0].numel()")
         code.writeline(f"N = volume(input_shape[{indices_len}: ])")
         code.newline()
+        # Determine if int32 offsets are safe for all tensors
+        code.writeline(
+            "int32_offset = can_use_int32_index(input) and can_use_int32_index(out)"
+        )
+        for i in range(indices_len):
+            code.writeline(
+                f"int32_offset = int32_offset and can_use_int32_index(indices[{i}])"
+            )
+        code.newline()
         code.writeline("grid = lambda meta: (")
         with code.indent():
             code.writeline("triton.cdiv(M, meta['BLOCK_SIZE0']), ")
@@ -180,7 +203,7 @@ def generate_index_wrapper(
             args += [
                 f"out_stride[{i}]," for i in range(index_rank + inp_rank - indices_len)
             ]
-            args += ["M,", "N,"]
+            args += ["M,", "N,", "int32_offset,"]
             code.writelines(args)
         code.writeline(")")
         code.writeline("return input")

--- a/src/flag_gems/runtime/backend/_metax/ops/index_put.py
+++ b/src/flag_gems/runtime/backend/_metax/ops/index_put.py
@@ -41,6 +41,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("from flag_gems.utils import libentry, libtuner")
     code.writeline("from flag_gems import runtime")
     code.writeline("from flag_gems.utils.shape_utils import volume")
+    code.writeline("from flag_gems.utils.shape_utils import can_use_int32_index")
     code.writeline("from flag_gems.utils import triton_lang_extension as ext")
 
     code.newline()
@@ -71,6 +72,7 @@ def generate_index_put_kernel(
             "M,",
             "N,",
             "IS_ACCUMULATE: tl.constexpr,",
+            "INT32_OFFSET: tl.constexpr,",
             "BLOCK_SIZE0: tl.constexpr = 2,",
             "BLOCK_SIZE1: tl.constexpr = 2048,",
         ]
@@ -106,6 +108,18 @@ def generate_index_put_kernel(
             code.writeline(
                 f"cur_index{i} = tl.load(indices{i}_ptr + {' + '.join(comp)}, mask=mask0, other=0)"
             )
+        code.newline()
+
+        # Promote to int64 when INT32_OFFSET is False to prevent overflow
+        code.writeline("if not INT32_OFFSET:")
+        with code.indent():
+            for i in range(indices_len):
+                code.writeline(f"cur_index{i} = cur_index{i}.to(tl.int64)")
+            for i in range(index_rank):
+                code.writeline(f"indices_idx{i} = indices_idx{i}.to(tl.int64)")
+            for i in range(indices_len, inp_rank):
+                code.writeline(f"input_idx{i} = input_idx{i}.to(tl.int64)")
+
         code.newline()
         index_mask = [
             f"(cur_index{i} >= 0) & (cur_index{i} < input_shape{i})"
@@ -162,6 +176,15 @@ def generate_index_put_wrapper(
         code.writeline("M = indices[0].numel()")
         code.writeline(f"N = volume(input_shape[{indices_len}: ])")
         code.newline()
+        # Determine if int32 offsets are safe for all tensors
+        code.writeline(
+            "int32_offset = can_use_int32_index(input) and can_use_int32_index(values)"
+        )
+        for i in range(indices_len):
+            code.writeline(
+                f"int32_offset = int32_offset and can_use_int32_index(indices[{i}])"
+            )
+        code.newline()
         code.writeline("grid = lambda meta: (")
         with code.indent():
             code.writeline("triton.cdiv(M, meta['BLOCK_SIZE0']), ")
@@ -183,7 +206,7 @@ def generate_index_put_wrapper(
                 f"values_stride[{i}],"
                 for i in range(index_rank + inp_rank - indices_len)
             ]
-            args += ["M,", "N,", "accumulate==True,"]
+            args += ["M,", "N,", "accumulate==True,", "int32_offset,"]
             code.writelines(args)
         code.writeline(")")
         code.writeline("return input")

--- a/src/flag_gems/runtime/backend/_mthreads/ops/index_put.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/index_put.py
@@ -43,6 +43,7 @@ def generate_imports(code: IndentedBuffer) -> IndentedBuffer:
     code.writeline("from flag_gems.utils import libentry, libtuner")
     code.writeline("from flag_gems import runtime")
     code.writeline("from flag_gems.utils.shape_utils import volume")
+    code.writeline("from flag_gems.utils.shape_utils import can_use_int32_index")
     code.writeline("from flag_gems.utils import triton_lang_extension as ext")
 
     code.newline()
@@ -82,6 +83,7 @@ def generate_index_put_kernel(
             "M,",
             "N,",
             "IS_ACCUMULATE: tl.constexpr,",
+            "INT32_OFFSET: tl.constexpr,",
             "BLOCK_SIZE0: tl.constexpr,",
             "BLOCK_SIZE1: tl.constexpr,",
         ]
@@ -117,6 +119,18 @@ def generate_index_put_kernel(
             code.writeline(
                 f"cur_index{i} = tl.load(indices{i}_ptr + {' + '.join(comp)}, mask=mask0, other=0)"
             )
+        code.newline()
+
+        # Promote to int64 when INT32_OFFSET is False to prevent overflow
+        code.writeline("if not INT32_OFFSET:")
+        with code.indent():
+            for i in range(indices_len):
+                code.writeline(f"cur_index{i} = cur_index{i}.to(tl.int64)")
+            for i in range(index_rank):
+                code.writeline(f"indices_idx{i} = indices_idx{i}.to(tl.int64)")
+            for i in range(indices_len, inp_rank):
+                code.writeline(f"input_idx{i} = input_idx{i}.to(tl.int64)")
+
         code.newline()
         index_mask = [
             f"(cur_index{i} >= 0) & (cur_index{i} < input_shape{i})"
@@ -173,6 +187,15 @@ def generate_index_put_wrapper(
         code.writeline("M = indices[0].numel()")
         code.writeline(f"N = volume(input_shape[{indices_len}: ])")
         code.newline()
+        # Determine if int32 offsets are safe for all tensors
+        code.writeline(
+            "int32_offset = can_use_int32_index(input) and can_use_int32_index(values)"
+        )
+        for i in range(indices_len):
+            code.writeline(
+                f"int32_offset = int32_offset and can_use_int32_index(indices[{i}])"
+            )
+        code.newline()
         code.writeline("grid = lambda meta: (")
         with code.indent():
             code.writeline("triton.cdiv(M, meta['BLOCK_SIZE0']), ")
@@ -194,7 +217,7 @@ def generate_index_put_wrapper(
                 f"values_stride[{i}],"
                 for i in range(index_rank + inp_rank - indices_len)
             ]
-            args += ["M,", "N,", "accumulate==True,"]
+            args += ["M,", "N,", "accumulate==True,", "int32_offset,"]
             code.writelines(args)
         code.writeline(")")
         code.writeline("return input")

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -253,3 +253,31 @@ def test_index_error_too_many_indices(dtype):
 
     with pytest.raises(IndexError, match="too many indices"):
         flag_gems.index(inp, indices)
+
+
+@pytest.mark.index
+def test_index_large_tensor_int32_offset():
+    # Regression for #4153. For a tensor with more than 2**31 elements the
+    # kernel computed offset = index * stride in int32, which overflowed to a
+    # negative offset -> CUDA illegal memory access. The bug is dtype-agnostic
+    # (the offset is in element units), so int8 keeps the >2**31-element
+    # allocation near 2 GiB. int32 indices are the trigger (int64 would dodge it).
+    stride0 = 2**17  # = 8 * 128 * 128, mirrors the ssm_state row size
+    crit = 2**31 // stride0  # 16384: crit * stride0 == 2**31 > INT32_MAX
+    n_rows = crit + 1
+
+    try:
+        inp = torch.zeros((n_rows, stride0), dtype=torch.int8, device=flag_gems.device)
+    except RuntimeError as e:
+        if "out of memory" in str(e).lower():
+            pytest.skip("needs >2 GiB device memory for a >2**31-element tensor")
+        raise
+
+    inp[crit] = 7  # mark the row so a correct gather is distinguishable
+    idx = torch.tensor([crit], dtype=torch.int32, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp)
+    ref_out = torch.ops.aten.index(ref_inp, [utils.to_reference(idx)])
+    out = flag_gems.index(inp, [idx])
+
+    utils.gems_assert_equal(out, ref_out)

--- a/tests/test_index_put.py
+++ b/tests/test_index_put.py
@@ -327,3 +327,29 @@ def test_index_put_mixed_none_and_tensor(input_shape, indices_config, dtype):
 
     out = flag_gems.index_put(inp, indices, values, accumulate)
     utils.gems_assert_close(out, ref_out, dtype)
+
+
+@pytest.mark.index_put_
+def test_index_put__large_tensor_int32_offset():
+    # Regression for #4153, scatter side (same root cause as the index test).
+    # In-place on a >2**31-element tensor; the post-state is checked directly
+    # to avoid materializing a multi-GiB reference copy.
+    stride0 = 2**17
+    crit = 2**31 // stride0  # 16384: crit * stride0 == 2**31 > INT32_MAX
+    n_rows = crit + 1
+
+    try:
+        inp = torch.zeros((n_rows, stride0), dtype=torch.int8, device=flag_gems.device)
+    except RuntimeError as e:
+        if "out of memory" in str(e).lower():
+            pytest.skip("needs >2 GiB device memory for a >2**31-element tensor")
+        raise
+
+    idx = torch.tensor([crit], dtype=torch.int32, device=flag_gems.device)
+    values = torch.full((1, stride0), 7, dtype=torch.int8, device=flag_gems.device)
+
+    flag_gems.index_put_(inp, [idx], values, accumulate=False)
+
+    expected = torch.full((stride0,), 7, dtype=torch.int8, device=flag_gems.device)
+    assert torch.equal(inp[crit], expected)  # critical row written correctly
+    assert inp.sum(dtype=torch.int64).item() == 7 * stride0  # no stray writes


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description
The Triton `index` / `index_put` kernels compute element offsets as
`offset = index * stride` in int32. When the indexed tensor has more than
2**31 elements (e.g. a GDN/linear-attention `ssm_state` of shape
[24901, 8, 128, 128], stride0 = 131072), any index >= 16384 makes
`index * stride0 >= 2**31`, overflowing signed int32 to a negative offset.
The pointer then lands before the tensor base -> CUDA "illegal memory access".
(In vLLM this surfaced under high concurrency and was often reported from a
later `cat`/`nonzero` launch, because the CUDA error is asynchronous;
`CUDA_LAUNCH_BLOCKING=1` localizes it to the index kernel.)

This adopts the same `INT32_OFFSET` dual-path that `scatter.py` already uses:
- the wrapper computes `int32_offset = can_use_int32_index(...)` over every
  participating tensor and passes it to the kernel as a `tl.constexpr`;
- when `int32_offset` is False, the kernel promotes the index / coordinate
  variables to int64 before the offset multiply.

Because `INT32_OFFSET` is a constexpr, the small-tensor path is unchanged: the
int64 branch is eliminated at compile time, so the generated int32 kernel is
byte-identical to before. Large tensors take the int64 path.

### Changed
- src/flag_gems/ops/index.py        (fix)
- src/flag_gems/ops/index_put.py    (fix, symmetric to the above)
- tests/test_index.py               (regression test for the >2**31-element case)
- tests/test_index_put.py           (regression test for the >2**31-element case)


### Issue

Resolves #4153

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
No change on the existing (small-tensor) path: with `INT32_OFFSET=True` the
generated kernel is identical to the current one (constexpr dead-code
elimination), so no extra branch / register / ALU cost. For tensors above
2**31 elements the int64-offset path is taken; since this op is a
memory-bandwidth-bound gather/scatter, the extra int64 offset arithmetic is
hidden behind memory traffic and the throughput impact is negligible. Added
two regression tests (`tests/test_index.py`, `tests/test_index_put.py`) that
exercise the >2**31-element case with int32 indices.
### Reproduction & Verification
Before — vLLM `bench serve` (4k input / 1k output, 1000 concurrency) crashes in
the Qwen3-Next GDN linear-attention index/index_put path:
After this fix — the same benchmark completes with 0 failed requests
(1000 successful / 0 failed)



