### PR TITLE
Fix weight_norm_interface norm dtype truncation

### DIFF
--- a/src/flag_gems/ops/weightnorm.py
+++ b/src/flag_gems/ops/weightnorm.py
@@ -204,7 +204,7 @@ def weight_norm_interface(v, g, dim=0):
     v = v.contiguous()
     g = g.contiguous()
     output = torch.empty_like(v)
-    norm = torch.empty_like(g)
+    norm = torch.empty_like(g, dtype=torch.float32)
     if dim == 0:
         M = v.shape[0]
         N = math.prod(v.shape[1:])

--- a/tests/test_weight_norm_interface.py
+++ b/tests/test_weight_norm_interface.py
@@ -34,7 +34,9 @@ def test_weight_norm_interface(shape, dtype, dim):
     with flag_gems.use_gems():
         res_w_out, res_norm_out = torch._weight_norm_interface(v, g, dim)
     utils.gems_assert_close(res_w_out, ref_w_out, dtype, reduce_dim=reduce_size)
-    utils.gems_assert_close(res_norm_out, ref_norm_out, dtype, reduce_dim=reduce_size)
+    utils.gems_assert_close(
+        res_norm_out, ref_norm_out, torch.float32, reduce_dim=reduce_size
+    )
 
 
 @pytest.mark.weight_norm_interface_backward


### PR DESCRIPTION
Allocate norm as float32 instead of inheriting input dtype. When input is float16/bfloat16, the reduced-precision norm causes large errors in the backward pass (`1/norm³` amplifies truncation). PyTorch native always returns norm in float32; the fused path already does this correctly.

Update test assertion to compare norm as float32.

Fixes #4381