### PR TITLE
Allow cann850 and cann9 to be specified for workflow

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -93,6 +93,12 @@ jobs:
             h20)
               VENDOR="nvidia"
               ;;
+            cann850)
+              VENDOR="ascend-cann850"
+              ;;
+            cann9)
+              VENDOR="ascend-cann900"
+              ;;
             *)
               VENDOR="${RUNNER_LABEL}"
               ;;

--- a/.github/workflows/random-test.yaml
+++ b/.github/workflows/random-test.yaml
@@ -79,6 +79,12 @@ jobs:
             h20)
               VENDOR="nvidia"
               ;;
+            cann850)
+              VENDOR="ascend-cann850"
+              ;;
+            cann9)
+              VENDOR="ascend-cann900"
+              ;;
             *)
               VENDOR="${RUNNER_LABEL}"
               ;;


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

New Feature

### Description

We have two runners (at the moment) for the Ascend backend, one provisioned with CANN 8.5.0 and the other with CANN 9.0.0. Both runners have labels 'ascend' and '910b'. However, when we want to test if an operator works on CANN 9.0.0, we may want to do `/test | <op>:cann9` or `/test | <op>:cann850`. This PR provides such a flexibility.