### PR TITLE
fix: safe vllm install to protect torch/triton/flagtree

### DIFF
--- a/.github/actions/setup-flaggems/action.yml
+++ b/.github/actions/setup-flaggems/action.yml
@@ -20,13 +20,36 @@ runs:
     - name: Install vllm (nvidia only)
       if: startsWith(inputs.vendor, 'nvidia')
       shell: bash
+      env:
+        VLLM_VERSION: "0.21.0"
       run: |
         source .venv/bin/activate
-        uv pip install vllm==0.21.0 --torch-backend=cu130
+        # Record Layer 1 state before vllm install
+        uv pip freeze | grep -iE '^(torch|triton|flag)' | sort > /tmp/layer1-snapshot.txt
+
+        # Install vllm without deps to avoid overwriting torch/triton/flagtree
+        uv pip install --no-deps "vllm==${VLLM_VERSION}"
+
+        # Auto-generate safe dependency list (excludes torch, triton, nvidia-*, etc.)
+        python3 tools/vllm_safe_deps.py "vllm==${VLLM_VERSION}" > /tmp/vllm-safe-deps.txt
+
+        # Install only the safe deps, also --no-deps to prevent transitive pulls
+        uv pip install --no-deps -r /tmp/vllm-safe-deps.txt
+
+        # Verify Layer 1 packages were not modified
+        uv pip freeze | grep -iE '^(torch|triton|flag)' | sort > /tmp/layer2-snapshot.txt
+        if ! diff -q /tmp/layer1-snapshot.txt /tmp/layer2-snapshot.txt > /dev/null 2>&1; then
+          echo "::error::Layer 1 packages were modified by vllm install!"
+          diff /tmp/layer1-snapshot.txt /tmp/layer2-snapshot.txt
+          exit 1
+        fi
 
     - name: Check GPU availability
       if: inputs.gpu_check_script != ''
       shell: bash
       run: |
         source tools/env.sh ${{ inputs.vendor }}
-        bash ${{ inputs.gpu_check_script }}
+        GPU_OUTPUT=$(bash ${{ inputs.gpu_check_script }})
+        echo "$GPU_OUTPUT"
+        AVAILABLE_GPUS=$(echo "$GPU_OUTPUT" | grep "^Available GPUs:" | cut -d: -f2 | tr -d ' ')
+        echo "AVAILABLE_GPUS=${AVAILABLE_GPUS}" >> $GITHUB_ENV

--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -118,24 +118,10 @@ jobs:
           echo "checking out ${{ needs.preprocess.outputs.pull }}"
           gh pr checkout ${{ needs.preprocess.outputs.pull }}
 
-      - id: setup-flaggems
-        shell: bash
-        run: |
-          ./setup.sh ${BACKEND}
-          if [ "${BACKEND}" == "nvidia-cuda133" ]; then
-            source .venv/bin/activate
-            uv pip install vllm==0.21.0 --torch-backend=cu130
-          fi
-
-      - id: check-gpu
-        shell: bash
-        run: |
-          source .venv/bin/activate
-          source tools/env.sh ${BACKEND}
-          GPU_OUTPUT=$(bash tools/gpu_check_${VENDOR}.sh)
-          echo "$GPU_OUTPUT"
-          AVAILABLE_GPUS=$(echo "$GPU_OUTPUT" | grep "^Available GPUs:" | cut -d: -f2 | tr -d ' ')
-          echo "AVAILABLE_GPUS=${AVAILABLE_GPUS}" >> $GITHUB_ENV
+      - uses: ./.github/actions/setup-flaggems
+        with:
+          vendor: ${{ env.BACKEND }}
+          gpu_check_script: tools/gpu_check_${{ env.VENDOR }}.sh
 
       - id: run-tests
         shell: bash

--- a/tools/vllm_safe_deps.py
+++ b/tools/vllm_safe_deps.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+"""Extract vllm's pip-installable dependencies, excluding packages that
+conflict with the FlagOS runtime (torch, triton, nvidia-*, flashinfer, …).
+
+Usage
+-----
+    # Print safe dependency specs, one per line:
+    python tools/vllm_safe_deps.py vllm==0.21.0
+
+    # Use with pip/uv:
+    python tools/vllm_safe_deps.py vllm==0.21.0 | xargs uv pip install
+
+    # Custom blacklist (extend the built-in one):
+    python tools/vllm_safe_deps.py vllm==0.21.0 --exclude numba --exclude xgrammar
+
+The script fetches metadata from PyPI (no download/install), filters out
+hardware-specific packages, and prints one safe dependency per line.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import urllib.request
+
+# ── Packages provided by the FlagOS runtime layer ──────────────
+# These must NOT be installed/upgraded when adding vllm on top.
+BUILTIN_BLACKLIST: set[str] = {
+    # torch ecosystem — provided by vendor base image + FlagOS runtime
+    "torch",
+    "torchaudio",
+    "torchvision",
+    # triton / flagtree — compiler layer
+    "triton",
+    "triton-ascend",
+    "triton-gcu",
+    # NVIDIA-specific packages
+    "flashinfer-python",
+    "flashinfer-cubin",
+    "nvidia-cudnn-frontend",
+    "nvidia-cutlass-dsl",
+    "nvidia-cutlass-dsl-libs-base",
+    "humming-kernels",
+    "tokenspeed-mla",
+    "tokenspeed-triton",
+    # may pull nvidia-cuda-* runtime packages
+    "numba",
+    # tvm / tilelang — tightly coupled to hardware
+    "apache-tvm-ffi",
+    "tilelang",
+    # quack-kernels — CUDA-specific
+    "quack-kernels",
+}
+
+
+def _normalize(name: str) -> str:
+    """PEP 503 normalize: lowercase, replace [-_.] with -."""
+    return re.sub(r"[-_.]+", "-", name).lower()
+
+
+def _parse_dep_name(spec: str) -> str:
+    """Extract the package name from a requires_dist spec string.
+
+    Examples:
+        "torch==2.11.0"          → "torch"
+        "fastapi[standard]>=0.1" → "fastapi"
+        "six>=1.16; ..."         → "six"
+    """
+    # strip environment markers
+    spec = spec.split(";")[0].strip()
+    # strip extras and version
+    match = re.match(r"^([A-Za-z0-9]([A-Za-z0-9._-]*[A-Za-z0-9])?)", spec)
+    return match.group(1) if match else spec
+
+
+def _strip_version(spec: str) -> str:
+    """Return the spec without environment markers."""
+    return spec.split(";")[0].strip()
+
+
+def fetch_requires_dist(package_spec: str) -> list[str]:
+    """Fetch requires_dist from PyPI JSON API."""
+    # "vllm==0.21.0" → name="vllm", version="0.21.0"
+    if "==" in package_spec:
+        name, version = package_spec.split("==", 1)
+    else:
+        name = package_spec
+        version = None
+
+    if version:
+        url = f"https://pypi.org/pypi/{name}/{version}/json"
+    else:
+        url = f"https://pypi.org/pypi/{name}/json"
+
+    try:
+        with urllib.request.urlopen(url, timeout=30) as resp:
+            data = json.loads(resp.read())
+    except Exception as exc:
+        print(f"Error fetching metadata for {package_spec}: {exc}", file=sys.stderr)
+        sys.exit(1)
+
+    return data.get("info", {}).get("requires_dist") or []
+
+
+def filter_safe_deps(
+    requires_dist: list[str],
+    blacklist: set[str],
+) -> list[str]:
+    """Filter out blacklisted and extras-only dependencies."""
+    safe = []
+    blacklist_normalized = {_normalize(p) for p in blacklist}
+
+    for spec in requires_dist:
+        # Skip extras-only deps (e.g. 'zentorch ; extra == "zen"')
+        if "extra ==" in spec or "extra ==" in spec:
+            continue
+
+        dep_name = _parse_dep_name(spec)
+        if _normalize(dep_name) in blacklist_normalized:
+            continue
+
+        safe.append(_strip_version(spec))
+
+    return safe
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract safe vllm deps for FlagOS environments",
+    )
+    parser.add_argument(
+        "package",
+        help='Package spec, e.g. "vllm==0.21.0"',
+    )
+    parser.add_argument(
+        "--exclude",
+        action="append",
+        default=[],
+        help="Additional package names to exclude (can repeat)",
+    )
+    parser.add_argument(
+        "--show-blocked",
+        action="store_true",
+        help="Also print blocked packages (prefixed with #)",
+    )
+    args = parser.parse_args()
+
+    blacklist = BUILTIN_BLACKLIST | {_normalize(p) for p in args.exclude}
+    requires_dist = fetch_requires_dist(args.package)
+
+    if args.show_blocked:
+        blacklist_normalized = {_normalize(p) for p in blacklist}
+        for spec in requires_dist:
+            if "extra ==" in spec or "extra ==" in spec:
+                continue
+            dep_name = _parse_dep_name(spec)
+            stripped = _strip_version(spec)
+            if _normalize(dep_name) in blacklist_normalized:
+                print(f"# BLOCKED: {stripped}")
+            else:
+                print(stripped)
+    else:
+        safe = filter_safe_deps(requires_dist, blacklist)
+        for dep in safe:
+            print(dep)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Problem

`uv pip install vllm==0.21.0 --torch-backend=cu130` in the `setup-flaggems` action
and `command.yaml` pulls in packages that overwrite the FlagOS runtime layer:

- **triton** — overwrites flagtree's `site-packages/triton/` namespace
- **flashinfer-python/flashinfer-cubin** — NVIDIA-specific, unnecessary
- **nvidia-cudnn-frontend/nvidia-cutlass-dsl** — NVIDIA-specific
- **numba** — may pull additional `nvidia-cuda-*` runtime packages
- **tokenspeed-mla/tokenspeed-triton** — CUDA-specific

`--torch-backend=cu130` only protects `torch` itself; all other deps are installed unconditionally.

## Solution

Three-step safe install:
1. `uv pip install --no-deps vllm` — only the vllm package, no dependencies
2. `python3 tools/vllm_safe_deps.py vllm==0.21.0` — auto-generate safe dependency list from PyPI metadata, filtering out a blacklist of hardware-specific packages
3. `uv pip install --no-deps -r safe-deps.txt` — install only the safe deps (`--no-deps` to prevent transitive pulls via torch's triton dependency)
4. Layer 1 snapshot diff to fail fast if anything was overwritten

## Changes

- **`tools/vllm_safe_deps.py`** (new): Fetches vllm's `requires_dist` from PyPI JSON API, filters out blacklisted packages, outputs safe deps one per line
- **`.github/actions/setup-flaggems/action.yml`**: Replace direct `uv pip install vllm` with the safe install flow; add `AVAILABLE_GPUS` env var export in GPU check step
- **`.github/workflows/command.yaml`**: Remove inline setup/GPU-check steps, reuse `setup-flaggems` action (consistent with random-test, backend-test, cpp-op-test)

## Verification (h20, 2× NVIDIA H20)

| Check | Result |
|---|---|
| Layer 1 snapshot diff | ✅ Identical |
| `torch` | ✅ `2.11.0+cu130` unchanged |
| `triton` | ✅ `3.6.0` not reinstalled |
| `flag_gems` | ✅ `5.4.0dev` unchanged |
| `import vllm` | ✅ `0.21.0` works |
| flashinfer/numba/nvidia-cutlass/tokenspeed | ✅ None installed |

🤖 Generated with [Claude Code](https://claude.com/claude-code)