### PR TITLE
Update configuration for enflame backend

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ enflame = [
     "torch-gcu==2.10.0+3.7.20260408",
     "triton-gcu==3.6.0+1.0.20260521.cc.1.9.10",
     "flash-attn==2.7.2+torch.2.9.1.gcu.3.4.20260323",
-    #"flagtree==0.5.0+enflame.gitadb592d5",
+    "flagtree==0.6.0+enflame3.6",
 ]
 
 hygon = [

--- a/tools/env.sh
+++ b/tools/env.sh
@@ -26,6 +26,12 @@ case $BACKEND in
     export PATH=/usr/local/neuware/bin:$PATH
     export LD_LIBRARY_PATH=/usr/local/neuware/lib64:$LD_LIBRARY_PATH
     ;;
+  enflame)
+    # gcc-toolset-14 provides GLIBCXX_3.4.32+ required by some packages
+    if [ -d /opt/OpenCloudOS/gcc-toolset-14/root/usr/lib64 ]; then
+      export LD_LIBRARY_PATH=/opt/OpenCloudOS/gcc-toolset-14/root/usr/lib64:$LD_LIBRARY_PATH
+    fi
+    ;;
   hygon)
     source /opt/dtk-26.04/env.sh
     echo "PATH=$PATH"


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Update

### Description

The flagtree `0.6.0+enflame3.6` version is available and verified on the enflame backend. The new requirement is that gcc/g++ version has to be 13.0+. This is resolved by installing `gcc-toolset-14-c++` on the host, and then export `LD_LIBRARY_PATH`.