### PR TITLE
[KernelGen] Fix logit_out: accuracy_fail

### DIFF
--- a/benchmark/test_logit.py
+++ b/benchmark/test_logit.py
@@ -25,12 +25,11 @@ def test_logit_inplace():
     bench.run()
 
 
-@pytest.mark.skip(reason="The `out` parameter is not supported: issue #2688")
 @pytest.mark.logit_out
 def test_logit_out():
     bench = base.UnaryPointwiseOutBenchmark(
         op_name="logit_out",
-        torch_op=lambda a: torch.logit(a, eps=1e-6),
+        torch_op=lambda a, out=None: torch.logit(a, eps=1e-6, out=out),
         dtypes=consts.FLOAT_DTYPES,
     )
     bench.run()

--- a/tests/test_logit.py
+++ b/tests/test_logit.py
@@ -36,3 +36,22 @@ def test_logit_(shape, dtype):
     with flag_gems.use_gems():
         res_out = inp.logit_(eps=1e-6)
     utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.logit_out
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_logit_out(shape, dtype):
+    torch.manual_seed(0)
+    base = torch.empty(shape, device=flag_gems.device, dtype=torch.float32).uniform_(
+        -4.0, 4.0
+    )
+    inp = torch.sigmoid(base).to(dtype=dtype)
+    out = torch.empty_like(inp)
+
+    ref_inp = utils.to_reference(inp, True)
+    ref_out = torch.empty_like(ref_inp)
+    torch.logit(ref_inp, eps=1e-6, out=ref_out)
+    with flag_gems.use_gems():
+        torch.logit(inp, eps=1e-6, out=out)
+    utils.gems_assert_close(out, ref_out, dtype)


### PR DESCRIPTION
## Summary
- **Operator:** logit_out
- **Error type:** accuracy_fail
- **Files modified:**
  - `benchmark/test_logit.py`
  - `tests/test_logit.py`

## Commit Message
```
Fix 543-internal: logit_out accuracy_fail

Co-Authored-By: Claude <noreply@anthropic.com>
```

## Verification
- Test command: `pytest -m 'logit_out' tests/ --ref cpu -vs`
- Benchmark command: `pytest -m 'logit_out' benchmark/ --level core --record log`

## Test Plan
- [ ] `pytest -m 'logit_out' tests/ --ref cpu -vs`
- [ ] `pytest -m 'logit_out' benchmark/ --level core --record log`

## Issue
- WEEKTEST-543
