### PR TITLE
add tests & benchmark of div_tensor_mode_,div_tensor_mode

### DIFF
--- a/benchmark/test_div.py
+++ b/benchmark/test_div.py
@@ -34,6 +34,49 @@ def test_div_inplace():
     bench.run()
 
 
+def _div_tensor_mode_input_fn(shape, dtype, device):
+    inp1 = utils.generate_tensor_input(shape, dtype, device)
+    inp2 = utils.generate_tensor_input(shape, dtype, device)
+    if dtype in consts.FLOAT_DTYPES:
+        inp2 = torch.where(inp2 >= 0, inp2 + 0.1, inp2 - 0.1)
+    else:
+        inp2 = torch.where(inp2 == 0, 1, inp2)
+    yield inp1, inp2
+
+
+@pytest.mark.div_tensor_mode
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+@pytest.mark.parametrize("rounding_mode", [None, "trunc", "floor"])
+def test_div_tensor_mode(rounding_mode):
+    dtypes = [torch.float32] if rounding_mode == "trunc" else consts.FLOAT_DTYPES
+    bench = base.GenericBenchmark(
+        op_name="div_tensor_mode",
+        input_fn=_div_tensor_mode_input_fn,
+        torch_op=lambda a, b: torch.div(a, b, rounding_mode=rounding_mode),
+        dtypes=dtypes,
+    )
+    bench.run()
+
+
+@pytest.mark.div_tensor_mode_
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+@pytest.mark.parametrize("rounding_mode", [None, "trunc", "floor"])
+def test_div_tensor_mode_inplace(rounding_mode):
+    dtypes = [torch.float32] if rounding_mode == "trunc" else consts.FLOAT_DTYPES
+    bench = base.GenericBenchmark(
+        op_name="div_tensor_mode_",
+        input_fn=_div_tensor_mode_input_fn,
+        torch_op=lambda a, b: a.div_(b, rounding_mode=rounding_mode),
+        dtypes=dtypes,
+        is_inplace=True,
+    )
+    bench.run()
+
+
 @pytest.mark.div_scalar_
 @pytest.mark.skipif(
     flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"

--- a/tests/test_div.py
+++ b/tests/test_div.py
@@ -43,6 +43,100 @@ def test_div_tensor_tensor_(shape, dtype):
     utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True)
 
 
+def _make_nonzero_float_tensor(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    return torch.where(inp >= 0, inp + 0.1, inp - 0.1)
+
+
+def _make_nonzero_int_tensor(shape, dtype):
+    inp = torch.randint(-100, 100, shape, dtype=dtype, device="cpu").to(
+        flag_gems.device
+    )
+    return torch.where(inp == 0, 1, inp)
+
+
+# div.Tensor_mode with rounding_mode keyword
+@pytest.mark.div_tensor_mode
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("rounding_mode", [None, "trunc", "floor"])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_div_tensor_mode_float(shape, rounding_mode, dtype):
+    if rounding_mode == "trunc" and dtype != torch.float32:
+        pytest.skip("tl.math.div_rz only supports float32/float64")
+
+    inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    inp2 = _make_nonzero_float_tensor(shape, dtype)
+    ref_inp1 = utils.to_reference(inp1, False)
+    ref_inp2 = utils.to_reference(inp2, False)
+
+    ref_out = torch.div(ref_inp1, ref_inp2, rounding_mode=rounding_mode)
+    with flag_gems.use_gems():
+        res_out = torch.div(inp1, inp2, rounding_mode=rounding_mode)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True)
+
+
+@pytest.mark.div_tensor_mode
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("rounding_mode", ["trunc", "floor"])
+@pytest.mark.parametrize("dtype", utils.INT_DTYPES)
+def test_div_tensor_mode_int(shape, rounding_mode, dtype):
+    inp1 = torch.randint(-100, 100, shape, dtype=dtype, device="cpu").to(
+        flag_gems.device
+    )
+    inp2 = _make_nonzero_int_tensor(shape, dtype)
+    ref_inp1 = utils.to_reference(inp1, False)
+    ref_inp2 = utils.to_reference(inp2, False)
+
+    ref_out = torch.div(ref_inp1, ref_inp2, rounding_mode=rounding_mode)
+    with flag_gems.use_gems():
+        res_out = torch.div(inp1, inp2, rounding_mode=rounding_mode)
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+# div_.Tensor_mode with rounding_mode keyword
+@pytest.mark.div_tensor_mode_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("rounding_mode", [None, "trunc", "floor"])
+@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
+def test_div_tensor_mode_float_(shape, rounding_mode, dtype):
+    if rounding_mode == "trunc" and dtype != torch.float32:
+        pytest.skip("tl.math.div_rz only supports float32/float64")
+
+    inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    inp2 = _make_nonzero_float_tensor(shape, dtype)
+    ref_inp1 = utils.to_reference(inp1.clone(), False)
+    ref_inp2 = utils.to_reference(inp2, False)
+
+    ref_out = ref_inp1.div_(ref_inp2, rounding_mode=rounding_mode)
+    with flag_gems.use_gems():
+        res_out = inp1.div_(inp2, rounding_mode=rounding_mode)
+
+    assert res_out is inp1
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True)
+
+
+@pytest.mark.div_tensor_mode_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("rounding_mode", ["trunc", "floor"])
+@pytest.mark.parametrize("dtype", utils.INT_DTYPES)
+def test_div_tensor_mode_int_(shape, rounding_mode, dtype):
+    inp1 = torch.randint(-100, 100, shape, dtype=dtype, device="cpu").to(
+        flag_gems.device
+    )
+    inp2 = _make_nonzero_int_tensor(shape, dtype)
+    ref_inp1 = utils.to_reference(inp1.clone(), False)
+    ref_inp2 = utils.to_reference(inp2, False)
+
+    ref_out = ref_inp1.div_(ref_inp2, rounding_mode=rounding_mode)
+    with flag_gems.use_gems():
+        res_out = inp1.div_(inp2, rounding_mode=rounding_mode)
+
+    assert res_out is inp1
+    utils.gems_assert_equal(res_out, ref_out)
+
+
 # div.Tensor with true_divide
 @pytest.mark.div_tensor
 @pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
Other

### Description
add tests & benchmark of div_tensor_mode_,div_tensor_mode

### Issue
closes: #4063 

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
benchmark on H20 HBM3
```
FlagGems/benchmark# pytest -s -m div_tensor_mode_
================================ test session starts ================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.13.0, xdoctest-1.0.2, rerunfailures-15.1, hypothesis-6.130.8, xdist-3.6.1, flakefinder-1.1.0, shard-0.1.2
collecting 222 items                                                                WARNING 07-06 07:54:47 [interface.py:869] Current platform cuda does not have '_pytestfixturefunction' attribute.
WARNING 07-06 07:54:47 [interface.py:869] Current platform cuda does not have '_pytestfixturefunction' attribute.
collected 836 items / 833 deselected / 3 selected                                   
Running 3 items in this shard

test_div.py 
Operator: div_tensor_mode_  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               3.614208            2.119840               1.705          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.006608            0.015136               0.437          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.063328            0.037824               1.674          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.063776            0.037760               1.689          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               3.616032            1.926832               1.877          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.908672            0.499360               1.820          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.006752            0.015808               0.427          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.015744            0.016032               0.982          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               2.208144            1.183536               1.866          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.007040            0.063936               0.110          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.015776            0.014848               1.063          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               2.208384            1.180416               1.871          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode_  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               8.706544            3.550944               2.452          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.007776            0.014272               0.545          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.129536            0.061152               2.118          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.129248            0.061312               2.108          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               8.706096            3.560352               2.445          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               2.034480            0.883968               2.302          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.007712            0.013760               0.560          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.026560            0.015456               1.718          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               5.172928            2.162784               2.392          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.007712            0.014240               0.542          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.026464            0.015616               1.695          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               5.174048            2.163104               2.392          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode_  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               8.366992            1.954080               4.282          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.007808            0.014144               0.552          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.128160            0.037824               3.388          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.128192            0.037952               3.378          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               8.367696            1.951744               4.287          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               1.985232            0.527904               3.761          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.007648            0.014400               0.531          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.025536            0.014912               1.712          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               4.976016            1.225184               4.061          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.007648            0.014176               0.540          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.025584            0.014080               1.817          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               4.975840            1.212640               4.103          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]

.
Operator: div_tensor_mode_  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               4.190880            4.978368               0.842          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.006848            0.013312               0.514          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.071200            0.084480               0.843          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.070688            0.084512               0.836          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               4.195584            4.938976               0.849          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               1.058512            1.362944               0.777          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.006752            0.012928               0.522          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.017408            0.018624               0.935          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               2.592448            3.077840               0.842          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.006976            0.012800               0.545          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.017184            0.018656               0.921          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               2.569360            3.098768               0.829          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]

.
Operator: div_tensor_mode_  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              15.272640           12.292496               1.242          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.011456            0.012256               0.935          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.244800            0.196864               1.243          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.244992            0.196928               1.244          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS              15.272032           12.294992               1.242          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               3.789760            3.083360               1.229          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.011552            0.011936               0.968          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.045312            0.035968               1.260          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               9.284000            7.571872               1.226          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.011712            0.012640               0.927          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.045600            0.036000               1.267          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               9.283552            7.572064               1.226          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode_  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              15.274176           12.696736               1.203          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.011584            0.012384               0.935          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.238976            0.193520               1.235          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.238912            0.193472               1.235          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS              15.275232           12.694880               1.203          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               3.721216            3.143472               1.184          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.011584            0.012480               0.928          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.045184            0.035936               1.257          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               9.191824            7.786256               1.181          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.011680            0.013024               0.897          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.044896            0.035936               1.249          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               9.192528            7.785760               1.181          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode_  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              16.061904           12.718784               1.263          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.011680            0.012832               0.910          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.247872            0.198496               1.249          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.247744            0.198560               1.248          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS              16.055424           12.721792               1.262          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               3.899424            3.145024               1.240          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.011872            0.012544               0.946          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.046016            0.036000               1.278          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               9.663264            7.781792               1.242          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.011872            0.012768               0.930          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.045696            0.035968               1.270          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               9.663200            7.781360               1.242          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]

.

=================== 3 passed, 833 deselected in 208.26s (0:03:28) ===================
```
```
FlagGems/benchmark# pytest -s -m div_tensor_mode
================================ test session starts ================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.13.0, xdoctest-1.0.2, rerunfailures-15.1, hypothesis-6.130.8, xdist-3.6.1, flakefinder-1.1.0, shard-0.1.2
collecting 222 items                                                                WARNING 07-06 07:56:21 [interface.py:869] Current platform cuda does not have '_pytestfixturefunction' attribute.
WARNING 07-06 07:56:21 [interface.py:869] Current platform cuda does not have '_pytestfixturefunction' attribute.
collected 836 items / 833 deselected / 3 selected                                   
Running 3 items in this shard

test_div.py 
Operator: div_tensor_mode  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.913920            2.221632               0.861          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.005344            0.031424               0.170          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.038560            0.051680               0.746          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.038336            0.051584               0.743          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               2.007296            1.977216               1.015          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.556448            0.519424               1.071          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.005824            0.030528               0.191          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.010656            0.030624               0.348          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               1.284288            1.220128               1.053          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.005728            0.030656               0.187          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.010624            0.030784               0.345          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               1.257312            1.236928               1.016          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               3.450368            3.544512               0.973          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.005408            0.030976               0.175          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.061888            0.062016               0.998          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.061664            0.061792               0.998          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               3.450720            3.544608               0.974          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.933040            0.887296               1.052          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.005664            0.029824               0.190          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.015104            0.031136               0.485          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               2.111008            2.154800               0.980          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.005632            0.030688               0.184          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.015104            0.031328               0.482          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               2.111392            2.155296               0.980          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.032880            1.989920               1.022          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.005376            0.030912               0.174          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.038560            0.051904               0.743          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.038400            0.051488               0.746          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               2.007648            1.952448               1.028          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.559584            0.522912               1.070          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.005728            0.029792               0.192          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.010656            0.030272               0.352          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               1.281024            1.223424               1.047          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.005696            0.029664               0.192          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.010656            0.030304               0.352          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               1.259712            1.219488               1.033          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]

.
Operator: div_tensor_mode  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               3.446528            3.765136               0.915          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.005536            0.028352               0.195          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.061888            0.067616               0.915          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.061760            0.067456               0.916          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               3.447840            3.752576               0.919          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.963232            1.076688               0.895          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.005824            0.028640               0.203          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.015104            0.028672               0.527          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               2.114720            2.377696               0.889          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.005728            0.028784               0.199          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.015008            0.028928               0.519          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               2.184864            2.425600               0.901          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]

.
Operator: div_tensor_mode  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               7.181760            6.423808               1.118          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008352            0.027584               0.303          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.119360            0.103232               1.156          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.119616            0.103552               1.155          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               7.189120            6.427488               1.118          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               1.801152            1.618448               1.113          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.008416            0.027200               0.309          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.024544            0.029984               0.819          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               4.382928            4.012656               1.092          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.008416            0.027680               0.304          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.024512            0.030720               0.798          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               4.382768            4.012480               1.092          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               6.875040            6.653744               1.033          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008160            0.026880               0.304          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.114368            0.101136               1.131          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.114624            0.101216               1.132          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               6.879488            6.626128               1.038          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               1.727312            1.667296               1.036          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.008320            0.027936               0.298          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.024384            0.030912               0.789          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               4.204800            4.129248               1.018          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.008256            0.027568               0.299          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.024320            0.030976               0.785          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               4.213216            4.140000               1.018          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               7.415872            6.579072               1.127          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008320            0.027424               0.303          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.123200            0.104832               1.175          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.123520            0.105152               1.175          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               7.421920            6.583424               1.127          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               1.861088            1.659328               1.122          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.008480            0.027808               0.305          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.025088            0.030432               0.824          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               4.529248            4.111840               1.102          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.008480            0.027648               0.307          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.025152            0.029504               0.852          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               4.529152            4.111840               1.101          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]

.

=================== 3 passed, 833 deselected in 160.75s (0:02:40) ===================
```
