### PR TITLE
Auto-generate version from git tags using setuptools-scm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,7 @@ name: release-build-wheels
 on:
   push:
     tags:
-      - 'v*'
+      - 'v[0-9]+.[0-9]+.[0-9]+'
 
 permissions:
   contents: read
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
 
       - name: Pull manylinux2_28 image
         run: docker pull quay.io/pypa/manylinux_2_28_x86_64
@@ -76,6 +78,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+        with:
+          fetch-depth: 0
 
       - name: Download built wheel
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ dist/
 .skbuild-info.json
 CMakeInit.txt
 
+# Auto-generated version file (setuptools-scm)
+src/flag_gems/_version.py
+
 # An auxiliary product of unittests
 /*.json
 tests/*.json

--- a/docs/content/en/release/_index.md
+++ b/docs/content/en/release/_index.md
@@ -1,0 +1,13 @@
+---
+title: Release
+weight: 70
+bookCollapseSection: true
+---
+
+# Release
+
+This section covers FlagGems versioning, packaging, and release procedures.
+
+- [Versioning](versioning/) — how version numbers are generated and the tag workflow
+- [Packaging](packaging/) — how to build source and binary distributions
+- [Changelog](../references/changelog/) — release history and changes

--- a/docs/content/en/release/packaging.md
+++ b/docs/content/en/release/packaging.md
@@ -1,6 +1,6 @@
 ---
-title: Packaging and Release
-weight: 50
+title: Packaging
+weight: 20
 ---
 
 # Packaging

--- a/docs/content/en/release/versioning.md
+++ b/docs/content/en/release/versioning.md
@@ -1,0 +1,108 @@
+---
+title: Versioning
+weight: 10
+---
+
+# Versioning
+
+FlagGems uses [setuptools-scm](https://github.com/pypa/setuptools-scm) to
+auto-generate version numbers from git tags following
+[PEP 440](https://peps.python.org/pep-0440/).
+
+## Version Format
+
+| Scenario | Example version |
+|----------|-----------------|
+| On a release tag `v5.4.0` | `5.4.0` |
+| N commits after dev tag `v5.4.0.dev0` | `5.4.0.devN+g<hash>` |
+| On a dev tag `v5.4.0.dev0` | `5.4.0.dev0` |
+
+**No version is hardcoded in any source file.** The version is derived entirely
+from git tags at build time.
+
+The `+g<hash>` suffix (local version label) is included in local and editable
+installs, allowing developers to `git checkout <hash>` for debugging. This
+suffix is automatically stripped when publishing to PyPI.
+
+## Tag Naming Rules
+
+| Tag pattern | Purpose | Triggers release CI? |
+|-------------|---------|---------------------|
+| `v5.4.0` | Stable release | ✅ Yes |
+| `v5.4.0.dev0` | Start of dev cycle | ❌ No |
+| `v5.4.0rc1` | Release candidate | ❌ No |
+| `v5.4.0.post1` | Post-release fix | ✅ Yes |
+
+## Development Cycle
+
+After each stable release, a dev tag is created to mark the start of the next
+version cycle:
+
+```
+v5.3.0          ← stable release
+  │
+  ├── commit 1  ← 5.4.0.dev1+gabcdef0
+  ├── commit 2  ← 5.4.0.dev2+g1234567
+  ├── ...
+  ├── commit N  ← 5.4.0.devN+g<hash>
+  │
+v5.4.0          ← next stable release
+  │
+v5.5.0.dev0     ← start of next dev cycle
+```
+
+## Release Process
+
+### Releasing a new version (e.g. v5.4.0)
+
+1. **Ensure all PRs for the release are merged into `master`.**
+
+2. **Tag the release:**
+   ```bash
+   git checkout master
+   git pull origin master
+   git tag v5.4.0
+   git push origin v5.4.0
+   ```
+
+3. **CI builds release artifacts automatically.**
+   The `release.yaml` workflow triggers on stable version tags
+   (`v<major>.<minor>.<patch>`) and builds the wheel, then publishes to PyPI.
+
+4. **Start the next dev cycle:**
+   ```bash
+   git tag v5.5.0.dev0
+   git push origin v5.5.0.dev0
+   ```
+   From this point, all commits on `master` produce versions like
+   `5.5.0.dev1+gabcdef0`.
+
+### Releasing a patch (e.g. v5.4.1)
+
+1. Create a release branch if needed:
+   ```bash
+   git checkout -b release/5.4 v5.4.0
+   ```
+2. Cherry-pick or merge fixes.
+3. Tag and push:
+   ```bash
+   git tag v5.4.1
+   git push origin v5.4.1
+   ```
+
+### Release candidates
+
+Tag as `v5.4.0rc1`, `v5.4.0rc2`, etc. These are PEP 440 pre-releases and
+will **not** trigger the release workflow (it only matches stable tags). To
+build RC wheels, trigger the workflow manually or adjust the tag filter
+temporarily.
+
+## Checking the Current Version
+
+```bash
+# From a git checkout (diagnostic, not required for install):
+python -m setuptools_scm
+
+# From an installed package:
+python -c "import flag_gems; print(flag_gems.__version__)"
+```

--- a/docs/content/zh-cn/release/_index.md
+++ b/docs/content/zh-cn/release/_index.md
@@ -1,0 +1,23 @@
+---
+title: 发布
+weight: 70
+bookCollapseSection: true
+---
+
+<!--
+# Release
+
+This section covers FlagGems versioning, packaging, and release procedures.
+-->
+# 发布
+
+本章节涵盖 FlagGems 版本管理、打包和发布流程。
+
+<!--
+- [Versioning](versioning/) — how version numbers are generated and the tag workflow
+- [Packaging](packaging/) — how to build source and binary distributions
+- [Changelog](../references/changelog/) — release history and changes
+-->
+- [版本管理](versioning/) — 版本号生成方式和标签工作流
+- [打包](packaging/) — 如何构建源码和二进制发行包
+- [变更历史](../references/changelog/) — 版本变更记录

--- a/docs/content/zh-cn/release/packaging.md
+++ b/docs/content/zh-cn/release/packaging.md
@@ -1,6 +1,6 @@
 ---
-title: 打包与发布
-weight: 50
+title: 打包
+weight: 20
 ---
 
 <!--

--- a/docs/content/zh-cn/release/versioning.md
+++ b/docs/content/zh-cn/release/versioning.md
@@ -1,0 +1,181 @@
+---
+title: 版本管理
+weight: 10
+---
+
+<!--
+# Versioning
+
+FlagGems uses [setuptools-scm](https://github.com/pypa/setuptools-scm) to
+auto-generate version numbers from git tags following
+[PEP 440](https://peps.python.org/pep-0440/).
+-->
+# 版本管理
+
+FlagGems 使用 [setuptools-scm](https://github.com/pypa/setuptools-scm)
+从 git 标签自动生成符合 [PEP 440](https://peps.python.org/pep-0440/) 规范的版本号。
+
+<!--
+## Version Format
+-->
+## 版本格式
+
+<!--
+| Scenario | Example version |
+|----------|-----------------|
+| On a release tag `v5.4.0` | `5.4.0` |
+| N commits after dev tag `v5.4.0.dev0` | `5.4.0.devN+g<hash>` |
+| On a dev tag `v5.4.0.dev0` | `5.4.0.dev0` |
+-->
+| 场景 | 版本号示例 |
+|------|-----------|
+| 位于发布标签 `v5.4.0` | `5.4.0` |
+| 在开发标签 `v5.4.0.dev0` 之后的第 N 次提交 | `5.4.0.devN+g<hash>` |
+| 位于开发标签 `v5.4.0.dev0` | `5.4.0.dev0` |
+
+<!--
+**No version is hardcoded in any source file.** The version is derived entirely
+from git tags at build time.
+
+The `+g<hash>` suffix (local version label) is included in local and editable
+installs, allowing developers to `git checkout <hash>` for debugging. This
+suffix is automatically stripped when publishing to PyPI.
+-->
+**源码中不硬编码任何版本号。** 版本号完全在构建时从 git 标签派生。
+
+`+g<hash>` 后缀（本地版本标签）会包含在本地安装和可编辑安装中，
+开发者可以通过 `git checkout <hash>` 定位到对应的提交进行调试。
+发布到 PyPI 时，该后缀会被自动去除。
+
+<!--
+## Tag Naming Rules
+-->
+## 标签命名规则
+
+<!--
+| Tag pattern | Purpose | Triggers release CI? |
+|-------------|---------|---------------------|
+| `v5.4.0` | Stable release | ✅ Yes |
+| `v5.4.0.dev0` | Start of dev cycle | ❌ No |
+| `v5.4.0rc1` | Release candidate | ❌ No |
+| `v5.4.0.post1` | Post-release fix | ✅ Yes |
+-->
+| 标签格式 | 用途 | 是否触发发布 CI？ |
+|----------|------|-------------------|
+| `v5.4.0` | 稳定版发布 | ✅ 是 |
+| `v5.4.0.dev0` | 开发周期开始 | ❌ 否 |
+| `v5.4.0rc1` | 候选版本 | ❌ 否 |
+| `v5.4.0.post1` | 修订版发布 | ✅ 是 |
+
+<!--
+## Development Cycle
+
+After each stable release, a dev tag is created to mark the start of the next
+version cycle:
+-->
+## 开发周期
+
+每次稳定版发布后，创建一个开发标签来标记下一个版本周期的开始：
+
+```
+v5.3.0          ← 稳定版发布
+  │
+  ├── commit 1  ← 5.4.0.dev1+gabcdef0
+  ├── commit 2  ← 5.4.0.dev2+g1234567
+  ├── ...
+  ├── commit N  ← 5.4.0.devN+g<hash>
+  │
+v5.4.0          ← 下一个稳定版发布
+  │
+v5.5.0.dev0     ← 新的开发周期开始
+```
+
+<!--
+## Release Process
+-->
+## 发布流程
+
+<!--
+### Releasing a new version (e.g. v5.4.0)
+
+1. **Ensure all PRs for the release are merged into `master`.**
+
+2. **Tag the release:**
+
+3. **CI builds release artifacts automatically.**
+   The `release.yaml` workflow triggers on stable version tags
+   (`v<major>.<minor>.<patch>`) and builds the wheel, then publishes to PyPI.
+
+4. **Start the next dev cycle:**
+   From this point, all commits on `master` produce versions like
+   `5.5.0.dev1+gabcdef0`.
+-->
+### 发布新版本（例如 v5.4.0）
+
+1. **确保该版本的所有 PR 已合并到 `master` 分支。**
+
+2. **打标签：**
+   ```bash
+   git checkout master
+   git pull origin master
+   git tag v5.4.0
+   git push origin v5.4.0
+   ```
+
+3. **CI 自动构建发布产物。**
+   `release.yaml` 工作流会在推送稳定版标签
+   （`v<major>.<minor>.<patch>`）时触发，自动构建 wheel 并发布到 PyPI。
+
+4. **启动下一个开发周期：**
+   ```bash
+   git tag v5.5.0.dev0
+   git push origin v5.5.0.dev0
+   ```
+   此后 `master` 上的所有提交将生成 `5.5.0.dev1+gabcdef0` 格式的版本号。
+
+<!--
+### Releasing a patch (e.g. v5.4.1)
+
+1. Create a release branch if needed.
+2. Cherry-pick or merge fixes.
+3. Tag and push.
+-->
+### 发布补丁版本（例如 v5.4.1）
+
+1. 如需要，创建发布分支：
+   ```bash
+   git checkout -b release/5.4 v5.4.0
+   ```
+2. Cherry-pick 或合并修复。
+3. 打标签并推送：
+   ```bash
+   git tag v5.4.1
+   git push origin v5.4.1
+   ```
+
+<!--
+### Release candidates
+
+Tag as `v5.4.0rc1`, `v5.4.0rc2`, etc. These are PEP 440 pre-releases and
+will **not** trigger the release workflow (it only matches stable tags). To
+build RC wheels, trigger the workflow manually or adjust the tag filter
+temporarily.
+-->
+### 候选版本
+
+使用 `v5.4.0rc1`、`v5.4.0rc2` 等格式打标签。这些属于 PEP 440
+预发布版本，**不会**触发发布工作流（仅匹配稳定版标签）。如需构建候选版本的
+wheel，可手动触发工作流或临时调整标签过滤规则。
+
+<!--
+## Checking the Current Version
+-->
+## 查看当前版本
+
+```bash
+# 从 git 检出目录查看（诊断用途，安装时不需要）：
+python -m setuptools_scm
+
+# 从已安装的包查看：
+python -c "import flag_gems; print(flag_gems.__version__)"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 # The cmake and ninja packages are not supposed to be listed in build-system.requires.
 # The version expectation is "cmake>=3.20,<4.0", "ninja==1.13.0".
 # They must be installed separately for `--no-build-isolation` to work.
-requires = ["setuptools>=64.0,<80.0", "scikit-build-core==0.12.2", "pybind11==3.0.3"]
+requires = ["setuptools>=64.0,<80.0", "scikit-build-core==0.12.2", "pybind11==3.0.3", "setuptools-scm>=8"]
 
 build-backend = "scikit_build_core.build"
 
@@ -10,7 +10,7 @@ build-backend = "scikit_build_core.build"
 
 name = "flag_gems"
 
-version = "5.4.0dev"
+dynamic = ["version"]
 
 description = "FlagGems is a function library written in Triton language."
 
@@ -219,6 +219,11 @@ build.verbose = true
 logging.level = "INFO"
 wheel.install-dir = "flag_gems"
 build-dir = "build/{cache_tag}"
+metadata.version.provider = "scikit_build_core.metadata.setuptools_scm"
+
+[tool.setuptools_scm]
+write_to = "src/flag_gems/_version.py"
+version_scheme = "no-guess-dev"
 
 [tool.uv]
 

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -19,7 +19,10 @@ from flag_gems.runtime import flagtune
 from flag_gems.runtime.backend import SpecOpRegistrar
 from flag_gems.runtime.op_registrar import GeneralOpRegistrar
 
-__version__ = "5.4.0dev"
+try:
+    from flag_gems._version import version as __version__
+except ImportError:
+    __version__ = "unknown"
 device = runtime.device.name
 vendor_name = runtime.device.vendor_name
 backend_info = runtime.device


### PR DESCRIPTION
## Summary

Replace hardcoded version `5.4.0dev` with automatic version generation from git tags using `setuptools-scm`.

## Changes

- **pyproject.toml**: Add `setuptools-scm>=8` to build deps, replace static `version` with `dynamic = ["version"]`, configure scikit-build-core metadata provider
- **src/flag_gems/__init__.py**: Import `__version__` from auto-generated `_version.py` instead of hardcoding
- **.gitignore**: Add `src/flag_gems/_version.py` (auto-generated at build time)
- **.github/workflows/release.yaml**: Restrict tag filter to stable releases only (`v[0-9]+.[0-9]+.[0-9]+`), add `fetch-depth: 0` for git history
- **docs/**: Create `release/` section (en + zh-cn) with versioning guide and packaging docs (moved from `references/release.md`)

## Version Format

| Scenario | Version |
|----------|---------|
| On release tag `v5.4.0` | `5.4.0` |
| N commits after `v5.4.0.dev0` | `5.4.0.devN+g<hash>` |

## Post-merge Action

After merging, tag the dev cycle start:
```bash
git tag v5.4.0.dev0
git push origin v5.4.0.dev0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)