### PR TITLE
run_tests: cap worker count to number of ops

### DIFF
--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -1050,6 +1050,11 @@ def main():
         gpu_ids = [int(x) for x in gpu_list if x.strip()]
     gpu_count = len(gpu_ids)
 
+    # Don't spawn more workers than there are ops to test
+    if gpu_count > op_count:
+        gpu_ids = gpu_ids[:op_count]
+        gpu_count = op_count
+
     op_width = min(max(len(op) for op in ops), 40) if ops else 20
 
     work_queue = Queue()


### PR DESCRIPTION
## Problem

When `--gpus` provides more GPU IDs than there are operators to test (e.g. `--gpus 0,1,3,5` but only 1 op), the script spawns idle worker processes and shows unnecessary GPU status lines in the display.

## Fix

Cap the number of GPU workers to the number of ops:

```python
if gpu_count > op_count:
    gpu_ids = gpu_ids[:op_count]
    gpu_count = op_count
```

This is especially relevant after #4528, where `gpu_check` may report multiple available GPUs but `command.yaml` typically tests a single operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)