### PR TITLE
Rename 'ilshift__' to 'ilshift'

### DIFF
--- a/benchmark/test_ilshift.py
+++ b/benchmark/test_ilshift.py
@@ -3,10 +3,10 @@ import pytest
 from . import base, consts
 
 
-@pytest.mark.ilshift__
-def test_ilshift__():
+@pytest.mark.ilshift
+def test_ilshift():
     bench = base.BinaryPointwiseBenchmark(
-        op_name="ilshift__",
+        op_name="ilshift",
         torch_op=lambda a, b: a.__ilshift__(b),
         dtypes=consts.INT_DTYPES,
         is_inplace=True,

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -3342,7 +3342,7 @@ ops:
     stages:
       - beta: '5.0'
       - stable: '5.3'
-  - id: ilshift__
+  - id: ilshift
     description: Computes the in-place bitwise left shift of `self` by `other` bits.
     for:
       - __ilshift__.Tensor

--- a/tests/test_ilshift.py
+++ b/tests/test_ilshift.py
@@ -14,10 +14,10 @@ INPLACE_BITWISE_SHAPES = [
 ]
 
 
-@pytest.mark.ilshift__
+@pytest.mark.ilshift
 @pytest.mark.parametrize("shapes", INPLACE_BITWISE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.ALL_INT_DTYPES + [torch.uint8])
-def test_ilshift__(shapes, dtype):
+def test_ilshift(shapes, dtype):
     shape_a, shape_b = shapes
     res_a = torch.randint(0, 100, shape_a, dtype=dtype, device="cpu").to(
         flag_gems.device


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Bug Fix

### Description

The `__ilshift__` operator is using a special Pythonic naming that has double underscores both before and after the name. Since the leading underscore is not acceptable as a `pytest.mark`, we need to drop the underscores entirely rather than simply removing the leading underscores.