### PR TITLE
Improve setup logic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -195,12 +195,16 @@ Repository = "https://github.com/flagos-ai/FlagGems"
 Documentation = "https://flagos-ai.github.io/FlagGems"
 "Bug Tracker" = "https://github.com/flagos-ai/FlagGems/issues"
 
+[project.scripts]
+flaggems-setup = "flag_gems._setup:main"
+
 [tool.setuptools.packages.find]
 
 where = ["src"]
 
 [tool.setuptools.package-data]
 
+"flag_gems" = ["backends.yaml"]
 "flag_gems.runtime" = ["*/**/*.yaml"]
 
 [tool.scikit-build]

--- a/setup.sh
+++ b/setup.sh
@@ -1,40 +1,6 @@
 #!/bin/bash
 set -euo pipefail
 
-SUPPORTED_VENDORS=(
-  "ascend-cann850"
-  "ascend-cann900"
-  "cambricon"
-  "enflame"
-  "hygon"
-  "iluvatar"
-  "kunlunxin"
-  "metax"
-  "mthreads"
-  "nvidia"
-  "spacemit"
-  "sunrise"
-  "thead"
-  "tsingmicro"
-)
-
-declare -A PYTHON_SUPPORTED=(
-  ["ascend-cann850"]="3.11"
-  ["ascend-cann900"]="3.11"
-  ["cambricon"]="3.10"
-  ["enflame"]="3.12"
-  ["hygon"]="3.10"
-  ["iluvatar"]="3.10"
-  ["kunlunxin"]="3.10"
-  ["metax"]="3.12"
-  ["mthreads"]="3.10"
-  ["nvidia"]="3.12"
-  ["spacemit"]="3.12"
-  ["sunrise"]="3.10"
-  ["thead"]="3.12"
-  ["tsingmicro"]="3.10"
-)
-
 RED='\033[0;31m'
 GREEN='\033[0;32m'
 NC='\033[0m'
@@ -42,27 +8,48 @@ NC='\033[0m'
 ok()   { printf " ${GREEN}[OK]${NC}\n"; }
 fail() { printf " ${RED}[FAILED]${NC}\n"; exit 1; }
 
-valid_vendor() {
-  local needle=$1
-  for item in "${SUPPORTED_VENDORS[@]}"; do
-    [ "$item" == "$needle" ] && return 0
-  done
-  return 1
-}
+BACKENDS_YAML="src/flag_gems/backends.yaml"
 
 # ── Validate argument ─────────────────────────────────────────
-[ "$#" -eq 1 ] || { echo "Usage: $0 <VENDOR>"; exit 1; }
+[ "$#" -eq 1 ] || { echo "Usage: $0 <BACKEND>"; exit 1; }
 
-VENDOR=${1}
-valid_vendor "$VENDOR" || {
-  echo "Invalid vendor '${VENDOR}'"
-  echo "Supported: ${SUPPORTED_VENDORS[*]}"
+BACKEND="${1}"
+
+# ── Read config from backends.yaml ────────────────────────────
+if [ ! -f "$BACKENDS_YAML" ]; then
+  echo "Error: $BACKENDS_YAML not found. Run from the FlagGems repo root."
   exit 1
-}
-printf "Vendor: ${VENDOR}"
-ok
+fi
 
-PYTHON_VERSION=${PYTHON_SUPPORTED[$VENDOR]}
+eval $(python3 -c "
+import yaml, sys, json
+
+cfg = yaml.safe_load(open('${BACKENDS_YAML}'))
+key = '${BACKEND}'
+
+if key not in cfg['backends']:
+    avail = ', '.join(cfg['backends'].keys())
+    print(f'echo \"Unknown backend: {key}\"; echo \"Available: {avail}\"; exit 1')
+    sys.exit()
+
+b = cfg['backends'][key]
+vendor = key.rsplit('-', 1)[0] if '-' in key else key
+index_url = b.get('index') or cfg['pypi_base'].format(vendor=vendor)
+
+print(f'PYTHON_VERSION={b[\"python\"]}')
+print(f'VENDOR={vendor}')
+print(f'FLAGOS_PYPI={index_url}')
+print(f'MIRROR={cfg[\"mirror\"]}')
+
+# Encode deps and post_install as space-separated strings
+deps = ' '.join(b.get('deps', []))
+post = ' '.join(b.get('post_install', []))
+print(f'BACKEND_DEPS=\"{deps}\"')
+print(f'POST_INSTALL=\"{post}\"')
+")
+
+printf "Backend: ${BACKEND} (vendor: ${VENDOR})"
+ok
 
 # ── Detect or install uv ─────────────────────────────────────
 UV_VERSION="0.11.22"
@@ -74,7 +61,6 @@ if command -v uv &>/dev/null; then
   ok
 else
   printf " not found, installing ...\n"
-  # Ensure HOME is correct — some runners inherit HOME=/root from sudo
   export HOME=$(eval echo ~"$(whoami)")
   ARCH=$(uname -m)
   mkdir -p "$HOME/.local/bin"
@@ -103,15 +89,7 @@ ok
 
 # ── Source vendor environment ─────────────────────────────────
 export USE_TRITON="${USE_TRITON:-}"
-source tools/env.sh "${VENDOR}"
-
-# ── FLAGOS PyPI index ─────────────────────────────────────────
-PYPI_VENDOR=${VENDOR}
-if [[ "$VENDOR" == ascend-* ]]; then
-  PYPI_VENDOR="ascend"
-fi
-export FLAGOS_PYPI="https://resource.flagos.net/repository/flagos-pypi-${PYPI_VENDOR}/simple"
-ALIYUN_PYPI="https://mirrors.aliyun.com/pypi/simple"
+source tools/env.sh "${BACKEND}"
 
 # ── Install build tools ──────────────────────────────────────
 printf "Installing build tools ..."
@@ -121,35 +99,35 @@ uv pip install -q \
   "pybind11==3.0.3" \
   "cmake>=3.20,<4" \
   "ninja==1.13.0" \
-  --index "${ALIYUN_PYPI}" \
+  --index "${MIRROR}" \
   || fail
 ok
 
 # ── Install FlagGems ──────────────────────────────────────────
-printf "Installing FlagGems [${VENDOR}] ..."
-uv pip install ".[${VENDOR}]" \
+printf "Installing FlagGems [${BACKEND}] ..."
+uv pip install ".[${BACKEND}]" \
   --default-index "${FLAGOS_PYPI}" \
-  --index https://mirrors.aliyun.com/pypi/simple \
+  --index "${MIRROR}" \
   || fail
 ok
 
 # ── Vendor-specific post-install ──────────────────────────────
-if [ "$VENDOR" = "ascend-cann900" ]; then
-  printf "Overriding triton with triton-ascend 3.2.1 ..."
-  uv pip install -q "triton-ascend==3.2.1" --index "${FLAGOS_PYPI}" || fail
-  ok
+if [ -n "${POST_INSTALL}" ]; then
+  for pkg in ${POST_INSTALL}; do
+    printf "Post-install: ${pkg} ..."
+    uv pip install -q "${pkg}" --default-index "${FLAGOS_PYPI}" || fail
+    ok
+  done
 fi
 
-if [ "$VENDOR" = "kunlunxin" ]; then
-  printf "Replacing triton with Kunlunxin override ..."
-  uv pip install -q "triton==3.0.0+a48aedef" --index "${FLAGOS_PYPI}" || fail
+# Kunlunxin-specific cleanup
+if [ "$BACKEND" = "kunlunxin" ]; then
   uv pip uninstall -q pytest-repeat 2>/dev/null || true
-  ok
 fi
 
 # ── Install test dependencies ─────────────────────────────────
 printf "Installing test dependencies ..."
-uv pip install -q ".[test]" --index "${ALIYUN_PYPI}" || fail
+uv pip install -q ".[test]" --index "${MIRROR}" || fail
 ok
 
-printf "\n${GREEN}FlagGems setup complete for ${VENDOR}${NC}\n"
+printf "\n${GREEN}FlagGems setup complete for ${BACKEND}${NC}\n"

--- a/src/flag_gems/_setup.py
+++ b/src/flag_gems/_setup.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""flaggems-setup — Install vendor-specific dependencies for FlagGems.
+
+Usage:
+    flaggems-setup <backend>          # e.g. nvidia, ascend-cann900
+    flaggems-setup --list             # show available backends
+    flaggems-setup <backend> --dry-run # show what would be installed
+"""
+import argparse
+import shutil
+import subprocess
+import sys
+from importlib.resources import files
+from pathlib import Path
+
+import yaml
+
+
+def load_config():
+    """Load backends.yaml from the installed package."""
+    try:
+        data = files("flag_gems").joinpath("backends.yaml").read_text()
+    except Exception:
+        # Fallback: try loading from source tree
+        p = Path(__file__).parent / "backends.yaml"
+        if not p.exists():
+            print("Error: backends.yaml not found", file=sys.stderr)
+            sys.exit(1)
+        data = p.read_text()
+    return yaml.safe_load(data)
+
+
+def derive_vendor(backend_key):
+    """Derive vendor name from backend key.
+
+    'ascend-cann900' → 'ascend'
+    'nvidia'         → 'nvidia'
+    """
+    return backend_key.rsplit("-", 1)[0] if "-" in backend_key else backend_key
+
+
+def get_index_url(vendor, cfg):
+    """Generate the PyPI index URL for a vendor."""
+    return cfg["pypi_base"].format(vendor=vendor)
+
+
+def detect_pip():
+    """Detect available pip command: prefer 'uv pip', fall back to 'pip'."""
+    if shutil.which("uv"):
+        return ["uv", "pip"]
+    if shutil.which("pip"):
+        return ["pip"]
+    print("Error: neither 'uv' nor 'pip' found in PATH", file=sys.stderr)
+    sys.exit(1)
+
+
+def run(cmd, dry_run=False):
+    """Run a command, or print it if dry_run."""
+    cmd_str = " ".join(cmd)
+    if dry_run:
+        print(f"  [dry-run] {cmd_str}")
+        return
+    print(f"  $ {cmd_str}")
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        print(
+            f"Error: command failed with exit code {result.returncode}", file=sys.stderr
+        )
+        sys.exit(result.returncode)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        prog="flaggems-setup",
+        description="Install vendor-specific dependencies for FlagGems.",
+    )
+    parser.add_argument(
+        "backend",
+        nargs="?",
+        help="Backend to install (e.g. nvidia, ascend-cann900)",
+    )
+    parser.add_argument("--list", action="store_true", help="List available backends")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Show commands without executing"
+    )
+    parser.add_argument(
+        "--pip", default=None, help="pip command to use (default: auto-detect)"
+    )
+    args = parser.parse_args()
+
+    cfg = load_config()
+
+    if args.list:
+        print("Available backends:\n")
+        for key, info in cfg["backends"].items():
+            vendor = derive_vendor(key)
+            n_deps = len(info.get("deps", []))
+            post = " + post_install" if info.get("post_install") else ""
+            print(
+                f"  {key:<20s}  python={info['python']}  vendor={vendor}  ({n_deps} deps{post})"
+            )
+        return
+
+    if not args.backend:
+        parser.print_help()
+        sys.exit(1)
+
+    backend_key = args.backend
+    if backend_key not in cfg["backends"]:
+        print(f"Error: unknown backend '{backend_key}'", file=sys.stderr)
+        print("Run 'flaggems-setup --list' to see available backends.", file=sys.stderr)
+        sys.exit(1)
+
+    backend = cfg["backends"][backend_key]
+    vendor = derive_vendor(backend_key)
+    index = backend.get("index") or get_index_url(vendor, cfg)
+    mirror = cfg["mirror"]
+    deps = backend.get("deps", [])
+    post_install = backend.get("post_install", [])
+    pip = args.pip.split() if args.pip else detect_pip()
+
+    print(f"Backend:  {backend_key}")
+    print(f"Vendor:   {vendor}")
+    print(f"Python:   {backend['python']}")
+    print(f"Index:    {index}")
+    print(f"Mirror:   {mirror}")
+    print(f"Deps:     {len(deps)} packages")
+    print()
+
+    # Step 1: Install vendor deps (no transitive deps)
+    print("[Step 1] Installing vendor packages (--no-deps) ...")
+    run(
+        [*pip, "install", "--no-deps", "--index-url", index, *deps],
+        dry_run=args.dry_run,
+    )
+    print()
+
+    # Step 2: Install transitive deps from mirror
+    print("[Step 2] Installing transitive dependencies ...")
+    run([*pip, "install", "--index-url", mirror, *deps], dry_run=args.dry_run)
+    print()
+
+    # Step 3: Post-install overrides
+    if post_install:
+        print("[Step 3] Post-install overrides ...")
+        for pkg in post_install:
+            run([*pip, "install", "--index-url", index, pkg], dry_run=args.dry_run)
+        print()
+
+    print(f"✅ FlagGems vendor dependencies installed for {backend_key}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -1,0 +1,142 @@
+# FlagGems Backend Configuration
+#
+# Single source of truth for all vendor/backend dependencies.
+# Used by: setup.sh, flaggems-setup CLI, CI workflows.
+#
+# Vendor is derived from the backend key: everything before the last '-'.
+# e.g. "ascend-cann900" → vendor "ascend"
+# Single-segment keys (e.g. "nvidia") use the whole key as vendor.
+#
+# The PyPI index URL is auto-generated:
+#   pypi_base.format(vendor=<derived_vendor>)
+# Override per-backend with an explicit "index:" field if needed.
+
+pypi_base: "https://resource.flagos.net/repository/flagos-pypi-{vendor}/simple"
+mirror: "https://mirrors.aliyun.com/pypi/simple"
+
+backends:
+  ascend-cann850:
+    python: "3.11"
+    deps:
+      - torch==2.9.0+cpu
+      - torch-npu==2.9.0
+      - flagtree==0.5.0+ascend3.2
+
+  ascend-cann900:
+    python: "3.11"
+    deps:
+      - torch==2.10.0+cpu
+      - torch-npu==2.10.0
+      - triton==3.5.0
+    post_install:
+      - triton-ascend==3.2.1
+
+  cambricon:
+    python: "3.10"
+    deps:
+      - cambricon_dali==0.13.0
+      - torch==2.7.1+cpu
+      - torch-mlu==1.29.2+torch2.7.1
+      - torch-mlu-ops==1.8.0+torch2.7.1
+      - triton==3.2.0+mlu1.7.2
+
+  enflame:
+    python: "3.12"
+    deps:
+      - pyefml==1.9.10
+      - torch==2.10.0+cpu
+      - torchaudio==2.10.0+cpu
+      - torchvision==0.25.0+cpu
+      - torch-gcu==2.10.0+3.7.20260408
+      - triton-gcu==3.6.0+1.0.20260521.cc.1.9.10
+      - flash-attn==2.7.2+torch.2.9.1.gcu.3.4.20260323
+
+  hygon:
+    python: "3.10"
+    deps:
+      - torch==2.9.0+das.opt1.dtk2604
+      - flagtree==0.5.0+hcu3.0
+
+  iluvatar:
+    python: "3.10"
+    deps:
+      - torch==2.7.1+corex.4.4.0
+      - torchaudio==2.7.1+corex.4.4.0
+      - torchvision==0.22.1+corex.4.4.0
+      - triton==3.1.0+corex.4.4.0
+
+  kunlunxin:
+    python: "3.10"
+    deps:
+      - apex==0.1
+      - benchflow==1.0.0
+      - colorama==0.4.6
+      - flash_attn==2.4.2+7e2dd4d
+      - hydrax==0.1.0
+      - hyperparameter==0.5.6
+      - psutil==6.1.0
+      - regex==2026.4.4
+      - torch==2.9.0+cu129
+      - torchaudio==2.9.0+cu129
+      - torchvision==0.24.0+cu129
+      - torch_plugin==0.1.0
+      - torch_xray==2.0.4
+      - xformers==0.0.29+1e7a8ec.d20260114
+      - xmlir==1.0.0.1
+    post_install:
+      - triton==3.0.0+a48aedef
+
+  metax:
+    python: "3.12"
+    deps:
+      - torch==2.8.0+metax3.7.2.0
+      - torchaudio==2.4.1+metax3.7.2.0
+      - torchvision==0.15.1+metax3.7.2.0
+      - flagtree==3.1.0+metax3.7.2.0
+      - flash_attn==2.6.3+metax3.7.2.0torch2.8
+
+  mthreads:
+    python: "3.10"
+    deps:
+      - torch==2.9.0+musa.4.3.6
+      - torch_musa==2.9.0
+      - triton==3.6.0+git89458660
+      - mkl==2024.0.0
+
+  nvidia:
+    python: "3.12"
+    deps:
+      - torch==2.11.0+cu130
+      - torchvision==0.26.0+cu130
+      - triton==3.6.0
+
+  spacemit:
+    python: "3.12"
+    deps:
+      - torch==2.8.0+spacemit.0
+      - triton==3.6.0+spacemit.a5
+
+  sunrise:
+    python: "3.10"
+    deps:
+      - torch==2.11.0+cpu
+      - torchaudio==2.11.0+cpu
+      - torchvision==0.26.0+cpu
+      - torch-ptpu==0.2.1+gaf2c267.torch2.11
+      - triton==3.4.0.6+gite4f6d6e4
+
+  thead:
+    python: "3.12"
+    deps:
+      - torch==2.9.0+ppu2.0.0.oe
+      - triton==3.5.0+ppu2.0.0.oe
+
+  tsingmicro:
+    python: "3.10"
+    deps:
+      - torch==2.7.0+cpu
+      - torchvision==0.22.0+cpu
+      - torchaudio==2.7.0+cpu
+      - torch_txda==0.1.0+20260610.3968e515
+      - txops==0.1.0+20260508.60287151
+      - flagtree==0.5.0.post20260612+git705a4064


### PR DESCRIPTION
### PR Category

User Experience

### Type of Change

New Feature

### Outline

Primary changes:

- Adds a `backends.yaml` file as central storage for backend related setup data.
- Adds a `_setup.py` as the `flaggems_setup` CLI entry point, for installing dependencies after shallow install.
- Revises the `setup.sh` script by removing hardcoded data and post-install steps.

Major scenarios supported:

- For developers:

  ```shell
  git clone https://github.com/flagos-ai/FlagGems
  setup.sh <backend>
  ```

- For end users using the downloaded wheel package (on baremetal or in container):

  ```
  pip install flag_gems
  flaggems-setup <backend>
  ```

- For developers building a container image:

  ```
  pip install flag_gems
  flaggems-setup <backend>
  ```

This is a first step towards a unified, generic setup experience.

