### PR TITLE
[KernelGen] Fix multinomial: accuracy_fail

### DIFF
--- a/src/flag_gems/ops/multinomial.py
+++ b/src/flag_gems/ops/multinomial.py
@@ -26,15 +26,15 @@ def multinomial_with_replacement(
     n = tl.program_id(0) * NBLOCK + tl.arange(0, NBLOCK)
     rv, _, _, _ = uniform(philox_seed, philox_offset, y_off + n)
 
-    # Do a binary search for each random number on the cumulative probabilities.
-    # Each random number always selects the leftmost index of the data greater
-    # than or equal to itself. However, this is likely to give a wrong result
-    # in case the first probability is zero which is not expected to selected.
-    # This error happens when the tossed random number is also zero. To avoid
-    # this mistake, we simply perturb random variable with a small number.
-    rv += 0.0001
-    rv = tl.where(rv > 0.9999, 0.9999, rv)
-
+    # Do a binary search for each random number on the cumulative
+    # probabilities, selecting the leftmost index whose cumulative probability
+    # is strictly greater than the random value (the textbook inverse-CDF
+    # sample). The strict comparison makes zero-probability categories --
+    # including a zero-probability leading category, even when the tossed
+    # random value is zero -- impossible to select, so no perturbation of the
+    # random value is needed. Perturbing it (e.g. rv += eps) would bias
+    # sampling against small-probability categories whose cumulative mass falls
+    # below the perturbation.
     cdf_ptr += tl.program_id(1) * K
     start = tl.zeros((NBLOCK,), dtype=tl.int32)
     end = tl.zeros((NBLOCK,), dtype=tl.int32) + K - 1
@@ -42,8 +42,8 @@ def multinomial_with_replacement(
     for _ in range(steps):
         mid = start + (end - start) // 2
         x = tl.load(cdf_ptr + mid, mask=n < N)
-        start = tl.where(x < rv, mid + 1, start)
-        end = tl.where(x < rv, end, mid)
+        start = tl.where(x <= rv, mid + 1, start)
+        end = tl.where(x <= rv, end, mid)
 
     # Returns the last index in case of an overflow
     start = tl.where(start >= K, K - 1, start)


### PR DESCRIPTION
## Summary
- **Operator:** multinomial
- **Error type:** accuracy_fail
- **Files modified:**
  - `src/flag_gems/ops/multinomial.py`

## Commit Message
```
Fix 528-internal: multinomial accuracy_fail
```

## Verification
- Test command: `pytest -m 'multinomial' tests/ --ref cpu -vs`
- Benchmark command: `pytest -m 'multinomial' benchmark/ --level core --record log`

## Test Plan
- [ ] `pytest -m 'multinomial' tests/ --ref cpu -vs`
- [ ] `pytest -m 'multinomial' benchmark/ --level core --record log`

## Issue
- WEEKTEST-528
