### PR TITLE
[Performance Optimization] Improve log_softmax_out non-inner reduction

### DIFF
--- a/src/flag_gems/ops/log_softmax.py
+++ b/src/flag_gems/ops/log_softmax.py
@@ -13,6 +13,66 @@ logger = logging.getLogger(__name__)
 
 
 @libentry()
+@triton.heuristics(runtime.get_heuristic_config("softmax_non_inner"))
+@triton.jit
+def log_softmax_kernel_non_inner(
+    output_ptr,
+    input_ptr,
+    M,
+    N,
+    K,
+    TILE_N: tl.constexpr,
+    TILE_K: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    pid_m = ext.program_id(0)
+    pid_k = ext.program_id(1)
+    k_offsets = pid_k * TILE_K + tl.arange(0, TILE_K)
+
+    if ONE_TILE_PER_CTA:
+        n_offsets = tl.arange(0, TILE_N)
+        offsets = pid_m * N * K + n_offsets[:, None] * K + k_offsets[None, :]
+        mask = (n_offsets[:, None] < N) & (k_offsets[None, :] < K)
+        inp = tl.load(input_ptr + offsets, mask=mask, other=-float("inf")).to(
+            tl.float32
+        )
+        m = tl.max(inp, 0)
+        z = tl.sum(tl.exp(inp - m[None, :]), 0)
+        out = inp - m[None, :] - tl.log(z)[None, :]
+        tl.store(output_ptr + offsets, out, mask=mask)
+    else:
+        m = tl.full([TILE_N, TILE_K], value=float("-inf"), dtype=tl.float32)
+        z = tl.full([TILE_N, TILE_K], value=0.0, dtype=tl.float32)
+
+        for start_n in range(0, N, TILE_N):
+            n_offsets = start_n + tl.arange(0, TILE_N)
+            offsets = pid_m * N * K + n_offsets[:, None] * K + k_offsets[None, :]
+            mask = (n_offsets[:, None] < N) & (k_offsets[None, :] < K)
+            inp = tl.load(input_ptr + offsets, mask=mask, other=-float("inf")).to(
+                tl.float32
+            )
+            m_new = tl.maximum(inp, m)
+            all_neg_inf = m_new == float("-inf")
+            z = tl.where(all_neg_inf, z, z * tl.exp(m - m_new) + tl.exp(inp - m_new))
+            m = m_new
+
+        m_reduced = tl.max(m, 0)
+        z = tl.sum(z * tl.exp(m - m_reduced[None, :]), 0)
+        m = m_reduced
+        log_z = tl.log(z)
+
+        for start_n in range(0, N, TILE_N):
+            n_offsets = start_n + tl.arange(0, TILE_N)
+            offsets = pid_m * N * K + n_offsets[:, None] * K + k_offsets[None, :]
+            mask = (n_offsets[:, None] < N) & (k_offsets[None, :] < K)
+            inp = tl.load(input_ptr + offsets, mask=mask, other=-float("inf")).to(
+                tl.float32
+            )
+            out = inp - m[None, :] - log_z[None, :]
+            tl.store(output_ptr + offsets, out, mask=mask)
+
+
+@libentry()
 @triton.jit
 def log_softmax_kernel(
     output_ptr,
@@ -117,19 +177,29 @@ def log_softmax_out(self, dim, half_to_float=False, *, out):
         )
     K = inp.numel() // M // N
 
-    grid = lambda meta: (
-        triton.cdiv(M, meta["BLOCK_M"]),
-        K,
-    )
     with torch_device_fn.device(inp.device):
-        log_softmax_kernel[grid](
-            out,
-            inp,
-            M,
-            N,
-            K,
-            num_warps=8,
-        )
+        if K > 1:
+            grid = lambda meta: (M, triton.cdiv(K, meta["TILE_K"]), 1)
+            log_softmax_kernel_non_inner[grid](
+                out,
+                inp,
+                M,
+                N,
+                K,
+            )
+        else:
+            grid = lambda meta: (
+                triton.cdiv(M, meta["BLOCK_M"]),
+                K,
+            )
+            log_softmax_kernel[grid](
+                out,
+                inp,
+                M,
+                N,
+                K,
+                num_warps=8,
+            )
     return out
 
 


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Performance Optimization

### Description
- Add a non-inner `log_softmax_out` kernel for reductions where the reduced dimension is not the innermost dimension.
- Process `reduce x output` tiles so each program handles a contiguous block of `K` values and improves memory coalescing.
- Keep the original kernel for `K == 1`, where reduce access is already contiguous.

### Issue
N/A

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
#### iluvatar
- GPU: `Iluvatar BI-V150`
- OS: `Ubuntu 24.04`
- Python: `3.12.11`
- Torch: `2.10.0`
- Triton: `3.1.0`
- FlagTree: `0.6.0+iluvatar.git19bc3194`
- FlagGems: `5.4.0dev+giteb51a3dd`
- Vendor: `iluvatar`
- Device: `cuda`

`log_softmax_out` average speedup improves from x0.522 to x1.512:

| shape | dim | dtype | latency_base | latency | speedup |
| ----- | --: | ----- | -----------: | ------: | ------: |
| (64,64) | 1 | torch.float16 | 0.006 | 0.007 | 0.809 |
| (1024,1024) | 1 | torch.float16 | 0.021 | 0.021 | 0.962 |
| (4096,4096) | 1 | torch.float16 | 0.205 | 0.252 | 0.813 |
| (64,512,512) | 1 | torch.float16 | 0.787 | 0.190 | 4.136 |
| (1024,1024,1024) | 1 | torch.float16 | 18.811 | 11.152 | 1.687 |
| (64,64) | 1 | torch.float32 | 0.006 | 0.007 | 0.834 |
| (1024,1024) | 1 | torch.float32 | 0.025 | 0.028 | 0.891 |
| (4096,4096) | 1 | torch.float32 | 0.258 | 0.363 | 0.710 |
| (64,512,512) | 1 | torch.float32 | 0.755 | 0.353 | 2.139 |
| (1024,1024,1024) | 1 | torch.float32 | 29.054 | 22.350 | 1.300 |
| (64,64) | 1 | torch.bfloat16 | 0.006 | 0.007 | 0.800 |
| (1024,1024) | 1 | torch.bfloat16 | 0.021 | 0.021 | 0.964 |
| (4096,4096) | 1 | torch.bfloat16 | 0.205 | 0.251 | 0.814 |
| (64,512,512) | 1 | torch.bfloat16 | 0.787 | 0.190 | 4.136 |
| (1024,1024,1024) | 1 | torch.bfloat16 | 18.840 | 11.154 | 1.689 |

### Optimization Details
Before this change, `log_softmax_out` launched one program per `K` value. For 3D inputs reduced on `dim=1`, `K` can be large, so loads along the reduce dimension used a large stride and could not be coalesced efficiently.

This change adds a `K > 1` non-inner path that processes a contiguous block of `K` values for each reduce tile. This keeps memory access coalesced for non-inner reductions while preserving the original `K == 1` path for innermost reductions.