### PR TITLE
Fix gh install failure in command.yaml when HOME is not writable

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -89,6 +89,7 @@ jobs:
         env:
           GH_VERSION: "2.95.0"
         run: |
+          export HOME=$(eval echo ~"$(whoami)")
           GH_DIR="${HOME}/.local/bin"
           if command -v gh &>/dev/null; then
             echo "gh already available: $(gh --version | head -1)"


### PR DESCRIPTION
Same issue as `setup.sh` (fixed in #4345): some CI runners inherit `HOME=/root` from a sudo context while running as a non-root user, causing:

```
mkdir: cannot create directory '/root/.local/bin': Permission denied
```

in the `setup-gh` step of `command.yaml`.

### Fix

Resolve the real home directory from `/etc/passwd` via `whoami` before using `$HOME/.local/bin`.

Ref: https://github.com/flagos-ai/FlagGems/actions/runs/28148620071/job/83361059009