### PR TITLE
Optimize std dim reduction

### DIFF
--- a/src/flag_gems/ops/std.py
+++ b/src/flag_gems/ops/std.py
@@ -231,20 +231,21 @@ def std(x, dim=None, *, correction=None, keepdim=False):
         BLOCK_NUM = triton.cdiv(N, BLOCK_N_MAP)
         tmp_sum = torch.empty((BLOCK_NUM,), dtype=torch.float32, device=x.device)
         tmp_sum_sq = torch.empty((BLOCK_NUM,), dtype=torch.float32, device=x.device)
-        _std_map_kernel[(BLOCK_NUM,)](
-            x.contiguous(), tmp_sum, tmp_sum_sq, N, BLOCK_N_MAP
-        )
         out = torch.empty([], device=x.device, dtype=x.dtype)
         BLOCK_SIZE_REDUCE = 1024
-        _std_reduce_kernel[(1,)](
-            tmp_sum,
-            tmp_sum_sq,
-            out,
-            N,
-            effective_correction,
-            BLOCK_NUM,
-            BLOCK_SIZE_REDUCE,
-        )
+        with torch_device_fn.device(x.device):
+            _std_map_kernel[(BLOCK_NUM,)](
+                x.contiguous(), tmp_sum, tmp_sum_sq, N, BLOCK_N_MAP
+            )
+            _std_reduce_kernel[(1,)](
+                tmp_sum,
+                tmp_sum_sq,
+                out,
+                N,
+                effective_correction,
+                BLOCK_NUM,
+                BLOCK_SIZE_REDUCE,
+            )
         return out.view([1] * input_ndim) if keepdim else out
 
     else:

--- a/src/flag_gems/ops/std.py
+++ b/src/flag_gems/ops/std.py
@@ -5,7 +5,8 @@ import triton
 import triton.language as tl
 
 from flag_gems import runtime
-from flag_gems.utils import dim_compress
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import dim_compress, libentry
 
 logger = logging.getLogger(__name__)
 
@@ -99,16 +100,132 @@ def _std_fused_dim_kernel(
     tl.store(out_ptrs, std_dev.to(Out.dtype.element_ty), mask=row_mask)
 
 
+@libentry()
+@triton.heuristics(runtime.get_heuristic_config("softmax_inner"))
+@triton.jit(do_not_specialize=["correction"])
+def _std_dim_kernel_inner(
+    Out,
+    X,
+    M,
+    N,
+    correction,
+    TILE_N: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+
+    # Pass 1: compute mean
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)
+        mask = n_offsets < N
+        x = tl.load(X + pid_m * N + n_offsets, mask=mask, other=0.0).to(tl.float32)
+        mean = tl.sum(x, axis=0) / N
+    else:
+        sum_acc = tl.zeros((TILE_N,), dtype=tl.float32)
+        for start_n in range(0, N, TILE_N):
+            n_offsets = start_n + tl.arange(0, TILE_N)
+            mask = n_offsets < N
+            x = tl.load(X + pid_m * N + n_offsets, mask=mask, other=0.0).to(tl.float32)
+            sum_acc += x
+        mean = tl.sum(sum_acc, axis=0) / N
+
+    # Pass 2: compute sum of squared deviations
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)
+        mask = n_offsets < N
+        x = tl.load(X + pid_m * N + n_offsets, mask=mask, other=0.0).to(tl.float32)
+        diff = x - mean
+        sq_sum = tl.sum(tl.where(mask, diff * diff, 0.0), axis=0)
+    else:
+        sq_acc = tl.zeros((TILE_N,), dtype=tl.float32)
+        for start_n in range(0, N, TILE_N):
+            n_offsets = start_n + tl.arange(0, TILE_N)
+            mask = n_offsets < N
+            x = tl.load(X + pid_m * N + n_offsets, mask=mask, other=0.0).to(tl.float32)
+            diff = x - mean
+            sq_acc += tl.where(mask, diff * diff, 0.0)
+        sq_sum = tl.sum(sq_acc, axis=0)
+
+    denom = N - correction
+    var = sq_sum / tl.maximum(denom, 1e-12)
+    std_dev = tl.sqrt(tl.maximum(var, 0.0))
+    tl.store(Out + pid_m, std_dev.to(Out.dtype.element_ty), mask=pid_m < M)
+
+
+@libentry()
+@triton.heuristics(runtime.get_heuristic_config("softmax_non_inner"))
+@triton.jit(do_not_specialize=["correction"])
+def _std_dim_kernel_non_inner(
+    Out,
+    X,
+    M,
+    N,
+    K,
+    correction,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_k = tl.program_id(1)
+    k_offsets = pid_k * TILE_K + tl.arange(0, TILE_K)[None, :]
+
+    # Pass 1: compute mean
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)[:, None]
+        mask = (n_offsets < N) & (k_offsets < K)
+        offsets = pid_m * N * K + n_offsets * K + k_offsets
+        x = tl.load(X + offsets, mask=mask, other=0.0).to(tl.float32)
+        mean = tl.sum(x, axis=0, keep_dims=True) / N
+    else:
+        sum_acc = tl.zeros((TILE_N, TILE_K), dtype=tl.float32)
+        for start_n in range(0, N, TILE_N):
+            n_offsets = start_n + tl.arange(0, TILE_N)[:, None]
+            mask = (n_offsets < N) & (k_offsets < K)
+            offsets = pid_m * N * K + n_offsets * K + k_offsets
+            x = tl.load(X + offsets, mask=mask, other=0.0).to(tl.float32)
+            sum_acc += x
+        mean = tl.sum(sum_acc, axis=0, keep_dims=True) / N
+
+    # Pass 2: compute sum of squared deviations
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)[:, None]
+        mask = (n_offsets < N) & (k_offsets < K)
+        offsets = pid_m * N * K + n_offsets * K + k_offsets
+        x = tl.load(X + offsets, mask=mask, other=0.0).to(tl.float32)
+        diff = x - mean
+        sq_sum = tl.sum(tl.where(mask, diff * diff, 0.0), axis=0, keep_dims=True)
+    else:
+        sq_acc = tl.zeros((TILE_N, TILE_K), dtype=tl.float32)
+        for start_n in range(0, N, TILE_N):
+            n_offsets = start_n + tl.arange(0, TILE_N)[:, None]
+            mask = (n_offsets < N) & (k_offsets < K)
+            offsets = pid_m * N * K + n_offsets * K + k_offsets
+            x = tl.load(X + offsets, mask=mask, other=0.0).to(tl.float32)
+            diff = x - mean
+            sq_acc += tl.where(mask, diff * diff, 0.0)
+        sq_sum = tl.sum(sq_acc, axis=0, keep_dims=True)
+
+    denom = N - correction
+    var = sq_sum / tl.maximum(denom, 1e-12)
+    std_dev = tl.sqrt(tl.maximum(var, 0.0))
+    out_offsets = pid_m * K + k_offsets
+    tl.store(Out + out_offsets, std_dev.to(Out.dtype.element_ty), mask=k_offsets < K)
+
+
 def std(x, dim=None, *, correction=None, keepdim=False):
+    logger.debug("GEMS STD")
     effective_correction = 1.0 if correction is None else float(correction)
     original_shape = x.shape
     input_ndim = x.ndim
 
     if dim is None:
-        logger.debug("GEMS STD (Global Simple Map-Reduce Path)")
         N = x.numel()
         if N == 0 or N - effective_correction <= 0:
             return torch.full([], float("nan"), device=x.device, dtype=x.dtype)
+        if N == 1 and effective_correction == 0.0:
+            out = torch.zeros([], device=x.device, dtype=x.dtype)
+            return out.view([1] * input_ndim) if keepdim else out
 
         BLOCK_N_MAP = 1024
         BLOCK_NUM = triton.cdiv(N, BLOCK_N_MAP)
@@ -131,15 +248,64 @@ def std(x, dim=None, *, correction=None, keepdim=False):
         return out.view([1] * input_ndim) if keepdim else out
 
     else:
-        logger.warning(
-            f"GEMS std: Using compatible but non-optimal path for dim={dim} (dim_compress)."
-        )
-
         if isinstance(dim, int):
             dim_list = [dim]
         else:
             dim_list = list(dim)
         dim_list_normalized = [d % input_ndim for d in dim_list]
+
+        if len(dim_list_normalized) == 1:
+            dim0 = dim_list_normalized[0]
+            shape = list(original_shape)
+            N = shape[dim0]
+            M = 1
+            for size in shape[:dim0]:
+                M *= size
+            K = 1
+            for size in shape[dim0 + 1 :]:
+                K *= size
+            shape[dim0] = 1
+
+            if M * N * K > 0 and (N - effective_correction <= 0):
+                final_shape = shape if keepdim else shape[:dim0] + shape[dim0 + 1 :]
+                return torch.full(
+                    final_shape,
+                    float("nan"),
+                    device=x.device,
+                    dtype=x.dtype,
+                )
+
+            if N == 1 and effective_correction == 0.0:
+                final_shape = shape if keepdim else shape[:dim0] + shape[dim0 + 1 :]
+                return torch.zeros(final_shape, device=x.device, dtype=x.dtype)
+
+            out = torch.empty(shape, device=x.device, dtype=x.dtype)
+            if M * N * K == 0:
+                return out.squeeze(dim=dim0) if not keepdim else out
+
+            x_contiguous = x.contiguous()
+            with torch_device_fn.device(x.device):
+                if K > 1:
+                    grid = lambda META: (M, triton.cdiv(K, META["TILE_K"]), 1)
+                    _std_dim_kernel_non_inner[grid](
+                        out,
+                        x_contiguous,
+                        M,
+                        N,
+                        K,
+                        effective_correction,
+                    )
+                else:
+                    grid = (M, 1, 1)
+                    _std_dim_kernel_inner[grid](
+                        out,
+                        x_contiguous,
+                        M,
+                        N,
+                        effective_correction,
+                    )
+
+            return out.squeeze(dim=dim0) if not keepdim else out
 
         x_view = dim_compress(x, dim_list_normalized)
 


### PR DESCRIPTION
### PR Category
ops

### Type of Change
Performance Optimization

### Description
Optimize `torch.std(..., dim=...)` single-dimension reduction by adding native Triton fast paths for inner and non-inner reductions. Existing global and multi-dimension fallback behavior is preserved.

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
```bash
python -m pytest benchmark/test_std.py -m std -s
```

Compared with the previous FlagGems implementation, the new single-dim `std` fast path improves Gems latency by **4.61x geomean** across `dim=1` benchmark cases:

| dtype | Geomean improvement |
|---|---:|
| fp16 | 4.68x |
| fp32 | 4.45x |
| bf16 | 4.71x |

Representative improvements:

| dtype | shape | Before Gems latency | After Gems latency | Improvement |
|---|---|---:|---:|---:|
| fp32 | `[64, 16, 64], dim=1` | 0.149184 ms | 0.007680 ms | 19.43x |
| fp16 | `[64, 16, 64], dim=1` | 0.148400 ms | 0.007712 ms | 19.24x |
| bf16 | `[64, 16, 64], dim=1` | 0.148448 ms | 0.007712 ms | 19.25x |
| fp16 | `[1024, 1024, 1024], dim=1` | 10.214080 ms | 0.958624 ms | 10.65x |
| bf16 | `[1024, 1024, 1024], dim=1` | 10.316928 ms | 0.969584 ms | 10.64x |
| fp32 | `[1024, 1024, 1024], dim=1` | 10.194784 ms | 1.400416 ms | 7.28x |

Global reduction cases are mostly unchanged, as this PR primarily targets `std(..., dim=...)`.

After this optimization, Gems is also faster than Torch on most non-degenerate single-dim reduction benchmark cases. Representative optimized Gems-vs-Torch speedups:

| dtype | shape | Torch latency | Optimized Gems latency | Gems vs Torch speedup |
|---|---|---:|---:|---:|
| fp16 | `[64, 256, 64], dim=1` | 0.029920 ms | 0.009408 ms | 3.18x |
| bf16 | `[64, 256, 64], dim=1` | 0.030800 ms | 0.009440 ms | 3.26x |
| fp32 | `[64, 256, 64], dim=1` | 0.029600 ms | 0.009952 ms | 2.97x |
| fp16 | `[1024, 1048576], dim=1` | 1.987136 ms | 0.678192 ms | 2.93x |
| bf16 | `[1024, 1048576], dim=1` | 1.999264 ms | 0.695456 ms | 2.88x |
| fp32 | `[1024, 4096], dim=1` | 0.038048 ms | 0.012800 ms | 2.97x |
| fp16 | `[64, 4096, 64], dim=1` | 0.072416 ms | 0.031104 ms | 2.33x |
| fp32 | `[64, 4096, 64], dim=1` | 0.083296 ms | 0.040096 ms | 2.08x |
| bf16 | `[64, 4096, 64], dim=1` | 0.068384 ms | 0.031072 ms | 2.20x |

Known slower cases are very small degenerate reductions such as `[1024, 1], dim=1` and `[64, 1, 64], dim=1`, where launch overhead dominates.
