### PR TITLE
[Performance Optimization] Improve reflection_pad1d_backward

### DIFF
--- a/src/flag_gems/ops/reflection_pad1d_backward.py
+++ b/src/flag_gems/ops/reflection_pad1d_backward.py
@@ -25,27 +25,33 @@ def reflection_pad1d_backward_kernel(
     pid_w = tl.program_id(axis=1)
 
     offs_w = pid_w * BLOCK_W + tl.arange(0, BLOCK_W)
-    mask_out = offs_w < W_out
+    mask = offs_w < W_in
 
     base_out = pid_b * W_out
     base_in = pid_b * W_in
 
-    # Load gradient from output and cast to float32 for accumulation
-    grad = tl.load(grad_output_ptr + base_out + offs_w, mask=mask_out, other=0.0)
-    grad_f32 = grad.to(tl.float32)
+    # Each input element receives the center gradient and, when reflected,
+    # at most one contribution from each padded side.
+    center_out = pad_left + offs_w
+    acc = tl.load(grad_output_ptr + base_out + center_out, mask=mask, other=0.0).to(
+        tl.float32
+    )
 
-    # Compute reflected index for each output position
-    x = offs_w.to(tl.int32) - pad_left
-    Wm1 = W_in - 1
-    p = 2 * Wm1
+    left_mask = mask & (offs_w > 0) & (offs_w <= pad_left)
+    left_out = tl.where(left_mask, pad_left - offs_w, 0)
+    acc += tl.load(grad_output_ptr + base_out + left_out, mask=left_mask, other=0.0).to(
+        tl.float32
+    )
 
-    t = tl.abs(x)
-    m = t % p
-    iw = tl.where(m < W_in, m, p - m)
+    pad_right = W_out - W_in - pad_left
+    right_start = W_in - pad_right - 1
+    right_mask = mask & (offs_w < W_in - 1) & (offs_w >= right_start)
+    right_out = tl.where(right_mask, pad_left + 2 * (W_in - 1) - offs_w, 0)
+    acc += tl.load(
+        grad_output_ptr + base_out + right_out, mask=right_mask, other=0.0
+    ).to(tl.float32)
 
-    # Atomically accumulate gradient to input positions (float32 for atomic safety)
-    grad_input_offset = base_in + iw
-    tl.atomic_add(grad_input_ptr + grad_input_offset, grad_f32, mask=mask_out)
+    tl.store(grad_input_ptr + base_in + offs_w, acc, mask=mask)
 
 
 def _launch_reflection_pad1d_backward(
@@ -74,24 +80,17 @@ def _launch_reflection_pad1d_backward(
     leading_shape = x.shape[:-1]
     B = int(math.prod(leading_shape)) if len(leading_shape) > 0 else 1
 
-    # Initialize grad_input as float32 for safe accumulation
-    grad_input = torch.zeros_like(x, dtype=torch.float32)
-
     # No padding case - just copy
     if pad_left == 0 and pad_right == 0:
         if W_out != W_in:
             raise RuntimeError(
                 "Internal error: W_out should equal W_in when no padding"
             )
+        grad_input = torch.empty_like(x)
         grid = (B, triton.cdiv(W_in, 256))
         with torch_device_fn.device(x.device):
-            _copy_rows_kernel_f32[grid](grad_output, grad_input, B, W_in, BLOCK_W=256)
-        if grad_input.dtype == x.dtype:
-            return grad_input
-        result = torch.empty_like(x)
-        with torch_device_fn.device(x.device):
-            _copy_rows_kernel[grid](grad_input, result, B, W_in, BLOCK_W=256)
-        return result
+            _copy_rows_kernel[grid](grad_output, grad_input, B, W_in, BLOCK_W=256)
+        return grad_input
 
     # Validate input dimensions
     if W_in < 2:
@@ -103,31 +102,13 @@ def _launch_reflection_pad1d_backward(
             "padding values must be less than the input width for reflection padding"
         )
 
-    grid = (B, triton.cdiv(W_out, 256))
+    grad_input = torch.empty_like(x)
+    grid = (B, triton.cdiv(W_in, 256))
     with torch_device_fn.device(x.device):
         reflection_pad1d_backward_kernel[grid](
             grad_output, grad_input, B, W_in, pad_left, W_out, BLOCK_W=256
         )
-    if grad_input.dtype == x.dtype:
-        return grad_input
-    result = torch.empty_like(x)
-    cast_grid = (B, triton.cdiv(W_in, 256))
-    with torch_device_fn.device(x.device):
-        _copy_rows_kernel[cast_grid](grad_input, result, B, W_in, BLOCK_W=256)
-    return result
-
-
-@triton.jit
-def _copy_rows_kernel_f32(in_ptr, out_ptr, B, W, BLOCK_W: tl.constexpr):
-    pid_b = tl.program_id(axis=0)
-    pid_w = tl.program_id(axis=1)
-
-    offs_w = pid_w * BLOCK_W + tl.arange(0, BLOCK_W)
-    mask = (offs_w < W) & (pid_b < B)
-
-    base = pid_b * W
-    vals = tl.load(in_ptr + base + offs_w, mask=mask, other=0.0).to(tl.float32)
-    tl.store(out_ptr + base + offs_w, vals, mask=mask)
+    return grad_input
 
 
 @triton.jit


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Performance Optimization

### Description
- Rework `reflection_pad1d_backward` from output-driven scatter to input-driven gather.
- Remove `atomic_add` accumulation by directly gathering each input element's reflected output contributions.
- Avoid the `float32` temporary grad input and the extra low-precision cast copy kernel for `float16` / `bfloat16`.
- Launch the main Triton kernel over `W_in` instead of `W_out` and write the final dtype directly.

### Issue
N/A

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
#### iluvatar
- GPU: `Iluvatar BI-V150`
- OS: `Ubuntu 24.04`
- Python: `3.12.11`
- Torch: `2.10.0`
- Triton: `3.1.0`
- FlagTree: `0.6.0+iluvatar.git19bc3194`
- FlagGems: `5.4.0dev+git29358a51`
- Vendor: `iluvatar`
- Device: `cuda`

`reflection_pad1d_backward` average speedup improves from x0.824 to x1.765:

|     |  fp16 |  fp32 |  bf16 | PerfAvg |
| --- | ----: | ----: | ----: | ------: |
| Before | 0.727 | 1.013 | 0.732 |   0.824 |
| After | 2.014 | 1.624 | 1.657 |   1.765 |

| grad_output shape | input shape | padding | dtype          | latency_base | latency | speedup |
| ----------------- | ----------- | ------- | -------------- | -----------: | ------: | ------: |
| (2,6)             | (2,3)       | (1,2)   | torch.float16  |        0.006 |   0.003 |   1.719 |
| (4,11)            | (4,8)       | (1,2)   | torch.float16  |        0.006 |   0.004 |   1.669 |
| (8,19)            | (8,16)      | (1,2)   | torch.float16  |        0.007 |   0.004 |   1.620 |
| (1,35)            | (1,32)      | (1,2)   | torch.float16  |        0.013 |   0.004 |   3.813 |
| (4,67)            | (4,64)      | (1,2)   | torch.float16  |        0.006 |   0.004 |   1.660 |
| (8,131)           | (8,128)     | (1,2)   | torch.float16  |        0.007 |   0.004 |   1.600 |
| (2,6)             | (2,3)       | (1,2)   | torch.float32  |        0.006 |   0.003 |   1.664 |
| (4,11)            | (4,8)       | (1,2)   | torch.float32  |        0.006 |   0.004 |   1.606 |
| (8,19)            | (8,16)      | (1,2)   | torch.float32  |        0.007 |   0.004 |   1.574 |
| (1,35)            | (1,32)      | (1,2)   | torch.float32  |        0.006 |   0.004 |   1.661 |
| (4,67)            | (4,64)      | (1,2)   | torch.float32  |        0.006 |   0.004 |   1.646 |
| (8,131)           | (8,128)     | (1,2)   | torch.float32  |        0.007 |   0.004 |   1.592 |
| (2,6)             | (2,3)       | (1,2)   | torch.bfloat16 |        0.006 |   0.003 |   1.733 |
| (4,11)            | (4,8)       | (1,2)   | torch.bfloat16 |        0.006 |   0.004 |   1.674 |
| (8,19)            | (8,16)      | (1,2)   | torch.bfloat16 |        0.007 |   0.004 |   1.620 |
| (1,35)            | (1,32)      | (1,2)   | torch.bfloat16 |        0.006 |   0.004 |   1.707 |
| (4,67)            | (4,64)      | (1,2)   | torch.bfloat16 |        0.006 |   0.004 |   1.669 |
| (8,131)           | (8,128)     | (1,2)   | torch.bfloat16 |        0.007 |   0.004 |   1.542 |