### PR TITLE
Rename the artifact from on-demand workflow

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -172,7 +172,7 @@ jobs:
       - id: upload-results
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
-          name: ondemand-test
+          name: ${{ needs.preprocess.outputs.op }}-${{ env.BACKEND }}
           path: results/
 
       - id: attach-result-link


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

The artifact generated from the on-demand test workflow was always 'ondemand-test.zip'. This is not convenient, and I'm not sure if there could be conflicts. This PR proposes a more intuitive naming of the artifact.