### PR TITLE
Fix uv install failure when HOME is not writable

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -74,7 +74,10 @@ if command -v uv &>/dev/null; then
   ok
 else
   printf " not found, installing ...\n"
+  # Ensure HOME is correct — some runners inherit HOME=/root from sudo
+  export HOME=$(eval echo ~"$(whoami)")
   ARCH=$(uname -m)
+  mkdir -p "$HOME/.local/bin"
   curl -sSf "${UV_MIRROR}/uv-${ARCH}-${UV_VERSION}-linux-gnu.tar.gz" \
     | tar xz -C "$HOME/.local/bin" 2>/dev/null \
     || { curl -LsSf https://astral.sh/uv/install.sh | sh; }


### PR DESCRIPTION
Some CI runners inherit `HOME=/root` from a sudo context while running as a non-root user, causing:

```
mkdir: cannot create directory '/root/.local/bin': Permission denied
```

when `setup.sh` tries to install `uv`.

### Fix

Resolve the real home directory from `/etc/passwd` via `whoami` before creating the install directory. This ensures `$HOME/.local/bin` is always writable by the current user.

Ref: https://github.com/flagos-ai/FlagGems/actions/runs/28147835203/job/83358724225