### PR TITLE
Split nvidia backend into nvidia-cuda128 and nvidia-cuda133

### DIFF
--- a/.github/backends.json
+++ b/.github/backends.json
@@ -49,7 +49,14 @@
     "enabled": true
   },
   {
-    "vendor": "nvidia",
+    "vendor": "nvidia-cuda128",
+    "runner_label": "h20-cu128",
+    "label": "vendor/NVIDIA",
+    "gpu_check": "tools/gpu_check_nvidia.sh",
+    "enabled": false
+  },
+  {
+    "vendor": "nvidia-cuda133",
     "runner_label": "h20",
     "label": "vendor/NVIDIA",
     "gpu_check": "tools/gpu_check_nvidia.sh",

--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -63,9 +63,14 @@ jobs:
           RUNNER_LABEL: ${{ needs.preprocess.outputs.runner }}
         run: |
           case "${RUNNER_LABEL}" in
-            h20|a100|h100)
+            h20)
               VENDOR="nvidia"
-              BACKEND="nvidia"
+              BACKEND="nvidia-cuda133"
+              ;;
+            a100|h100)
+              # TODO: verify CUDA version on a100/h100, then set correct backend
+              VENDOR="nvidia"
+              BACKEND="nvidia-cuda133"
               ;;
             cann850)
               VENDOR="ascend"
@@ -117,7 +122,7 @@ jobs:
         shell: bash
         run: |
           ./setup.sh ${BACKEND}
-          if [ "${BACKEND}" == "nvidia" ]; then
+          if [ "${BACKEND}" == "nvidia-cuda133" ]; then
             source .venv/bin/activate
             uv pip install vllm==0.21.0 --torch-backend=cu130
           fi

--- a/.github/workflows/random-test.yaml
+++ b/.github/workflows/random-test.yaml
@@ -55,27 +55,45 @@ jobs:
           RUNNER_LABEL: ${{ inputs.runner }}
         run: |
           case "${RUNNER_LABEL}" in
-            h20)       VENDOR="nvidia" ;;
-            cann850)   VENDOR="ascend-cann850" ;;
-            cann9)     VENDOR="ascend-cann900" ;;
-            *)         VENDOR="${RUNNER_LABEL}" ;;
+            h20)
+              VENDOR="nvidia"
+              BACKEND="nvidia-cuda133"
+              ;;
+            a100|h100)
+              VENDOR="nvidia"
+              BACKEND="nvidia-cuda133"
+              ;;
+            cann850)
+              VENDOR="ascend"
+              BACKEND="ascend-cann850"
+              ;;
+            cann9)
+              VENDOR="ascend"
+              BACKEND="ascend-cann900"
+              ;;
+            *)
+              VENDOR="${RUNNER_LABEL}"
+              BACKEND="${RUNNER_LABEL}"
+              ;;
           esac
           echo "VENDOR=${VENDOR}" >> $GITHUB_OUTPUT
           echo "VENDOR=${VENDOR}" >> $GITHUB_ENV
+          echo "BACKEND=${BACKEND}" >> $GITHUB_OUTPUT
+          echo "BACKEND=${BACKEND}" >> $GITHUB_ENV
 
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
         continue-on-error: true
       - uses: ./.github/actions/checkout-retry
       - uses: ./.github/actions/setup-flaggems
         with:
-          vendor: ${{ steps.resolve.outputs.VENDOR }}
+          vendor: ${{ steps.resolve.outputs.BACKEND }}
           gpu_check_script: tools/gpu_check_${{ steps.resolve.outputs.VENDOR }}.sh
 
       - name: Run tests
         shell: bash
         run: |
           source .venv/bin/activate
-          source tools/env.sh ${VENDOR}
+          source tools/env.sh ${BACKEND}
           tools/run_tests.py --ops ${{ inputs.operators }} --gpus ${{ inputs.gpus }}
 
       - name: Upload results

--- a/container/flaggems-nvidia-13.3
+++ b/container/flaggems-nvidia-13.3
@@ -54,7 +54,7 @@ RUN uv pip install --no-cache-dir \
         "pip"
 
 # ── PyTorch + Triton/FlagTree  ─────────────────────────────────
-RUN uv pip install --no-cache-dir ".[nvidia]" \
+RUN uv pip install --no-cache-dir ".[nvidia-cuda133]" \
     --default-index ${FLAGOS_PYPI} \
     --index ${EXTRA_PYPI} \
     --trusted-host resource.flagos.net

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -134,11 +134,18 @@ mthreads = [
     # "flagtree==0.5.1+mthreads3.6",
 ]
 
-nvidia = [
+nvidia-cuda128 = [
+    "torch==2.10.0+cu128",
+    "torchaudio==2.10.0+cu128",
+    "torchvision==0.25.0+cu128",
+    "flagtree==0.6.0",
+]
+
+nvidia-cuda133 = [
     "torch==2.11.0+cu130",
+    "torchaudio==2.11.0+cu130",
     "torchvision==0.26.0+cu130",
-    "triton==3.6.0",
-    # "flagtree==0.5.1+3.6",
+    "flagtree==0.6.0",
 ]
 
 spacemit = [

--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -26,13 +26,24 @@ pypi_base: "https://resource.flagos.net/repository/flagos-pypi-{vendor}/simple"
 mirror: "https://mirrors.aliyun.com/pypi/simple"
 
 backends:
-  nvidia:
+  nvidia-cuda128:
+    python: "3.12"
+    cmake_backend: CUDA
+    triton: triton==3.6.0
+    flagtree: flagtree==0.6.0
+    deps:
+      - torch==2.10.0+cu128
+      - torchaudio==2.10.0+cu128
+      - torchvision==0.25.0+cu128
+
+  nvidia-cuda133:
     python: "3.12"
     cmake_backend: CUDA
     triton: triton==3.6.0
     flagtree: flagtree==0.6.0
     deps:
       - torch==2.11.0+cu130
+      - torchaudio==2.11.0+cu130
       - torchvision==0.26.0+cu130
 
   ascend-cann850:

--- a/tools/env.sh
+++ b/tools/env.sh
@@ -62,7 +62,7 @@ case $BACKEND in
       export LD_LIBRARY_PATH=${SITE_PACKAGES}/triton/backends/metax/lib:$LD_LIBRARY_PATH
     fi
     ;;
-  nvidia)
+  nvidia|nvidia-cuda128|nvidia-cuda133)
     export PATH=/usr/local/cuda/bin:$PATH
     export LD_LIBRARY_PATH=/usr/local/cuda/lib64:$LD_LIBRARY_PATH
     ;;


### PR DESCRIPTION
Follow the same multi-backend pattern used by Ascend (`ascend-cann850` / `ascend-cann900`). This allows supporting different CUDA toolkit versions with their corresponding PyTorch builds on the same vendor. The host driver is backward compatible, so a CUDA 13.3 host can run CUDA 12.8 containers.

### Changes

| File | Change |
|------|--------|
| `pyproject.toml` | `nvidia` → `nvidia-cuda128` + `nvidia-cuda133` (using flagtree) |
| `backends.yaml` | Split into two entries with torchaudio added |
| `backends.json` | `nvidia-cuda128` (disabled) + `nvidia-cuda133` (enabled, h20) |
| `command.yaml` | h20 → `nvidia-cuda133`, vllm check updated |
| `random-test.yaml` | Add proper VENDOR/BACKEND split |
| `env.sh` | `nvidia\|nvidia-cuda128\|nvidia-cuda133` case pattern |
| `container/flaggems-nvidia-13.3` | `.[nvidia]` → `.[nvidia-cuda133]` |

### Notes

- `nvidia-cuda128` is added as `enabled: false` in `backends.json` until a runner is configured
- `random-test.yaml` now separates VENDOR (for `gpu_check_${VENDOR}.sh`) from BACKEND (for `setup.sh` / `env.sh`), consistent with `command.yaml`
- a100/h100 runner labels default to `nvidia-cuda133` with a TODO to verify their CUDA versions