### PR TITLE
Cleanse the operator registry again

### DIFF
--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -903,17 +903,6 @@ ops:
       - Math
     stages:
       - stable: '2.2'
-  - id: ilshift__
-    description: Computes the in-place bitwise left shift of `self` by `other` bits.
-    for:
-      - __ilshift__.Tensor
-    labels:
-      - aten
-      - KernelGen
-    kind:
-      - Math
-    stages:
-      - alpha: '5.4'
   - id: bitwise_left_shift
     description: Computes the left arithmetic shift of `input` by `other` bits.
     for:
@@ -2070,6 +2059,18 @@ ops:
       - Math
     stages:
       - beta: '5.3'
+  - id: efficient_attention_backward
+    description: |
+      Backward kernel for FlashAttention, computing gradients of queries, keys, values, and attention outputs efficiently.
+    for:
+      - _efficient_attention_backward
+    labels:
+      - aten
+      - NoCPU
+    kind:
+      - NeuralNetwork
+    stages:
+      - beta: '5.4'
   - id: einsum
     description: |
       Sums the product of the elements of the input `operands` along dimensions specified using a notation
@@ -2117,18 +2118,6 @@ ops:
       - NeuralNetwork
     stages:
       - stable: '4.0'
-  - id: efficient_attention_backward
-    description: |
-      Backward kernel for FlashAttention, computing gradients of queries, keys, values, and attention outputs efficiently.
-    for:
-      - _efficient_attention_backward
-    labels:
-      - aten
-      - NoCPU
-    kind:
-      - NeuralNetwork
-    stages:
-      - beta: '5.4'
   - id: embedding
     description: |
       Generate a simple lookup table that looks up embeddings in a fixed dictionary and size.
@@ -3353,6 +3342,17 @@ ops:
     stages:
       - beta: '5.0'
       - stable: '5.3'
+  - id: ilshift__
+    description: Computes the in-place bitwise left shift of `self` by `other` bits.
+    for:
+      - __ilshift__.Tensor
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - Math
+    stages:
+      - alpha: '5.4'
   - id: index
     description: |
       Extract, access or modify specific elements, slices, or subsets of data within a tensor.
@@ -4473,98 +4473,6 @@ ops:
       - NeuralNetwork
     stages:
       - stable: '2.2'
-  - id: normal_
-    description: Random sampling operator (normal_).
-    for:
-      - normal_
-    labels:
-      - skip_precision_check
-    kind:
-      - Tensor
-    stages:
-      - alpha: '5.3'
-  - id: renorm
-    description: >
-      Returns a tensor where each sub-tensor along the given dimension
-      is normalized such that the p-norm is lower than a max norm value.
-    for:
-      - renorm
-    labels:
-      - aten
-      - KernelGen
-    kind:
-      - Math
-    stages:
-      - alpha: '5.3'
-  - id: renorm_
-    description: The in-place version of `renorm()`.
-    for:
-      - renorm_
-    labels:
-      - aten
-      - KernelGen
-    kind:
-      - Math
-    stages:
-      - alpha: '5.3'
-  - id: reflection_pad1d_backward
-    description: Computes the gradient of reflection_pad1d with respect to the input tensor.
-    for:
-      - reflection_pad1d_backward
-    labels:
-      - aten
-      - KernelGen
-    kind:
-      - Math
-    stages:
-      - alpha: '5.3'
-  - id: resize_output
-    description: |
-      Resizes tensor output storage and copies overlapping elements.
-    for:
-      - _resize_output
-    labels:
-      - aten
-      - KernelGen
-    kind:
-      - Math
-    stages:
-      - alpha: '5.3'
-  - id: rot90
-    description: Triton kernel implementation for rot90.
-    for:
-      - rot90
-    labels:
-      - aten
-      - KernelGen
-    kind:
-      - Math
-    stages:
-      - alpha: '5.3'
-  - id: smooth_l1_loss
-    description: Compute the smooth L1 loss between input and target tensors.
-    for:
-      - smooth_l1_loss
-    labels:
-      - aten
-      - pointwise
-      - nn.functional
-    kind:
-      - NeuralNetwork
-    stages:
-      - alpha: '5.3'
-  - id: smooth_l1_loss_backward
-    description: Compute the gradient of smooth L1 loss with respect to the input tensor.
-    for:
-      - smooth_l1_loss_backward
-    labels:
-      - aten
-      - pointwise
-      - nn.functional
-    kind:
-      - NeuralNetwork
-    stages:
-      - alpha: '5.3'
   - id: mul
     description: Multiplies `input` by `other`.
     for:
@@ -4850,7 +4758,7 @@ ops:
     kind:
       - Tensor
     stages:
-      - alpha: '5.1'
+      - alpha: '5.3'
   - id: normal_float_float_
     description: |
       Returns a tensor of random numbers drawn from separate normal distributions
@@ -5690,6 +5598,18 @@ ops:
     stages:
       - stable: '3.0'
     cpp: '4.0'
+  - id: resize_output
+    description: |
+      Resizes tensor output storage and copies overlapping elements.
+    for:
+      - _resize_output
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - Math
+    stages:
+      - alpha: '5.3'
   - id: resolve_conj
     description: |
       Returns a new tensor with materialized conjugation if `input`'s conjugate bit is set to True,
@@ -7238,8 +7158,8 @@ ops:
       - stable: '5.0'
   - id: unfold_copy
     description: >
-      Returns a view of the original tensor which contains all slices of size from self tensor
-      in the specified dimension with given step between two slices.
+      Returns a view of the original tensor which contains all slices of size from self tensor in the specified dimension with given step between two slices.
+
     for:
       - unfold_copy
     labels:


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Update

### Description

This PR cleanse the operator registry:

#### Removed 7 duplicate entries (639 → 632 ops)

  | id | Reason |
  |---|---|
  | `normal_` (alpha: 5.1) | Duplicate — kept the alpha: 5.3 entry |
  | `reflection_pad1d_backward` | Identical duplicate |
  | `renorm` (alpha: 5.3) | Duplicate — kept the alpha: 5.4 entry |
  | `renorm_` (alpha: 5.3) | Duplicate — kept the alpha: 5.4 entry |
  | `rot90` (alpha: 5.3) | Duplicate — kept the alpha: 5.4 entry |
  | `smooth_l1_loss` | Identical duplicate |
  | `smooth_l1_loss_backward` | Identical duplicate |

#### Fixed 4 sort-order violations

  | id | Was incorrectly placed after | Correct position |
  |---|---|---|
  | `bitwise_left_shift` | `ilshift__` | `b...` block |
  | `efficient_attention_backward` | `elu_backward` | `e...` block |
  | `reflection_pad1d_backward` | `renorm_` | `r...` block |
  | `mul` | `smooth_l1_loss_backward` | `m...` block |


