### PR TITLE
Add FlagTune configs for w8a8_block_fp8_bmm

### DIFF
--- a/src/flag_gems/runtime/backend/_nvidia/hopper/general_ops_hopper_expand.yaml
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/general_ops_hopper_expand.yaml
@@ -180,3 +180,26 @@ fused_marlin_moe_mxfp4:
       K: align32
       BLOCK_SIZE_M: align32
       SWAP_AB: default
+w8a8_block_fp8_bmm:
+  - config:
+    param_map:
+      META:
+        TILE_ORDER: tile_order
+      num_stages: stages
+      num_warps: warps
+    tile_order:
+      - 0
+      - 1
+    stages:
+      - 3
+      - 4
+      - 5
+      - 6
+      - 7
+    warps:
+      - 4
+  - strategy:
+      B: default
+      M_aligned: align32
+      N: align32
+      K: align32

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/w8a8_block_fp8_bmm.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/w8a8_block_fp8_bmm.py
@@ -14,6 +14,9 @@ from triton.experimental.gluon.language.nvidia.hopper import (
 from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
 from triton.language.core import _aggregate as aggregate
 
+from flag_gems import runtime
+from flag_gems.utils import libentry, libtuner
+
 _TORCH_TO_GL_DTYPE = {
     torch.float8_e4m3fn: gl.float8e4nv,
     torch.float8_e5m2: gl.float8e5,
@@ -375,14 +378,13 @@ def load_partition(channel, config, tensors):
             counter = counter.increment()
 
 
-@triton.autotune(
-    configs=[
-        triton.Config({"TILE_ORDER": tile_order}, num_warps=nw, num_stages=ns)
-        for nw in (4, 8)
-        for ns in (4, 6, 8)
-        for tile_order in (0, 1)  # 0=horizontal (n fastest), 1=vertical (m fastest)
-    ],
+@libentry()
+@libtuner(
+    configs=runtime.get_tuned_config("w8a8_block_fp8_bmm"),
     key=["B", "M_aligned", "N", "K"],
+    strategy=["default", "align32", "align32", "align32"],
+    flagtune_op_name="w8a8_block_fp8_bmm",
+    flagtune_expand_op_name="w8a8_block_fp8_bmm",
 )
 @gluon.jit
 def w8a8_block_fp8_bmm_kernel(

--- a/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
@@ -2359,3 +2359,21 @@ fused_marlin_moe_mxfp4:
   - META: {BLOCK_SIZE_N: 256, GROUP_SIZE_M: 1}
     num_warps: 4
     num_stages: 4
+
+w8a8_block_fp8_bmm:
+  - gen: true
+    param_map:
+      META:
+        TILE_ORDER: tile_order
+      num_warps: warps
+      num_stages: stages
+    tile_order:
+      - 0
+      - 1
+    warps:
+      - 4
+      - 8
+    stages:
+      - 4
+      - 6
+      - 8

--- a/src/flag_gems/runtime/common.py
+++ b/src/flag_gems/runtime/common.py
@@ -69,6 +69,7 @@ DEFAULT_STRATEGIES = {
         "align32",
         "default",
     ],
+    "w8a8_block_fp8_bmm": ["default", "align32", "align32", "align32"],
     "mm_splitk": ["align32", "align32", "align32", "align32", "align32"],
 }
 
@@ -88,6 +89,7 @@ OP_KEY_ORDERS = {
     "w8a8_block_fp8_general": ["M", "N", "K", "stride_am", "stride_bk"],
     "w8a8_block_fp8_general_splitk": ["M", "N", "K", "stride_am", "stride_bk"],
     "w8a8_block_fp8_general_tma": ["M", "N", "K", "stride_am", "stride_bk", "dtype"],
+    "w8a8_block_fp8_bmm": ["B", "M_aligned", "N", "K"],
     "mm_splitk": ["M", "N", "K", "stride_am", "stride_bk"],
 }
 

--- a/src/flag_gems/runtime/configs_loader.py
+++ b/src/flag_gems/runtime/configs_loader.py
@@ -265,6 +265,19 @@ class TunedConfigLoader(object):
                 for w in ranges["w"]
             ]
 
+        if op_name == "w8a8_block_fp8_bmm":
+            return [
+                triton.Config(
+                    {"TILE_ORDER": tile_order},
+                    num_stages=s,
+                    num_warps=w,
+                    pre_hook=pre_hook,
+                )
+                for tile_order in ranges["TILE_ORDER"]
+                for s in ranges["s"]
+                for w in ranges["w"]
+            ]
+
         if op_name == "w8a8_block_fp8_general":
             return [
                 triton.Config(
@@ -450,6 +463,10 @@ class TunedConfigLoader(object):
             ),
             "w8a8_block_fp8_general_tma": self._build_single_expand_spec(
                 "w8a8_block_fp8_general_tma"
+            ),
+            "w8a8_block_fp8_bmm": self._build_single_expand_spec(
+                "w8a8_block_fp8_bmm",
+                expand_yaml_path=self._get_expand_config_path("w8a8_block_fp8_bmm"),
             ),
             "mm_splitk": self._build_single_expand_spec("mm_splitk"),
             "sparse_attention": self._build_single_expand_spec("sparse_attention"),

--- a/src/flag_gems/runtime/flagtune.py
+++ b/src/flag_gems/runtime/flagtune.py
@@ -170,6 +170,11 @@ register_flagtune_op(
     default=False,
     description="W8A8 block FP8 matrix multiplication",
 )
+register_flagtune_op(
+    "w8a8_block_fp8_bmm",
+    default=False,
+    description="W8A8 block FP8 batched matrix multiplication",
+)
 
 # DEFAULT_FLAGTUNE_INCLUDE and SUPPORTED_FLAGTUNE_OPS are provided by __getattr__.
 __all__ = [  # noqa: F822


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

### Description
- Use FlagOSTune to optimized w8a8_block_fp8_bmm.
- Achieved up to 25.28% performance improvement on H20 compared with the version without FlagTune.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
