### PR TITLE
Add GPU check script for Cambricon MLU backend

### DIFF
--- a/container/flaggems-cambricon-4.4.3
+++ b/container/flaggems-cambricon-4.4.3
@@ -1,0 +1,82 @@
+# ============================================================
+# FlagGems development image for Cambricon Neuware 4.4.3
+# ============================================================
+
+# ── Build arguments ────────────────────────────────────────────
+ARG BASE_IMAGE=cambricon-neuware:4.4.3
+ARG PYTHON_VERSION=3.10
+ARG FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-cambricon/simple
+ARG EXTRA_PYPI=https://mirrors.aliyun.com/pypi/simple
+ARG INCLUDE_TESTS=true
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS builder
+
+ARG PYTHON_VERSION
+ARG FLAGOS_PYPI
+ARG EXTRA_PYPI
+ARG INCLUDE_TESTS
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── Prepare uv and virtual environment ─────────────────────────
+# Install 'uv' to /usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+RUN uv venv /flagos --python ${PYTHON_VERSION} --relocatable
+ENV VIRTUAL_ENV=/flagos \
+    PATH="/flagos/bin:${PATH}"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+RUN uv pip install --no-cache-dir --index ${EXTRA_PYPI} \
+  "setuptools>=64.0,<80.0" \
+  "scikit-build-core==0.12.2" \
+  "pybind11==3.0.3" \
+  "cmake>=3.20,<4.0" \
+  "ninja==1.13.0" \
+  "pip"
+
+# TODO: Add support to C++ wrapper operators
+# ENV CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=METAX"
+# ENV CMAKE_PREFIX_PATH="$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')"
+RUN uv pip install --no-cache-dir ".[cambricon]" \
+      --default-index ${FLAGOS_PYPI} \
+      --index ${EXTRA_PYPI} \
+      --trusted-host resource.flagos.net \
+      --trusted-host mirrors.aliyun.com
+RUN uv pip install --no-cache-dir ".[test]" \
+      --index ${EXTRA_PYPI} \
+      --trusted-host mirrors.aliyun.com
+
+RUN mkdir /app
+RUN if [ "$INCLUDE_TESTS" = "true" ]; then \
+      cp -r /build/FlagGems/tests /app/tests && \
+      cp -r /build/FlagGems/benchmark /app/benchmark && \
+      cp /build/FlagGems/pytest.ini /app; \
+    fi
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── Copy uv and Python from builder ────────────────────────────
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /root/.local/share/uv /root/.local/share/uv
+COPY --from=builder /flagos /flagos
+
+# ── Copy tests and benchmarks into container if required ───────
+COPY --from=builder /app /app
+WORKDIR /app
+
+# Note: VIRTUAL_ENV and PATH are not sharable between stages
+ENV VIRTUAL_ENV=/flagos \
+   PATH="/flagos/bin:${PATH}"
+
+ENTRYPOINT ["bash"]

--- a/tools/gpu_check_cambricon.sh
+++ b/tools/gpu_check_cambricon.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+
+# Configuration parameters
+mem_threshold=30000     # Maximum memory usage limit (MB)
+sleep_interval=120      # Wait time (seconds), default is 2 minutes
+max_wait=1200           # Maximum wait time (seconds), default is 20 minutes
+
+# Get the number of Cambricon MLU cards from cnmon output
+# Memory lines look like:
+# | 7         52C     85 W/ 500 W |     0 MiB/ 81920 MiB | FULL          Default |
+gpu_count=$(cnmon | grep -cP '\d+ MiB/ \d+ MiB')
+
+if [ $? -ne 0 ]; then
+    echo "Failed to run cnmon. Please check if cnmon is installed and working correctly."
+    exit 1
+fi
+
+if [ "$gpu_count" -eq 0 ]; then
+    echo "No Cambricon MLUs detected. Please ensure you have MLU cards installed and properly configured."
+    exit 1
+fi
+
+echo "Detected $gpu_count Cambricon MLU card(s)."
+
+waited_time=0
+while true; do
+    need_wait=false
+    i=0
+
+    printf " MLU  Total (MiB)  Used (MiB)  Free (MiB)\n"
+    cnmon | grep -oP '\d+ MiB/ \d+ MiB' | while read -r line; do
+        used_i=$(echo "$line" | grep -oP '^\d+')
+        total_i=$(echo "$line" | grep -oP '\d+(?= MiB$)')
+
+        if [ -z "$used_i" ] || [ -z "$total_i" ]; then
+            echo "Warning: Failed to parse memory info for card $i."
+            i=$((i + 1))
+            continue
+        fi
+
+        free_i=$((total_i - used_i))
+
+        printf "%4d%'13d%'12d%'12d\n" $i ${total_i} ${used_i} ${free_i}
+        if [ $free_i -lt $mem_threshold ]; then
+            need_wait=true
+            break
+        fi
+        i=$((i + 1))
+    done
+
+    if [ "$need_wait" = false ]; then
+        echo "All MLUs have sufficient memory, proceeding with execution."
+        break
+    fi
+
+    echo "MLU memory is insufficient, waiting for $sleep_interval seconds before retrying..."
+    sleep $sleep_interval
+    waited_time=$(( waited_time + sleep_interval ))
+    if [ $waited_time -gt $max_wait ]; then
+        break
+    fi
+done


### PR DESCRIPTION
Add `tools/gpu_check_cambricon.sh` following the same pattern as the existing `gpu_check_sunrise.sh` script. Uses `cnmon` to detect MLU cards and poll memory availability before proceeding with test execution.

Tested on cambricon node (8× MLU590-M9DE, 80 GiB each).