### PR TITLE
add logit_out op tests & benchmark

### DIFF
--- a/benchmark/test_logit.py
+++ b/benchmark/test_logit.py
@@ -25,12 +25,11 @@ def test_logit_inplace():
     bench.run()
 
 
-@pytest.mark.skip(reason="The `out` parameter is not supported: issue #2688")
 @pytest.mark.logit_out
 def test_logit_out():
     bench = base.UnaryPointwiseOutBenchmark(
         op_name="logit_out",
-        torch_op=lambda a: torch.logit(a, eps=1e-6),
+        torch_op=lambda a, out: torch.logit(a, eps=1e-6, out=out),
         dtypes=consts.FLOAT_DTYPES,
     )
     bench.run()

--- a/tests/test_logit.py
+++ b/tests/test_logit.py
@@ -36,3 +36,50 @@ def test_logit_(shape, dtype):
     with flag_gems.use_gems():
         res_out = inp.logit_(eps=1e-6)
     utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.logit_out
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_logit_out(shape, dtype):
+    torch.manual_seed(0)
+    base = torch.empty(shape, device=flag_gems.device, dtype=torch.float32).uniform_(
+        -4.0, 4.0
+    )
+    inp = torch.sigmoid(base).to(dtype=dtype)
+    ref_inp = utils.to_reference(inp, True)
+    ref_out = torch.logit(ref_inp, eps=1e-6)
+
+    out = torch.empty_like(inp)
+    original_ptr = out.data_ptr()
+    with flag_gems.use_gems():
+        res_out = torch.logit(inp, eps=1e-6, out=out)
+
+    assert res_out.data_ptr() == original_ptr
+    assert out.data_ptr() == original_ptr
+    utils.gems_assert_close(out, ref_out, dtype)
+
+
+@pytest.mark.logit_out
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_logit_out_non_contiguous_out(dtype):
+    torch.manual_seed(0)
+    shape = (4, 7)
+    base = torch.empty(shape, device=flag_gems.device, dtype=torch.float32).uniform_(
+        -4.0, 4.0
+    )
+    inp = torch.sigmoid(base).to(dtype=dtype)
+    ref_inp = utils.to_reference(inp, True)
+    ref_out = torch.logit(ref_inp, eps=1e-6)
+
+    out_base = torch.empty(
+        (shape[0], shape[1] * 2), device=flag_gems.device, dtype=dtype
+    )
+    out = out_base[:, ::2]
+    assert not out.is_contiguous()
+
+    with flag_gems.use_gems():
+        res_out = torch.logit(inp, eps=1e-6, out=out)
+
+    assert res_out.data_ptr() == out.data_ptr()
+    utils.gems_assert_close(out, ref_out, dtype)


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
Other

### Description
add logit_out op tests & benchmark

### Issue
closes: #4069 #2688 

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
benchmark on H20 HBM3
```
FlagGems/benchmark# pytest -s -m logit_out
================================ test session starts ================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.13.0, xdoctest-1.0.2, rerunfailures-15.1, hypothesis-6.130.8, xdist-3.6.1, flakefinder-1.1.0, shard-0.1.2
collecting 195 items                                                                WARNING 06-30 03:13:11 [interface.py:869] Current platform cuda does not have '_pytestfixturefunction' attribute.
collected 763 items / 762 deselected / 1 selected                                   
Running 1 items in this shard

test_logit.py 
Operator: logit_out  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               3.104928            2.727456               1.138               0.394          ([torch.Size([1073741824])], {'out': torch.Size([1073741824])})
SUCCESS               0.005904            0.005184               1.139               0.001          ([torch.Size([64, 64])], {'out': torch.Size([64, 64])})
SUCCESS               0.054880            0.048416               1.134               0.347          ([torch.Size([4096, 4096])], {'out': torch.Size([4096, 4096])})
SUCCESS               0.054976            0.048512               1.133               0.346          ([torch.Size([64, 512, 512])], {'out': torch.Size([64, 512, 512])})
SUCCESS               3.106304            2.727744               1.139               0.394          ([torch.Size([1024, 1024, 1024])], {'out': torch.Size([1024, 1024, 1024])})
SUCCESS               0.005856            0.015936               0.367               0.000          ([torch.Size([1024, 1])], {'out': torch.Size([1024, 1])})
SUCCESS               0.005888            0.005440               1.082               0.003          ([torch.Size([1024, 16])], {'out': torch.Size([1024, 16])})
SUCCESS               0.006656            0.006080               1.095               0.043          ([torch.Size([1024, 256])], {'out': torch.Size([1024, 256])})
SUCCESS               0.018176            0.016352               1.112               0.257          ([torch.Size([1024, 4096])], {'out': torch.Size([1024, 4096])})
SUCCESS               0.200288            0.176256               1.136               0.381          ([torch.Size([1024, 65536])], {'out': torch.Size([1024, 65536])})
SUCCESS               0.005920            0.005280               1.121               0.001          ([torch.Size([64, 64, 1])], {'out': torch.Size([64, 64, 1])})
SUCCESS               0.006016            0.005408               1.112               0.012          ([torch.Size([64, 64, 16])], {'out': torch.Size([64, 64, 16])})
SUCCESS               0.008928            0.007904               1.130               0.133          ([torch.Size([64, 64, 256])], {'out': torch.Size([64, 64, 256])})
SUCCESS               0.054816            0.048480               1.131               0.346          ([torch.Size([64, 64, 4096])], {'out': torch.Size([64, 64, 4096])})


Operator: logit_out  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               3.421600            2.970848               1.152               0.361          ([torch.Size([1073741824])], {'out': torch.Size([1073741824])})
SUCCESS               0.005888            0.005344               1.102               0.001          ([torch.Size([64, 64])], {'out': torch.Size([64, 64])})
SUCCESS               0.056160            0.063616               0.883               0.264          ([torch.Size([4096, 4096])], {'out': torch.Size([4096, 4096])})
SUCCESS               0.056160            0.064256               0.874               0.261          ([torch.Size([64, 512, 512])], {'out': torch.Size([64, 512, 512])})
SUCCESS               3.433728            2.975392               1.154               0.361          ([torch.Size([1024, 1024, 1024])], {'out': torch.Size([1024, 1024, 1024])})
SUCCESS               0.005664            0.005088               1.113               0.000          ([torch.Size([1024, 1])], {'out': torch.Size([1024, 1])})
SUCCESS               0.006016            0.005280               1.139               0.003          ([torch.Size([1024, 16])], {'out': torch.Size([1024, 16])})
SUCCESS               0.006720            0.006016               1.117               0.044          ([torch.Size([1024, 256])], {'out': torch.Size([1024, 256])})
SUCCESS               0.019072            0.017728               1.076               0.237          ([torch.Size([1024, 4096])], {'out': torch.Size([1024, 4096])})
SUCCESS               0.272544            0.186528               1.461               0.360          ([torch.Size([1024, 65536])], {'out': torch.Size([1024, 65536])})
SUCCESS               0.005792            0.005312               1.090               0.001          ([torch.Size([64, 64, 1])], {'out': torch.Size([64, 64, 1])})
SUCCESS               0.006080            0.005632               1.080               0.012          ([torch.Size([64, 64, 16])], {'out': torch.Size([64, 64, 16])})
SUCCESS               0.009504            0.008416               1.129               0.125          ([torch.Size([64, 64, 256])], {'out': torch.Size([64, 64, 256])})
SUCCESS               0.056096            0.062896               0.892               0.267          ([torch.Size([64, 64, 4096])], {'out': torch.Size([64, 64, 4096])})


Operator: logit_out  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               3.143744            2.877984               1.092               0.373          ([torch.Size([1073741824])], {'out': torch.Size([1073741824])})
SUCCESS               0.005824            0.005344               1.090               0.001          ([torch.Size([64, 64])], {'out': torch.Size([64, 64])})
SUCCESS               0.055264            0.050960               1.084               0.329          ([torch.Size([4096, 4096])], {'out': torch.Size([4096, 4096])})
SUCCESS               0.055648            0.051072               1.090               0.329          ([torch.Size([64, 512, 512])], {'out': torch.Size([64, 512, 512])})
SUCCESS               3.143776            2.877696               1.092               0.373          ([torch.Size([1024, 1024, 1024])], {'out': torch.Size([1024, 1024, 1024])})
SUCCESS               0.005632            0.004992               1.128               0.000          ([torch.Size([1024, 1])], {'out': torch.Size([1024, 1])})
SUCCESS               0.005888            0.005440               1.082               0.003          ([torch.Size([1024, 16])], {'out': torch.Size([1024, 16])})
SUCCESS               0.006784            0.006144               1.104               0.043          ([torch.Size([1024, 256])], {'out': torch.Size([1024, 256])})
SUCCESS               0.018272            0.016960               1.077               0.247          ([torch.Size([1024, 4096])], {'out': torch.Size([1024, 4096])})
SUCCESS               0.202528            0.185536               1.092               0.362          ([torch.Size([1024, 65536])], {'out': torch.Size([1024, 65536])})
SUCCESS               0.005888            0.005312               1.108               0.001          ([torch.Size([64, 64, 1])], {'out': torch.Size([64, 64, 1])})
SUCCESS               0.006144            0.005536               1.110               0.012          ([torch.Size([64, 64, 16])], {'out': torch.Size([64, 64, 16])})
SUCCESS               0.009024            0.008064               1.119               0.130          ([torch.Size([64, 64, 256])], {'out': torch.Size([64, 64, 256])})
SUCCESS               0.055584            0.050880               1.092               0.330          ([torch.Size([64, 64, 4096])], {'out': torch.Size([64, 64, 4096])})

.

=================== 1 passed, 762 deselected in 66.35s (0:01:06) ====================
```
```
FlagGems/benchmark# pytest -s test_logit.py::test_logit_out
================================ test session starts ================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.13.0, xdoctest-1.0.2, rerunfailures-15.1, hypothesis-6.130.8, xdist-3.6.1, flakefinder-1.1.0, shard-0.1.2
collected 1 item                                                                    
Running 1 items in this shard

test_logit.py 
Operator: logit_out  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               3.106352            2.726544               1.139               0.394          ([torch.Size([1073741824])], {'out': torch.Size([1073741824])})
SUCCESS               0.005952            0.005120               1.163               0.001          ([torch.Size([64, 64])], {'out': torch.Size([64, 64])})
SUCCESS               0.054784            0.048384               1.132               0.347          ([torch.Size([4096, 4096])], {'out': torch.Size([4096, 4096])})
SUCCESS               0.054976            0.048576               1.132               0.345          ([torch.Size([64, 512, 512])], {'out': torch.Size([64, 512, 512])})
SUCCESS               3.106496            2.727552               1.139               0.394          ([torch.Size([1024, 1024, 1024])], {'out': torch.Size([1024, 1024, 1024])})
SUCCESS               0.005600            0.005152               1.087               0.000          ([torch.Size([1024, 1])], {'out': torch.Size([1024, 1])})
SUCCESS               0.006080            0.005472               1.111               0.003          ([torch.Size([1024, 16])], {'out': torch.Size([1024, 16])})
SUCCESS               0.006432            0.005856               1.098               0.045          ([torch.Size([1024, 256])], {'out': torch.Size([1024, 256])})
SUCCESS               0.018112            0.016192               1.119               0.259          ([torch.Size([1024, 4096])], {'out': torch.Size([1024, 4096])})
SUCCESS               0.200320            0.176288               1.136               0.381          ([torch.Size([1024, 65536])], {'out': torch.Size([1024, 65536])})
SUCCESS               0.005984            0.005376               1.113               0.001          ([torch.Size([64, 64, 1])], {'out': torch.Size([64, 64, 1])})
SUCCESS               0.006208            0.005632               1.102               0.012          ([torch.Size([64, 64, 16])], {'out': torch.Size([64, 64, 16])})
SUCCESS               0.009120            0.007872               1.159               0.133          ([torch.Size([64, 64, 256])], {'out': torch.Size([64, 64, 256])})
SUCCESS               0.054912            0.048384               1.135               0.347          ([torch.Size([64, 64, 4096])], {'out': torch.Size([64, 64, 4096])})


Operator: logit_out  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               3.380000            2.990144               1.130               0.359          ([torch.Size([1073741824])], {'out': torch.Size([1073741824])})
SUCCESS               0.006016            0.005440               1.106               0.001          ([torch.Size([64, 64])], {'out': torch.Size([64, 64])})
SUCCESS               0.056448            0.060000               0.941               0.280          ([torch.Size([4096, 4096])], {'out': torch.Size([4096, 4096])})
SUCCESS               0.056544            0.057456               0.984               0.292          ([torch.Size([64, 512, 512])], {'out': torch.Size([64, 512, 512])})
SUCCESS               3.422528            2.972768               1.151               0.361          ([torch.Size([1024, 1024, 1024])], {'out': torch.Size([1024, 1024, 1024])})
SUCCESS               0.005824            0.005056               1.152               0.000          ([torch.Size([1024, 1])], {'out': torch.Size([1024, 1])})
SUCCESS               0.006080            0.005504               1.105               0.003          ([torch.Size([1024, 16])], {'out': torch.Size([1024, 16])})
SUCCESS               0.006784            0.006144               1.104               0.043          ([torch.Size([1024, 256])], {'out': torch.Size([1024, 256])})
SUCCESS               0.019136            0.017568               1.089               0.239          ([torch.Size([1024, 4096])], {'out': torch.Size([1024, 4096])})
SUCCESS               0.262336            0.188032               1.395               0.357          ([torch.Size([1024, 65536])], {'out': torch.Size([1024, 65536])})
SUCCESS               0.005824            0.005440               1.071               0.001          ([torch.Size([64, 64, 1])], {'out': torch.Size([64, 64, 1])})
SUCCESS               0.006048            0.005696               1.062               0.012          ([torch.Size([64, 64, 16])], {'out': torch.Size([64, 64, 16])})
SUCCESS               0.009408            0.008432               1.116               0.124          ([torch.Size([64, 64, 256])], {'out': torch.Size([64, 64, 256])})
SUCCESS               0.056320            0.060704               0.928               0.276          ([torch.Size([64, 64, 4096])], {'out': torch.Size([64, 64, 4096])})


Operator: logit_out  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               3.143520            2.878016               1.092               0.373          ([torch.Size([1073741824])], {'out': torch.Size([1073741824])})
SUCCESS               0.005984            0.005376               1.113               0.001          ([torch.Size([64, 64])], {'out': torch.Size([64, 64])})
SUCCESS               0.055232            0.050880               1.086               0.330          ([torch.Size([4096, 4096])], {'out': torch.Size([4096, 4096])})
SUCCESS               0.055552            0.051136               1.086               0.328          ([torch.Size([64, 512, 512])], {'out': torch.Size([64, 512, 512])})
SUCCESS               3.143872            2.879904               1.092               0.373          ([torch.Size([1024, 1024, 1024])], {'out': torch.Size([1024, 1024, 1024])})
SUCCESS               0.005792            0.005184               1.117               0.000          ([torch.Size([1024, 1])], {'out': torch.Size([1024, 1])})
SUCCESS               0.006080            0.005504               1.105               0.003          ([torch.Size([1024, 16])], {'out': torch.Size([1024, 16])})
SUCCESS               0.006624            0.005920               1.119               0.044          ([torch.Size([1024, 256])], {'out': torch.Size([1024, 256])})
SUCCESS               0.018240            0.017024               1.071               0.246          ([torch.Size([1024, 4096])], {'out': torch.Size([1024, 4096])})
SUCCESS               0.202304            0.185728               1.089               0.361          ([torch.Size([1024, 65536])], {'out': torch.Size([1024, 65536])})
SUCCESS               0.005760            0.005152               1.118               0.001          ([torch.Size([64, 64, 1])], {'out': torch.Size([64, 64, 1])})
SUCCESS               0.006208            0.005344               1.162               0.012          ([torch.Size([64, 64, 16])], {'out': torch.Size([64, 64, 16])})
SUCCESS               0.008992            0.008256               1.089               0.127          ([torch.Size([64, 64, 256])], {'out': torch.Size([64, 64, 256])})
SUCCESS               0.055328            0.051136               1.082               0.328          ([torch.Size([64, 64, 4096])], {'out': torch.Size([64, 64, 4096])})

.

================================ 1 passed in 42.56s =================================
```