### PR TITLE
[Mthreads] Fix heuristic fallback for log_softmax

### DIFF
--- a/src/flag_gems/runtime/backend/__init__.py
+++ b/src/flag_gems/runtime/backend/__init__.py
@@ -398,12 +398,9 @@ def get_unused_ops(vendor_name=None):
 
 def get_heuristic_config(vendor_name=None):
     config_name = "heuristics_config_utils"
+    vendor_name = vendor_name or "nvidia"
     mod_name = f"_{vendor_name}.{config_name}"
-    try:
-        _state.heuristic_config_module = importlib.import_module(mod_name)
-    except Exception:
-        mod_name = f"_nvidia.{config_name}"
-        _state.heuristic_config_module = importlib.import_module(mod_name)
+    _state.heuristic_config_module = importlib.import_module(mod_name)
     return getattr(_state.heuristic_config_module, "HEURISTICS_CONFIGS", None)
 
 

--- a/tests/test_backend_heuristics.py
+++ b/tests/test_backend_heuristics.py
@@ -1,0 +1,28 @@
+import pytest
+
+from flag_gems.runtime import backend
+
+
+def test_non_nvidia_heuristic_import_failure_does_not_fallback(monkeypatch):
+    imported_modules = []
+    import_module = backend.importlib.import_module
+
+    def fake_import_module(module_name):
+        imported_modules.append(module_name)
+        if module_name == "_mthreads.heuristics_config_utils":
+            raise ModuleNotFoundError("simulated mthreads heuristic import failure")
+        return import_module(module_name)
+
+    monkeypatch.setattr(backend.importlib, "import_module", fake_import_module)
+
+    with pytest.raises(ModuleNotFoundError, match="mthreads heuristic"):
+        backend.get_heuristic_config("mthreads")
+
+    assert "_nvidia.heuristics_config_utils" not in imported_modules
+
+
+def test_mthreads_softmax_non_inner_uses_mthreads_heuristic():
+    configs = backend.get_heuristic_config("mthreads")
+    tile_k = configs["softmax_non_inner"]["TILE_K"]
+
+    assert tile_k.__module__ == "_mthreads.heuristics_config_utils"


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description
Fix mthreads heuristic config loading so mthreads log_softmax no longer falls back to NVIDIA heuristics when vendor-specific heuristic loading is required. Add regression tests to ensure mthreads softmax_non_inner uses the mthreads heuristic and does not silently import NVIDIA heuristics on mthreads import failure.

### Issue
- Resolves #2967

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
No performance benchmark was added. This change only fixes backend heuristic selection and does not modify the log_softmax kernel or heuristic formula.

Validation on MTT S5000:
- `tests/test_backend_heuristics.py -q`: 2 passed
- `tests/test_log_softmax.py -q`: 36 passed
