### PR TITLE
Fix CMakeLists.txt for git cloning libtriton_jit

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,8 +96,9 @@ else()
   set(TRITON_JIT_INSTALL ON) # install triton jit
   set(BACKEND ${FLAGGEMS_BACKEND} CACHE STRING "Backend for TritonJIT" FORCE)
   FetchContent_Declare(TritonJIT
-    GIT_REPOSITORY https://github.com/flagos-ai/libtriton_jit
-    GIT_TAG master
+    URL https://resource.flagos.net/repository/flagos-filestore/libtriton_jit/libtriton_jit-0.2.0-rc0.1.tar.gz
+    # GIT_REPOSITORY https://github.com/flagos-ai/libtriton_jit
+    # GIT_TAG master
     # SOURCE_DIR <your local source dir of libtriton_jit>
   )
   FetchContent_MakeAvailable(TritonJIT)


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Optimization

### Description

Our connection to github.com is not as stable, reliable as expected. Checking out libtriton_jit every time is flaky. This PR fixes the CMakeLists.txt to fetch archive from our local server.