### PR TITLE
Update workflow files to use revised backend labels

### DIFF
--- a/.github/actions/setup-flaggems/action.yml
+++ b/.github/actions/setup-flaggems/action.yml
@@ -3,7 +3,7 @@ description: "Run setup.sh for a vendor and optionally check GPU availability"
 
 inputs:
   vendor:
-    description: "FlagGems vendor name (e.g. nvidia, mthreads, ascend-cann900)"
+    description: "FlagGems backend name (e.g. nvidia-cuda133, mthreads, ascend-cann900)"
     required: true
   gpu_check_script:
     description: "Path to GPU check script (leave empty to skip)"
@@ -18,7 +18,7 @@ runs:
       run: ./setup.sh ${{ inputs.vendor }}
 
     - name: Install vllm (nvidia only)
-      if: inputs.vendor == 'nvidia'
+      if: startsWith(inputs.vendor, 'nvidia')
       shell: bash
       run: |
         source .venv/bin/activate

--- a/.github/workflows/cpp-op-test.yaml
+++ b/.github/workflows/cpp-op-test.yaml
@@ -15,7 +15,7 @@ jobs:
       - uses: ./.github/actions/checkout-retry
       - uses: ./.github/actions/setup-flaggems
         with:
-          vendor: nvidia
+          vendor: nvidia-cuda133
           gpu_check_script: tools/gpu_check_nvidia.sh
 
       - shell: bash

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -160,7 +160,7 @@ jobs:
     if: contains(needs.preprocess.outputs.labels, 'ops/alpha')
     uses: ./.github/workflows/backend-test.yaml
     with:
-      vendor: nvidia
+      vendor: nvidia-cuda133
       runner_label: h20
       gpu_check_script: tools/gpu_check_nvidia.sh
       test_script: tools/test-op-experimental.sh


### PR DESCRIPTION
Update remaining workflow files that still use bare `nvidia` instead of the revised `nvidia-cuda133` backend label.

- `cpp-op-test.yaml`: `vendor: nvidia` → `nvidia-cuda133`
- `unittest.yaml`: `vendor: nvidia` → `nvidia-cuda133`
- `setup-flaggems/action.yml`: vllm install condition changed to `startsWith(inputs.vendor, 'nvidia')` to support all nvidia variants