### PR TITLE
Fix ascend backend

### DIFF
--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -77,7 +77,7 @@ jobs:
           ./setup.sh ${{ inputs.vendor }}
           if [ "${RUNNER_LABEL}" == "h20" ]; then
              source .venv/bin/activate
-             uv pip install --no-cache-dir vllm==0.21.0 --torch-backend=cu130
+             uv pip install vllm==0.21.0 --torch-backend=cu130
           fi
       - id: check-gpu
         if: ${{ inputs.gpu_check_script != '' }}

--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -105,7 +105,7 @@ jobs:
           # Install vllm for testing
           if [ "${VENDOR}" == "nvidia" ]; then
              source .venv/bin/activate
-             uv pip install --no-cache-dir vllm==0.21.0 --torch-backend=cu130
+             uv pip install vllm==0.21.0 --torch-backend=cu130
           fi
 
       - name: Check GPU availability

--- a/.github/workflows/random-test.yaml
+++ b/.github/workflows/random-test.yaml
@@ -92,7 +92,7 @@ jobs:
           # Install vllm for testing
           if [ "${VENDOR}" == "nvidia" ]; then
              source .venv/bin/activate
-             uv pip install --no-cache-dir vllm==0.21.0 --torch-backend=cu130
+             uv pip install vllm==0.21.0 --torch-backend=cu130
           fi
 
       - name: Check GPU availability

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -146,14 +146,14 @@ jobs:
         run: |
           bash tools/test-examples.sh ${{ needs.preprocess.outputs.pr_id }}
 
-  backend-ascend:
+  backend-ascend-cann850:
     needs: preprocess
     # The ascend backend runners need to be reconfigured.
     if: false
     # if: contains(needs.preprocess.outputs.labels, 'vendor/Ascend')
     uses: ./.github/workflows/backend-test.yaml
     with:
-      vendor: ascend
+      vendor: ascend-cann850
       runner_label: ascend
       gpu_check_script: tools/gpu_check_ascend.sh
       changed_files: ${{ join(needs.preprocess.outputs.changed_files, ' ') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,13 +52,13 @@ dependencies = [
 
 [project.optional-dependencies]
 
-ascend = [
+ascend-cann850 = [
     "torch==2.9.0+cpu",
     "torch-npu==2.9.0",
     "flagtree==0.5.0+ascend3.2",
 ]
 
-ascend-cann9 = [
+ascend-cann900 = [
     "torch==2.10.0+cpu",
     "torch-npu==2.10.0",
     "triton==3.5.0",

--- a/setup.sh
+++ b/setup.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 SUPPORTED_VENDORS=(
-  "ascend"
-  "ascend-cann9"
+  "ascend-cann850"
+  "ascend-cann900"
   "enflame"
   "hygon"
   "iluvatar"
@@ -18,8 +18,8 @@ SUPPORTED_VENDORS=(
 
 # TODO: Add thead PPU
 declare -A PYTHON_SUPPORTED=(
-  ["ascend"]="3.11"
-  ["ascend-cann9"]="3.11"
+  ["ascend-cann850"]="3.11"
+  ["ascend-cann900"]="3.11"
   ["enflame"]="3.12"
   ["hygon"]="3.10"
   ["iluvatar"]="3.10"
@@ -113,7 +113,7 @@ fi
 
 # Install FlagGems
 PYPI_VENDOR=${VENDOR}
-if [ "$VENDOR" = "ascend-cann9" ]; then
+if [[ "$VENDOR" == ascend-* ]]; then
   PYPI_VENDOR="ascend"
 fi
 export FLAGOS_PYPI="https://resource.flagos.net/repository/flagos-pypi-${PYPI_VENDOR}/simple"
@@ -137,7 +137,7 @@ fi
 #---- Vendor-specific installation steps -------------
 source tools/env.sh ${VENDOR}
 
-if [ "$VENDOR" = "ascend-cann9" ]; then
+if [ "$VENDOR" = "ascend-cann900" ]; then
   uv pip install triton==3.5.0
   uv pip install "triton-ascend==3.2.1" --index ${FLAGOS_PYPI}
 fi

--- a/tools/env.sh
+++ b/tools/env.sh
@@ -2,7 +2,7 @@ VENDOR=$1
 echo "Setting up environment variable for vendor $VENDOR"
 
 case $VENDOR in
-  ascend|ascend-cann9)
+  ascend-cann850|ascend-cann900)
     # This script is provided by the Huawei Ascend CANN toolkit installation.
     if [ -f /usr/local/Ascend/ascend-toolkit/set_env.sh ]; then
       source /usr/local/Ascend/ascend-toolkit/set_env.sh


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The existing naming of backend ('ascend' versus 'ascend-cann9') might be confusing. It smells like a generalization relationship, but it actually is not. This PR explicitly changes 'ascend' to 'ascend-cann850' and 'ascend-cann9' to 'ascend-cann900' so that the naming is more accurate.