### PR TITLE
fix(sparse_attention): pad H dimension to satisfy tl.dot minimum size

### DIFF
--- a/benchmark/test_sparse_attention.py
+++ b/benchmark/test_sparse_attention.py
@@ -69,7 +69,6 @@ class SparseAttentionBenchmark(base.Benchmark):
             yield q, kv, attn_sink, topk_idxs, 1.0 / math.sqrt(dim)
 
 
-@pytest.mark.skip(reason="The test case fails with many exceptions: #2669")
 @pytest.mark.skipif(flag_gems.device == "cpu", reason="Unsupported in CPU mode")
 @pytest.mark.sparse_attn_triton
 def test_sparse_attn_triton():

--- a/src/flag_gems/fused/sparse_attention.py
+++ b/src/flag_gems/fused/sparse_attention.py
@@ -31,6 +31,7 @@ def sparse_attn_triton_kernel(
     stride_idxk,
     scale,
     topk,
+    H_ACTUAL,
     BLOCK: tl.constexpr,
     D: tl.constexpr,
     H: tl.constexpr,
@@ -42,8 +43,9 @@ def sparse_attn_triton_kernel(
     q_base = Q + pid_b * stride_qb + pid_m * stride_qm
     offs_h = tl.arange(0, H)
     offs_d = tl.arange(0, D)
+    h_mask = offs_h < H_ACTUAL
     q_ptrs = q_base + offs_h[:, None] * stride_qh + offs_d[None, :] * stride_qd
-    q_block = tl.load(q_ptrs)  # (H, D) bf16
+    q_block = tl.load(q_ptrs, mask=h_mask[:, None], other=0.0)  # (H, D) bf16
 
     # ---- base pointers ----
     kv_base = KV + pid_b * stride_kvb
@@ -95,7 +97,7 @@ def sparse_attn_triton_kernel(
         sum_exp = sum_exp * correction + scores_sum
 
     # ---- incorporate attn_sink ----
-    sink_vals = tl.load(attn_sink + offs_h)  # (H,)
+    sink_vals = tl.load(attn_sink + offs_h, mask=h_mask, other=0.0)  # (H,)
     sum_exp = sum_exp + tl.exp(sink_vals - scores_max)
 
     # ---- normalize ----
@@ -104,7 +106,7 @@ def sparse_attn_triton_kernel(
     # ---- store output: (H, D) ----
     o_base = O + pid_b * stride_ob + pid_m * stride_om
     o_ptrs = o_base + offs_h[:, None] * stride_oh + offs_d[None, :] * stride_od
-    tl.store(o_ptrs, acc_o.to(tl.bfloat16))
+    tl.store(o_ptrs, acc_o.to(tl.bfloat16), mask=h_mask[:, None])
 
 
 # ---------------------------------------------------------------------------
@@ -121,6 +123,7 @@ def sparse_attn_triton(
     topk = topk_idxs.shape[-1]
     o = torch.empty_like(q)
     BLOCK = 64
+    h_padded = max(16, triton.next_power_of_2(h))
 
     grid = (m, b)  # each program handles ALL h heads
     sparse_attn_triton_kernel[grid](
@@ -145,9 +148,10 @@ def sparse_attn_triton(
         topk_idxs.stride(2),
         softmax_scale,
         topk,
+        h,
         BLOCK=BLOCK,
         D=d,
-        H=h,
+        H=h_padded,
         num_warps=8,  # 256 threads, matching tilelang
     )
     return o

--- a/src/flag_gems/fused/sparse_attention.py
+++ b/src/flag_gems/fused/sparse_attention.py
@@ -77,9 +77,8 @@ def sparse_attn_triton_kernel(
         # -- scores: Q @ KV^T -> (H, BLOCK) via GEMM --
         acc_s = tl.dot(q_block, tl.trans(kv_block))  # (H, D) @ (D, BLOCK) = (H, BLOCK)
         acc_s = acc_s * scale
-        # mask invalid positions to -inf
-        mask_bias = tl.where(valid_mask, 0.0, float("-inf"))  # (BLOCK,)
-        acc_s = acc_s + mask_bias[None, :]  # broadcast: (H, BLOCK)
+        # mask invalid positions to -inf (apply on 2D tensor to avoid layout mismatch)
+        acc_s = tl.where(valid_mask[None, :], acc_s, float("-inf"))
 
         # -- online softmax update --
         scores_max_prev = scores_max

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -160,9 +160,6 @@ def sparse_attention_ref(q, kv, attn_sink, topk_idxs, scale):
     return out.to(q.dtype)
 
 
-@pytest.mark.skip(
-    reason="Issue #2809: The operator fails this test on Nvidia at least."
-)
 @pytest.mark.skipif(cfg.TO_CPU, reason="Unsupported in CPU mode")
 @pytest.mark.sparse_attn_triton
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

Fix two bugs in the `sparse_attention` Triton kernel that caused both benchmark and accuracy tests to fail on NVIDIA GPUs.

### Bug 1: `tl.dot` minimum dimension size (Closes #2669)

Triton `tl.dot` requires all matrix dimensions (M, N, K) >= 16, but the kernel used H (num_heads) directly as a tile dimension which can be < 16 (e.g. H=8). Pad H to `max(16, next_power_of_2(h))` and mask loads/stores with the actual head count `H_ACTUAL`, aligned with the existing MUSA backend approach.

### Bug 2: `tl.where` layout mismatch (Closes #2809)

The 1D `tl.where(valid_mask, 0.0, float("-inf"))` produces a tensor whose GPU layout is incompatible with the 2D `acc_s` from `tl.dot`, causing `arith.select` shape mismatch during Triton TTGIR compilation. Replace with a direct 2D `tl.where` on `acc_s`.

## Changes

- `src/flag_gems/fused/sparse_attention.py`: Add `H_ACTUAL` parameter with padding, fix `tl.where` layout
- `benchmark/test_sparse_attention.py`: Remove `@pytest.mark.skip` for #2669
- `tests/test_flash_attention.py`: Remove `@pytest.mark.skip` for #2809

Closes #2669
Closes #2809

🤖 Generated with [Claude Code](https://claude.com/claude-code)