### PR TITLE
Fix unbound variable errors when sourcing vendor env scripts

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -99,7 +99,6 @@ printf "Python: $(python --version)"
 ok
 
 # ── Source vendor environment ─────────────────────────────────
-export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
 export USE_TRITON="${USE_TRITON:-}"
 source tools/env.sh "${VENDOR}"
 

--- a/tools/env.sh
+++ b/tools/env.sh
@@ -1,6 +1,14 @@
 BACKEND=$1
 echo "Setting up environment variable for backend $BACKEND"
 
+# Vendor env scripts append to these variables without guarding against unset.
+# Default them here so callers with `set -u` (e.g. setup.sh) don't fail.
+export CMAKE_PREFIX_PATH="${CMAKE_PREFIX_PATH:-}"
+export C_INCLUDE_PATH="${C_INCLUDE_PATH:-}"
+export CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH:-}"
+export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
+export LIBRARY_PATH="${LIBRARY_PATH:-}"
+
 case $BACKEND in
   ascend-cann850|ascend-cann900)
     # This script is provided by the Huawei Ascend CANN toolkit installation.


### PR DESCRIPTION
Vendor-provided env scripts (e.g. Hygon `/opt/dtk-26.04/env.sh`) append to `CMAKE_PREFIX_PATH`, `C_INCLUDE_PATH`, `CPLUS_INCLUDE_PATH`, `LD_LIBRARY_PATH`, and `LIBRARY_PATH` without checking if they are set. This causes `unbound variable` errors when `setup.sh` runs with `set -u`.

```
/opt/dtk-26.04/env.sh: line 38: CMAKE_PREFIX_PATH: unbound variable
```

### Fix

Default all five variables at the top of `tools/env.sh` (before the vendor `case` block), and remove the now-redundant `LD_LIBRARY_PATH` default from `setup.sh`.

Tested on the hygon node — `source tools/env.sh hygon` under `set -euo pipefail` now succeeds.