### PR TITLE
Add Iluvatar-specific CodeGenConfig for pointwise_dynamic ops

### DIFF
--- a/src/flag_gems/utils/codegen_config_utils.py
+++ b/src/flag_gems/utils/codegen_config_utils.py
@@ -128,6 +128,13 @@ CODEGEN_COFIGS = {
         True,
         prefer_1d_tile=int(triton.__version__[0]) < 3,
     ),
+    vendors.ILUVATAR: CodeGenConfig(
+        1024,
+        (65536, 65536, 65536),
+        32,
+        False,
+        prefer_1d_tile=True,
+    ),
     vendors.TSINGMICRO: CodeGenConfig(
         4096,
         (16, 16, 16),


### PR DESCRIPTION
## Summary

- Add vendors.ILUVATAR entry to CODEGEN_CONFIGS with max_tile_size=1024, prefer_block_pointer=False, prefer_1d_tile=True
- Previously Iluvatar fell back to NVIDIA config which uses block pointers -- suboptimal on Iluvatar's Triton 3.1.0
- Validated across 20 pointwise_dynamic operators: **+4.4% average improvement, 0 regressions**

## Iluvatar BI-V150: CodeGenConfig Validation (20 pointwise_dynamic ops)

**Baseline**: NVIDIA fallback config (`max_tile_size=512, prefer_block_pointer=True`)
**Patched**: Iluvatar-specific config (`max_tile_size=1024, prefer_block_pointer=False, prefer_1d_tile=True`)

### float16

| Op | Baseline | Patched | Delta |
|---|---|---|---|
| abs | 0.808 | 1.038 | **+28.5%** |
| acos | 0.759 | 0.931 | **+22.7%** |
| add | 0.884 | 1.063 | **+20.2%** |
| atan | 0.791 | 1.008 | **+27.5%** |
| ceil | 0.805 | 0.806 | +0.1% |
| cos | 0.820 | 0.818 | -0.2% |
| exp | 0.816 | 0.817 | +0.0% |
| gelu | 0.810 | 0.815 | +0.6% |
| log | 0.797 | 0.793 | -0.5% |
| mul | 0.884 | 0.887 | +0.3% |
| neg | 0.810 | 0.809 | -0.0% |
| reciprocal | 0.813 | 0.813 | +0.0% |
| relu | 0.838 | 0.838 | +0.0% |
| rsqrt | 0.840 | 0.841 | +0.0% |
| sigmoid | 0.820 | 0.822 | +0.2% |
| sin | 0.822 | 0.821 | -0.1% |
| silu | 0.821 | 0.822 | +0.2% |
| sqrt | 0.806 | 0.808 | +0.2% |
| tanh | 0.820 | 0.818 | -0.2% |
| **Average** | | | **+5.2%** |

### float32

| Op | Baseline | Patched | Delta |
|---|---|---|---|
| abs | 0.975 | 0.997 | +2.3% |
| acos | 1.028 | 1.054 | +2.5% |
| add | 0.860 | 0.968 | **+12.6%** |
| atan | 1.006 | 1.035 | +2.9% |
| ceil | 0.973 | 0.974 | +0.0% |
| cos | 1.010 | 1.011 | +0.1% |
| exp | 0.996 | 0.996 | +0.0% |
| gelu | 1.022 | 1.023 | +0.2% |
| log | 1.003 | 1.005 | +0.2% |
| mul | 0.868 | 0.871 | +0.4% |
| neg | 0.976 | 0.974 | -0.3% |
| reciprocal | 0.982 | 0.980 | -0.2% |
| relu | 1.009 | 1.006 | -0.2% |
| rsqrt | 1.011 | 1.011 | -0.0% |
| sigmoid | 1.006 | 1.005 | -0.1% |
| sin | 1.013 | 1.013 | -0.0% |
| silu | 1.005 | 1.006 | +0.1% |
| sqrt | 0.980 | 0.974 | -0.6% |
| tanh | 1.022 | 1.023 | +0.1% |
| **Average** | | | **+1.0%** |

### bfloat16

| Op | Baseline | Patched | Delta |
|---|---|---|---|
| abs | 0.808 | 1.038 | **+28.5%** |
| acos | 0.760 | 0.952 | **+25.3%** |
| add | 0.885 | 1.060 | **+19.8%** |
| atan | 0.792 | 1.023 | **+29.1%** |
| ceil | 0.805 | 0.806 | +0.1% |
| cos | 0.818 | 0.821 | +0.4% |
| exp | 0.817 | 0.818 | +0.1% |
| gelu | 0.816 | 0.811 | -0.6% |
| log | 0.796 | 0.798 | +0.2% |
| mul | 0.884 | 0.883 | -0.1% |
| neg | 0.808 | 0.805 | -0.4% |
| reciprocal | 0.812 | 0.813 | +0.1% |
| relu | 0.839 | 0.838 | -0.1% |
| rsqrt | 0.841 | 0.842 | +0.1% |
| sigmoid | 0.829 | 0.826 | -0.3% |
| sin | 0.823 | 0.824 | +0.2% |
| silu | 0.830 | 0.838 | +1.0% |
| sqrt | 0.807 | 0.808 | +0.1% |
| tanh | 0.817 | 0.818 | +0.1% |
| **Average** | | | **+5.5%** |

### int16

| Op | Baseline | Patched | Delta |
|---|---|---|---|
| bitwise_not | 0.805 | 1.034 | **+28.5%** |
| **Average** | | | **+28.5%** |

### complex64

| Op | Baseline | Patched | Delta |
|---|---|---|---|
| add | 1.215 | 1.318 | **+8.4%** |
| **Average** | | | **+8.4%** |

### int32

| Op | Baseline | Patched | Delta |
|---|---|---|---|
| bitwise_not | 1.212 | 1.244 | +2.6% |
| **Average** | | | **+2.6%** |

### Overall

- **Overall avg speedup improvement**: +4.4%
- **Big winners** (>5% faster): 11/60
- **Small winners** (1-5% faster): 5/60
- **Neutral** (within 1%): 44/60
- **Regressions** (>1% slower): 0/60
