### PR TITLE
Improve support to C++ operators

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -22,7 +22,7 @@ if [ ! -f "$BACKENDS_YAML" ]; then
 fi
 
 eval $(python3 -c "
-import yaml, sys, json
+import yaml, sys
 
 cfg = yaml.safe_load(open('${BACKENDS_YAML}'))
 key = '${BACKEND}'
@@ -41,11 +41,22 @@ print(f'VENDOR={vendor}')
 print(f'FLAGOS_PYPI={index_url}')
 print(f'MIRROR={cfg[\"mirror\"]}')
 
-# Encode deps and post_install as space-separated strings
 deps = ' '.join(b.get('deps', []))
-post = ' '.join(b.get('post_install', []))
 print(f'BACKEND_DEPS=\"{deps}\"')
-print(f'POST_INSTALL=\"{post}\"')
+
+# Encode post_install: split into install and uninstall lists
+post_install = []
+post_uninstall = []
+for item in b.get('post_install', []):
+    if isinstance(item, dict) and 'uninstall' in item:
+        post_uninstall.append(item['uninstall'])
+    else:
+        post_install.append(item)
+print(f'POST_INSTALL=\"{\" \".join(post_install)}\"')
+print(f'POST_UNINSTALL=\"{\" \".join(post_uninstall)}\"')
+
+cmake_backend = b.get('cmake_backend', '')
+print(f'CMAKE_BACKEND={cmake_backend}')
 ")
 
 printf "Backend: ${BACKEND} (vendor: ${VENDOR})"
@@ -103,9 +114,29 @@ uv pip install -q \
   || fail
 ok
 
+# ── C++ extensions ───────────────────────────────────────────
+# Set ENABLE_CPP=1 to build C++ wrapped operators.
+# Default: OFF (C++ extensions require vendor SDK and toolchain).
+if [ "${ENABLE_CPP:-0}" = "1" ]; then
+  if [ -z "${CMAKE_BACKEND}" ]; then
+    echo "Error: ENABLE_CPP=1 but backend '${BACKEND}' does not support C++ extensions"
+    exit 1
+  fi
+  export CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=${CMAKE_BACKEND}"
+  printf "C++ extensions: ON (${CMAKE_BACKEND})"
+  ok
+else
+  printf "C++ extensions: OFF"
+  ok
+fi
+
 # ── Install FlagGems ──────────────────────────────────────────
+# Use --no-build-isolation so the build process reuses the build tools
+# already installed in the current venv (setuptools, scikit-build-core, etc.)
+# This is safe for all backends — when CMAKE_ARGS is not set, C++ extensions
+# are not built and cmake/ninja are not invoked.
 printf "Installing FlagGems [${BACKEND}] ..."
-uv pip install ".[${BACKEND}]" \
+uv pip install --no-build-isolation ".[${BACKEND}]" \
   --default-index "${FLAGOS_PYPI}" \
   --index "${MIRROR}" \
   || fail
@@ -120,9 +151,12 @@ if [ -n "${POST_INSTALL}" ]; then
   done
 fi
 
-# Kunlunxin-specific cleanup
-if [ "$BACKEND" = "kunlunxin" ]; then
-  uv pip uninstall -q pytest-repeat 2>/dev/null || true
+if [ -n "${POST_UNINSTALL}" ]; then
+  for pkg in ${POST_UNINSTALL}; do
+    printf "Post-uninstall: ${pkg} ..."
+    uv pip uninstall -q "${pkg}" 2>/dev/null || true
+    ok
+  done
 fi
 
 # ── Install test dependencies ─────────────────────────────────

--- a/src/flag_gems/_setup.py
+++ b/src/flag_gems/_setup.py
@@ -142,12 +142,24 @@ def main():
 
     # Step 3: Post-install overrides
     if post_install:
-        print("[Step 3] Post-install overrides ...")
-        for pkg in post_install:
-            run([*pip, "install", "--index-url", index, pkg], dry_run=args.dry_run)
-        print()
+        installs = [p for p in post_install if not isinstance(p, dict)]
+        uninstalls = [
+            p["uninstall"]
+            for p in post_install
+            if isinstance(p, dict) and "uninstall" in p
+        ]
+        if installs:
+            print("[Step 3] Post-install overrides ...")
+            for pkg in installs:
+                run([*pip, "install", "--index-url", index, pkg], dry_run=args.dry_run)
+            print()
+        if uninstalls:
+            print("[Step 3] Post-install uninstalls ...")
+            for pkg in uninstalls:
+                run([*pip, "uninstall", "-y", pkg], dry_run=args.dry_run)
+            print()
 
-    print(f"✅ FlagGems vendor dependencies installed for {backend_key}")
+    print(f"FlagGems vendor dependencies installed for {backend_key}")
 
 
 if __name__ == "__main__":

--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -10,6 +10,11 @@
 # The PyPI index URL is auto-generated:
 #   pypi_base.format(vendor=<derived_vendor>)
 # Override per-backend with an explicit "index:" field if needed.
+#
+# cmake_backend: maps to FLAGGEMS_BACKEND in CMakeLists.txt.
+# Only present for backends that support C++ extensions.
+# When set, setup.sh passes -DFLAGGEMS_BUILD_C_EXTENSIONS=ON
+# -DFLAGGEMS_BACKEND=<value> to cmake via CMAKE_ARGS.
 
 pypi_base: "https://resource.flagos.net/repository/flagos-pypi-{vendor}/simple"
 mirror: "https://mirrors.aliyun.com/pypi/simple"
@@ -17,6 +22,7 @@ mirror: "https://mirrors.aliyun.com/pypi/simple"
 backends:
   ascend-cann850:
     python: "3.11"
+    cmake_backend: NPU
     deps:
       - torch==2.9.0+cpu
       - torch-npu==2.9.0
@@ -24,6 +30,7 @@ backends:
 
   ascend-cann900:
     python: "3.11"
+    cmake_backend: NPU
     deps:
       - torch==2.10.0+cpu
       - torch-npu==2.10.0
@@ -42,6 +49,7 @@ backends:
 
   enflame:
     python: "3.12"
+    cmake_backend: GCU
     deps:
       - pyefml==1.9.10
       - torch==2.10.0+cpu
@@ -59,6 +67,7 @@ backends:
 
   iluvatar:
     python: "3.10"
+    cmake_backend: IX
     deps:
       - torch==2.7.1+corex.4.4.0
       - torchaudio==2.7.1+corex.4.4.0
@@ -85,6 +94,7 @@ backends:
       - xmlir==1.0.0.1
     post_install:
       - triton==3.0.0+a48aedef
+      - uninstall: pytest-repeat
 
   metax:
     python: "3.12"
@@ -97,6 +107,7 @@ backends:
 
   mthreads:
     python: "3.10"
+    cmake_backend: MUSA
     deps:
       - torch==2.9.0+musa.4.3.6
       - torch_musa==2.9.0
@@ -105,6 +116,7 @@ backends:
 
   nvidia:
     python: "3.12"
+    cmake_backend: CUDA
     deps:
       - torch==2.11.0+cu130
       - torchvision==0.26.0+cu130


### PR DESCRIPTION
### PR Category

User Experience

### Type of Change

New Feature

### Description

Improve setup logic to better support C++ operators for developers and CI auto-deploy.
The C++ operator support (default to off) can be enabled using `ENABLE_CPP=1` before invoking `setup.sh <vendor>`. The backend support facts are encoded in the backends.yaml file now.
Fixed the `uv pip install ".[${VENDOR}]"` command to use `--no-build-isolation` which has no side-effect even if 1) no C++ operator support exists; 2) C++ operator support has been manually disabled (for speedup setting or debugging purpose).

This PR also formalizes the `setup.sh` by moving post-install operations (specific to Kunlunxin at the moment) to `backends.yaml`. 