### PR TITLE
Remove extra LD_LIBRARY_PATH setting for metax

### DIFF
--- a/tools/env.sh
+++ b/tools/env.sh
@@ -48,10 +48,6 @@ case $BACKEND in
     export MACA_PATH=/opt/maca
     export LD_LIBRARY_PATH=$MACA_PATH/lib:$LD_LIBRARY_PATH
     export LD_LIBRARY_PATH=$MACA_PATH/mxgpu_llvm/lib:$LD_LIBRARY_PATH
-    if [ -z "${USE_TRITON}" ]; then
-      SITE_PACKAGES=$VIRTUAL_ENV/lib/python3.12/site-packages
-      export LD_LIBRARY_PATH=${SITE_PACKAGES}/triton/backends/metax/lib:$LD_LIBRARY_PATH
-    fi
     ;;
   nvidia|nvidia-cuda128|nvidia-cuda133)
     export PATH=/usr/local/cuda/bin:$PATH


### PR DESCRIPTION
### PR Category

User Experience

### Type of Change

Bug Fix

### Description

Previously, the flagtree package from metax has rpath incorrectly hard-coded. After fixing the rpath of the `triton.so` file, we don't need the extra LD_LIBRARY_PATH settings now.