### PR TITLE
add outplace_fused_experts op tests & benchmark

### DIFF
--- a/benchmark/test_outplace_fused_experts.py
+++ b/benchmark/test_outplace_fused_experts.py
@@ -90,17 +90,6 @@ def _vllm_outplace_fused_experts_wrapper(hidden_states, w1, w2, topk_weights, to
     )
 
 
-def _gems_outplace_fused_experts_wrapper(hidden_states, w1, w2, topk_weights, topk_ids):
-    """Wrapper to call FlagGems outplace_fused_experts."""
-    return flag_gems.outplace_fused_experts(
-        hidden_states,
-        w1,
-        w2,
-        topk_weights,
-        topk_ids,
-    )
-
-
 @pytest.mark.outplace_fused_experts
 @pytest.mark.skipif(not HAS_VLLM_FUSED_MOE, reason="vLLM not installed")
 def test_outplace_fused_experts_gems_vs_vllm():
@@ -112,5 +101,5 @@ def test_outplace_fused_experts_gems_vs_vllm():
         torch_op=_vllm_outplace_fused_experts_wrapper,
         dtypes=[torch.bfloat16, torch.float16],
     )
-    bench.set_gems(_gems_outplace_fused_experts_wrapper)
+    bench.set_gems(flag_gems.outplace_fused_experts)
     bench.run()

--- a/benchmark/test_outplace_fused_experts.py
+++ b/benchmark/test_outplace_fused_experts.py
@@ -1,0 +1,116 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import base
+
+try:
+    from vllm.model_executor.layers.fused_moe.fused_moe import (
+        fused_experts_impl as vllm_fused_experts_impl,
+    )
+
+    HAS_VLLM_FUSED_MOE = True
+except ImportError:
+    HAS_VLLM_FUSED_MOE = False
+
+
+class OutplaceFusedExpertsBenchmark(base.Benchmark):
+    """
+    Benchmark for outplace_fused_experts comparing FlagGems Triton kernel vs vLLM.
+    """
+
+    def __init__(self, op_name, torch_op, dtypes):
+        super().__init__(op_name=op_name, torch_op=torch_op, dtypes=dtypes)
+
+    def set_shapes(self, shape_file_path=None):
+        # (num_tokens, num_experts, hidden_size, intermediate_size, topk)
+        self.shapes = [
+            # Mixtral-like shapes
+            (1, 8, 4096, 14336, 2),
+            (4, 8, 4096, 14336, 2),
+            (16, 8, 4096, 14336, 2),
+            (64, 8, 4096, 14336, 2),
+            (128, 8, 4096, 14336, 2),
+            (256, 8, 4096, 14336, 2),
+            (512, 8, 4096, 14336, 2),
+            # DeepSeek-V3-like shapes (TP=8 shard)
+            (1, 256, 7168, 2048, 8),
+            (4, 256, 7168, 2048, 8),
+            (16, 256, 7168, 2048, 8),
+            (64, 256, 7168, 2048, 8),
+            (128, 256, 7168, 2048, 8),
+            (256, 256, 7168, 2048, 8),
+        ]
+
+    def get_input_iter(self, cur_dtype):
+        for config in self.shapes:
+            yield from self._fused_moe_input_fn(config, cur_dtype)
+
+    def _fused_moe_input_fn(self, config, dtype):
+        num_tokens, num_experts, hidden_size, intermediate_size, topk = config
+        device = flag_gems.device
+
+        hidden_states = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype)
+        w1 = torch.randn(
+            num_experts,
+            intermediate_size * 2,
+            hidden_size,
+            device=device,
+            dtype=dtype,
+        )
+        w2 = torch.randn(
+            num_experts,
+            hidden_size,
+            intermediate_size,
+            device=device,
+            dtype=dtype,
+        )
+
+        gating = torch.randn(
+            num_tokens, num_experts, device=device, dtype=torch.float32
+        )
+        topk_weights, topk_ids = torch.topk(torch.softmax(gating, dim=-1), topk, dim=-1)
+        topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+        topk_weights = topk_weights.to(dtype)
+
+        yield (hidden_states, w1, w2, topk_weights, topk_ids)
+
+
+def _vllm_outplace_fused_experts_wrapper(hidden_states, w1, w2, topk_weights, topk_ids):
+    """Wrapper to call vLLM fused_experts_impl out-of-place."""
+    return vllm_fused_experts_impl(
+        hidden_states.clone(),
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+        inplace=False,
+        activation="silu",
+    )
+
+
+def _gems_outplace_fused_experts_wrapper(hidden_states, w1, w2, topk_weights, topk_ids):
+    """Wrapper to call FlagGems outplace_fused_experts."""
+    return flag_gems.outplace_fused_experts(
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+    )
+
+
+@pytest.mark.outplace_fused_experts
+@pytest.mark.skipif(not HAS_VLLM_FUSED_MOE, reason="vLLM not installed")
+def test_outplace_fused_experts_gems_vs_vllm():
+    """
+    Benchmark FlagGems outplace_fused_experts vs vLLM outplace fused_experts_impl (bf16/fp16).
+    """
+    bench = OutplaceFusedExpertsBenchmark(
+        op_name="outplace_fused_experts",
+        torch_op=_vllm_outplace_fused_experts_wrapper,
+        dtypes=[torch.bfloat16, torch.float16],
+    )
+    bench.set_gems(_gems_outplace_fused_experts_wrapper)
+    bench.run()

--- a/tests/test_outplace_fused_experts.py
+++ b/tests/test_outplace_fused_experts.py
@@ -1,0 +1,141 @@
+import random
+
+import pytest
+import torch
+
+import flag_gems
+
+if flag_gems.vendor_name == "sunrise":
+    QUICK_MODE = True  # "--ref cpu" too slow for big shape.
+else:
+    from .conftest import QUICK_MODE
+
+random.seed(42)
+
+FUSED_MOE_CONFIGS = [
+    # (num_tokens, num_experts, hidden_size, intermediate_size, topk)
+    (1, 8, 128, 256, 2),
+    (4, 8, 128, 256, 2),
+    (8, 4, 64, 128, 2),
+    (16, 8, 256, 512, 2),
+    (32, 8, 128, 256, 4),
+]
+
+if not QUICK_MODE:
+    FUSED_MOE_CONFIGS += [
+        (64, 8, 256, 512, 2),
+        (128, 16, 128, 256, 4),
+        (4, 16, 512, 1024, 2),
+        # Mixtral-like shapes
+        (1, 8, 4096, 14336, 2),
+        (16, 8, 4096, 14336, 2),
+        (64, 8, 4096, 14336, 2),
+        # DeepSeek-V3-like shapes (TP=8 shard)
+        (1, 256, 7168, 2048, 8),
+        (16, 256, 7168, 2048, 8),
+        (64, 256, 7168, 2048, 8),
+    ]
+
+
+def torch_fused_moe_reference(
+    hidden_states: torch.Tensor,
+    w1: torch.Tensor,
+    w2: torch.Tensor,
+    topk_weights: torch.Tensor,
+    topk_ids: torch.Tensor,
+) -> torch.Tensor:
+    """Pure PyTorch reference implementation of fused MoE."""
+    M, K = hidden_states.shape
+    topk = topk_ids.shape[1]
+    output = torch.zeros(M, K, device=hidden_states.device, dtype=hidden_states.dtype)
+
+    for m in range(M):
+        for j in range(topk):
+            e = topk_ids[m, j].item()
+            weight = topk_weights[m, j]
+            z = hidden_states[m].to(torch.float32) @ w1[e].T.to(torch.float32)
+            D = z.shape[-1] // 2
+            gate = z[:D]
+            up = z[D:]
+            s = (gate * torch.sigmoid(gate)) * up
+            r = s @ w2[e].T.to(torch.float32)
+            output[m] += (weight.to(torch.float32) * r).to(output.dtype)
+
+    return output
+
+
+def _make_inputs(config, dtype):
+    num_tokens, num_experts, hidden_size, intermediate_size, topk = config
+    device = flag_gems.device
+
+    torch.manual_seed(0)
+
+    hidden_states = torch.randn(num_tokens, hidden_size, device=device, dtype=dtype)
+    w1 = torch.randn(
+        num_experts, intermediate_size * 2, hidden_size, device=device, dtype=dtype
+    ) * (1.0 / hidden_size**0.5)
+    w2 = torch.randn(
+        num_experts, hidden_size, intermediate_size, device=device, dtype=dtype
+    ) * (1.0 / intermediate_size**0.5)
+
+    gating = torch.randn(num_tokens, num_experts, device=device, dtype=torch.float32)
+    topk_weights, topk_ids = torch.topk(torch.softmax(gating, dim=-1), topk, dim=-1)
+    topk_weights = topk_weights / topk_weights.sum(dim=-1, keepdim=True)
+    topk_weights = topk_weights.to(dtype)
+
+    return hidden_states, w1, w2, topk_weights, topk_ids
+
+
+def _synchronize():
+    if flag_gems.vendor_name == "ascend":
+        torch.npu.synchronize()
+    elif flag_gems.vendor_name == "sunrise":
+        torch.ptpu.synchronize()
+    else:
+        torch.cuda.synchronize()
+
+
+@pytest.mark.outplace_fused_experts
+@pytest.mark.parametrize("config", FUSED_MOE_CONFIGS)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_outplace_fused_experts_accuracy(config, dtype):
+    """Test outplace_fused_experts returns correct results."""
+    hidden_states, w1, w2, topk_weights, topk_ids = _make_inputs(config, dtype)
+
+    ref = torch_fused_moe_reference(hidden_states, w1, w2, topk_weights, topk_ids)
+
+    result = flag_gems.outplace_fused_experts(
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+    )
+
+    _synchronize()
+
+    rtol = 1e-1
+    atol = max(1e-2, ref.abs().max().item() * 1e-5)
+    torch.testing.assert_close(result, ref, rtol=rtol, atol=atol)
+
+
+@pytest.mark.outplace_fused_experts
+@pytest.mark.parametrize("config", FUSED_MOE_CONFIGS)
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float16])
+def test_outplace_fused_experts_does_not_modify_input(config, dtype):
+    """Test outplace_fused_experts leaves hidden_states unchanged."""
+    hidden_states, w1, w2, topk_weights, topk_ids = _make_inputs(config, dtype)
+    original_hidden_states = hidden_states.clone()
+
+    result = flag_gems.outplace_fused_experts(
+        hidden_states,
+        w1,
+        w2,
+        topk_weights,
+        topk_ids,
+    )
+
+    _synchronize()
+
+    assert result.data_ptr() != hidden_states.data_ptr()
+    torch.testing.assert_close(hidden_states, original_hidden_states, rtol=0, atol=0)


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
Other

### Description
add outplace_fused_experts op tests & benchmark

### Issue
closes: #4073 

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
benchmark on H20 HBM3
```
FlagGems/benchmark# pytest -s -m outplace_fused_experts
================================ test session starts ================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.13.0, xdoctest-1.0.2, rerunfailures-15.1, hypothesis-6.130.8, xdist-3.6.1, flakefinder-1.1.0, shard-0.1.2
collecting 195 items                                                                WARNING 06-30 02:29:39 [interface.py:869] Current platform cuda does not have '_pytestfixturefunction' attribute.
collected 764 items / 763 deselected / 1 selected                                   
Running 1 items in this shard

test_outplace_fused_experts.py WARNING 06-30 02:29:45 [fused_moe.py:1073] Using default MoE config. Performance might be sub-optimal! Config file not found at /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/configs/E=8,N=14336,device_name=NVIDIA_H20.json
WARNING 06-30 02:30:03 [fused_moe.py:1073] Using default MoE config. Performance might be sub-optimal! Config file not found at /usr/local/lib/python3.12/dist-packages/vllm/model_executor/layers/fused_moe/configs/E=256,N=2048,device_name=NVIDIA_H20.json

Operator: outplace_fused_experts  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.235648            0.281280               0.838          [torch.Size([1, 4096]), torch.Size([8, 28672, 4096]), torch.Size([8, 4096, 14336]), torch.Size([1, 2]), torch.Size([1, 2])]
SUCCESS               0.762832            0.719072               1.061          [torch.Size([4, 4096]), torch.Size([8, 28672, 4096]), torch.Size([8, 4096, 14336]), torch.Size([4, 2]), torch.Size([4, 2])]
SUCCESS               0.955488            0.867552               1.101          [torch.Size([16, 4096]), torch.Size([8, 28672, 4096]), torch.Size([8, 4096, 14336]), torch.Size([16, 2]), torch.Size([16, 2])]
SUCCESS               1.253504            1.194496               1.049          [torch.Size([64, 4096]), torch.Size([8, 28672, 4096]), torch.Size([8, 4096, 14336]), torch.Size([64, 2]), torch.Size([64, 2])]
SUCCESS               1.588288            1.564224               1.015          [torch.Size([128, 4096]), torch.Size([8, 28672, 4096]), torch.Size([8, 4096, 14336]), torch.Size([128, 2]), torch.Size([128, 2])]
SUCCESS               2.071392            2.024352               1.023          [torch.Size([256, 4096]), torch.Size([8, 28672, 4096]), torch.Size([8, 4096, 14336]), torch.Size([256, 2]), torch.Size([256, 2])]
SUCCESS               3.475712            6.176384               0.563          [torch.Size([512, 4096]), torch.Size([8, 28672, 4096]), torch.Size([8, 4096, 14336]), torch.Size([512, 2]), torch.Size([512, 2])]
SUCCESS               0.244096            0.278336               0.877          [torch.Size([1, 7168]), torch.Size([256, 4096, 7168]), torch.Size([256, 7168, 2048]), torch.Size([1, 8]), torch.Size([1, 8])]
SUCCESS               0.918496            0.926720               0.991          [torch.Size([4, 7168]), torch.Size([256, 4096, 7168]), torch.Size([256, 7168, 2048]), torch.Size([4, 8]), torch.Size([4, 8])]
SUCCESS               2.606288            2.443968               1.066          [torch.Size([16, 7168]), torch.Size([256, 4096, 7168]), torch.Size([256, 7168, 2048]), torch.Size([16, 8]), torch.Size([16, 8])]
SUCCESS               7.760160            5.451344               1.424          [torch.Size([64, 7168]), torch.Size([256, 4096, 7168]), torch.Size([256, 7168, 2048]), torch.Size([64, 8]), torch.Size([64, 8])]
SUCCESS               9.908096            6.104880               1.623          [torch.Size([128, 7168]), torch.Size([256, 4096, 7168]), torch.Size([256, 7168, 2048]), torch.Size([128, 8]), torch.Size([128, 8])]
SUCCESS              10.322944            6.696032               1.542          [torch.Size([256, 7168]), torch.Size([256, 4096, 7168]), torch.Size([256, 7168, 2048]), torch.Size([256, 8]), torch.Size([256, 8])]


Operator: outplace_fused_experts  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.237744            0.287824               0.826          [torch.Size([1, 4096]), torch.Size([8, 28672, 4096]), torch.Size([8, 4096, 14336]), torch.Size([1, 2]), torch.Size([1, 2])]
SUCCESS               0.677088            0.650864               1.040          [torch.Size([4, 4096]), torch.Size([8, 28672, 4096]), torch.Size([8, 4096, 14336]), torch.Size([4, 2]), torch.Size([4, 2])]
SUCCESS               0.958240            0.941584               1.018          [torch.Size([16, 4096]), torch.Size([8, 28672, 4096]), torch.Size([8, 4096, 14336]), torch.Size([16, 2]), torch.Size([16, 2])]
SUCCESS               1.297536            1.222016               1.062          [torch.Size([64, 4096]), torch.Size([8, 28672, 4096]), torch.Size([8, 4096, 14336]), torch.Size([64, 2]), torch.Size([64, 2])]
SUCCESS               1.460928            1.497536               0.976          [torch.Size([128, 4096]), torch.Size([8, 28672, 4096]), torch.Size([8, 4096, 14336]), torch.Size([128, 2]), torch.Size([128, 2])]
SUCCESS               2.386912            2.318240               1.030          [torch.Size([256, 4096]), torch.Size([8, 28672, 4096]), torch.Size([8, 4096, 14336]), torch.Size([256, 2]), torch.Size([256, 2])]
SUCCESS               3.429984            5.670080               0.605          [torch.Size([512, 4096]), torch.Size([8, 28672, 4096]), torch.Size([8, 4096, 14336]), torch.Size([512, 2]), torch.Size([512, 2])]
SUCCESS               0.243872            0.281344               0.867          [torch.Size([1, 7168]), torch.Size([256, 4096, 7168]), torch.Size([256, 7168, 2048]), torch.Size([1, 8]), torch.Size([1, 8])]
SUCCESS               0.898320            0.883040               1.017          [torch.Size([4, 7168]), torch.Size([256, 4096, 7168]), torch.Size([256, 7168, 2048]), torch.Size([4, 8]), torch.Size([4, 8])]
SUCCESS               2.757680            2.557728               1.078          [torch.Size([16, 7168]), torch.Size([256, 4096, 7168]), torch.Size([256, 7168, 2048]), torch.Size([16, 8]), torch.Size([16, 8])]
SUCCESS               7.709952            5.454320               1.414          [torch.Size([64, 7168]), torch.Size([256, 4096, 7168]), torch.Size([256, 7168, 2048]), torch.Size([64, 8]), torch.Size([64, 8])]
SUCCESS               9.866832            6.099232               1.618          [torch.Size([128, 7168]), torch.Size([256, 4096, 7168]), torch.Size([256, 7168, 2048]), torch.Size([128, 8]), torch.Size([128, 8])]
SUCCESS              10.405568            6.765984               1.538          [torch.Size([256, 7168]), torch.Size([256, 4096, 7168]), torch.Size([256, 7168, 2048]), torch.Size([256, 8]), torch.Size([256, 8])]

.

=================== 1 passed, 763 deselected in 108.47s (0:01:48) ===================
```
