### PR TITLE
[Ascend] fix argmax crash: remove duplicate @libentry() on argmax_kernel

### DIFF
--- a/src/flag_gems/runtime/backend/_ascend/ops/argmax.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/argmax.py
@@ -52,7 +52,6 @@ def argmax_kernel_2(mid_value, mid_index, out, mid_size, BLOCK_MID: tl.constexpr
 
 
 @libentry()
-@libentry()
 @triton.heuristics(runtime.get_heuristic_config("argmax"))
 @triton.jit
 def argmax_kernel(


### PR DESCRIPTION
Fixes #4466

`argmax_kernel`（Ascend 后端）上重复叠了两个 `@libentry()`，运行时 `LibEntry` 解包遇到嵌套 LibEntry，抛 `RuntimeError: Invalid Runtime Function`，导致 NPU 上 `torch.argmax(x, dim=-1)`（如 SGLang sampler）崩溃。

其余 7 个后端（`_cambricon/_kunlunxin/_tsingmicro/_enflame/_spacemit/ 主库`）的 `argmax_kernel` 均为单个 `@libentry()`。引入于 #1831。

本 PR 删除重复的 `@libentry()`，最小改动一行。根因分析详见 #4466。
