### PR TITLE
Drop the non-existent special.gammainc.out operator

### DIFF
--- a/benchmark/test_special_gammainc.py
+++ b/benchmark/test_special_gammainc.py
@@ -1,7 +1,7 @@
 import pytest
 import torch
 
-from . import base, utils
+from . import base
 
 
 @pytest.mark.special_gammainc
@@ -9,25 +9,6 @@ def test_special_gammainc():
     bench = base.BinaryPointwiseBenchmark(
         op_name="special_gammainc",
         torch_op=torch.special.gammainc,
-        # float32 only: gammainc series expansion is numerically unstable in lower precisions
-        dtypes=[torch.float32],
-    )
-    bench.run()
-
-
-def _input_fn_out(shape, dtype, device):
-    x = utils.generate_tensor_input(shape, dtype, device)
-    y = utils.generate_tensor_input(shape, dtype, device)
-    out = torch.empty_like(x)
-    yield x, y, {"out": out}
-
-
-@pytest.mark.special_gammainc_out
-def test_special_gammainc_out():
-    bench = base.GenericBenchmark(
-        op_name="special_gammainc_out",
-        input_fn=_input_fn_out,
-        torch_op=torch.ops.aten.special_gammainc.out,
         # float32 only: gammainc series expansion is numerically unstable in lower precisions
         dtypes=[torch.float32],
     )

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -6946,11 +6946,8 @@ ops:
   - id: special_gammainc
     description: |
       Computes the regularized lower incomplete gamma function P(a, x) element-wise.
-      A variant with output saved to a provided `out` tensor is also registered
-      as `special.gammainc.out`.
     for:
       - special.gammainc
-      - special.gammainc.out
     labels:
       - aten
       - KernelGen

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -601,7 +601,6 @@ _FULL_CONFIG = (
     ("special_hermite_polynomial_h", special_hermite_polynomial_h),
     ("special_chebyshev_polynomial_v", special_chebyshev_polynomial_v),
     ("special.gammainc", special_gammainc),
-    ("special.gammainc.out", special_gammainc),
     ("special_i0e", special_i0e),
     ("special_i0e.out", special_i0e_out),
     ("special_i1", special_i1),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -433,7 +433,7 @@ from flag_gems.ops.softplus import softplus
 from flag_gems.ops.softshrink import softshrink, softshrink_out
 from flag_gems.ops.sort import sort, sort_stable
 from flag_gems.ops.special_chebyshev_polynomial_v import special_chebyshev_polynomial_v
-from flag_gems.ops.special_gammainc import special_gammainc, special_gammainc_out
+from flag_gems.ops.special_gammainc import special_gammainc
 from flag_gems.ops.special_hermite_polynomial_h import special_hermite_polynomial_h
 from flag_gems.ops.special_i0e import special_i0e, special_i0e_out
 from flag_gems.ops.special_i1 import special_i1, special_i1_out
@@ -1027,7 +1027,6 @@ __all__ = [
     "sort_stable",
     "special_chebyshev_polynomial_v",
     "special_gammainc",
-    "special_gammainc_out",
     "special_hermite_polynomial_h",
     "special_i0e",
     "special_i0e_out",

--- a/src/flag_gems/ops/special_gammainc.py
+++ b/src/flag_gems/ops/special_gammainc.py
@@ -170,28 +170,5 @@ def special_gammainc(a: torch.Tensor, x: torch.Tensor, *, out: torch.Tensor = No
             f"gammainc: second input tensor must be on {flag_gems.device} device"
         )
 
-    if out is None:
-        if not a.is_floating_point():
-            a = a.to(torch.get_default_dtype())
-        if not x.is_floating_point():
-            x = x.to(torch.get_default_dtype())
-        out_dtype = torch.promote_types(a.dtype, x.dtype)
-        out = torch.empty_like(a, dtype=out_dtype, device=a.device)
-    else:
-        if out.device.type != flag_gems.device:
-            raise ValueError(
-                f"gammainc_out: output tensor must be on {flag_gems.device} device"
-            )
-        if not out.is_floating_point():
-            raise TypeError("gammainc_out: output tensor must be a floating point type")
-        if a.numel() != x.numel() or a.numel() != out.numel():
-            raise ValueError(
-                "gammainc_out: input and output must have the same number of elements"
-            )
     _launch_gammainc(out, a, x)
     return out
-
-
-def special_gammainc_out(a: torch.Tensor, x: torch.Tensor, out: torch.Tensor):
-    logger.debug("GEMS SPECIAL_GAMMAINC_OUT")
-    return special_gammainc(a, x, out=out)

--- a/tests/test_special_gammainc.py
+++ b/tests/test_special_gammainc.py
@@ -25,27 +25,6 @@ def test_special_gammainc(shape, dtype):
     utils.gems_assert_close(res_out, ref_out, dtype)
 
 
-@pytest.mark.special_gammainc_out
-@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
-# float32 only: gammainc series expansion is numerically unstable in lower precisions
-@pytest.mark.parametrize("dtype", [torch.float32])
-def test_special_gammainc_out(shape, dtype):
-    # Use positive values for gammainc as it's defined for non-negative inputs
-    x = torch.rand(shape, dtype=dtype, device=flag_gems.device) * 10 + 0.1
-    y = torch.rand(shape, dtype=dtype, device=flag_gems.device) * 10 + 0.1
-
-    ref_x = utils.to_reference(x, True)
-    ref_y = utils.to_reference(y, True)
-    ref_out_buf = torch.empty(shape, dtype=ref_x.dtype, device=ref_x.device)
-    ref_out = torch.ops.aten.special_gammainc.out(ref_x, ref_y, out=ref_out_buf)
-
-    res_out_buf = torch.empty(shape, dtype=dtype, device=flag_gems.device)
-    with flag_gems.use_gems():
-        res_out = torch.ops.aten.special_gammainc.out(x, y, out=res_out_buf)
-
-    utils.gems_assert_close(res_out, ref_out, dtype)
-
-
 # Boundary tests for mathematical correctness
 @pytest.mark.special_gammainc
 @pytest.mark.parametrize("dtype", [torch.float32])


### PR DESCRIPTION
### PR Category

Operator

### Type of Change

Bug fix

### Description

In previous PRs, we invented a non-existent operator `special.gammainc.out` that is blocking all PRs after that. The error context is as follows:

```
tests/accuracy_utils.py:277: AssertionError
------------------------------ Captured log call -------------------------------
WARNING  root:error.py:15 Skipped registering operator: This is not allowed since there's already a kernel registered from python overriding log1p's behavior for CUDA dispatch key and aten namespace.
WARNING  root:error.py:15 Skipped registering operator: expected eof but found '.' here:
special.gammainc.out
                ~ <--- HERE
=========================== short test summary info ============================

```