### PR TITLE
Change test count to time

### DIFF
--- a/benchmark/base.py
+++ b/benchmark/base.py
@@ -40,6 +40,30 @@ else:
         pass
 
 
+def get_iter_count(fn):
+    if Config.mode == consts.BenchMode.OPERATOR:
+        torch_device_fn.synchronize()
+        start = time.time()
+        for _ in range(5):
+            fn()
+        torch_device_fn.synchronize()
+        end = time.time()
+        latency = (end - start) / 5
+    elif Config.mode == consts.BenchMode.WRAPPER:
+        torch_device_fn.synchronize()
+        start = time.time()
+        for _ in range(5):
+            fn()
+        end = time.time()
+        torch_device_fn.synchronize()
+        latency = (end - start) / 5
+    else:
+        raise ValueError("Unsupport Benchmark Mode.")
+    return max(1, int(Config.warm_up / latency)), max(
+        1, int(Config.repetition / latency)
+    )
+
+
 class Benchmark:
     device: str = device
     DEFAULT_METRICS = consts.DEFAULT_METRICS
@@ -257,15 +281,16 @@ class Benchmark:
                 (out,), xs, grad_outputs=(dout,), retain_graph=True
             )
         if Config.mode == consts.BenchMode.OPERATOR:
-            for i in range(Config.warm_up):
+            n_warm, n_rep = get_iter_count(fn)
+            for i in range(n_warm):
                 fn()
             torch_device_fn.synchronize()
             start = time.time()
-            for i in range(Config.repetition):
+            for i in range(n_rep):
                 fn()
             torch_device_fn.synchronize()
             end = time.time()
-            latency = (end - start) / Config.repetition * 1000
+            latency = (end - start) / n_rep * 1000
         elif Config.mode == consts.BenchMode.KERNEL:
             do_bench = triton.testing.do_bench
             latency = do_bench(
@@ -276,14 +301,15 @@ class Benchmark:
                 grad_to_none=xs if self.is_backward else None,
             )
         elif Config.mode == consts.BenchMode.WRAPPER:
-            for i in range(Config.warm_up):
+            n_warm, n_rep = get_iter_count(fn)
+            for i in range(n_warm):
                 fn()
             torch_device_fn.synchronize()
             start = time.time()
-            for i in range(Config.repetition):
+            for i in range(n_rep):
                 fn()
             end = time.time()
-            latency = (end - start) / Config.repetition * 1000
+            latency = (end - start) / n_rep * 1000
         else:
             raise ValueError("Undefined Value of Benchmark Mode.")
         # average latency in ms

--- a/benchmark/base.py
+++ b/benchmark/base.py
@@ -48,7 +48,7 @@ def get_iter_count(fn):
             fn()
         torch_device_fn.synchronize()
         end = time.time()
-        latency = (end - start) / 5
+        latency = (end - start) / 5 * 1000
     elif Config.mode == consts.BenchMode.WRAPPER:
         torch_device_fn.synchronize()
         start = time.time()
@@ -56,7 +56,7 @@ def get_iter_count(fn):
             fn()
         end = time.time()
         torch_device_fn.synchronize()
-        latency = (end - start) / 5
+        latency = (end - start) / 5 * 1000
     else:
         raise ValueError("Unsupport Benchmark Mode.")
     return max(1, int(Config.warm_up / latency)), max(

--- a/benchmark/conftest.py
+++ b/benchmark/conftest.py
@@ -62,8 +62,8 @@ class BenchConfig:
     def __init__(self):
         self.mode = consts.BenchMode.KERNEL
         self.bench_level = consts.BenchLevel.COMPREHENSIVE
-        self.warm_up = consts.DEFAULT_WARMUP_COUNT
-        self.repetition = consts.DEFAULT_ITER_COUNT
+        self.warm_up = consts.DEFAULT_WARMUP_TIME
+        self.repetition = consts.DEFAULT_ITER_TIME
 
         # Speed Up Benchmark Test, Big Shape Will Cause Timeout
         if vendor_name == "kunlunxin":
@@ -105,14 +105,14 @@ def pytest_addoption(parser):
 
     parser.addoption(
         "--warmup",
-        default=consts.DEFAULT_WARMUP_COUNT,
-        help="Number of warmup runs before benchmark run.",
+        default=consts.DEFAULT_WARMUP_TIME,
+        help="Time(ms) of warmup runs before benchmark run.",
     )
 
     parser.addoption(
         "--iter",
-        default=consts.DEFAULT_ITER_COUNT,
-        help="Number of reps for each benchmark run.",
+        default=consts.DEFAULT_ITER_TIME,
+        help="Time(ms) of reps for each benchmark run.",
     )
 
     parser.addoption(

--- a/benchmark/consts.py
+++ b/benchmark/consts.py
@@ -31,8 +31,8 @@ def get_fp8_dtype():
 
 FP8_DTYPES = [get_fp8_dtype()]
 
-DEFAULT_WARMUP_COUNT = 1000
-DEFAULT_ITER_COUNT = 100
+DEFAULT_WARMUP_TIME = 1000
+DEFAULT_ITER_TIME = 100
 
 # LEGACY_SHAPES are maintained for legacy benchmark SIZE settings and may be removed in the future.
 # Do not reference this elsewhere.


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
OP Test
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Refactor
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
In the `triton.testing.do_bench` function, the `warmup` and `rep` parameters represent the warmup/rep time (in ms). This pr parameter unifies the parameters into time across different modes.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
