### PR TITLE
[MTHREADS] fix soft_margin_loss performance with two-phase reduction

### DIFF
--- a/src/flag_gems/ops/soft_margin_loss.py
+++ b/src/flag_gems/ops/soft_margin_loss.py
@@ -32,8 +32,8 @@ def _soft_margin_loss_elementwise_kernel(
 
 
 @triton.jit
-def _soft_margin_loss_sum_kernel(
-    x_ptr, y_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr
+def _soft_margin_loss_partial_sum_kernel(
+    x_ptr, y_ptr, mid_ptr, n_elements, BLOCK_SIZE: tl.constexpr
 ):
     pid = tl.program_id(axis=0)
     block_start = pid * BLOCK_SIZE
@@ -51,7 +51,18 @@ def _soft_margin_loss_sum_kernel(
     vals = tl.where(mask, vals, 0.0)
 
     acc = tl.sum(vals, axis=0)
-    tl.atomic_add(out_ptr, acc)
+    tl.store(mid_ptr + pid, acc)
+
+
+@triton.jit
+def _soft_margin_loss_final_reduce_kernel(
+    mid_ptr, out_ptr, mid_size, BLOCK_MID: tl.constexpr
+):
+    offsets = tl.arange(0, BLOCK_MID)
+    mask = offsets < mid_size
+    vals = tl.load(mid_ptr + offsets, mask=mask, other=0.0).to(tl.float32)
+    acc = tl.sum(vals, axis=0)
+    tl.store(out_ptr, acc)
 
 
 def _normalize_reduction(reduction):
@@ -119,11 +130,16 @@ def soft_margin_loss(input: torch.Tensor, target: torch.Tensor, reduction="mean"
                 return torch.full(
                     (), float("nan"), device=input.device, dtype=input.dtype
                 )
-        tmp_sum = torch.zeros((), device=input.device, dtype=torch.float32)
         BLOCK_SIZE = 1024
-        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-        _soft_margin_loss_sum_kernel[grid](
-            input, target, tmp_sum, n_elements, BLOCK_SIZE=BLOCK_SIZE
+        mid_size = triton.cdiv(n_elements, BLOCK_SIZE)
+        block_mid = triton.next_power_of_2(mid_size)
+        mid = torch.empty((mid_size,), device=input.device, dtype=torch.float32)
+        _soft_margin_loss_partial_sum_kernel[(mid_size,)](
+            input, target, mid, n_elements, BLOCK_SIZE=BLOCK_SIZE
+        )
+        tmp_sum = torch.zeros((), device=input.device, dtype=torch.float32)
+        _soft_margin_loss_final_reduce_kernel[(1,)](
+            mid, tmp_sum, mid_size, BLOCK_MID=block_mid
         )
         if red == 2:
             # sum
@@ -186,11 +202,16 @@ def soft_margin_loss_out(
             else:
                 out.fill_(float("nan"))
             return out
-        tmp_sum = torch.zeros((), device=input.device, dtype=torch.float32)
         BLOCK_SIZE = 1024
-        grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
-        _soft_margin_loss_sum_kernel[grid](
-            input, target, tmp_sum, n_elements, BLOCK_SIZE=BLOCK_SIZE
+        mid_size = triton.cdiv(n_elements, BLOCK_SIZE)
+        block_mid = triton.next_power_of_2(mid_size)
+        mid = torch.empty((mid_size,), device=input.device, dtype=torch.float32)
+        _soft_margin_loss_partial_sum_kernel[(mid_size,)](
+            input, target, mid, n_elements, BLOCK_SIZE=BLOCK_SIZE
+        )
+        tmp_sum = torch.zeros((), device=input.device, dtype=torch.float32)
+        _soft_margin_loss_final_reduce_kernel[(1,)](
+            mid, tmp_sum, mid_size, BLOCK_MID=block_mid
         )
         if red == 2:
             out.fill_(tmp_sum.to(dtype=input.dtype))


### PR DESCRIPTION
The original _soft_margin_loss_sum_kernel used tl.atomic_add on a single scalar output for every thread block, causing severe atomic contention when grid size is large (e.g., ~1M blocks for 1G elements). This made the kernel 50-70x slower than the PyTorch native implementation.

Fix: adopt the two-phase reduction pattern (already used by smooth_l1_loss and vdot in this repo):

Phase 1 - _soft_margin_loss_partial_sum_kernel:
  Each block computes its partial loss sum and writes to mid[pid] via
  tl.store (independent addresses, zero atomic contention).

Phase 2 - _soft_margin_loss_final_reduce_kernel:
  A single block loads the mid array and reduces it to the final scalar
  via tl.sum.

Performance improvement: speedup goes from 0.014-0.022x to 2.4-3.2x across all large shapes (150-230x relative improvement). All 27 accuracy tests pass.
