### PR TITLE
Improve the setup.sh script

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 SUPPORTED_VENDORS=(
   "ascend-cann850"
@@ -16,7 +17,6 @@ SUPPORTED_VENDORS=(
   "tsingmicro"
 )
 
-# TODO: Add thead PPU
 declare -A PYTHON_SUPPORTED=(
   ["ascend-cann850"]="3.11"
   ["ascend-cann900"]="3.11"
@@ -37,121 +37,115 @@ RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
 
+ok()   { printf " ${GREEN}[OK]${NC}\n"; }
+fail() { printf " ${RED}[FAILED]${NC}\n"; exit 1; }
+
 valid_vendor() {
-  needle=$1
-  for item in "${SUPPORTED_VENDORS[@]}" ; do
-    [ $item == "$needle" ] && return 0
+  local needle=$1
+  for item in "${SUPPORTED_VENDORS[@]}"; do
+    [ "$item" == "$needle" ] && return 0
   done
   return 1
 }
 
-# Validate argument count
-[ "$#" -eq 1 ] || { echo "Please specify <VENDOR>"; exit 1; }
+# ── Validate argument ─────────────────────────────────────────
+[ "$#" -eq 1 ] || { echo "Usage: $0 <VENDOR>"; exit 1; }
 
-# Validate vendor name
 VENDOR=${1}
-valid_vendor $VENDOR
-if [ "$?" != 0 ]; then
-    echo "Invalid vendor '${VENDOR}' specified ..."
-    echo "Please specify one of: ${SUPPORTED_VENDORS[@]}"
-    exit 1
-fi
-printf "Checking vendor ... ${VENDOR} $GREEN[OK]$NC\n"
-
-printf "Detecting pyenv ... "
-pyenv_version=$(pyenv --version 2>/dev/null | awk '{print $NF}')
-if [ "$?" != 0 ]; then
-  # pyenv not installed
-  printf "NOT FOUND $GREEN[OK]$NC\n"
-else
-  printf "${pyenv_version} $GREEN[OK]$NC\n"
-
-  if [ x"$PYENV_ROOT" == x ]; then
-    # Initialize pyenv virtual environment
-    export PYENV_ROOT="$HOME/.pyenv"
-    export PATH="$PYENV_ROOT/bin:$PATH"
-    eval "$(pyenv init - bash)"
-  fi
-fi
-
-# Validate Python version
-printf "Checking Python version ... "
-python_version=$(python --version 2>/dev/null | awk '{print $NF}')
-expected_version=${PYTHON_SUPPORTED[$VENDOR]}
-if [[ "$python_version" == *"$expected_version"* ]]; then
-  printf "${python_version} $GREEN[OK]$NC\n"
-else
-  printf "${python_version}, expecting '${expected_version}.*' $RED[FAILED]$NC"
+valid_vendor "$VENDOR" || {
+  echo "Invalid vendor '${VENDOR}'"
+  echo "Supported: ${SUPPORTED_VENDORS[*]}"
   exit 1
-fi
+}
+printf "Vendor: ${VENDOR}"
+ok
 
-# Validate uv install
-printf "Checking uv ... "
-uv_version=$(uv --version 2>/dev/null | cut -d ' ' -f 2)
-if [ -n "$uv_version" ];  then
-  printf "uv ${uv_version} ${GREEN}[OK]${NC}\n"
+PYTHON_VERSION=${PYTHON_SUPPORTED[$VENDOR]}
+
+# ── Detect or install uv ─────────────────────────────────────
+UV_VERSION="0.11.22"
+UV_MIRROR="https://resource.flagos.net/repository/flagos-filestore/utils"
+
+printf "Checking uv ..."
+if command -v uv &>/dev/null; then
+  printf " $(uv --version)"
+  ok
 else
-  printf "${RED}NOT FOUND${NC}\n"
-  # Install uv and upgrade pip if necessary
-  printf "Installing/upgrading pip and uv ... "
-  pip install uv --index-url https://mirrors.aliyun.com/pypi/simple \
-  || exit 1;
+  printf " not found, installing ...\n"
+  ARCH=$(uname -m)
+  curl -sSf "${UV_MIRROR}/uv-${ARCH}-${UV_VERSION}-linux-gnu.tar.gz" \
+    | tar xz -C "$HOME/.local/bin" 2>/dev/null \
+    || { curl -LsSf https://astral.sh/uv/install.sh | sh; }
+  export PATH="$HOME/.local/bin:$PATH"
+  command -v uv &>/dev/null || { printf "uv installation"; fail; }
+  printf "Installed $(uv --version)"
+  ok
 fi
 
-# Start installation
-printf "Installing FlagGems for ${VENDOR}\n"
+# ── Install Python via uv ────────────────────────────────────
+printf "Installing Python ${PYTHON_VERSION} ..."
+uv python install "${PYTHON_VERSION}" --python-preference only-managed -q || fail
+ok
 
-printf "Creating virtual environment ... "
-uv venv -q -c
-if [ "$?" != 0 ]; then
-  printf "$RED{FAILED]$NC\n"
-  exit 1
-else
-  printf "$GREEN[OK]$NC\n"
-  source .venv/bin/activate
-fi
+# ── Create virtual environment ────────────────────────────────
+printf "Creating virtual environment ..."
+uv venv .venv --python "${PYTHON_VERSION}" --python-preference only-managed -q || fail
+ok
+source .venv/bin/activate
 
-# Install FlagGems
+printf "Python: $(python --version)"
+ok
+
+# ── Source vendor environment ─────────────────────────────────
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+export USE_TRITON="${USE_TRITON:-}"
+source tools/env.sh "${VENDOR}"
+
+# ── FLAGOS PyPI index ─────────────────────────────────────────
 PYPI_VENDOR=${VENDOR}
 if [[ "$VENDOR" == ascend-* ]]; then
   PYPI_VENDOR="ascend"
 fi
 export FLAGOS_PYPI="https://resource.flagos.net/repository/flagos-pypi-${PYPI_VENDOR}/simple"
-printf "Install build tools ... "
-uv pip install \
+ALIYUN_PYPI="https://mirrors.aliyun.com/pypi/simple"
+
+# ── Install build tools ──────────────────────────────────────
+printf "Installing build tools ..."
+uv pip install -q \
   "setuptools>=64.0" \
   "scikit-build-core==0.12.2" \
   "pybind11==3.0.3" \
   "cmake>=3.20,<4" \
-  "ninja==1.13.0"
+  "ninja==1.13.0" \
+  --index "${ALIYUN_PYPI}" \
+  || fail
+ok
 
-if [ "$?" != 0 ]; then
-  printf "$RED[FAILED]$NC\n"
-  exit 1
-else
-  printf "$GREEN[OK]$NC\n"
-fi
+# ── Install FlagGems ──────────────────────────────────────────
+printf "Installing FlagGems [${VENDOR}] ..."
+uv pip install ".[${VENDOR}]" \
+  --default-index "${FLAGOS_PYPI}" \
+  --index https://mirrors.aliyun.com/pypi/simple \
+  || fail
+ok
 
-# export USE_TRITON=0
-
-#---- Vendor-specific installation steps -------------
-source tools/env.sh ${VENDOR}
-
+# ── Vendor-specific post-install ──────────────────────────────
 if [ "$VENDOR" = "ascend-cann900" ]; then
-  uv pip install triton==3.5.0
-  uv pip install "triton-ascend==3.2.1" --index ${FLAGOS_PYPI}
+  printf "Overriding triton with triton-ascend 3.2.1 ..."
+  uv pip install -q "triton-ascend==3.2.1" --index "${FLAGOS_PYPI}" || fail
+  ok
 fi
 
-uv pip install ".[${VENDOR}]" --default-index ${FLAGOS_PYPI} \
-    --index https://mirrors.aliyun.com/pypi/simple \
-
-# Kunlunxin needs an override of the default Triton installed (3.5.0)
 if [ "$VENDOR" = "kunlunxin" ]; then
-  uv pip install "triton==3.0.0+a48aedef" --index ${FLAGOS_PYPI}
-  # Kunlunxin triton drags in a buggy pytest plugin which has to be uninstalled
-  uv pip uninstall pytest-repeat
+  printf "Replacing triton with Kunlunxin override ..."
+  uv pip install -q "triton==3.0.0+a48aedef" --index "${FLAGOS_PYPI}" || fail
+  uv pip uninstall -q pytest-repeat 2>/dev/null || true
+  ok
 fi
 
-uv pip install ".[test]"
+# ── Install test dependencies ─────────────────────────────────
+printf "Installing test dependencies ..."
+uv pip install -q ".[test]" --index "${ALIYUN_PYPI}" || fail
+ok
 
-[ "$?" == 0 ] || { echo "Failed to setup FlagGems" ; exit 1; }
+printf "\n${GREEN}FlagGems setup complete for ${VENDOR}${NC}\n"


### PR DESCRIPTION
### PR Category

User Experience

### Type of Change

Optimization

### Description

This PR updates the setup.sh script with following changes:

- use `set -euo pipefail` for better error handling;
- adopt `|| fail` pattern across the script;
- Install python automatically via `uv python install` with `--python-preference only-managed`;
- Download `uv` from FLAGOS mirror, falls back to `astral.sh`, no more pip dependency;
- Create virtual environment with `uv`, using uv-managed python rather than pyenv managed one;
- Use aliyun mirror for build tools, flaggems install and test tools install, eliminating dependency over pypi.org;
- Set defaults for `LD_LIBRARY_PATH` and `USE_TRITON`;
- Install build tools in quiet mode, using Aliyun mirror;
- Eliminate external dependency on pyenv, pip and Python version; the only dependency now is `curl` and `bash 4+`.
