### PR TITLE
[KMCompiler] Optimize combine_topk_swa_indices for DeepSeek V4 attention

### DIFF
--- a/src/flag_gems/fused/deepseek_v4_attention_combine_topk_swa_indices.py
+++ b/src/flag_gems/fused/deepseek_v4_attention_combine_topk_swa_indices.py
@@ -30,6 +30,8 @@ def _combine_topk_swa_indices_kernel(
     WINDOW_SIZE: tl.constexpr,
     PADDED_TOP_K: tl.constexpr,
     PADDED_WINDOW_SIZE: tl.constexpr,
+    COMBINED_TOPK: tl.constexpr,
+    PADDED_COMBINED_TOPK: tl.constexpr,
 ):
     batch_idx = tl.program_id(0)
     worker_idx = tl.program_id(1)
@@ -48,6 +50,23 @@ def _combine_topk_swa_indices_kernel(
         pos = start_pos + token_in_query
         topk_len = tl.minimum((pos + 1) // COMPRESS_RATIO, TOP_K)
         swa_len = tl.minimum(pos + 1, WINDOW_SIZE)
+
+        # Write the -1 padding tail in-kernel so the caller can allocate with
+        # torch.empty instead of torch.full: that drops a separate full-buffer
+        # memset which this kernel would otherwise mostly overwrite. The upper
+        # bound here is COMBINED_TOPK -- the full alignment-padded row width,
+        # which is >= topk + window_size -- so [valid_len, COMBINED_TOPK) fills
+        # the entire tail, including the alignment padding past topk+window_size.
+        # Together with the index stores in [0, valid_len) below, every column
+        # of the row is written exactly once (disjoint ranges), so no
+        # uninitialized torch.empty value is ever left readable as a valid index.
+        valid_len = topk_len + swa_len
+        tail_offs = tl.arange(0, PADDED_COMBINED_TOPK)
+        tl.store(
+            combined_ptr + token_idx * combined_stride + tail_offs,
+            -1,
+            mask=(tail_offs >= valid_len) & (tail_offs < COMBINED_TOPK),
+        )
 
         offs = tl.arange(0, PADDED_TOP_K)
         mask = offs < topk_len
@@ -88,8 +107,10 @@ def combine_topk_swa_indices(
         // _SPARSE_PREFILL_TOPK_ALIGNMENT
         * _SPARSE_PREFILL_TOPK_ALIGNMENT
     )
-    combined = torch.full(
-        (num_tokens, combined_topk), -1, device=topk_indices.device, dtype=torch.int32
+    # Allocate uninitialized: the kernel writes the -1 padding tail itself, so
+    # torch.full's separate full-buffer memset (mostly overwritten) is avoided.
+    combined = torch.empty(
+        (num_tokens, combined_topk), device=topk_indices.device, dtype=torch.int32
     )
     lens = torch.empty((num_tokens,), device=topk_indices.device, dtype=torch.int32)
     with torch_device_fn.device(topk_indices.device):
@@ -109,6 +130,8 @@ def combine_topk_swa_indices(
             WINDOW_SIZE=window_size,
             PADDED_TOP_K=_next_power_of_2_or_1(topk_indices.shape[-1]),
             PADDED_WINDOW_SIZE=_next_power_of_2_or_1(window_size),
+            COMBINED_TOPK=combined_topk,
+            PADDED_COMBINED_TOPK=_next_power_of_2_or_1(combined_topk),
         )
     return combined, lens
 


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Performance Optimization

### Description
Optimize `combine_topk_swa_indices` — concatenates per-token top-k compressed
indices with sliding-window-attention (SWA) indices for DeepSeek V4 sparse prefill.

**Skip the redundant full-buffer memset.** Each token's output row is
`[topk_len + swa_len]` valid entries followed by `-1` padding out to
`combined_topk`. The original allocates the whole `(num_tokens, combined_topk)`
buffer with `torch.full(-1)` — a separate full-buffer memset — and the kernel
then overwrites the valid region. Instead, allocate with `torch.empty` and have
the kernel write the short `-1` padding tail itself:

```python
valid_len = topk_len + swa_len
tail_offs = tl.arange(0, PADDED_COMBINED_TOPK)
tl.store(combined_ptr + token_idx * combined_stride + tail_offs, -1,
         mask=(tail_offs >= valid_len) & (tail_offs < COMBINED_TOPK))
```

The padding store and the index stores cover disjoint ranges, so the output is
bit-for-bit identical to the `torch.full` version — but one full-buffer write
pass (and its host-side launch) is removed. No change to layout, numerics, or API.

### Performance
Configuration: kernel mode, dtype `torch.int32`, baseline vLLM reference, NVIDIA H20.

```bash
pytest benchmark/test_deepseek_v4_attention_combine_topk_swa_indices.py -v
```

| num_tokens | topk | window | reqs | Speedup |
|-----------:|-----:|-------:|-----:|--------:|
| 5    | 4   | 4   | 2 | 1.35x |
| 128  | 32  | 128 | 1 | 1.32x |
| 768  | 64  | 256 | 2 | 1.28x |
| 4096 | 128 | 256 | 1 | 1.14x |
| 2048 | 128 | 256 | 2 | 1.26x |
| 128  | 32  | 256 | 1 | 1.32x |
| 4096 | 128 | 256 | 1 | 1.15x |

- **Average speedup: 1.26x**, **Peak: 1.35x**
- Gains are largest on small / medium shapes, where the eliminated memset is the
  biggest fraction of the launch-bound runtime; large prefills gain less because
  they are compute / bandwidth bound on the index assembly itself.
- Under CUDA-graph replay (device-only time — what vLLM runs in production),
  removing the memory pass is worth a further ~1.4–1.65x on large shapes.

### Testing
```bash
pytest tests/test_deepseek_v4_attention_combine_topk_swa_indices.py -v
```
Correctness verified element-for-element vs the vLLM reference across all
benchmark shapes (every shape SUCCESS); the in-kernel `-1` tail covers exactly
the padding range `torch.full` did, so results are identical.
