### PR TITLE
Persist corrected HOME to GITHUB_ENV in command.yaml

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -90,6 +90,7 @@ jobs:
           GH_VERSION: "2.95.0"
         run: |
           export HOME=$(eval echo ~"$(whoami)")
+          echo "HOME=${HOME}" >> $GITHUB_ENV
           GH_DIR="${HOME}/.local/bin"
           if command -v gh &>/dev/null; then
             echo "gh already available: $(gh --version | head -1)"


### PR DESCRIPTION
The `HOME` fix in the `setup-gh` step (#4346) only applies within that step. Subsequent steps still see `HOME=/root`, causing `gh` to fail:

```
warning: failed to load config: open /root/.config/gh/config.yml: permission denied
failed to create root command: failed to read configuration: open /root/.config/gh/config.yml: permission denied
```

### Fix

Write the corrected `HOME` to `$GITHUB_ENV` so it persists across all subsequent steps in the job.

Ref: https://github.com/flagos-ai/FlagGems/actions/runs/28151005283/job/83368479442