### PR TITLE
add normed_cumsum op tests & benchmark

### DIFF
--- a/benchmark/test_normed_cumsum.py
+++ b/benchmark/test_normed_cumsum.py
@@ -1,0 +1,28 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import base, consts
+
+
+def torch_normed_cumsum(inp, dim=-1):
+    return torch.cumsum(inp, dim=dim) / inp.sum(dim=dim, keepdim=True)
+
+
+def input_fn(shape, dtype, device):
+    inp = torch.rand(shape, dtype=dtype, device=device) + 0.1
+    dim = -1
+    yield inp, dim
+
+
+@pytest.mark.normed_cumsum
+def test_normed_cumsum():
+    bench = base.GenericBenchmark(
+        input_fn=input_fn,
+        op_name="normed_cumsum",
+        torch_op=torch_normed_cumsum,
+        dtypes=consts.FLOAT_DTYPES,
+    )
+    bench.set_gems(flag_gems.normed_cumsum)
+    bench.run()

--- a/src/flag_gems/ops/cumsum.py
+++ b/src/flag_gems/ops/cumsum.py
@@ -573,7 +573,7 @@ def normed_cumsum(inp, dim=-1):
 
         if inp.dtype != torch.float64:
             acc_dtype = torch.float32
-        sums = torch.empty((n_rows, n_chunks), dtype=acc_dtype, device=device.name)
+        sums = torch.empty((n_rows, n_chunks), dtype=acc_dtype, device=device)
         cumsums = torch.empty_like(sums)
         block_cumsum_kernel[grid](
             inp,

--- a/tests/test_normed_cumsum.py
+++ b/tests/test_normed_cumsum.py
@@ -1,0 +1,69 @@
+import random
+import time
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+if cfg.QUICK_MODE:
+    FLOAT_DTYPES = [torch.float32]
+    NORMED_CUMSUM_CASES = [
+        ((17,), -1),
+        ((4, 33), -1),
+        ((7, 19), 0),
+        ((2, 5, 31), -1),
+    ]
+else:
+    FLOAT_DTYPES = utils.FLOAT_DTYPES
+    NORMED_CUMSUM_CASES = [
+        ((17,), -1),
+        ((2637,), -1),
+        ((4, 33), -1),
+        ((32, 1025), -1),
+        ((7, 19), 0),
+        ((513, 16), 0),
+        ((2, 5, 31), -1),
+        ((4, 8, 257), -1),
+    ]
+
+random.seed(time.time() // 100)
+
+
+def torch_normed_cumsum(inp, dim=-1):
+    ref_inp = utils.to_reference(inp, True)
+    return torch.cumsum(ref_inp, dim=dim) / ref_inp.sum(dim=dim, keepdim=True)
+
+
+@pytest.mark.normed_cumsum
+@pytest.mark.parametrize(("shape", "dim"), NORMED_CUMSUM_CASES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_normed_cumsum(shape, dim, dtype):
+    torch.manual_seed(0)
+    inp = torch.rand(shape, dtype=dtype, device=flag_gems.device) + 0.1
+
+    ref_out = torch_normed_cumsum(inp, dim=dim)
+    res_out = flag_gems.normed_cumsum(inp, dim=dim)
+
+    utils.gems_assert_close(
+        res_out,
+        ref_out,
+        dtype,
+        reduce_dim=shape[dim],
+        atol=1e-3,
+    )
+
+
+@pytest.mark.normed_cumsum
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_normed_cumsum_output_is_normalized(dtype):
+    torch.manual_seed(0)
+    inp = torch.rand((4, 257), dtype=dtype, device=flag_gems.device) + 0.1
+
+    res_out = flag_gems.normed_cumsum(inp)
+
+    expected_last = torch.ones_like(res_out[..., -1])
+    utils.gems_assert_close(res_out[..., -1], expected_last, dtype, atol=1e-3)

--- a/tests/test_normed_cumsum.py
+++ b/tests/test_normed_cumsum.py
@@ -65,5 +65,5 @@ def test_normed_cumsum_output_is_normalized(dtype):
 
     res_out = flag_gems.normed_cumsum(inp)
 
-    expected_last = torch.ones_like(res_out[..., -1])
+    expected_last = utils.to_reference(torch.ones_like(res_out[..., -1]))
     utils.gems_assert_close(res_out[..., -1], expected_last, dtype, atol=1e-3)


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
Other

### Description
add normed_cumsum op tests & benchmark

### Issue
closes: #4072 

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
benchmark on H20 HBM3
```
FlagGems/benchmark# pytest -s -m normed_cumsum
================================ test session starts ================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.13.0, xdoctest-1.0.2, rerunfailures-15.1, hypothesis-6.130.8, xdist-3.6.1, flakefinder-1.1.0, shard-0.1.2
collecting 195 items                                                                WARNING 06-30 02:38:57 [interface.py:869] Current platform cuda does not have '_pytestfixturefunction' attribute.
collected 764 items / 763 deselected / 1 selected                                   
Running 1 items in this shard

test_normed_cumsum.py 
Operator: normed_cumsum  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              11.261328           17.668385               0.637          [torch.Size([1073741824]), -1]
SUCCESS               0.013024            0.006784               1.920          [torch.Size([64, 64]), -1]
SUCCESS               0.273104            0.146144               1.869          [torch.Size([4096, 4096]), -1]
SUCCESS               0.212768            0.572416               0.372          [torch.Size([64, 512, 512]), -1]
SUCCESS              16.144000           16.161552               0.999          [torch.Size([1024, 1024, 1024]), -1]
SUCCESS               2.837040            4.431744               0.640          [torch.Size([268435456]), -1]
SUCCESS               0.112864            0.174464               0.647          [torch.Size([10000, 1]), -1]
SUCCESS               0.046304            0.176896               0.262          [torch.Size([10000, 256]), -1]
SUCCESS               8.385984            4.997952               1.678          [torch.Size([10000, 65536]), -1]
SUCCESS               0.015712            0.007264               2.163          [torch.Size([100, 1, 100]), -1]
SUCCESS               0.053632            0.431232               0.124          [torch.Size([100, 256, 100]), -1]
SUCCESS              72.422173           94.037155               0.770          [torch.Size([100, 65536, 100]), -1]


Operator: normed_cumsum  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              10.193760           17.145985               0.595          [torch.Size([1073741824]), -1]
SUCCESS               0.012384            0.006976               1.775          [torch.Size([64, 64]), -1]
SUCCESS               0.306880            0.147360               2.083          [torch.Size([4096, 4096]), -1]
SUCCESS               0.241632            0.575840               0.420          [torch.Size([64, 512, 512]), -1]
SUCCESS              16.668575           16.404624               1.016          [torch.Size([1024, 1024, 1024]), -1]
SUCCESS               2.562288            4.301952               0.596          [torch.Size([268435456]), -1]
SUCCESS               0.104512            0.167424               0.624          [torch.Size([10000, 1]), -1]
SUCCESS               0.048736            0.176832               0.276          [torch.Size([10000, 256]), -1]
SUCCESS               9.048912            6.261376               1.445          [torch.Size([10000, 65536]), -1]
SUCCESS               0.015200            0.007456               2.039          [torch.Size([100, 1, 100]), -1]
SUCCESS               0.053856            0.444224               0.121          [torch.Size([100, 256, 100]), -1]
SUCCESS              68.204544           95.457214               0.715          [torch.Size([100, 65536, 100]), -1]


Operator: normed_cumsum  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              10.367264           17.616480               0.588          [torch.Size([1073741824]), -1]
SUCCESS               0.013984            0.006912               2.023          [torch.Size([64, 64]), -1]
SUCCESS               0.275168            0.146112               1.883          [torch.Size([4096, 4096]), -1]
SUCCESS               0.213312            0.572416               0.373          [torch.Size([64, 512, 512]), -1]
SUCCESS              16.196095           16.156143               1.002          [torch.Size([1024, 1024, 1024]), -1]
SUCCESS               2.611392            4.425696               0.590          [torch.Size([268435456]), -1]
SUCCESS               0.113728            0.174336               0.652          [torch.Size([10000, 1]), -1]
SUCCESS               0.045664            0.176832               0.258          [torch.Size([10000, 256]), -1]
SUCCESS               8.391168            4.996608               1.679          [torch.Size([10000, 65536]), -1]
SUCCESS               0.015392            0.007296               2.110          [torch.Size([100, 1, 100]), -1]
SUCCESS               0.054752            0.432128               0.127          [torch.Size([100, 256, 100]), -1]
SUCCESS              72.445633           93.934883               0.771          [torch.Size([100, 65536, 100]), -1]

.

=================== 1 passed, 763 deselected in 89.13s (0:01:29) ====================
```
