### PR TITLE
Use vendor name in backend-tests job names

### DIFF
--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -73,7 +73,15 @@ jobs:
             const fs = require('fs');
             const backends = JSON.parse(fs.readFileSync('.github/backends.json', 'utf8'));
             const labels = JSON.parse(${{ steps.get-labels.outputs.result }} || '[]');
-            const matrix = backends.filter(b => b.enabled && labels.includes(b.label));
+            const filtered = backends.filter(b => b.enabled && labels.includes(b.label));
+            const matrix = {
+              vendor: filtered.map(b => b.vendor),
+              include: filtered.map(b => ({
+                vendor: b.vendor,
+                runner_label: b.runner_label,
+                gpu_check: b.gpu_check
+              }))
+            };
             core.setOutput('matrix', JSON.stringify(matrix));
 
   build-doc:
@@ -131,16 +139,15 @@ jobs:
 
   backend-tests:
     needs: preprocess
-    if: fromJSON(needs.preprocess.outputs.backend_matrix)[0] != null
+    if: fromJSON(needs.preprocess.outputs.backend_matrix).vendor[0] != null
     strategy:
       fail-fast: false
-      matrix:
-        backend: ${{ fromJSON(needs.preprocess.outputs.backend_matrix) }}
+      matrix: ${{ fromJSON(needs.preprocess.outputs.backend_matrix) }}
     uses: ./.github/workflows/backend-test.yaml
     with:
-      vendor: ${{ matrix.backend.vendor }}
-      runner_label: ${{ matrix.backend.runner_label }}
-      gpu_check_script: ${{ matrix.backend.gpu_check }}
+      vendor: ${{ matrix.vendor }}
+      runner_label: ${{ matrix.runner_label }}
+      gpu_check_script: ${{ matrix.gpu_check }}
       changed_files: ${{ join(needs.preprocess.outputs.changed_files, ' ') }}
       pr_id: ${{ needs.preprocess.outputs.pr_id }}
     secrets:

--- a/container/flaggems-cambricon-4.4.3
+++ b/container/flaggems-cambricon-4.4.3
@@ -1,0 +1,82 @@
+# ============================================================
+# FlagGems development image for Cambricon Neuware 4.4.3
+# ============================================================
+
+# ── Build arguments ────────────────────────────────────────────
+ARG BASE_IMAGE=cambricon-neuware:4.4.3
+ARG PYTHON_VERSION=3.10
+ARG FLAGOS_PYPI=https://resource.flagos.net/repository/flagos-pypi-cambricon/simple
+ARG EXTRA_PYPI=https://mirrors.aliyun.com/pypi/simple
+ARG INCLUDE_TESTS=true
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS builder
+
+ARG PYTHON_VERSION
+ARG FLAGOS_PYPI
+ARG EXTRA_PYPI
+ARG INCLUDE_TESTS
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── Prepare uv and virtual environment ─────────────────────────
+# Install 'uv' to /usr/local/bin
+RUN curl -LsSf https://astral.sh/uv/install.sh | env UV_INSTALL_DIR=/usr/local/bin sh
+RUN uv venv /flagos --python ${PYTHON_VERSION} --relocatable
+ENV VIRTUAL_ENV=/flagos \
+    PATH="/flagos/bin:${PATH}"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+RUN uv pip install --no-cache-dir --index ${EXTRA_PYPI} \
+  "setuptools>=64.0,<80.0" \
+  "scikit-build-core==0.12.2" \
+  "pybind11==3.0.3" \
+  "cmake>=3.20,<4.0" \
+  "ninja==1.13.0" \
+  "pip"
+
+# TODO: Add support to C++ wrapper operators
+# ENV CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=METAX"
+# ENV CMAKE_PREFIX_PATH="$(python -c 'import torch; print(torch.utils.cmake_prefix_path)')"
+RUN uv pip install --no-cache-dir ".[cambricon]" \
+      --default-index ${FLAGOS_PYPI} \
+      --index ${EXTRA_PYPI} \
+      --trusted-host resource.flagos.net \
+      --trusted-host mirrors.aliyun.com
+RUN uv pip install --no-cache-dir ".[test]" \
+      --index ${EXTRA_PYPI} \
+      --trusted-host mirrors.aliyun.com
+
+RUN mkdir /app
+RUN if [ "$INCLUDE_TESTS" = "true" ]; then \
+      cp -r /build/FlagGems/tests /app/tests && \
+      cp -r /build/FlagGems/benchmark /app/benchmark && \
+      cp /build/FlagGems/pytest.ini /app; \
+    fi
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS runtime
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── Copy uv and Python from builder ────────────────────────────
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /root/.local/share/uv /root/.local/share/uv
+COPY --from=builder /flagos /flagos
+
+# ── Copy tests and benchmarks into container if required ───────
+COPY --from=builder /app /app
+WORKDIR /app
+
+# Note: VIRTUAL_ENV and PATH are not sharable between stages
+ENV VIRTUAL_ENV=/flagos \
+   PATH="/flagos/bin:${PATH}"
+
+ENTRYPOINT ["bash"]


### PR DESCRIPTION
Restructure the backend matrix from a flat array to a proper GitHub Actions matrix with `vendor` as the key dimension.

**Before:** job names show as `backend-tests (0)`, `backend-tests (1)`, etc.

**After:** job names show as `backend-tests (nvidia)`, `backend-tests (ascend-cann850)`, `backend-tests (hygon)`, etc.

### Changes

- In `preprocess`, build the matrix as `{vendor: [...], include: [...]}` instead of a flat array of objects
- In `backend-tests`, use `matrix.vendor` / `matrix.runner_label` / `matrix.gpu_check` directly instead of `matrix.backend.*`
- Update the `if` condition to check `fromJSON(...).vendor[0]`