### PR TITLE
[MTHREADS] fix log10 perf

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -14,6 +14,7 @@ from .index_add import index_add, index_add_
 from .index_put import _index_put_impl_, index_put, index_put_
 from .index_select import index_select
 from .log import log
+from .log10 import log10, log10_, log10_out
 from .log_softmax import (
     log_softmax,
     log_softmax_backward,
@@ -74,6 +75,9 @@ __all__ = [
     "_index_put_impl_",
     "index_select",
     "log",
+    "log10",
+    "log10_",
+    "log10_out",
     "log_softmax",
     "log_softmax_backward",
     "log_softmax_backward_out",

--- a/src/flag_gems/runtime/backend/_mthreads/ops/log.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/log.py
@@ -36,6 +36,7 @@ def log_kernel(
     dtype_size,
     BLOCK_SIZE: tl.constexpr,
     USE_APPROX: tl.constexpr,
+    SCALE: tl.constexpr,
 ):
     pid = tl.program_id(0)
     offsets = pid * BLOCK_SIZE + tl.arange(0, BLOCK_SIZE)
@@ -52,15 +53,13 @@ def log_kernel(
         k = exp.to(tl.int32) - 127
         t = (m - 1.0) / (m + 1.0)
         t2 = t * t
-        # t4 = t2 * t2
-        # t6 = t4 * t2
         log_m = 2.0 * (t + t2 * t * (1.0 / 3.0 + t2 * (1.0 / 5.0 + t2 * (1.0 / 7.0))))
         log_val = log_m + k.to(tl.float32) * 0.6931471805599453
         nan_or_inf = tl.where(zero_mask, -float("inf"), float("nan"))
         y = tl.where(pos_mask, log_val, nan_or_inf)
     else:
         y = tl_extra_shim.log(x_fp32)
-    tl.store(out_ptr + offsets, y, mask=mask)
+    tl.store(out_ptr + offsets, y * SCALE, mask=mask)
 
 
 def _use_triton_kernel(x: torch.Tensor) -> Tuple[bool, int]:
@@ -73,11 +72,15 @@ def _use_triton_kernel(x: torch.Tensor) -> Tuple[bool, int]:
     return True, x.element_size()
 
 
-def _launch_log(x: torch.Tensor, out: torch.Tensor, dtype_size: int):
+def _launch_log(
+    x: torch.Tensor, out: torch.Tensor, dtype_size: int, scale: float = 1.0
+):
     n_elements = out.numel()
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
     with torch_device_fn.device(out.device):
-        log_kernel[grid](x, out, n_elements, dtype_size, USE_APPROX=dtype_size == 2)
+        log_kernel[grid](
+            x, out, n_elements, dtype_size, USE_APPROX=dtype_size == 2, SCALE=scale
+        )
     return out
 
 

--- a/src/flag_gems/runtime/backend/_mthreads/ops/log10.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/log10.py
@@ -1,0 +1,47 @@
+import logging
+from typing import Tuple
+
+import torch
+
+from flag_gems.ops.log10 import log10 as default_log10
+from flag_gems.ops.log10 import log10_ as default_log10_
+from flag_gems.ops.log10 import log10_out as default_log10_out
+from flag_gems.runtime.backend._mthreads.ops.log import _launch_log, _use_triton_kernel
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_INV_LN10 = 0.4342944819032518
+
+
+def _should_use_triton(x: torch.Tensor) -> Tuple[bool, int]:
+    return _use_triton_kernel(x)
+
+
+def log10(x):
+    logger.debug("GEMS_MTHREADS LOG10")
+    use_triton, dtype_size = _should_use_triton(x)
+    if not use_triton:
+        return default_log10(x)
+
+    out = torch.empty_like(x)
+    return _launch_log(x, out, dtype_size, scale=_INV_LN10)
+
+
+def log10_(x):
+    logger.debug("GEMS_MTHREADS LOG10_")
+    use_triton, dtype_size = _should_use_triton(x)
+    if not use_triton:
+        return default_log10_(x)
+
+    return _launch_log(x, x, dtype_size, scale=_INV_LN10)
+
+
+def log10_out(x, out):
+    logger.debug("GEMS_MTHREADS LOG10_OUT")
+    use_triton, dtype_size = _should_use_triton(x)
+    if not use_triton:
+        return default_log10_out(x, out)
+
+    return _launch_log(x, out, dtype_size, scale=_INV_LN10)


### PR DESCRIPTION
Add MTHREADS log10 backend reusing log_kernel with a SCALE parameter.

The generic log10_ operator used @pointwise_dynamic which scored 0.27x-0.45x speedup (2-4x slower than PyTorch MUSA baseline).

Instead of duplicating the log kernel, this patch adds a SCALE constexpr to the existing autotuned log_kernel so that log10 can reuse the same code path (including tl_extra_shim.log for fp32 and fast bit-manipulation approximation for fp16/bf16).

Changes:
- log.py: add SCALE: tl.constexpr=1.0 to log_kernel, pass through _launch_log (zero overhead for existing log)
- log10.py (new): call _launch_log with scale=1/ln(10)
- \_\_init\_\_.py: register log10/log10_/log10_out for dispatch

Before -> After (speedup, Gems/Torch):
fp16  [4096,4096]  0.33x -> 1.15x  
fp16  [1024,65536] 0.27x -> 1.02x  
fp32  [1024,65536] 0.44x -> 1.02x  
bf16  [1024,65536] 0.28x -> 1.01x  

