### PR TITLE
Simplify flag_gems version detection in run_tests.py

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -183,7 +183,6 @@ tsingmicro = [
 test = [
     "distro==1.9.0",
     "coverage==7.13.5",
-    "gitpython==3.1.50",
     "openpyxl==3.1.5",
     "pytest==9.0.3",
     "pytest-md-report==0.8.0",

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -28,7 +28,6 @@ from pathlib import Path
 
 import consts
 import distro
-import git
 import yaml
 
 import flag_gems
@@ -293,14 +292,8 @@ def _probe_triton():
 def _probe_flaggems():
     try:
         version = flag_gems.__version__
-        repo = git.Repo(search_parent_directories=True)
-        sha = repo.head.object.hexsha
-        ver_str = f"{version}+git{sha[:8]}"
-        ENV_INFO["flag_gems"] = {"version": ver_str}
-        pinfo(f"flag_gems detected ... {ver_str}")
-    except RuntimeError as e:
-        perror(f"{e}")
-        sys.exit(-1)
+        ENV_INFO["flag_gems"] = {"version": version}
+        pinfo(f"flag_gems detected ... {version}")
     except Exception as e:
         perror(f"{e}")
         perror("flag_gems has not been installed, please run `uv pip install -e .`")


### PR DESCRIPTION
## Summary

Now that `__version__` includes the git hash via setuptools-scm (e.g. `5.4.0.dev456+gc08802d`), there is no need to manually query git for the commit SHA in `run_tests.py`.

## Changes

- **tools/run_tests.py**: Remove `git.Repo` version string construction, simplify `_probe_flaggems()` to use `flag_gems.__version__` directly. Remove unused `import git`.
- **pyproject.toml**: Remove `gitpython` from test dependencies (no longer used anywhere).

🤖 Generated with [Claude Code](https://claude.com/claude-code)