### PR TITLE
fix hcu import error

### DIFF
--- a/src/flag_gems/utils/libentry.py
+++ b/src/flag_gems/utils/libentry.py
@@ -775,7 +775,7 @@ class LibEntry(triton.KernelInterface):
     def key(self, spec_args, dns_args, const_args):
         def spec_arg(arg):
             if hasattr(arg, "data_ptr"):
-                if device.vendor_name == "hygon":
+                if device.vendor_name == "hygon" and hasattr(triton.backends, "hcu"):
                     from triton.backends.hcu.compiler import HIPBackend
 
                     if hasattr(HIPBackend, "get_tensor_specialization"):


### PR DESCRIPTION
### PR Category
Other

### Type of Change
Bug Fix

### Description
Updated the Hygon-specific autotune key generation path to be compatible with older Triton versions. The HCU backend-specific tensor specialization logic is now only used when `triton.backends.hcu` is available; otherwise, it falls back to the existing dtype/divisibility-based key. This avoids import errors on Hygon environments with older Triton packages while preserving the new specialization behavior on newer versions.

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
N/A
