### PR TITLE
Fix psum_text comparison when before has no performance data

### DIFF
--- a/tools/psum_text
+++ b/tools/psum_text
@@ -136,7 +136,7 @@ def parse_single_accuracy():
     else:
         data1 = DATA.get("result", {})
 
-    op = list(data1.keys())[0]
+    op = list(data1.keys())[0] if data1 else list(data2.keys())[0]
     op_data1 = data1.get(op, {}).get("accuracy", {})
     op_data2 = {}
     if ARGS.compare:
@@ -192,9 +192,9 @@ def parse_single_accuracy():
 def parse_single_performance():
     def _get_summary(op_data, case=None):
         status = op_data.get("status", "OK")
-        duration = op_data1.get("duration", 0)
+        duration = op_data.get("duration", 0)
         if status in ["Skipped", "Failed"]:
-            reason = op_data1.get("reason", "Unknown")
+            reason = op_data.get("reason", "Unknown")
             reason = "<blockquote>" + reason.replace("\n", "<br/>") + "</blockquote>"
             if status == "Failed":
                 status = "<span style='color:Red'>Failed</span>"
@@ -216,12 +216,14 @@ def parse_single_performance():
     if ARGS.compare:
         data1 = DATA["before"].get("result", {})
         data2 = DATA["after"].get("result", {})
-        op = list(data1.keys())[0]
+        op = list(data1.keys())[0] if data1 else list(data2.keys())[0]
         op_data2 = data2.get(op, {}).get("performance", {})
     else:
         data1 = DATA.get("result", {})
+        data2 = {}
 
-    op = list(data1.keys())[0]
+    if not ARGS.compare:
+        op = list(data1.keys())[0]
     op_data1 = data1.get(op, {}).get("performance", {})
 
     lines = []
@@ -306,6 +308,29 @@ def parse_single_performance():
             for shp, res2 in ddata2.get("details", {}).items():
                 if shp in ddata1.get("details", {}):
                     continue
+                s2 = res2.get("speedup", 0)
+                b2 = res2.get("base", 0)
+                g2 = res2.get("gems", 0)
+                line = (
+                    f"| | 0 -> {s2:.3f} |"
+                    f" 0 -> {b2:.3f} |"
+                    f" 0 -> {g2:.3f} |"
+                    f" `{shp}` |"
+                )
+                lines.append(line)
+
+    # Handle dtypes that only exist in the 'after' data
+    if ARGS.compare:
+        for dtype, ddata2 in perf_data2.items():
+            if dtype in perf_data1:
+                continue
+            speedup2 = ddata2.get("speedup", 0)
+            spd_str = f"**0 -> {speedup2:.3f}**"
+            spd_str = f"<span style='color:Green'>**{spd_str}**</span>"
+            line = f"| {dtype} | {spd_str} | - | - | - |"
+            lines.append(line)
+
+            for shp, res2 in ddata2.get("details", {}).items():
                 s2 = res2.get("speedup", 0)
                 b2 = res2.get("base", 0)
                 g2 = res2.get("gems", 0)


### PR DESCRIPTION
## Problem

When comparing an existing operator (before) that has no performance data with a new implementation (after) that does, the markdown table is not properly generated:

- Op name lookup crashes if before result is empty
- `_get_summary()` always reads from `op_data1` instead of its parameter, showing wrong data for the after case
- Dtypes only in after data are silently skipped (the loop only iterates over before dtypes)

## Fixes

1. **Op name fallback**: use after data when before data is empty
2. **`_get_summary` bug**: change `op_data1` references to `op_data` (the function parameter)
3. **After-only dtypes**: add a second pass for dtypes present in after but not in before

🤖 Generated with [Claude Code](https://claude.com/claude-code)