### PR TITLE
Post failure report when on-demand test fails to execute

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -180,3 +180,20 @@ jobs:
           message-path: report.md
           message-id: ${{ needs.preprocess.outputs.op }}-${{ needs.preprocess.outputs.runner }}
           allow-repeats: True
+
+      - id: failure-report
+        if: failure()
+        uses: mshick/add-pr-comment@ec328af66588ab8f77cdeb2c264f14aba45bbf59  # 3.12.0
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          message: |
+            ## ❌ On-demand test failed
+
+            **Operator:** `${{ needs.preprocess.outputs.op }}`
+            **Runner:** `${{ needs.preprocess.outputs.runner }}`
+            **Backend:** ${{ env.BACKEND }}
+
+            The test failed to complete. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
+          message-id: ${{ needs.preprocess.outputs.op }}-${{ needs.preprocess.outputs.runner }}
+          allow-repeats: True


### PR DESCRIPTION
When any step before the test report (setup, checkout, GPU check, etc.) fails, no PR comment is posted — the user only sees a red X with no context.

Add a `failure-report` step with `if: failure()` that posts a brief diagnostic comment including operator name, runner, backend, and a link to the workflow run.