### PR TITLE
Remove skip annotation from trace benchmark

### DIFF
--- a/benchmark/test_trace.py
+++ b/benchmark/test_trace.py
@@ -11,7 +11,6 @@ def _input_fn(shape, dtype, device):
     yield inp,
 
 
-@pytest.mark.skip(reason="Test case failure: issue #2663")
 @pytest.mark.trace
 def test_trace():
     if flag_gems.vendor_name == "mthreads":


### PR DESCRIPTION
## Remove skip annotation from trace benchmark

The trace benchmark was skipped due to issue #2663, but it passes on all 5 tested backends with good speedups.

closes: #2663

### NVIDIA H20

| Dtype | 64x64 | 256x256 | 1024x1024 | 4096x4096 | 1024x65536 |
|-------|-------|---------|-----------|-----------|------------|
| fp16 | 1.065 | 1.133 | 1.133 | 0.847 | 1.120 |
| fp32 | 1.091 | 1.057 | 1.139 | 0.857 | 1.139 |
| bf16 | 1.110 | 1.080 | 1.115 | 0.853 | 1.108 |
| int16 | 1.538 | 1.576 | 1.818 | 1.166 | 1.809 |
| int32 | 1.421 | 1.613 | 1.751 | 1.158 | 1.820 |

### MetaX C550

| Dtype | 64x64 | 256x256 | 1024x1024 | 4096x4096 | 1024x65536 |
|-------|-------|---------|-----------|-----------|------------|
| fp16 | 1.322 | 1.322 | 1.155 | 1.000 | 1.192 |
| fp32 | 1.316 | 1.305 | 1.227 | 1.122 | 1.162 |
| bf16 | 1.368 | 1.333 | 1.217 | 1.051 | 1.187 |
| int16 | 1.379 | 1.450 | 1.522 | 0.938 | 1.432 |
| int32 | 1.356 | 1.467 | 1.576 | 1.174 | 1.385 |

### Hygon BW2000

| Dtype | 64x64 | 256x256 | 1024x1024 | 4096x4096 | 1024x65536 |
|-------|-------|---------|-----------|-----------|------------|
| fp16 | 1.732 | 1.805 | 2.024 | 1.609 | 1.811 |
| fp32 | 1.683 | 1.756 | 1.976 | 1.582 | 1.811 |
| bf16 | 1.732 | 1.805 | 2.024 | 1.569 | 1.811 |
| int16 | 1.923 | 2.341 | 2.805 | 1.833 | 2.241 |
| int32 | 2.439 | 2.341 | 2.854 | 1.743 | 2.259 |

### Mthreads S5000

| Dtype | 64x64 | 256x256 | 1024x1024 | 4096x4096 | 1024x65536 |
|-------|-------|---------|-----------|-----------|------------|
| fp16 | 2.679 | 2.177 | 1.363 | 0.528 | 1.358 |
| fp32 | 1.975 | 1.851 | 1.096 | 0.537 | 1.070 |
| bf16 | 2.646 | 2.223 | 1.474 | 0.574 | 1.460 |

### Iluvatar BI-V150

| Dtype | 64x64 | 256x256 | 1024x1024 | 4096x4096 | 1024x65536 |
|-------|-------|---------|-----------|-----------|------------|
| fp16 | 2.469 | 2.380 | 2.045 | 1.291 | 2.018 |
| fp32 | 2.551 | 2.584 | 2.057 | 1.249 | 2.047 |
| bf16 | 2.540 | 2.336 | 2.058 | 1.285 | 2.015 |
| int16 | 3.638 | 2.945 | 2.575 | 1.905 | 2.506 |
| int32 | 3.633 | 2.957 | 2.506 | 1.926 | 2.515 |
