### PR TITLE
Add benchmark test for addmv_out

### DIFF
--- a/benchmark/test_addmv.py
+++ b/benchmark/test_addmv.py
@@ -33,3 +33,22 @@ def test_addmv():
         dtypes=consts.FLOAT_DTYPES,
     )
     bench.run()
+
+
+def _input_fn_out(m, n, cur_dtype, device):
+    mat = torch.randn([m, n], dtype=cur_dtype, device=device)
+    vec = torch.randn([n], dtype=cur_dtype, device=device)
+    bias = torch.randn([m], dtype=cur_dtype, device=device)
+    out = torch.empty([m], dtype=cur_dtype, device=device)
+    yield bias, mat, vec, {"out": out}
+
+
+@pytest.mark.addmv_out
+def test_addmv_out():
+    bench = AddmvBenchmark(
+        op_name="addmv_out",
+        input_fn=_input_fn_out,
+        torch_op=torch.addmv,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.run()


### PR DESCRIPTION
## Summary

- Add missing benchmark test for `addmv_out` operator in `benchmark/test_addmv.py`
- Follows the same pattern as `addmm_out` benchmark: `_input_fn_out` yields `{"out": out}` dict

## Benchmark Results

Columns: `latency_base` (ms) / `latency_gems` (ms) / `speedup`

### NVIDIA H20

| Shape | float16 | float32 | bfloat16 |
|-------|---------|---------|----------|
| 64×64 | 0.008 / 0.006 / 1.32 | 0.008 / 0.005 / 1.44 | 0.008 / 0.006 / 1.34 |
| 256×256 | 0.008 / 0.006 / 1.50 | 0.008 / 0.006 / 1.48 | 0.008 / 0.006 / 1.38 |
| 1024×1024 | 0.011 / 0.007 / 1.59 | 0.025 / 0.008 / 3.24 | 0.011 / 0.007 / 1.49 |
| 4096×4096 | 0.022 / 0.022 / 0.97 | 0.033 / 0.036 / 0.90 | 0.022 / 0.022 / 0.97 |
| 1024×65536 | 0.059 / 0.082 / 0.71 | 0.106 / 0.106 / 1.00 | 0.059 / 0.083 / 0.71 |

### Ascend 910B (CANN 9.0.0, hw25)

| Shape | float16 | float32 | bfloat16 |
|-------|---------|---------|----------|
| 64×64 | 0.003 / 0.154 / 0.02 | 0.003 / 0.149 / 0.02 | 0.003 / 0.151 / 0.02 |
| 256×256 | 0.013 / 0.146 / 0.09 | 0.004 / 0.151 / 0.03 | 0.013 / 0.147 / 0.09 |
| 1024×1024 | 0.022 / 0.151 / 0.15 | 0.012 / 0.155 / 0.08 | 0.022 / 0.150 / 0.15 |
| 4096×4096 | 0.164 / 0.170 / 0.97 | 0.135 / 0.168 / 0.81 | 0.165 / 0.169 / 0.97 |
| 1024×65536 | 0.577 / 0.408 / 1.41 | 1.161 / 0.591 / 1.96 | 0.575 / 0.406 / 1.42 |

### MetaX C550

| Shape | float16 | float32 | bfloat16 |
|-------|---------|---------|----------|
| 64×64 | 0.018 / 0.015 / 1.21 | 0.018 / 0.016 / 1.11 | 0.017 / 0.014 / 1.21 |
| 256×256 | 0.018 / 0.015 / 1.18 | 0.020 / 0.015 / 1.33 | 0.018 / 0.015 / 1.18 |
| 1024×1024 | 0.020 / 0.019 / 1.05 | 0.021 / 0.068 / 0.31 | 0.020 / 0.019 / 1.07 |
| 4096×4096 | 0.040 / 0.047 / 0.84 | 0.060 / 0.061 / 0.97 | 0.040 / 0.047 / 0.85 |
| 1024×65536 | 0.099 / 0.291 / 0.34 | 0.182 / 0.373 / 0.49 | 0.099 / 0.291 / 0.34 |

### Mthreads S5000

| Shape | float16 | float32 | bfloat16 |
|-------|---------|---------|----------|
| 64×64 | 0.011 / 0.003 / 3.11 | 0.012 / 0.003 / 3.68 | 0.005 / 0.003 / 1.36 |
| 256×256 | 0.005 / 0.005 / 1.16 | 0.028 / 0.004 / 7.00 | 0.006 / 0.005 / 1.16 |
| 1024×1024 | 0.009 / 0.009 / 1.03 | 0.093 / 0.010 / 9.74 | 0.009 / 0.009 / 1.04 |
| 4096×4096 | 0.053 / 0.058 / 0.91 | 0.355 / 0.091 / 3.90 | 0.053 / 0.058 / 0.91 |
| 1024×65536 | 0.214 / 0.266 / 0.81 | 6.130 / 0.271 / 22.65 | 0.222 / 0.277 / 0.80 |

## Note

Ascend CANN 8.5.0 (hw26) fails because `aclnnAddmv` does not support `bfloat16` — this is a pre-existing backend limitation that also affects the existing `addmv` benchmark.

## Test plan

- [x] Benchmark passed on NVIDIA H20
- [x] Benchmark passed on Ascend 910B (CANN 9.0.0)
- [x] Benchmark passed on MetaX C550
- [x] Benchmark passed on Mthreads S5000