### PR TITLE
Fix check-gpu step and failure-report duplicates in command.yaml

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -125,6 +125,7 @@ jobs:
       - id: check-gpu
         shell: bash
         run: |
+          source .venv/bin/activate
           source tools/env.sh ${BACKEND}
           bash tools/gpu_check_${VENDOR}.sh
 
@@ -196,4 +197,3 @@ jobs:
 
             The test failed to complete. Check the [workflow run](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}) for details.
           message-id: ${{ needs.preprocess.outputs.op }}-${{ needs.preprocess.outputs.runner }}
-          allow-repeats: True


### PR DESCRIPTION
Two fixes:

1. **Activate venv before sourcing env.sh in check-gpu step**: `env.sh` needs `python` on PATH (iluvatar's sysconfig call) and `$VIRTUAL_ENV` (metax, mthreads). Without venv activation, the iluvatar case fails with exit code 127 (`python: command not found`).

2. **Remove `allow-repeats` from failure-report step**: retries were posting duplicate failure comments on the PR. With `message-id` set and no `allow-repeats`, retries update the same comment.

Ref: https://github.com/flagos-ai/FlagGems/actions/runs/28308235181/job/83868242439