### PR TITLE
fix(broadcast_to): use pin_memory to avoid illegal CPU->CUDA copy in CUDA graph capture

### DIFF
--- a/src/flag_gems/ops/broadcast_to.py
+++ b/src/flag_gems/ops/broadcast_to.py
@@ -144,12 +144,14 @@ def broadcast_to(x, size):
 
     # Create device arrays for shapes/strides with padding for MAX_DIMS
     pad_len = STATIC_MAX - out_ndim
+
     # torch.tensor(..., device=cuda) first allocates on CPU then copies to CUDA.
     # This implicit unpinned CPU->CUDA copy is illegal during CUDA graph capture
     # (triggered by models with attention_bias=True or mlp_bias=True that route
     # through addmm -> broadcast_to).
     # Fix: allocate on CPU with pin_memory=True, then transfer non-blocking.
     # The device.type guard avoids calling pin_memory() on CPU-only tensors.
+
     def _to_device(data, device):
         t = torch.tensor(data, dtype=torch.int64)
         if device.type == "cuda":

--- a/src/flag_gems/ops/broadcast_to.py
+++ b/src/flag_gems/ops/broadcast_to.py
@@ -153,7 +153,7 @@ def broadcast_to(x, size):
     # The device.type guard avoids calling pin_memory() on CPU-only tensors.
 
     def _to_device(data, device):
-        t = torch.tensor(data, dtype=torch.int64)
+        t = torch.tensor(data, dtype=torch.int64, device='cpu')
         if device.type == "cuda":
             t = t.pin_memory()
         return t.to(device, non_blocking=True)

--- a/src/flag_gems/ops/broadcast_to.py
+++ b/src/flag_gems/ops/broadcast_to.py
@@ -144,15 +144,21 @@ def broadcast_to(x, size):
 
     # Create device arrays for shapes/strides with padding for MAX_DIMS
     pad_len = STATIC_MAX - out_ndim
-    out_shape_arr = torch.tensor(
-        out_shape + [1] * pad_len, dtype=torch.int64, device=x.device
-    )
-    out_cumprod_arr = torch.tensor(
-        out_cumprod_right + [1] * pad_len, dtype=torch.int64, device=x.device
-    )
-    in_stride_arr = torch.tensor(
-        in_stride_eff + [0] * pad_len, dtype=torch.int64, device=x.device
-    )
+    # torch.tensor(..., device=cuda) first allocates on CPU then copies to CUDA.
+    # This implicit unpinned CPU->CUDA copy is illegal during CUDA graph capture
+    # (triggered by models with attention_bias=True or mlp_bias=True that route
+    # through addmm -> broadcast_to).
+    # Fix: allocate on CPU with pin_memory=True, then transfer non-blocking.
+    # The device.type guard avoids calling pin_memory() on CPU-only tensors.
+    def _to_device(data, device):
+        t = torch.tensor(data, dtype=torch.int64)
+        if device.type == "cuda":
+            t = t.pin_memory()
+        return t.to(device, non_blocking=True)
+
+    out_shape_arr = _to_device(out_shape + [1] * pad_len, x.device)
+    out_cumprod_arr = _to_device(out_cumprod_right + [1] * pad_len, x.device)
+    in_stride_arr = _to_device(in_stride_eff + [0] * pad_len, x.device)
 
     grid = lambda meta: (triton.cdiv(n_elements, meta["BLOCK_SIZE"]),)
 

--- a/src/flag_gems/ops/broadcast_to.py
+++ b/src/flag_gems/ops/broadcast_to.py
@@ -154,7 +154,7 @@ def broadcast_to(x, size):
 
     def _to_device(data, device):
         t = torch.tensor(data, dtype=torch.int64, device='cpu')
-        if device.type == "cuda":
+        if device.type == flag_gems.device:
             t = t.pin_memory()
         return t.to(device, non_blocking=True)
 

--- a/src/flag_gems/ops/broadcast_to.py
+++ b/src/flag_gems/ops/broadcast_to.py
@@ -19,6 +19,8 @@ import torch
 import triton
 import triton.language as tl
 
+import flag_gems
+
 logger = logging.getLogger(__name__)
 
 
@@ -153,7 +155,7 @@ def broadcast_to(x, size):
     # The device.type guard avoids calling pin_memory() on CPU-only tensors.
 
     def _to_device(data, device):
-        t = torch.tensor(data, dtype=torch.int64, device='cpu')
+        t = torch.tensor(data, dtype=torch.int64, device="cpu")
         if device.type == flag_gems.device:
             t = t.pin_memory()
         return t.to(device, non_blocking=True)


### PR DESCRIPTION
## Problem

`broadcast_to` crashes during CUDA graph capture when the input is on a CUDA device:

```
RuntimeError: Cannot copy between CPU and CUDA tensors during CUDA graph capture
unless the CPU tensor is pinned. Please use tensor.pin_memory() or allocate the
tensor with pin_memory=True.
```

### Root cause

`broadcast_to.py:147~155` creates three shape/stride tensors with `torch.tensor(..., device=x.device)`:

```python
out_shape_arr   = torch.tensor(out_shape + [1] * pad_len,         dtype=torch.int64, device=x.device)
out_cumprod_arr = torch.tensor(out_cumprod_right + [1] * pad_len, dtype=torch.int64, device=x.device)
in_stride_arr   = torch.tensor(in_stride_eff + [0] * pad_len,     dtype=torch.int64, device=x.device)
```

`torch.tensor(..., device=cuda)` internally allocates on CPU first, then copies to CUDA. This implicit **unpinned** CPU→CUDA copy is legal in eager mode but **illegal inside a CUDA graph capture region** (PyTorch requirement: all CPU→CUDA copies during capture must use pinned memory).

### Trigger condition

Any model that passes a bias through `addmm` → `broadcast_to` during CUDA graph capture. Concretely: models with `attention_bias: true` or `mlp_bias: true` in their config (e.g. `XiaomiMiMo/MiMo-7B-RL`). Models without bias (`attention_bias: false`) don't reach this code path and are unaffected.

## Fix

Replace the three `torch.tensor(..., device=x.device)` calls with a helper that pins memory before transferring:

```python
def _to_device(data, device):
    t = torch.tensor(data, dtype=torch.int64)
    if device.type == "cuda":
        t = t.pin_memory()
    return t.to(device, non_blocking=True)

out_shape_arr   = _to_device(out_shape + [1] * pad_len,         x.device)
out_cumprod_arr = _to_device(out_cumprod_right + [1] * pad_len, x.device)
in_stride_arr   = _to_device(in_stride_eff + [0] * pad_len,     x.device)
```

The `device.type == "cuda"` guard prevents `pin_memory()` from being called on CPU tensors (which would raise an error in CPU-only environments).

## Verification

Tested on A800 80GB with vllm 0.24.0 + FlagGems (latest):

- `XiaomiMiMo/MiMo-7B-RL` (`attention_bias: true`): offline inference with CUDA graph enabled → **PASS** after fix
