### PR TITLE
Fix hardsigmoid_out benchmark

### DIFF
--- a/benchmark/test_hardsigmoid.py
+++ b/benchmark/test_hardsigmoid.py
@@ -14,12 +14,11 @@ def test_hardsigmoid():
     bench.run()
 
 
-@pytest.mark.skip(reason="Hardsigmoid doesn't accept 'out': issue #2686")
 @pytest.mark.hardsigmoid_out
 def test_hardsigmoid_out():
     bench = base.UnaryPointwiseOutBenchmark(
         op_name="hardsigmoid_out",
-        torch_op=torch.nn.functional.hardsigmoid,
+        torch_op=torch.ops.aten.hardsigmoid.out,
         dtypes=consts.FLOAT_DTYPES,
     )
     bench.run()


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
Bug Fix

### Description
Fix hardsigmoid_out benchmark

### Issue
closes: #2686 

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
benchmark result on H20 HBM3
```
FlagGems/benchmark# pytest -s -m hardsigmoid_out
================================== test session starts ==================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.13.0, xdoctest-1.0.2, rerunfailures-15.1, hypothesis-6.130.8, xdist-3.6.1, flakefinder-1.1.0, shard-0.1.2
collecting 180 items                                                                    WARNING 06-23 03:13:56 [interface.py:869] Current platform cuda does not have '_pytestfixturefunction' attribute.
collected 720 items / 719 deselected / 1 selected                                       
Running 1 items in this shard

test_hardsigmoid.py 
Operator: hardsigmoid_out  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               3.702512            3.713424               0.997               0.289          ([torch.Size([1073741824])], {'out': torch.Size([1073741824])})
SUCCESS               0.005440            0.005152               1.056               0.001          ([torch.Size([64, 64])], {'out': torch.Size([64, 64])})
SUCCESS               0.026272            0.025824               1.017               0.650          ([torch.Size([4096, 4096])], {'out': torch.Size([4096, 4096])})
SUCCESS               0.026144            0.025696               1.017               0.653          ([torch.Size([64, 512, 512])], {'out': torch.Size([64, 512, 512])})
SUCCESS               3.067936            3.710400               0.827               0.289          ([torch.Size([1024, 1024, 1024])], {'out': torch.Size([1024, 1024, 1024])})
SUCCESS               0.005024            0.005152               0.975               0.000          ([torch.Size([1024, 1])], {'out': torch.Size([1024, 1])})
SUCCESS               0.005280            0.005216               1.012               0.003          ([torch.Size([1024, 16])], {'out': torch.Size([1024, 16])})
SUCCESS               0.005664            0.005824               0.973               0.045          ([torch.Size([1024, 256])], {'out': torch.Size([1024, 256])})
SUCCESS               0.010688            0.010624               1.006               0.395          ([torch.Size([1024, 4096])], {'out': torch.Size([1024, 4096])})
SUCCESS               0.085664            0.084672               1.012               0.793          ([torch.Size([1024, 65536])], {'out': torch.Size([1024, 65536])})
SUCCESS               0.005504            0.005344               1.030               0.001          ([torch.Size([64, 64, 1])], {'out': torch.Size([64, 64, 1])})
SUCCESS               0.005696            0.005344               1.066               0.012          ([torch.Size([64, 64, 16])], {'out': torch.Size([64, 64, 16])})
SUCCESS               0.007040            0.006816               1.033               0.154          ([torch.Size([64, 64, 256])], {'out': torch.Size([64, 64, 256])})
SUCCESS               0.026336            0.025664               1.026               0.654          ([torch.Size([64, 64, 4096])], {'out': torch.Size([64, 64, 4096])})


Operator: hardsigmoid_out  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               2.347392            2.344544               1.001               0.458          ([torch.Size([1073741824])], {'out': torch.Size([1073741824])})
SUCCESS               0.005280            0.005216               1.012               0.001          ([torch.Size([64, 64])], {'out': torch.Size([64, 64])})
SUCCESS               0.043104            0.043120               1.000               0.389          ([torch.Size([4096, 4096])], {'out': torch.Size([4096, 4096])})
SUCCESS               0.043136            0.043264               0.997               0.388          ([torch.Size([64, 512, 512])], {'out': torch.Size([64, 512, 512])})
SUCCESS               2.345056            2.342560               1.001               0.458          ([torch.Size([1024, 1024, 1024])], {'out': torch.Size([1024, 1024, 1024])})
SUCCESS               0.005088            0.005280               0.964               0.000          ([torch.Size([1024, 1])], {'out': torch.Size([1024, 1])})
SUCCESS               0.005600            0.005472               1.023               0.003          ([torch.Size([1024, 16])], {'out': torch.Size([1024, 16])})
SUCCESS               0.006080            0.006080               1.000               0.043          ([torch.Size([1024, 256])], {'out': torch.Size([1024, 256])})
SUCCESS               0.015296            0.015456               0.990               0.271          ([torch.Size([1024, 4096])], {'out': torch.Size([1024, 4096])})
SUCCESS               0.153040            0.153056               1.000               0.438          ([torch.Size([1024, 65536])], {'out': torch.Size([1024, 65536])})
SUCCESS               0.005280            0.005200               1.015               0.001          ([torch.Size([64, 64, 1])], {'out': torch.Size([64, 64, 1])})
SUCCESS               0.005520            0.005440               1.015               0.012          ([torch.Size([64, 64, 16])], {'out': torch.Size([64, 64, 16])})
SUCCESS               0.008000            0.007744               1.033               0.135          ([torch.Size([64, 64, 256])], {'out': torch.Size([64, 64, 256])})
SUCCESS               0.043040            0.043216               0.996               0.388          ([torch.Size([64, 64, 4096])], {'out': torch.Size([64, 64, 4096])})


Operator: hardsigmoid_out  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               1.273184            3.706592               0.343               0.290          ([torch.Size([1073741824])], {'out': torch.Size([1073741824])})
SUCCESS               0.005504            0.005376               1.024               0.001          ([torch.Size([64, 64])], {'out': torch.Size([64, 64])})
SUCCESS               0.026336            0.025824               1.020               0.650          ([torch.Size([4096, 4096])], {'out': torch.Size([4096, 4096])})
SUCCESS               0.026432            0.025728               1.027               0.652          ([torch.Size([64, 512, 512])], {'out': torch.Size([64, 512, 512])})
SUCCESS               1.373280            1.260176               1.090               0.852          ([torch.Size([1024, 1024, 1024])], {'out': torch.Size([1024, 1024, 1024])})
SUCCESS               0.005280            0.004960               1.065               0.000          ([torch.Size([1024, 1])], {'out': torch.Size([1024, 1])})
SUCCESS               0.005600            0.005216               1.074               0.003          ([torch.Size([1024, 16])], {'out': torch.Size([1024, 16])})
SUCCESS               0.005952            0.005824               1.022               0.045          ([torch.Size([1024, 256])], {'out': torch.Size([1024, 256])})
SUCCESS               0.010528            0.010400               1.012               0.403          ([torch.Size([1024, 4096])], {'out': torch.Size([1024, 4096])})
SUCCESS               0.086208            0.084736               1.017               0.792          ([torch.Size([1024, 65536])], {'out': torch.Size([1024, 65536])})
SUCCESS               0.005504            0.005376               1.024               0.001          ([torch.Size([64, 64, 1])], {'out': torch.Size([64, 64, 1])})
SUCCESS               0.005664            0.005568               1.017               0.012          ([torch.Size([64, 64, 16])], {'out': torch.Size([64, 64, 16])})
SUCCESS               0.007136            0.007072               1.009               0.148          ([torch.Size([64, 64, 256])], {'out': torch.Size([64, 64, 256])})
SUCCESS               0.026240            0.025664               1.022               0.654          ([torch.Size([64, 64, 4096])], {'out': torch.Size([64, 64, 4096])})

.

===================== 1 passed, 719 deselected in 76.63s (0:01:16) ======================
```
