### PR TITLE
Use internal mirror for gh CLI download

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -98,7 +98,7 @@ jobs:
             echo "${GH_DIR}" >> $GITHUB_PATH
           else
             mkdir -p "${GH_DIR}"
-            curl -fsSL "https://github.com/cli/cli/releases/download/v${GH_VERSION}/gh_${GH_VERSION}_linux_amd64.tar.gz" \
+            curl -fsSL "https://resource.flagos.net/repository/flagos-filestore/github/gh_${GH_VERSION}_linux_amd64.tar.gz" \
               | tar -xz --strip-components=2 -C "${GH_DIR}" "gh_${GH_VERSION}_linux_amd64/bin/gh"
             echo "Installed gh ${GH_VERSION} to ${GH_DIR}"
             echo "${GH_DIR}" >> $GITHUB_PATH


### PR DESCRIPTION
Switch the gh CLI download in `command.yaml` from `github.com` to the internal `flagos.net` mirror for faster and more reliable downloads on self-hosted runners.