### PR TITLE
Separate compiler selection from deps in backends.yaml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,14 +55,13 @@ dependencies = [
 ascend-cann850 = [
     "torch==2.9.0+cpu",
     "torch-npu==2.9.0",
-    "flagtree==0.5.0+ascend3.2",
+    "flagtree==0.6.0+ascend3.2",
 ]
 
 ascend-cann900 = [
     "torch==2.10.0+cpu",
     "torch-npu==2.10.0",
-    "triton==3.5.0",
-    # "triton-ascend==3.2.1",
+    "flagtree==0.6.0+ascend3.5",
 ]
 
 cambricon = [
@@ -86,7 +85,7 @@ enflame = [
 
 hygon = [
     "torch==2.9.0+das.opt1.dtk2604",
-    "flagtree==0.5.0+hcu3.0",
+    "flagtree==0.5.1+hcu3.1",
 ]
 
 iluvatar = [

--- a/setup.sh
+++ b/setup.sh
@@ -44,7 +44,19 @@ print(f'MIRROR={cfg[\"mirror\"]}')
 deps = ' '.join(b.get('deps', []))
 print(f'BACKEND_DEPS=\"{deps}\"')
 
-# Encode post_install: split into install and uninstall lists
+cmake_backend = b.get('cmake_backend', '')
+print(f'CMAKE_BACKEND={cmake_backend}')
+
+ft = b.get('flagtree', '')
+if isinstance(ft, list):
+    ft = ' '.join(ft)
+print(f'FLAGTREE_PKGS=\"{ft}\"')
+
+tr = b.get('triton', '')
+if isinstance(tr, list):
+    tr = ' '.join(tr)
+print(f'TRITON_PKGS=\"{tr}\"')
+
 post_install = []
 post_uninstall = []
 for item in b.get('post_install', []):
@@ -54,9 +66,6 @@ for item in b.get('post_install', []):
         post_install.append(item)
 print(f'POST_INSTALL=\"{\" \".join(post_install)}\"')
 print(f'POST_UNINSTALL=\"{\" \".join(post_uninstall)}\"')
-
-cmake_backend = b.get('cmake_backend', '')
-print(f'CMAKE_BACKEND={cmake_backend}')
 ")
 
 printf "Backend: ${BACKEND} (vendor: ${VENDOR})"
@@ -132,15 +141,58 @@ fi
 
 # ── Install FlagGems ──────────────────────────────────────────
 # Use --no-build-isolation so the build process reuses the build tools
-# already installed in the current venv (setuptools, scikit-build-core, etc.)
-# This is safe for all backends — when CMAKE_ARGS is not set, C++ extensions
-# are not built and cmake/ninja are not invoked.
+# already installed in the current venv.
 printf "Installing FlagGems [${BACKEND}] ..."
 uv pip install --no-build-isolation ".[${BACKEND}]" \
   --default-index "${FLAGOS_PYPI}" \
   --index "${MIRROR}" \
   || fail
 ok
+
+# ── Compiler selection ───────────────────────────────────────
+# COMPILER controls which Triton-compatible compiler to use:
+#   COMPILER=flagtree → use FlagTree (default when available)
+#   COMPILER=triton   → use vendor Triton
+#   unset             → auto: FlagTree if available, otherwise Triton
+COMPILER="${COMPILER:-}"
+
+if [ -z "${COMPILER}" ]; then
+  if [ -n "${FLAGTREE_PKGS}" ]; then
+    COMPILER=flagtree
+  else
+    COMPILER=triton
+  fi
+fi
+
+if [ "${COMPILER}" = "flagtree" ]; then
+  if [ -n "${FLAGTREE_PKGS}" ]; then
+    # FlagTree installs into site-packages/triton, so any existing
+    # triton-prefixed packages must be removed first.
+    TRITON_INSTALLED=$(uv pip list 2>/dev/null | awk '{print $1}' | grep -i '^triton' || true)
+    if [ -n "${TRITON_INSTALLED}" ]; then
+      printf "Replacing Triton with FlagTree ..."
+      echo "${TRITON_INSTALLED}" | xargs uv pip uninstall -q 2>/dev/null || true
+      ok
+    fi
+    printf "Installing FlagTree ..."
+    uv pip install -q ${FLAGTREE_PKGS} --default-index "${FLAGOS_PYPI}" || fail
+    ok
+  else
+    printf "FlagTree not available for ${BACKEND}, using Triton\n"
+    COMPILER=triton
+  fi
+fi
+
+if [ "${COMPILER}" = "triton" ] && [ -n "${TRITON_PKGS}" ]; then
+  printf "Installing Triton ..."
+  uv pip install -q ${TRITON_PKGS} --default-index "${FLAGOS_PYPI}" || fail
+  ok
+fi
+
+if [ "${COMPILER}" != "flagtree" ] && [ "${COMPILER}" != "triton" ]; then
+  echo "Error: unknown COMPILER value '${COMPILER}' (expected 'flagtree' or 'triton')"
+  exit 1
+fi
 
 # ── Vendor-specific post-install ──────────────────────────────
 if [ -n "${POST_INSTALL}" ]; then

--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -13,69 +13,91 @@
 #
 # cmake_backend: maps to FLAGGEMS_BACKEND in CMakeLists.txt.
 # Only present for backends that support C++ extensions.
-# When set, setup.sh passes -DFLAGGEMS_BUILD_C_EXTENSIONS=ON
-# -DFLAGGEMS_BACKEND=<value> to cmake via CMAKE_ARGS.
+#
+# Compiler packages (triton / flagtree) are NOT in deps.
+# They are installed as a post-install step controlled by the COMPILER
+# environment variable:
+#   COMPILER=flagtree (default when available) or COMPILER=triton
+#
+# "triton:" — vendor-specific Triton packages for this backend
+# "flagtree:" — FlagTree package for this backend (preferred)
 
 pypi_base: "https://resource.flagos.net/repository/flagos-pypi-{vendor}/simple"
 mirror: "https://mirrors.aliyun.com/pypi/simple"
 
 backends:
+  nvidia:
+    python: "3.12"
+    cmake_backend: CUDA
+    triton: triton==3.6.0
+    flagtree: flagtree==0.6.0
+    deps:
+      - torch==2.11.0+cu130
+      - torchvision==0.26.0+cu130
+
   ascend-cann850:
     python: "3.11"
     cmake_backend: NPU
+    triton: triton-ascend==3.2.0
+    flagtree: flagtree==0.6.0+ascend3.2
     deps:
       - torch==2.9.0+cpu
       - torch-npu==2.9.0
-      - flagtree==0.5.0+ascend3.2
 
   ascend-cann900:
     python: "3.11"
     cmake_backend: NPU
+    triton:
+      - triton==3.5.0
+      - triton-ascend==3.2.1
+    flagtree: flagtree==0.6.0+ascend3.5
     deps:
       - torch==2.10.0+cpu
       - torch-npu==2.10.0
-      - triton==3.5.0
-    post_install:
-      - triton-ascend==3.2.1
 
   cambricon:
     python: "3.10"
+    triton: triton==3.2.0+mlu1.7.2
     deps:
       - cambricon_dali==0.13.0
       - torch==2.7.1+cpu
       - torch-mlu==1.29.2+torch2.7.1
       - torch-mlu-ops==1.8.0+torch2.7.1
-      - triton==3.2.0+mlu1.7.2
 
   enflame:
     python: "3.12"
     cmake_backend: GCU
+    triton: triton-gcu==3.6.0+1.0.20260521.cc.1.9.10
+    flagtree: flagtree==0.6.0+enflame3.6
     deps:
       - pyefml==1.9.10
       - torch==2.10.0+cpu
       - torchaudio==2.10.0+cpu
       - torchvision==0.25.0+cpu
       - torch-gcu==2.10.0+3.7.20260408
-      - triton-gcu==3.6.0+1.0.20260521.cc.1.9.10
       - flash-attn==2.7.2+torch.2.9.1.gcu.3.4.20260323
 
   hygon:
     python: "3.10"
+    triton: triton==3.3.0+das.opt1.dtk2604.torch290
+    flagtree: flagtree==0.5.1+hcu3.1
     deps:
       - torch==2.9.0+das.opt1.dtk2604
-      - flagtree==0.5.0+hcu3.0
 
   iluvatar:
     python: "3.10"
     cmake_backend: IX
+    triton: triton==3.1.0+corex.4.4.0
+    flagtree: flagtree==0.5.1+iluvatar3.1
     deps:
       - torch==2.7.1+corex.4.4.0
       - torchaudio==2.7.1+corex.4.4.0
       - torchvision==0.22.1+corex.4.4.0
-      - triton==3.1.0+corex.4.4.0
 
   kunlunxin:
     python: "3.10"
+    triton: triton==3.0.0+a48aedef
+    flagtree: flagtree==0.5.1+xpu3.0
     deps:
       - apex==0.1
       - benchflow==1.0.0
@@ -93,62 +115,57 @@ backends:
       - xformers==0.0.29+1e7a8ec.d20260114
       - xmlir==1.0.0.1
     post_install:
-      - triton==3.0.0+a48aedef
       - uninstall: pytest-repeat
 
   metax:
     python: "3.12"
+    triton: triton==3.0.0+metax3.7.2.0
+    flagtree: flagtree==3.1.0+metax3.7.2.0
     deps:
       - torch==2.8.0+metax3.7.2.0
       - torchaudio==2.4.1+metax3.7.2.0
       - torchvision==0.15.1+metax3.7.2.0
-      - flagtree==3.1.0+metax3.7.2.0
       - flash_attn==2.6.3+metax3.7.2.0torch2.8
 
   mthreads:
     python: "3.10"
     cmake_backend: MUSA
+    triton: triton==3.6.0+git89458660
+    flagtree: flagtree==0.6.0+mthreads3.6
     deps:
       - torch==2.9.0+musa.4.3.6
       - torch_musa==2.9.0
-      - triton==3.6.0+git89458660
       - mkl==2024.0.0
-
-  nvidia:
-    python: "3.12"
-    cmake_backend: CUDA
-    deps:
-      - torch==2.11.0+cu130
-      - torchvision==0.26.0+cu130
-      - triton==3.6.0
 
   spacemit:
     python: "3.12"
+    triton: triton==3.6.0+spacemit.a5
     deps:
       - torch==2.8.0+spacemit.0
-      - triton==3.6.0+spacemit.a5
 
   sunrise:
     python: "3.10"
+    triton: triton==3.4.0.6+gite4f6d6e4
+    flagtree: flagtree==0.4.0+sunrise3.4
     deps:
       - torch==2.11.0+cpu
       - torchaudio==2.11.0+cpu
       - torchvision==0.26.0+cpu
       - torch-ptpu==0.2.1+gaf2c267.torch2.11
-      - triton==3.4.0.6+gite4f6d6e4
 
   thead:
     python: "3.12"
+    triton: triton==3.5.0+ppu2.0.0.oe
     deps:
       - torch==2.9.0+ppu2.0.0.oe
-      - triton==3.5.0+ppu2.0.0.oe
 
   tsingmicro:
     python: "3.10"
+    triton: triton==3.3.0+gitfe2a28fa
+    flagtree: flagtree==0.5.0.post20260612+git705a4064
     deps:
       - torch==2.7.0+cpu
       - torchvision==0.22.0+cpu
       - torchaudio==2.7.0+cpu
       - torch_txda==0.1.0+20260610.3968e515
       - txops==0.1.0+20260508.60287151
-      - flagtree==0.5.0.post20260612+git705a4064


### PR DESCRIPTION
## Summary

- Remove triton/flagtree packages from `deps` in `backends.yaml`; compiler installation is now a post-install step controlled by `COMPILER` env var (`flagtree` by default, `triton` as fallback)
- Add compiler selection logic to `setup.sh`: auto-detect available compiler, uninstall existing triton-prefixed packages before installing FlagTree
- Add `ENABLE_CPP` env var to control C++ extension builds
- Unify `post_install` handling (install + uninstall from yaml)

## pyproject.toml golden config updates

- ascend-cann850: flagtree 0.5.0+ascend3.2 → 0.6.0+ascend3.2
- ascend-cann900: triton 3.5.0 → flagtree 0.6.0+ascend3.5
- hygon: flagtree 0.5.0+hcu3.0 → 0.5.1+hcu3.1

## Compiler selection usage

```bash
# Default: FlagTree (when available for the backend)
./setup.sh nvidia

# Explicit Triton
COMPILER=triton ./setup.sh nvidia

# FlagTree not available → auto fallback to Triton
./setup.sh cambricon
```