### PR TITLE
add remainder_scalar tests & benchmark

### DIFF
--- a/benchmark/test_remainder.py
+++ b/benchmark/test_remainder.py
@@ -56,6 +56,17 @@ def remainder_scalar_input_fn(shape, dtype, device):
     yield inp, scalar
 
 
+@pytest.mark.remainder_scalar
+def test_remainder_scalar():
+    bench = base.GenericBenchmark(
+        input_fn=remainder_scalar_input_fn,
+        op_name="remainder_scalar",
+        torch_op=torch.remainder,
+        dtypes=consts.INT_DTYPES,
+    )
+    bench.run()
+
+
 @pytest.mark.remainder_scalar_
 def test_remainder_scalar_inplace():
     bench = base.GenericBenchmark(

--- a/tests/test_remainder.py
+++ b/tests/test_remainder.py
@@ -90,6 +90,24 @@ def test_remainder_(shape, dtype):
         utils.gems_assert_equal(res_out, ref_out)
 
 
+@pytest.mark.remainder_scalar
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.INT_DTYPES)
+@pytest.mark.parametrize("scalar", [7, -7])
+def test_remainder_scalar(shape, dtype, scalar):
+    inp = torch.randint(
+        torch.iinfo(dtype).min, torch.iinfo(dtype).max, shape, dtype=dtype, device="cpu"
+    ).to(flag_gems.device)
+
+    ref_inp = utils.to_reference(inp, False)
+    ref_out = torch.remainder(ref_inp, scalar)
+
+    with flag_gems.use_gems():
+        res_out = torch.remainder(inp, scalar)
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
 @pytest.mark.remainder_scalar_
 @pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.INT_DTYPES)


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
Other

### Description
add remainder_scalar tests & benchmark

### Issue
close: #4074 

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
benchmark on H20 HBM3
```
FlagGems/benchmark# pytest -s -m remainder_scalar
==================================== test session starts ====================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.13.0, xdoctest-1.0.2, rerunfailures-15.1, hypothesis-6.130.8, xdist-3.6.1, flakefinder-1.1.0, shard-0.1.2
collecting 194 items                                                                        WARNING 06-29 03:22:38 [interface.py:869] Current platform cuda does not have '_pytestfixturefunction' attribute.
collected 763 items / 762 deselected / 1 selected                                           
Running 1 items in this shard

test_remainder.py 
Operator: remainder_scalar  Performance Test (dtype=torch.int16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.943392            2.531552               0.768          [torch.Size([1073741824]), 2115]
SUCCESS               0.005024            0.023888               0.210          [torch.Size([64, 64]), 26463]
SUCCESS               0.036064            0.055168               0.654          [torch.Size([4096, 4096]), 19864]
SUCCESS               0.036192            0.055344               0.654          [torch.Size([64, 512, 512]), 2194]
SUCCESS               2.032576            2.528032               0.804          [torch.Size([1024, 1024, 1024]), 15451]
SUCCESS               0.569536            0.644800               0.883          [torch.Size([268435456]), -3662]
SUCCESS               0.005696            0.022752               0.250          [torch.Size([10000, 1]), 16665]
SUCCESS               0.009920            0.023520               0.422          [torch.Size([10000, 256]), -16116]
SUCCESS               1.242688            1.579040               0.787          [torch.Size([10000, 65536]), 19465]
SUCCESS               0.005792            0.024416               0.237          [torch.Size([100, 1, 100]), 32393]
SUCCESS               0.009824            0.024768               0.397          [torch.Size([100, 256, 100]), 19111]
SUCCESS               1.247744            1.578720               0.790          [torch.Size([100, 65536, 100]), 29926]


Operator: remainder_scalar  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.513600            3.063296               0.821          [torch.Size([1073741824]), -456256186]
SUCCESS               0.005024            0.023232               0.216          [torch.Size([64, 64]), -200780155]
SUCCESS               0.043072            0.056992               0.756          [torch.Size([4096, 4096]), 98875239]
SUCCESS               0.042368            0.057280               0.740          [torch.Size([64, 512, 512]), 696154568]
SUCCESS               2.488896            3.079456               0.808          [torch.Size([1024, 1024, 1024]), 968719449]
SUCCESS               0.642016            0.891840               0.720          [torch.Size([268435456]), 1382972108]
SUCCESS               0.005920            0.023296               0.254          [torch.Size([10000, 1]), -1224474184]
SUCCESS               0.011264            0.024816               0.454          [torch.Size([10000, 256]), 2062213112]
SUCCESS               1.551664            2.064032               0.752          [torch.Size([10000, 65536]), -287160470]
SUCCESS               0.005984            0.023200               0.258          [torch.Size([100, 1, 100]), 1519335213]
SUCCESS               0.011264            0.024096               0.467          [torch.Size([100, 256, 100]), -2058333499]
SUCCESS               1.543440            2.065088               0.747          [torch.Size([100, 65536, 100]), 451295029]

.

============================ 1 passed, 762 deselected in 52.69s =============================
```
