### PR TITLE
Hopper FA3 benchmark

### DIFF
--- a/benchmark/conftest.py
+++ b/benchmark/conftest.py
@@ -119,6 +119,69 @@ def pytest_addoption(parser):
         "--query", action="store_true", default=False, help="Enable query mode"
     )
 
+    try:
+        parser.addoption(
+            "--flash-attn-varlen-fa-version",
+            action="store",
+            type=int,
+            default=2,
+            choices=[2, 3],
+            help=(
+                "FA version used by flash_attn_varlen_func accuracy and benchmark "
+                "tests."
+            ),
+        )
+    except ValueError:
+        # Mixed test+benchmark pytest runs may already register this option in
+        # tests/conftest.py. Reuse the existing option in that case.
+        pass
+
+    try:
+        parser.addoption(
+            "--flash-attn-varlen-enable-vllm",
+            action="store_true",
+            default=False,
+            help=(
+                "Enable vLLM flash-attention baseline benchmarks for "
+                "flash_attn_varlen_func. FA3 benchmarks run FlagGems-only by "
+                "default."
+            ),
+        )
+    except ValueError:
+        # Mixed test+benchmark pytest runs may already register this option in
+        # tests/conftest.py. Reuse the existing option in that case.
+        pass
+
+    try:
+        parser.addoption(
+            "--flash-attn-varlen-case",
+            action="store",
+            default="all",
+            choices=["all", "qwenCase", "prefillDecodePageCase"],
+            help=(
+                "Select flash_attn_varlen_func benchmark cases. 'all' runs both "
+                "qwenCase and prefillDecodePageCase."
+            ),
+        )
+    except ValueError:
+        # Mixed test+benchmark pytest runs may already register this option in
+        # tests/conftest.py. Reuse the existing option in that case.
+        pass
+
+    try:
+        parser.addoption(
+            "--hopper-mm-version",
+            action="store",
+            default="original",
+            required=False,
+            choices=["original", "wasp"],
+            help="Hopper mm implementation used by mm accuracy and benchmark tests.",
+        )
+    except ValueError:
+        # Mixed test+benchmark pytest runs may already register this option in
+        # tests/conftest.py. Reuse the existing option in that case.
+        pass
+
     parser.addoption(
         "--metrics",
         action="append",

--- a/benchmark/test_flash_attn_varlen_func.py
+++ b/benchmark/test_flash_attn_varlen_func.py
@@ -5,15 +5,81 @@ import torch
 
 import flag_gems
 
-from . import base, utils
+from tests.hopper_fa3_utils import (
+    HAS_VLLM_FA,
+    VLLM_FA_HAS_BLOCK_TABLE,
+    VLLM_FA_HAS_SEQUSED_K,
+    Shape as HopperFA3Shape,
+    Tensors as HopperFA3Tensors,
+    attn_flops as hopper_fa3_attn_flops,
+    benchmark_shapes as hopper_fa3_benchmark_shapes,
+    dispatch_source as hopper_fa3_dispatch_source,
+    dispatches_to_hopper as dispatches_to_hopper_fa3,
+    is_fa3_supported as is_hopper_fa3_supported,
+    make_varlen as make_hopper_fa3_varlen,
+    run_flag_gems as run_hopper_fa3,
+    run_vllm_fa as run_vllm_hopper_fa3,
+)
+
+from . import base, consts, utils
 
 vendor_name = flag_gems.vendor_name
+
+
+def _selected_fa_version(pytestconfig) -> int:
+    return pytestconfig.getoption("flash_attn_varlen_fa_version")
+
+
+def _vllm_benchmark_enabled(pytestconfig) -> bool:
+    return bool(pytestconfig.getoption("flash_attn_varlen_enable_vllm"))
+
+
+def _selected_case(pytestconfig) -> str:
+    return pytestconfig.getoption("flash_attn_varlen_case")
+
+
+def _skip_unless_case_enabled(pytestconfig, case_name: str) -> None:
+    selected_case = _selected_case(pytestconfig)
+    if selected_case not in ("all", case_name):
+        pytest.skip(f"{case_name} is disabled by --flash-attn-varlen-case.")
+
+
+def _skip_unless_vllm_baseline_available() -> None:
+    if utils.SkipVersion("vllm", "<0.9"):
+        pytest.skip(
+            "vLLM version prior to 0.9 does not include the "
+            "flash_attn_varlen_func API."
+        )
+    if utils.SkipVersion("torch", "<2.7"):
+        pytest.skip("Torch version prior to 2.7 is not compatible with VLLM.")
+
+
+def _skip_unless_selected_fa_supported(pytestconfig) -> None:
+    fa_version = _selected_fa_version(pytestconfig)
+    if fa_version == 3 and not is_hopper_fa3_supported():
+        pytest.skip("FA3 requires CUDA Hopper with Triton FA3 support.")
+
+
+def _assert_flash_attn_varlen_uses_hopper_backend() -> None:
+    if not dispatches_to_hopper_fa3():
+        pytest.fail(
+            "flag_gems.flash_attn_varlen_func is not routed to the Hopper "
+            f"backend; source={hopper_fa3_dispatch_source()}"
+        )
+
+
+def _hopper_benchmark_shape_skip_reason(shape: HopperFA3Shape) -> Optional[str]:
+    if shape.paged and not (VLLM_FA_HAS_BLOCK_TABLE and VLLM_FA_HAS_SEQUSED_K):
+        return "vLLM flash-attention lacks paged KV benchmark support"
+    return None
 
 
 class FlashAttnVarlenBenchmark(base.Benchmark):
     """
     benchmark for flash_attn_varlen_func
     """
+
+    fa_version = 2
 
     def set_shapes(self, shape_file_path: Optional[List[Any]] = None):
         # Collecting from qwen/Qwen3-1.7B
@@ -215,9 +281,98 @@ class FlashAttnVarlenBenchmark(base.Benchmark):
                 "cp_world_size": 1,
                 "cp_rank": 0,
                 "cp_tot_seqused_k": None,
-                "fa_version": 2,
+                "fa_version": self.fa_version,
             },
         )
+
+
+def _hopper_fa3_gems_wrapper(
+    tensors: HopperFA3Tensors, shape: HopperFA3Shape, fa_version: int
+):
+    if fa_version == 2:
+        kwargs = {
+            "max_seqlen_q": tensors.max_seqlen_q,
+            "cu_seqlens_q": tensors.cu_seqlens_q,
+            "max_seqlen_k": tensors.max_seqlen_k,
+            "softmax_scale": shape.head_dim**-0.5,
+            "causal": shape.causal,
+            "fa_version": fa_version,
+        }
+        if shape.paged:
+            kwargs["seqused_k"] = tensors.seqused_k
+            kwargs["block_table"] = tensors.block_table
+        else:
+            kwargs["cu_seqlens_k"] = tensors.cu_seqlens_k
+        return flag_gems.ops.flash_attn_varlen_func(
+            tensors.q, tensors.k, tensors.v, **kwargs
+        )
+    return run_hopper_fa3(tensors, shape, fa_version=fa_version)
+
+
+def _hopper_fa3_vllm_wrapper(
+    tensors: HopperFA3Tensors, shape: HopperFA3Shape, fa_version: int
+):
+    return run_vllm_hopper_fa3(tensors, shape, fa_version=fa_version)
+
+
+class HopperFA3Benchmark(base.Benchmark):
+    DEFAULT_METRICS = consts.DEFAULT_METRICS[:] + ["tflops"]
+    DEFAULT_SHAPE_DESC = (
+        "name, seq_lens, num_query_heads, num_kv_heads, head_dim, causal, paged"
+    )
+    fa_version = 3
+    use_vllm_baseline = False
+
+    def set_shapes(self, shape_file_path=None):
+        self.shapes = hopper_fa3_benchmark_shapes()
+
+    def init_user_config(self):
+        super().init_user_config()
+        supported_shapes = []
+        skipped_reasons = []
+        for shape in self.shapes:
+            skip_reason = (
+                _hopper_benchmark_shape_skip_reason(shape)
+                if self.use_vllm_baseline
+                else None
+            )
+            if skip_reason:
+                skipped_reasons.append(f"{shape.name}: {skip_reason}")
+                continue
+            supported_shapes.append(shape)
+        if not supported_shapes:
+            details = "; ".join(skipped_reasons) if skipped_reasons else "none"
+            pytest.skip(f"No Hopper varlen benchmark shapes are supported ({details}).")
+        self.shapes = supported_shapes
+
+    def get_input_iter(self, dtype):
+        for idx, shape in enumerate(self.shapes):
+            tensors = make_hopper_fa3_varlen(shape, dtype, self.device, seed=2026 + idx)
+            yield tensors, shape, self.fa_version
+
+    def unpack_to_args_kwargs(self, input_tuple):
+        return list(input_tuple), {}
+
+    def record_shapes(
+        self, tensors: HopperFA3Tensors, shape: HopperFA3Shape, fa_version: int
+    ):
+        return {
+            "name": shape.name,
+            "seq_lens": shape.seq_lens,
+            "num_query_heads": shape.nh_q,
+            "num_kv_heads": shape.nh_k,
+            "head_dim": shape.head_dim,
+            "causal": shape.causal,
+            "paged": shape.paged,
+            "max_seqlen_q": tensors.max_seqlen_q,
+            "max_seqlen_k": tensors.max_seqlen_k,
+            "fa_version": fa_version,
+        }
+
+    def get_tflops(
+        self, op, tensors: HopperFA3Tensors, shape: HopperFA3Shape, fa_version: int
+    ):
+        return hopper_fa3_attn_flops(shape)
 
 
 def flash_attn_varlen_legacy(*args, **kwargs):
@@ -285,30 +440,72 @@ def flash_attn_varlen_legacy(*args, **kwargs):
     return result
 
 
-@pytest.mark.skipif(
-    utils.SkipVersion("vllm", "<0.9"),
-    reason="vLLM version prior to 0.9 does not include the flash_attn_varlen_func API.",
-)
-@pytest.mark.skipif(
-    utils.SkipVersion("torch", "<2.7"),
-    reason="Torch version prior to 2.7 is not compatible with VLLM.",
-)
 @pytest.mark.skipif(vendor_name == "hygon", reason="#2816: RuntimeError")
 @pytest.mark.skipif(vendor_name == "cambricon", reason="#2886: TypeError")
 @pytest.mark.flash_attn_varlen_func
-def test_flash_attn_varlen_func(monkeypatch):
+def test_flash_attn_varlen_func(monkeypatch, pytestconfig):
+    _skip_unless_case_enabled(pytestconfig, "qwenCase")
     monkeypatch.setenv("VLLM_CONFIGURE_LOGGING", "0")
+    fa_version = _selected_fa_version(pytestconfig)
+    _skip_unless_selected_fa_supported(pytestconfig)
+    if fa_version == 3:
+        _assert_flash_attn_varlen_uses_hopper_backend()
 
-    if vendor_name == "iluvatar":
-        # iluvatar does not have updated vllm_flash_attn, use conversion wrapper
-        flash_attn_varlen_func = flash_attn_varlen_legacy
+    use_vllm_baseline = _vllm_benchmark_enabled(pytestconfig)
+
+    if not use_vllm_baseline:
+        flash_attn_varlen_func = flag_gems.flash_attn_varlen_func
     else:
-        from vllm.vllm_flash_attn.flash_attn_interface import flash_attn_varlen_func
+        _skip_unless_vllm_baseline_available()
+        if vendor_name == "iluvatar":
+            # iluvatar does not have updated vllm_flash_attn, use conversion wrapper
+            flash_attn_varlen_func = flash_attn_varlen_legacy
+        else:
+            from vllm.vllm_flash_attn.flash_attn_interface import (
+                flash_attn_varlen_func,
+            )
+
+    gems_op = (
+        flag_gems.flash_attn_varlen_func
+        if fa_version == 3
+        else flag_gems.ops.flash_attn_varlen_func
+    )
 
     bench = FlashAttnVarlenBenchmark(
         op_name="flash_attn_varlen_func",
         torch_op=flash_attn_varlen_func,
-        gems_op=flag_gems.ops.flash_attn_varlen_func,
+        gems_op=gems_op,
         dtypes=[torch.float16, torch.bfloat16],
+        fa_version=fa_version,
     )
+    if not use_vllm_baseline:
+        bench.metrics = ["latency"]
+    bench.run()
+
+
+@pytest.mark.hopper_fa3
+@pytest.mark.flash_attn_varlen_func
+def test_flash_attn_varlen_func_hopper_fa3(pytestconfig):
+    _skip_unless_case_enabled(pytestconfig, "prefillDecodePageCase")
+    _skip_unless_selected_fa_supported(pytestconfig)
+    use_vllm_baseline = _vllm_benchmark_enabled(pytestconfig)
+    if use_vllm_baseline and not HAS_VLLM_FA:
+        pytest.skip("requires vLLM flash-attention as the benchmark baseline")
+    fa_version = _selected_fa_version(pytestconfig)
+    if fa_version == 3:
+        _assert_flash_attn_varlen_uses_hopper_backend()
+    bench = HopperFA3Benchmark(
+        op_name="hopper_fa3",
+        torch_op=(
+            _hopper_fa3_vllm_wrapper
+            if use_vllm_baseline
+            else _hopper_fa3_gems_wrapper
+        ),
+        gems_op=_hopper_fa3_gems_wrapper,
+        dtypes=[torch.float16, torch.bfloat16],
+        fa_version=fa_version,
+        use_vllm_baseline=use_vllm_baseline,
+    )
+    if not use_vllm_baseline:
+        bench.metrics = ["latency", "tflops"]
     bench.run()

--- a/src/flag_gems/patches/patch_vllm_all.py
+++ b/src/flag_gems/patches/patch_vllm_all.py
@@ -8,6 +8,15 @@ import flag_gems
 from flag_gems.patches.patch_util import patch_module_method, patch_vllm_lib
 
 
+def _metadata_max_num_splits(metadata) -> int:
+    if metadata is None:
+        return 0
+    value = getattr(metadata, "max_num_splits", None)
+    if value is None:
+        value = getattr(metadata, "num_splits", 0)
+    return int(value or 0)
+
+
 def custom_gems_rms_forward_cuda(self, x, residual=None):
     from flag_gems.modules.normalization import gems_rms_forward
 
@@ -211,6 +220,14 @@ def custom_gems_flash_attention_impl_forward(
             max_seqlen_k = local_metadata.local_max_seq_len
             block_table = local_metadata.local_block_table
             scheduler_metadata = local_metadata.local_scheduler_metadata
+            num_splits = int(
+                getattr(
+                    local_metadata,
+                    "local_max_num_splits",
+                    _metadata_max_num_splits(local_metadata),
+                )
+                or 0
+            )
         else:
             cu_seqlens_q = attn_metadata.query_start_loc
             seqused_k = attn_metadata.seq_lens
@@ -218,6 +235,7 @@ def custom_gems_flash_attention_impl_forward(
             max_seqlen_k = attn_metadata.max_seq_len
             block_table = attn_metadata.block_table
             scheduler_metadata = attn_metadata.scheduler_metadata
+            num_splits = _metadata_max_num_splits(attn_metadata)
 
         descale_shape = (cu_seqlens_q.shape[0] - 1, key.shape[1])
 
@@ -242,7 +260,7 @@ def custom_gems_flash_attention_impl_forward(
             k_descale=layer._k_scale.expand(descale_shape),
             v_descale=layer._v_scale.expand(descale_shape),
             s_aux=None,
-            num_splits=0,
+            num_splits=num_splits,
             cp_world_size=1,
             cp_rank=0,
             cp_tot_seqused_k=None,
@@ -497,7 +515,7 @@ def custom_gems_flashattn_mla_forward_decode(
         return_softmax_lse=self.need_to_return_lse_for_decode,
         fa_version=2,
         scheduler_metadata=attn_metadata.decode.scheduler_metadata,
-        num_splits=0,
+        num_splits=_metadata_max_num_splits(attn_metadata.decode),
         cp_world_size=self.dcp_world_size,
         cp_rank=self.dcp_rank,
         cp_tot_seqused_k=attn_metadata.decode.dcp_tot_seq_lens,

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/__init__.py
@@ -1,6 +1,7 @@
 import triton
 
 if triton.__version__ >= "3.4":
+    from .attention import flash_attn_varlen_func, flash_attn_varlen_opt_func
     from .fill import (  # noqa: F401
         fill_scalar,
         fill_scalar_,
@@ -13,6 +14,7 @@ if triton.__version__ >= "3.4":
     from .mul import mul  # noqa: F401
     from .sqrt import sqrt, sqrt_  # noqa: F401
     from .w8a8_block_fp8_matmul import w8a8_block_fp8_matmul  # noqa: F401
+    from .attention import flash_attn_varlen_func, flash_attn_varlen_opt_func # noqa: F401
 
 # The Gluon FP8 block-wise BMM kernel and fp8_einsum require Triton >= 3.6.0.
 if triton.__version__ >= "3.6.0":

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/attention.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/attention.py
@@ -1,0 +1,152 @@
+# src/flag_gems/runtime/backend/_nvidia/hopper/ops/attention.py
+"""
+Hopper-specific overrides for flash-attention varlen entry points.
+Loaded by BackendArchEvent.get_arch_ops() on sm_90+; replaces the generic
+flash_attn_varlen_func / flash_attn_varlen_opt_func in flag_gems globals.
+"""
+import logging
+
+import torch
+
+from flag_gems.config import use_c_extension
+from flag_gems.ops.flash_api import mha_varlan_fwd, mha_varlan_fwd_opt
+from flag_gems.runtime import torch_device_fn
+
+from .flash_api_v3 import is_fa3_supported, mha_varlan_fwd_v3
+
+logger = logging.getLogger(__name__)
+
+
+def _maybe_contiguous(x):
+    return x.contiguous() if x is not None and x.stride(-1) != 1 else x
+
+
+def flash_attn_varlen_func(
+    q,
+    k,
+    v,
+    max_seqlen_q,
+    cu_seqlens_q,
+    max_seqlen_k,
+    cu_seqlens_k=None,
+    seqused_k=None,
+    q_v=None,
+    dropout_p=0.0,
+    softmax_scale=None,
+    causal=False,
+    window_size=None,
+    softcap=0.0,
+    alibi_slopes=None,
+    deterministic=False,
+    return_attn_probs=False,
+    block_table=None,
+    return_softmax_lse=False,
+    out=None,
+    scheduler_metadata=None,
+    q_descale=None,
+    k_descale=None,
+    v_descale=None,
+    s_aux=None,
+    num_splits=0,
+    cp_world_size=1,
+    cp_rank=0,
+    cp_tot_seqused_k=None,
+    fa_version=3,
+):
+    if fa_version not in (2, 3):
+        raise RuntimeError(f"Unsupported fa_version={fa_version}")
+    if fa_version == 3 and not is_fa3_supported():
+        logger.warning("FA3 requested but unavailable; falling back to FA2.")
+        fa_version = 2
+    if use_c_extension:
+        from flag_gems.ops.attention import flash_attn_varlen_func as _generic
+
+        return _generic(
+            q,
+            k,
+            v,
+            max_seqlen_q,
+            cu_seqlens_q,
+            max_seqlen_k,
+            cu_seqlens_k,
+            seqused_k,
+            q_v,
+            dropout_p,
+            softmax_scale,
+            causal,
+            window_size,
+            softcap,
+            alibi_slopes,
+            deterministic,
+            return_attn_probs,
+            block_table,
+            return_softmax_lse,
+            out,
+            scheduler_metadata,
+            q_descale,
+            k_descale,
+            v_descale,
+            s_aux,
+            num_splits,
+            cp_world_size,
+            cp_rank,
+            cp_tot_seqused_k,
+            fa_version,
+        )
+
+    assert cu_seqlens_k is not None or seqused_k is not None
+    assert cu_seqlens_k is None or seqused_k is None
+    assert block_table is None or seqused_k is not None
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** (-0.5)
+    real_window_size = (
+        (-1, -1) if window_size is None else (window_size[0], window_size[1])
+    )
+
+    q, k, v = [_maybe_contiguous(x) for x in (q, k, v)]
+    dummy_cu_seqlens_k = torch.empty_like(cu_seqlens_q)
+    max_seqlen_q = (
+        max_seqlen_q.item() if hasattr(max_seqlen_q, "item") else max_seqlen_q
+    )
+    max_seqlen_k = (
+        max_seqlen_k.item() if hasattr(max_seqlen_k, "item") else max_seqlen_k
+    )
+
+    launcher_args = (
+        q,
+        k,
+        v,
+        out,
+        cu_seqlens_q,
+        dummy_cu_seqlens_k if cu_seqlens_k is None else cu_seqlens_k,
+        seqused_k,
+        None,
+        block_table,
+        alibi_slopes,
+        max_seqlen_q,
+        max_seqlen_k,
+        dropout_p,
+        softmax_scale,
+        False,
+        causal,
+        real_window_size[0],
+        real_window_size[1],
+        softcap,
+        return_softmax_lse and dropout_p > 0,
+        None,
+    )
+    if fa_version == 3:
+        out, q, k, v, softmax_lse, *_ = mha_varlan_fwd_v3(
+            *launcher_args,
+            scheduler_metadata=scheduler_metadata,
+            num_splits=num_splits,
+        )
+    else:
+        out, q, k, v, softmax_lse, *_ = mha_varlan_fwd(*launcher_args)
+    return (out, softmax_lse) if return_softmax_lse else out
+
+
+def flash_attn_varlen_opt_func(*args, **kwargs):
+    # Mirrors the generic attention.py _opt path, swapping the launcher to
+    # mha_varlan_fwd_opt for FA2 while keeping mha_varlan_fwd_v3 for FA3.
+    ...

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/README.md
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/README.md
@@ -1,0 +1,67 @@
+# Hopper FA3 TLE Kernels
+
+This package contains the active Hopper FA3 TLE forward kernels used through
+`ops/flash_kernel_v3.py` and `flash_api_v3.py`.  Decode-only prototypes that
+are not part of the current dispatch path live in `bak/`.
+
+## Active Dispatch Surface
+
+| File | Role |
+| --- | --- |
+| `kernels.py` | Public re-export layer for the active FA3 kernels. |
+| `planning.py` | Minimal vLLM-style metadata dispatch helper. |
+| `utils.py` | Shared masks, ALiBi, paged gather, TLE copy/barrier helpers, and autotune helpers. |
+| `fa_hopper_persistent_pingpong.py` | Long/prefill kernel used by metadata prefill dispatch. |
+| `fa_hopper_short.py` | Short prefill kernel used by metadata prefill dispatch. |
+| `fa_hopper_direct.py` | Direct decode kernel used when cache-KV metadata is present without split-KV. |
+| `fa_hopper_decode_flashdecoding.py` | Flash-Decoding split-KV path used when cache-KV metadata has `num_splits > 1`. |
+
+## Metadata Dispatch
+
+The default FA3 path follows vLLM-style metadata semantics instead of routing
+by a best-known workload fallback table:
+
+- dense vs paged: `block_table is None` vs a valid block table
+- prefill: `max_query_len > 1` and no cache-KV length tensor
+- direct decode: cache-KV lengths are present and the effective split count is 1
+- multi-token/speculative decode: `max_query_len > 1` and cache-KV lengths are present
+- split-KV / Flash-Decoding: cache-KV lengths are present and the effective split count is greater than 1
+
+When cache-KV lengths are present and the caller passes `num_splits=0`, the
+launcher can compute vLLM-style scheduler metadata.  By default this metadata
+does not force the current TLE split-KV kernel, because that kernel is not yet
+equivalent to vLLM's tile scheduler implementation and can regress paged/decode
+workloads.  Set `FLAG_GEMS_FA3_TLE_AUTO_SPLITKV=1` to opt into the experimental
+metadata-driven split-KV route.
+
+Dynamic per-sequence split counts are generated and logged.  The active TLE
+split-KV kernel still uses the maximum split count as its static launch shape,
+with per-batch dynamic split counts only used to skip extra split programs.
+
+Debug/override knobs:
+
+```bash
+FLAG_GEMS_FA3_TLE_LOG_PLAN=1           # print metadata/kernel information
+FLAG_GEMS_FA3_TLE_AUTO_SPLITKV=1       # experimental metadata-driven split-KV
+FLAG_GEMS_FA3_TLE_PAGED_PREFILL_ROUTE=auto|direct|long
+FLAG_GEMS_FA3_TLE_PAGED_PREFILL_MIN_Q=1024
+FLAG_GEMS_FA3_TLE_PAGED_PREFILL_MIN_AVG_Q=128
+```
+
+`PAGED_PREFILL_ROUTE=auto` keeps decode and short/medium paged workloads on the
+direct path, but routes large paged prefill-like requests to the long persistent
+kernel when both thresholds are met.  Use `direct` to reproduce the old route
+and `long` to force the candidate route for paged cache-KV requests.
+
+## Archived Experiments
+
+The following decode-only experiments are archived in `bak/`:
+
+- `fa_hopper_decode_onepass.py`
+- `fa_hopper_decode_splitkv.py`
+- `fa_hopper_decode_paged_lb.py`
+- `fa_hopper_decode_seesaw.py`
+- `experimental_registry.py`
+
+They remain importable for `scripts/run_fa3_decode_experiments.py`, but are not
+re-exported by `kernels.py` and are not selected by default dispatch.

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/__init__.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/__init__.py
@@ -1,0 +1,22 @@
+"""Hopper FA3 kernel suite.
+
+The modules in this package provide the implementation backing the historical
+``ops.flash_kernel_v3`` import path, plus script-facing registry helpers for
+comparing warp-specialization variants.
+"""
+
+from .registry import (
+    WSVariant,
+    get_variant,
+    iter_variants,
+    resolve_variant_names,
+    variant_names,
+)
+
+__all__ = [
+    "WSVariant",
+    "get_variant",
+    "iter_variants",
+    "resolve_variant_names",
+    "variant_names",
+]

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/best_known.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/best_known.py
@@ -1,0 +1,109 @@
+"""Best-known FA3 routing policy.
+
+The policy is intentionally conservative: keep FA3 on workloads where the
+current implementation is consistently ahead, and transparently route weak
+decode/paged cases to the existing FA2 launcher unless the user explicitly
+forces a FA3 family for experiments.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import os
+
+
+_BEST_ROUTE_MODES = ("auto", "fa3_only", "fa2_only")
+ROUTE_CURRENT_FA3 = "current_fa3"
+ROUTE_RESTORED_FA3 = "restored_fa3"
+ROUTE_FA2_FALLBACK = "fa2_fallback"
+
+
+@dataclass(frozen=True)
+class FA3BestRoute:
+    route: str
+    workload: str
+    reason: str
+
+
+def fa3_tle_best_route_mode() -> str:
+    value = os.getenv("FLAG_GEMS_FA3_TLE_BEST_ROUTE", "fa3_only").strip().lower()
+    if value not in _BEST_ROUTE_MODES:
+        raise RuntimeError(
+            "invalid FLAG_GEMS_FA3_TLE_BEST_ROUTE="
+            f"{value!r}; expected one of {', '.join(_BEST_ROUTE_MODES)}"
+        )
+    return value
+
+
+def classify_fa3_workload(
+    *,
+    total_q: int,
+    batch_size: int,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    is_paged: bool,
+) -> str:
+    prefix = "paged" if is_paged else "dense"
+    avg_q = total_q / max(batch_size, 1)
+
+    if max_seqlen_q <= 8:
+        return f"{prefix}_decode"
+    if max_seqlen_q <= 32 and max_seqlen_k >= 1024:
+        return f"{prefix}_decodeish_long_k"
+    if max_seqlen_q <= 128 and max_seqlen_k <= 128:
+        return f"{prefix}_short"
+    if max_seqlen_q <= 128:
+        return f"{prefix}_mixed_short"
+    if is_paged and max_seqlen_q > 512 and avg_q <= 128:
+        return "paged_serve_mixed"
+    if max_seqlen_q <= 1024 and max_seqlen_k <= 1024:
+        return f"{prefix}_medium_or_prefill"
+    if is_paged:
+        return "paged_uniform_prefill"
+    return "dense_prefill_or_long"
+
+
+def select_fa3_best_route(
+    *,
+    total_q: int,
+    batch_size: int,
+    max_seqlen_q: int,
+    max_seqlen_k: int,
+    is_paged: bool,
+    force_family_id: int,
+) -> FA3BestRoute:
+    mode = fa3_tle_best_route_mode()
+    workload = classify_fa3_workload(
+        total_q=total_q,
+        batch_size=batch_size,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        is_paged=is_paged,
+    )
+
+    if mode == "fa2_only":
+        return FA3BestRoute(ROUTE_FA2_FALLBACK, workload, "env fa2_only")
+    if mode == "fa3_only":
+        return FA3BestRoute(ROUTE_CURRENT_FA3, workload, "env fa3_only")
+    if force_family_id != -1:
+        return FA3BestRoute(ROUTE_CURRENT_FA3, workload, "forced FA3 family")
+
+    if workload in ("dense_prefill_or_long", "paged_serve_mixed"):
+        return FA3BestRoute(ROUTE_CURRENT_FA3, workload, "best-known FA3 win")
+
+    return FA3BestRoute(
+        ROUTE_FA2_FALLBACK,
+        workload,
+        "best-known FA2 fallback until restored FA3 kernel is verified",
+    )
+
+
+__all__ = [
+    "FA3BestRoute",
+    "ROUTE_CURRENT_FA3",
+    "ROUTE_RESTORED_FA3",
+    "ROUTE_FA2_FALLBACK",
+    "classify_fa3_workload",
+    "fa3_tle_best_route_mode",
+    "select_fa3_best_route",
+]

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/fa_hopper_decode_flashdecoding.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/fa_hopper_decode_flashdecoding.py
@@ -1,0 +1,421 @@
+"""Flash-Decoding-style split-KV decode FA3 TLE experimental kernels.
+
+This family keeps one program per effective query row, batch, head, and KV
+split.  Each split writes partial online-softmax state and a separate combine
+kernel produces the final output.  ``SPLIT_POLICY`` selects the KV ownership:
+
+* ``0``: contiguous KV-block ranges, matching the Flash-Decoding split-KV idea.
+* ``1``: round-robin KV blocks, useful as a load-balanced paged-KV variant.
+"""
+
+from .utils import *  # noqa: F401,F403
+from .utils import _decode_apply_alibi, _decode_apply_mask
+from .fa_hopper_splitkv import (
+    flash_varlen_fwd_v3_tle_splitkv_combine_kernel as flash_varlen_fwd_v3_tle_decode_flashdecoding_combine_kernel,
+)
+
+
+def _fa3_decode_flashdecoding_configs():
+    configs = []
+    for block_n in (64, 128, 256):
+        for num_warps in (4, 8):
+            if block_n == 64 and num_warps == 8:
+                continue
+            configs.append(
+                triton.Config(
+                    {"BLOCK_N": block_n},
+                    num_stages=3,
+                    num_warps=num_warps,
+                )
+            )
+    return configs
+
+
+def _prune_fa3_decode_flashdecoding_configs(configs, nargs, **kwargs):
+    head_dim = kwargs.get("d", nargs.get("d"))
+    is_paged = kwargs.get("is_paged", nargs.get("is_paged"))
+    split_policy = kwargs.get("SPLIT_POLICY", nargs.get("SPLIT_POLICY", 0))
+
+    kept = []
+    for cfg in configs:
+        block_n = cfg.kwargs["BLOCK_N"]
+        if is_paged and block_n > 128:
+            continue
+        if split_policy == 1 and block_n > 128:
+            continue
+        if head_dim >= 192 and block_n > 128:
+            continue
+        kept.append(cfg)
+    return kept or [configs[0]]
+
+
+@triton.jit
+def _decode_flashdecoding_visit_block(
+    n_block,
+    q_row,
+    q_len,
+    k_len,
+    d: tl.constexpr,
+    softcap: tl.constexpr,
+    scale_softmax_log2: tl.constexpr,
+    window_size_left: tl.constexpr,
+    window_size_right: tl.constexpr,
+    is_softcap: tl.constexpr,
+    is_causal: tl.constexpr,
+    is_local: tl.constexpr,
+    is_alibi: tl.constexpr,
+    is_paged: tl.constexpr,
+    alibi_slope,
+    q_vec,
+    k_base,
+    v_base,
+    k_row_stride,
+    v_row_stride,
+    page_table_ptr_b,
+    block_size: tl.constexpr,
+    m_i,
+    l_i,
+    acc,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM_PADDED: tl.constexpr,
+    PAGED_GATHER_MODE: tl.constexpr,
+):
+    d_idx = tl.arange(0, HEAD_DIM_PADDED)
+    n_idx = tl.arange(0, BLOCK_N)
+    col_idx = n_block * BLOCK_N + n_idx
+    if is_paged:
+        cache_idx = _paged_blockwise_cache_indices(
+            n_block * BLOCK_N,
+            n_idx,
+            k_len,
+            page_table_ptr_b,
+            block_size,
+            BLOCK_N,
+            PAGED_GATHER_MODE,
+            BOUNDARY_CHECK=True,
+        )
+    else:
+        cache_idx = col_idx
+
+    k_tile = tl.load(
+        k_base + cache_idx[:, None] * k_row_stride + d_idx[None, :],
+        mask=(col_idx[:, None] < k_len) & (d_idx[None, :] < d),
+        other=0.0,
+    ).to(tl.float32)
+    scores = tl.sum(k_tile * q_vec[None, :], 1)
+    scores = _apply_softcap_v3(scores, softcap, is_softcap)
+    scores = _decode_apply_alibi(
+        scores,
+        col_idx,
+        q_row,
+        q_len,
+        k_len,
+        IS_CAUSAL=is_causal,
+        IS_ALIBI=is_alibi,
+        alibi_slope=alibi_slope,
+    )
+    scores = _decode_apply_mask(
+        scores,
+        col_idx,
+        q_row,
+        q_len,
+        k_len,
+        window_size_left,
+        window_size_right,
+        IS_BORDER=True,
+        IS_CAUSAL=is_causal,
+        IS_LOCAL=is_local,
+    )
+
+    m_new = tl.maximum(m_i, tl.max(scores, 0))
+    m_safe = tl.where(m_new == float("-inf"), 0.0, m_new)
+    alpha = tl.math.exp2((m_i - m_safe) * scale_softmax_log2)
+    p_scores = tl.math.exp2(
+        scores * scale_softmax_log2 - m_safe * scale_softmax_log2
+    )
+    l_new = l_i * alpha + tl.sum(p_scores, 0)
+
+    v_tile = tl.load(
+        v_base + cache_idx[:, None] * v_row_stride + d_idx[None, :],
+        mask=(col_idx[:, None] < k_len) & (d_idx[None, :] < d),
+        other=0.0,
+    ).to(tl.float32)
+    acc = acc * alpha + tl.sum(p_scores[:, None] * v_tile, 0)
+    return m_new, l_new, acc
+
+
+@libentry()
+@triton.autotune(
+    configs=_fa3_decode_flashdecoding_configs(),
+    prune_configs_by={
+        "early_config_prune": _prune_fa3_decode_flashdecoding_configs
+    },
+    key=[
+        "d",
+        "is_paged",
+        "is_causal",
+        "is_local",
+        "is_alibi",
+        "seqlen_q",
+        "seqlen_k",
+        "total_q",
+        "NUM_SPLITS",
+        "SPLIT_POLICY",
+    ],
+)
+@triton.heuristics(
+    values={
+        "BLOCK_K": _heur_block_k,
+    }
+)
+@triton.jit(
+    do_not_specialize=[
+        "q_batch_stride",
+        "k_batch_stride",
+        "v_batch_stride",
+        "o_batch_stride",
+        "b",
+        "bk",
+        "seqlen_q",
+        "seqlen_k",
+        "seqlen_q_rounded",
+        "seqlen_k_rounded",
+        "total_q",
+    ]
+)
+def flash_varlen_fwd_v3_tle_decode_flashdecoding_kernel(
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    o_ptr,
+    p_ptr,
+    softmax_lse_ptr,
+    q_row_stride,
+    k_row_stride,
+    v_row_stride,
+    q_head_stride,
+    k_head_stride,
+    v_head_stride,
+    o_row_stride,
+    o_head_stride,
+    q_batch_stride,
+    k_batch_stride,
+    v_batch_stride,
+    o_batch_stride,
+    is_cu_seqlens_q: tl.constexpr,
+    cu_seqlens_q_ptr,
+    is_cu_seqlens_k: tl.constexpr,
+    cu_seqlens_k_ptr,
+    is_seqused_k: tl.constexpr,
+    seqused_k_ptr,
+    b,
+    bk,
+    h: tl.constexpr,
+    hk: tl.constexpr,
+    h_hk_ratio: tl.constexpr,
+    seqlen_q,
+    seqlen_k,
+    seqlen_q_rounded,
+    seqlen_k_rounded,
+    d: tl.constexpr,
+    d_rounded: tl.constexpr,
+    is_softcap: tl.constexpr,
+    softcap: tl.constexpr,
+    scale_softmax: tl.constexpr,
+    scale_softmax_log2: tl.constexpr,
+    is_dropout: tl.constexpr,
+    p_dropout: tl.constexpr,
+    rp_dropout: tl.constexpr,
+    p_dropout_in_uint8_t: tl.constexpr,
+    philox_args,
+    return_softmax: tl.constexpr,
+    is_causal: tl.constexpr,
+    is_local: tl.constexpr,
+    window_size_left: tl.constexpr,
+    window_size_right: tl.constexpr,
+    seqlenq_ngroups_swapped: tl.constexpr,
+    is_paged: tl.constexpr,
+    is_alibi: tl.constexpr,
+    alibi_slopes_ptr,
+    alibi_slopes_batch_stride: tl.constexpr,
+    total_q,
+    page_table_ptr,
+    page_table_batch_stride: tl.constexpr,
+    block_size: tl.constexpr,
+    partial_out_ptr,
+    partial_m_ptr,
+    partial_l_ptr,
+    scheduler_metadata_ptr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    SPLIT_POLICY: tl.constexpr,
+    HAS_SCHEDULER_METADATA: tl.constexpr,
+    PAGED_GATHER_MODE: tl.constexpr = 2,
+):
+    q_row = tl.program_id(0)
+    bid = tl.program_id(1)
+    hid_split = tl.program_id(2)
+    hid = hid_split % h
+    split_id = hid_split // h
+    HEAD_DIM_PADDED: tl.constexpr = BLOCK_K
+
+    if is_cu_seqlens_q:
+        q_eos = tl.load(cu_seqlens_q_ptr + bid + 1).to(tl.int32)
+        q_bos = tl.load(cu_seqlens_q_ptr + bid).to(tl.int32)
+        q_len = q_eos - q_bos
+        q_offset = q_bos * q_row_stride
+        lse_offset = q_bos
+    else:
+        q_len = seqlen_q
+        q_offset = bid * q_batch_stride
+        lse_offset = bid * seqlen_q
+
+    if is_cu_seqlens_k:
+        k_eos = tl.load(cu_seqlens_k_ptr + bid + 1).to(tl.int32)
+        k_bos = tl.load(cu_seqlens_k_ptr + bid).to(tl.int32)
+        k_len_cache = k_eos - k_bos
+    else:
+        k_len_cache = seqlen_k
+        k_bos = 0
+
+    if is_seqused_k:
+        k_len = tl.load(seqused_k_ptr + bid).to(tl.int32)
+    else:
+        k_len = k_len_cache
+
+    split_count = NUM_SPLITS
+    if HAS_SCHEDULER_METADATA:
+        split_count = tl.load(scheduler_metadata_ptr + 1 + bid).to(tl.int32)
+        split_count = tl.minimum(tl.maximum(split_count, 1), NUM_SPLITS)
+
+    if q_row < q_len:
+        d_idx = tl.arange(0, HEAD_DIM_PADDED)
+        kv_head = hid // h_hk_ratio
+        q_base = q_ptr + q_offset + hid * q_head_stride
+        if is_paged:
+            page_table_ptr_b = page_table_ptr + bid * page_table_batch_stride
+            k_base = k_ptr + kv_head * k_head_stride
+            v_base = v_ptr + kv_head * v_head_stride
+        else:
+            page_table_ptr_b = page_table_ptr
+            k_base = k_ptr + k_bos * k_row_stride + kv_head * k_head_stride
+            v_base = v_ptr + k_bos * v_row_stride + kv_head * v_head_stride
+
+        if is_alibi:
+            alibi_slope = tl.load(
+                alibi_slopes_ptr + bid * alibi_slopes_batch_stride + hid
+            )
+            alibi_slope = alibi_slope / scale_softmax
+        else:
+            alibi_slope = 0.0
+
+        q_vec = tl.load(
+            q_base + q_row * q_row_stride + d_idx,
+            mask=d_idx < d,
+            other=0.0,
+        ).to(tl.float32)
+
+        n_blocks = tl.cdiv(k_len, BLOCK_N)
+        m_i = tl.full((), float("-inf"), dtype=tl.float32)
+        l_i = tl.full((), 0.0, dtype=tl.float32)
+        acc = tl.zeros([HEAD_DIM_PADDED], dtype=tl.float32)
+
+        if SPLIT_POLICY == 0:
+            blocks_per_split = tl.cdiv(n_blocks, split_count)
+            split_block_start = split_id * blocks_per_split
+            split_block_end = tl.minimum(n_blocks, split_block_start + blocks_per_split)
+
+            if split_id < split_count and split_block_start < split_block_end:
+                for n_block in tl.range(
+                    split_block_start,
+                    split_block_end,
+                    step=1,
+                    num_stages=3,
+                ):
+                    m_i, l_i, acc = _decode_flashdecoding_visit_block(
+                        n_block,
+                        q_row,
+                        q_len,
+                        k_len,
+                        d,
+                        softcap,
+                        scale_softmax_log2,
+                        window_size_left,
+                        window_size_right,
+                        is_softcap,
+                        is_causal,
+                        is_local,
+                        is_alibi,
+                        is_paged,
+                        alibi_slope,
+                        q_vec,
+                        k_base,
+                        v_base,
+                        k_row_stride,
+                        v_row_stride,
+                        page_table_ptr_b,
+                        block_size,
+                        m_i,
+                        l_i,
+                        acc,
+                        BLOCK_N,
+                        HEAD_DIM_PADDED,
+                        PAGED_GATHER_MODE,
+                    )
+        else:
+            if split_id < split_count and split_id < n_blocks:
+                for n_block in tl.range(
+                    split_id,
+                    n_blocks,
+                    step=NUM_SPLITS,
+                    num_stages=3,
+                ):
+                    m_i, l_i, acc = _decode_flashdecoding_visit_block(
+                        n_block,
+                        q_row,
+                        q_len,
+                        k_len,
+                        d,
+                        softcap,
+                        scale_softmax_log2,
+                        window_size_left,
+                        window_size_right,
+                        is_softcap,
+                        is_causal,
+                        is_local,
+                        is_alibi,
+                        is_paged,
+                        alibi_slope,
+                        q_vec,
+                        k_base,
+                        v_base,
+                        k_row_stride,
+                        v_row_stride,
+                        page_table_ptr_b,
+                        block_size,
+                        m_i,
+                        l_i,
+                        acc,
+                        BLOCK_N,
+                        HEAD_DIM_PADDED,
+                        PAGED_GATHER_MODE,
+                    )
+
+        partial_row = lse_offset + q_row
+        part_base = split_id * h * total_q * d + hid * total_q * d
+        tl.store(
+            partial_out_ptr + part_base + partial_row * d + d_idx,
+            acc,
+            mask=d_idx < d,
+        )
+
+        stat_base = split_id * h * total_q + hid * total_q
+        tl.store(partial_m_ptr + stat_base + partial_row, m_i)
+        tl.store(partial_l_ptr + stat_base + partial_row, l_i)
+
+
+__all__ = [
+    "flash_varlen_fwd_v3_tle_decode_flashdecoding_kernel",
+    "flash_varlen_fwd_v3_tle_decode_flashdecoding_combine_kernel",
+]

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/fa_hopper_direct.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/fa_hopper_direct.py
@@ -1,0 +1,413 @@
+"""Direct one-pass FA3 TLE kernel family."""
+
+from .utils import *  # noqa: F401,F403
+def _fa3_direct_configs():
+    configs = []
+    for block_m in (16, 32, 64, 128):
+        for block_n in (32, 64, 128, 256):
+            stage_choices = (2, 3) if block_n <= 128 else (3,)
+            warp_choices = (4,)
+            if block_n >= 64 and (block_m >= 64 or block_m == 16):
+                warp_choices = (4, 8)
+            for num_stages in stage_choices:
+                for num_warps in warp_choices:
+                    configs.append(
+                        triton.Config(
+                            {"BLOCK_M": block_m, "BLOCK_N": block_n},
+                            num_stages=num_stages,
+                            num_warps=num_warps,
+                        )
+                    )
+    return configs
+
+
+def _prune_fa3_direct_configs(configs, nargs, **kwargs):
+    head_dim = kwargs.get("d", nargs.get("d"))
+    is_paged = kwargs.get("is_paged", nargs.get("is_paged"))
+    seqlen_k = kwargs.get("seqlen_k", nargs.get("seqlen_k", 0))
+    shape_bucket = kwargs.get(
+        "DIRECT_SHAPE_BUCKET",
+        nargs.get("DIRECT_SHAPE_BUCKET", _FA3_TLE_BUCKET_DIRECT_SMALL),
+    )
+
+    kept = []
+    for cfg in configs:
+        block_m = cfg.kwargs["BLOCK_M"]
+        block_n = cfg.kwargs["BLOCK_N"]
+        if shape_bucket in (
+            _FA3_TLE_BUCKET_DIRECT_DECODE,
+            _FA3_TLE_BUCKET_DIRECT_PAGED_DECODE,
+        ):
+            if block_m != 16 or block_n < 64:
+                continue
+            if head_dim >= 192 and block_n > 128:
+                continue
+            if is_paged and block_n > 128:
+                continue
+        else:
+            if block_n > 128:
+                continue
+            if block_m < 64:
+                continue
+            if seqlen_k <= 128 and block_n < 64:
+                continue
+            if head_dim > 128 and block_n > 64:
+                continue
+        if head_dim > 192 and block_n > 128:
+            continue
+        kept.append(cfg)
+
+    if kept:
+        return kept
+    return [configs[0]]
+
+
+
+@libentry()
+@triton.autotune(
+    configs=_fa3_direct_configs(),
+    prune_configs_by={"early_config_prune": _prune_fa3_direct_configs},
+    key=[
+        "d",
+        "is_paged",
+        "is_causal",
+        "is_local",
+        "is_alibi",
+        "seqlen_q",
+        "seqlen_k",
+        "total_q",
+        "DIRECT_SHAPE_BUCKET",
+        "MIN_Q_LEN_TO_PROCESS",
+        "MAX_Q_LEN_TO_PROCESS",
+    ],
+)
+@triton.heuristics(
+    values={
+        "BLOCK_K": _heur_block_k,
+    }
+)
+@triton.jit(
+    do_not_specialize=[
+        "q_batch_stride",
+        "k_batch_stride",
+        "v_batch_stride",
+        "o_batch_stride",
+        "b",
+        "bk",
+        "seqlen_q",
+        "seqlen_k",
+        "seqlen_q_rounded",
+        "seqlen_k_rounded",
+        "total_q",
+    ]
+)
+def flash_varlen_fwd_v3_tle_direct_kernel(
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    o_ptr,
+    p_ptr,
+    softmax_lse_ptr,
+    q_row_stride,
+    k_row_stride,
+    v_row_stride,
+    q_head_stride,
+    k_head_stride,
+    v_head_stride,
+    o_row_stride,
+    o_head_stride,
+    q_batch_stride,
+    k_batch_stride,
+    v_batch_stride,
+    o_batch_stride,
+    is_cu_seqlens_q: tl.constexpr,
+    cu_seqlens_q_ptr,
+    is_cu_seqlens_k: tl.constexpr,
+    cu_seqlens_k_ptr,
+    is_seqused_k: tl.constexpr,
+    seqused_k_ptr,
+    b,
+    bk,
+    h: tl.constexpr,
+    hk: tl.constexpr,
+    h_hk_ratio: tl.constexpr,
+    seqlen_q,
+    seqlen_k,
+    seqlen_q_rounded,
+    seqlen_k_rounded,
+    d: tl.constexpr,
+    d_rounded: tl.constexpr,
+    is_softcap: tl.constexpr,
+    softcap: tl.constexpr,
+    scale_softmax: tl.constexpr,
+    scale_softmax_log2: tl.constexpr,
+    is_dropout: tl.constexpr,
+    p_dropout: tl.constexpr,
+    rp_dropout: tl.constexpr,
+    p_dropout_in_uint8_t: tl.constexpr,
+    philox_args,
+    return_softmax: tl.constexpr,
+    is_causal: tl.constexpr,
+    is_local: tl.constexpr,
+    window_size_left: tl.constexpr,
+    window_size_right: tl.constexpr,
+    seqlenq_ngroups_swapped: tl.constexpr,
+    is_paged: tl.constexpr,
+    is_alibi: tl.constexpr,
+    alibi_slopes_ptr,
+    alibi_slopes_batch_stride: tl.constexpr,
+    total_q,
+    page_table_ptr,
+    page_table_batch_stride: tl.constexpr,
+    block_size: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    DIRECT_SHAPE_BUCKET: tl.constexpr,
+    MIN_Q_LEN_TO_PROCESS: tl.constexpr,
+    MAX_Q_LEN_TO_PROCESS: tl.constexpr,
+    PAGED_GATHER_MODE: tl.constexpr = 2,
+):
+    m_block = tl.program_id(0)
+    bid = tl.program_id(1)
+    hid = tl.program_id(2)
+    HEAD_DIM_PADDED: tl.constexpr = BLOCK_K
+
+    if is_cu_seqlens_q:
+        q_eos = tl.load(cu_seqlens_q_ptr + bid + 1).to(tl.int32)
+        q_bos = tl.load(cu_seqlens_q_ptr + bid).to(tl.int32)
+        q_len = q_eos - q_bos
+        q_offset = q_bos * q_row_stride
+        o_offset = q_bos * o_row_stride
+        lse_offset = q_bos
+    else:
+        q_len = seqlen_q
+        q_offset = bid * q_batch_stride
+        o_offset = bid * o_batch_stride
+        lse_offset = bid * seqlen_q
+
+    if is_cu_seqlens_k:
+        k_eos = tl.load(cu_seqlens_k_ptr + bid + 1).to(tl.int32)
+        k_bos = tl.load(cu_seqlens_k_ptr + bid).to(tl.int32)
+        k_len_cache = k_eos - k_bos
+    else:
+        k_len_cache = seqlen_k
+        k_bos = 0
+
+    if is_seqused_k:
+        k_len = tl.load(seqused_k_ptr + bid).to(tl.int32)
+    else:
+        k_len = k_len_cache
+
+    process_q = (q_len >= MIN_Q_LEN_TO_PROCESS) & (q_len <= MAX_Q_LEN_TO_PROCESS)
+    process_q = process_q & (m_block * BLOCK_M < q_len)
+    if process_q:
+        if is_local:
+            n_block_min = tl.maximum(
+                0,
+                (m_block * BLOCK_M + k_len - q_len - window_size_left) // BLOCK_N,
+            )
+        else:
+            n_block_min = 0
+
+        n_block_max = tl.cdiv(k_len, BLOCK_N)
+        if is_causal or is_local:
+            n_block_max = tl.minimum(
+                n_block_max,
+                tl.cdiv(
+                    (m_block + 1) * BLOCK_M
+                    + k_len
+                    - q_len
+                    + window_size_right,
+                    BLOCK_N,
+                ),
+            )
+
+        if is_alibi:
+            alibi_slope = tl.load(
+                alibi_slopes_ptr + bid * alibi_slopes_batch_stride + hid
+            )
+            alibi_slope = alibi_slope / scale_softmax
+        else:
+            alibi_slope = 0.0
+
+        q_base = q_ptr + q_offset + hid * q_head_stride
+        o_base = o_ptr + o_offset + hid * o_head_stride
+        kv_head = hid // h_hk_ratio
+        if is_paged:
+            page_table_ptr_b = page_table_ptr + bid * page_table_batch_stride
+            k_base = k_ptr + kv_head * k_head_stride
+            v_base = v_ptr + kv_head * v_head_stride
+        else:
+            k_base = k_ptr + k_bos * k_row_stride + kv_head * k_head_stride
+            v_base = v_ptr + k_bos * v_row_stride + kv_head * v_head_stride
+
+        row_idx_q = m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+        d_idx = tl.arange(0, HEAD_DIM_PADDED)
+        q_tile = tl.load(
+            q_base + row_idx_q[:, None] * q_row_stride + d_idx[None, :],
+            mask=(row_idx_q[:, None] < q_len) & (d_idx[None, :] < d),
+            other=0.0,
+        )
+        rowmax = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+        rowsum = tl.zeros([BLOCK_M], dtype=tl.float32)
+        acc = tl.zeros([BLOCK_M, HEAD_DIM_PADDED], dtype=tl.float32)
+
+        if is_causal or is_local:
+            n_masking_steps = tl.cdiv(BLOCK_M + window_size_right + 1, BLOCK_N)
+        else:
+            n_masking_steps = 1
+        n_masking_steps = tl.maximum(
+            0, tl.minimum(n_block_max - n_block_min, n_masking_steps)
+        )
+
+        n_block_start_mask = n_block_max - 1
+        for step in tl.range(0, n_masking_steps):
+            n_block = n_block_start_mask - step
+            col_idx = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
+            kv_mask = col_idx < k_len
+            if is_paged:
+                cache_idx = _paged_blockwise_cache_indices(
+                    n_block * BLOCK_N,
+                    tl.arange(0, BLOCK_N),
+                    k_len,
+                    page_table_ptr_b,
+                    block_size,
+                    BLOCK_N,
+                    PAGED_GATHER_MODE,
+                    BOUNDARY_CHECK=True,
+                )
+            else:
+                cache_idx = col_idx
+
+            bK = tl.load(
+                k_base + cache_idx[None, :] * k_row_stride + d_idx[:, None],
+                mask=(d_idx[:, None] < d) & kv_mask[None, :],
+                other=0.0,
+            )
+            bV = tl.load(
+                v_base + cache_idx[:, None] * v_row_stride + d_idx[None, :],
+                mask=kv_mask[:, None] & (d_idx[None, :] < d),
+                other=0.0,
+            )
+
+            S = tl.dot(q_tile, bK, out_dtype=tl.float32)
+            S = _apply_softcap_v3(S, softcap, is_softcap)
+            S = _apply_alibi_v3(
+                S,
+                col_idx,
+                row_idx_q,
+                q_len,
+                k_len,
+                IS_CAUSAL=is_causal,
+                IS_ALIBI=is_alibi,
+                alibi_slope=alibi_slope,
+            )
+            S = _apply_mask_v3(
+                S,
+                col_idx,
+                row_idx_q,
+                q_len,
+                k_len,
+                window_size_left,
+                window_size_right,
+                IS_EVEN_MN=False,
+                IS_CAUSAL=is_causal,
+                IS_LOCAL=is_local,
+            )
+            alpha, P, rowmax, rowsum = _softmax_online_deferred(
+                S,
+                rowmax,
+                rowsum,
+                softmax_scale_log2e=scale_softmax_log2,
+                IS_BORDER=True,
+            )
+            acc = acc * alpha[:, None]
+            acc = tl.dot(P.to(v_ptr.dtype.element_ty), bV, acc, out_dtype=tl.float32)
+
+        n_dense_end = n_block_max - n_masking_steps
+        for n_block in tl.range(
+            n_dense_end - 1,
+            n_block_min - 1,
+            step=-1,
+            num_stages=3,
+        ):
+            col_idx = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
+            if is_paged:
+                cache_idx = _paged_blockwise_cache_indices(
+                    n_block * BLOCK_N,
+                    tl.arange(0, BLOCK_N),
+                    k_len,
+                    page_table_ptr_b,
+                    block_size,
+                    BLOCK_N,
+                    PAGED_GATHER_MODE,
+                    BOUNDARY_CHECK=False,
+                )
+            else:
+                cache_idx = col_idx
+
+            bK = tl.load(
+                k_base + cache_idx[None, :] * k_row_stride + d_idx[:, None],
+                mask=d_idx[:, None] < d,
+                other=0.0,
+            )
+            bV = tl.load(
+                v_base + cache_idx[:, None] * v_row_stride + d_idx[None, :],
+                mask=d_idx[None, :] < d,
+                other=0.0,
+            )
+
+            S = tl.dot(q_tile, bK, out_dtype=tl.float32)
+            S = _apply_softcap_v3(S, softcap, is_softcap)
+            S = _apply_alibi_v3(
+                S,
+                col_idx,
+                row_idx_q,
+                q_len,
+                k_len,
+                IS_CAUSAL=is_causal,
+                IS_ALIBI=is_alibi,
+                alibi_slope=alibi_slope,
+            )
+            S = _apply_mask_v3(
+                S,
+                col_idx,
+                row_idx_q,
+                q_len,
+                k_len,
+                window_size_left,
+                window_size_right,
+                IS_EVEN_MN=True,
+                IS_CAUSAL=False,
+                IS_LOCAL=is_local,
+            )
+            alpha, P, rowmax, rowsum = _softmax_online_deferred(
+                S,
+                rowmax,
+                rowsum,
+                softmax_scale_log2e=scale_softmax_log2,
+                IS_BORDER=is_local,
+            )
+            acc = acc * alpha[:, None]
+            acc = tl.dot(P.to(v_ptr.dtype.element_ty), bV, acc, out_dtype=tl.float32)
+
+        invalid = (rowsum == 0) | (rowsum != rowsum)
+        inv_sum = tl.where(invalid, 1.0, 1.0 / rowsum)
+        acc = acc * inv_sum[:, None]
+        lse = tl.where(
+            invalid,
+            float("inf"),
+            rowmax * scale_softmax + tl.log(rowsum),
+        )
+        tl.store(
+            o_base + row_idx_q[:, None] * o_row_stride + d_idx[None, :],
+            acc.to(o_ptr.dtype.element_ty),
+            mask=(row_idx_q[:, None] < q_len) & (d_idx[None, :] < d),
+        )
+        lse_ptr = softmax_lse_ptr + hid * total_q + lse_offset + row_idx_q
+        tl.store(lse_ptr, lse, mask=row_idx_q < q_len)
+
+
+
+__all__ = ["flash_varlen_fwd_v3_tle_direct_kernel"]

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/fa_hopper_nonpersistent_tlx_style.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/fa_hopper_nonpersistent_tlx_style.py
@@ -1,0 +1,613 @@
+"""Nonpersistent TLX-style FA3 WS kernel implementation.
+
+The producer gathers dense or paged K/V into shared memory, fences the async
+shared proxy, and releases mbarriers before the consumer issues WGMMA.
+"""
+
+from .utils import *  # noqa: F401,F403
+@libentry()
+@triton.autotune(
+    configs=_fa3_ws_short_configs(),
+    prune_configs_by={"early_config_prune": _prune_fa3_ws_short_configs},
+    key=[
+        "d",
+        "is_paged",
+        "is_causal",
+        "is_local",
+        "is_alibi",
+        "seqlen_q",
+        "seqlen_k",
+        "total_q",
+        "WS_SHORT_SHAPE_BUCKET",
+        "MIN_Q_LEN_TO_PROCESS",
+        "MAX_Q_LEN_TO_PROCESS",
+    ],
+)
+@triton.heuristics(
+    values={
+        "BLOCK_K": _heur_block_k,
+    }
+)
+@triton.jit(
+    do_not_specialize=[
+        "q_batch_stride",
+        "k_batch_stride",
+        "v_batch_stride",
+        "o_batch_stride",
+        "b",
+        "bk",
+        "seqlen_q",
+        "seqlen_k",
+        "seqlen_q_rounded",
+        "seqlen_k_rounded",
+        "total_q",
+    ]
+)
+def flash_varlen_fwd_v3_tle_ws_short_kernel(
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    o_ptr,
+    p_ptr,
+    softmax_lse_ptr,
+    q_row_stride,
+    k_row_stride,
+    v_row_stride,
+    q_head_stride,
+    k_head_stride,
+    v_head_stride,
+    o_row_stride,
+    o_head_stride,
+    q_batch_stride,
+    k_batch_stride,
+    v_batch_stride,
+    o_batch_stride,
+    is_cu_seqlens_q: tl.constexpr,
+    cu_seqlens_q_ptr,
+    is_cu_seqlens_k: tl.constexpr,
+    cu_seqlens_k_ptr,
+    is_seqused_k: tl.constexpr,
+    seqused_k_ptr,
+    b,
+    bk,
+    h: tl.constexpr,
+    hk: tl.constexpr,
+    h_hk_ratio: tl.constexpr,
+    seqlen_q,
+    seqlen_k,
+    seqlen_q_rounded,
+    seqlen_k_rounded,
+    d: tl.constexpr,
+    d_rounded: tl.constexpr,
+    is_softcap: tl.constexpr,
+    softcap: tl.constexpr,
+    scale_softmax: tl.constexpr,
+    scale_softmax_log2: tl.constexpr,
+    is_dropout: tl.constexpr,
+    p_dropout: tl.constexpr,
+    rp_dropout: tl.constexpr,
+    p_dropout_in_uint8_t: tl.constexpr,
+    philox_args,
+    return_softmax: tl.constexpr,
+    is_causal: tl.constexpr,
+    is_local: tl.constexpr,
+    window_size_left: tl.constexpr,
+    window_size_right: tl.constexpr,
+    seqlenq_ngroups_swapped: tl.constexpr,
+    is_paged: tl.constexpr,
+    is_alibi: tl.constexpr,
+    alibi_slopes_ptr,
+    alibi_slopes_batch_stride: tl.constexpr,
+    total_q,
+    page_table_ptr,
+    page_table_batch_stride: tl.constexpr,
+    block_size: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    NUM_BUFFERS_Q: tl.constexpr,
+    NUM_BUFFERS_KV: tl.constexpr,
+    NUM_MMA_WARPS: tl.constexpr,
+    NUM_MMA_GROUPS: tl.constexpr,
+    Q_STAGE_CAPACITY: tl.constexpr,
+    KV_STAGE_CAPACITY: tl.constexpr,
+    USE_TMA_QO: tl.constexpr,
+    USE_TMA_KV: tl.constexpr,
+    FAMILY_ID: tl.constexpr,
+    WS_SHORT_SHAPE_BUCKET: tl.constexpr,
+    MIN_Q_LEN_TO_PROCESS: tl.constexpr,
+    MAX_Q_LEN_TO_PROCESS: tl.constexpr,
+    PAGED_GATHER_MODE: tl.constexpr = 2,
+):
+    HEAD_DIM_PADDED: tl.constexpr = BLOCK_K
+    INPUT_DTYPE = q_ptr.dtype.element_ty
+    MANUAL_COPY_ARRIVALS: tl.constexpr = 1
+
+    q_smem = tle.gpu.alloc(
+        [1, BLOCK_M, HEAD_DIM_PADDED],
+        dtype=INPUT_DTYPE,
+        layout=None,
+        scope=tle.gpu.smem,
+    )
+    k_smem = tle.gpu.alloc(
+        [KV_STAGE_CAPACITY, BLOCK_N, HEAD_DIM_PADDED],
+        dtype=INPUT_DTYPE,
+        layout=None,
+        scope=tle.gpu.smem,
+    )
+    v_smem = tle.gpu.alloc(
+        [KV_STAGE_CAPACITY, BLOCK_N, HEAD_DIM_PADDED],
+        dtype=INPUT_DTYPE,
+        layout=None,
+        scope=tle.gpu.smem,
+    )
+
+    q_empty = tle.gpu.alloc_barriers(
+        num_barriers=1,
+        arrive_count=1,
+        init=tle.gpu.READY,
+    )
+    q_full = tle.gpu.alloc_barriers(
+        num_barriers=1,
+        arrive_count=1,
+        expect_bytes=BLOCK_M * HEAD_DIM_PADDED * 2,
+    )
+    q_full_manual = tle.gpu.alloc_barriers(num_barriers=1, arrive_count=1)
+    k_empty = tle.gpu.alloc_barriers(
+        num_barriers=KV_STAGE_CAPACITY,
+        arrive_count=1,
+        init=tle.gpu.READY,
+    )
+    k_full = tle.gpu.alloc_barriers(
+        num_barriers=KV_STAGE_CAPACITY,
+        arrive_count=1,
+        expect_bytes=BLOCK_N * HEAD_DIM_PADDED * 2,
+    )
+    k_full_manual = tle.gpu.alloc_barriers(
+        num_barriers=KV_STAGE_CAPACITY,
+        arrive_count=MANUAL_COPY_ARRIVALS,
+    )
+    v_empty = tle.gpu.alloc_barriers(
+        num_barriers=KV_STAGE_CAPACITY,
+        arrive_count=1,
+        init=tle.gpu.READY,
+    )
+    v_full = tle.gpu.alloc_barriers(
+        num_barriers=KV_STAGE_CAPACITY,
+        arrive_count=1,
+        expect_bytes=BLOCK_N * HEAD_DIM_PADDED * 2,
+    )
+    v_full_manual = tle.gpu.alloc_barriers(
+        num_barriers=KV_STAGE_CAPACITY,
+        arrive_count=MANUAL_COPY_ARRIVALS,
+    )
+
+    with tle.gpu.async_tasks():
+        with tle.gpu.async_task("producer"):
+            m_block = tl.program_id(0)
+            bid = tl.program_id(1)
+            hid = tl.program_id(2)
+
+            if is_cu_seqlens_q:
+                q_eos = tl.load(cu_seqlens_q_ptr + bid + 1).to(tl.int32)
+                q_bos = tl.load(cu_seqlens_q_ptr + bid).to(tl.int32)
+                q_len = q_eos - q_bos
+                q_offset = q_bos * q_row_stride
+            else:
+                q_len = seqlen_q
+                q_offset = bid * q_batch_stride
+
+            if is_cu_seqlens_k:
+                k_eos = tl.load(cu_seqlens_k_ptr + bid + 1).to(tl.int32)
+                k_bos = tl.load(cu_seqlens_k_ptr + bid).to(tl.int32)
+                k_len_cache = k_eos - k_bos
+            else:
+                k_len_cache = seqlen_k
+                k_bos = 0
+
+            if is_seqused_k:
+                k_len = tl.load(seqused_k_ptr + bid).to(tl.int32)
+            else:
+                k_len = k_len_cache
+
+            process_q_tile = (q_len >= MIN_Q_LEN_TO_PROCESS) & (
+                q_len <= MAX_Q_LEN_TO_PROCESS
+            )
+            valid_q_tile = (m_block * BLOCK_M < q_len) & process_q_tile
+            if valid_q_tile:
+                if is_local:
+                    n_block_min = tl.maximum(
+                        0,
+                        (
+                            m_block * BLOCK_M
+                            + k_len
+                            - q_len
+                            - window_size_left
+                        )
+                        // BLOCK_N,
+                    )
+                else:
+                    n_block_min = 0
+
+                n_block_max = tl.cdiv(k_len, BLOCK_N)
+                if is_causal or is_local:
+                    n_block_max = tl.minimum(
+                        n_block_max,
+                        tl.cdiv(
+                            (m_block + 1) * BLOCK_M
+                            + k_len
+                            - q_len
+                            + window_size_right,
+                            BLOCK_N,
+                        ),
+                    )
+
+                if n_block_min < n_block_max:
+                    kv_head = hid // h_hk_ratio
+                    q_base = q_ptr + q_offset + hid * q_head_stride
+                    q_desc = tl.make_tensor_descriptor(
+                        base=q_base,
+                        shape=[q_len, d],
+                        strides=[q_row_stride, 1],
+                        block_shape=[BLOCK_M, HEAD_DIM_PADDED],
+                    )
+                    if is_paged:
+                        page_table_ptr_b = page_table_ptr + bid * page_table_batch_stride
+                        k_base = k_ptr + kv_head * k_head_stride
+                        v_base = v_ptr + kv_head * v_head_stride
+                    else:
+                        k_base = k_ptr + k_bos * k_row_stride + kv_head * k_head_stride
+                        v_base = v_ptr + k_bos * v_row_stride + kv_head * v_head_stride
+                        k_desc = tl.make_tensor_descriptor(
+                            base=k_base,
+                            shape=[k_len_cache, d],
+                            strides=[k_row_stride, 1],
+                            block_shape=[BLOCK_N, HEAD_DIM_PADDED],
+                        )
+                        v_desc = tl.make_tensor_descriptor(
+                            base=v_base,
+                            shape=[k_len_cache, d],
+                            strides=[v_row_stride, 1],
+                            block_shape=[BLOCK_N, HEAD_DIM_PADDED],
+                        )
+
+                    tle.gpu.barrier_wait(q_empty[0], phaseIdx=0)
+                    tle.gpu.copy(
+                        q_desc,
+                        q_smem.slot(0),
+                        [BLOCK_M, HEAD_DIM_PADDED],
+                        [m_block * BLOCK_M, 0],
+                        barrier=q_full[0],
+                    )
+
+                    accum_cnt_kv = 0
+                    n_block = n_block_min
+                    while n_block < n_block_max:
+                        kv_buf, kv_phase_idx = _buf_phase_tle(
+                            accum_cnt_kv, NUM_BUFFERS_KV
+                        )
+                        kv_offset = n_block * BLOCK_N
+
+                        tle.gpu.barrier_wait(k_empty[kv_buf], phaseIdx=kv_phase_idx)
+                        if is_paged:
+                            _copy_paged_kv_tile_to_smem(
+                                k_base,
+                                k_row_stride,
+                                page_table_ptr_b,
+                                k_smem.slot(kv_buf),
+                                kv_offset,
+                                k_len,
+                                d,
+                                block_size,
+                                BLOCK_N,
+                                HEAD_DIM_PADDED,
+                                PAGED_GATHER_MODE,
+                            )
+                            _fence_async_shared_cta()
+                            tle.gpu.barrier_arrive(
+                                k_full_manual[kv_buf],
+                                arrive_count=MANUAL_COPY_ARRIVALS,
+                                phaseIdx=kv_phase_idx,
+                            )
+                        else:
+                            tle.gpu.copy(
+                                k_desc,
+                                k_smem.slot(kv_buf),
+                                [BLOCK_N, HEAD_DIM_PADDED],
+                                [kv_offset, 0],
+                                barrier=k_full[kv_buf],
+                            )
+
+                        tle.gpu.barrier_wait(v_empty[kv_buf], phaseIdx=kv_phase_idx)
+                        if is_paged:
+                            _copy_paged_kv_tile_to_smem(
+                                v_base,
+                                v_row_stride,
+                                page_table_ptr_b,
+                                v_smem.slot(kv_buf),
+                                kv_offset,
+                                k_len,
+                                d,
+                                block_size,
+                                BLOCK_N,
+                                HEAD_DIM_PADDED,
+                                PAGED_GATHER_MODE,
+                            )
+                            _fence_async_shared_cta()
+                            tle.gpu.barrier_arrive(
+                                v_full_manual[kv_buf],
+                                arrive_count=MANUAL_COPY_ARRIVALS,
+                                phaseIdx=kv_phase_idx,
+                            )
+                        else:
+                            tle.gpu.copy(
+                                v_desc,
+                                v_smem.slot(kv_buf),
+                                [BLOCK_N, HEAD_DIM_PADDED],
+                                [kv_offset, 0],
+                                barrier=v_full[kv_buf],
+                            )
+
+                        accum_cnt_kv += 1
+                        n_block += 1
+
+        with tle.gpu.async_task(
+            num_warps=NUM_MMA_WARPS,
+            registers=232,
+            name="mma",
+        ):
+            m_block = tl.program_id(0)
+            bid = tl.program_id(1)
+            hid = tl.program_id(2)
+
+            if is_cu_seqlens_q:
+                q_eos = tl.load(cu_seqlens_q_ptr + bid + 1).to(tl.int32)
+                q_bos = tl.load(cu_seqlens_q_ptr + bid).to(tl.int32)
+                q_len = q_eos - q_bos
+                o_offset = q_bos * o_row_stride
+                lse_offset = q_bos
+            else:
+                q_len = seqlen_q
+                o_offset = bid * o_batch_stride
+                lse_offset = bid * seqlen_q
+
+            if is_cu_seqlens_k:
+                k_eos = tl.load(cu_seqlens_k_ptr + bid + 1).to(tl.int32)
+                k_bos = tl.load(cu_seqlens_k_ptr + bid).to(tl.int32)
+                k_len_cache = k_eos - k_bos
+            else:
+                k_len_cache = seqlen_k
+
+            if is_seqused_k:
+                k_len = tl.load(seqused_k_ptr + bid).to(tl.int32)
+            else:
+                k_len = k_len_cache
+
+            if is_alibi:
+                alibi_slope = tl.load(
+                    alibi_slopes_ptr + bid * alibi_slopes_batch_stride + hid
+                )
+                alibi_slope = alibi_slope / scale_softmax
+            else:
+                alibi_slope = 0.0
+
+            process_q_tile = (q_len >= MIN_Q_LEN_TO_PROCESS) & (
+                q_len <= MAX_Q_LEN_TO_PROCESS
+            )
+            valid_q_tile = (m_block * BLOCK_M < q_len) & process_q_tile
+            if valid_q_tile:
+                if is_local:
+                    n_block_min = tl.maximum(
+                        0,
+                        (
+                            m_block * BLOCK_M
+                            + k_len
+                            - q_len
+                            - window_size_left
+                        )
+                        // BLOCK_N,
+                    )
+                else:
+                    n_block_min = 0
+
+                n_block_max = tl.cdiv(k_len, BLOCK_N)
+                if is_causal or is_local:
+                    n_block_max = tl.minimum(
+                        n_block_max,
+                        tl.cdiv(
+                            (m_block + 1) * BLOCK_M
+                            + k_len
+                            - q_len
+                            + window_size_right,
+                            BLOCK_N,
+                        ),
+                    )
+
+                row_idx_q = m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+                o_base = o_ptr + o_offset + hid * o_head_stride
+                o_desc = tl.make_tensor_descriptor(
+                    base=o_base,
+                    shape=[q_len, d],
+                    strides=[o_row_stride, 1],
+                    block_shape=[BLOCK_M, HEAD_DIM_PADDED],
+                )
+
+                if n_block_min < n_block_max:
+                    rowmax = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+                    rowsum = tl.zeros([BLOCK_M], dtype=tl.float32)
+                    acc = tl.zeros([BLOCK_M, HEAD_DIM_PADDED], dtype=tl.float32)
+
+                    tle.gpu.barrier_wait(q_full[0], phaseIdx=0)
+
+                    accum_cnt_kv = 0
+                    kv_buf, kv_phase_idx = _buf_phase_tle(
+                        accum_cnt_kv, NUM_BUFFERS_KV
+                    )
+                    if is_paged:
+                        tle.gpu.barrier_wait(
+                            k_full_manual[kv_buf], phaseIdx=kv_phase_idx
+                        )
+                    else:
+                        tle.gpu.barrier_wait(k_full[kv_buf], phaseIdx=kv_phase_idx)
+
+                    qk = tle.gpu.wgmma(
+                        q_smem.slot(0),
+                        k_smem.slot(kv_buf),
+                        out_dtype=tl.float32,
+                        trans_b=True,
+                    )
+                    qk = tle.gpu.wgmma_wait(0, qk)
+                    tle.gpu.barrier_arrive(k_empty[kv_buf], phaseIdx=kv_phase_idx)
+
+                    n_block = n_block_min
+                    col_idx = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
+                    qk = _apply_softcap_v3(qk, softcap, is_softcap)
+                    qk = _apply_alibi_v3(
+                        qk,
+                        col_idx,
+                        row_idx_q,
+                        q_len,
+                        k_len,
+                        IS_CAUSAL=is_causal,
+                        IS_ALIBI=is_alibi,
+                        alibi_slope=alibi_slope,
+                    )
+                    qk = _apply_mask_v3(
+                        qk,
+                        col_idx,
+                        row_idx_q,
+                        q_len,
+                        k_len,
+                        window_size_left,
+                        window_size_right,
+                        IS_EVEN_MN=False,
+                        IS_CAUSAL=is_causal,
+                        IS_LOCAL=is_local,
+                    )
+                    alpha, p, rowmax, rowsum = _softmax_online_deferred(
+                        qk,
+                        rowmax,
+                        rowsum,
+                        softmax_scale_log2e=scale_softmax_log2,
+                        IS_BORDER=True,
+                    )
+
+                    accum_cnt_kv += 1
+                    n_block += 1
+                    while n_block < n_block_max:
+                        kv_buf, kv_phase_idx = _buf_phase_tle(
+                            accum_cnt_kv, NUM_BUFFERS_KV
+                        )
+                        if is_paged:
+                            tle.gpu.barrier_wait(
+                                k_full_manual[kv_buf], phaseIdx=kv_phase_idx
+                            )
+                        else:
+                            tle.gpu.barrier_wait(
+                                k_full[kv_buf], phaseIdx=kv_phase_idx
+                            )
+                        p_prev = p
+                        qk = tle.gpu.wgmma(
+                            q_smem.slot(0),
+                            k_smem.slot(kv_buf),
+                            out_dtype=tl.float32,
+                            trans_b=True,
+                        )
+                        qk = tle.gpu.wgmma_wait(0, qk)
+                        tle.gpu.barrier_arrive(
+                            k_empty[kv_buf], phaseIdx=kv_phase_idx
+                        )
+
+                        col_idx = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
+                        qk = _apply_softcap_v3(qk, softcap, is_softcap)
+                        qk = _apply_alibi_v3(
+                            qk,
+                            col_idx,
+                            row_idx_q,
+                            q_len,
+                            k_len,
+                            IS_CAUSAL=is_causal,
+                            IS_ALIBI=is_alibi,
+                            alibi_slope=alibi_slope,
+                        )
+                        qk = _apply_mask_v3(
+                            qk,
+                            col_idx,
+                            row_idx_q,
+                            q_len,
+                            k_len,
+                            window_size_left,
+                            window_size_right,
+                            IS_EVEN_MN=False,
+                            IS_CAUSAL=is_causal,
+                            IS_LOCAL=is_local,
+                        )
+                        alpha, p, rowmax, rowsum = _softmax_online_deferred(
+                            qk,
+                            rowmax,
+                            rowsum,
+                            softmax_scale_log2e=scale_softmax_log2,
+                            IS_BORDER=True,
+                        )
+
+                        v_buf, v_phase_idx = _buf_phase_tle(
+                            accum_cnt_kv - 1, NUM_BUFFERS_KV
+                        )
+                        if is_paged:
+                            tle.gpu.barrier_wait(
+                                v_full_manual[v_buf], phaseIdx=v_phase_idx
+                            )
+                        else:
+                            tle.gpu.barrier_wait(v_full[v_buf], phaseIdx=v_phase_idx)
+                        acc = tle.gpu.wgmma(
+                            p_prev.to(INPUT_DTYPE),
+                            v_smem.slot(v_buf),
+                            acc,
+                        )
+                        acc = tle.gpu.wgmma_wait(0, acc)
+                        tle.gpu.barrier_arrive(v_empty[v_buf], phaseIdx=v_phase_idx)
+                        acc = acc * alpha[:, None]
+
+                        accum_cnt_kv += 1
+                        n_block += 1
+
+                    v_buf, v_phase_idx = _buf_phase_tle(
+                        accum_cnt_kv - 1, NUM_BUFFERS_KV
+                    )
+                    if is_paged:
+                        tle.gpu.barrier_wait(
+                            v_full_manual[v_buf], phaseIdx=v_phase_idx
+                        )
+                    else:
+                        tle.gpu.barrier_wait(v_full[v_buf], phaseIdx=v_phase_idx)
+                    acc = tle.gpu.wgmma(p.to(INPUT_DTYPE), v_smem.slot(v_buf), acc)
+
+                    acc = tle.gpu.wgmma_wait(0, acc)
+                    tle.gpu.barrier_arrive(q_empty[0], phaseIdx=0)
+                    tle.gpu.barrier_arrive(v_empty[v_buf], phaseIdx=v_phase_idx)
+
+                    invalid = (rowsum == 0) | (rowsum != rowsum)
+                    inv_sum = tl.where(invalid, 1.0, 1.0 / rowsum)
+                    acc = acc * inv_sum[:, None]
+                    lse = tl.where(
+                        invalid,
+                        float("inf"),
+                        rowmax * scale_softmax + tl.log(rowsum),
+                    )
+                else:
+                    acc = tl.zeros([BLOCK_M, HEAD_DIM_PADDED], dtype=tl.float32)
+                    lse = tl.full([BLOCK_M], float("inf"), dtype=tl.float32)
+
+                o_desc.store([m_block * BLOCK_M, 0], acc.to(o_ptr.dtype.element_ty))
+                lse_ptr = softmax_lse_ptr + hid * total_q + lse_offset + row_idx_q
+                tl.store(lse_ptr, lse, mask=row_idx_q < q_len)
+
+
+
+
+nonpersistent_ws_kernel = flash_varlen_fwd_v3_tle_ws_short_kernel
+
+__all__ = [
+    "flash_varlen_fwd_v3_tle_ws_short_kernel",
+    "nonpersistent_ws_kernel",
+]

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/fa_hopper_persistent_pingpong.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/fa_hopper_persistent_pingpong.py
@@ -1,0 +1,907 @@
+"""Persistent ping-pong FA3 WS kernel implementation.
+
+This module owns the experimental persistent implementation. It is split from
+``flash_kernel_v3.py`` so scripts can import this implementation directly.
+"""
+
+from .utils import *  # noqa: F401,F403
+@libentry()
+@triton.autotune(
+    configs=_fa3_tle_configs(),
+    prune_configs_by={"early_config_prune": _prune_fa3_tle_configs},
+    key=[
+        "d",
+        "is_paged",
+        "is_causal",
+        "is_local",
+        "is_alibi",
+        "seqlen_q",
+        "seqlen_k",
+        "total_q",
+        "SHAPE_BUCKET",
+        "FORCE_FAMILY_ID",
+    ],
+)
+@triton.heuristics(
+    values={
+        "BLOCK_K": _heur_block_k,
+    }
+)
+@triton.jit(
+    do_not_specialize=[
+        "q_batch_stride",
+        "k_batch_stride",
+        "v_batch_stride",
+        "o_batch_stride",
+        "b",
+        "bk",
+        "seqlen_q",
+        "seqlen_k",
+        "seqlen_q_rounded",
+        "seqlen_k_rounded",
+        "total_q",
+    ]
+)
+def flash_varlen_fwd_v3_tle_kernel(
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    o_ptr,
+    p_ptr,
+    softmax_lse_ptr,
+    q_row_stride,
+    k_row_stride,
+    v_row_stride,
+    q_head_stride,
+    k_head_stride,
+    v_head_stride,
+    o_row_stride,
+    o_head_stride,
+    q_batch_stride,
+    k_batch_stride,
+    v_batch_stride,
+    o_batch_stride,
+    is_cu_seqlens_q: tl.constexpr,
+    cu_seqlens_q_ptr,
+    is_cu_seqlens_k: tl.constexpr,
+    cu_seqlens_k_ptr,
+    is_seqused_k: tl.constexpr,
+    seqused_k_ptr,
+    b,
+    bk,
+    h: tl.constexpr,
+    hk: tl.constexpr,
+    h_hk_ratio: tl.constexpr,
+    seqlen_q,
+    seqlen_k,
+    seqlen_q_rounded,
+    seqlen_k_rounded,
+    d: tl.constexpr,
+    d_rounded: tl.constexpr,
+    is_softcap: tl.constexpr,
+    softcap: tl.constexpr,
+    scale_softmax: tl.constexpr,
+    scale_softmax_log2: tl.constexpr,
+    is_dropout: tl.constexpr,
+    p_dropout: tl.constexpr,
+    rp_dropout: tl.constexpr,
+    p_dropout_in_uint8_t: tl.constexpr,
+    philox_args,
+    return_softmax: tl.constexpr,
+    is_causal: tl.constexpr,
+    is_local: tl.constexpr,
+    window_size_left: tl.constexpr,
+    window_size_right: tl.constexpr,
+    seqlenq_ngroups_swapped: tl.constexpr,
+    is_paged: tl.constexpr,
+    is_alibi: tl.constexpr,
+    alibi_slopes_ptr,
+    alibi_slopes_batch_stride: tl.constexpr,
+    total_q,
+    page_table_ptr,
+    page_table_batch_stride: tl.constexpr,
+    block_size: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    NUM_BUFFERS_Q: tl.constexpr,
+    NUM_BUFFERS_KV: tl.constexpr,
+    NUM_MMA_WARPS: tl.constexpr,
+    NUM_MMA_GROUPS: tl.constexpr,
+    Q_STAGE_CAPACITY: tl.constexpr,
+    KV_STAGE_CAPACITY: tl.constexpr,
+    USE_TMA_QO: tl.constexpr,
+    USE_TMA_KV: tl.constexpr,
+    FAMILY_ID: tl.constexpr,
+    SHAPE_BUCKET: tl.constexpr,
+    FORCE_FAMILY_ID: tl.constexpr,
+    MIN_Q_LEN_TO_PROCESS: tl.constexpr,
+    MAX_Q_LEN_TO_PROCESS: tl.constexpr,
+    PAGED_GATHER_MODE: tl.constexpr = 2,
+):
+    BM_SPLIT: tl.constexpr = BLOCK_M // NUM_MMA_GROUPS
+    HEAD_DIM_PADDED: tl.constexpr = BLOCK_K
+    INPUT_DTYPE = q_ptr.dtype.element_ty
+    THREADS_IN_MMA_GROUPS: tl.constexpr = NUM_MMA_WARPS * 32
+
+    q_smem = tle.gpu.alloc(
+        [Q_STAGE_CAPACITY, BM_SPLIT, HEAD_DIM_PADDED],
+        dtype=INPUT_DTYPE,
+        layout=None,
+        scope=tle.gpu.smem,
+    )
+    k_smem = tle.gpu.alloc(
+        [KV_STAGE_CAPACITY, BLOCK_N, HEAD_DIM_PADDED],
+        dtype=INPUT_DTYPE,
+        layout=None,
+        scope=tle.gpu.smem,
+    )
+    v_smem = tle.gpu.alloc(
+        [KV_STAGE_CAPACITY, BLOCK_N, HEAD_DIM_PADDED],
+        dtype=INPUT_DTYPE,
+        layout=None,
+        scope=tle.gpu.smem,
+    )
+
+    q_empties = tle.gpu.alloc_barriers(
+        num_barriers=Q_STAGE_CAPACITY,
+        arrive_count=1,
+        init=tle.gpu.READY,
+    )
+    q_fulls = tle.gpu.alloc_barriers(
+        num_barriers=Q_STAGE_CAPACITY,
+        arrive_count=1,
+        expect_bytes=BM_SPLIT * HEAD_DIM_PADDED * 2,
+    )
+    q_fulls_manual = tle.gpu.alloc_barriers(
+        num_barriers=Q_STAGE_CAPACITY,
+        arrive_count=1,
+    )
+    k_empties = tle.gpu.alloc_barriers(
+        num_barriers=KV_STAGE_CAPACITY,
+        arrive_count=NUM_MMA_GROUPS,
+        init=tle.gpu.READY,
+    )
+    k_fulls = tle.gpu.alloc_barriers(
+        num_barriers=KV_STAGE_CAPACITY,
+        arrive_count=1,
+        expect_bytes=BLOCK_N * HEAD_DIM_PADDED * 2,
+    )
+    k_fulls_manual = tle.gpu.alloc_barriers(
+        num_barriers=KV_STAGE_CAPACITY,
+        arrive_count=1,
+    )
+    v_empties = tle.gpu.alloc_barriers(
+        num_barriers=KV_STAGE_CAPACITY,
+        arrive_count=NUM_MMA_GROUPS,
+        init=tle.gpu.READY,
+    )
+    v_fulls = tle.gpu.alloc_barriers(
+        num_barriers=KV_STAGE_CAPACITY,
+        arrive_count=1,
+        expect_bytes=BLOCK_N * HEAD_DIM_PADDED * 2,
+    )
+    v_fulls_manual = tle.gpu.alloc_barriers(
+        num_barriers=KV_STAGE_CAPACITY,
+        arrive_count=1,
+    )
+
+    pingpong = tle.gpu.alloc_barriers(
+        num_barriers=2,
+        arrive_count=THREADS_IN_MMA_GROUPS,
+    )
+    ping_to_c0 = pingpong[0]
+    ping_to_c1 = pingpong[1]
+
+    with tle.gpu.async_tasks():
+        with tle.gpu.async_task("producer"):
+            prog_id = tl.program_id(0)
+            num_progs = tl.num_programs(0)
+            num_pid_m = tl.cdiv(seqlen_q, BLOCK_M)
+            total_tiles = num_pid_m * b * h
+
+            tile_idx = prog_id
+            tile_count = 0
+            accum_cnt_kv = 0
+            while tile_idx < total_tiles:
+                m_block, bid, hid = _persistent_tile_coords(tile_idx, num_pid_m, b)
+
+                if is_cu_seqlens_q:
+                    q_eos = tl.load(cu_seqlens_q_ptr + bid + 1).to(tl.int32)
+                    q_bos = tl.load(cu_seqlens_q_ptr + bid).to(tl.int32)
+                    q_len = q_eos - q_bos
+                    q_offset = q_bos * q_row_stride
+                else:
+                    q_len = seqlen_q
+                    q_offset = bid * q_batch_stride
+
+                if is_cu_seqlens_k:
+                    k_eos = tl.load(cu_seqlens_k_ptr + bid + 1).to(tl.int32)
+                    k_bos = tl.load(cu_seqlens_k_ptr + bid).to(tl.int32)
+                    k_len_cache = k_eos - k_bos
+                else:
+                    k_len_cache = seqlen_k
+                    k_bos = 0
+
+                if is_seqused_k:
+                    k_len = tl.load(seqused_k_ptr + bid).to(tl.int32)
+                else:
+                    k_len = k_len_cache
+
+                process_q_tile = (q_len >= MIN_Q_LEN_TO_PROCESS) & (
+                    q_len <= MAX_Q_LEN_TO_PROCESS
+                )
+                valid_q_tile = (m_block * BLOCK_M < q_len) & process_q_tile
+                if valid_q_tile:
+                    if is_local:
+                        n_block_min = tl.maximum(
+                            0,
+                            (
+                                m_block * BLOCK_M
+                                + k_len
+                                - q_len
+                                - window_size_left
+                            )
+                            // BLOCK_N,
+                        )
+                    else:
+                        n_block_min = 0
+
+                    n_block_max = tl.cdiv(k_len, BLOCK_N)
+                    if is_causal or is_local:
+                        n_block_max = tl.minimum(
+                            n_block_max,
+                            tl.cdiv(
+                                (m_block + 1) * BLOCK_M
+                                + k_len
+                                - q_len
+                                + window_size_right,
+                                BLOCK_N,
+                            ),
+                        )
+
+                    if n_block_min < n_block_max:
+                        kv_head = hid // h_hk_ratio
+                        q_base = q_ptr + q_offset + hid * q_head_stride
+                        if is_paged:
+                            page_table_ptr_b = page_table_ptr + bid * page_table_batch_stride
+                            k_base = k_ptr + kv_head * k_head_stride
+                            v_base = v_ptr + kv_head * v_head_stride
+                        else:
+                            k_base = (
+                                k_ptr
+                                + k_bos * k_row_stride
+                                + kv_head * k_head_stride
+                            )
+                            v_base = (
+                                v_ptr
+                                + k_bos * v_row_stride
+                                + kv_head * v_head_stride
+                            )
+
+                        if USE_TMA_QO:
+                            q_desc = tl.make_tensor_descriptor(
+                                base=q_base,
+                                shape=[q_len, d],
+                                strides=[q_row_stride, 1],
+                                block_shape=[BM_SPLIT, HEAD_DIM_PADDED],
+                            )
+                        if (not is_paged) and USE_TMA_KV:
+                            k_desc = tl.make_tensor_descriptor(
+                                base=k_base,
+                                shape=[k_len_cache, d],
+                                strides=[k_row_stride, 1],
+                                block_shape=[BLOCK_N, HEAD_DIM_PADDED],
+                            )
+                            v_desc = tl.make_tensor_descriptor(
+                                base=v_base,
+                                shape=[k_len_cache, d],
+                                strides=[v_row_stride, 1],
+                                block_shape=[BLOCK_N, HEAD_DIM_PADDED],
+                            )
+
+                        q_buf, q_phase_idx = _buf_phase_tle(
+                            tile_count, NUM_BUFFERS_Q
+                        )
+                        q0_idx = q_buf
+                        q1_idx = q_buf + NUM_BUFFERS_Q
+
+                        tle.gpu.barrier_wait(q_empties[q0_idx], phaseIdx=q_phase_idx)
+                        if USE_TMA_QO:
+                            tle.gpu.copy(
+                                q_desc,
+                                q_smem.slot(q0_idx),
+                                [BM_SPLIT, HEAD_DIM_PADDED],
+                                [m_block * BLOCK_M, 0],
+                                barrier=q_fulls[q0_idx],
+                            )
+                        else:
+                            _copy_dense_tile_to_smem(
+                                q_base,
+                                q_row_stride,
+                                q_smem.slot(q0_idx),
+                                m_block * BLOCK_M,
+                                q_len,
+                                d,
+                                BM_SPLIT,
+                                HEAD_DIM_PADDED,
+                            )
+                            _fence_async_shared_cta()
+                            tle.gpu.barrier_arrive(
+                                q_fulls_manual[q0_idx], phaseIdx=q_phase_idx
+                            )
+
+                        kv_buf, kv_phase_idx = _buf_phase_tle(
+                            accum_cnt_kv, NUM_BUFFERS_KV
+                        )
+                        kv_offset = n_block_min * BLOCK_N
+                        tle.gpu.barrier_wait(k_empties[kv_buf], phaseIdx=kv_phase_idx)
+                        if is_paged:
+                            _copy_paged_kv_tile_to_smem(
+                                k_base,
+                                k_row_stride,
+                                page_table_ptr_b,
+                                k_smem.slot(kv_buf),
+                                kv_offset,
+                                k_len,
+                                d,
+                                block_size,
+                                BLOCK_N,
+                                HEAD_DIM_PADDED,
+                                PAGED_GATHER_MODE,
+                            )
+                            _fence_async_shared_cta()
+                            tle.gpu.barrier_arrive(
+                                k_fulls_manual[kv_buf], phaseIdx=kv_phase_idx
+                            )
+                        elif USE_TMA_KV:
+                            tle.gpu.copy(
+                                k_desc,
+                                k_smem.slot(kv_buf),
+                                [BLOCK_N, HEAD_DIM_PADDED],
+                                [kv_offset, 0],
+                                barrier=k_fulls[kv_buf],
+                            )
+                        else:
+                            _copy_dense_tile_to_smem(
+                                k_base,
+                                k_row_stride,
+                                k_smem.slot(kv_buf),
+                                kv_offset,
+                                k_len,
+                                d,
+                                BLOCK_N,
+                                HEAD_DIM_PADDED,
+                            )
+                            _fence_async_shared_cta()
+                            tle.gpu.barrier_arrive(
+                                k_fulls_manual[kv_buf], phaseIdx=kv_phase_idx
+                            )
+
+                        if NUM_MMA_GROUPS == 2:
+                            tle.gpu.barrier_wait(
+                                q_empties[q1_idx], phaseIdx=q_phase_idx
+                            )
+                            if USE_TMA_QO:
+                                tle.gpu.copy(
+                                    q_desc,
+                                    q_smem.slot(q1_idx),
+                                    [BM_SPLIT, HEAD_DIM_PADDED],
+                                    [m_block * BLOCK_M + BM_SPLIT, 0],
+                                    barrier=q_fulls[q1_idx],
+                                )
+                            else:
+                                _copy_dense_tile_to_smem(
+                                    q_base,
+                                    q_row_stride,
+                                    q_smem.slot(q1_idx),
+                                    m_block * BLOCK_M + BM_SPLIT,
+                                    q_len,
+                                    d,
+                                    BM_SPLIT,
+                                    HEAD_DIM_PADDED,
+                                )
+                                _fence_async_shared_cta()
+                                tle.gpu.barrier_arrive(
+                                    q_fulls_manual[q1_idx], phaseIdx=q_phase_idx
+                                )
+
+                        tle.gpu.barrier_wait(v_empties[kv_buf], phaseIdx=kv_phase_idx)
+                        if is_paged:
+                            _copy_paged_kv_tile_to_smem(
+                                v_base,
+                                v_row_stride,
+                                page_table_ptr_b,
+                                v_smem.slot(kv_buf),
+                                kv_offset,
+                                k_len,
+                                d,
+                                block_size,
+                                BLOCK_N,
+                                HEAD_DIM_PADDED,
+                                PAGED_GATHER_MODE,
+                            )
+                            _fence_async_shared_cta()
+                            tle.gpu.barrier_arrive(
+                                v_fulls_manual[kv_buf], phaseIdx=kv_phase_idx
+                            )
+                        elif USE_TMA_KV:
+                            tle.gpu.copy(
+                                v_desc,
+                                v_smem.slot(kv_buf),
+                                [BLOCK_N, HEAD_DIM_PADDED],
+                                [kv_offset, 0],
+                                barrier=v_fulls[kv_buf],
+                            )
+                        else:
+                            _copy_dense_tile_to_smem(
+                                v_base,
+                                v_row_stride,
+                                v_smem.slot(kv_buf),
+                                kv_offset,
+                                k_len,
+                                d,
+                                BLOCK_N,
+                                HEAD_DIM_PADDED,
+                            )
+                            _fence_async_shared_cta()
+                            tle.gpu.barrier_arrive(
+                                v_fulls_manual[kv_buf], phaseIdx=kv_phase_idx
+                            )
+                        accum_cnt_kv += 1
+
+                        n_block = n_block_min + 1
+                        while n_block < n_block_max:
+                            kv_buf, kv_phase_idx = _buf_phase_tle(
+                                accum_cnt_kv, NUM_BUFFERS_KV
+                            )
+                            kv_offset = n_block * BLOCK_N
+
+                            tle.gpu.barrier_wait(
+                                k_empties[kv_buf], phaseIdx=kv_phase_idx
+                            )
+                            if is_paged:
+                                _copy_paged_kv_tile_to_smem(
+                                    k_base,
+                                    k_row_stride,
+                                    page_table_ptr_b,
+                                    k_smem.slot(kv_buf),
+                                    kv_offset,
+                                    k_len,
+                                    d,
+                                    block_size,
+                                    BLOCK_N,
+                                    HEAD_DIM_PADDED,
+                                    PAGED_GATHER_MODE,
+                                )
+                                _fence_async_shared_cta()
+                                tle.gpu.barrier_arrive(
+                                    k_fulls_manual[kv_buf], phaseIdx=kv_phase_idx
+                                )
+                            elif USE_TMA_KV:
+                                tle.gpu.copy(
+                                    k_desc,
+                                    k_smem.slot(kv_buf),
+                                    [BLOCK_N, HEAD_DIM_PADDED],
+                                    [kv_offset, 0],
+                                    barrier=k_fulls[kv_buf],
+                                )
+                            else:
+                                _copy_dense_tile_to_smem(
+                                    k_base,
+                                    k_row_stride,
+                                    k_smem.slot(kv_buf),
+                                    kv_offset,
+                                    k_len,
+                                    d,
+                                    BLOCK_N,
+                                    HEAD_DIM_PADDED,
+                                )
+                                _fence_async_shared_cta()
+                                tle.gpu.barrier_arrive(
+                                    k_fulls_manual[kv_buf], phaseIdx=kv_phase_idx
+                                )
+
+                            tle.gpu.barrier_wait(
+                                v_empties[kv_buf], phaseIdx=kv_phase_idx
+                            )
+                            if is_paged:
+                                _copy_paged_kv_tile_to_smem(
+                                    v_base,
+                                    v_row_stride,
+                                    page_table_ptr_b,
+                                    v_smem.slot(kv_buf),
+                                    kv_offset,
+                                    k_len,
+                                    d,
+                                    block_size,
+                                    BLOCK_N,
+                                    HEAD_DIM_PADDED,
+                                    PAGED_GATHER_MODE,
+                                )
+                                _fence_async_shared_cta()
+                                tle.gpu.barrier_arrive(
+                                    v_fulls_manual[kv_buf], phaseIdx=kv_phase_idx
+                                )
+                            elif USE_TMA_KV:
+                                tle.gpu.copy(
+                                    v_desc,
+                                    v_smem.slot(kv_buf),
+                                    [BLOCK_N, HEAD_DIM_PADDED],
+                                    [kv_offset, 0],
+                                    barrier=v_fulls[kv_buf],
+                                )
+                            else:
+                                _copy_dense_tile_to_smem(
+                                    v_base,
+                                    v_row_stride,
+                                    v_smem.slot(kv_buf),
+                                    kv_offset,
+                                    k_len,
+                                    d,
+                                    BLOCK_N,
+                                    HEAD_DIM_PADDED,
+                                )
+                                _fence_async_shared_cta()
+                                tle.gpu.barrier_arrive(
+                                    v_fulls_manual[kv_buf], phaseIdx=kv_phase_idx
+                                )
+                            accum_cnt_kv += 1
+                            n_block += 1
+
+                        tile_count += 1
+
+                tile_idx += num_progs
+
+        with tle.gpu.async_task(
+            num_warps=NUM_MMA_WARPS // NUM_MMA_GROUPS,
+            registers=232,
+            replicate=NUM_MMA_GROUPS,
+            name="mma",
+        ):
+            cid: tl.constexpr = tle.gpu.async_task_replica_id()
+            prog_id = tl.program_id(0)
+            num_progs = tl.num_programs(0)
+            num_pid_m = tl.cdiv(seqlen_q, BLOCK_M)
+            total_tiles = num_pid_m * b * h
+
+            if NUM_MMA_GROUPS == 2 and cid == 1:
+                tle.gpu.barrier_arrive(ping_to_c0)
+
+            tile_idx = prog_id
+            tile_count = 0
+            accum_cnt_kv = 0
+            while tile_idx < total_tiles:
+                m_block, bid, hid = _persistent_tile_coords(tile_idx, num_pid_m, b)
+
+                if is_cu_seqlens_q:
+                    q_eos = tl.load(cu_seqlens_q_ptr + bid + 1).to(tl.int32)
+                    q_bos = tl.load(cu_seqlens_q_ptr + bid).to(tl.int32)
+                    q_len = q_eos - q_bos
+                    o_offset = q_bos * o_row_stride
+                    lse_offset = q_bos
+                else:
+                    q_len = seqlen_q
+                    o_offset = bid * o_batch_stride
+                    lse_offset = bid * seqlen_q
+
+                if is_cu_seqlens_k:
+                    k_eos = tl.load(cu_seqlens_k_ptr + bid + 1).to(tl.int32)
+                    k_bos = tl.load(cu_seqlens_k_ptr + bid).to(tl.int32)
+                    k_len_cache = k_eos - k_bos
+                else:
+                    k_len_cache = seqlen_k
+
+                if is_seqused_k:
+                    k_len = tl.load(seqused_k_ptr + bid).to(tl.int32)
+                else:
+                    k_len = k_len_cache
+
+                if is_alibi:
+                    alibi_slope = tl.load(
+                        alibi_slopes_ptr + bid * alibi_slopes_batch_stride + hid
+                    )
+                    alibi_slope = alibi_slope / scale_softmax
+                else:
+                    alibi_slope = 0.0
+
+                process_q_tile = (q_len >= MIN_Q_LEN_TO_PROCESS) & (
+                    q_len <= MAX_Q_LEN_TO_PROCESS
+                )
+                valid_q_tile = (m_block * BLOCK_M < q_len) & process_q_tile
+                if valid_q_tile:
+                    if is_local:
+                        n_block_min = tl.maximum(
+                            0,
+                            (
+                                m_block * BLOCK_M
+                                + k_len
+                                - q_len
+                                - window_size_left
+                            )
+                            // BLOCK_N,
+                        )
+                    else:
+                        n_block_min = 0
+
+                    n_block_max = tl.cdiv(k_len, BLOCK_N)
+                    if is_causal or is_local:
+                        n_block_max = tl.minimum(
+                            n_block_max,
+                            tl.cdiv(
+                                (m_block + 1) * BLOCK_M
+                                + k_len
+                                - q_len
+                                + window_size_right,
+                                BLOCK_N,
+                            ),
+                        )
+
+                    row_idx_q = (
+                        m_block * BLOCK_M
+                        + cid * BM_SPLIT
+                        + tl.arange(0, BM_SPLIT)
+                    )
+                    o_base = o_ptr + o_offset + hid * o_head_stride
+                    if USE_TMA_QO:
+                        o_desc = tl.make_tensor_descriptor(
+                            base=o_base,
+                            shape=[q_len, d],
+                            strides=[o_row_stride, 1],
+                            block_shape=[BM_SPLIT, HEAD_DIM_PADDED],
+                        )
+
+                    if n_block_min < n_block_max:
+                        rowmax = tl.full(
+                            [BM_SPLIT], float("-inf"), dtype=tl.float32
+                        )
+                        rowsum = tl.zeros([BM_SPLIT], dtype=tl.float32)
+                        acc = tl.zeros(
+                            [BM_SPLIT, HEAD_DIM_PADDED], dtype=tl.float32
+                        )
+
+                        q_buf, q_phase_idx = _buf_phase_tle(
+                            tile_count, NUM_BUFFERS_Q
+                        )
+                        q_idx = q_buf + cid * NUM_BUFFERS_Q
+                        if USE_TMA_QO:
+                            tle.gpu.barrier_wait(
+                                q_fulls[q_idx], phaseIdx=q_phase_idx
+                            )
+                        else:
+                            tle.gpu.barrier_wait(
+                                q_fulls_manual[q_idx], phaseIdx=q_phase_idx
+                            )
+
+                        kv_buf, kv_phase_idx = _buf_phase_tle(
+                            accum_cnt_kv, NUM_BUFFERS_KV
+                        )
+                        if is_paged or (not USE_TMA_KV):
+                            tle.gpu.barrier_wait(
+                                k_fulls_manual[kv_buf], phaseIdx=kv_phase_idx
+                            )
+                        else:
+                            tle.gpu.barrier_wait(
+                                k_fulls[kv_buf], phaseIdx=kv_phase_idx
+                            )
+
+                        if NUM_MMA_GROUPS == 2:
+                            if cid == 0:
+                                tle.gpu.barrier_wait(ping_to_c0)
+                            else:
+                                tle.gpu.barrier_wait(ping_to_c1)
+                        qk = tle.gpu.wgmma(
+                            q_smem.slot(q_idx),
+                            k_smem.slot(kv_buf),
+                            out_dtype=tl.float32,
+                            trans_b=True,
+                        )
+                        if NUM_MMA_GROUPS == 2:
+                            if cid == 0:
+                                tle.gpu.barrier_arrive(ping_to_c1)
+                            else:
+                                tle.gpu.barrier_arrive(ping_to_c0)
+
+                        qk = tle.gpu.wgmma_wait(0, qk)
+                        tle.gpu.barrier_arrive(
+                            k_empties[kv_buf], phaseIdx=kv_phase_idx
+                        )
+
+                        n_block = n_block_min
+                        col_idx = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
+                        qk = _apply_softcap_v3(qk, softcap, is_softcap)
+                        qk = _apply_alibi_v3(
+                            qk,
+                            col_idx,
+                            row_idx_q,
+                            q_len,
+                            k_len,
+                            IS_CAUSAL=is_causal,
+                            IS_ALIBI=is_alibi,
+                            alibi_slope=alibi_slope,
+                        )
+                        qk = _apply_mask_v3(
+                            qk,
+                            col_idx,
+                            row_idx_q,
+                            q_len,
+                            k_len,
+                            window_size_left,
+                            window_size_right,
+                            IS_EVEN_MN=False,
+                            IS_CAUSAL=is_causal,
+                            IS_LOCAL=is_local,
+                        )
+                        alpha, p, rowmax, rowsum = _softmax_online_deferred(
+                            qk,
+                            rowmax,
+                            rowsum,
+                            softmax_scale_log2e=scale_softmax_log2,
+                            IS_BORDER=True,
+                        )
+                        accum_cnt_kv += 1
+                        n_block += 1
+
+                        while n_block < n_block_max:
+                            kv_buf, kv_phase_idx = _buf_phase_tle(
+                                accum_cnt_kv, NUM_BUFFERS_KV
+                            )
+                            if is_paged or (not USE_TMA_KV):
+                                tle.gpu.barrier_wait(
+                                    k_fulls_manual[kv_buf], phaseIdx=kv_phase_idx
+                                )
+                            else:
+                                tle.gpu.barrier_wait(
+                                    k_fulls[kv_buf], phaseIdx=kv_phase_idx
+                                )
+
+                            if NUM_MMA_GROUPS == 2:
+                                if cid == 0:
+                                    tle.gpu.barrier_wait(ping_to_c0)
+                                else:
+                                    tle.gpu.barrier_wait(ping_to_c1)
+                            qk = tle.gpu.wgmma(
+                                q_smem.slot(q_idx),
+                                k_smem.slot(kv_buf),
+                                out_dtype=tl.float32,
+                                trans_b=True,
+                            )
+                            if NUM_MMA_GROUPS == 2:
+                                if cid == 0:
+                                    tle.gpu.barrier_arrive(ping_to_c1)
+                                else:
+                                    tle.gpu.barrier_arrive(ping_to_c0)
+
+                            v_buf, v_phase_idx = _buf_phase_tle(
+                                accum_cnt_kv - 1, NUM_BUFFERS_KV
+                            )
+                            if is_paged or (not USE_TMA_KV):
+                                tle.gpu.barrier_wait(
+                                    v_fulls_manual[v_buf], phaseIdx=v_phase_idx
+                                )
+                            else:
+                                tle.gpu.barrier_wait(
+                                    v_fulls[v_buf], phaseIdx=v_phase_idx
+                                )
+                            acc = tle.gpu.wgmma(
+                                p.to(INPUT_DTYPE),
+                                v_smem.slot(v_buf),
+                                acc,
+                            )
+
+                            qk = tle.gpu.wgmma_wait(1, qk)
+                            tle.gpu.barrier_arrive(
+                                k_empties[kv_buf], phaseIdx=kv_phase_idx
+                            )
+
+                            col_idx = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
+                            qk = _apply_softcap_v3(qk, softcap, is_softcap)
+                            qk = _apply_alibi_v3(
+                                qk,
+                                col_idx,
+                                row_idx_q,
+                                q_len,
+                                k_len,
+                                IS_CAUSAL=is_causal,
+                                IS_ALIBI=is_alibi,
+                                alibi_slope=alibi_slope,
+                            )
+                            qk = _apply_mask_v3(
+                                qk,
+                                col_idx,
+                                row_idx_q,
+                                q_len,
+                                k_len,
+                                window_size_left,
+                                window_size_right,
+                                IS_EVEN_MN=False,
+                                IS_CAUSAL=is_causal,
+                                IS_LOCAL=is_local,
+                            )
+                            alpha, p, rowmax, rowsum = _softmax_online_deferred(
+                                qk,
+                                rowmax,
+                                rowsum,
+                                softmax_scale_log2e=scale_softmax_log2,
+                                IS_BORDER=True,
+                            )
+
+                            acc = tle.gpu.wgmma_wait(0, acc)
+                            tle.gpu.barrier_arrive(
+                                v_empties[v_buf], phaseIdx=v_phase_idx
+                            )
+                            acc = acc * alpha[:, None]
+
+                            accum_cnt_kv += 1
+                            n_block += 1
+
+                        v_buf, v_phase_idx = _buf_phase_tle(
+                            accum_cnt_kv - 1, NUM_BUFFERS_KV
+                        )
+                        if is_paged or (not USE_TMA_KV):
+                            tle.gpu.barrier_wait(
+                                v_fulls_manual[v_buf], phaseIdx=v_phase_idx
+                            )
+                        else:
+                            tle.gpu.barrier_wait(
+                                v_fulls[v_buf], phaseIdx=v_phase_idx
+                            )
+                        acc = tle.gpu.wgmma(p.to(INPUT_DTYPE), v_smem.slot(v_buf), acc)
+
+                        acc = tle.gpu.wgmma_wait(1, acc)
+                        tle.gpu.barrier_arrive(q_empties[q_idx], phaseIdx=q_phase_idx)
+
+                        acc = tle.gpu.wgmma_wait(0, acc)
+                        tle.gpu.barrier_arrive(
+                            v_empties[v_buf], phaseIdx=v_phase_idx
+                        )
+
+                        invalid = (rowsum == 0) | (rowsum != rowsum)
+                        inv_sum = tl.where(invalid, 1.0, 1.0 / rowsum)
+                        acc = acc * inv_sum[:, None]
+                        lse = tl.where(
+                            invalid,
+                            float("inf"),
+                            rowmax * scale_softmax + tl.log(rowsum),
+                        )
+                        tile_count += 1
+                    else:
+                        acc = tl.zeros(
+                            [BM_SPLIT, HEAD_DIM_PADDED], dtype=tl.float32
+                        )
+                        lse = tl.full([BM_SPLIT], float("inf"), dtype=tl.float32)
+
+                    if USE_TMA_QO:
+                        o_desc.store(
+                            [m_block * BLOCK_M + cid * BM_SPLIT, 0],
+                            acc.to(o_ptr.dtype.element_ty),
+                        )
+                    else:
+                        _store_dense_tile_from_regs(
+                            o_base,
+                            o_row_stride,
+                            acc.to(o_ptr.dtype.element_ty),
+                            m_block * BLOCK_M + cid * BM_SPLIT,
+                            q_len,
+                            d,
+                            BM_SPLIT,
+                            HEAD_DIM_PADDED,
+                        )
+                    lse_ptr = softmax_lse_ptr + hid * total_q + lse_offset + row_idx_q
+                    tl.store(lse_ptr, lse, mask=row_idx_q < q_len)
+
+                tile_idx += num_progs
+
+
+
+
+flash_varlen_fwd_v3_tle_ws_simple_kernel = flash_varlen_fwd_v3_tle_kernel
+persistent_pingpong_kernel = flash_varlen_fwd_v3_tle_kernel
+ws_simple_kernel = flash_varlen_fwd_v3_tle_ws_simple_kernel
+
+__all__ = [
+    "flash_varlen_fwd_v3_tle_kernel",
+    "flash_varlen_fwd_v3_tle_ws_simple_kernel",
+    "persistent_pingpong_kernel",
+    "ws_simple_kernel",
+]

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/fa_hopper_short.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/fa_hopper_short.py
@@ -1,0 +1,433 @@
+"""Short / serve FA3 TLE kernel family."""
+
+from .utils import *  # noqa: F401,F403
+def _fa3_short_configs():
+    configs = []
+    for block_m in (16, 32, 64, 128):
+        for block_n in (32, 64, 128):
+            warp_choices = (4, 8) if block_m >= 64 and block_n >= 64 else (4,)
+            for num_warps in warp_choices:
+                configs.append(
+                    triton.Config(
+                        {"BLOCK_M": block_m, "BLOCK_N": block_n},
+                        num_stages=3,
+                        num_warps=num_warps,
+                    )
+                )
+    return configs
+
+
+def _prune_fa3_short_configs(configs, nargs, **kwargs):
+    head_dim = kwargs.get("d", nargs.get("d"))
+    is_paged = kwargs.get("is_paged", nargs.get("is_paged"))
+    shape_bucket = kwargs.get(
+        "SHORT_SHAPE_BUCKET", nargs.get("SHORT_SHAPE_BUCKET", _FA3_TLE_BUCKET_SHORT)
+    )
+
+    kept = []
+    for cfg in configs:
+        block_m = cfg.kwargs["BLOCK_M"]
+        block_n = cfg.kwargs["BLOCK_N"]
+        if shape_bucket == _FA3_TLE_BUCKET_DECODE:
+            if block_m > 32 or block_n < 64:
+                continue
+        elif shape_bucket == _FA3_TLE_BUCKET_PAGED_DECODE:
+            if block_m > 32 or block_n > 64:
+                continue
+        elif shape_bucket == _FA3_TLE_BUCKET_SERVE_SHORT:
+            if block_m < 16 or block_m > 32 or block_n < 64:
+                continue
+        elif shape_bucket == _FA3_TLE_BUCKET_PAGED_SERVE_SHORT:
+            if block_m < 16 or block_m > 32 or block_n > 64:
+                continue
+        elif shape_bucket == _FA3_TLE_BUCKET_PAGED_SMALL:
+            if block_m < 16 or block_m > 64 or block_n > 64:
+                continue
+        elif shape_bucket == _FA3_TLE_BUCKET_PAGED_MEDIUM:
+            if block_m < 64 or block_n < 64:
+                continue
+        elif shape_bucket == _FA3_TLE_BUCKET_SHORT:
+            if block_m < 32 or block_m > 64:
+                continue
+        if head_dim > 128 and block_n > 64:
+            continue
+        if head_dim > 192 and block_n > 64:
+            continue
+        if is_paged and block_n > 64 and block_m > 32:
+            continue
+        kept.append(cfg)
+
+    if kept:
+        return kept
+    return [configs[0]]
+
+
+
+@libentry()
+@triton.autotune(
+    configs=_fa3_short_configs(),
+    prune_configs_by={"early_config_prune": _prune_fa3_short_configs},
+    key=[
+        "d",
+        "is_paged",
+        "is_causal",
+        "is_local",
+        "is_alibi",
+        "SHORT_SHAPE_BUCKET",
+        "MIN_Q_LEN_TO_PROCESS",
+        "MAX_Q_LEN_TO_PROCESS",
+    ],
+)
+@triton.heuristics(
+    values={
+        "BLOCK_K": _heur_block_k,
+    }
+)
+@triton.jit(
+    do_not_specialize=[
+        "q_batch_stride",
+        "k_batch_stride",
+        "v_batch_stride",
+        "o_batch_stride",
+        "b",
+        "bk",
+        "seqlen_q",
+        "seqlen_k",
+        "seqlen_q_rounded",
+        "seqlen_k_rounded",
+        "total_q",
+    ]
+)
+def flash_varlen_fwd_v3_tle_short_kernel(
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    o_ptr,
+    p_ptr,
+    softmax_lse_ptr,
+    q_row_stride,
+    k_row_stride,
+    v_row_stride,
+    q_head_stride,
+    k_head_stride,
+    v_head_stride,
+    o_row_stride,
+    o_head_stride,
+    q_batch_stride,
+    k_batch_stride,
+    v_batch_stride,
+    o_batch_stride,
+    is_cu_seqlens_q: tl.constexpr,
+    cu_seqlens_q_ptr,
+    is_cu_seqlens_k: tl.constexpr,
+    cu_seqlens_k_ptr,
+    is_seqused_k: tl.constexpr,
+    seqused_k_ptr,
+    b,
+    bk,
+    h: tl.constexpr,
+    hk: tl.constexpr,
+    h_hk_ratio: tl.constexpr,
+    seqlen_q,
+    seqlen_k,
+    seqlen_q_rounded,
+    seqlen_k_rounded,
+    d: tl.constexpr,
+    d_rounded: tl.constexpr,
+    is_softcap: tl.constexpr,
+    softcap: tl.constexpr,
+    scale_softmax: tl.constexpr,
+    scale_softmax_log2: tl.constexpr,
+    is_dropout: tl.constexpr,
+    p_dropout: tl.constexpr,
+    rp_dropout: tl.constexpr,
+    p_dropout_in_uint8_t: tl.constexpr,
+    philox_args,
+    return_softmax: tl.constexpr,
+    is_causal: tl.constexpr,
+    is_local: tl.constexpr,
+    window_size_left: tl.constexpr,
+    window_size_right: tl.constexpr,
+    seqlenq_ngroups_swapped: tl.constexpr,
+    is_paged: tl.constexpr,
+    is_alibi: tl.constexpr,
+    alibi_slopes_ptr,
+    alibi_slopes_batch_stride: tl.constexpr,
+    total_q,
+    page_table_ptr,
+    page_table_batch_stride: tl.constexpr,
+    block_size: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    SHORT_SHAPE_BUCKET: tl.constexpr,
+    MIN_Q_LEN_TO_PROCESS: tl.constexpr,
+    MAX_Q_LEN_TO_PROCESS: tl.constexpr,
+    PAGED_GATHER_MODE: tl.constexpr = 2,
+):
+    m_block = tl.program_id(0)
+    bid = tl.program_id(1)
+    hid = tl.program_id(2)
+    HEAD_DIM_PADDED: tl.constexpr = BLOCK_K
+
+    if is_cu_seqlens_q:
+        q_eos = tl.load(cu_seqlens_q_ptr + bid + 1).to(tl.int32)
+        q_bos = tl.load(cu_seqlens_q_ptr + bid).to(tl.int32)
+        q_len = q_eos - q_bos
+        q_offset = q_bos * q_row_stride
+        o_offset = q_bos * o_row_stride
+        lse_offset = q_bos
+    else:
+        q_len = seqlen_q
+        q_offset = bid * q_batch_stride
+        o_offset = bid * o_batch_stride
+        lse_offset = bid * seqlen_q
+
+    if is_cu_seqlens_k:
+        k_eos = tl.load(cu_seqlens_k_ptr + bid + 1).to(tl.int32)
+        k_bos = tl.load(cu_seqlens_k_ptr + bid).to(tl.int32)
+        k_len_cache = k_eos - k_bos
+    else:
+        k_len_cache = seqlen_k
+        k_bos = 0
+
+    if is_seqused_k:
+        k_len = tl.load(seqused_k_ptr + bid).to(tl.int32)
+    else:
+        k_len = k_len_cache
+
+    process_q = (q_len >= MIN_Q_LEN_TO_PROCESS) & (q_len <= MAX_Q_LEN_TO_PROCESS)
+    process_q = process_q & (m_block * BLOCK_M < q_len)
+    if process_q:
+        if is_local:
+            n_block_min = tl.maximum(
+                0,
+                (m_block * BLOCK_M + k_len - q_len - window_size_left) // BLOCK_N,
+            )
+        else:
+            n_block_min = 0
+
+        n_block_max = tl.cdiv(k_len, BLOCK_N)
+        if is_causal or is_local:
+            n_block_max = tl.minimum(
+                n_block_max,
+                tl.cdiv(
+                    (m_block + 1) * BLOCK_M
+                    + k_len
+                    - q_len
+                    + window_size_right,
+                    BLOCK_N,
+                ),
+            )
+
+        if (not is_causal) and (not is_local):
+            n_masking_steps = 1
+        else:
+            n_masking_steps = tl.cdiv(BLOCK_M, BLOCK_N) + 1
+        n_masking_steps = tl.maximum(
+            0, tl.minimum(n_block_max - n_block_min, n_masking_steps)
+        )
+
+        if is_alibi:
+            alibi_slope = tl.load(
+                alibi_slopes_ptr + bid * alibi_slopes_batch_stride + hid
+            )
+            alibi_slope = alibi_slope / scale_softmax
+        else:
+            alibi_slope = 0.0
+
+        q_base = q_ptr + q_offset + hid * q_head_stride
+        q_desc = tl.make_tensor_descriptor(
+            base=q_base,
+            shape=[q_len, d],
+            strides=[q_row_stride, 1],
+            block_shape=[BLOCK_M, HEAD_DIM_PADDED],
+        )
+        o_base = o_ptr + o_offset + hid * o_head_stride
+        o_desc = tl.make_tensor_descriptor(
+            base=o_base,
+            shape=[q_len, d],
+            strides=[o_row_stride, 1],
+            block_shape=[BLOCK_M, HEAD_DIM_PADDED],
+        )
+
+        kv_head = hid // h_hk_ratio
+        if is_paged:
+            page_table_ptr_b = page_table_ptr + bid * page_table_batch_stride
+            k_base = k_ptr + kv_head * k_head_stride
+            v_base = v_ptr + kv_head * v_head_stride
+        else:
+            k_base = k_ptr + k_bos * k_row_stride + kv_head * k_head_stride
+            v_base = v_ptr + k_bos * v_row_stride + kv_head * v_head_stride
+            k_desc = tl.make_tensor_descriptor(
+                base=k_base,
+                shape=[k_len_cache, d],
+                strides=[k_row_stride, 1],
+                block_shape=[BLOCK_N, HEAD_DIM_PADDED],
+            )
+            v_desc = tl.make_tensor_descriptor(
+                base=v_base,
+                shape=[k_len_cache, d],
+                strides=[v_row_stride, 1],
+                block_shape=[BLOCK_N, HEAD_DIM_PADDED],
+            )
+
+        q_tile = q_desc.load([m_block * BLOCK_M, 0])
+        row_idx_q = m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+        rowmax = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+        rowsum = tl.zeros([BLOCK_M], dtype=tl.float32)
+        acc = tl.zeros([BLOCK_M, HEAD_DIM_PADDED], dtype=tl.float32)
+
+        n_block_start_mask = n_block_max - 1
+        for step in tl.range(0, n_masking_steps):
+            n_block = n_block_start_mask - step
+            col_idx = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
+
+            if is_paged:
+                cache_idx = _paged_blockwise_cache_indices(
+                    n_block * BLOCK_N,
+                    tl.arange(0, BLOCK_N),
+                    k_len,
+                    page_table_ptr_b,
+                    block_size,
+                    BLOCK_N,
+                    PAGED_GATHER_MODE,
+                    BOUNDARY_CHECK=False,
+                )
+                d_idx = tl.arange(0, HEAD_DIM_PADDED)
+                d_mask = d_idx < d
+                kv_mask = col_idx < k_len
+                bK = tl.load(
+                    k_base + cache_idx[None, :] * k_row_stride + d_idx[:, None],
+                    mask=d_mask[:, None] & kv_mask[None, :],
+                    other=0.0,
+                )
+                bV = tl.load(
+                    v_base + cache_idx[:, None] * v_row_stride + d_idx[None, :],
+                    mask=kv_mask[:, None] & d_mask[None, :],
+                    other=0.0,
+                )
+            else:
+                bK = tl.trans(k_desc.load([n_block * BLOCK_N, 0]))
+                bV = v_desc.load([n_block * BLOCK_N, 0])
+
+            S = tl.dot(q_tile, bK, out_dtype=tl.float32)
+            S = _apply_softcap_v3(S, softcap, is_softcap)
+            S = _apply_alibi_v3(
+                S,
+                col_idx,
+                row_idx_q,
+                q_len,
+                k_len,
+                IS_CAUSAL=is_causal,
+                IS_ALIBI=is_alibi,
+                alibi_slope=alibi_slope,
+            )
+            S = _apply_mask_v3(
+                S,
+                col_idx,
+                row_idx_q,
+                q_len,
+                k_len,
+                window_size_left,
+                window_size_right,
+                IS_EVEN_MN=False,
+                IS_CAUSAL=is_causal,
+                IS_LOCAL=is_local,
+            )
+            alpha, P, rowmax, rowsum = _softmax_online_deferred(
+                S,
+                rowmax,
+                rowsum,
+                softmax_scale_log2e=scale_softmax_log2,
+                IS_BORDER=True,
+            )
+            acc = acc * alpha[:, None]
+            acc = tl.dot(P.to(v_ptr.dtype.element_ty), bV, acc, out_dtype=tl.float32)
+
+        n_dense_end = n_block_max - n_masking_steps
+        for n_block in tl.range(
+            n_dense_end - 1,
+            n_block_min - 1,
+            step=-1,
+            num_stages=3,
+        ):
+            col_idx = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
+            if is_paged:
+                cache_idx = _paged_blockwise_cache_indices(
+                    n_block * BLOCK_N,
+                    tl.arange(0, BLOCK_N),
+                    k_len,
+                    page_table_ptr_b,
+                    block_size,
+                    BLOCK_N,
+                    PAGED_GATHER_MODE,
+                    BOUNDARY_CHECK=True,
+                )
+                d_idx = tl.arange(0, HEAD_DIM_PADDED)
+                d_mask = d_idx < d
+                kv_mask = col_idx < k_len
+                bK = tl.load(
+                    k_base + cache_idx[None, :] * k_row_stride + d_idx[:, None],
+                    mask=d_mask[:, None] & kv_mask[None, :],
+                    other=0.0,
+                )
+                bV = tl.load(
+                    v_base + cache_idx[:, None] * v_row_stride + d_idx[None, :],
+                    mask=kv_mask[:, None] & d_mask[None, :],
+                    other=0.0,
+                )
+            else:
+                bK = tl.trans(k_desc.load([n_block * BLOCK_N, 0]))
+                bV = v_desc.load([n_block * BLOCK_N, 0])
+
+            S = tl.dot(q_tile, bK, out_dtype=tl.float32)
+            S = _apply_softcap_v3(S, softcap, is_softcap)
+            S = _apply_alibi_v3(
+                S,
+                col_idx,
+                row_idx_q,
+                q_len,
+                k_len,
+                IS_CAUSAL=is_causal,
+                IS_ALIBI=is_alibi,
+                alibi_slope=alibi_slope,
+            )
+            S = _apply_mask_v3(
+                S,
+                col_idx,
+                row_idx_q,
+                q_len,
+                k_len,
+                window_size_left,
+                window_size_right,
+                IS_EVEN_MN=True,
+                IS_CAUSAL=False,
+                IS_LOCAL=is_local,
+            )
+            alpha, P, rowmax, rowsum = _softmax_online_deferred(
+                S,
+                rowmax,
+                rowsum,
+                softmax_scale_log2e=scale_softmax_log2,
+                IS_BORDER=is_local,
+            )
+            acc = acc * alpha[:, None]
+            acc = tl.dot(P.to(v_ptr.dtype.element_ty), bV, acc, out_dtype=tl.float32)
+
+        invalid = (rowsum == 0) | (rowsum != rowsum)
+        inv_sum = tl.where(invalid, 1.0, 1.0 / rowsum)
+        acc = acc * inv_sum[:, None]
+        lse = tl.where(
+            invalid,
+            float("inf"),
+            rowmax * scale_softmax + tl.log(rowsum),
+        )
+        o_desc.store([m_block * BLOCK_M, 0], acc.to(o_ptr.dtype.element_ty))
+        lse_row = m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+        lse_ptr = softmax_lse_ptr + hid * total_q + lse_offset + lse_row
+        tl.store(lse_ptr, lse, mask=lse_row < q_len)
+
+
+
+__all__ = ["flash_varlen_fwd_v3_tle_short_kernel"]

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/fa_hopper_splitkv.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/fa_hopper_splitkv.py
@@ -1,0 +1,461 @@
+"""Split-KV decode FA3 TLE kernel family."""
+
+from .utils import *  # noqa: F401,F403
+def _fa3_splitkv_configs():
+    configs = []
+    for block_m in (16, 32, 64):
+        for block_n in (64, 128):
+            configs.append(
+                triton.Config(
+                    {"BLOCK_M": block_m, "BLOCK_N": block_n},
+                    num_stages=3,
+                    num_warps=4,
+                )
+            )
+    return configs
+
+
+def _prune_fa3_splitkv_configs(configs, nargs, **kwargs):
+    head_dim = kwargs.get("d", nargs.get("d"))
+    is_paged = kwargs.get("is_paged", nargs.get("is_paged"))
+    num_splits = kwargs.get("NUM_SPLITS", nargs.get("NUM_SPLITS", 1))
+
+    kept = []
+    for cfg in configs:
+        block_m = cfg.kwargs["BLOCK_M"]
+        block_n = cfg.kwargs["BLOCK_N"]
+        if block_m > 32 and num_splits > 2:
+            continue
+        if is_paged and block_n > 64:
+            continue
+        if head_dim > 128 and block_n > 64:
+            continue
+        if head_dim > 192 and block_m > 32:
+            continue
+        smem_bytes = (
+            (block_m + 2 * block_n) * _next_power_of_2_host(head_dim) * 2
+        )
+        if smem_bytes > 192 * 1024:
+            continue
+        kept.append(cfg)
+
+    if kept:
+        return kept
+    return [configs[0]]
+
+
+
+@libentry()
+@triton.autotune(
+    configs=_fa3_splitkv_configs(),
+    prune_configs_by={"early_config_prune": _prune_fa3_splitkv_configs},
+    key=[
+        "d",
+        "is_paged",
+        "is_causal",
+        "is_local",
+        "is_alibi",
+        "NUM_SPLITS",
+    ],
+)
+@triton.heuristics(
+    values={
+        "BLOCK_K": _heur_block_k,
+    }
+)
+@triton.jit(
+    do_not_specialize=[
+        "q_batch_stride",
+        "k_batch_stride",
+        "v_batch_stride",
+        "o_batch_stride",
+        "b",
+        "bk",
+        "seqlen_q",
+        "seqlen_k",
+        "seqlen_q_rounded",
+        "seqlen_k_rounded",
+        "total_q",
+    ]
+)
+def flash_varlen_fwd_v3_tle_splitkv_kernel(
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    o_ptr,
+    p_ptr,
+    softmax_lse_ptr,
+    q_row_stride,
+    k_row_stride,
+    v_row_stride,
+    q_head_stride,
+    k_head_stride,
+    v_head_stride,
+    o_row_stride,
+    o_head_stride,
+    q_batch_stride,
+    k_batch_stride,
+    v_batch_stride,
+    o_batch_stride,
+    is_cu_seqlens_q: tl.constexpr,
+    cu_seqlens_q_ptr,
+    is_cu_seqlens_k: tl.constexpr,
+    cu_seqlens_k_ptr,
+    is_seqused_k: tl.constexpr,
+    seqused_k_ptr,
+    b,
+    bk,
+    h: tl.constexpr,
+    hk: tl.constexpr,
+    h_hk_ratio: tl.constexpr,
+    seqlen_q,
+    seqlen_k,
+    seqlen_q_rounded,
+    seqlen_k_rounded,
+    d: tl.constexpr,
+    d_rounded: tl.constexpr,
+    is_softcap: tl.constexpr,
+    softcap: tl.constexpr,
+    scale_softmax: tl.constexpr,
+    scale_softmax_log2: tl.constexpr,
+    is_dropout: tl.constexpr,
+    p_dropout: tl.constexpr,
+    rp_dropout: tl.constexpr,
+    p_dropout_in_uint8_t: tl.constexpr,
+    philox_args,
+    return_softmax: tl.constexpr,
+    is_causal: tl.constexpr,
+    is_local: tl.constexpr,
+    window_size_left: tl.constexpr,
+    window_size_right: tl.constexpr,
+    seqlenq_ngroups_swapped: tl.constexpr,
+    is_paged: tl.constexpr,
+    is_alibi: tl.constexpr,
+    alibi_slopes_ptr,
+    alibi_slopes_batch_stride: tl.constexpr,
+    total_q,
+    page_table_ptr,
+    page_table_batch_stride: tl.constexpr,
+    block_size: tl.constexpr,
+    partial_out_ptr,
+    partial_m_ptr,
+    partial_l_ptr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+    PAGED_GATHER_MODE: tl.constexpr = 2,
+):
+    m_block = tl.program_id(0)
+    bid = tl.program_id(1)
+    hid_split = tl.program_id(2)
+    hid = hid_split % h
+    split_id = hid_split // h
+    HEAD_DIM_PADDED: tl.constexpr = BLOCK_K
+
+    if is_cu_seqlens_q:
+        q_eos = tl.load(cu_seqlens_q_ptr + bid + 1).to(tl.int32)
+        q_bos = tl.load(cu_seqlens_q_ptr + bid).to(tl.int32)
+        q_len = q_eos - q_bos
+        q_offset = q_bos * q_row_stride
+        lse_offset = q_bos
+    else:
+        q_len = seqlen_q
+        q_offset = bid * q_batch_stride
+        lse_offset = bid * seqlen_q
+
+    if is_cu_seqlens_k:
+        k_eos = tl.load(cu_seqlens_k_ptr + bid + 1).to(tl.int32)
+        k_bos = tl.load(cu_seqlens_k_ptr + bid).to(tl.int32)
+        k_len_cache = k_eos - k_bos
+    else:
+        k_len_cache = seqlen_k
+        k_bos = 0
+
+    if is_seqused_k:
+        k_len = tl.load(seqused_k_ptr + bid).to(tl.int32)
+    else:
+        k_len = k_len_cache
+
+    process_q = m_block * BLOCK_M < q_len
+    if process_q:
+        if is_local:
+            n_block_min = tl.maximum(
+                0,
+                (m_block * BLOCK_M + k_len - q_len - window_size_left) // BLOCK_N,
+            )
+        else:
+            n_block_min = 0
+
+        n_block_max = tl.cdiv(k_len, BLOCK_N)
+        if is_causal or is_local:
+            n_block_max = tl.minimum(
+                n_block_max,
+                tl.cdiv(
+                    (m_block + 1) * BLOCK_M
+                    + k_len
+                    - q_len
+                    + window_size_right,
+                    BLOCK_N,
+                ),
+            )
+
+        n_blocks = tl.maximum(0, n_block_max - n_block_min)
+        blocks_per_split = tl.cdiv(n_blocks, NUM_SPLITS)
+        split_block_start = n_block_min + split_id * blocks_per_split
+        split_block_end = tl.minimum(
+            n_block_max, split_block_start + blocks_per_split
+        )
+
+        if is_alibi:
+            alibi_slope = tl.load(
+                alibi_slopes_ptr + bid * alibi_slopes_batch_stride + hid
+            )
+            alibi_slope = alibi_slope / scale_softmax
+        else:
+            alibi_slope = 0.0
+
+        q_base = q_ptr + q_offset + hid * q_head_stride
+        q_desc = tl.make_tensor_descriptor(
+            base=q_base,
+            shape=[q_len, d],
+            strides=[q_row_stride, 1],
+            block_shape=[BLOCK_M, HEAD_DIM_PADDED],
+        )
+
+        kv_head = hid // h_hk_ratio
+        if is_paged:
+            page_table_ptr_b = page_table_ptr + bid * page_table_batch_stride
+            k_base = k_ptr + kv_head * k_head_stride
+            v_base = v_ptr + kv_head * v_head_stride
+        else:
+            k_base = k_ptr + k_bos * k_row_stride + kv_head * k_head_stride
+            v_base = v_ptr + k_bos * v_row_stride + kv_head * v_head_stride
+            k_desc = tl.make_tensor_descriptor(
+                base=k_base,
+                shape=[k_len_cache, d],
+                strides=[k_row_stride, 1],
+                block_shape=[BLOCK_N, HEAD_DIM_PADDED],
+            )
+            v_desc = tl.make_tensor_descriptor(
+                base=v_base,
+                shape=[k_len_cache, d],
+                strides=[v_row_stride, 1],
+                block_shape=[BLOCK_N, HEAD_DIM_PADDED],
+            )
+
+        q_tile = q_desc.load([m_block * BLOCK_M, 0])
+        row_idx_q = m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+        rowmax = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+        rowsum = tl.zeros([BLOCK_M], dtype=tl.float32)
+        acc = tl.zeros([BLOCK_M, HEAD_DIM_PADDED], dtype=tl.float32)
+
+        if split_block_start < split_block_end:
+            for n_block in tl.range(
+                split_block_end - 1,
+                split_block_start - 1,
+                step=-1,
+                num_stages=3,
+            ):
+                col_idx = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
+                if is_paged:
+                    cache_idx = _paged_blockwise_cache_indices(
+                        n_block * BLOCK_N,
+                        tl.arange(0, BLOCK_N),
+                        k_len,
+                        page_table_ptr_b,
+                        block_size,
+                        BLOCK_N,
+                        PAGED_GATHER_MODE,
+                        BOUNDARY_CHECK=True,
+                    )
+                    d_idx = tl.arange(0, HEAD_DIM_PADDED)
+                    d_mask = d_idx < d
+                    kv_mask = col_idx < k_len
+                    bK = tl.load(
+                        k_base + cache_idx[None, :] * k_row_stride + d_idx[:, None],
+                        mask=d_mask[:, None] & kv_mask[None, :],
+                        other=0.0,
+                    )
+                    bV = tl.load(
+                        v_base + cache_idx[:, None] * v_row_stride + d_idx[None, :],
+                        mask=kv_mask[:, None] & d_mask[None, :],
+                        other=0.0,
+                    )
+                else:
+                    bK = tl.trans(k_desc.load([n_block * BLOCK_N, 0]))
+                    bV = v_desc.load([n_block * BLOCK_N, 0])
+
+                S = tl.dot(q_tile, bK, out_dtype=tl.float32)
+                S = _apply_softcap_v3(S, softcap, is_softcap)
+                S = _apply_alibi_v3(
+                    S,
+                    col_idx,
+                    row_idx_q,
+                    q_len,
+                    k_len,
+                    IS_CAUSAL=is_causal,
+                    IS_ALIBI=is_alibi,
+                    alibi_slope=alibi_slope,
+                )
+                S = _apply_mask_v3(
+                    S,
+                    col_idx,
+                    row_idx_q,
+                    q_len,
+                    k_len,
+                    window_size_left,
+                    window_size_right,
+                    IS_EVEN_MN=False,
+                    IS_CAUSAL=is_causal,
+                    IS_LOCAL=is_local,
+                )
+                alpha, P, rowmax, rowsum = _softmax_online_deferred(
+                    S,
+                    rowmax,
+                    rowsum,
+                    softmax_scale_log2e=scale_softmax_log2,
+                    IS_BORDER=True,
+                )
+                acc = acc * alpha[:, None]
+                acc = tl.dot(
+                    P.to(v_ptr.dtype.element_ty), bV, acc, out_dtype=tl.float32
+                )
+
+        partial_row = lse_offset + row_idx_q
+        part_base = split_id * h * total_q * d + hid * total_q * d
+        cols = tl.arange(0, HEAD_DIM_PADDED)
+        part_ptrs = (
+            partial_out_ptr
+            + part_base
+            + partial_row[:, None] * d
+            + cols[None, :]
+        )
+        part_mask = (row_idx_q[:, None] < q_len) & (cols[None, :] < d)
+        tl.store(part_ptrs, acc, mask=part_mask)
+
+        stat_base = split_id * h * total_q + hid * total_q
+        stat_ptrs = partial_m_ptr + stat_base + partial_row
+        tl.store(stat_ptrs, rowmax, mask=row_idx_q < q_len)
+        stat_ptrs = partial_l_ptr + stat_base + partial_row
+        tl.store(stat_ptrs, rowsum, mask=row_idx_q < q_len)
+
+
+@libentry()
+@triton.jit(
+    do_not_specialize=[
+        "o_batch_stride",
+        "b",
+        "seqlen_q",
+        "total_q",
+    ]
+)
+def flash_varlen_fwd_v3_tle_splitkv_combine_kernel(
+    o_ptr,
+    softmax_lse_ptr,
+    partial_out_ptr,
+    partial_m_ptr,
+    partial_l_ptr,
+    o_row_stride,
+    o_head_stride,
+    o_batch_stride,
+    is_cu_seqlens_q: tl.constexpr,
+    cu_seqlens_q_ptr,
+    b,
+    h: tl.constexpr,
+    seqlen_q,
+    d: tl.constexpr,
+    total_q,
+    scale_softmax: tl.constexpr,
+    scale_softmax_log2: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    NUM_SPLITS: tl.constexpr,
+):
+    m_block = tl.program_id(0)
+    bid = tl.program_id(1)
+    hid = tl.program_id(2)
+    HEAD_DIM_PADDED: tl.constexpr = BLOCK_K
+
+    if is_cu_seqlens_q:
+        q_eos = tl.load(cu_seqlens_q_ptr + bid + 1).to(tl.int32)
+        q_bos = tl.load(cu_seqlens_q_ptr + bid).to(tl.int32)
+        q_len = q_eos - q_bos
+        o_offset = q_bos * o_row_stride
+        lse_offset = q_bos
+    else:
+        q_len = seqlen_q
+        o_offset = bid * o_batch_stride
+        lse_offset = bid * seqlen_q
+
+    row_idx = m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+    partial_row = lse_offset + row_idx
+    valid_row = row_idx < q_len
+    cols = tl.arange(0, HEAD_DIM_PADDED)
+
+    m_global = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+    for split_id in tl.static_range(0, NUM_SPLITS):
+        stat_base = split_id * h * total_q + hid * total_q
+        m_i = tl.load(
+            partial_m_ptr + stat_base + partial_row,
+            mask=valid_row,
+            other=float("-inf"),
+        )
+        m_global = tl.maximum(m_global, m_i)
+
+    m_safe = tl.where(m_global == float("-inf"), 0.0, m_global)
+    l_global = tl.zeros([BLOCK_M], dtype=tl.float32)
+    acc = tl.zeros([BLOCK_M, HEAD_DIM_PADDED], dtype=tl.float32)
+    for split_id in tl.static_range(0, NUM_SPLITS):
+        stat_base = split_id * h * total_q + hid * total_q
+        m_i = tl.load(
+            partial_m_ptr + stat_base + partial_row,
+            mask=valid_row,
+            other=float("-inf"),
+        )
+        l_i = tl.load(
+            partial_l_ptr + stat_base + partial_row,
+            mask=valid_row,
+            other=0.0,
+        )
+        alpha = tl.math.exp2((m_i - m_safe) * scale_softmax_log2)
+        alpha = tl.where((m_i == float("-inf")) | (l_i == 0.0), 0.0, alpha)
+        part_base = split_id * h * total_q * d + hid * total_q * d
+        part_ptrs = (
+            partial_out_ptr
+            + part_base
+            + partial_row[:, None] * d
+            + cols[None, :]
+        )
+        part = tl.load(
+            part_ptrs,
+            mask=valid_row[:, None] & (cols[None, :] < d),
+            other=0.0,
+        )
+        acc += part * alpha[:, None]
+        l_global += l_i * alpha
+
+    invalid = (l_global == 0) | (l_global != l_global)
+    inv_sum = tl.where(invalid, 1.0, 1.0 / l_global)
+    acc = acc * inv_sum[:, None]
+    lse = tl.where(
+        invalid,
+        float("inf"),
+        m_global * scale_softmax + tl.log(l_global),
+    )
+
+    o_base = o_ptr + o_offset + hid * o_head_stride
+    o_ptrs = o_base + row_idx[:, None] * o_row_stride + cols[None, :]
+    tl.store(
+        o_ptrs,
+        acc.to(o_ptr.dtype.element_ty),
+        mask=valid_row[:, None] & (cols[None, :] < d),
+    )
+    lse_ptr = softmax_lse_ptr + hid * total_q + lse_offset + row_idx
+    tl.store(lse_ptr, lse, mask=valid_row)
+
+
+__all__ = [
+    "flash_varlen_fwd_v3_tle_splitkv_kernel",
+    "flash_varlen_fwd_v3_tle_splitkv_combine_kernel",
+]

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/kernels.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/kernels.py
@@ -1,0 +1,28 @@
+"""Public compatibility surface for the active Hopper FA3 TLE kernels."""
+
+from .utils import (
+    TLE_FA3_AVAILABLE,
+    fa3_tle_paged_gather_mode,
+    fa3_tle_paged_gather_name,
+)
+from .planning import FA3MetadataDispatch, fa3_tle_metadata_dispatch
+from .fa_hopper_persistent_pingpong import flash_varlen_fwd_v3_tle_kernel
+from .fa_hopper_short import flash_varlen_fwd_v3_tle_short_kernel
+from .fa_hopper_direct import flash_varlen_fwd_v3_tle_direct_kernel
+from .fa_hopper_decode_flashdecoding import (
+    flash_varlen_fwd_v3_tle_decode_flashdecoding_combine_kernel,
+    flash_varlen_fwd_v3_tle_decode_flashdecoding_kernel,
+)
+
+__all__ = [
+    "TLE_FA3_AVAILABLE",
+    "FA3MetadataDispatch",
+    "fa3_tle_metadata_dispatch",
+    "fa3_tle_paged_gather_mode",
+    "fa3_tle_paged_gather_name",
+    "flash_varlen_fwd_v3_tle_kernel",
+    "flash_varlen_fwd_v3_tle_short_kernel",
+    "flash_varlen_fwd_v3_tle_direct_kernel",
+    "flash_varlen_fwd_v3_tle_decode_flashdecoding_kernel",
+    "flash_varlen_fwd_v3_tle_decode_flashdecoding_combine_kernel",
+]

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/planning.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/planning.py
@@ -1,0 +1,54 @@
+"""Minimal vLLM-style FA3 metadata dispatch helpers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class FA3MetadataDispatch:
+    is_paged: bool
+    has_cache_kv: bool
+    mode: str
+    split_kv: bool
+    requested_num_splits: int
+    has_scheduler_metadata: bool
+    metadata_source: str = "none"
+
+    @property
+    def layout(self) -> str:
+        return "paged" if self.is_paged else "dense"
+
+
+def fa3_tle_metadata_dispatch(
+    *,
+    max_query_len: int,
+    is_paged: bool,
+    has_cache_kv: bool,
+    num_splits: int,
+    has_scheduler_metadata: bool = False,
+    metadata_source: str = "none",
+) -> FA3MetadataDispatch:
+    requested_num_splits = max(0, int(num_splits or 0))
+    split_kv = has_cache_kv and requested_num_splits > 1
+    if not has_cache_kv:
+        mode = "prefill"
+    elif split_kv:
+        mode = "splitkv_decode"
+    elif max_query_len <= 1:
+        mode = "direct_decode"
+    else:
+        mode = "multi_token_decode"
+
+    return FA3MetadataDispatch(
+        is_paged=is_paged,
+        has_cache_kv=has_cache_kv,
+        mode=mode,
+        split_kv=split_kv,
+        requested_num_splits=requested_num_splits,
+        has_scheduler_metadata=has_scheduler_metadata,
+        metadata_source=metadata_source,
+    )
+
+
+__all__ = ["FA3MetadataDispatch", "fa3_tle_metadata_dispatch"]

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/registry.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/registry.py
@@ -1,0 +1,186 @@
+"""Registry for experimental FA3 warp-specialized variants."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Iterable
+
+
+@dataclass(frozen=True)
+class WSVariant:
+    name: str
+    force_path: str
+    kernel_module: str
+    persistent: bool
+    sync_mode: str
+    paged: bool
+    shape_kind: str
+    description: str
+
+
+_VARIANTS: dict[str, WSVariant] = {
+    "ws_simple_dense_decode": WSVariant(
+        name="ws_simple_dense_decode",
+        force_path="ws_simple",
+        kernel_module="fa_hopper_persistent_pingpong",
+        persistent=True,
+        sync_mode="pingpong",
+        paged=False,
+        shape_kind="decode",
+        description="Persistent ping-pong WS, dense decode shape.",
+    ),
+    "ws_simple_paged_decode": WSVariant(
+        name="ws_simple_paged_decode",
+        force_path="ws_simple",
+        kernel_module="fa_hopper_persistent_pingpong",
+        persistent=True,
+        sync_mode="pingpong",
+        paged=True,
+        shape_kind="paged_decode",
+        description="Persistent ping-pong WS, paged decode gather shape.",
+    ),
+    "ws_simple_small_dense": WSVariant(
+        name="ws_simple_small_dense",
+        force_path="ws_simple",
+        kernel_module="fa_hopper_persistent_pingpong",
+        persistent=True,
+        sync_mode="pingpong",
+        paged=False,
+        shape_kind="small",
+        description="Persistent ping-pong WS, small dense shape.",
+    ),
+    "ws_short_dense_decode": WSVariant(
+        name="ws_short_dense_decode",
+        force_path="ws_short",
+        kernel_module="fa_hopper_nonpersistent_tlx_style",
+        persistent=False,
+        sync_mode="sync",
+        paged=False,
+        shape_kind="decode",
+        description="Nonpersistent TLX-style WS, dense decode shape.",
+    ),
+    "ws_short_paged_decode": WSVariant(
+        name="ws_short_paged_decode",
+        force_path="ws_short",
+        kernel_module="fa_hopper_nonpersistent_tlx_style",
+        persistent=False,
+        sync_mode="sync",
+        paged=True,
+        shape_kind="paged_decode",
+        description="Nonpersistent TLX-style WS, paged decode gather shape.",
+    ),
+    "ws_short_small_dense": WSVariant(
+        name="ws_short_small_dense",
+        force_path="ws_short",
+        kernel_module="fa_hopper_nonpersistent_tlx_style",
+        persistent=False,
+        sync_mode="sync",
+        paged=False,
+        shape_kind="small",
+        description="Nonpersistent TLX-style WS, small dense shape.",
+    ),
+    "ws_sync_decode": WSVariant(
+        name="ws_sync_decode",
+        force_path="ws_sync_decode",
+        kernel_module="fa_hopper_nonpersistent_tlx_style",
+        persistent=False,
+        sync_mode="sync",
+        paged=False,
+        shape_kind="decode",
+        description="Explicit sync candidate, dense decode shape.",
+    ),
+    "ws_sync_small": WSVariant(
+        name="ws_sync_small",
+        force_path="ws_sync_small",
+        kernel_module="fa_hopper_nonpersistent_tlx_style",
+        persistent=False,
+        sync_mode="sync",
+        paged=False,
+        shape_kind="small",
+        description="Explicit sync candidate, small dense shape.",
+    ),
+    "ws_sync_paged_decode": WSVariant(
+        name="ws_sync_paged_decode",
+        force_path="ws_sync_paged_decode",
+        kernel_module="fa_hopper_nonpersistent_tlx_style",
+        persistent=False,
+        sync_mode="sync",
+        paged=True,
+        shape_kind="paged_decode",
+        description="Explicit sync candidate, paged decode gather shape.",
+    ),
+    "ws_pipe2_decode": WSVariant(
+        name="ws_pipe2_decode",
+        force_path="ws_pipe2_decode",
+        kernel_module="fa_hopper_nonpersistent_tlx_style",
+        persistent=False,
+        sync_mode="pipe2",
+        paged=False,
+        shape_kind="decode",
+        description="Two-stage pipeline candidate, dense decode shape.",
+    ),
+    "ws_pipe2_paged_decode": WSVariant(
+        name="ws_pipe2_paged_decode",
+        force_path="ws_pipe2_paged_decode",
+        kernel_module="fa_hopper_nonpersistent_tlx_style",
+        persistent=False,
+        sync_mode="pipe2",
+        paged=True,
+        shape_kind="paged_decode",
+        description="Two-stage pipeline candidate, paged decode gather shape.",
+    ),
+}
+
+_ALIASES: dict[str, tuple[str, ...]] = {
+    "all": tuple(_VARIANTS),
+    "persistent": tuple(name for name, spec in _VARIANTS.items() if spec.persistent),
+    "nonpersistent": tuple(name for name, spec in _VARIANTS.items() if not spec.persistent),
+    "paged": tuple(name for name, spec in _VARIANTS.items() if spec.paged),
+    "dense": tuple(name for name, spec in _VARIANTS.items() if not spec.paged),
+    "ws_simple": (
+        "ws_simple_dense_decode",
+        "ws_simple_paged_decode",
+        "ws_simple_small_dense",
+    ),
+    "ws_short": (
+        "ws_short_dense_decode",
+        "ws_short_paged_decode",
+        "ws_short_small_dense",
+    ),
+}
+
+
+def variant_names() -> tuple[str, ...]:
+    return tuple(_VARIANTS)
+
+
+def iter_variants() -> Iterable[WSVariant]:
+    return _VARIANTS.values()
+
+
+def get_variant(name: str) -> WSVariant:
+    try:
+        return _VARIANTS[name]
+    except KeyError as exc:
+        allowed = ", ".join(sorted((*_VARIANTS, *_ALIASES)))
+        raise KeyError(f"unknown FA3 WS variant {name!r}; expected one of {allowed}") from exc
+
+
+def resolve_variant_names(selection: str | Iterable[str]) -> tuple[str, ...]:
+    if isinstance(selection, str):
+        selections = [selection]
+    else:
+        selections = list(selection)
+
+    resolved: list[str] = []
+    for item in selections:
+        key = item.strip()
+        if not key:
+            continue
+        names = _ALIASES.get(key, (key,))
+        for name in names:
+            if name not in _VARIANTS:
+                get_variant(name)
+            if name not in resolved:
+                resolved.append(name)
+    return tuple(resolved)

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/utils.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/fa3_ws/utils.py
@@ -1,0 +1,852 @@
+"""Shared code for experimental Hopper FA3 WS kernels.
+
+This file is mechanically split from ``flash_kernel_v3.py`` so the experimental
+WS variants can live as standalone kernel modules while preserving the proven
+TLE helper implementations.
+"""
+
+import os
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import libentry, tl_extra_shim
+
+try:
+    import triton.experimental.tle.language as tle
+
+    TLE_FA3_AVAILABLE = True
+except Exception:
+    tle = None
+    TLE_FA3_AVAILABLE = False
+_FA3_TLE_FAMILY_LONG = 0
+_FA3_TLE_FAMILY_SHORT = 1
+_FA3_TLE_FAMILY_SPLITKV = 2
+_FA3_TLE_FAMILY_MIXED = 3
+_FA3_TLE_FAMILY_DECODE = 4
+_FA3_TLE_FAMILY_PAGED_DECODE = 5
+_FA3_TLE_FAMILY_SERVE = 6
+_FA3_TLE_FAMILY_PAGED_SERVE = 7
+_FA3_TLE_FAMILY_DIRECT = 8
+_FA3_TLE_FAMILY_WS_SIMPLE = 9
+_FA3_TLE_FAMILY_WS_SHORT = 10
+_FA3_TLE_FAMILY_WS_SYNC_DECODE = 11
+_FA3_TLE_FAMILY_WS_PIPE2_DECODE = 12
+_FA3_TLE_FAMILY_WS_SYNC_SMALL = 13
+_FA3_TLE_FAMILY_WS_SYNC_PAGED_DECODE = 14
+_FA3_TLE_FAMILY_WS_PIPE2_PAGED_DECODE = 15
+_FA3_TLE_FAMILY_AUTO = -1
+
+_FA3_TLE_PAGED_GATHER_LEGACY = 0
+_FA3_TLE_PAGED_GATHER_BLOCKWISE = 1
+_FA3_TLE_PAGED_GATHER_AUTO = 2
+_FA3_TLE_PAGED_GATHER_NAMES = {
+    _FA3_TLE_PAGED_GATHER_LEGACY: "legacy",
+    _FA3_TLE_PAGED_GATHER_BLOCKWISE: "blockwise",
+    _FA3_TLE_PAGED_GATHER_AUTO: "auto",
+}
+
+
+def fa3_tle_paged_gather_mode() -> int:
+    value = os.getenv("FLAG_GEMS_FA3_TLE_PAGED_GATHER", "auto").strip().lower()
+    allowed = {
+        "legacy": _FA3_TLE_PAGED_GATHER_LEGACY,
+        "blockwise": _FA3_TLE_PAGED_GATHER_BLOCKWISE,
+        "auto": _FA3_TLE_PAGED_GATHER_AUTO,
+    }
+    if value not in allowed:
+        raise RuntimeError(
+            "invalid FLAG_GEMS_FA3_TLE_PAGED_GATHER="
+            f"{value!r}; expected one of {', '.join(sorted(allowed))}"
+        )
+    return allowed[value]
+
+
+def fa3_tle_paged_gather_name(mode: int) -> str:
+    return _FA3_TLE_PAGED_GATHER_NAMES.get(mode, f"unknown({mode})")
+
+_FA3_TLE_BUCKET_LONG = 0
+_FA3_TLE_BUCKET_SHORT = 1
+_FA3_TLE_BUCKET_SPLITKV = 2
+_FA3_TLE_BUCKET_MIXED_LONG = 3
+_FA3_TLE_BUCKET_MIXED_SHORT = 4
+_FA3_TLE_BUCKET_DECODE = 5
+_FA3_TLE_BUCKET_PAGED_DECODE = 6
+_FA3_TLE_BUCKET_SERVE_SHORT = 7
+_FA3_TLE_BUCKET_PAGED_SERVE_SHORT = 8
+_FA3_TLE_BUCKET_PAGED_SMALL = 9
+_FA3_TLE_BUCKET_PAGED_MEDIUM = 10
+_FA3_TLE_BUCKET_DIRECT_DECODE = 11
+_FA3_TLE_BUCKET_DIRECT_PAGED_DECODE = 12
+_FA3_TLE_BUCKET_DIRECT_SMALL = 13
+_FA3_TLE_BUCKET_WS_SMALL_DENSE = 14
+_FA3_TLE_BUCKET_WS_DECODE = 15
+_FA3_TLE_BUCKET_WS_PAGED_DECODE = 16
+_FA3_TLE_BUCKET_WS_SHORT_SMALL_DENSE = 17
+_FA3_TLE_BUCKET_WS_SHORT_DECODE = 18
+_FA3_TLE_BUCKET_WS_SHORT_PAGED_DECODE = 19
+_FA3_TLE_BUCKET_WS_SYNC_DECODE = 20
+_FA3_TLE_BUCKET_WS_PIPE2_DECODE = 21
+_FA3_TLE_BUCKET_WS_SYNC_SMALL = 22
+_FA3_TLE_BUCKET_WS_SYNC_PAGED_DECODE = 23
+_FA3_TLE_BUCKET_WS_PIPE2_PAGED_DECODE = 24
+
+_FA3_TLE_FORCE_PATHS = {
+    "auto": _FA3_TLE_FAMILY_AUTO,
+    "long": _FA3_TLE_FAMILY_LONG,
+    "short": _FA3_TLE_FAMILY_SHORT,
+    "splitkv": _FA3_TLE_FAMILY_SPLITKV,
+    "mixed": _FA3_TLE_FAMILY_MIXED,
+    "decode": _FA3_TLE_FAMILY_DECODE,
+    "paged_decode": _FA3_TLE_FAMILY_PAGED_DECODE,
+    "serve": _FA3_TLE_FAMILY_SERVE,
+    "paged_serve": _FA3_TLE_FAMILY_PAGED_SERVE,
+    "direct": _FA3_TLE_FAMILY_DIRECT,
+    "ws_simple": _FA3_TLE_FAMILY_WS_SIMPLE,
+    "ws_short": _FA3_TLE_FAMILY_WS_SHORT,
+    "ws_sync_decode": _FA3_TLE_FAMILY_WS_SYNC_DECODE,
+    "ws_pipe2_decode": _FA3_TLE_FAMILY_WS_PIPE2_DECODE,
+    "ws_sync_small": _FA3_TLE_FAMILY_WS_SYNC_SMALL,
+    "ws_sync_paged_decode": _FA3_TLE_FAMILY_WS_SYNC_PAGED_DECODE,
+    "ws_pipe2_paged_decode": _FA3_TLE_FAMILY_WS_PIPE2_PAGED_DECODE,
+}
+
+_FA3_TLE_WS_CANDIDATE_NAMES = {
+    _FA3_TLE_FAMILY_WS_SYNC_DECODE: "ws_sync_decode",
+    _FA3_TLE_FAMILY_WS_PIPE2_DECODE: "ws_pipe2_decode",
+    _FA3_TLE_FAMILY_WS_SYNC_SMALL: "ws_sync_small",
+    _FA3_TLE_FAMILY_WS_SYNC_PAGED_DECODE: "ws_sync_paged_decode",
+    _FA3_TLE_FAMILY_WS_PIPE2_PAGED_DECODE: "ws_pipe2_paged_decode",
+}
+
+_FA3_TLE_WS_CANDIDATE_BUCKETS = {
+    _FA3_TLE_FAMILY_WS_SYNC_DECODE: _FA3_TLE_BUCKET_WS_SYNC_DECODE,
+    _FA3_TLE_FAMILY_WS_PIPE2_DECODE: _FA3_TLE_BUCKET_WS_PIPE2_DECODE,
+    _FA3_TLE_FAMILY_WS_SYNC_SMALL: _FA3_TLE_BUCKET_WS_SYNC_SMALL,
+    _FA3_TLE_FAMILY_WS_SYNC_PAGED_DECODE: _FA3_TLE_BUCKET_WS_SYNC_PAGED_DECODE,
+    _FA3_TLE_FAMILY_WS_PIPE2_PAGED_DECODE: _FA3_TLE_BUCKET_WS_PIPE2_PAGED_DECODE,
+}
+
+_FA3_TLE_WS_PIPE2_BUCKETS = (
+    _FA3_TLE_BUCKET_WS_PIPE2_DECODE,
+    _FA3_TLE_BUCKET_WS_PIPE2_PAGED_DECODE,
+)
+
+_FA3_TLE_WS_PAGED_DECODE_BUCKETS = (
+    _FA3_TLE_BUCKET_WS_SHORT_PAGED_DECODE,
+    _FA3_TLE_BUCKET_WS_SYNC_PAGED_DECODE,
+    _FA3_TLE_BUCKET_WS_PIPE2_PAGED_DECODE,
+)
+
+_FA3_TLE_WS_SYNC_BUCKETS = (
+    _FA3_TLE_BUCKET_WS_SHORT_SMALL_DENSE,
+    _FA3_TLE_BUCKET_WS_SHORT_DECODE,
+    _FA3_TLE_BUCKET_WS_SHORT_PAGED_DECODE,
+    _FA3_TLE_BUCKET_WS_SYNC_DECODE,
+    _FA3_TLE_BUCKET_WS_SYNC_SMALL,
+    _FA3_TLE_BUCKET_WS_SYNC_PAGED_DECODE,
+)
+
+
+def _next_power_of_2_host(value: int) -> int:
+    return 1 << (value - 1).bit_length()
+
+
+def _fa3_tle_config(
+    *,
+    family_id,
+    block_m,
+    block_n,
+    num_buffers_kv,
+    num_mma_groups,
+    num_mma_warps,
+    use_tma_qo,
+    use_tma_kv,
+):
+    return triton.Config(
+        {
+            "FAMILY_ID": family_id,
+            "BLOCK_M": block_m,
+            "BLOCK_N": block_n,
+            "NUM_BUFFERS_Q": 1,
+            "NUM_BUFFERS_KV": num_buffers_kv,
+            "NUM_MMA_WARPS": num_mma_warps,
+            "NUM_MMA_GROUPS": num_mma_groups,
+            "Q_STAGE_CAPACITY": _next_power_of_2_host(num_mma_groups),
+            "KV_STAGE_CAPACITY": _next_power_of_2_host(num_buffers_kv),
+            "USE_TMA_QO": use_tma_qo,
+            "USE_TMA_KV": use_tma_kv,
+        },
+        num_warps=4,
+    )
+
+
+def _fa3_tle_configs():
+    return [
+        _fa3_tle_config(
+            family_id=_FA3_TLE_FAMILY_LONG,
+            block_m=128,
+            block_n=128,
+            num_buffers_kv=2,
+            num_mma_groups=2,
+            num_mma_warps=8,
+            use_tma_qo=True,
+            use_tma_kv=True,
+        ),
+        _fa3_tle_config(
+            family_id=_FA3_TLE_FAMILY_LONG,
+            block_m=128,
+            block_n=64,
+            num_buffers_kv=1,
+            num_mma_groups=2,
+            num_mma_warps=8,
+            use_tma_qo=True,
+            use_tma_kv=True,
+        ),
+        _fa3_tle_config(
+            family_id=_FA3_TLE_FAMILY_WS_SIMPLE,
+            block_m=64,
+            block_n=64,
+            num_buffers_kv=1,
+            num_mma_groups=1,
+            num_mma_warps=4,
+            use_tma_qo=False,
+            use_tma_kv=False,
+        ),
+        _fa3_tle_config(
+            family_id=_FA3_TLE_FAMILY_WS_SIMPLE,
+            block_m=64,
+            block_n=128,
+            num_buffers_kv=1,
+            num_mma_groups=1,
+            num_mma_warps=4,
+            use_tma_qo=False,
+            use_tma_kv=False,
+        ),
+        _fa3_tle_config(
+            family_id=_FA3_TLE_FAMILY_WS_SIMPLE,
+            block_m=128,
+            block_n=64,
+            num_buffers_kv=1,
+            num_mma_groups=1,
+            num_mma_warps=4,
+            use_tma_qo=False,
+            use_tma_kv=False,
+        ),
+        _fa3_tle_config(
+            family_id=_FA3_TLE_FAMILY_WS_SIMPLE,
+            block_m=128,
+            block_n=128,
+            num_buffers_kv=1,
+            num_mma_groups=1,
+            num_mma_warps=4,
+            use_tma_qo=False,
+            use_tma_kv=False,
+        ),
+    ]
+
+
+def _fa3_tle_config_smem_bytes(cfg, head_dim: int) -> int:
+    block_k = _next_power_of_2_host(head_dim)
+    block_m = cfg.kwargs["BLOCK_M"]
+    block_n = cfg.kwargs["BLOCK_N"]
+    num_groups = cfg.kwargs["NUM_MMA_GROUPS"]
+    bm_split = block_m // num_groups
+    q_stage = cfg.kwargs["Q_STAGE_CAPACITY"]
+    kv_stage = cfg.kwargs["KV_STAGE_CAPACITY"]
+    elems = q_stage * bm_split * block_k
+    elems += 2 * kv_stage * block_n * block_k
+    return elems * 2
+
+
+def _prune_fa3_tle_configs(configs, nargs, **kwargs):
+    head_dim = kwargs.get("d", nargs.get("d"))
+    is_paged = kwargs.get("is_paged", nargs.get("is_paged"))
+    shape_bucket = kwargs.get(
+        "SHAPE_BUCKET", nargs.get("SHAPE_BUCKET", _FA3_TLE_BUCKET_LONG)
+    )
+    force_family_id = kwargs.get(
+        "FORCE_FAMILY_ID", nargs.get("FORCE_FAMILY_ID", _FA3_TLE_FAMILY_AUTO)
+    )
+
+    kept = []
+    for cfg in configs:
+        family_id = cfg.kwargs["FAMILY_ID"]
+        block_n = cfg.kwargs["BLOCK_N"]
+        block_m = cfg.kwargs["BLOCK_M"]
+        num_groups = cfg.kwargs["NUM_MMA_GROUPS"]
+
+        if force_family_id in (
+            _FA3_TLE_FAMILY_LONG,
+            _FA3_TLE_FAMILY_SHORT,
+            _FA3_TLE_FAMILY_SPLITKV,
+            _FA3_TLE_FAMILY_WS_SIMPLE,
+        ) and family_id != force_family_id:
+            continue
+        if force_family_id == _FA3_TLE_FAMILY_MIXED:
+            if shape_bucket == _FA3_TLE_BUCKET_MIXED_LONG:
+                if family_id != _FA3_TLE_FAMILY_LONG:
+                    continue
+            elif family_id not in (
+                _FA3_TLE_FAMILY_SHORT,
+                _FA3_TLE_FAMILY_SPLITKV,
+            ):
+                continue
+
+        if force_family_id == _FA3_TLE_FAMILY_AUTO:
+            if shape_bucket in (_FA3_TLE_BUCKET_LONG, _FA3_TLE_BUCKET_MIXED_LONG):
+                if family_id != _FA3_TLE_FAMILY_LONG:
+                    continue
+            elif shape_bucket == _FA3_TLE_BUCKET_SHORT:
+                if family_id != _FA3_TLE_FAMILY_SHORT:
+                    continue
+            elif shape_bucket in (
+                _FA3_TLE_BUCKET_WS_SMALL_DENSE,
+                _FA3_TLE_BUCKET_WS_DECODE,
+                _FA3_TLE_BUCKET_WS_PAGED_DECODE,
+            ):
+                if family_id != _FA3_TLE_FAMILY_WS_SIMPLE:
+                    continue
+            else:
+                if family_id not in (
+                    _FA3_TLE_FAMILY_SHORT,
+                    _FA3_TLE_FAMILY_SPLITKV,
+                ):
+                    continue
+
+        if family_id == _FA3_TLE_FAMILY_WS_SIMPLE:
+            if shape_bucket == _FA3_TLE_BUCKET_WS_DECODE and block_m != 64:
+                continue
+            if (
+                shape_bucket == _FA3_TLE_BUCKET_WS_PAGED_DECODE
+                and (block_m != 64 or block_n != 64)
+            ):
+                continue
+            if shape_bucket == _FA3_TLE_BUCKET_WS_SMALL_DENSE and block_m < 64:
+                continue
+            if head_dim >= 192 and block_n > 64:
+                continue
+            if is_paged and block_n > 64:
+                continue
+
+        if head_dim > 128 and block_n > 64:
+            continue
+        if (
+            head_dim >= 128
+            and family_id not in (_FA3_TLE_FAMILY_LONG, _FA3_TLE_FAMILY_WS_SIMPLE)
+            and block_m > 64
+        ):
+            continue
+        if head_dim > 128 and cfg.kwargs["NUM_BUFFERS_KV"] > 1 and block_n >= 64:
+            continue
+        if head_dim > 192 and block_n > 64:
+            continue
+        if block_m % num_groups != 0:
+            continue
+        if is_paged and block_n > 128:
+            continue
+        if _fa3_tle_config_smem_bytes(cfg, head_dim) > 220 * 1024:
+            continue
+        kept.append(cfg)
+
+    if kept:
+        return kept
+    return [configs[0]]
+
+
+def _fa3_ws_short_configs():
+    return [
+        _fa3_tle_config(
+            family_id=_FA3_TLE_FAMILY_WS_SHORT,
+            block_m=64,
+            block_n=64,
+            num_buffers_kv=1,
+            num_mma_groups=1,
+            num_mma_warps=4,
+            use_tma_qo=True,
+            use_tma_kv=True,
+        ),
+        _fa3_tle_config(
+            family_id=_FA3_TLE_FAMILY_WS_SHORT,
+            block_m=64,
+            block_n=128,
+            num_buffers_kv=1,
+            num_mma_groups=1,
+            num_mma_warps=4,
+            use_tma_qo=True,
+            use_tma_kv=True,
+        ),
+        _fa3_tle_config(
+            family_id=_FA3_TLE_FAMILY_WS_SHORT,
+            block_m=64,
+            block_n=64,
+            num_buffers_kv=2,
+            num_mma_groups=1,
+            num_mma_warps=4,
+            use_tma_qo=True,
+            use_tma_kv=True,
+        ),
+        _fa3_tle_config(
+            family_id=_FA3_TLE_FAMILY_WS_SHORT,
+            block_m=64,
+            block_n=128,
+            num_buffers_kv=2,
+            num_mma_groups=1,
+            num_mma_warps=4,
+            use_tma_qo=True,
+            use_tma_kv=True,
+        ),
+    ]
+
+
+def _prune_fa3_ws_short_configs(configs, nargs, **kwargs):
+    head_dim = kwargs.get("d", nargs.get("d"))
+    is_paged = kwargs.get("is_paged", nargs.get("is_paged"))
+    shape_bucket = kwargs.get(
+        "WS_SHORT_SHAPE_BUCKET",
+        nargs.get("WS_SHORT_SHAPE_BUCKET", _FA3_TLE_BUCKET_WS_SHORT_SMALL_DENSE),
+    )
+
+    kept = []
+    for cfg in configs:
+        block_n = cfg.kwargs["BLOCK_N"]
+        num_buffers_kv = cfg.kwargs["NUM_BUFFERS_KV"]
+
+        if shape_bucket in _FA3_TLE_WS_PIPE2_BUCKETS:
+            if num_buffers_kv != 2:
+                continue
+        elif shape_bucket in _FA3_TLE_WS_SYNC_BUCKETS:
+            if num_buffers_kv != 1:
+                continue
+
+        if shape_bucket in _FA3_TLE_WS_PAGED_DECODE_BUCKETS and block_n != 64:
+            continue
+        if head_dim >= 192 and block_n != 64:
+            continue
+        if is_paged and head_dim > 128 and block_n != 64:
+            continue
+        if _fa3_tle_config_smem_bytes(cfg, head_dim) > 220 * 1024:
+            continue
+        kept.append(cfg)
+
+    if kept:
+        return kept
+
+    want_pipe2 = shape_bucket in _FA3_TLE_WS_PIPE2_BUCKETS
+    for cfg in configs:
+        if (cfg.kwargs["NUM_BUFFERS_KV"] == 2) == want_pipe2:
+            return [cfg]
+    return [configs[0]]
+
+
+@triton.jit
+def _apply_softcap_v3(S, softcap, IS_SOFTCAP: tl.constexpr):
+    if IS_SOFTCAP:
+        S = tl_extra_shim.tanh(S * softcap)
+    return S
+
+
+@triton.jit
+def _apply_alibi_v3(
+    S,
+    col_idx,
+    row_idx,
+    max_seqlen_q,
+    max_seqlen_k,
+    IS_CAUSAL: tl.constexpr,
+    IS_ALIBI: tl.constexpr,
+    alibi_slope,
+):
+    if IS_ALIBI:
+        if IS_CAUSAL:
+            bias = alibi_slope * (-max_seqlen_k + 1 + col_idx[None, :]).to(tl.float32)
+            S += bias
+        else:
+            bias = -alibi_slope * tl.abs(
+                col_idx[None, :] - max_seqlen_k + max_seqlen_q - row_idx[:, None]
+            ).to(tl.float32)
+            S += bias
+    return S
+
+
+@triton.jit
+def _apply_mask_v3(
+    S,
+    col_idx,
+    row_idx,
+    max_seqlen_q,
+    max_seqlen_k,
+    window_size_left,
+    window_size_right,
+    IS_EVEN_MN: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+    IS_LOCAL: tl.constexpr,
+):
+    if IS_CAUSAL or IS_LOCAL or (not IS_EVEN_MN):
+        col_lb = tl.maximum(0, row_idx + max_seqlen_k - max_seqlen_q - window_size_left)
+        col_rb = tl.minimum(
+            max_seqlen_k - 1,
+            row_idx + max_seqlen_k - max_seqlen_q + window_size_right,
+        )
+        if IS_CAUSAL:
+            S = tl.where(col_idx[None, :] > col_rb[:, None], float("-inf"), S)
+        if IS_LOCAL:
+            S = tl.where(
+                (col_idx[None, :] > col_rb[:, None])
+                | (col_idx[None, :] < col_lb[:, None]),
+                float("-inf"),
+                S,
+            )
+        if (not IS_LOCAL) and (not IS_CAUSAL) and (not IS_EVEN_MN):
+            S = tl.where(col_idx[None, :] >= max_seqlen_k, float("-inf"), S)
+    return S
+
+
+@triton.jit
+def _softmax_online_deferred(
+    S,
+    m_prev,
+    l_prev,
+    softmax_scale_log2e: tl.constexpr,
+    IS_BORDER: tl.constexpr,
+):
+    m_new = tl.maximum(m_prev, tl.max(S, 1))
+    if IS_BORDER:
+        m_safe = tl.where(m_new == float("-inf"), 0.0, m_new)
+    else:
+        m_safe = m_new
+
+    alpha = tl.math.exp2((m_prev - m_safe) * softmax_scale_log2e)
+    m_scaled = tl.where(m_new == float("-inf"), 0.0, m_safe * softmax_scale_log2e)
+    P = tl.math.exp2(S * softmax_scale_log2e - m_scaled[:, None])
+    l_new = l_prev * alpha + tl.sum(P, 1)
+    return alpha, P, m_new, l_new
+
+
+@triton.jit
+def _virtual_to_cache(
+    virtual_index,
+    max_virtual_index,
+    page_table_ptr,
+    block_size,
+    BOUNDARY_CHECK: tl.constexpr = False,
+):
+    virtual_page_index = virtual_index // block_size
+    page_offset = virtual_index % block_size
+    if BOUNDARY_CHECK:
+        page_block_index = tl.load(
+            page_table_ptr + virtual_page_index,
+            mask=virtual_index < max_virtual_index,
+            other=0,
+        ).to(tl.int32)
+    else:
+        page_block_index = tl.load(page_table_ptr + virtual_page_index).to(tl.int32)
+    return page_block_index * block_size + page_offset
+
+
+@triton.jit
+def _paged_blockwise_cache_indices(
+    n_start,
+    offsets,
+    max_virtual_index,
+    page_table_ptr,
+    block_size: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    PAGED_GATHER_MODE: tl.constexpr,
+    BOUNDARY_CHECK: tl.constexpr = True,
+):
+    logical_idx = n_start + offsets
+    if PAGED_GATHER_MODE == 0 or (block_size != 16 and block_size != 32):
+        return _virtual_to_cache(
+            logical_idx,
+            max_virtual_index,
+            page_table_ptr,
+            block_size,
+            BOUNDARY_CHECK=BOUNDARY_CHECK,
+        )
+
+    cache_idx = logical_idx.to(tl.int32)
+    if block_size == 16:
+        for page_base in tl.static_range(0, BLOCK_N, 16):
+            first_idx = n_start + page_base
+            page_idx = first_idx // 16
+            if BOUNDARY_CHECK:
+                page_block = tl.load(
+                    page_table_ptr + page_idx,
+                    mask=first_idx < max_virtual_index,
+                    other=0,
+                ).to(tl.int32)
+            else:
+                page_block = tl.load(page_table_ptr + page_idx).to(tl.int32)
+            in_page = (offsets >= page_base) & (offsets < page_base + 16)
+            candidate = page_block * 16 + (logical_idx % 16)
+            cache_idx = tl.where(in_page, candidate, cache_idx)
+    else:
+        for page_base in tl.static_range(0, BLOCK_N, 32):
+            first_idx = n_start + page_base
+            page_idx = first_idx // 32
+            if BOUNDARY_CHECK:
+                page_block = tl.load(
+                    page_table_ptr + page_idx,
+                    mask=first_idx < max_virtual_index,
+                    other=0,
+                ).to(tl.int32)
+            else:
+                page_block = tl.load(page_table_ptr + page_idx).to(tl.int32)
+            in_page = (offsets >= page_base) & (offsets < page_base + 32)
+            candidate = page_block * 32 + (logical_idx % 32)
+            cache_idx = tl.where(in_page, candidate, cache_idx)
+    return cache_idx
+
+
+@triton.jit
+def _decode_apply_alibi(
+    scores,
+    col_idx,
+    row_idx,
+    q_len,
+    k_len,
+    IS_CAUSAL: tl.constexpr,
+    IS_ALIBI: tl.constexpr,
+    alibi_slope,
+):
+    if IS_ALIBI:
+        if IS_CAUSAL:
+            scores += alibi_slope * (-k_len + 1 + col_idx).to(tl.float32)
+        else:
+            scores += -alibi_slope * tl.abs(col_idx - k_len + q_len - row_idx).to(
+                tl.float32
+            )
+    return scores
+
+
+@triton.jit
+def _decode_apply_mask(
+    scores,
+    col_idx,
+    row_idx,
+    q_len,
+    k_len,
+    window_size_left,
+    window_size_right,
+    IS_BORDER: tl.constexpr,
+    IS_CAUSAL: tl.constexpr,
+    IS_LOCAL: tl.constexpr,
+):
+    if IS_BORDER:
+        scores = tl.where(col_idx < k_len, scores, float("-inf"))
+    if IS_CAUSAL or IS_LOCAL:
+        col_lb = tl.maximum(0, row_idx + k_len - q_len - window_size_left)
+        col_rb = tl.minimum(k_len - 1, row_idx + k_len - q_len + window_size_right)
+        if IS_CAUSAL:
+            scores = tl.where(col_idx <= col_rb, scores, float("-inf"))
+        if IS_LOCAL:
+            scores = tl.where(
+                (col_idx >= col_lb) & (col_idx <= col_rb),
+                scores,
+                float("-inf"),
+            )
+    return scores
+
+
+def _heur_block_k(args):
+    return triton.next_power_of_2(args["d"])
+
+
+@triton.jit
+def _buf_phase_tle(count, num_buffers: tl.constexpr):
+    buf = count % num_buffers
+    phase_idx = count // num_buffers
+    return buf, phase_idx
+
+
+@triton.jit
+def _persistent_tile_coords(tile_idx, num_pid_m, batch_size):
+    m_block = tile_idx % num_pid_m
+    hb = tile_idx // num_pid_m
+    bid = hb % batch_size
+    hid = hb // batch_size
+    return m_block, bid, hid
+
+
+@triton.jit
+def _fence_async_shared_cta():
+    tl.inline_asm_elementwise(
+        "mov.u32 $0, 0x0; membar.cta; fence.proxy.async.shared::cta;",
+        constraints="=r",
+        args=(),
+        dtype=(tl.int32,),
+        is_pure=False,
+        pack=1,
+    )
+
+
+@triton.jit
+def _copy_paged_kv_tile_to_smem(
+    src_base,
+    row_stride,
+    page_table_ptr_b,
+    smem_tile,
+    n_offset,
+    k_len,
+    d: tl.constexpr,
+    block_size: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM_PADDED: tl.constexpr,
+    PAGED_GATHER_MODE: tl.constexpr = 2,
+):
+    for row_base in tl.static_range(0, BLOCK_N, 32):
+        row_offsets = tl.arange(0, 32)
+        rows = row_base + row_offsets
+        logical_idx = n_offset + rows
+        row_valid = logical_idx < k_len
+        cache_idx = _paged_blockwise_cache_indices(
+            n_offset + row_base,
+            row_offsets,
+            k_len,
+            page_table_ptr_b,
+            block_size,
+            32,
+            PAGED_GATHER_MODE,
+            BOUNDARY_CHECK=True,
+        )
+
+        for col_base in tl.static_range(0, HEAD_DIM_PADDED, 32):
+            cols = col_base + tl.arange(0, 32)
+            src_ptrs = src_base + cache_idx[:, None] * row_stride + cols[None, :]
+            load_mask = row_valid[:, None] & (cols[None, :] < d)
+            # Keep paged gather loads on Triton's default cache policy. On this
+            # TLE producer path, evict_last can lower to an illegal instruction.
+            vals = tl.load(
+                src_ptrs,
+                mask=load_mask,
+                other=0.0,
+            )
+            smem_rows = tl.broadcast_to(rows[:, None], (32, 32))
+            smem_cols = tl.broadcast_to(cols[None, :], (32, 32))
+            smem_ptrs = tle.gpu.local_ptr(smem_tile, (smem_rows, smem_cols))
+            tl.store(smem_ptrs, vals)
+
+
+# Debug-only variant. Do not use it in default WS paged paths: the extra
+# arithmetic on loaded values has triggered runtime hangs in nonpersistent WS.
+@triton.jit
+def _copy_paged_kv_tile_to_smem_sync_safe(
+    src_base,
+    row_stride,
+    page_table_ptr_b,
+    smem_tile,
+    n_offset,
+    k_len,
+    d: tl.constexpr,
+    block_size: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    HEAD_DIM_PADDED: tl.constexpr,
+    PAGED_GATHER_MODE: tl.constexpr = 2,
+):
+    for row_base in tl.static_range(0, BLOCK_N, 32):
+        row_offsets = tl.arange(0, 32)
+        rows = row_base + row_offsets
+        logical_idx = n_offset + rows
+        row_valid = logical_idx < k_len
+        cache_idx = _paged_blockwise_cache_indices(
+            n_offset + row_base,
+            row_offsets,
+            k_len,
+            page_table_ptr_b,
+            block_size,
+            32,
+            PAGED_GATHER_MODE,
+            BOUNDARY_CHECK=True,
+        )
+
+        for col_base in tl.static_range(0, HEAD_DIM_PADDED, 32):
+            cols = col_base + tl.arange(0, 32)
+            src_ptrs = src_base + cache_idx[:, None] * row_stride + cols[None, :]
+            load_mask = row_valid[:, None] & (cols[None, :] < d)
+            vals = tl.load(src_ptrs, mask=load_mask, other=0.0)
+            vals = vals + 0.0
+            smem_rows = tl.broadcast_to(rows[:, None], (32, 32))
+            smem_cols = tl.broadcast_to(cols[None, :], (32, 32))
+            smem_ptrs = tle.gpu.local_ptr(smem_tile, (smem_rows, smem_cols))
+            tl.store(smem_ptrs, vals)
+
+
+@triton.jit
+def _copy_dense_tile_to_smem(
+    src_base,
+    row_stride,
+    smem_tile,
+    row_offset,
+    row_count,
+    d: tl.constexpr,
+    BLOCK_ROWS: tl.constexpr,
+    HEAD_DIM_PADDED: tl.constexpr,
+):
+    for row_base in tl.static_range(0, BLOCK_ROWS, 32):
+        rows = row_base + tl.arange(0, 32)
+        logical_rows = row_offset + rows
+        row_valid = logical_rows < row_count
+        for col_base in tl.static_range(0, HEAD_DIM_PADDED, 32):
+            cols = col_base + tl.arange(0, 32)
+            vals = tl.load(
+                src_base + logical_rows[:, None] * row_stride + cols[None, :],
+                mask=row_valid[:, None] & (cols[None, :] < d),
+                other=0.0,
+            )
+            smem_rows = tl.broadcast_to(rows[:, None], (32, 32))
+            smem_cols = tl.broadcast_to(cols[None, :], (32, 32))
+            smem_ptrs = tle.gpu.local_ptr(smem_tile, (smem_rows, smem_cols))
+            tl.store(smem_ptrs, vals)
+
+
+@triton.jit
+def _copy_dense_tile_to_smem_sync_safe(
+    src_base,
+    row_stride,
+    smem_tile,
+    row_offset,
+    row_count,
+    d: tl.constexpr,
+    BLOCK_ROWS: tl.constexpr,
+    HEAD_DIM_PADDED: tl.constexpr,
+):
+    for row_base in tl.static_range(0, BLOCK_ROWS, 32):
+        rows = row_base + tl.arange(0, 32)
+        logical_rows = row_offset + rows
+        row_valid = logical_rows < row_count
+        for col_base in tl.static_range(0, HEAD_DIM_PADDED, 32):
+            cols = col_base + tl.arange(0, 32)
+            vals = tl.load(
+                src_base + logical_rows[:, None] * row_stride + cols[None, :],
+                mask=row_valid[:, None] & (cols[None, :] < d),
+                other=0.0,
+            )
+            vals = vals + 0.0
+            smem_rows = tl.broadcast_to(rows[:, None], (32, 32))
+            smem_cols = tl.broadcast_to(cols[None, :], (32, 32))
+            smem_ptrs = tle.gpu.local_ptr(smem_tile, (smem_rows, smem_cols))
+            tl.store(smem_ptrs, vals)
+
+
+@triton.jit
+def _store_dense_tile_from_regs(
+    dst_base,
+    row_stride,
+    vals,
+    row_offset,
+    row_count,
+    d: tl.constexpr,
+    BLOCK_ROWS: tl.constexpr,
+    HEAD_DIM_PADDED: tl.constexpr,
+):
+    rows = row_offset + tl.arange(0, BLOCK_ROWS)
+    cols = tl.arange(0, HEAD_DIM_PADDED)
+    ptrs = dst_base + rows[:, None] * row_stride + cols[None, :]
+    mask = (rows[:, None] < row_count) & (cols[None, :] < d)
+    tl.store(ptrs, vals, mask=mask)
+
+
+
+
+__all__ = [name for name in globals() if not name.startswith("__")]

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/flash_api_v3.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/flash_api_v3.py
@@ -1,0 +1,682 @@
+"""
+Host-side launcher for the TLE-only Hopper FA3 varlen forward kernel.
+
+The public signature and return tuple intentionally match
+``flag_gems.ops.flash_api.mha_varlan_fwd`` so the Hopper attention override can
+dispatch to this file for ``fa_version=3``.  Unsupported FA3 inputs fail fast
+with a clear RuntimeError; the older non-TLE FA3 kernel is intentionally absent.
+"""
+
+import logging
+import os
+
+import torch
+import triton
+
+import flag_gems
+from flag_gems.ops.flash_api import fwd_params
+from flag_gems.runtime import torch_device_fn
+
+from .flash_kernel_v3 import (
+    TLE_FA3_AVAILABLE,
+    fa3_tle_paged_gather_mode,
+    fa3_tle_paged_gather_name,
+    flash_varlen_fwd_v3_tle_direct_kernel,
+    flash_varlen_fwd_v3_tle_decode_flashdecoding_combine_kernel,
+    flash_varlen_fwd_v3_tle_decode_flashdecoding_kernel,
+    flash_varlen_fwd_v3_tle_kernel,
+    flash_varlen_fwd_v3_tle_short_kernel,
+    fa3_tle_metadata_dispatch,
+)
+from .fa3_ws.utils import (
+    _FA3_TLE_BUCKET_DIRECT_DECODE,
+    _FA3_TLE_BUCKET_DIRECT_PAGED_DECODE,
+    _FA3_TLE_BUCKET_LONG,
+    _FA3_TLE_BUCKET_PAGED_MEDIUM,
+    _FA3_TLE_BUCKET_PAGED_SMALL,
+    _FA3_TLE_BUCKET_SHORT,
+    _FA3_TLE_FAMILY_AUTO,
+)
+
+logger = logging.getLogger(__name__)
+
+_TMA_ALLOCATOR_REGISTERED = False
+
+
+def _check_device(x):
+    if x.device.type != flag_gems.device:
+        raise RuntimeError(f"expected {flag_gems.device} tensor, got {x.device}")
+
+
+def _ensure_tma_allocator():
+    global _TMA_ALLOCATOR_REGISTERED
+    if _TMA_ALLOCATOR_REGISTERED:
+        return
+    if not hasattr(triton, "set_allocator"):
+        raise RuntimeError(
+            "TLE FA3 requires Triton with on-device TMA descriptors "
+            "(missing triton.set_allocator)."
+        )
+
+    def _alloc_fn(size: int, alignment: int, stream):
+        return torch.empty(size, device="cuda", dtype=torch.int8)
+
+    triton.set_allocator(_alloc_fn)
+    _TMA_ALLOCATOR_REGISTERED = True
+
+
+def _auto_splitkv_from_metadata() -> bool:
+    return os.getenv("FLAG_GEMS_FA3_TLE_AUTO_SPLITKV") == "1"
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.getenv(name)
+    if value is None or value == "":
+        return default
+    try:
+        return int(value)
+    except ValueError as exc:
+        raise RuntimeError(f"invalid {name}={value!r}; expected an integer") from exc
+
+
+def _paged_prefill_route() -> str:
+    value = os.getenv("FLAG_GEMS_FA3_TLE_PAGED_PREFILL_ROUTE", "auto")
+    value = value.strip().lower()
+    allowed = {"auto", "direct", "long"}
+    if value not in allowed:
+        raise RuntimeError(
+            "invalid FLAG_GEMS_FA3_TLE_PAGED_PREFILL_ROUTE="
+            f"{value!r}; expected one of {', '.join(sorted(allowed))}"
+        )
+    return value
+
+
+def is_fa3_supported() -> bool:
+    if not TLE_FA3_AVAILABLE:
+        return False
+    if not torch.cuda.is_available():
+        return False
+    if torch.cuda.get_device_capability()[0] < 9:
+        return False
+    try:
+        import triton.language as tl
+
+        return hasattr(tl, "make_tensor_descriptor") and hasattr(
+            triton, "set_allocator"
+        )
+    except Exception:
+        return False
+
+
+def _round_multiple(value: int, multiple: int) -> int:
+    return (value + multiple - 1) // multiple * multiple
+
+
+def _tma_strides_are_aligned(tensor: torch.Tensor) -> bool:
+    elem_bytes = tensor.element_size()
+    return all((stride * elem_bytes) % 16 == 0 for stride in tensor.stride()[:-1])
+
+
+def _ws_short_tma_strides_are_aligned(q, k, v, out, is_paged: bool) -> bool:
+    if not _tma_strides_are_aligned(q) or not _tma_strides_are_aligned(out):
+        return False
+    if is_paged:
+        return True
+    return _tma_strides_are_aligned(k) and _tma_strides_are_aligned(v)
+
+
+def _require_tle_supported(
+    q,
+    k,
+    v,
+    out,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    seqused_k,
+    page_table,
+    alibi_slopes,
+    max_seqlen_q,
+    max_seqlen_k,
+    p_dropout,
+    return_softmax,
+    leftpad_k,
+):
+    if not is_fa3_supported():
+        raise RuntimeError(
+            "TLE FA3 requires CUDA Hopper, Triton TMA descriptors, and "
+            "triton.experimental.tle."
+        )
+    if q.dtype not in (torch.float16, torch.bfloat16):
+        raise RuntimeError(
+            "TLE FA3 currently supports torch.float16 and torch.bfloat16 inputs only."
+        )
+    if k.dtype != q.dtype or v.dtype != q.dtype:
+        raise RuntimeError("TLE FA3 requires q, k, and v to have the same dtype.")
+    if p_dropout != 0:
+        raise RuntimeError("TLE FA3 does not support dropout.")
+    if return_softmax:
+        raise RuntimeError("TLE FA3 does not support returning the softmax matrix.")
+    if leftpad_k is not None:
+        raise RuntimeError("TLE FA3 does not support leftpad_k.")
+    if q.ndim != 3:
+        raise RuntimeError(f"TLE FA3 expects q with shape (total_q, h, d), got {q.shape}.")
+    if q.stride(-1) != 1 or k.stride(-1) != 1 or v.stride(-1) != 1:
+        raise RuntimeError("TLE FA3 requires q/k/v to be contiguous in the head dimension.")
+    if cu_seqlens_q.dtype != torch.int32 or not cu_seqlens_q.is_contiguous():
+        raise RuntimeError("TLE FA3 requires contiguous int32 cu_seqlens_q.")
+    if cu_seqlens_k.dtype != torch.int32 or not cu_seqlens_k.is_contiguous():
+        raise RuntimeError("TLE FA3 requires contiguous int32 cu_seqlens_k placeholder.")
+    if seqused_k is not None and (
+        seqused_k.dtype != torch.int32 or not seqused_k.is_contiguous()
+    ):
+        raise RuntimeError("TLE FA3 requires contiguous int32 seqused_k when provided.")
+    if max_seqlen_q <= 0 or max_seqlen_k <= 0:
+        raise RuntimeError("TLE FA3 requires positive max_seqlen_q and max_seqlen_k.")
+
+    head_size = q.shape[-1]
+    if head_size < 32 or head_size > 256 or head_size % 8 != 0:
+        raise RuntimeError("TLE FA3 requires 32 <= head_dim <= 256 and head_dim % 8 == 0.")
+
+    is_paged = page_table is not None
+    if is_paged:
+        if page_table.dtype != torch.int32 or page_table.ndim != 2:
+            raise RuntimeError("TLE FA3 paged mode requires an int32 2D block table.")
+        if page_table.stride(-1) != 1:
+            raise RuntimeError("TLE FA3 paged mode requires contiguous block-table rows.")
+        if seqused_k is None:
+            raise RuntimeError("TLE FA3 paged mode requires seqused_k.")
+        if k.ndim != 4 or v.ndim != 4:
+            raise RuntimeError("TLE FA3 paged mode expects k/v cache shape (pages, block, hk, d).")
+    else:
+        if k.ndim != 3 or v.ndim != 3:
+            raise RuntimeError("TLE FA3 dense mode expects k/v shape (total_k, hk, d).")
+
+    if out is not None and out.dtype != q.dtype:
+        raise RuntimeError("TLE FA3 requires output dtype to match q.")
+    if alibi_slopes is not None:
+        if alibi_slopes.dtype != torch.float32 or alibi_slopes.stride(-1) != 1:
+            raise RuntimeError("TLE FA3 requires fp32 ALiBi slopes with last stride 1.")
+
+
+def mha_varlan_fwd_v3(
+    q,
+    k,
+    v,
+    out,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    seqused_k,
+    leftpad_k,
+    page_table,
+    alibi_slopes,
+    max_seqlen_q,
+    max_seqlen_k,
+    p_dropout,
+    softmax_scale,
+    zero_tensors,
+    is_causal,
+    window_size_left,
+    window_size_right,
+    softcap,
+    return_softmax,
+    gen,
+    scheduler_metadata=None,
+    num_splits=0,
+):
+    _check_device(q)
+    _check_device(k)
+    _check_device(v)
+    q_device = q.device
+    max_seqlen_q = int(max_seqlen_q)
+    max_seqlen_k = int(max_seqlen_k)
+    num_splits = int(num_splits or 0)
+    if num_splits < 0:
+        raise RuntimeError("TLE FA3 requires num_splits >= 0.")
+    if softmax_scale is None:
+        softmax_scale = q.shape[-1] ** -0.5
+
+    _require_tle_supported(
+        q,
+        k,
+        v,
+        out,
+        cu_seqlens_q,
+        cu_seqlens_k,
+        seqused_k,
+        page_table,
+        alibi_slopes,
+        max_seqlen_q,
+        max_seqlen_k,
+        p_dropout,
+        return_softmax,
+        leftpad_k,
+    )
+
+    is_paged = page_table is not None
+    if not is_paged:
+        page_table = torch.empty((0, 0), device=q_device, dtype=torch.int32)
+
+    total_q, num_heads, head_size = q.size()
+    num_heads_k = k.size(2) if is_paged else k.size(1)
+    batch_size = cu_seqlens_q.numel() - 1
+    block_size = k.size(1) if is_paged else 1
+    num_pages = k.size(0) if is_paged else 0
+    k_batch_size = num_pages
+    page_table_batch_stride = page_table.stride(0)
+
+    if k.size() != v.size():
+        raise RuntimeError("TLE FA3 requires k and v to have the same shape.")
+    if cu_seqlens_q.size() != (batch_size + 1,):
+        raise RuntimeError("cu_seqlens_q must have shape (batch_size + 1,).")
+    if cu_seqlens_k.size() != (batch_size + 1,):
+        raise RuntimeError("cu_seqlens_k must have shape (batch_size + 1,).")
+    if seqused_k is not None and seqused_k.size() != (batch_size,):
+        raise RuntimeError("seqused_k must have shape (batch_size,).")
+    if scheduler_metadata is not None:
+        if scheduler_metadata.dtype != torch.int32 or not scheduler_metadata.is_contiguous():
+            raise RuntimeError("scheduler_metadata must be contiguous int32 when provided.")
+        if scheduler_metadata.device != q_device:
+            raise RuntimeError("scheduler_metadata must be on the same device as q.")
+    if num_heads % num_heads_k != 0:
+        raise RuntimeError("TLE FA3 requires num_heads % num_heads_k == 0.")
+
+    if max_seqlen_q == 1 and alibi_slopes is None:
+        is_causal = False
+    if is_causal:
+        window_size_right = 0
+    if window_size_left >= max_seqlen_k:
+        window_size_left = -1
+    if window_size_right >= max_seqlen_k:
+        window_size_right = -1
+    is_local = window_size_left >= 0
+
+    metadata_max_query_len = max_seqlen_q
+    metadata_num_heads = num_heads
+    metadata_cu_seqlens_q = cu_seqlens_q
+
+    seqlenq_ngroups_swapped = (
+        max_seqlen_q == 1
+        and alibi_slopes is None
+        and num_heads > num_heads_k
+        and window_size_left < 0
+        and window_size_right < 0
+    )
+    q_groups = num_heads // num_heads_k
+    if seqlenq_ngroups_swapped:
+        q = (
+            q.reshape((batch_size, num_heads_k, q_groups, head_size))
+            .transpose(1, 2)
+            .reshape(batch_size * q_groups, num_heads_k, head_size)
+        )
+        max_seqlen_q = q_groups
+        num_heads = num_heads_k
+        cu_seqlens_q = None
+        q_batch_stride = q.stride(0) * max_seqlen_q
+        k_batch_stride = k.stride(0)
+        v_batch_stride = v.stride(0)
+    else:
+        q_batch_stride = 0
+        k_batch_stride = 0
+        v_batch_stride = 0
+        o_batch_stride = 0
+
+    total_q = q.size(0)
+    if q.shape != (total_q, num_heads, head_size):
+        raise RuntimeError("internal TLE FA3 q shape mismatch after optional swap.")
+    if is_paged:
+        expected = (num_pages, block_size, num_heads_k, head_size)
+        if k.shape != expected or v.shape != expected:
+            raise RuntimeError(f"TLE FA3 expected paged k/v shape {expected}.")
+    if k.stride() != v.stride():
+        raise RuntimeError("TLE FA3 requires k and v to have matching strides.")
+
+    if alibi_slopes is not None:
+        if alibi_slopes.device != q_device:
+            raise RuntimeError("ALiBi slopes must be on the same device as q.")
+        if alibi_slopes.shape == (num_heads,):
+            alibi_slopes_batch_stride = 0
+        elif alibi_slopes.shape == (batch_size, num_heads):
+            alibi_slopes_batch_stride = alibi_slopes.stride(0)
+        else:
+            raise RuntimeError(
+                "ALiBi slopes must have shape (num_heads,) or (batch_size, num_heads)."
+            )
+        is_alibi = True
+    else:
+        alibi_slopes_batch_stride = 0
+        is_alibi = False
+
+    if softcap > 0.0:
+        is_softcap = True
+        adjusted_softcap = softmax_scale / softcap
+        adjusted_scale_softmax = softcap
+        adjusted_scale_softmax_log2e = softcap * 1.4426950408889634
+    else:
+        is_softcap = False
+        adjusted_softcap = 0.0
+        adjusted_scale_softmax = softmax_scale
+        adjusted_scale_softmax_log2e = softmax_scale * 1.4426950408889634
+
+    def _metadata_max_num_splits(metadata) -> int:
+        if metadata is None or metadata.numel() <= 1:
+            return 1
+        dynamic = metadata[1 : 1 + batch_size]
+        if dynamic.numel() == 0:
+            return 1
+        return max(1, int(dynamic.max().item()))
+
+    scheduler_metadata_source = "none"
+    effective_num_splits = max(0, int(num_splits or 0))
+    auto_splitkv = _auto_splitkv_from_metadata()
+    if seqused_k is not None:
+        if scheduler_metadata is not None:
+            scheduler_metadata_source = "explicit_metadata"
+            if effective_num_splits <= 0:
+                metadata_num_splits = _metadata_max_num_splits(scheduler_metadata)
+                effective_num_splits = metadata_num_splits if auto_splitkv else 1
+                if not auto_splitkv:
+                    scheduler_metadata_source = "explicit_metadata_no_auto_split"
+        elif effective_num_splits <= 0:
+            scheduler_metadata = flag_gems.get_scheduler_metadata(
+                batch_size=batch_size,
+                max_seqlen_q=metadata_max_query_len,
+                max_seqlen_k=max_seqlen_k,
+                num_heads=metadata_num_heads,
+                num_heads_k=num_heads_k,
+                headdim=head_size,
+                headdim_v=head_size,
+                qkv_dtype=q.dtype,
+                seqused_k=seqused_k,
+                cu_seqlens_q=metadata_cu_seqlens_q,
+                cu_seqlens_k=None,
+                page_size=block_size if is_paged else None,
+                is_causal=is_causal,
+                window_size_left=window_size_left,
+                window_size_right=window_size_right,
+                has_softcap=is_softcap,
+                num_splits=0,
+            )
+            metadata_num_splits = _metadata_max_num_splits(scheduler_metadata)
+            effective_num_splits = metadata_num_splits if auto_splitkv else 1
+            scheduler_metadata_source = (
+                "auto_metadata_split"
+                if auto_splitkv
+                else "auto_metadata_no_auto_split"
+            )
+        else:
+            scheduler_metadata_source = "explicit_num_splits"
+    effective_num_splits = max(1, effective_num_splits)
+
+    head_size_rounded = _round_multiple(head_size, 32) if head_size <= 192 else 256
+    seqlen_q_rounded = _round_multiple(max_seqlen_q, 128)
+    seqlen_k_rounded = _round_multiple(max_seqlen_k, 32)
+
+    with torch_device_fn.device(q_device):
+        if out is not None:
+            out_ = out
+            if seqlenq_ngroups_swapped:
+                out = torch.empty_like(q)
+        else:
+            out_ = None
+            out = torch.empty_like(q)
+
+        if seqlenq_ngroups_swapped:
+            o_batch_stride = out.stride(0) * max_seqlen_q
+
+        lse = torch.empty((num_heads, total_q), dtype=torch.float32, device=q_device)
+        p = torch.empty((), device=q_device)
+        philox_args = torch.empty((2,), dtype=torch.int64, device=q_device)
+
+        if zero_tensors:
+            out.zero_()
+            lse.fill_(float("-inf"))
+
+        params = fwd_params(
+            q,
+            k,
+            v,
+            out,
+            p,
+            lse,
+            q.stride(-3),
+            k.stride(-3),
+            v.stride(-3),
+            q.stride(-2),
+            k.stride(-2),
+            v.stride(-2),
+            out.stride(-3),
+            out.stride(-2),
+            q_batch_stride,
+            k_batch_stride,
+            v_batch_stride,
+            o_batch_stride,
+            cu_seqlens_q is not None,
+            cu_seqlens_q,
+            seqused_k is None,
+            cu_seqlens_k,
+            seqused_k is not None,
+            seqused_k,
+            batch_size,
+            k_batch_size,
+            num_heads,
+            num_heads_k,
+            num_heads // num_heads_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            seqlen_q_rounded,
+            seqlen_k_rounded,
+            head_size,
+            head_size_rounded,
+            is_softcap,
+            adjusted_softcap,
+            adjusted_scale_softmax,
+            adjusted_scale_softmax_log2e,
+            False,
+            0.0,
+            1.0,
+            255,
+            philox_args,
+            False,
+            is_causal,
+            is_local,
+            window_size_left,
+            window_size_right,
+            seqlenq_ngroups_swapped,
+            is_paged,
+            is_alibi,
+            alibi_slopes,
+            alibi_slopes_batch_stride,
+            total_q,
+            page_table,
+            page_table_batch_stride,
+            block_size,
+        )
+
+        _ensure_tma_allocator()
+        num_sms = torch.cuda.get_device_properties(q_device).multi_processor_count
+        args = tuple(getattr(params, k) for k in params.__slots__)
+        paged_gather_mode = fa3_tle_paged_gather_mode()
+        dispatch = fa3_tle_metadata_dispatch(
+            max_query_len=metadata_max_query_len,
+            is_paged=is_paged,
+            has_cache_kv=seqused_k is not None,
+            num_splits=effective_num_splits,
+            has_scheduler_metadata=scheduler_metadata is not None,
+            metadata_source=scheduler_metadata_source,
+        )
+        avg_query_len = total_q / max(batch_size, 1)
+        paged_prefill_route = _paged_prefill_route()
+        paged_prefill_candidate = (
+            dispatch.has_cache_kv
+            and is_paged
+            and not dispatch.split_kv
+            and metadata_max_query_len
+            >= _env_int("FLAG_GEMS_FA3_TLE_PAGED_PREFILL_MIN_Q", 1024)
+            and avg_query_len
+            >= _env_int("FLAG_GEMS_FA3_TLE_PAGED_PREFILL_MIN_AVG_Q", 128)
+        )
+        if paged_prefill_route == "direct":
+            paged_prefill_long = False
+        elif paged_prefill_route == "long":
+            paged_prefill_long = (
+                dispatch.has_cache_kv and is_paged and not dispatch.split_kv
+            )
+        else:
+            paged_prefill_long = paged_prefill_candidate
+
+        def _require_tma_aligned():
+            if (
+                not _tma_strides_are_aligned(q)
+                or not _tma_strides_are_aligned(out)
+                or (not is_paged and not _tma_strides_are_aligned(k))
+                or (not is_paged and not _tma_strides_are_aligned(v))
+            ):
+                raise RuntimeError(
+                    "TLE FA3 TMA-backed path requires 16-byte aligned Q/K/V/O strides."
+                )
+
+        def _log_dispatch(kernel_name: str, splits: int = 1):
+            logger.debug(
+                "kernel: flash_varlen_fwd_v3_tle kernel=%s layout=%s mode=%s splits=%s",
+                kernel_name,
+                dispatch.layout,
+                dispatch.mode,
+                splits,
+            )
+            if os.getenv("FLAG_GEMS_FA3_TLE_LOG_PLAN") == "1":
+                print(
+                    "FLAG_GEMS_FA3_TLE_PLAN "
+                    f"layout={dispatch.layout} mode={dispatch.mode} "
+                    f"kernel={kernel_name} splits={splits} scheduler_metadata="
+                    f"{dispatch.has_scheduler_metadata} metadata_source="
+                    f"{dispatch.metadata_source} paged_gather="
+                    f"{fa3_tle_paged_gather_name(paged_gather_mode)}"
+                )
+
+        if dispatch.split_kv and dispatch.has_cache_kv:
+            _log_dispatch("flashdecoding", effective_num_splits)
+            partial_out = torch.empty(
+                (effective_num_splits, num_heads, total_q, head_size),
+                dtype=torch.float32,
+                device=q_device,
+            )
+            partial_m = torch.empty(
+                (effective_num_splits, num_heads, total_q),
+                dtype=torch.float32,
+                device=q_device,
+            )
+            partial_l = torch.empty_like(partial_m)
+            split_grid = (max_seqlen_q, batch_size, num_heads * effective_num_splits)
+            flash_varlen_fwd_v3_tle_decode_flashdecoding_kernel[split_grid](
+                *args,
+                partial_out,
+                partial_m,
+                partial_l,
+                scheduler_metadata if scheduler_metadata is not None else page_table,
+                NUM_SPLITS=effective_num_splits,
+                SPLIT_POLICY=0,
+                HAS_SCHEDULER_METADATA=scheduler_metadata is not None,
+                PAGED_GATHER_MODE=paged_gather_mode,
+            )
+            combine_block_m = 8
+            combine_grid = (
+                triton.cdiv(max_seqlen_q, combine_block_m),
+                batch_size,
+                num_heads,
+            )
+            flash_varlen_fwd_v3_tle_decode_flashdecoding_combine_kernel[combine_grid](
+                out,
+                lse,
+                partial_out,
+                partial_m,
+                partial_l,
+                out.stride(-3),
+                out.stride(-2),
+                o_batch_stride,
+                cu_seqlens_q is not None,
+                cu_seqlens_q,
+                batch_size,
+                num_heads,
+                max_seqlen_q,
+                head_size,
+                total_q,
+                adjusted_scale_softmax,
+                adjusted_scale_softmax_log2e,
+                BLOCK_M=combine_block_m,
+                BLOCK_K=1 << (head_size - 1).bit_length(),
+                NUM_SPLITS=effective_num_splits,
+            )
+        elif dispatch.has_cache_kv and not paged_prefill_long:
+            _log_dispatch("direct")
+            grid = lambda meta: (
+                triton.cdiv(max_seqlen_q, meta["BLOCK_M"]),
+                batch_size,
+                num_heads,
+            )
+            flash_varlen_fwd_v3_tle_direct_kernel[grid](
+                *args,
+                DIRECT_SHAPE_BUCKET=_FA3_TLE_BUCKET_DIRECT_PAGED_DECODE
+                if is_paged
+                else _FA3_TLE_BUCKET_DIRECT_DECODE,
+                MIN_Q_LEN_TO_PROCESS=0,
+                MAX_Q_LEN_TO_PROCESS=2**31 - 1,
+                PAGED_GATHER_MODE=paged_gather_mode,
+            )
+        elif max_seqlen_q <= 128 or total_q / max(batch_size, 1) <= 64:
+            _require_tma_aligned()
+            _log_dispatch("short")
+            if is_paged and max_seqlen_q <= 512 and max_seqlen_k <= 1024:
+                short_bucket = (
+                    _FA3_TLE_BUCKET_PAGED_SMALL
+                    if max_seqlen_q <= 128
+                    else _FA3_TLE_BUCKET_PAGED_MEDIUM
+                )
+            else:
+                short_bucket = _FA3_TLE_BUCKET_SHORT
+            grid = lambda meta: (
+                triton.cdiv(max_seqlen_q, meta["BLOCK_M"]),
+                batch_size,
+                num_heads,
+            )
+            flash_varlen_fwd_v3_tle_short_kernel[grid](
+                *args,
+                SHORT_SHAPE_BUCKET=short_bucket,
+                MIN_Q_LEN_TO_PROCESS=0,
+                MAX_Q_LEN_TO_PROCESS=2**31 - 1,
+                PAGED_GATHER_MODE=paged_gather_mode,
+            )
+        else:
+            _require_tma_aligned()
+            _log_dispatch("long_paged_prefill" if paged_prefill_long else "long")
+            grid = lambda meta: (
+                min(
+                    num_sms,
+                    triton.cdiv(max_seqlen_q, meta["BLOCK_M"])
+                    * batch_size
+                    * num_heads,
+                ),
+            )
+            flash_varlen_fwd_v3_tle_kernel[grid](
+                *args,
+                SHAPE_BUCKET=_FA3_TLE_BUCKET_LONG,
+                FORCE_FAMILY_ID=_FA3_TLE_FAMILY_AUTO,
+                MIN_Q_LEN_TO_PROCESS=0,
+                MAX_Q_LEN_TO_PROCESS=2**31 - 1,
+                PAGED_GATHER_MODE=paged_gather_mode,
+            )
+
+        if seqlenq_ngroups_swapped:
+            out = out.reshape(
+                batch_size, max_seqlen_q, num_heads_k, head_size
+            ).transpose(1, 2)
+            if out_ is not None:
+                out_.view(batch_size, num_heads_k, max_seqlen_q, head_size).copy_(out)
+                out = out_
+            else:
+                out = out.reshape(batch_size, num_heads_k * max_seqlen_q, head_size)
+            lse = lse.reshape(num_heads_k, batch_size, max_seqlen_q)
+            lse = lse.reshape(num_heads_k * max_seqlen_q, batch_size)
+
+        unused = torch.empty((), dtype=torch.int64, device=q_device)
+
+    return out, q, k, v, lse, philox_args, unused, p

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/flash_kernel_v3.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/flash_kernel_v3.py
@@ -1,0 +1,18 @@
+"""Compatibility re-export for Hopper FA3 kernels.
+
+The FA3 implementations now live under ``ops.fa3_ws``.  This module preserves
+the historical import path used by ``flash_api_v3.py`` and external callers.
+"""
+
+from .fa3_ws import kernels as _fa3_ws_kernels
+from .fa3_ws.kernels import *  # noqa: F401,F403
+
+__all__ = _fa3_ws_kernels.__all__
+
+
+def __getattr__(name):
+    return getattr(_fa3_ws_kernels, name)
+
+
+def __dir__():
+    return sorted(set(__all__) | set(globals()) | set(dir(_fa3_ws_kernels)))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -51,6 +51,68 @@ def pytest_addoption(parser):
         action="store_true",
         help="run tests on quick mode",
     )
+    try:
+        parser.addoption(
+            "--flash-attn-varlen-fa-version",
+            action="store",
+            type=int,
+            default=2,
+            choices=[2, 3],
+            help=(
+                "FA version used by flash_attn_varlen_func accuracy and benchmark "
+                "tests."
+            ),
+        )
+    except ValueError:
+        # Mixed test+benchmark pytest runs may already register this option in
+        # benchmark/conftest.py. Reuse the existing option in that case.
+        pass
+
+    try:
+        parser.addoption(
+            "--flash-attn-varlen-enable-vllm",
+            action="store_true",
+            default=False,
+            help=(
+                "Enable vLLM flash-attention baseline benchmarks for "
+                "flash_attn_varlen_func. FA3 benchmarks run FlagGems-only by "
+                "default."
+            ),
+        )
+    except ValueError:
+        # Mixed test+benchmark pytest runs may already register this option in
+        # benchmark/conftest.py. Reuse the existing option in that case.
+        pass
+
+    try:
+        parser.addoption(
+            "--flash-attn-varlen-case",
+            action="store",
+            default="all",
+            choices=["all", "qwenCase", "prefillDecodePageCase"],
+            help=(
+                "Select flash_attn_varlen_func benchmark cases. 'all' runs both "
+                "qwenCase and prefillDecodePageCase."
+            ),
+        )
+    except ValueError:
+        # Mixed test+benchmark pytest runs may already register this option in
+        # benchmark/conftest.py. Reuse the existing option in that case.
+        pass
+
+    try:
+        parser.addoption(
+            "--hopper-mm-version",
+            action="store",
+            default="original",
+            required=False,
+            choices=["original", "wasp"],
+            help="Hopper mm implementation used by mm accuracy and benchmark tests.",
+        )
+    except ValueError:
+        # Mixed test+benchmark pytest runs may already register this option in
+        # benchmark/conftest.py. Reuse the existing option in that case.
+        pass
 
     try:
         parser.addoption(

--- a/tests/hopper_fa3_utils.py
+++ b/tests/hopper_fa3_utils.py
@@ -1,0 +1,517 @@
+import inspect
+import math
+import os
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+import torch
+
+import flag_gems
+
+
+os.environ.setdefault("VLLM_CONFIGURE_LOGGING", "0")
+
+
+try:
+    from flag_gems.runtime.backend._nvidia.hopper.ops.flash_api_v3 import (
+        is_fa3_supported as _backend_is_fa3_supported,
+    )
+except ImportError:
+    _backend_is_fa3_supported = None
+except Exception:
+    _backend_is_fa3_supported = None
+
+
+try:
+    from vllm.vllm_flash_attn.flash_attn_interface import (
+        flash_attn_varlen_func as vllm_fa_varlen,
+    )
+
+    HAS_VLLM_FA = True
+    _vllm_fa_params = set(inspect.signature(vllm_fa_varlen).parameters.keys())
+    VLLM_FA_HAS_FA_VERSION = "fa_version" in _vllm_fa_params
+    VLLM_FA_HAS_BLOCK_TABLE = "block_table" in _vllm_fa_params
+    VLLM_FA_HAS_SEQUSED_K = "seqused_k" in _vllm_fa_params
+except ImportError:
+    vllm_fa_varlen = None
+    HAS_VLLM_FA = False
+    VLLM_FA_HAS_FA_VERSION = False
+    VLLM_FA_HAS_BLOCK_TABLE = False
+    VLLM_FA_HAS_SEQUSED_K = False
+except Exception:
+    vllm_fa_varlen = None
+    HAS_VLLM_FA = False
+    VLLM_FA_HAS_FA_VERSION = False
+    VLLM_FA_HAS_BLOCK_TABLE = False
+    VLLM_FA_HAS_SEQUSED_K = False
+
+
+@dataclass(frozen=True)
+class Shape:
+    name: str
+    seq_lens: List[Tuple[int, int]]
+    nh_q: int
+    nh_k: int
+    head_dim: int
+    causal: bool
+    paged: bool = False
+    block_size: int = 16
+    overcommit: float = 1.5
+
+
+@dataclass
+class Tensors:
+    q: torch.Tensor
+    k: torch.Tensor
+    v: torch.Tensor
+    cu_seqlens_q: torch.Tensor
+    cu_seqlens_k: Optional[torch.Tensor]
+    seqused_k: torch.Tensor
+    block_table: Optional[torch.Tensor]
+    max_seqlen_q: int
+    max_seqlen_k: int
+
+
+def is_fa3_supported() -> bool:
+    if _backend_is_fa3_supported is not None:
+        return _backend_is_fa3_supported()
+    if flag_gems.device != "cuda" or not torch.cuda.is_available():
+        return False
+    return torch.cuda.get_device_capability()[0] >= 9
+
+
+def accuracy_shapes() -> List[Shape]:
+    return [
+        Shape("dense_prefill_mha", [(64, 64), (48, 48)], 4, 4, 64, False),
+        Shape("dense_causal_gqa", [(64, 64), (1, 128), (17, 96)], 8, 2, 128, True),
+        Shape("dense_decode_gqa", [(1, 128), (1, 256), (1, 384)], 8, 2, 128, True),
+        Shape(
+            "paged_decode_gqa",
+            [(1, 128), (1, 192), (1, 256), (1, 320)],
+            8,
+            2,
+            128,
+            True,
+            paged=True,
+            block_size=16,
+        ),
+    ]
+
+
+def benchmark_shapes() -> List[Shape]:
+    prefill = [
+        Shape("prefill_b4_s2k_d128_mha", [(2048, 2048)] * 4, 32, 32, 128, True),
+        Shape("prefill_b4_s4k_d128_mha", [(4096, 4096)] * 4, 32, 32, 128, True),
+        Shape("prefill_b4_s8k_d128_mha", [(8192, 8192)] * 4, 32, 32, 128, True),
+        Shape("prefill_b2_s16k_d128_mha", [(16384, 16384)] * 2, 32, 32, 128, True),
+        Shape("prefill_b4_s4k_d128_gqa4", [(4096, 4096)] * 4, 32, 8, 128, True),
+        Shape("prefill_b4_s8k_d128_gqa4", [(8192, 8192)] * 4, 32, 8, 128, True),
+        Shape("prefill_b8_s2k_d64_mha", [(2048, 2048)] * 8, 16, 16, 64, False),
+    ]
+
+    decode = [
+        Shape("decode_b16_kv1k_d128_gqa4", [(1, 1024)] * 16, 32, 8, 128, True),
+        Shape("decode_b8_kv1k_d192_gqa4", [(1, 1024)] * 8, 32, 8, 192, True),
+        Shape("decode_b8_kv1k_d256_gqa4", [(1, 1024)] * 8, 32, 8, 256, True),
+        Shape(
+            "decode_b16_mixed_d128_gqa4",
+            [(1, 512), (1, 1024), (1, 2048), (1, 4096)] * 4,
+            32,
+            8,
+            128,
+            True,
+        ),
+        Shape("decode_b32_kv2k_d128_gqa4", [(1, 2048)] * 32, 32, 8, 128, True),
+    ]
+
+    varlen = [
+        Shape(
+            "varlen_mixed_d128_gqa4",
+            [(2048, 2048), (1, 4096), (1, 4096), (1024, 1024), (1, 8192), (1, 1024)],
+            32,
+            8,
+            128,
+            True,
+        ),
+        Shape(
+            "varlen_serve_b32_1pf_31dec_d128_gqa4",
+            [(2048, 2048)] + [(1, 1024 + 64 * i) for i in range(31)],
+            32,
+            8,
+            128,
+            True,
+        ),
+        Shape(
+            "varlen_longtail_d128_gqa4",
+            [(16384, 16384)] + [(256, 256)] * 16,
+            32,
+            8,
+            128,
+            True,
+        ),
+    ]
+
+    paged = [
+        Shape(
+            "paged_decode_b16_kvmix_bs16_d128_gqa4",
+            [(1, 1024 + 256 * i) for i in range(16)],
+            32,
+            8,
+            128,
+            True,
+            paged=True,
+            block_size=16,
+        ),
+        Shape(
+            "paged_decode_b8_bs16_d192_gqa4",
+            [(1, 1024 + 128 * i) for i in range(8)],
+            32,
+            8,
+            192,
+            True,
+            paged=True,
+            block_size=16,
+        ),
+        Shape(
+            "paged_decode_b8_bs16_d256_gqa4",
+            [(1, 1024 + 128 * i) for i in range(8)],
+            32,
+            8,
+            256,
+            True,
+            paged=True,
+            block_size=16,
+        ),
+        Shape(
+            "paged_decode_b64_bs16_d128_gqa4",
+            [(1, 512 + 128 * i) for i in range(64)],
+            32,
+            8,
+            128,
+            True,
+            paged=True,
+            block_size=16,
+        ),
+        Shape(
+            "paged_serve_b32_1pf_31dec_bs16_d128_gqa4",
+            [(2048, 2048)] + [(1, 1024 + 96 * i) for i in range(31)],
+            32,
+            8,
+            128,
+            True,
+            paged=True,
+            block_size=16,
+        ),
+        Shape(
+            "paged_uniform_b4_s4k_bs16_d128_mha",
+            [(4096, 4096)] * 4,
+            32,
+            32,
+            128,
+            True,
+            paged=True,
+            block_size=16,
+        ),
+    ]
+
+    return prefill + decode + varlen + paged
+
+
+def make_varlen(shape: Shape, dtype: torch.dtype, device: str, seed: int = 0) -> Tensors:
+    if shape.paged:
+        return _make_paged_varlen(shape, dtype, device, seed)
+    return _make_dense_varlen(shape, dtype, device, seed)
+
+
+def _make_dense_varlen(
+    shape: Shape, dtype: torch.dtype, device: str, seed: int
+) -> Tensors:
+    gen = torch.Generator(device=device).manual_seed(seed)
+    cu_q = [0]
+    cu_k = [0]
+    for q_len, k_len in shape.seq_lens:
+        cu_q.append(cu_q[-1] + q_len)
+        cu_k.append(cu_k[-1] + k_len)
+
+    q = torch.randn(
+        (cu_q[-1], shape.nh_q, shape.head_dim),
+        dtype=dtype,
+        device=device,
+        generator=gen,
+    ) * 0.5
+    k = torch.randn(
+        (cu_k[-1], shape.nh_k, shape.head_dim),
+        dtype=dtype,
+        device=device,
+        generator=gen,
+    ) * 0.5
+    v = torch.randn(
+        (cu_k[-1], shape.nh_k, shape.head_dim),
+        dtype=dtype,
+        device=device,
+        generator=gen,
+    ) * 0.5
+
+    return Tensors(
+        q=q,
+        k=k,
+        v=v,
+        cu_seqlens_q=torch.tensor(cu_q, dtype=torch.int32, device=device),
+        cu_seqlens_k=torch.tensor(cu_k, dtype=torch.int32, device=device),
+        seqused_k=torch.tensor(
+            [k_len for _, k_len in shape.seq_lens],
+            dtype=torch.int32,
+            device=device,
+        ),
+        block_table=None,
+        max_seqlen_q=max(q_len for q_len, _ in shape.seq_lens),
+        max_seqlen_k=max(k_len for _, k_len in shape.seq_lens),
+    )
+
+
+def _make_paged_varlen(
+    shape: Shape, dtype: torch.dtype, device: str, seed: int
+) -> Tensors:
+    gen = torch.Generator(device=device).manual_seed(seed)
+    cpu_gen = torch.Generator().manual_seed(seed + 1)
+    block_size = shape.block_size
+
+    cu_q = [0]
+    for q_len, _ in shape.seq_lens:
+        cu_q.append(cu_q[-1] + q_len)
+    q = torch.randn(
+        (cu_q[-1], shape.nh_q, shape.head_dim),
+        dtype=dtype,
+        device=device,
+        generator=gen,
+    ) * 0.5
+
+    blocks_per_req = [
+        (k_len + block_size - 1) // block_size for _, k_len in shape.seq_lens
+    ]
+    max_blocks_per_req = max(blocks_per_req)
+    total_virtual_blocks = sum(blocks_per_req)
+    num_physical_blocks = max(1, int(total_virtual_blocks * shape.overcommit))
+
+    perm = torch.randperm(num_physical_blocks, generator=cpu_gen)[:total_virtual_blocks]
+    block_table = torch.zeros(
+        (len(shape.seq_lens), max_blocks_per_req), dtype=torch.int32, device=device
+    )
+    offset = 0
+    for req_idx, num_blocks in enumerate(blocks_per_req):
+        block_table[req_idx, :num_blocks] = perm[
+            offset : offset + num_blocks
+        ].to(dtype=torch.int32, device=device)
+        offset += num_blocks
+
+    k_cache = torch.randn(
+        (num_physical_blocks, block_size, shape.nh_k, shape.head_dim),
+        dtype=dtype,
+        device=device,
+        generator=gen,
+    ) * 0.5
+    v_cache = torch.randn(
+        (num_physical_blocks, block_size, shape.nh_k, shape.head_dim),
+        dtype=dtype,
+        device=device,
+        generator=gen,
+    ) * 0.5
+    seqused_k = torch.tensor(
+        [k_len for _, k_len in shape.seq_lens], dtype=torch.int32, device=device
+    )
+
+    return Tensors(
+        q=q,
+        k=k_cache,
+        v=v_cache,
+        cu_seqlens_q=torch.tensor(cu_q, dtype=torch.int32, device=device),
+        cu_seqlens_k=None,
+        seqused_k=seqused_k,
+        block_table=block_table,
+        max_seqlen_q=max(q_len for q_len, _ in shape.seq_lens),
+        max_seqlen_k=max(k_len for _, k_len in shape.seq_lens),
+    )
+
+
+def run_flag_gems(tensors: Tensors, shape: Shape, fa_version: int = 3) -> torch.Tensor:
+    kwargs = {
+        "max_seqlen_q": tensors.max_seqlen_q,
+        "cu_seqlens_q": tensors.cu_seqlens_q,
+        "max_seqlen_k": tensors.max_seqlen_k,
+        "softmax_scale": 1.0 / math.sqrt(shape.head_dim),
+        "causal": shape.causal,
+        "fa_version": fa_version,
+    }
+    if shape.paged:
+        kwargs["seqused_k"] = tensors.seqused_k
+        kwargs["block_table"] = tensors.block_table
+    else:
+        kwargs["cu_seqlens_k"] = tensors.cu_seqlens_k
+
+    return flag_gems.flash_attn_varlen_func(tensors.q, tensors.k, tensors.v, **kwargs)
+
+
+def run_vllm_fa(tensors: Tensors, shape: Shape, fa_version: int = 3) -> torch.Tensor:
+    if not HAS_VLLM_FA:
+        raise NotImplementedError("vLLM flash-attention is unavailable")
+
+    extra = {
+        "softmax_scale": 1.0 / math.sqrt(shape.head_dim),
+        "causal": shape.causal,
+    }
+    if VLLM_FA_HAS_FA_VERSION:
+        extra["fa_version"] = fa_version
+
+    if shape.paged:
+        if not VLLM_FA_HAS_BLOCK_TABLE:
+            raise NotImplementedError("vLLM flash-attention lacks block_table support")
+        if not VLLM_FA_HAS_SEQUSED_K:
+            raise NotImplementedError("vLLM flash-attention lacks seqused_k support")
+        out = vllm_fa_varlen(
+            tensors.q,
+            tensors.k,
+            tensors.v,
+            max_seqlen_q=tensors.max_seqlen_q,
+            cu_seqlens_q=tensors.cu_seqlens_q,
+            max_seqlen_k=tensors.max_seqlen_k,
+            seqused_k=tensors.seqused_k,
+            block_table=tensors.block_table,
+            **extra,
+        )
+    else:
+        out = vllm_fa_varlen(
+            tensors.q,
+            tensors.k,
+            tensors.v,
+            max_seqlen_q=tensors.max_seqlen_q,
+            cu_seqlens_q=tensors.cu_seqlens_q,
+            max_seqlen_k=tensors.max_seqlen_k,
+            cu_seqlens_k=tensors.cu_seqlens_k,
+            **extra,
+        )
+    return out[0] if isinstance(out, tuple) else out
+
+
+def eager_reference(tensors: Tensors, shape: Shape) -> torch.Tensor:
+    scale = 1.0 / math.sqrt(shape.head_dim)
+    cu_q = tensors.cu_seqlens_q
+    if shape.paged:
+        seqs_k, seqs_v = _gather_paged_to_dense(
+            tensors.k, tensors.v, tensors.block_table, tensors.seqused_k
+        )
+    else:
+        seqs_k = []
+        seqs_v = []
+        for batch_idx in range(cu_q.numel() - 1):
+            k_begin = tensors.cu_seqlens_k[batch_idx]
+            k_end = tensors.cu_seqlens_k[batch_idx + 1]
+            seqs_k.append(tensors.k[k_begin:k_end])
+            seqs_v.append(tensors.v[k_begin:k_end])
+
+    outputs = []
+    for batch_idx in range(cu_q.numel() - 1):
+        q_begin = cu_q[batch_idx]
+        q_end = cu_q[batch_idx + 1]
+        q_b = tensors.q[q_begin:q_end]
+        k_b = seqs_k[batch_idx]
+        v_b = seqs_v[batch_idx]
+        q_len, num_q_heads, _ = q_b.shape
+        k_len = k_b.size(0)
+
+        if k_b.size(1) != num_q_heads:
+            repeat = num_q_heads // k_b.size(1)
+            k_b = k_b.repeat_interleave(repeat, dim=1)
+            v_b = v_b.repeat_interleave(repeat, dim=1)
+
+        q_heads = q_b.transpose(0, 1).float()
+        k_heads = k_b.transpose(0, 1).float()
+        v_heads = v_b.transpose(0, 1).float()
+        scores = (q_heads @ k_heads.transpose(-1, -2)) * scale
+        if shape.causal:
+            mask = torch.ones(
+                q_len, k_len, dtype=torch.bool, device=tensors.q.device
+            ).tril(diagonal=k_len - q_len)
+            scores = scores.masked_fill(~mask, float("-inf"))
+        probs = torch.softmax(scores, dim=-1)
+        outputs.append((probs @ v_heads).transpose(0, 1).to(tensors.q.dtype))
+
+    return torch.cat(outputs, dim=0)
+
+
+def build_reference(
+    tensors: Tensors,
+    shape: Shape,
+    fa_version: int = 3,
+    prefer_vllm: bool = True,
+) -> Tuple[torch.Tensor, str]:
+    if prefer_vllm and HAS_VLLM_FA:
+        try:
+            with torch.inference_mode():
+                return run_vllm_fa(tensors, shape, fa_version), "vllm_fa"
+        except NotImplementedError:
+            pass
+    with torch.inference_mode():
+        return eager_reference(tensors, shape), "eager_fp32"
+
+
+def _gather_paged_to_dense(
+    k_cache: torch.Tensor,
+    v_cache: torch.Tensor,
+    block_table: torch.Tensor,
+    seqused_k: torch.Tensor,
+) -> Tuple[List[torch.Tensor], List[torch.Tensor]]:
+    block_size = k_cache.size(1)
+    seqs_k = []
+    seqs_v = []
+    for req_idx in range(seqused_k.numel()):
+        k_len = int(seqused_k[req_idx].item())
+        num_blocks = (k_len + block_size - 1) // block_size
+        block_ids = block_table[req_idx, :num_blocks].to(torch.long)
+        k_flat = k_cache.index_select(0, block_ids).reshape(
+            -1, k_cache.size(2), k_cache.size(3)
+        )
+        v_flat = v_cache.index_select(0, block_ids).reshape(
+            -1, v_cache.size(2), v_cache.size(3)
+        )
+        seqs_k.append(k_flat[:k_len])
+        seqs_v.append(v_flat[:k_len])
+    return seqs_k, seqs_v
+
+
+def tolerances(dtype: torch.dtype, max_k: int, ref_kind: str) -> Tuple[float, float]:
+    if ref_kind == "vllm_fa":
+        atol = 3e-3 if dtype == torch.bfloat16 else 1.5e-3
+        rtol = 3e-3 if dtype == torch.bfloat16 else 1.5e-3
+    else:
+        atol = 1e-2 if dtype == torch.bfloat16 else 5e-3
+        rtol = 1e-2 if dtype == torch.bfloat16 else 5e-3
+    if max_k >= 8192:
+        atol *= 2.0
+        rtol *= 2.0
+    return atol, rtol
+
+
+def attn_flops(shape: Shape) -> float:
+    flops = 0.0
+    for q_len, k_len in shape.seq_lens:
+        flops += 4.0 * q_len * k_len * shape.head_dim * shape.nh_q
+    if shape.causal:
+        flops *= 0.5
+    return flops
+
+
+def output_tensor(out: torch.Tensor) -> torch.Tensor:
+    return out[0] if isinstance(out, tuple) else out
+
+
+def max_mean_abs(out: torch.Tensor, ref: torch.Tensor) -> Tuple[float, float]:
+    diff = (out.float() - ref.float()).abs()
+    return diff.max().item(), diff.mean().item()
+
+
+def dispatch_source() -> str:
+    return inspect.getsourcefile(flag_gems.flash_attn_varlen_func) or ""
+
+
+def dispatches_to_hopper() -> bool:
+    return "runtime/backend/_nvidia/hopper/ops" in dispatch_source().replace("\\", "/")

--- a/tests/test_fa3_best_known_route.py
+++ b/tests/test_fa3_best_known_route.py
@@ -1,0 +1,139 @@
+import pytest
+
+from flag_gems.runtime.backend._nvidia.hopper.ops.fa3_ws.best_known import (
+    ROUTE_CURRENT_FA3,
+    ROUTE_FA2_FALLBACK,
+    classify_fa3_workload,
+    fa3_tle_best_route_mode,
+    select_fa3_best_route,
+)
+
+
+def test_fa3_best_route_env_validation(monkeypatch):
+    monkeypatch.setenv("FLAG_GEMS_FA3_TLE_BEST_ROUTE", "bad")
+    with pytest.raises(RuntimeError, match="FLAG_GEMS_FA3_TLE_BEST_ROUTE"):
+        fa3_tle_best_route_mode()
+
+
+def test_fa3_best_route_default_is_non_fallback(monkeypatch):
+    monkeypatch.delenv("FLAG_GEMS_FA3_TLE_BEST_ROUTE", raising=False)
+    assert fa3_tle_best_route_mode() == "fa3_only"
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected",
+    [
+        (
+            dict(
+                total_q=8192,
+                batch_size=4,
+                max_seqlen_q=2048,
+                max_seqlen_k=2048,
+                is_paged=False,
+            ),
+            "dense_prefill_or_long",
+        ),
+        (
+            dict(
+                total_q=16,
+                batch_size=16,
+                max_seqlen_q=1,
+                max_seqlen_k=1024,
+                is_paged=True,
+            ),
+            "paged_decode",
+        ),
+        (
+            dict(
+                total_q=4096,
+                batch_size=32,
+                max_seqlen_q=2048,
+                max_seqlen_k=4096,
+                is_paged=True,
+            ),
+            "paged_serve_mixed",
+        ),
+        (
+            dict(
+                total_q=16384,
+                batch_size=4,
+                max_seqlen_q=4096,
+                max_seqlen_k=4096,
+                is_paged=True,
+            ),
+            "paged_uniform_prefill",
+        ),
+    ],
+)
+def test_fa3_best_workload_classification(kwargs, expected):
+    assert classify_fa3_workload(**kwargs) == expected
+
+
+def test_fa3_best_route_default_keeps_fa3():
+    kwargs = dict(
+        total_q=16,
+        batch_size=16,
+        max_seqlen_q=1,
+        max_seqlen_k=1024,
+        is_paged=True,
+    )
+    route = select_fa3_best_route(force_family_id=-1, **kwargs)
+    assert route.route == ROUTE_CURRENT_FA3
+
+
+@pytest.mark.parametrize(
+    "kwargs,expected_route",
+    [
+        (
+            dict(
+                total_q=8192,
+                batch_size=4,
+                max_seqlen_q=2048,
+                max_seqlen_k=2048,
+                is_paged=False,
+            ),
+            ROUTE_CURRENT_FA3,
+        ),
+        (
+            dict(
+                total_q=16,
+                batch_size=16,
+                max_seqlen_q=1,
+                max_seqlen_k=1024,
+                is_paged=True,
+            ),
+            ROUTE_FA2_FALLBACK,
+        ),
+    ],
+)
+def test_fa3_best_route_legacy_auto(monkeypatch, kwargs, expected_route):
+    monkeypatch.setenv("FLAG_GEMS_FA3_TLE_BEST_ROUTE", "auto")
+    route = select_fa3_best_route(force_family_id=-1, **kwargs)
+    assert route.route == expected_route
+
+
+def test_fa3_best_route_force_family_keeps_fa3():
+    route = select_fa3_best_route(
+        total_q=16,
+        batch_size=16,
+        max_seqlen_q=1,
+        max_seqlen_k=1024,
+        is_paged=True,
+        force_family_id=5,
+    )
+    assert route.route == ROUTE_CURRENT_FA3
+
+
+def test_fa3_best_route_env_overrides(monkeypatch):
+    kwargs = dict(
+        total_q=8192,
+        batch_size=4,
+        max_seqlen_q=2048,
+        max_seqlen_k=2048,
+        is_paged=False,
+        force_family_id=-1,
+    )
+    monkeypatch.setenv("FLAG_GEMS_FA3_TLE_BEST_ROUTE", "fa2_only")
+    assert select_fa3_best_route(**kwargs).route == ROUTE_FA2_FALLBACK
+    monkeypatch.setenv("FLAG_GEMS_FA3_TLE_BEST_ROUTE", "fa3_only")
+    assert select_fa3_best_route(**kwargs).route == ROUTE_CURRENT_FA3

--- a/tests/test_fa3_metadata_dispatch.py
+++ b/tests/test_fa3_metadata_dispatch.py
@@ -1,0 +1,60 @@
+from flag_gems.runtime.backend._nvidia.hopper.ops.fa3_ws.planning import (
+    fa3_tle_metadata_dispatch,
+)
+
+
+def test_metadata_dispatch_dense_prefill():
+    route = fa3_tle_metadata_dispatch(
+        max_query_len=128,
+        is_paged=False,
+        has_cache_kv=False,
+        num_splits=0,
+    )
+    assert route.layout == "dense"
+    assert route.mode == "prefill"
+    assert not route.split_kv
+
+
+def test_metadata_dispatch_paged_decode():
+    route = fa3_tle_metadata_dispatch(
+        max_query_len=1,
+        is_paged=True,
+        has_cache_kv=True,
+        num_splits=0,
+    )
+    assert route.layout == "paged"
+    assert route.mode == "direct_decode"
+    assert not route.split_kv
+
+
+def test_metadata_dispatch_multi_token_decode_splitkv():
+    route = fa3_tle_metadata_dispatch(
+        max_query_len=4,
+        is_paged=True,
+        has_cache_kv=True,
+        num_splits=4,
+        has_scheduler_metadata=True,
+    )
+    assert route.layout == "paged"
+    assert route.mode == "splitkv_decode"
+    assert route.split_kv
+    assert route.requested_num_splits == 4
+    assert route.has_scheduler_metadata
+    assert route.metadata_source == "none"
+
+
+def test_metadata_dispatch_splitkv_requires_more_than_one_split():
+    one_split = fa3_tle_metadata_dispatch(
+        max_query_len=1,
+        is_paged=True,
+        has_cache_kv=True,
+        num_splits=1,
+    )
+    many_splits = fa3_tle_metadata_dispatch(
+        max_query_len=1,
+        is_paged=True,
+        has_cache_kv=True,
+        num_splits=2,
+    )
+    assert not one_split.split_kv
+    assert many_splits.split_kv

--- a/tests/test_fa3_paged_gather_smoke.py
+++ b/tests/test_fa3_paged_gather_smoke.py
@@ -1,0 +1,129 @@
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.runtime.backend._nvidia.hopper.ops.fa3_ws.planning import (
+    fa3_tle_metadata_dispatch,
+)
+
+from .hopper_fa3_utils import (
+    Shape,
+    build_reference,
+    is_fa3_supported,
+    make_varlen,
+    max_mean_abs,
+    output_tensor,
+    run_flag_gems,
+    tolerances,
+)
+
+
+def _skip_unless_hopper_fa3(pytestconfig) -> None:
+    if pytestconfig.getoption("flash_attn_varlen_fa_version") != 3:
+        pytest.skip("Hopper FA3 smoke only runs with fa_version=3.")
+    if not is_fa3_supported():
+        pytest.skip("requires CUDA Hopper with TLE FA3 support.")
+
+
+_PAGED_SMOKE_SHAPES = [
+    Shape(
+        "paged_decode_q1_flashdecoding",
+        [(1, 128), (1, 192), (1, 256)],
+        8,
+        2,
+        128,
+        True,
+        paged=True,
+        block_size=16,
+    ),
+    Shape(
+        "paged_decodeish_q16_longk_flashdecoding",
+        [(16, 1024)] + [(1, 512)] * 15,
+        8,
+        2,
+        128,
+        True,
+        paged=True,
+        block_size=16,
+    ),
+    Shape(
+        "paged_short_blockwise",
+        [(64, 64), (32, 96), (1, 128)],
+        8,
+        2,
+        128,
+        True,
+        paged=True,
+        block_size=16,
+    ),
+    Shape(
+        "paged_benchmark_mixed_short",
+        [(1, 1328), (5, 18), (129, 463)],
+        8,
+        2,
+        128,
+        True,
+        paged=True,
+        block_size=32,
+    ),
+]
+
+
+@pytest.mark.hopper_fa3
+@pytest.mark.flash_attn_varlen_func
+@pytest.mark.parametrize(
+    "max_q,is_paged,has_cache_kv,num_splits,expected_mode,expected_split",
+    [
+        (4, True, True, 4, "splitkv_decode", True),
+        (16, True, True, 1, "multi_token_decode", False),
+        (64, True, True, 0, "multi_token_decode", False),
+        (129, True, False, 0, "prefill", False),
+    ],
+    ids=[
+        "q1-gqa-swapped-flashdecoding",
+        "q16-longk-flashdecoding",
+        "short-paged",
+        "benchmark-mixed-short",
+    ],
+)
+def test_fa3_paged_plan_smoke(
+    max_q,
+    is_paged,
+    has_cache_kv,
+    num_splits,
+    expected_mode,
+    expected_split,
+):
+    route = fa3_tle_metadata_dispatch(
+        max_query_len=max_q,
+        is_paged=is_paged,
+        has_cache_kv=has_cache_kv,
+        num_splits=num_splits,
+        has_scheduler_metadata=num_splits > 0,
+    )
+    assert route.mode == expected_mode
+    assert route.layout == "paged"
+    assert route.split_kv == expected_split
+
+
+@pytest.mark.hopper_fa3
+@pytest.mark.flash_attn_varlen_func
+@pytest.mark.parametrize("paged_gather", ["auto", "blockwise", "legacy"])
+@pytest.mark.parametrize("shape", _PAGED_SMOKE_SHAPES, ids=lambda shape: shape.name)
+@torch.inference_mode()
+def test_fa3_paged_gather_correctness_smoke(
+    monkeypatch, pytestconfig, paged_gather, shape
+):
+    _skip_unless_hopper_fa3(pytestconfig)
+    monkeypatch.setenv("FLAG_GEMS_FA3_TLE_PAGED_GATHER", paged_gather)
+
+    tensors = make_varlen(shape, torch.float16, flag_gems.device, seed=2041)
+    ref, ref_kind = build_reference(tensors, shape, fa_version=3)
+    out = output_tensor(run_flag_gems(tensors, shape, fa_version=3))
+    atol, rtol = tolerances(torch.float16, tensors.max_seqlen_k, ref_kind)
+    max_abs, mean_abs = max_mean_abs(out, ref)
+    msg = (
+        f"shape={shape.name}, paged_gather={paged_gather}, ref={ref_kind}, "
+        f"max_abs={max_abs:.3e}, mean_abs={mean_abs:.3e}"
+    )
+    torch.testing.assert_close(out.float(), ref.float(), atol=atol, rtol=rtol, msg=msg)

--- a/tests/test_fa3_ws_variants.py
+++ b/tests/test_fa3_ws_variants.py
@@ -1,0 +1,143 @@
+import os
+
+import pytest
+import torch
+
+import flag_gems
+from flag_gems.runtime.backend._nvidia.hopper.ops.fa3_ws.registry import (
+    get_variant,
+    variant_names,
+)
+
+from .hopper_fa3_utils import (
+    Shape,
+    build_reference,
+    is_fa3_supported,
+    make_varlen,
+    max_mean_abs,
+    output_tensor,
+    run_flag_gems,
+    tolerances,
+)
+
+
+def _shape_for_variant(name: str) -> Shape:
+    spec = get_variant(name)
+    if spec.shape_kind == "paged_decode":
+        if spec.persistent:
+            return Shape(
+                f"{name}_paged_decode",
+                [(1, 128)],
+                4,
+                4,
+                128,
+                True,
+                paged=True,
+                block_size=16,
+            )
+        return Shape(
+            f"{name}_paged_decode",
+            [(1, 128)],
+            4,
+            4,
+            128,
+            True,
+            paged=True,
+            block_size=16,
+        )
+    if spec.shape_kind == "small":
+        return Shape(
+            f"{name}_small",
+            [(64, 64), (32, 96), (1, 128)],
+            8,
+            2,
+            128,
+            True,
+        )
+    if spec.persistent:
+        return Shape(f"{name}_decode", [(1, 512)], 4, 4, 128, True)
+    return Shape(f"{name}_decode", [(1, 1024)] * 4, 8, 2, 128, True)
+
+
+def _install_variant_kernel(spec) -> None:
+    from flag_gems.runtime.backend._nvidia.hopper.ops import flash_api_v3
+
+    if spec.kernel_module == "fa_hopper_persistent_pingpong":
+        from flag_gems.runtime.backend._nvidia.hopper.ops.fa3_ws import (
+            fa_hopper_persistent_pingpong,
+        )
+
+        flash_api_v3.flash_varlen_fwd_v3_tle_kernel = (
+            fa_hopper_persistent_pingpong.flash_varlen_fwd_v3_tle_kernel
+        )
+        flash_api_v3.flash_varlen_fwd_v3_tle_ws_simple_kernel = (
+            fa_hopper_persistent_pingpong.flash_varlen_fwd_v3_tle_ws_simple_kernel
+        )
+        return
+    if spec.kernel_module == "fa_hopper_nonpersistent_tlx_style":
+        from flag_gems.runtime.backend._nvidia.hopper.ops.fa3_ws import (
+            fa_hopper_nonpersistent_tlx_style,
+        )
+
+        flash_api_v3.flash_varlen_fwd_v3_tle_ws_short_kernel = (
+            fa_hopper_nonpersistent_tlx_style.flash_varlen_fwd_v3_tle_ws_short_kernel
+        )
+        return
+    raise AssertionError(f"unknown kernel module {spec.kernel_module}")
+
+
+@pytest.mark.hopper_fa3
+@pytest.mark.flash_attn_varlen_func
+@pytest.mark.parametrize("variant_name", variant_names())
+@torch.inference_mode()
+def test_fa3_ws_variant_smoke(monkeypatch, pytestconfig, variant_name):
+    if pytestconfig.getoption("flash_attn_varlen_fa_version") != 3:
+        pytest.skip("Hopper FA3 coverage only runs with fa_version=3.")
+    if not is_fa3_supported():
+        pytest.skip("requires CUDA Hopper with TLE FA3 support.")
+
+    spec = get_variant(variant_name)
+    _install_variant_kernel(spec)
+    monkeypatch.setenv("FLAG_GEMS_FA3_TLE_FORCE_PATH", spec.force_path)
+    if spec.paged:
+        monkeypatch.setenv("FLAG_GEMS_FA3_TLE_ALLOW_RISKY_PAGED_D128", "1")
+        monkeypatch.setenv("FLAG_GEMS_FA3_TLE_ALLOW_RISKY_PAGED_SMALL", "1")
+
+    shape = _shape_for_variant(variant_name)
+    tensors = make_varlen(shape, torch.float16, flag_gems.device, seed=2030)
+    ref, ref_kind = build_reference(tensors, shape, fa_version=3)
+    out = output_tensor(run_flag_gems(tensors, shape, fa_version=3))
+    atol, rtol = tolerances(torch.float16, tensors.max_seqlen_k, ref_kind)
+    max_abs, mean_abs = max_mean_abs(out, ref)
+    torch.testing.assert_close(
+        out.float(),
+        ref.float(),
+        atol=atol,
+        rtol=rtol,
+        msg=(
+            f"variant={variant_name}, ref={ref_kind}, "
+            f"max_abs={max_abs:.3e}, mean_abs={mean_abs:.3e}"
+        ),
+    )
+
+
+def test_fa3_ws_registry_named_barrier_contract():
+    # The TLE named-barrier API keeps arrive_count as the PTX total participant
+    # thread count.  Two consumer warp groups therefore still use 256, not 512.
+    source = os.path.join(
+        os.path.dirname(__file__),
+        "..",
+        "src",
+        "flag_gems",
+        "runtime",
+        "backend",
+        "_nvidia",
+        "hopper",
+        "ops",
+        "flash_kernel_v3.py",
+    )
+    with open(source, encoding="utf-8") as f:
+        text = f.read()
+    assert "THREADS_IN_MMA_GROUPS: tl.constexpr = NUM_MMA_WARPS * 32" in text
+    assert "arrive_count=THREADS_IN_MMA_GROUPS" in text
+    assert "arrive_count=THREADS_IN_MMA_GROUPS * 2" not in text

--- a/tests/test_flash_attn_varlen_func.py
+++ b/tests/test_flash_attn_varlen_func.py
@@ -6,9 +6,339 @@ import torch
 import flag_gems
 
 from . import accuracy_utils as utils
+from .hopper_fa3_utils import (
+    Shape as HopperFA3Shape,
+    accuracy_shapes as hopper_fa3_accuracy_shapes,
+    build_reference as build_hopper_fa3_reference,
+    dispatch_source as hopper_fa3_dispatch_source,
+    dispatches_to_hopper as dispatches_to_hopper_fa3,
+    is_fa3_supported as is_hopper_fa3_supported,
+    make_varlen as make_hopper_fa3_varlen,
+    max_mean_abs as hopper_fa3_max_mean_abs,
+    output_tensor as hopper_fa3_output_tensor,
+    run_flag_gems as run_hopper_fa3,
+    tolerances as hopper_fa3_tolerances,
+)
 
 device = flag_gems.device
 vendor_name = flag_gems.vendor_name
+
+
+def _selected_fa_version(pytestconfig) -> int:
+    return pytestconfig.getoption("flash_attn_varlen_fa_version")
+
+
+def _skip_unless_hopper_fa3(pytestconfig) -> None:
+    if _selected_fa_version(pytestconfig) != 3:
+        pytest.skip("Hopper FA3 coverage only runs with fa_version=3.")
+    if not is_hopper_fa3_supported():
+        pytest.skip("requires CUDA Hopper with Triton FA3 support.")
+
+
+def _skip_unless_selected_fa_supported(pytestconfig) -> None:
+    fa_version = _selected_fa_version(pytestconfig)
+    if fa_version == 3 and not is_hopper_fa3_supported():
+        pytest.skip("FA3 requires CUDA Hopper with Triton FA3 support.")
+
+
+def _skip_unsupported_fa3_legacy_paged_case(
+    pytestconfig,
+    *,
+    optimize_init: bool = False,
+) -> None:
+    if _selected_fa_version(pytestconfig) != 3:
+        return
+    _skip_unless_selected_fa_supported(pytestconfig)
+    if optimize_init:
+        pytest.skip("FA3 opt-init path is not implemented for this test.")
+
+
+def _is_fa3_supported() -> bool:
+    try:
+        from flag_gems.runtime.backend._nvidia.hopper.ops.flash_api_v3 import (
+            is_fa3_supported,
+        )
+
+        return is_fa3_supported()
+    except Exception:
+        if flag_gems.device != "cuda" or not torch.cuda.is_available():
+            return False
+        return torch.cuda.get_device_capability()[0] >= 9
+
+
+def _run_flash_attn_varlen_func(
+    q,
+    k,
+    v,
+    cu_seqlens_q,
+    seqused_k,
+    max_seqlen_q,
+    max_seqlen_k,
+    softmax_scale,
+    causal,
+    window_size,
+    block_table,
+    softcap,
+    alibi_slopes=None,
+    optimize_init=False,
+    fa_version=2,
+):
+    if fa_version == 3:
+        if optimize_init:
+            pytest.skip("FA3 opt-init path is not implemented for this test.")
+        if not _is_fa3_supported():
+            pytest.skip("FA3 requires CUDA Hopper with Triton FA3 support.")
+        op = flag_gems.flash_attn_varlen_func
+    elif vendor_name == "cambricon":
+        op = flag_gems.flash_attn_varlen_func
+    elif optimize_init:
+        op = flag_gems.ops.flash_attn_varlen_opt_func
+    else:
+        op = flag_gems.ops.flash_attn_varlen_func
+
+    return op(
+        q=q,
+        k=k,
+        v=v,
+        cu_seqlens_q=cu_seqlens_q,
+        seqused_k=seqused_k,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_k=max_seqlen_k,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        window_size=window_size,
+        block_table=block_table,
+        softcap=softcap,
+        alibi_slopes=alibi_slopes,
+        fa_version=fa_version,
+    )
+
+
+@pytest.mark.hopper_fa3
+@pytest.mark.flash_attn_varlen_func
+def test_flash_attn_varlen_func_hopper_fa3_dispatch(pytestconfig):
+    _skip_unless_hopper_fa3(pytestconfig)
+    assert dispatches_to_hopper_fa3(), (
+        "flag_gems.flash_attn_varlen_func is not routed to the Hopper backend; "
+        f"source={hopper_fa3_dispatch_source()}"
+    )
+
+
+@pytest.mark.hopper_fa3
+@pytest.mark.flash_attn_varlen_func
+@pytest.mark.parametrize(
+    "shape", hopper_fa3_accuracy_shapes(), ids=lambda shape: shape.name
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@torch.inference_mode()
+def test_flash_attn_varlen_func_hopper_fa3_accuracy(pytestconfig, shape, dtype):
+    _skip_unless_selected_fa_supported(pytestconfig)
+    fa_version = _selected_fa_version(pytestconfig)
+    tensors = make_hopper_fa3_varlen(shape, dtype, flag_gems.device, seed=2026)
+    ref, ref_kind = build_hopper_fa3_reference(
+        tensors, shape, fa_version=fa_version
+    )
+    out = hopper_fa3_output_tensor(
+        run_hopper_fa3(tensors, shape, fa_version=fa_version)
+    )
+    atol, rtol = hopper_fa3_tolerances(dtype, tensors.max_seqlen_k, ref_kind)
+
+    max_abs, mean_abs = hopper_fa3_max_mean_abs(out, ref)
+    msg = (
+        f"shape={shape.name}, dtype={dtype}, fa_version={fa_version}, ref={ref_kind}, "
+        f"max_abs={max_abs:.3e}, mean_abs={mean_abs:.3e}"
+    )
+    torch.testing.assert_close(out.float(), ref.float(), atol=atol, rtol=rtol, msg=msg)
+
+
+@pytest.mark.hopper_fa3
+@pytest.mark.flash_attn_varlen_func
+@pytest.mark.parametrize(
+    "force_path,shape",
+    [
+        ("long", hopper_fa3_accuracy_shapes()[0]),
+        ("short", hopper_fa3_accuracy_shapes()[2]),
+        ("decode", hopper_fa3_accuracy_shapes()[2]),
+        ("splitkv", hopper_fa3_accuracy_shapes()[2]),
+        ("splitkv", hopper_fa3_accuracy_shapes()[3]),
+        ("paged_decode", hopper_fa3_accuracy_shapes()[3]),
+        (
+            "direct",
+            HopperFA3Shape(
+                "force_direct_dense_small",
+                [(64, 64), (32, 96), (1, 128)],
+                8,
+                2,
+                128,
+                True,
+            ),
+        ),
+        (
+            "auto",
+            HopperFA3Shape(
+                "auto_paged_small",
+                [(32, 128), (64, 512), (1, 256)],
+                8,
+                2,
+                128,
+                True,
+                paged=True,
+                block_size=16,
+            ),
+        ),
+        (
+            "auto",
+            HopperFA3Shape(
+                "auto_paged_medium",
+                [(512, 512)],
+                8,
+                2,
+                128,
+                True,
+                paged=True,
+                block_size=16,
+            ),
+        ),
+        (
+            "mixed",
+            HopperFA3Shape(
+                "force_mixed_dense_serve",
+                [(128, 128), (1, 256), (1, 320), (1, 384)],
+                8,
+                2,
+                128,
+                True,
+            ),
+        ),
+        (
+            "serve",
+            HopperFA3Shape(
+                "force_serve_dense",
+                [(128, 128), (1, 256), (1, 320), (1, 384)],
+                8,
+                2,
+                128,
+                True,
+            ),
+        ),
+        (
+            "mixed",
+            HopperFA3Shape(
+                "force_mixed_paged_serve",
+                [(128, 128), (1, 256), (1, 320), (1, 384)],
+                8,
+                2,
+                128,
+                True,
+                paged=True,
+                block_size=16,
+            ),
+        ),
+        (
+            "paged_serve",
+            HopperFA3Shape(
+                "force_paged_serve",
+                [(128, 128), (1, 256), (1, 320), (1, 384)],
+                8,
+                2,
+                128,
+                True,
+                paged=True,
+                block_size=16,
+            ),
+        ),
+    ],
+    ids=lambda item: item if isinstance(item, str) else item.name,
+)
+@torch.inference_mode()
+def test_flash_attn_varlen_func_hopper_fa3_force_paths(
+    monkeypatch, pytestconfig, force_path, shape
+):
+    _skip_unless_hopper_fa3(pytestconfig)
+    monkeypatch.setenv("FLAG_GEMS_FA3_TLE_FORCE_PATH", force_path)
+    tensors = make_hopper_fa3_varlen(shape, torch.float16, flag_gems.device, seed=2027)
+    ref, ref_kind = build_hopper_fa3_reference(tensors, shape, fa_version=3)
+    out = hopper_fa3_output_tensor(run_hopper_fa3(tensors, shape, fa_version=3))
+    atol, rtol = hopper_fa3_tolerances(torch.float16, tensors.max_seqlen_k, ref_kind)
+    max_abs, mean_abs = hopper_fa3_max_mean_abs(out, ref)
+    msg = (
+        f"force_path={force_path}, shape={shape.name}, ref={ref_kind}, "
+        f"max_abs={max_abs:.3e}, mean_abs={mean_abs:.3e}"
+    )
+    torch.testing.assert_close(out.float(), ref.float(), atol=atol, rtol=rtol, msg=msg)
+
+
+@pytest.mark.hopper_fa3
+@pytest.mark.flash_attn_varlen_func
+@pytest.mark.parametrize(
+    "decode_strategy,shape",
+    [
+        ("onepass", hopper_fa3_accuracy_shapes()[2]),
+        ("short", hopper_fa3_accuracy_shapes()[2]),
+        ("splitkv", hopper_fa3_accuracy_shapes()[3]),
+        ("flashdecoding", hopper_fa3_accuracy_shapes()[3]),
+    ],
+    ids=lambda item: item if isinstance(item, str) else item.name,
+)
+@torch.inference_mode()
+def test_flash_attn_varlen_func_hopper_fa3_decode_strategies(
+    monkeypatch, pytestconfig, decode_strategy, shape
+):
+    _skip_unless_hopper_fa3(pytestconfig)
+    monkeypatch.setenv("FLAG_GEMS_FA3_TLE_FORCE_PATH", "auto")
+    monkeypatch.setenv("FLAG_GEMS_FA3_TLE_DECODE_STRATEGY", decode_strategy)
+    tensors = make_hopper_fa3_varlen(shape, torch.float16, flag_gems.device, seed=2028)
+    ref, ref_kind = build_hopper_fa3_reference(tensors, shape, fa_version=3)
+    out = hopper_fa3_output_tensor(run_hopper_fa3(tensors, shape, fa_version=3))
+    atol, rtol = hopper_fa3_tolerances(torch.float16, tensors.max_seqlen_k, ref_kind)
+    max_abs, mean_abs = hopper_fa3_max_mean_abs(out, ref)
+    msg = (
+        f"decode_strategy={decode_strategy}, shape={shape.name}, ref={ref_kind}, "
+        f"max_abs={max_abs:.3e}, mean_abs={mean_abs:.3e}"
+    )
+    torch.testing.assert_close(out.float(), ref.float(), atol=atol, rtol=rtol, msg=msg)
+
+
+@pytest.mark.hopper_fa3
+@pytest.mark.flash_attn_varlen_func
+@pytest.mark.parametrize("small_strategy", ["direct", "short"])
+@torch.inference_mode()
+def test_flash_attn_varlen_func_hopper_fa3_small_strategies(
+    monkeypatch, pytestconfig, small_strategy
+):
+    _skip_unless_hopper_fa3(pytestconfig)
+    monkeypatch.setenv("FLAG_GEMS_FA3_TLE_FORCE_PATH", "auto")
+    monkeypatch.setenv("FLAG_GEMS_FA3_TLE_SMALL_STRATEGY", small_strategy)
+    shape = HopperFA3Shape(
+        f"small_strategy_{small_strategy}",
+        [(64, 64), (32, 96), (1, 128)],
+        8,
+        2,
+        128,
+        True,
+    )
+    tensors = make_hopper_fa3_varlen(shape, torch.float16, flag_gems.device, seed=2029)
+    ref, ref_kind = build_hopper_fa3_reference(tensors, shape, fa_version=3)
+    out = hopper_fa3_output_tensor(run_hopper_fa3(tensors, shape, fa_version=3))
+    atol, rtol = hopper_fa3_tolerances(torch.float16, tensors.max_seqlen_k, ref_kind)
+    max_abs, mean_abs = hopper_fa3_max_mean_abs(out, ref)
+    msg = (
+        f"small_strategy={small_strategy}, ref={ref_kind}, "
+        f"max_abs={max_abs:.3e}, mean_abs={mean_abs:.3e}"
+    )
+    torch.testing.assert_close(out.float(), ref.float(), atol=atol, rtol=rtol, msg=msg)
+
+
+@pytest.mark.hopper_fa3
+@pytest.mark.flash_attn_varlen_func
+@torch.inference_mode()
+def test_flash_attn_varlen_func_hopper_fa3_mixed_dtype_unsupported(pytestconfig):
+    _skip_unless_hopper_fa3(pytestconfig)
+    shape = hopper_fa3_accuracy_shapes()[0]
+    tensors = make_hopper_fa3_varlen(shape, torch.float16, flag_gems.device, seed=2026)
+    tensors.k = tensors.k.to(torch.bfloat16)
+    with pytest.raises(RuntimeError, match="same dtype"):
+        run_hopper_fa3(tensors, shape, fa_version=3)
 
 
 # Following varlen and paged attn tests are copied from
@@ -93,6 +423,7 @@ def ref_paged_attn(
     return torch.cat(outputs, dim=0)
 
 
+@pytest.mark.hopper_fa3
 @pytest.mark.flash_attn_varlen_func
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="Issue #2815: Not supported")
 @pytest.mark.skipif(vendor_name == "hygon", reason="Issue #2816: Not working")
@@ -109,6 +440,7 @@ def ref_paged_attn(
 @torch.inference_mode()
 def test_flash_attn_varlen_func(
     monkeypatch,
+    pytestconfig,
     seq_lens: List[Tuple[int, int]],
     num_heads: Tuple[int, int],
     head_size: int,
@@ -122,10 +454,14 @@ def test_flash_attn_varlen_func(
 ) -> None:
     if vendor_name == "mthreads":
         monkeypatch.setenv("MUSA_ENABLE_SQMMA", "1")
+    fa_version = _selected_fa_version(pytestconfig)
+    _skip_unsupported_fa3_legacy_paged_case(
+        pytestconfig, optimize_init=optimize_init
+    )
 
     # (Issue) numerical stability concern
     if alibi is True and soft_cap is not None:
-        return
+        pytest.skip("ALiBi + softcap reference is disabled for this test.")
 
     with torch.device(flag_gems.device):
         utils.init_seed(1234567890)
@@ -181,58 +517,23 @@ def test_flash_attn_varlen_func(
         else:
             alibi_slopes, attn_bias = None, None
 
-        if vendor_name == "cambricon":
-            output = flag_gems.flash_attn_varlen_func(
-                q=query,
-                k=key_cache,
-                v=value_cache,
-                cu_seqlens_q=cu_query_lens,
-                seqused_k=seqused_k,
-                max_seqlen_q=max_query_len,
-                max_seqlen_k=max_kv_len,
-                softmax_scale=scale,
-                causal=causal,
-                window_size=window_size,
-                block_table=block_tables,
-                softcap=soft_cap if soft_cap is not None else 0,
-                alibi_slopes=alibi_slopes,
-                fa_version=2,
-            )
-        else:
-            if optimize_init:
-                output = flag_gems.ops.flash_attn_varlen_opt_func(
-                    q=query,
-                    k=key_cache,
-                    v=value_cache,
-                    cu_seqlens_q=cu_query_lens,
-                    seqused_k=seqused_k,
-                    max_seqlen_q=max_query_len,
-                    max_seqlen_k=max_kv_len,
-                    softmax_scale=scale,
-                    causal=causal,
-                    window_size=window_size,
-                    block_table=block_tables,
-                    softcap=soft_cap if soft_cap is not None else 0,
-                    alibi_slopes=alibi_slopes,
-                    fa_version=2,
-                )
-            else:
-                output = flag_gems.ops.flash_attn_varlen_func(
-                    q=query,
-                    k=key_cache,
-                    v=value_cache,
-                    cu_seqlens_q=cu_query_lens,
-                    seqused_k=seqused_k,
-                    max_seqlen_q=max_query_len,
-                    max_seqlen_k=max_kv_len,
-                    softmax_scale=scale,
-                    causal=causal,
-                    window_size=window_size,
-                    block_table=block_tables,
-                    softcap=soft_cap if soft_cap is not None else 0,
-                    alibi_slopes=alibi_slopes,
-                    fa_version=2,
-                )
+        output = _run_flash_attn_varlen_func(
+            q=query,
+            k=key_cache,
+            v=value_cache,
+            cu_seqlens_q=cu_query_lens,
+            seqused_k=seqused_k,
+            max_seqlen_q=max_query_len,
+            max_seqlen_k=max_kv_len,
+            softmax_scale=scale,
+            causal=causal,
+            window_size=window_size,
+            block_table=block_tables,
+            softcap=soft_cap if soft_cap is not None else 0,
+            alibi_slopes=alibi_slopes,
+            optimize_init=optimize_init,
+            fa_version=fa_version,
+        )
 
         ref_output = ref_paged_attn(
             query=query,
@@ -253,6 +554,7 @@ def test_flash_attn_varlen_func(
 
 @pytest.mark.skipif(vendor_name == "kunlunxin", reason="Issue #2815: Not working")
 @pytest.mark.skipif(vendor_name == "hygon", reason="Issue #2816: Not working")
+@pytest.mark.hopper_fa3
 @pytest.mark.flash_attn_varlen_func
 @pytest.mark.parametrize("seq_lens", [[(1, 1328), (1, 18), (1, 463)]])
 @pytest.mark.parametrize("num_heads", [(8, 2)])
@@ -265,6 +567,7 @@ def test_flash_attn_varlen_func(
 @torch.inference_mode()
 def test_flash_attn_varlen_func_swap_qg(
     monkeypatch,
+    pytestconfig,
     seq_lens: List[Tuple[int, int]],
     num_heads: Tuple[int, int],
     head_size: int,
@@ -276,7 +579,8 @@ def test_flash_attn_varlen_func_swap_qg(
 ) -> None:
     if vendor_name == "mthreads":
         monkeypatch.setenv("MUSA_ENABLE_SQMMA", "1")
-
+    fa_version = _selected_fa_version(pytestconfig)
+    _skip_unsupported_fa3_legacy_paged_case(pytestconfig)
     with torch.device(flag_gems.device):
         utils.init_seed(1234567890)
         num_seqs = len(seq_lens)
@@ -310,38 +614,21 @@ def test_flash_attn_varlen_func_swap_qg(
             device=device,
         )
 
-        if vendor_name == "cambricon":
-            output = flag_gems.flash_attn_varlen_func(
-                q=query,
-                k=key_cache,
-                v=value_cache,
-                cu_seqlens_q=cu_query_lens,
-                seqused_k=seqused_k,
-                max_seqlen_q=max_query_len,
-                max_seqlen_k=max_kv_len,
-                softmax_scale=scale,
-                causal=True,
-                window_size=window_size,
-                block_table=block_tables,
-                softcap=soft_cap if soft_cap is not None else 0,
-                fa_version=2,
-            )
-        else:
-            output = flag_gems.ops.flash_attn_varlen_func(
-                q=query,
-                k=key_cache,
-                v=value_cache,
-                cu_seqlens_q=cu_query_lens,
-                seqused_k=seqused_k,
-                max_seqlen_q=max_query_len,
-                max_seqlen_k=max_kv_len,
-                softmax_scale=scale,
-                causal=True,
-                window_size=window_size,
-                block_table=block_tables,
-                softcap=soft_cap if soft_cap is not None else 0,
-                fa_version=2,
-            )
+        output = _run_flash_attn_varlen_func(
+            q=query,
+            k=key_cache,
+            v=value_cache,
+            cu_seqlens_q=cu_query_lens,
+            seqused_k=seqused_k,
+            max_seqlen_q=max_query_len,
+            max_seqlen_k=max_kv_len,
+            softmax_scale=scale,
+            causal=True,
+            window_size=window_size,
+            block_table=block_tables,
+            softcap=soft_cap if soft_cap is not None else 0,
+            fa_version=fa_version,
+        )
 
         ref_output = ref_paged_attn(
             query=query,


### PR DESCRIPTION
related to FlagTree PR: https://github.com/flagos-ai/FlagTree/pull/707

# How to run
``` sh
python -m pytest benchmark/test_flash_attn_varlen_func.py -q \
  --flash-attn-varlen-fa-version=2 \
  --record json \
  --output hopper_fa2_benchmark_tle.json

python -m pytest benchmark/test_flash_attn_varlen_func.py -q \
  --flash-attn-varlen-fa-version=3 \
  --record json \
  --output hopper_fa3_benchmark_tle2.json
  
# 默认: --flash-attn-varlen-case=all
#   跑 qwenCase + prefillDecodePageCase

# 只跑旧测试集:
#   --flash-attn-varlen-case=qwenCase

# 只跑新增测试集:
#   --flash-attn-varlen-case=prefillDecodePageCase

# --flash-attn-varlen-fa-version=2
#   跑 FA2，覆盖 qwenCase + prefillDecodePageCase

# --flash-attn-varlen-fa-version=3
#   跑 Hopper FA3，覆盖 qwenCase + prefillDecodePageCase，并检查 Hopper backend

# --flash-attn-varlen-enable-vllm
#   额外启用 vLLM baseline，覆盖当前选择的 case
```
