### PR TITLE
Fix median/nanmedian test crash on int16 in quick mode

### DIFF
--- a/tests/test_median.py
+++ b/tests/test_median.py
@@ -36,7 +36,7 @@ MEDIAN_OPS = ["median", "median_out", "median_dim", "median_dim_values"]
 
 
 def _make_input(shape, dtype):
-    if dtype in utils.ALL_INT_DTYPES or dtype in (torch.int8, torch.uint8):
+    if not dtype.is_floating_point:
         numel = 1
         for size in shape:
             numel *= size

--- a/tests/test_nanmedian.py
+++ b/tests/test_nanmedian.py
@@ -39,7 +39,7 @@ def _make_input(shape, dtype, with_nan=True):
         inp = torch.randint(0, 101, shape, dtype=dtype, device="cpu").to(
             flag_gems.device
         )
-    elif dtype in utils.ALL_INT_DTYPES or dtype is torch.int8:
+    elif not dtype.is_floating_point:
         inp = torch.randint(-100, 101, shape, dtype=dtype, device="cpu").to(
             flag_gems.device
         )


### PR DESCRIPTION
## Problem

In quick-cpu mode, `test_median.py` and `test_nanmedian.py` crash on `torch.int16` inputs:

```
RuntimeError: "normal_kernel_cuda" not implemented for 'Short'
```

Both `_make_input()` functions check `dtype in utils.ALL_INT_DTYPES` to decide whether to use `torch.randint` (for ints) vs `torch.randn` (for floats). In QUICK_MODE, `ALL_INT_DTYPES = [torch.int32]` — it does not include `torch.int16`. So `int16` falls through to `torch.randn(..., dtype=torch.int16)` which is unsupported.

This is a test-only bug — the median/nanmedian operators handle int16 correctly.

Reference: https://github.com/flagos-ai/FlagGems/actions/runs/27878424327/job/82501732630

## Fix

Replace the dtype-list membership check with `not dtype.is_floating_point` to correctly handle all integer types regardless of mode.

## Test results (NVIDIA H20, quick-cpu mode)

| Test | Result |
|------|--------|
| test_median.py (full, `--quick --ref cpu`) | 265 passed (80.51s) |
| test_nanmedian.py::test_nanmedian_dim_values_large_int | 4 passed (3.40s) |

closes: #4238
