### PR TITLE
Cache gh CLI install on self-hosted runners

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -85,9 +85,23 @@ jobs:
         continue-on-error: true
       - uses: ./.github/actions/checkout-retry
       - name: setup-gh
-        uses: sersoft-gmbh/setup-gh-cli-action@v3
-        with:
-          version: stable
+        shell: bash
+        env:
+          GH_VERSION: "2.95.0"
+        run: |
+          GH_DIR="${HOME}/.local/bin"
+          if command -v gh &>/dev/null; then
+            echo "gh already available: $(gh --version | head -1)"
+          elif [ -x "${GH_DIR}/gh" ]; then
+            echo "gh found at ${GH_DIR}: $("${GH_DIR}/gh" --version | head -1)"
+            echo "${GH_DIR}" >> $GITHUB_PATH
+          else
+            mkdir -p "${GH_DIR}"
+            curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+              | tar -xz --strip-components=2 -C "${GH_DIR}" "gh_${GH_VERSION}_linux_amd64/bin/gh"
+            echo "Installed gh ${GH_VERSION} to ${GH_DIR}"
+            echo "${GH_DIR}" >> $GITHUB_PATH
+          fi
       - id: checkout-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace `sersoft-gmbh/setup-gh-cli-action@v3` with a shell script that caches the `gh` binary
- The third-party action is downloaded from GitHub on every run, which fails on runners with unstable network connectivity
- The new script checks three locations in order:
  1. Natively installed `gh` in `$PATH` (no action needed)
  2. Previously cached binary at `~/.local/bin/gh` (add to `$GITHUB_PATH`)
  3. Fresh download to `~/.local/bin/gh` (only on first run, persists for future runs)

## Test plan

- [ ] Trigger `/test` on a PR targeting a runner without native `gh` — first run downloads, second run uses cache
- [ ] Trigger `/test` on a runner with native `gh` — skips download entirely