### PR TITLE
[QC] Enable swap_ab on H20 for small-tile fp8 blockwise GEMM

### DIFF
--- a/src/flag_gems/fused/fused_moe.py
+++ b/src/flag_gems/fused/fused_moe.py
@@ -157,6 +157,12 @@ def _get_device_name() -> str:
     return name
 
 
+@functools.lru_cache(maxsize=1)
+def _is_h20() -> bool:
+    """Whether the current device is an NVIDIA H20 (gates the FP8 MoE swap_ab default)."""
+    return "H20" in _get_device_name().split("_")
+
+
 def get_moe_configs(
     E: int,
     N: int,
@@ -366,7 +372,10 @@ def get_default_config(
             "GROUP_SIZE_M": 8 if (is_large_m and avg_tokens_per_expert > 16) else 1,
             "num_warps": 8 if (is_large_m and block_m > 32) else 4,
             "num_stages": 4 if M >= 1024 else 3,
-            "SWAP_AB": False,
+            # H20: swap_ab puts the larger N dim on the wgmma M-axis, a measured
+            # win on H20 for small token tiles (block_m<=32) but a regression for
+            # large tiles (e.g. 16k/32k-token prefill), so gate on both.
+            "SWAP_AB": _is_h20() and block_m <= 32,
         }
     elif dtype in _PLAIN_HALF_CONFIG_DTYPES:
         # Routed rows per expert drives block_m.  Each token contributes topk


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

Operator; Benchmark

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

Performance Optimization

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

Enable `swap_ab` on H20 and `block_m <= 32` for fp8 fused_moe.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

Performance test command
```bash
pytest -x -vv -s benchmark/test_fused_moe_fp8_blockwise.py::test_fused_moe_fp8_blockwise
```

Performance result
> cuda 13.0.2
> torch=2.11.0
> vLLM=0.20.2
> hpc-ops commit 8bb4731ceec4167377c3849e0a6a2f13f18f8d30

Mixtral-8x7B (E=8, H=4096, I=14336, TopK=2) on H20

| Tokens | Original (swap off) | Optimized (swap on) | Speedup | vLLM | vs vLLM | hpc-ops | vs hpc-ops |
|---|---|---|---|---|---|---|---|
| 1 | 0.183 | 0.143 | 1.28x | 0.189 | 1.33x | 0.120 | 0.84x |
| 4 | 0.434 | 0.359 | 1.21x | 0.428 | 1.19x | 0.287 | 0.80x |
| 8 | 0.604 | 0.514 | 1.18x | 0.602 | 1.17x | 0.415 | 0.81x |
| 16 | 0.606 | 0.515 | 1.18x | 0.602 | 1.17x | 0.422 | 0.82x |
| 32 | 0.607 | 0.517 | 1.17x | 0.607 | 1.17x | 0.426 | 0.82x |
| 64 | 0.836 | 0.768 | 1.09x | 0.846 | 1.10x | 0.479 | 0.62x |
| 128 | 1.407 | 1.107 | 1.27x | 0.778 | 0.70x | 0.560 | 0.51x |
| 256 | 1.196 | 1.192 | 1.00x | 1.210 | 1.01x | 1.147 | 0.96x |
| 512 | 1.805 | 1.804 | 1.00x | 1.871 | 1.04x | 1.741 | 0.97x |

DeepSeek-V3-TP8 (E=256, H=7168, I=2048, TopK=8) on H20

| Tokens | Original (swap off) | Optimized (swap on) | Speedup | vLLM | vs vLLM | hpc-ops | vs hpc-ops |
|---|---|---|---|---|---|---|---|
| 1 | 0.176 | 0.116 | 1.51x | 0.180 | 1.55x | 0.140 | 1.21x |
| 4 | 0.560 | 0.401 | 1.40x | 0.570 | 1.42x | 0.416 | 1.04x |
| 8 | 1.066 | 0.748 | 1.43x | 1.092 | 1.46x | 0.692 | 0.93x |
| 16 | 1.675 | 1.528 | 1.10x | 1.729 | 1.13x | 1.279 | 0.84x |
| 32 | 2.806 | 2.545 | 1.10x | 2.872 | 1.13x | 2.133 | 0.84x |
| 64 | 3.598 | 3.395 | 1.06x | 3.846 | 1.13x | 2.785 | 0.82x |
| 128 | 4.167 | 3.954 | 1.05x | 5.554 | 1.40x | 3.289 | 0.83x |
| 256 | 4.332 | 4.054 | 1.07x | 5.614 | 1.38x | 3.399 | 0.84x |

Qwen3.5-397B-A17B (E=512, H=4096, I=1024, TopK=10) on H20

| Tokens | Original (swap off) | Optimized (swap on) | Speedup | vLLM | vs vLLM | hpc-ops | vs hpc-ops |
|---|---|---|---|---|---|---|---|
| 1 | 0.084 | 0.056 | 1.50x | 0.090 | 1.61x | 0.114 | 2.03x |
| 4 | 0.220 | 0.156 | 1.41x | 0.227 | 1.45x | 0.195 | 1.25x |
| 8 | 0.399 | 0.281 | 1.42x | 0.410 | 1.46x | 0.303 | 1.08x |
| 16 | 0.670 | 0.618 | 1.08x | 0.677 | 1.10x | 0.529 | 0.86x |
| 32 | 1.105 | 1.009 | 1.10x | 1.123 | 1.11x | 0.854 | 0.85x |
| 64 | 1.728 | 1.634 | 1.06x | 1.827 | 1.12x | 1.336 | 0.82x |
| 128 | 2.272 | 2.139 | 1.06x | 3.119 | 1.46x | 1.736 | 0.81x |
| 256 | 2.437 | 2.335 | 1.04x | 3.349 | 1.43x | 1.938 | 0.83x |
| 16384 | 22.457 | 22.401 | 1.00x | 19.833 | 0.89x | 17.952 | 0.80x |
| 32768 | 41.225 | 40.852 | 1.01x | 38.031 | 0.93x | 34.945 | 0.86x |