### PR TITLE
Widen normal distribution test tolerance to reduce flakiness

### DIFF
--- a/tests/test_normal.py
+++ b/tests/test_normal.py
@@ -30,8 +30,8 @@ def test_normal_(shape, dtype):
     mean = torch.mean(ref_out)
     std = torch.std(ref_out)
 
-    assert torch.abs(mean - 3.0) < 0.1
-    assert torch.abs(std - 10.0) < 0.1
+    assert torch.abs(mean - 3.0) < 0.2
+    assert torch.abs(std - 10.0) < 0.2
 
 
 @pytest.mark.normal_float_tensor
@@ -56,8 +56,8 @@ def test_normal_float_tensor(shape, dtype):
     mean = torch.mean(ref_out)
     std = torch.std(ref_out)
 
-    assert torch.abs(mean - 3.0) < 0.1
-    assert torch.abs(std - 10.0) < 0.1
+    assert torch.abs(mean - 3.0) < 0.2
+    assert torch.abs(std - 10.0) < 0.2
 
 
 @pytest.mark.normal_tensor_float
@@ -81,8 +81,8 @@ def test_normal_tensor_float(shape, dtype):
     mean = torch.mean(ref_out)
     std = torch.std(ref_out)
 
-    assert torch.abs(mean - 3.0) < 0.1
-    assert torch.abs(std - 10.0) < 0.1
+    assert torch.abs(mean - 3.0) < 0.2
+    assert torch.abs(std - 10.0) < 0.2
 
 
 @pytest.mark.normal_tensor_tensor
@@ -107,5 +107,5 @@ def test_normal_tensor_tensor(shape, dtype):
     mean = torch.mean(ref_out)
     std = torch.std(ref_out)
 
-    assert torch.abs(mean - 3.0) < 0.1
-    assert torch.abs(std - 10.0) < 0.1
+    assert torch.abs(mean - 3.0) < 0.2
+    assert torch.abs(std - 10.0) < 0.2


### PR DESCRIPTION
The threshold of 0.1 with N=96,000 samples from Normal(3, 10) is only ~3.1σ, causing ~0.19% failure probability per assertion. With 8 assertions across 4 test functions, sporadic CI failures are expected.

Widen to 0.2 (~6.2σ) which effectively eliminates false failures while still catching genuine bugs.

Fixes #4385