### PR TITLE
Fix Iluvatar triton plugin loading in venv

### DIFF
--- a/tools/env.sh
+++ b/tools/env.sh
@@ -45,10 +45,17 @@ case $BACKEND in
     # which use -undefined dynamic_lookup or bundle their own copy.
     # When Python is uv-managed, the shared lib lives outside standard
     # search paths, so we must add it explicitly.
-    PYTHON_LIBDIR=$(python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))" 2>/dev/null)
-    if [ -n "$PYTHON_LIBDIR" ]; then
-      export LD_LIBRARY_PATH=$PYTHON_LIBDIR:$LD_LIBRARY_PATH
+    if command -v python &>/dev/null; then
+      PYTHON_LIBDIR=$(python -c "import sysconfig; print(sysconfig.get_config_var('LIBDIR'))" 2>/dev/null) || true
+      if [ -n "$PYTHON_LIBDIR" ]; then
+        export LD_LIBRARY_PATH=$PYTHON_LIBDIR:$LD_LIBRARY_PATH
+      fi
     fi
+    # Iluvatar's libtriton.so has the plugin search path hardcoded to
+    # /usr/local/lib/python3.10/site-packages/triton/_C at compile time.
+    # Add the venv's triton/_C to LD_LIBRARY_PATH so the plugin is found.
+    SITE_PACKAGES=$VIRTUAL_ENV/lib/python3.10/site-packages
+    export LD_LIBRARY_PATH=${SITE_PACKAGES}/triton/_C:$LD_LIBRARY_PATH
     ;;
   kunlunxin)
     export LD_LIBRARY_PATH=/xcudart/lib:/usr/local/cuda/lib64


### PR DESCRIPTION
Iluvatar's `libtriton.so` has the plugin search path hardcoded to `/usr/local/lib/python3.10/site-packages/triton/_C` at compile time. When running in a venv, the plugin (`iluvatarTritonPlugin.so`) is at `$VIRTUAL_ENV/lib/python3.10/site-packages/triton/_C` instead, causing:

```
Warnings: can not find Plugin.so at default path
Failed to load plugin: /usr/local/lib/python3.10/site-packages/triton/_C/iluvatarTritonPlugin.so: cannot open shared object file
```

Add the venv's `triton/_C` to `LD_LIBRARY_PATH`, following the same pattern used by the mthreads backend.

Also guard the `python` sysconfig call with `command -v` so `env.sh` doesn't fail when sourced before venv activation.

Ref: https://github.com/flagos-ai/FlagGems/actions/runs/28309909620/job/83872801059