### PR TITLE
Fix renorm fp16 precision: allocate norms buffer in fp32

### DIFF
--- a/src/flag_gems/ops/renorm.py
+++ b/src/flag_gems/ops/renorm.py
@@ -113,7 +113,7 @@ def renorm(input, p, dim, maxnorm):
         N = input.numel() // M
 
         input = input.contiguous()
-        norms = torch.empty((M,), dtype=input.dtype, device=input.device)
+        norms = torch.empty((M,), dtype=torch.float32, device=input.device)
 
         BLOCK = min(triton.next_power_of_2(N), 128)
         grid = (M,)
@@ -167,7 +167,7 @@ def renorm_(input, p, dim, maxnorm):
         N = input.numel() // M
 
         input = input.contiguous()
-        norms = torch.empty((M,), dtype=input.dtype, device=input.device)
+        norms = torch.empty((M,), dtype=torch.float32, device=input.device)
 
         BLOCK = min(triton.next_power_of_2(N), 128)
         grid = (M,)


### PR DESCRIPTION
## Problem

The `renorm` kernel computes p-norms in fp32 for fp16/bf16 inputs (correct), but the intermediate norms buffer was allocated in `input.dtype`:

```python
norms = torch.empty((M,), dtype=input.dtype, device=input.device)
```

This truncated the fp32 norm values back to fp16 when stored, causing intermittent accuracy failures in the daily CI on fp16 inputs.

Reference: https://github.com/flagos-ai/FlagGems/actions/runs/27878424327/job/82501732630

## Fix

Allocate the norms buffer in `torch.float32` so the full-precision norm is preserved between the two kernel launches (`renorm_kernel_norms` → `renorm_kernel_scale`). Applied to both `renorm()` and `renorm_()`.

## Test results (270/270 passed on all 5 backends)

| Backend | Result |
|---------|--------|
| NVIDIA H20 | 270/270 passed (12.11s) |
| MetaX C550 | 270/270 passed (20.58s) |
| Hygon BW2000 | 270/270 passed (22.29s) |
| Mthreads S5000 | 270/270 passed (17.77s) |
| Iluvatar BI-V150 | 270/270 passed (25.46s) |

closes: #4236
