### PR TITLE
Remove the extra post-install step for Kunlunxin

### DIFF
--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -125,8 +125,6 @@ backends:
       - torch_xray==2.0.4
       - xformers==0.0.29+1e7a8ec.d20260114
       - xmlir==1.0.0.1
-    post_install:
-      - uninstall: pytest-repeat
 
   metax:
     python: "3.12"


### PR DESCRIPTION
### PR Category

User Experience

### Type of Change

Bug Fix

### Description

The vanilla torch_xray==2.0.4 package from Kunlunxin has extra dependencies on pytest, pytest-repeat, pytest-timeout, pytest-xdist. The dependency over pytest-repeat is a blocker for running FlagGems operators (i.e. `repeat` operator). After fixing the package metadata, we don't need to manually uninstall the pytest-repeat package now.