### PR TITLE
gpu_check: report available GPUs instead of requiring all free

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -132,7 +132,10 @@ jobs:
         run: |
           source .venv/bin/activate
           source tools/env.sh ${BACKEND}
-          bash tools/gpu_check_${VENDOR}.sh
+          GPU_OUTPUT=$(bash tools/gpu_check_${VENDOR}.sh)
+          echo "$GPU_OUTPUT"
+          AVAILABLE_GPUS=$(echo "$GPU_OUTPUT" | grep "^Available GPUs:" | cut -d: -f2 | tr -d ' ')
+          echo "AVAILABLE_GPUS=${AVAILABLE_GPUS}" >> $GITHUB_ENV
 
       - id: run-tests
         shell: bash
@@ -142,6 +145,7 @@ jobs:
           source .venv/bin/activate
           source tools/env.sh ${BACKEND}
           tools/run_tests.py --ops ${{ needs.preprocess.outputs.op }} \
+            --gpus "${AVAILABLE_GPUS}" \
             --dump-output \
             --output-dir results_new
 
@@ -154,6 +158,7 @@ jobs:
           else
             git checkout master
             tools/run_tests.py --ops ${{ needs.preprocess.outputs.op }} \
+              --gpus "${AVAILABLE_GPUS}" \
               --dump-output \
               --output-dir results_old
 

--- a/tools/gpu_check_ascend.sh
+++ b/tools/gpu_check_ascend.sh
@@ -1,12 +1,11 @@
 #!/bin/bash
 
 # Configuration parameters
-mem_threshold=30000     # Maximum memory usage limit (MB)
-sleep_time=120             # Wait time (seconds), default is 2 minutes
+mem_threshold=30000     # Minimum free memory required (MB)
+sleep_time=120          # Wait time between retries (seconds)
+max_wait=600           # Maximum total wait time (seconds)
 
 # Get the number of NPU chips from npu-smi info output
-# Chip lines look like: "| 0     0                   | 0000:9D:00.0  | 0           0    / 0          2894 / 65536         |"
-# Count lines that contain HBM usage pattern "xxxx / xxxxx" at the end (the HBM-Usage column)
 npu_smi_output=$(npu-smi info)
 
 if [ $? -ne 0 ]; then
@@ -14,9 +13,6 @@ if [ $? -ne 0 ]; then
     exit 1
 fi
 
-# Count chip lines (lines with Chip/Phy-ID and HBM usage info)
-npu_count=$(echo "$npu_smi_output" | grep -cP '\d+\s*/\s*\d+\s*\|\s*$')
-# Each NPU card has 2 chips, but we check per-chip
 npu_count=$(echo "$npu_smi_output" | grep -c "OK")
 
 if [ "$npu_count" -eq 0 ]; then
@@ -25,35 +21,32 @@ if [ "$npu_count" -eq 0 ]; then
 fi
 
 echo "Detected $npu_count Ascend NPU chip(s)."
-
 echo "$npu_smi_output"
 
+waited_time=0
 while true; do
     npu_smi_output=$(npu-smi info 2>/dev/null)
 
     if [ $? -ne 0 ]; then
-        echo "Failed to query NPU information. Please check if npu-smi is working correctly."
+        echo "Failed to query NPU information."
         exit 1
     fi
 
     # Parse HBM-Usage from chip lines
-    # Chip line example: "| 0     0                   | 0000:9D:00.0  | 0           0    / 0          2894 / 65536         |"
-    # Each chip line has 3 "xxx / yyy" patterns: Hugepages-Usage, Memory-Usage, HBM-Usage
-    # We extract the last "xxx / yyy" from each chip line (HBM-Usage)
     mapfile -t hbm_lines < <(echo "$npu_smi_output" | grep "0000:" | while IFS= read -r line; do
         echo "$line" | grep -oP '\d+\s*/\s*\d+' | tail -1
     done)
 
-    need_wait=false
+    available_gpus=()
     i=0
 
-    printf " GPU  Total (MiB)  Used (MiB)  Free (MiB)\n"
+    printf " NPU  Total (MiB)  Used (MiB)  Free (MiB)\n"
     for line in "${hbm_lines[@]}"; do
         used_i=$(echo "$line" | awk -F'/' '{gsub(/[[:space:]]/, "", $1); print $1}')
         total_i=$(echo "$line" | awk -F'/' '{gsub(/[[:space:]]/, "", $2); print $2}')
 
         if [ -z "$used_i" ] || [ -z "$total_i" ]; then
-            echo "Warning: Failed to parse memory infor for chip $i."
+            echo "Warning: Failed to parse memory info for chip $i."
             i=$((i + 1))
             continue
         fi
@@ -61,18 +54,23 @@ while true; do
         free_i=$((total_i - used_i))
 
         printf "%4d%'13d%'12d%'12d\n" $i ${total_i} ${used_i} ${free_i}
-        if [ $free_i -lt $mem_threshold ]; then
-            need_wait=true
-            break
+        if [ $free_i -ge $mem_threshold ]; then
+            available_gpus+=($i)
         fi
         i=$((i + 1))
     done
 
-    if [ "$need_wait" = false ]; then
-        echo "All NPUs have sufficient memory, proceeding with execution."
+    if [ ${#available_gpus[@]} -gt 0 ]; then
+        AVAILABLE_GPUS=$(IFS=,; echo "${available_gpus[*]}")
+        echo "Available GPUs: ${AVAILABLE_GPUS}"
         break
     fi
 
-    echo "NPU memory is insufficient, waiting for $sleep_time seconds before retrying..."
+    echo "No NPU has sufficient memory, waiting for $sleep_time seconds..."
     sleep $sleep_time
+    waited_time=$((waited_time + sleep_time))
+    if [ $waited_time -ge $max_wait ]; then
+        echo "Error: Timed out waiting for available NPU."
+        exit 1
+    fi
 done

--- a/tools/gpu_check_cambricon.sh
+++ b/tools/gpu_check_cambricon.sh
@@ -1,13 +1,11 @@
 #!/bin/bash
 
 # Configuration parameters
-mem_threshold=30000     # Maximum memory usage limit (MB)
-sleep_interval=120      # Wait time (seconds), default is 2 minutes
-max_wait=1200           # Maximum wait time (seconds), default is 20 minutes
+mem_threshold=30000     # Minimum free memory required (MB)
+sleep_interval=120      # Wait time between retries (seconds)
+max_wait=600           # Maximum total wait time (seconds)
 
 # Get the number of Cambricon MLU cards from cnmon output
-# Memory lines look like:
-# | 7         52C     85 W/ 500 W |     0 MiB/ 81920 MiB | FULL          Default |
 gpu_count=$(cnmon | grep -cP '\d+ MiB/ \d+ MiB')
 
 if [ $? -ne 0 ]; then
@@ -24,11 +22,11 @@ echo "Detected $gpu_count Cambricon MLU card(s)."
 
 waited_time=0
 while true; do
-    need_wait=false
+    available_gpus=()
     i=0
 
     printf " MLU  Total (MiB)  Used (MiB)  Free (MiB)\n"
-    cnmon | grep -oP '\d+ MiB/ \d+ MiB' | while read -r line; do
+    while read -r line; do
         used_i=$(echo "$line" | grep -oP '^\d+')
         total_i=$(echo "$line" | grep -oP '\d+(?= MiB$)')
 
@@ -41,22 +39,23 @@ while true; do
         free_i=$((total_i - used_i))
 
         printf "%4d%'13d%'12d%'12d\n" $i ${total_i} ${used_i} ${free_i}
-        if [ $free_i -lt $mem_threshold ]; then
-            need_wait=true
-            break
+        if [ $free_i -ge $mem_threshold ]; then
+            available_gpus+=($i)
         fi
         i=$((i + 1))
-    done
+    done < <(cnmon | grep -oP '\d+ MiB/ \d+ MiB')
 
-    if [ "$need_wait" = false ]; then
-        echo "All MLUs have sufficient memory, proceeding with execution."
+    if [ ${#available_gpus[@]} -gt 0 ]; then
+        AVAILABLE_GPUS=$(IFS=,; echo "${available_gpus[*]}")
+        echo "Available GPUs: ${AVAILABLE_GPUS}"
         break
     fi
 
-    echo "MLU memory is insufficient, waiting for $sleep_interval seconds before retrying..."
+    echo "No MLU has sufficient memory, waiting for $sleep_interval seconds..."
     sleep $sleep_interval
-    waited_time=$(( waited_time + sleep_interval ))
-    if [ $waited_time -gt $max_wait ]; then
-        break
+    waited_time=$((waited_time + sleep_interval))
+    if [ $waited_time -ge $max_wait ]; then
+        echo "Error: Timed out waiting for available MLU."
+        exit 1
     fi
 done

--- a/tools/gpu_check_enflame.sh
+++ b/tools/gpu_check_enflame.sh
@@ -1,14 +1,9 @@
 #!/bin/bash
 
 # Configuration parameters
-mem_threshold=30000     # Maximum memory usage limit (MB)
-sleep_interval=120          # Wait time (seconds), default is 2 minutes
-max_wait=1200
-
-# Sample output from efsmi -L
-# DEV    SN                Slot    ID           Bus             CPU Affinity     UUID
-# -------------------------------------------------------------------------------------------
-# 0      A0A8640510030     N/A     1ea0:2a22    0000:23:00.0    0-31             TPUH61160105
+mem_threshold=30000     # Minimum free memory required (MB)
+sleep_interval=120      # Wait time between retries (seconds)
+max_wait=600           # Maximum total wait time (seconds)
 
 # Count chip lines (lines with Bus info)
 gpu_count=$(efsmi -L | grep -cP '\d+\:\d+\:')
@@ -18,43 +13,41 @@ if [ "$gpu_count" -eq 0 ]; then
     exit 1
 fi
 
-echo "Detected $npu_count Enflame NPU chip(s)."
+echo "Detected $gpu_count Enflame GPU chip(s)."
 
 waited_time=0
 while true; do
-    need_wait=false
-    i=0
+    available_gpus=()
 
     printf " GPU  Total (MiB)  Used (MiB)  Free (MiB)\n"
-    for ((i = 0 ; i < $gpu_count ; i++ )); do
-	total_i=$(efsmi -i 0 -q -d MEMORY | awk '/Device Mem Info/,/BAR1/ { if (/Total Size/) {gsub(/[^0-9]/,"",$0); print $0}}')
-	free_i=$(efsmi -i 0 -q -d MEMORY | awk '/Device Mem Info/,/BAR1/ { if (/Free Size/) {gsub(/[^0-9]/,"",$0); print $0}}')
+    for ((i=0; i<$gpu_count; i++)); do
+        total_i=$(efsmi -i $i -q -d MEMORY | awk '/Device Mem Info/,/BAR1/ { if (/Total Size/) {gsub(/[^0-9]/,"",$0); print $0}}')
+        free_i=$(efsmi -i $i -q -d MEMORY | awk '/Device Mem Info/,/BAR1/ { if (/Free Size/) {gsub(/[^0-9]/,"",$0); print $0}}')
 
         if [ -z "$free_i" ] || [ -z "$total_i" ]; then
-            echo "Warning: Failed to parse memory infor for chip $i."
+            echo "Warning: Failed to parse memory info for chip $i."
             continue
         fi
 
         used_i=$((total_i - free_i))
 
         printf "%4d%'13d%'12d%'12d\n" $i ${total_i} ${used_i} ${free_i}
-        if [ $free_i -lt $mem_threshold ]; then
-            need_wait=true
-            break
+        if [ $free_i -ge $mem_threshold ]; then
+            available_gpus+=($i)
         fi
     done
 
-    if [ "$need_wait" = false ]; then
-        echo "All GPUs have sufficient memory, proceeding with execution."
+    if [ ${#available_gpus[@]} -gt 0 ]; then
+        AVAILABLE_GPUS=$(IFS=,; echo "${available_gpus[*]}")
+        echo "Available GPUs: ${AVAILABLE_GPUS}"
         break
     fi
 
-    echo "GPU memory is insufficient, waiting for $sleep_interval seconds before retrying..."
+    echo "No GPU has sufficient memory, waiting for $sleep_interval seconds..."
     sleep $sleep_interval
-
-    # Stop waiting if already waited too long
     waited_time=$((waited_time + sleep_interval))
-    if [ $waited_time -gt $max_wait ]; then
-        break
+    if [ $waited_time -ge $max_wait ]; then
+        echo "Error: Timed out waiting for available GPU."
+        exit 1
     fi
 done

--- a/tools/gpu_check_hygon.sh
+++ b/tools/gpu_check_hygon.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Configuration parameters
-mem_threshold=30000     # Maximum memory usage limit (MB)
-sleep_time=120          # Wait time (seconds)
+mem_threshold=30000     # Minimum free memory required (MB)
+sleep_time=120          # Wait time between retries (seconds)
+max_wait=600           # Maximum total wait time (seconds)
 
 # Check if hy-smi exists
 if ! command -v hy-smi &> /dev/null; then
@@ -11,7 +12,6 @@ if ! command -v hy-smi &> /dev/null; then
 fi
 
 # Get the number of DCUs
-# Count lines containing "Normal" or "C" (Temperature)
 gpu_count=$(hy-smi 2>/dev/null | grep -c "Normal")
 
 if [ "$gpu_count" -eq 0 ]; then
@@ -21,41 +21,44 @@ fi
 
 echo "Detected $gpu_count Hygon DCU card(s)."
 
+waited_time=0
 while true; do
     memory_usage=$(hy-smi --showmeminfo vram 2>/dev/null | awk 'BEGIN { FS=":" } /Used Memory/ { print $3 }')
     memory_total=$(hy-smi --showmeminfo vram 2>/dev/null | awk 'BEGIN { FS=":" } /Total Memory/ { print $3 }')
 
-    # Check if hy-smi command was successful
     if [ $? -ne 0 ]; then
-        echo "Failed to query GPU memory information. Please check if hy-smi is working correctly."
+        echo "Failed to query GPU memory information."
         exit 1
     fi
 
-    # Convert query results to arrays
     IFS=$' ' read -d '' -r -a usage_array <<< "$memory_usage"
     IFS=$' ' read -d '' -r -a total_array <<< "$memory_total"
 
-    need_wait=false
+    available_gpus=()
 
     printf " DCU  Total (MiB)  Used (MiB)  Free (MiB)\n"
     for ((i=0; i<$gpu_count; i++)); do
-        # trim 'M' from number
         total_i=${total_array[$i]}
         used_i=${usage_array[$i]}
         free_i=$((total_i - used_i))
 
         printf "%4d%'13d%'12d%'12d\n" $i ${total_i} ${used_i} ${free_i}
-        if [ $free_i -lt $mem_threshold ]; then
-            need_wait=true
-            break
+        if [ $free_i -ge $mem_threshold ]; then
+            available_gpus+=($i)
         fi
     done
 
-    if [ "$need_wait" = false ]; then
-        echo "All DCUs have sufficient memory."
+    if [ ${#available_gpus[@]} -gt 0 ]; then
+        AVAILABLE_GPUS=$(IFS=,; echo "${available_gpus[*]}")
+        echo "Available GPUs: ${AVAILABLE_GPUS}"
         break
     fi
 
-    echo "DCU memory is insufficient, waiting for $sleep_time seconds..."
+    echo "No DCU has sufficient memory, waiting for $sleep_time seconds..."
     sleep $sleep_time
+    waited_time=$((waited_time + sleep_time))
+    if [ $waited_time -ge $max_wait ]; then
+        echo "Error: Timed out waiting for available DCU."
+        exit 1
+    fi
 done

--- a/tools/gpu_check_iluvatar.sh
+++ b/tools/gpu_check_iluvatar.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Configuration parameters
-memory_usage_max=30000     # Maximum memory usage limit (MB)
-sleep_time=120             # Wait time (seconds), default is 2 minutes
+mem_threshold=30000     # Minimum free memory required (MB)
+sleep_time=120          # Wait time between retries (seconds)
+max_wait=600           # Maximum total wait time (seconds)
 
 export LD_LIBRARY_PATH=/usr/local/corex/lib:$LD_LIBRARY_PATH
 
@@ -18,41 +19,44 @@ echo "Detected $gpu_count Iluvatar GPU(s)."
 
 ixsmi
 
+waited_time=0
 while true; do
-    # Query GPU memory usage and total memory
     memory_usage=$(ixsmi --query-gpu=memory.used --format=csv,noheader,nounits 2>/dev/null)
     memory_total=$(ixsmi --query-gpu=memory.total --format=csv,noheader,nounits 2>/dev/null)
 
-    # Check if ixsmi command was successful
     if [ $? -ne 0 ]; then
-        echo "Failed to query GPU memory information. Please check if ixsmi is working correctly."
+        echo "Failed to query GPU memory information."
         exit 1
     fi
 
-    # Convert query results to arrays
     IFS=$'\n' read -d '' -r -a memory_usage_array <<< "$memory_usage"
     IFS=$'\n' read -d '' -r -a memory_total_array <<< "$memory_total"
 
-    need_wait=false
+    available_gpus=()
 
-    # Check the available memory for each GPU
+    printf " GPU  Total (MiB)  Used (MiB)  Free (MiB)\n"
     for ((i=0; i<$gpu_count; i++)); do
-        memory_usage_i=${memory_usage_array[$i]}
-        memory_total_i=${memory_total_array[$i]}
-        memory_remin_i=$((memory_total_i - memory_usage_i))
+        used_i=${memory_usage_array[$i]}
+        total_i=${memory_total_array[$i]}
+        free_i=$((total_i - used_i))
 
-        if [ $memory_remin_i -lt $memory_usage_max ]; then
-            need_wait=true
-            echo "GPU $i: Used ${memory_usage_i}MiB / Total ${memory_total_i}MiB (Available: ${memory_remin_i}MiB < ${memory_usage_max}MiB)"
-            break
+        printf "%4d%'13d%'12d%'12d\n" $i ${total_i} ${used_i} ${free_i}
+        if [ $free_i -ge $mem_threshold ]; then
+            available_gpus+=($i)
         fi
     done
 
-    if [ "$need_wait" = false ]; then
-        echo "All Iluvatar GPUs have sufficient available memory. Proceeding with execution."
+    if [ ${#available_gpus[@]} -gt 0 ]; then
+        AVAILABLE_GPUS=$(IFS=,; echo "${available_gpus[*]}")
+        echo "Available GPUs: ${AVAILABLE_GPUS}"
         break
     fi
 
-    echo "GPU memory is insufficient, waiting for $sleep_time seconds before retrying..."
+    echo "No GPU has sufficient memory, waiting for $sleep_time seconds..."
     sleep $sleep_time
+    waited_time=$((waited_time + sleep_time))
+    if [ $waited_time -ge $max_wait ]; then
+        echo "Error: Timed out waiting for available GPU."
+        exit 1
+    fi
 done

--- a/tools/gpu_check_kunlunxin.sh
+++ b/tools/gpu_check_kunlunxin.sh
@@ -1,13 +1,13 @@
 #!/bin/bash
 
 # Configuration parameters
-mem_threshold=30000     # Maximum memory usage limit (MB)
-sleep_time=120          # Wait time (seconds), default is 2 minutes
+mem_threshold=30000     # Minimum free memory required (MB)
+sleep_time=120          # Wait time between retries (seconds)
+max_wait=600           # Maximum total wait time (seconds)
 
 export XPU_HOME=/usr/local/xpu
 export PATH=$XPU_HOME/bin:$PATH
 export LD_LIBRARY_PATH=$XPU_HOME/lib:$LD_LIBRARY_PATH
-
 
 # Get the number of GPUs
 gpu_count=$(xpu-smi 2>/dev/null | grep -c 'P800')
@@ -19,44 +19,44 @@ fi
 
 echo "Detected $gpu_count KLX GPU(s)."
 
-xpu_smi
-
+waited_time=0
 while true; do
     memory_usage=$(xpu-smi | awk '/MiB \/ [0-9]*MiB/ { print $9 }')
     memory_total=$(xpu-smi | awk '/MiB \/ [0-9]*MiB/ { print $11 }')
 
-    # Check if tsm_smi command was successful
     if [ $? -ne 0 ]; then
-        echo "Failed to query GPU memory information. Please check if tsm_smi is working correctly."
+        echo "Failed to query GPU memory information."
         exit 1
     fi
 
-    # Convert query results to arrays
     IFS=$'\n' read -d '' -r -a usage_array <<< "$memory_usage"
     IFS=$'\n' read -d '' -r -a total_array <<< "$memory_total"
 
-    need_wait=false
+    available_gpus=()
 
-    # Check the available memory for each GPU
     printf " GPU  Total (MiB)  Used (MiB)  Free (MiB)\n"
     for ((i=0; i<$gpu_count; i++)); do
-        # trim 'M' from number
         total_i=${total_array[$i]%???}
         used_i=${usage_array[$i]%???}
         free_i=$((total_i - used_i))
 
         printf "%4d%'13d%'12d%'12d\n" $i ${total_i} ${used_i} ${free_i}
-        if [ $free_i -lt $mem_threshold ]; then
-            need_wait=true
-            break
+        if [ $free_i -ge $mem_threshold ]; then
+            available_gpus+=($i)
         fi
     done
 
-    if [ "$need_wait" = false ]; then
-        echo "All GPUs have sufficient memory."
+    if [ ${#available_gpus[@]} -gt 0 ]; then
+        AVAILABLE_GPUS=$(IFS=,; echo "${available_gpus[*]}")
+        echo "Available GPUs: ${AVAILABLE_GPUS}"
         break
     fi
 
-    echo "GPU memory is insufficient, waiting for $sleep_time seconds before retrying..."
+    echo "No GPU has sufficient memory, waiting for $sleep_time seconds..."
     sleep $sleep_time
+    waited_time=$((waited_time + sleep_time))
+    if [ $waited_time -ge $max_wait ]; then
+        echo "Error: Timed out waiting for available GPU."
+        exit 1
+    fi
 done

--- a/tools/gpu_check_metax.sh
+++ b/tools/gpu_check_metax.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Configuration parameters
-mem_threshold=30000     # Maximum memory usage limit (MB)
-sleep_time=120          # Wait time (seconds), default is 2 minutes
+mem_threshold=30000     # Minimum free memory required (MB)
+sleep_time=120          # Wait time between retries (seconds)
+max_wait=600           # Maximum total wait time (seconds)
 
 gpu_count=$(mx-smi | awk '/Attached/ {print $4}' 2>/dev/null)
 
@@ -18,10 +19,11 @@ fi
 
 echo "Detected $gpu_count MetaX GPU chip(s)."
 
+waited_time=0
 while true; do
     memory_info=$(mx-smi | awk '/MiB[[:space:]]| A/ { print $9 }')
-    need_wait=false
     readarray -t lines <<< "$memory_info"
+    available_gpus=()
     i=0
 
     printf " GPU  Total (MiB)  Used (MiB)  Free (MiB)\n"
@@ -36,18 +38,23 @@ while true; do
         free_i=$((total_i - used_i))
 
         printf "%4d%'13d%'12d%'12d\n" $i ${total_i} ${used_i} ${free_i}
-        if [ $free_i -lt $mem_threshold ]; then
-            need_wait=true
-            break
+        if [ $free_i -ge $mem_threshold ]; then
+            available_gpus+=($i)
         fi
         i=$((i + 1))
     done
 
-    if [ "$need_wait" = false ]; then
-        echo "All GPUs have sufficient memory, proceeding with execution."
+    if [ ${#available_gpus[@]} -gt 0 ]; then
+        AVAILABLE_GPUS=$(IFS=,; echo "${available_gpus[*]}")
+        echo "Available GPUs: ${AVAILABLE_GPUS}"
         break
     fi
 
-    echo "GPU memory is insufficient, waiting for $sleep_time seconds before retrying..."
+    echo "No GPU has sufficient memory, waiting for $sleep_time seconds..."
     sleep $sleep_time
+    waited_time=$((waited_time + sleep_time))
+    if [ $waited_time -ge $max_wait ]; then
+        echo "Error: Timed out waiting for available GPU."
+        exit 1
+    fi
 done

--- a/tools/gpu_check_mthreads.sh
+++ b/tools/gpu_check_mthreads.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-# Configuration
-mem_threshold=30000     # Maximum memory usage limit (MB)
-sleep_time=120             # Wait time (seconds), default is 2 minutes
+# Configuration parameters
+mem_threshold=30000     # Minimum free memory required (MB)
+sleep_time=120          # Wait time between retries (seconds)
+max_wait=600           # Maximum total wait time (seconds)
 
 export MUSA_INSTALL_PATH=/usr/local/musa
 export PATH=$MUSA_INSTALL_PATH/bin:$PATH
@@ -17,21 +18,17 @@ if [ "$gpu_count" -eq 0 ]; then
 fi
 echo "Detected $gpu_count Moore Threads GPU(s)."
 
+waited_time=0
 while true; do
-    need_wait=false
+    available_gpus=()
 
     printf " GPU  Total (MiB)  Used (MiB)  Free (MiB)\n"
-    # Check the available memory for each GPU
     for ((i=0; i<$gpu_count; i++)); do
-        # Query GPU memory information using mthreads-gmi
         memory_output=$(mthreads-gmi -q -d MEMORY -i $i 2>/dev/null)
 
-        # Parse memory values from "FB Memory Usage" section
-        # Format: "Total                                     :  81920MiB"
         total_i=$(echo "$memory_output" | grep -A 3 "FB Memory Usage" | grep "Total" | grep -oP '\d+' | head -1)
         used_i=$(echo "$memory_output" | grep -A 3 "FB Memory Usage" | grep "Used" | grep -oP '\d+' | head -1)
 
-        # Check if we got valid memory values
         if [ -z "$used_i" ] || [ -z "$total_i" ]; then
             echo "Warning: Failed to query GPU $i memory information."
             continue
@@ -40,18 +37,22 @@ while true; do
         free_i=$((total_i - used_i))
 
         printf "%4d%'13d%'12d%'12d\n" $i ${total_i} ${used_i} ${free_i}
-        if [[ $free_i -lt $mem_threshold ]]; then
-            need_wait=true
-            echo "GPU $i: Used ${used_i}MB / Total ${total}MB (Available: ${free_i}MB < ${mem_threshold}MB)"
-            break
+        if [ $free_i -ge $mem_threshold ]; then
+            available_gpus+=($i)
         fi
     done
 
-    if [ "$need_wait" = "false" ]; then
-        echo "All Moore Threads GPUs have sufficient memory, proceeding with execution."
+    if [ ${#available_gpus[@]} -gt 0 ]; then
+        AVAILABLE_GPUS=$(IFS=,; echo "${available_gpus[*]}")
+        echo "Available GPUs: ${AVAILABLE_GPUS}"
         break
     fi
 
-    echo "GPU memory is insufficient, waiting for $sleep_time seconds before retrying..."
+    echo "No GPU has sufficient memory, waiting for $sleep_time seconds..."
     sleep $sleep_time
+    waited_time=$((waited_time + sleep_time))
+    if [ $waited_time -ge $max_wait ]; then
+        echo "Error: Timed out waiting for available GPU."
+        exit 1
+    fi
 done

--- a/tools/gpu_check_nvidia.sh
+++ b/tools/gpu_check_nvidia.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Configuration parameters
-mem_threshold=30000     # Maximum memory usage limit (MB)
-sleep_time=120          # Wait time (seconds)
+mem_threshold=30000     # Minimum free memory required (MB)
+sleep_time=120          # Wait time between retries (seconds)
+max_wait=600           # Maximum total wait time (seconds)
 
 # Check if nvidia-smi exists
 if ! command -v nvidia-smi &> /dev/null; then
@@ -20,49 +21,47 @@ fi
 
 echo "Detected $gpu_count NVIDIA GPU card(s)."
 
+waited_time=0
 while true; do
-    need_wait=false
+    available_gpus=()
 
-    printf " PPU  Total (MiB)  Used (MiB)  Free (MiB)\n"
-    # Iterate through each card
+    printf " GPU  Total (MiB)  Used (MiB)  Free (MiB)\n"
     for ((i=0; i<$gpu_count; i++)); do
-        # 1. Get information for a single card
-        # 2. Use grep -oP to extract the string in format "NumberMiB / NumberMiB"
-        # 3. The regex matches: digits + MiB + whitespace + / + whitespace + digits + MiB
         mem_line=$(nvidia-smi -i $i 2>/dev/null | grep -oP '\d+MiB\s*/\s*\d+MiB')
 
         if [ -z "$mem_line" ]; then
             echo "Warning: Failed to query memory on GPU $i."
-            need_wait=true
-            break
+            continue
         fi
 
-        # Extract Used and Total
-        # mem_line format example: 2MiB / 97920MiB
-        used_i=$(echo "$mem_line" | grep -oP '^\d+')           # Extract digits at the beginning
-        total_i=$(echo "$mem_line" | grep -oP '/\s*\K\d+')     # Extract digits after /
+        used_i=$(echo "$mem_line" | grep -oP '^\d+')
+        total_i=$(echo "$mem_line" | grep -oP '/\s*\K\d+')
 
         if [ -z "$total_i" ] || [ -z "$used_i" ]; then
              echo "Warning: Parse error for GPU $i. Raw: '$mem_line'"
-             need_wait=true
-             break
+             continue
         fi
 
         free_i=$((total_i - used_i))
 
         printf "%4d%'13d%'12d%'12d\n" $i ${total_i} ${used_i} ${free_i}
 
-        if [ $free_i -lt $mem_threshold ]; then
-            need_wait=true
-            break
+        if [ $free_i -ge $mem_threshold ]; then
+            available_gpus+=($i)
         fi
     done
 
-    if [ "$need_wait" = false ]; then
-        echo "All GPUs have sufficient memory."
+    if [ ${#available_gpus[@]} -gt 0 ]; then
+        AVAILABLE_GPUS=$(IFS=,; echo "${available_gpus[*]}")
+        echo "Available GPUs: ${AVAILABLE_GPUS}"
         break
     fi
 
-    echo "GPU memory is insufficient, waiting for $sleep_time seconds..."
+    echo "No GPU has sufficient memory, waiting for $sleep_time seconds..."
     sleep $sleep_time
+    waited_time=$((waited_time + sleep_time))
+    if [ $waited_time -ge $max_wait ]; then
+        echo "Error: Timed out waiting for available GPU."
+        exit 1
+    fi
 done

--- a/tools/gpu_check_sunrise.sh
+++ b/tools/gpu_check_sunrise.sh
@@ -1,17 +1,12 @@
 #!/bin/bash
 
 # Configuration parameters
-mem_threshold=30000     # Maximum memory usage limit (MB)
-sleep_interval=120      # Wait time (seconds), default is 2 minutes
-max_wait=1200           # Maximum wait time (seconds), default is 20 minutes
+mem_threshold=30000     # Minimum free memory required (MB)
+sleep_interval=120      # Wait time between retries (seconds)
+max_wait=600           # Maximum total wait time (seconds)
 
 # Get the number of Sunrise chips from pt_smi output
-# Chip lines look like:
-# |   0  SR-SUN-S2-X1-PCIE   N/A  | 00000000:8D:00.0     N/A |                    0 |
-# | N/A   34C    P7    89W / 400W |            0B / 62847MiB |       0%         N/A |
-# Count lines that contain HBM usage pattern "xxxx / xxxxx" at the end (the HBM-Usage column)
 gpu_count=$(pt_smi | grep -cP '\d+B / \d+MiB')
-echo $gpu_count
 
 if [ $? -ne 0 ]; then
     echo "Failed to run pt_smi. Please check if pt_smi is installed and working correctly."
@@ -27,18 +22,16 @@ echo "Detected $gpu_count Sunrise GPU chip(s)."
 
 waited_time=0
 while true; do
-    smi_output=$(pt_smi | grep -oP '\d+B / \d+MiB')
-
-    need_wait=false
+    available_gpus=()
     i=0
 
     printf " GPU  Total (MiB)  Used (MiB)  Free (MiB)\n"
-    pt_smi | grep -oP '\d+B / \d+MiB' | while read -r line; do
+    while read -r line; do
         used_i=$(echo "$line" | grep -oP '^\d+')
-	total_i=$(echo "$line" | grep -oP '\d+(?=MiB)')
+        total_i=$(echo "$line" | grep -oP '\d+(?=MiB)')
 
         if [ -z "$used_i" ] || [ -z "$total_i" ]; then
-            echo "Warning: Failed to parse memory infor for chip $i."
+            echo "Warning: Failed to parse memory info for chip $i."
             i=$((i + 1))
             continue
         fi
@@ -46,22 +39,23 @@ while true; do
         free_i=$((total_i - used_i))
 
         printf "%4d%'13d%'12d%'12d\n" $i ${total_i} ${used_i} ${free_i}
-        if [ $free_i -lt $mem_threshold ]; then
-            need_wait=true
-            break
+        if [ $free_i -ge $mem_threshold ]; then
+            available_gpus+=($i)
         fi
         i=$((i + 1))
-    done
+    done < <(pt_smi | grep -oP '\d+B / \d+MiB')
 
-    if [ "$need_wait" = false ]; then
-        echo "All GPUs have sufficient memory, proceeding with execution."
+    if [ ${#available_gpus[@]} -gt 0 ]; then
+        AVAILABLE_GPUS=$(IFS=,; echo "${available_gpus[*]}")
+        echo "Available GPUs: ${AVAILABLE_GPUS}"
         break
     fi
 
-    echo "GPU memory is insufficient, waiting for $sleep_time seconds before retrying..."
+    echo "No GPU has sufficient memory, waiting for $sleep_interval seconds..."
     sleep $sleep_interval
-    waited_time=$(( waited_time + sleep_interval ))
-    if [ $waited_time -gt $max_wait ]; then
-        break
+    waited_time=$((waited_time + sleep_interval))
+    if [ $waited_time -ge $max_wait ]; then
+        echo "Error: Timed out waiting for available GPU."
+        exit 1
     fi
 done

--- a/tools/gpu_check_thead.sh
+++ b/tools/gpu_check_thead.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Configuration parameters
-mem_threshold=30000     # Maximum memory usage limit (MB)
-sleep_time=120          # Wait time (seconds)
+mem_threshold=30000     # Minimum free memory required (MB)
+sleep_time=120          # Wait time between retries (seconds)
+max_wait=600           # Maximum total wait time (seconds)
 
 # Check if ppu-smi exists
 if ! command -v ppu-smi &> /dev/null; then
@@ -20,49 +21,47 @@ fi
 
 echo "Detected $gpu_count T-Head PPU card(s)."
 
+waited_time=0
 while true; do
-    need_wait=false
+    available_gpus=()
 
     printf " PPU  Total (MiB)  Used (MiB)  Free (MiB)\n"
-    # Iterate through each card
     for ((i=0; i<$gpu_count; i++)); do
-        # 1. Get information for a single card
-        # 2. Use grep -oP to extract the string in format "NumberMiB / NumberMiB"
-        # 3. The regex matches: digits + MiB + whitespace + / + whitespace + digits + MiB
         mem_line=$(ppu-smi -i $i 2>/dev/null | grep -oP '\d+MiB\s*/\s*\d+MiB')
 
         if [ -z "$mem_line" ]; then
             echo "Warning: Failed to query PPU $i memory."
-            need_wait=true
-            break
+            continue
         fi
 
-        # Extract Used and Total
-        # mem_line format example: 2MiB / 97920MiB
-        used_i=$(echo "$mem_line" | grep -oP '^\d+')           # Extract digits at the beginning
-        total_i=$(echo "$mem_line" | grep -oP '/\s*\K\d+')     # Extract digits after /
+        used_i=$(echo "$mem_line" | grep -oP '^\d+')
+        total_i=$(echo "$mem_line" | grep -oP '/\s*\K\d+')
 
         if [ -z "$total_i" ] || [ -z "$used_i" ]; then
              echo "Warning: Parse error for PPU $i. Raw: '$mem_line'"
-             need_wait=true
-             break
+             continue
         fi
 
         free_i=$((total_i - used_i))
 
         printf "%4d%'13d%'12d%'12d\n" $i ${total_i} ${used_i} ${free_i}
 
-        if [ $free_i -lt $mem_threshold ]; then
-            need_wait=true
-            break
+        if [ $free_i -ge $mem_threshold ]; then
+            available_gpus+=($i)
         fi
     done
 
-    if [ "$need_wait" = false ]; then
-        echo "All PPUs have sufficient memory."
+    if [ ${#available_gpus[@]} -gt 0 ]; then
+        AVAILABLE_GPUS=$(IFS=,; echo "${available_gpus[*]}")
+        echo "Available GPUs: ${AVAILABLE_GPUS}"
         break
     fi
 
-    echo "PPU memory is insufficient, waiting for $sleep_time seconds..."
+    echo "No PPU has sufficient memory, waiting for $sleep_time seconds..."
     sleep $sleep_time
+    waited_time=$((waited_time + sleep_time))
+    if [ $waited_time -ge $max_wait ]; then
+        echo "Error: Timed out waiting for available PPU."
+        exit 1
+    fi
 done

--- a/tools/gpu_check_tsingmicro.sh
+++ b/tools/gpu_check_tsingmicro.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
 # Configuration parameters
-mem_threshold=30000     # Maximum memory usage limit (MB)
-sleep_time=120             # Wait time (seconds), default is 2 minutes
+mem_threshold=30000     # Minimum free memory required (MB)
+sleep_time=120          # Wait time between retries (seconds)
+max_wait=600           # Maximum total wait time (seconds)
 
 export KUIPER_HOME=/home/secure/runtime/kuiper
 export PATH=$KUIPER_HOME/bin:$PATH
@@ -18,42 +19,44 @@ fi
 
 echo "Detected $gpu_count TsingMicro card(s)."
 
+waited_time=0
 while true; do
     memory_usage=$(tsm_smi | awk '{if ($2=="|") {print $9} else if ($4=="|" && $11!="|") {print $11} }')
     memory_total=$(tsm_smi | awk '{if ($2=="|") {print $11} else if ($4=="|" && $11!="|") {print $13} }')
 
-    # Check if tsm_smi command was successful
     if [ $? -ne 0 ]; then
-        echo "Failed to query GPU memory information. Please check if tsm_smi is working correctly."
+        echo "Failed to query GPU memory information."
         exit 1
     fi
 
-    # Convert query results to arrays
     IFS=$'\n' read -d '' -r -a usage_array <<< "$memory_usage"
     IFS=$'\n' read -d '' -r -a total_array <<< "$memory_total"
 
-    need_wait=false
+    available_gpus=()
 
-    # Check the available memory for each GPU
     printf " GPU  Total (MiB)  Used (MiB)  Free (MiB)\n"
     for ((i=0; i<$gpu_count; i++)); do
-        # trim 'M' from number
         total_i=${total_array[$i]%?}
         used_i=${usage_array[$i]%?}
         free_i=$((total_i - used_i))
 
         printf "%4d%'13d%'12d%'12d\n" $i ${total_i} ${used_i} ${free_i}
-        if [ $free_i -lt $mem_threshold ]; then
-            need_wait=true
-            break
+        if [ $free_i -ge $mem_threshold ]; then
+            available_gpus+=($i)
         fi
     done
 
-    if [ "$need_wait" = false ]; then
-        echo "All GPUs have sufficient memory."
+    if [ ${#available_gpus[@]} -gt 0 ]; then
+        AVAILABLE_GPUS=$(IFS=,; echo "${available_gpus[*]}")
+        echo "Available GPUs: ${AVAILABLE_GPUS}"
         break
     fi
 
-    echo "GPU memory is insufficient, waiting for $sleep_time seconds before retrying..."
+    echo "No GPU has sufficient memory, waiting for $sleep_time seconds..."
     sleep $sleep_time
+    waited_time=$((waited_time + sleep_time))
+    if [ $waited_time -ge $max_wait ]; then
+        echo "Error: Timed out waiting for available GPU."
+        exit 1
+    fi
 done


### PR DESCRIPTION
## Problem

The gpu_check scripts required **all** GPUs to have sufficient free memory before proceeding. This is overly strict — the `command.yaml` workflow typically tests a single operator and only needs **one** GPU with enough memory.

## Changes

### gpu_check_*.sh (all 12 backends)

- Changed from "all must pass" to "collect available GPUs"
- Only wait/retry when **no** GPU has sufficient memory
- Output `Available GPUs: 0,1,3,...` on the last line for downstream consumption
- Unified `max_wait` timeout to 600 seconds

### command.yaml

- Capture `AVAILABLE_GPUS` from gpu_check output
- Pass `--gpus "${AVAILABLE_GPUS}"` to both `run_tests.py` invocations (new op + baseline)

## Example output

```
Detected 8 NVIDIA GPU card(s).
 GPU  Total (MiB)  Used (MiB)  Free (MiB)
   0        97920            2        97918
   1        97920        45000        52920
   2        97920        97000          920
   3        97920            5        97915
Available GPUs: 0,1,3
```

closes: #4527