### PR TITLE
[KMCompiler]Optimize per-token group FP8 quantization

### DIFF
--- a/src/flag_gems/ops/per_token_group_quant_fp8.py
+++ b/src/flag_gems/ops/per_token_group_quant_fp8.py
@@ -37,7 +37,7 @@ def _per_token_group_quant_fp8(
     row = g_id // groups_per_row
     row_g_id = g_id % groups_per_row
 
-    y_ptr += (row * y_row_stride) + (row_g_id * group_size)
+    y_ptr += row * y_row_stride + row_g_id * group_size
     y_q_ptr += g_id * group_size
     y_s_ptr += g_id
 
@@ -99,7 +99,7 @@ def _per_token_group_quant_fp8_colmajor(
 
 
 @triton.jit
-def _per_token_group_quant_fp8_m2(
+def _per_token_group_quant_fp8_vec(
     y_ptr,
     y_q_ptr,
     y_s_ptr,
@@ -111,60 +111,46 @@ def _per_token_group_quant_fp8_m2(
     fp8_max,
     scale_ue8m0,
     BLOCK: tl.constexpr,
+    NGROUPS: tl.constexpr,
 ):
     groups_per_row = y_num_columns // group_size
+    programs_per_row = groups_per_row // NGROUPS
+
     pid = tl.program_id(0)
-    pairs_per_row = groups_per_row // 2
-    row = pid // pairs_per_row
-    pair_id = pid % pairs_per_row
+    row = pid // programs_per_row
+    program_id = pid % programs_per_row
 
-    group0 = pair_id * 2
-    group1 = group0 + 1
+    start_group = program_id * NGROUPS
+    start_gid = row * groups_per_row + start_group
 
-    g0 = row * groups_per_row + group0
-    g1 = g0 + 1
-
-    base = y_ptr + row * y_row_stride
-
-    y_ptr0 = base + group0 * group_size
-    y_ptr1 = base + group1 * group_size
-
-    y_q_ptr0 = y_q_ptr + g0 * group_size
-    y_q_ptr1 = y_q_ptr + g1 * group_size
-
-    y_s_ptr0 = y_s_ptr + g0
-    y_s_ptr1 = y_s_ptr + g1
-
+    group_ids = tl.arange(0, NGROUPS)
     cols = tl.arange(0, BLOCK)
-    mask = cols < group_size
+    offsets = (
+        row * y_row_stride
+        + start_group * group_size
+        + group_ids[:, None] * group_size
+        + cols[None, :]
+    )
+    mask = cols[None, :] < group_size
 
-    y0 = tl.load(y_ptr0 + cols, mask=mask, other=0.0).to(tl.float32)
-    y1 = tl.load(y_ptr1 + cols, mask=mask, other=0.0).to(tl.float32)
-
-    abs0 = tl.abs(y0)
-    abs1 = tl.abs(y1)
-
-    max0 = tl.max(abs0)
-    max1 = tl.max(abs1)
-
-    y_s0 = tl.maximum(max0, eps) / fp8_max
-    y_s1 = tl.maximum(max1, eps) / fp8_max
+    y = tl.load(y_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    _absmax = tl.maximum(tl.max(tl.abs(y), axis=1), eps)
+    y_s = _absmax / fp8_max
 
     if scale_ue8m0:
-        y_s0 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s0), 1e-10))))
-        y_s1 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s1), 1e-10))))
+        y_s = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s), 1e-10))))
 
-    y_q0 = tl.clamp(y0 / y_s0, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q1 = tl.clamp(y1 / y_s1, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
+    y_q = tl.clamp(y / y_s[:, None], fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
+    output_offsets = (
+        start_gid * group_size + group_ids[:, None] * group_size + cols[None, :]
+    )
 
-    tl.store(y_q_ptr0 + cols, y_q0, mask=mask)
-    tl.store(y_s_ptr0, y_s0)
-    tl.store(y_q_ptr1 + cols, y_q1, mask=mask)
-    tl.store(y_s_ptr1, y_s1)
+    tl.store(y_q_ptr + output_offsets, y_q, mask=mask)
+    tl.store(y_s_ptr + start_gid + group_ids, y_s)
 
 
 @triton.jit
-def _per_token_group_quant_fp8_colmajor_m2(
+def _per_token_group_quant_fp8_colmajor_vec(
     y_ptr,
     y_q_ptr,
     y_s_ptr,
@@ -177,536 +163,51 @@ def _per_token_group_quant_fp8_colmajor_m2(
     fp8_max,
     scale_ue8m0,
     BLOCK: tl.constexpr,
+    NGROUPS: tl.constexpr,
 ):
     groups_per_row = y_num_columns // group_size
+    programs_per_row = groups_per_row // NGROUPS
+
     pid = tl.program_id(0)
-    pairs_per_row = groups_per_row // 2
-    row = pid // pairs_per_row
-    pair_id = pid % pairs_per_row
+    row = pid // programs_per_row
+    program_id = pid % programs_per_row
 
-    group0 = pair_id * 2
-    group1 = group0 + 1
+    start_group = program_id * NGROUPS
+    start_gid = row * groups_per_row + start_group
 
-    g0 = row * groups_per_row + group0
-    g1 = g0 + 1
-
-    base = y_ptr + row * y_row_stride
-
-    y_ptr0 = base + group0 * group_size
-    y_ptr1 = base + group1 * group_size
-
-    y_q_ptr0 = y_q_ptr + g0 * group_size
-    y_q_ptr1 = y_q_ptr + g1 * group_size
-
-    y_s_ptr0 = y_s_ptr + group0 * y_s_col_stride + row
-    y_s_ptr1 = y_s_ptr + group1 * y_s_col_stride + row
-
+    group_ids = tl.arange(0, NGROUPS)
     cols = tl.arange(0, BLOCK)
-    mask = cols < group_size
+    offsets = (
+        row * y_row_stride
+        + start_group * group_size
+        + group_ids[:, None] * group_size
+        + cols[None, :]
+    )
+    mask = cols[None, :] < group_size
 
-    y0 = tl.load(y_ptr0 + cols, mask=mask, other=0.0).to(tl.float32)
-    y1 = tl.load(y_ptr1 + cols, mask=mask, other=0.0).to(tl.float32)
-
-    abs0 = tl.abs(y0)
-    abs1 = tl.abs(y1)
-
-    max0 = tl.max(abs0)
-    max1 = tl.max(abs1)
-
-    y_s0 = tl.maximum(max0, eps) / fp8_max
-    y_s1 = tl.maximum(max1, eps) / fp8_max
+    y = tl.load(y_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    _absmax = tl.maximum(tl.max(tl.abs(y), axis=1), eps)
+    y_s = _absmax / fp8_max
 
     if scale_ue8m0:
-        y_s0 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s0), 1e-10))))
-        y_s1 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s1), 1e-10))))
-
-    y_q0 = tl.clamp(y0 / y_s0, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q1 = tl.clamp(y1 / y_s1, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-
-    tl.store(y_q_ptr0 + cols, y_q0, mask=mask)
-    tl.store(y_s_ptr0, y_s0)
-    tl.store(y_q_ptr1 + cols, y_q1, mask=mask)
-    tl.store(y_s_ptr1, y_s1)
-
-
-@triton.jit
-def _per_token_group_quant_fp8_m4(
-    y_ptr,
-    y_q_ptr,
-    y_s_ptr,
-    group_size,
-    y_num_columns,
-    y_row_stride,
-    eps,
-    fp8_min,
-    fp8_max,
-    scale_ue8m0,
-    BLOCK: tl.constexpr,
-):
-    groups_per_row = y_num_columns // group_size
-    pid = tl.program_id(0)
-    pairs_per_row = groups_per_row // 4
-    row = pid // pairs_per_row
-    pair_id = pid % pairs_per_row
-
-    group0 = pair_id * 4
-    group1 = group0 + 1
-    group2 = group0 + 2
-    group3 = group0 + 3
-
-    g0 = row * groups_per_row + group0
-    g1 = g0 + 1
-    g2 = g1 + 1
-    g3 = g2 + 1
-
-    base = y_ptr + row * y_row_stride
-
-    y_ptr0 = base + group0 * group_size
-    y_ptr1 = base + group1 * group_size
-    y_ptr2 = base + group2 * group_size
-    y_ptr3 = base + group3 * group_size
-
-    y_q_ptr0 = y_q_ptr + g0 * group_size
-    y_q_ptr1 = y_q_ptr + g1 * group_size
-    y_q_ptr2 = y_q_ptr + g2 * group_size
-    y_q_ptr3 = y_q_ptr + g3 * group_size
-
-    y_s_ptr0 = y_s_ptr + g0
-    y_s_ptr1 = y_s_ptr + g1
-    y_s_ptr2 = y_s_ptr + g2
-    y_s_ptr3 = y_s_ptr + g3
-
-    cols = tl.arange(0, BLOCK)
-    mask = cols < group_size
-
-    y0 = tl.load(y_ptr0 + cols, mask=mask, other=0.0).to(tl.float32)
-    y1 = tl.load(y_ptr1 + cols, mask=mask, other=0.0).to(tl.float32)
-    y2 = tl.load(y_ptr2 + cols, mask=mask, other=0.0).to(tl.float32)
-    y3 = tl.load(y_ptr3 + cols, mask=mask, other=0.0).to(tl.float32)
-
-    abs0 = tl.abs(y0)
-    abs1 = tl.abs(y1)
-    abs2 = tl.abs(y2)
-    abs3 = tl.abs(y3)
-
-    max0 = tl.max(abs0)
-    max1 = tl.max(abs1)
-    max2 = tl.max(abs2)
-    max3 = tl.max(abs3)
-
-    y_s0 = tl.maximum(max0, eps) / fp8_max
-    y_s1 = tl.maximum(max1, eps) / fp8_max
-    y_s2 = tl.maximum(max2, eps) / fp8_max
-    y_s3 = tl.maximum(max3, eps) / fp8_max
-
-    if scale_ue8m0:
-        y_s0 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s0), 1e-10))))
-        y_s1 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s1), 1e-10))))
-        y_s2 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s2), 1e-10))))
-        y_s3 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s3), 1e-10))))
-
-    y_q0 = tl.clamp(y0 / y_s0, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q1 = tl.clamp(y1 / y_s1, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q2 = tl.clamp(y2 / y_s2, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q3 = tl.clamp(y3 / y_s3, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-
-    tl.store(y_q_ptr0 + cols, y_q0, mask=mask)
-    tl.store(y_s_ptr0, y_s0)
-    tl.store(y_q_ptr1 + cols, y_q1, mask=mask)
-    tl.store(y_s_ptr1, y_s1)
-    tl.store(y_q_ptr2 + cols, y_q2, mask=mask)
-    tl.store(y_s_ptr2, y_s2)
-    tl.store(y_q_ptr3 + cols, y_q3, mask=mask)
-    tl.store(y_s_ptr3, y_s3)
-
-
-@triton.jit
-def _per_token_group_quant_fp8_colmajor_m4(
-    y_ptr,
-    y_q_ptr,
-    y_s_ptr,
-    group_size,
-    y_num_columns,
-    y_row_stride,
-    y_s_col_stride,
-    eps,
-    fp8_min,
-    fp8_max,
-    scale_ue8m0,
-    BLOCK: tl.constexpr,
-):
-    groups_per_row = y_num_columns // group_size
-    pid = tl.program_id(0)
-    pairs_per_row = groups_per_row // 4
-    row = pid // pairs_per_row
-    pair_id = pid % pairs_per_row
-
-    group0 = pair_id * 4
-    group1 = group0 + 1
-    group2 = group1 + 1
-    group3 = group2 + 1
-
-    g0 = row * groups_per_row + group0
-    g1 = g0 + 1
-    g2 = g1 + 1
-    g3 = g2 + 1
-
-    base = y_ptr + row * y_row_stride
-
-    y_ptr0 = base + group0 * group_size
-    y_ptr1 = base + group1 * group_size
-    y_ptr2 = base + group2 * group_size
-    y_ptr3 = base + group3 * group_size
-
-    y_q_ptr0 = y_q_ptr + g0 * group_size
-    y_q_ptr1 = y_q_ptr + g1 * group_size
-    y_q_ptr2 = y_q_ptr + g2 * group_size
-    y_q_ptr3 = y_q_ptr + g3 * group_size
-
-    y_s_ptr0 = y_s_ptr + group0 * y_s_col_stride + row
-    y_s_ptr1 = y_s_ptr + group1 * y_s_col_stride + row
-    y_s_ptr2 = y_s_ptr + group2 * y_s_col_stride + row
-    y_s_ptr3 = y_s_ptr + group3 * y_s_col_stride + row
-
-    cols = tl.arange(0, BLOCK)
-    mask = cols < group_size
-
-    y0 = tl.load(y_ptr0 + cols, mask=mask, other=0.0).to(tl.float32)
-    y1 = tl.load(y_ptr1 + cols, mask=mask, other=0.0).to(tl.float32)
-    y2 = tl.load(y_ptr2 + cols, mask=mask, other=0.0).to(tl.float32)
-    y3 = tl.load(y_ptr3 + cols, mask=mask, other=0.0).to(tl.float32)
-
-    abs0 = tl.abs(y0)
-    abs1 = tl.abs(y1)
-    abs2 = tl.abs(y2)
-    abs3 = tl.abs(y3)
-
-    max0 = tl.max(abs0)
-    max1 = tl.max(abs1)
-    max2 = tl.max(abs2)
-    max3 = tl.max(abs3)
-
-    y_s0 = tl.maximum(max0, eps) / fp8_max
-    y_s1 = tl.maximum(max1, eps) / fp8_max
-    y_s2 = tl.maximum(max2, eps) / fp8_max
-    y_s3 = tl.maximum(max3, eps) / fp8_max
-
-    if scale_ue8m0:
-        y_s0 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s0), 1e-10))))
-        y_s1 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s1), 1e-10))))
-        y_s2 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s2), 1e-10))))
-        y_s3 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s3), 1e-10))))
-
-    y_q0 = tl.clamp(y0 / y_s0, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q1 = tl.clamp(y1 / y_s1, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q2 = tl.clamp(y2 / y_s2, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q3 = tl.clamp(y3 / y_s3, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-
-    tl.store(y_q_ptr0 + cols, y_q0, mask=mask)
-    tl.store(y_s_ptr0, y_s0)
-    tl.store(y_q_ptr1 + cols, y_q1, mask=mask)
-    tl.store(y_s_ptr1, y_s1)
-    tl.store(y_q_ptr2 + cols, y_q2, mask=mask)
-    tl.store(y_s_ptr2, y_s2)
-    tl.store(y_q_ptr3 + cols, y_q3, mask=mask)
-    tl.store(y_s_ptr3, y_s3)
-
-
-@triton.jit
-def _per_token_group_quant_fp8_m8(
-    y_ptr,
-    y_q_ptr,
-    y_s_ptr,
-    group_size,
-    y_num_columns,
-    y_row_stride,
-    eps,
-    fp8_min,
-    fp8_max,
-    scale_ue8m0,
-    BLOCK: tl.constexpr,
-):
-    groups_per_row = y_num_columns // group_size
-    pid = tl.program_id(0)
-    pairs_per_row = groups_per_row // 8
-    row = pid // pairs_per_row
-    pair_id = pid % pairs_per_row
-
-    group0 = pair_id * 8
-    group1 = group0 + 1
-    group2 = group0 + 2
-    group3 = group0 + 3
-    group4 = group0 + 4
-    group5 = group0 + 5
-    group6 = group0 + 6
-    group7 = group0 + 7
-
-    g0 = row * groups_per_row + group0
-    g1 = g0 + 1
-    g2 = g1 + 1
-    g3 = g2 + 1
-    g4 = g3 + 1
-    g5 = g4 + 1
-    g6 = g5 + 1
-    g7 = g6 + 1
-
-    base = y_ptr + row * y_row_stride
-
-    y_ptr0 = base + group0 * group_size
-    y_ptr1 = base + group1 * group_size
-    y_ptr2 = base + group2 * group_size
-    y_ptr3 = base + group3 * group_size
-    y_ptr4 = base + group4 * group_size
-    y_ptr5 = base + group5 * group_size
-    y_ptr6 = base + group6 * group_size
-    y_ptr7 = base + group7 * group_size
-
-    y_q_ptr0 = y_q_ptr + g0 * group_size
-    y_q_ptr1 = y_q_ptr + g1 * group_size
-    y_q_ptr2 = y_q_ptr + g2 * group_size
-    y_q_ptr3 = y_q_ptr + g3 * group_size
-    y_q_ptr4 = y_q_ptr + g4 * group_size
-    y_q_ptr5 = y_q_ptr + g5 * group_size
-    y_q_ptr6 = y_q_ptr + g6 * group_size
-    y_q_ptr7 = y_q_ptr + g7 * group_size
-
-    y_s_ptr0 = y_s_ptr + g0
-    y_s_ptr1 = y_s_ptr + g1
-    y_s_ptr2 = y_s_ptr + g2
-    y_s_ptr3 = y_s_ptr + g3
-    y_s_ptr4 = y_s_ptr + g4
-    y_s_ptr5 = y_s_ptr + g5
-    y_s_ptr6 = y_s_ptr + g6
-    y_s_ptr7 = y_s_ptr + g7
-
-    cols = tl.arange(0, BLOCK)
-    mask = cols < group_size
-
-    y0 = tl.load(y_ptr0 + cols, mask=mask, other=0.0).to(tl.float32)
-    y1 = tl.load(y_ptr1 + cols, mask=mask, other=0.0).to(tl.float32)
-    y2 = tl.load(y_ptr2 + cols, mask=mask, other=0.0).to(tl.float32)
-    y3 = tl.load(y_ptr3 + cols, mask=mask, other=0.0).to(tl.float32)
-    y4 = tl.load(y_ptr4 + cols, mask=mask, other=0.0).to(tl.float32)
-    y5 = tl.load(y_ptr5 + cols, mask=mask, other=0.0).to(tl.float32)
-    y6 = tl.load(y_ptr6 + cols, mask=mask, other=0.0).to(tl.float32)
-    y7 = tl.load(y_ptr7 + cols, mask=mask, other=0.0).to(tl.float32)
-
-    abs0 = tl.abs(y0)
-    abs1 = tl.abs(y1)
-    abs2 = tl.abs(y2)
-    abs3 = tl.abs(y3)
-    abs4 = tl.abs(y4)
-    abs5 = tl.abs(y5)
-    abs6 = tl.abs(y6)
-    abs7 = tl.abs(y7)
-
-    max0 = tl.max(abs0)
-    max1 = tl.max(abs1)
-    max2 = tl.max(abs2)
-    max3 = tl.max(abs3)
-    max4 = tl.max(abs4)
-    max5 = tl.max(abs5)
-    max6 = tl.max(abs6)
-    max7 = tl.max(abs7)
-    y_s0 = tl.maximum(max0, eps) / fp8_max
-    y_s1 = tl.maximum(max1, eps) / fp8_max
-    y_s2 = tl.maximum(max2, eps) / fp8_max
-    y_s3 = tl.maximum(max3, eps) / fp8_max
-    y_s4 = tl.maximum(max4, eps) / fp8_max
-    y_s5 = tl.maximum(max5, eps) / fp8_max
-    y_s6 = tl.maximum(max6, eps) / fp8_max
-    y_s7 = tl.maximum(max7, eps) / fp8_max
-
-    if scale_ue8m0:
-        y_s0 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s0), 1e-10))))
-        y_s1 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s1), 1e-10))))
-        y_s2 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s2), 1e-10))))
-        y_s3 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s3), 1e-10))))
-        y_s4 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s4), 1e-10))))
-        y_s5 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s5), 1e-10))))
-        y_s6 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s6), 1e-10))))
-        y_s7 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s7), 1e-10))))
-
-    y_q0 = tl.clamp(y0 / y_s0, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q1 = tl.clamp(y1 / y_s1, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q2 = tl.clamp(y2 / y_s2, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q3 = tl.clamp(y3 / y_s3, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q4 = tl.clamp(y4 / y_s4, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q5 = tl.clamp(y5 / y_s5, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q6 = tl.clamp(y6 / y_s6, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q7 = tl.clamp(y7 / y_s7, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-
-    tl.store(y_q_ptr0 + cols, y_q0, mask=mask)
-    tl.store(y_s_ptr0, y_s0)
-    tl.store(y_q_ptr1 + cols, y_q1, mask=mask)
-    tl.store(y_s_ptr1, y_s1)
-    tl.store(y_q_ptr2 + cols, y_q2, mask=mask)
-    tl.store(y_s_ptr2, y_s2)
-    tl.store(y_q_ptr3 + cols, y_q3, mask=mask)
-    tl.store(y_s_ptr3, y_s3)
-    tl.store(y_q_ptr4 + cols, y_q4, mask=mask)
-    tl.store(y_s_ptr4, y_s4)
-    tl.store(y_q_ptr5 + cols, y_q5, mask=mask)
-    tl.store(y_s_ptr5, y_s5)
-    tl.store(y_q_ptr6 + cols, y_q6, mask=mask)
-    tl.store(y_s_ptr6, y_s6)
-    tl.store(y_q_ptr7 + cols, y_q7, mask=mask)
-    tl.store(y_s_ptr7, y_s7)
-
-
-@triton.jit
-def _per_token_group_quant_fp8_colmajor_m8(
-    y_ptr,
-    y_q_ptr,
-    y_s_ptr,
-    group_size,
-    y_num_columns,
-    y_row_stride,
-    y_s_col_stride,
-    eps,
-    fp8_min,
-    fp8_max,
-    scale_ue8m0,
-    BLOCK: tl.constexpr,
-):
-    groups_per_row = y_num_columns // group_size
-    pid = tl.program_id(0)
-    pairs_per_row = groups_per_row // 8
-    row = pid // pairs_per_row
-    pair_id = pid % pairs_per_row
-
-    group0 = pair_id * 8
-    group1 = group0 + 1
-    group2 = group1 + 1
-    group3 = group2 + 1
-    group4 = group3 + 1
-    group5 = group4 + 1
-    group6 = group5 + 1
-    group7 = group6 + 1
-
-    g0 = row * groups_per_row + group0
-    g1 = g0 + 1
-    g2 = g1 + 1
-    g3 = g2 + 1
-    g4 = g3 + 1
-    g5 = g4 + 1
-    g6 = g5 + 1
-    g7 = g6 + 1
-
-    base = y_ptr + row * y_row_stride
-
-    y_ptr0 = base + group0 * group_size
-    y_ptr1 = base + group1 * group_size
-    y_ptr2 = base + group2 * group_size
-    y_ptr3 = base + group3 * group_size
-    y_ptr4 = base + group4 * group_size
-    y_ptr5 = base + group5 * group_size
-    y_ptr6 = base + group6 * group_size
-    y_ptr7 = base + group7 * group_size
-
-    y_q_ptr0 = y_q_ptr + g0 * group_size
-    y_q_ptr1 = y_q_ptr + g1 * group_size
-    y_q_ptr2 = y_q_ptr + g2 * group_size
-    y_q_ptr3 = y_q_ptr + g3 * group_size
-    y_q_ptr4 = y_q_ptr + g4 * group_size
-    y_q_ptr5 = y_q_ptr + g5 * group_size
-    y_q_ptr6 = y_q_ptr + g6 * group_size
-    y_q_ptr7 = y_q_ptr + g7 * group_size
-
-    y_s_ptr0 = y_s_ptr + group0 * y_s_col_stride + row
-    y_s_ptr1 = y_s_ptr + group1 * y_s_col_stride + row
-    y_s_ptr2 = y_s_ptr + group2 * y_s_col_stride + row
-    y_s_ptr3 = y_s_ptr + group3 * y_s_col_stride + row
-    y_s_ptr4 = y_s_ptr + group4 * y_s_col_stride + row
-    y_s_ptr5 = y_s_ptr + group5 * y_s_col_stride + row
-    y_s_ptr6 = y_s_ptr + group6 * y_s_col_stride + row
-    y_s_ptr7 = y_s_ptr + group7 * y_s_col_stride + row
-
-    cols = tl.arange(0, BLOCK)
-    mask = cols < group_size
-
-    y0 = tl.load(y_ptr0 + cols, mask=mask, other=0.0).to(tl.float32)
-    y1 = tl.load(y_ptr1 + cols, mask=mask, other=0.0).to(tl.float32)
-    y2 = tl.load(y_ptr2 + cols, mask=mask, other=0.0).to(tl.float32)
-    y3 = tl.load(y_ptr3 + cols, mask=mask, other=0.0).to(tl.float32)
-    y4 = tl.load(y_ptr4 + cols, mask=mask, other=0.0).to(tl.float32)
-    y5 = tl.load(y_ptr5 + cols, mask=mask, other=0.0).to(tl.float32)
-    y6 = tl.load(y_ptr6 + cols, mask=mask, other=0.0).to(tl.float32)
-    y7 = tl.load(y_ptr7 + cols, mask=mask, other=0.0).to(tl.float32)
-
-    abs0 = tl.abs(y0)
-    abs1 = tl.abs(y1)
-    abs2 = tl.abs(y2)
-    abs3 = tl.abs(y3)
-    abs4 = tl.abs(y4)
-    abs5 = tl.abs(y5)
-    abs6 = tl.abs(y6)
-    abs7 = tl.abs(y7)
-
-    max0 = tl.max(abs0)
-    max1 = tl.max(abs1)
-    max2 = tl.max(abs2)
-    max3 = tl.max(abs3)
-    max4 = tl.max(abs4)
-    max5 = tl.max(abs5)
-    max6 = tl.max(abs6)
-    max7 = tl.max(abs7)
-
-    y_s0 = tl.maximum(max0, eps) / fp8_max
-    y_s1 = tl.maximum(max1, eps) / fp8_max
-    y_s2 = tl.maximum(max2, eps) / fp8_max
-    y_s3 = tl.maximum(max3, eps) / fp8_max
-    y_s4 = tl.maximum(max4, eps) / fp8_max
-    y_s5 = tl.maximum(max5, eps) / fp8_max
-    y_s6 = tl.maximum(max6, eps) / fp8_max
-    y_s7 = tl.maximum(max7, eps) / fp8_max
-
-    if scale_ue8m0:
-        y_s0 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s0), 1e-10))))
-        y_s1 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s1), 1e-10))))
-        y_s2 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s2), 1e-10))))
-        y_s3 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s3), 1e-10))))
-        y_s4 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s4), 1e-10))))
-        y_s5 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s5), 1e-10))))
-        y_s6 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s6), 1e-10))))
-        y_s7 = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s7), 1e-10))))
-
-    y_q0 = tl.clamp(y0 / y_s0, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q1 = tl.clamp(y1 / y_s1, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q2 = tl.clamp(y2 / y_s2, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q3 = tl.clamp(y3 / y_s3, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q4 = tl.clamp(y4 / y_s4, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q5 = tl.clamp(y5 / y_s5, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q6 = tl.clamp(y6 / y_s6, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-    y_q7 = tl.clamp(y7 / y_s7, fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
-
-    tl.store(y_q_ptr0 + cols, y_q0, mask=mask)
-    tl.store(y_s_ptr0, y_s0)
-    tl.store(y_q_ptr1 + cols, y_q1, mask=mask)
-    tl.store(y_s_ptr1, y_s1)
-    tl.store(y_q_ptr2 + cols, y_q2, mask=mask)
-    tl.store(y_s_ptr2, y_s2)
-    tl.store(y_q_ptr3 + cols, y_q3, mask=mask)
-    tl.store(y_s_ptr3, y_s3)
-    tl.store(y_q_ptr4 + cols, y_q4, mask=mask)
-    tl.store(y_s_ptr4, y_s4)
-    tl.store(y_q_ptr5 + cols, y_q5, mask=mask)
-    tl.store(y_s_ptr5, y_s5)
-    tl.store(y_q_ptr6 + cols, y_q6, mask=mask)
-    tl.store(y_s_ptr6, y_s6)
-    tl.store(y_q_ptr7 + cols, y_q7, mask=mask)
-    tl.store(y_s_ptr7, y_s7)
-
-
-def Groups_per_program(x, group_size) -> int:
-    if (x.shape[-1] // group_size) % 8 == 0:
-        return 8
-    elif (x.shape[-1] // group_size) % 4 == 0:
-        return 4
-    elif (x.shape[-1] // group_size) % 2 == 0:
-        return 2
-    else:
-        return 1
+        y_s = tl.exp2(tl.ceil(tl.log2(tl.maximum(tl.abs(y_s), 1e-10))))
+
+    y_q = tl.clamp(y / y_s[:, None], fp8_min, fp8_max).to(y_q_ptr.dtype.element_ty)
+    output_offsets = (
+        start_gid * group_size + group_ids[:, None] * group_size + cols[None, :]
+    )
+    scale_offsets = (start_group + group_ids) * y_s_col_stride + row
+
+    tl.store(y_q_ptr + output_offsets, y_q, mask=mask)
+    tl.store(y_s_ptr + scale_offsets, y_s)
+
+
+def _groups_per_program(x: torch.Tensor, group_size: int) -> int:
+    groups_per_row = x.shape[-1] // group_size
+    for groups in (8, 4, 2):
+        if groups_per_row % groups == 0:
+            return groups
+    return 1
 
 
 def per_token_group_quant_fp8(
@@ -718,7 +219,6 @@ def per_token_group_quant_fp8(
     scale_ue8m0: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     logger.debug("GEMS PER TOKEN GROUP QUANT FP8")
-    # dtype: The dype of output tensor. Note that only `torch.float8_e4m3fn`
     fp8_dtype = SUPPORTED_FP8_DTYPE if dtype is None else dtype
     assert x.shape[-1] % group_size == 0, (
         f"the last dimension of `x` {x.shape[-1]} must be divisible "
@@ -731,8 +231,7 @@ def per_token_group_quant_fp8(
     fp8_max = finfo.max
 
     x_q = torch.empty_like(x, device=x.device, dtype=fp8_dtype)
-    M = x.numel() // group_size
-    N = group_size
+    num_groups = x.numel() // group_size
 
     if column_major_scales:
         shape = (x.shape[-1] // group_size,) + x.shape[:-1]
@@ -741,13 +240,15 @@ def per_token_group_quant_fp8(
         shape = x.shape[:-1] + (x.shape[-1] // group_size,)
         x_s = torch.empty(shape, device=x.device, dtype=torch.float32)
 
-    BLOCK = triton.next_power_of_2(N)
-    num_warps = min(max(BLOCK // 256, 1), 8)
-    num_stages = 1
-    groups_per_program = Groups_per_program(x, group_size)
+    block = triton.next_power_of_2(group_size)
+    num_warps = min(max(block // 256, 1), 8)
+    groups_per_program = _groups_per_program(x, group_size)
+    grid = (num_groups // groups_per_program,)
+
     if column_major_scales:
-        if groups_per_program == 8:
-            _per_token_group_quant_fp8_colmajor_m8[(M // 8,)](
+        if groups_per_program > 1:
+            kernel = _per_token_group_quant_fp8_colmajor_vec
+            kernel[grid](
                 x,
                 x_q,
                 x_s,
@@ -759,46 +260,14 @@ def per_token_group_quant_fp8(
                 fp8_min=fp8_min,
                 fp8_max=fp8_max,
                 scale_ue8m0=scale_ue8m0,
-                BLOCK=BLOCK,
+                BLOCK=block,
+                NGROUPS=groups_per_program,
                 num_warps=num_warps,
-                num_stages=num_stages,
-            )
-        elif groups_per_program == 4:
-            _per_token_group_quant_fp8_colmajor_m4[(M // 4,)](
-                x,
-                x_q,
-                x_s,
-                group_size,
-                x.shape[1],
-                x.stride(0),
-                x_s.stride(1),
-                eps,
-                fp8_min=fp8_min,
-                fp8_max=fp8_max,
-                scale_ue8m0=scale_ue8m0,
-                BLOCK=BLOCK,
-                num_warps=num_warps,
-                num_stages=num_stages,
-            )
-        elif groups_per_program == 2:
-            _per_token_group_quant_fp8_colmajor_m2[(M // 2,)](
-                x,
-                x_q,
-                x_s,
-                group_size,
-                x.shape[1],
-                x.stride(0),
-                x_s.stride(1),
-                eps,
-                fp8_min=fp8_min,
-                fp8_max=fp8_max,
-                scale_ue8m0=scale_ue8m0,
-                BLOCK=BLOCK,
-                num_warps=num_warps,
-                num_stages=num_stages,
+                num_stages=1,
             )
         else:
-            _per_token_group_quant_fp8_colmajor[(M,)](
+            kernel = _per_token_group_quant_fp8_colmajor
+            kernel[grid](
                 x,
                 x_q,
                 x_s,
@@ -810,74 +279,44 @@ def per_token_group_quant_fp8(
                 fp8_min=fp8_min,
                 fp8_max=fp8_max,
                 scale_ue8m0=scale_ue8m0,
-                BLOCK=BLOCK,
+                BLOCK=block,
                 num_warps=num_warps,
-                num_stages=num_stages,
+                num_stages=1,
             )
+    elif groups_per_program > 1:
+        kernel = _per_token_group_quant_fp8_vec
+        kernel[grid](
+            x,
+            x_q,
+            x_s,
+            group_size,
+            x.shape[1],
+            x.stride(0),
+            eps,
+            fp8_min=fp8_min,
+            fp8_max=fp8_max,
+            scale_ue8m0=scale_ue8m0,
+            BLOCK=block,
+            NGROUPS=groups_per_program,
+            num_warps=num_warps,
+            num_stages=1,
+        )
     else:
-        if groups_per_program == 8:
-            _per_token_group_quant_fp8_m8[(M // 8,)](
-                x,
-                x_q,
-                x_s,
-                group_size,
-                x.shape[1],
-                x.stride(0),
-                eps,
-                fp8_min=fp8_min,
-                fp8_max=fp8_max,
-                scale_ue8m0=scale_ue8m0,
-                BLOCK=BLOCK,
-                num_warps=num_warps,
-                num_stages=num_stages,
-            )
-        elif groups_per_program == 4:
-            _per_token_group_quant_fp8_m4[(M // 4,)](
-                x,
-                x_q,
-                x_s,
-                group_size,
-                x.shape[1],
-                x.stride(0),
-                eps,
-                fp8_min=fp8_min,
-                fp8_max=fp8_max,
-                scale_ue8m0=scale_ue8m0,
-                BLOCK=BLOCK,
-                num_warps=num_warps,
-                num_stages=num_stages,
-            )
-        elif groups_per_program == 2:
-            _per_token_group_quant_fp8_m2[(M // 2,)](
-                x,
-                x_q,
-                x_s,
-                group_size,
-                x.shape[1],
-                x.stride(0),
-                eps,
-                fp8_min=fp8_min,
-                fp8_max=fp8_max,
-                scale_ue8m0=scale_ue8m0,
-                BLOCK=BLOCK,
-                num_warps=num_warps,
-                num_stages=num_stages,
-            )
-        else:
-            _per_token_group_quant_fp8[(M,)](
-                x,
-                x_q,
-                x_s,
-                group_size,
-                x.shape[1],
-                x.stride(0),
-                eps,
-                fp8_min=fp8_min,
-                fp8_max=fp8_max,
-                scale_ue8m0=scale_ue8m0,
-                BLOCK=BLOCK,
-                num_warps=num_warps,
-                num_stages=num_stages,
-            )
+        kernel = _per_token_group_quant_fp8
+        kernel[grid](
+            x,
+            x_q,
+            x_s,
+            group_size,
+            x.shape[1],
+            x.stride(0),
+            eps,
+            fp8_min=fp8_min,
+            fp8_max=fp8_max,
+            scale_ue8m0=scale_ue8m0,
+            BLOCK=block,
+            num_warps=num_warps,
+            num_stages=1,
+        )
 
     return x_q, x_s


### PR DESCRIPTION
## Optimization

The original implementation used six manually unrolled kernels for processing 2, 4, and 8 groups in row-major and column-major scale layouts.

This PR replaces them with two generic vectorized Triton kernels. Multiple groups are loaded as a `[NGROUPS, BLOCK]` tile, reduced with `tl.max(..., axis=1)`, quantized through broadcasting, and written back using a 2D store.

## Changes

- Replaced six `m2/m4/m8` unrolled kernels with two vectorized kernels.
- Preserved row-major and column-major scale layouts.
- Preserved the single-group fallback for odd group counts.
- Kept the public API unchanged.

## Performance

### Vectorized vs. manually unrolled implementation

Benchmark configuration:

- Mode: `kernel`
- Input dtype: `torch.bfloat16`
- Group size: `128`
- `scale_ue8m0=False`
- Speedup: `unrolled latency / vectorized latency`

| Input shape | Unrolled latency (ms) | Vectorized latency (ms) | Speedup |
|---:|---:|---:|---:|
| 1 × 7168 | 0.005728 | 0.005376 | 1.065× |
| 4 × 7168 | 0.005952 | 0.005440 | 1.094× |
| 16 × 7168 | 0.005888 | 0.005792 | 1.017× |
| 64 × 7168 | 0.006304 | 0.006080 | 1.037× |
| 128 × 7168 | 0.007104 | 0.006528 | 1.088× |
| 256 × 7168 | 0.008480 | 0.007680 | 1.104× |
| 512 × 7168 | 0.011040 | 0.009664 | 1.142× |
| 1024 × 7168 | 0.016128 | 0.013984 | 1.153× |
| 2048 × 7168 | 0.026496 | 0.022176 | 1.195× |
| 4096 × 7168 | 0.046272 | 0.037696 | 1.228× |
| 8192 × 7168 | 0.084864 | 0.068864 | 1.232× |
| 16384 × 7168 | 0.170896 | 0.139552 | 1.225× |
| 32768 × 7168 | 0.345392 | 0.284544 | 1.214× |
| 1 × 4096 | 0.005792 | 0.005472 | 1.058× |
| 4 × 4096 | 0.005856 | 0.005408 | 1.083× |
| 16 × 4096 | 0.005888 | 0.005632 | 1.045× |
| 64 × 4096 | 0.006048 | 0.005824 | 1.038× |
| 128 × 4096 | 0.006752 | 0.006464 | 1.045× |
| 256 × 4096 | 0.007296 | 0.006912 | 1.056× |
| 512 × 4096 | 0.008608 | 0.007904 | 1.089× |
| 1024 × 4096 | 0.011616 | 0.010272 | 1.131× |
| 2048 × 4096 | 0.017600 | 0.014976 | 1.175× |
| 4096 × 4096 | 0.029344 | 0.024256 | 1.210× |
| 8192 × 4096 | 0.051616 | 0.041856 | 1.233× |
| 16384 × 4096 | 0.095936 | 0.077280 | 1.241× |
| 32768 × 4096 | 0.198016 | 0.160224 | 1.236× |

- Maximum speedup: **1.241×**
- Average speedup: **1.132×**

### FlagGems vs. vLLM

Benchmark configuration:

- Mode: `kernel`
- Level: `comprehensive`
- Input dtype: `torch.bfloat16`
- `scale_ue8m0=False`
- Speedup: `vLLM latency / FlagGems latency`

| Input shape | Group size | vLLM latency (ms) | FlagGems latency (ms) | Speedup |
|---:|---:|---:|---:|---:|
| 7 × 512 | 512 | 0.006880 | 0.005376 | 1.280× |
| 7 × 4096 | 256 | 0.006976 | 0.006304 | 1.107× |
| 83 × 512 | 64 | 0.006080 | 0.005696 | 1.067× |
| 2048 × 4096 | 256 | 0.025568 | 0.016352 | 1.564× |
| 2048 × 13824 | 512 | 0.053792 | 0.049920 | 1.078× |
| 1 × 7168 | 128 | 0.005984 | 0.005888 | 1.016× |
| 4 × 7168 | 128 | 0.006272 | 0.005952 | 1.054× |
| 16 × 7168 | 128 | 0.006560 | 0.005952 | 1.102× |
| 64 × 7168 | 128 | 0.007040 | 0.006464 | 1.089× |
| 128 × 7168 | 128 | 0.008864 | 0.006976 | 1.271× |
| 256 × 7168 | 128 | 0.011104 | 0.008576 | 1.295× |
| 512 × 7168 | 128 | 0.015904 | 0.011008 | 1.445× |
| 1024 × 7168 | 128 | 0.025568 | 0.016096 | 1.588× |
| 2048 × 7168 | 128 | 0.044768 | 0.026496 | 1.690× |
| 4096 × 7168 | 128 | 0.082912 | 0.046176 | 1.796× |
| 8192 × 7168 | 128 | 0.158848 | 0.084768 | 1.874× |
| 16384 × 7168 | 128 | 0.310912 | 0.169376 | 1.836× |
| 32768 × 7168 | 128 | 0.614752 | 0.342928 | 1.793× |
| 1 × 4096 | 128 | 0.005952 | 0.005824 | 1.022× |
| 4 × 4096 | 128 | 0.006112 | 0.005888 | 1.038× |
| 16 × 4096 | 128 | 0.006400 | 0.005888 | 1.087× |
| 64 × 4096 | 128 | 0.006528 | 0.006048 | 1.079× |
| 128 × 4096 | 128 | 0.007168 | 0.006496 | 1.103× |
| 256 × 4096 | 128 | 0.009056 | 0.007392 | 1.225× |
| 512 × 4096 | 128 | 0.011616 | 0.008736 | 1.330× |
| 1024 × 4096 | 128 | 0.017184 | 0.011712 | 1.467× |
| 2048 × 4096 | 128 | 0.028128 | 0.017664 | 1.592× |
| 4096 × 4096 | 128 | 0.050176 | 0.029408 | 1.706× |
| 8192 × 4096 | 128 | 0.094144 | 0.051552 | 1.826× |
| 16384 × 4096 | 128 | 0.180960 | 0.095776 | 1.889× |
| 32768 × 4096 | 128 | 0.354304 | 0.196256 | 1.805× |

- Maximum speedup over vLLM: **1.889×**
- Average speedup over vLLM: **1.391×**