### PR TITLE
Disable flagtree for sunrise (requires GLIBC_2.39)

### DIFF
--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -157,7 +157,7 @@ backends:
   sunrise:
     python: "3.10"
     triton: triton==3.4.0.6+gite4f6d6e4
-    flagtree: flagtree==0.4.0+sunrise3.4
+    # flagtree==0.4.0+sunrise3.4 — requires GLIBC_2.39, unavailable on current system
     deps:
       - torch==2.11.0+cpu
       - torchaudio==2.11.0+cpu


### PR DESCRIPTION
flagtree==0.4.0+sunrise3.4 requires GLIBC_2.39 which is unavailable on the current sunrise system. Comment it out in backends.yaml so that setup.sh defaults to triton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)