### PR TITLE
Fix the vllm installation cache problem

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -77,7 +77,7 @@ jobs:
           ./setup.sh ${{ inputs.vendor }}
           if [ "${RUNNER_LABEL}" == "h20" ]; then
              source .venv/bin/activate
-             uv pip install --no-cache-dir vllm==0.21.0 --torch-backend=cu130
+             uv pip install vllm==0.21.0 --torch-backend=cu130
           fi
       - id: check-gpu
         if: ${{ inputs.gpu_check_script != '' }}

--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -105,7 +105,7 @@ jobs:
           # Install vllm for testing
           if [ "${VENDOR}" == "nvidia" ]; then
              source .venv/bin/activate
-             uv pip install --no-cache-dir vllm==0.21.0 --torch-backend=cu130
+             uv pip install vllm==0.21.0 --torch-backend=cu130
           fi
 
       - name: Check GPU availability

--- a/.github/workflows/random-test.yaml
+++ b/.github/workflows/random-test.yaml
@@ -92,7 +92,7 @@ jobs:
           # Install vllm for testing
           if [ "${VENDOR}" == "nvidia" ]; then
              source .venv/bin/activate
-             uv pip install --no-cache-dir vllm==0.21.0 --torch-backend=cu130
+             uv pip install vllm==0.21.0 --torch-backend=cu130
           fi
 
       - name: Check GPU availability


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The previous installation of vllm command was copy-pasted with `--no-cache-dir` set. This is wasting a lot of network traffic and it makes absolutely no sense.