### PR TITLE
add tests & benchmark of div_scalar_mode_,div_scalar_mode

### DIFF
--- a/benchmark/test_div.py
+++ b/benchmark/test_div.py
@@ -34,6 +34,88 @@ def test_div_inplace():
     bench.run()
 
 
+def _div_tensor_mode_input_fn(shape, dtype, device):
+    inp1 = utils.generate_tensor_input(shape, dtype, device)
+    inp2 = utils.generate_tensor_input(shape, dtype, device)
+    if dtype in consts.FLOAT_DTYPES:
+        inp2 = torch.where(inp2 >= 0, inp2 + 0.1, inp2 - 0.1)
+    else:
+        inp2 = torch.where(inp2 == 0, 1, inp2)
+    yield inp1, inp2
+
+
+def _div_scalar_mode_input_fn(shape, dtype, device):
+    inp = utils.generate_tensor_input(shape, dtype, device)
+    scalar = -2.5 if dtype in consts.FLOAT_DTYPES else -3
+    yield inp, scalar
+
+
+def _div_mode_dtypes(rounding_mode):
+    return [torch.float32] if rounding_mode == "trunc" else consts.FLOAT_DTYPES
+
+
+@pytest.mark.div_tensor_mode
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+@pytest.mark.parametrize("rounding_mode", [None, "trunc", "floor"])
+def test_div_tensor_mode(rounding_mode):
+    bench = base.GenericBenchmark(
+        op_name="div_tensor_mode",
+        input_fn=_div_tensor_mode_input_fn,
+        torch_op=lambda a, b: torch.div(a, b, rounding_mode=rounding_mode),
+        dtypes=_div_mode_dtypes(rounding_mode),
+    )
+    bench.run()
+
+
+@pytest.mark.div_tensor_mode_
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+@pytest.mark.parametrize("rounding_mode", [None, "trunc", "floor"])
+def test_div_tensor_mode_inplace(rounding_mode):
+    bench = base.GenericBenchmark(
+        op_name="div_tensor_mode_",
+        input_fn=_div_tensor_mode_input_fn,
+        torch_op=lambda a, b: a.div_(b, rounding_mode=rounding_mode),
+        dtypes=_div_mode_dtypes(rounding_mode),
+        is_inplace=True,
+    )
+    bench.run()
+
+
+@pytest.mark.div_scalar_mode
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+@pytest.mark.parametrize("rounding_mode", [None, "trunc", "floor"])
+def test_div_scalar_mode(rounding_mode):
+    bench = base.GenericBenchmark(
+        op_name="div_scalar_mode",
+        input_fn=_div_scalar_mode_input_fn,
+        torch_op=lambda a, b: torch.div(a, b, rounding_mode=rounding_mode),
+        dtypes=_div_mode_dtypes(rounding_mode),
+    )
+    bench.run()
+
+
+@pytest.mark.div_scalar_mode_
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+@pytest.mark.parametrize("rounding_mode", [None, "trunc", "floor"])
+def test_div_scalar_mode_inplace(rounding_mode):
+    bench = base.GenericBenchmark(
+        op_name="div_scalar_mode_",
+        input_fn=_div_scalar_mode_input_fn,
+        torch_op=lambda a, b: a.div_(b, rounding_mode=rounding_mode),
+        dtypes=_div_mode_dtypes(rounding_mode),
+        is_inplace=True,
+    )
+    bench.run()
+
+
 @pytest.mark.div_scalar_
 @pytest.mark.skipif(
     flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"

--- a/benchmark/test_div.py
+++ b/benchmark/test_div.py
@@ -60,13 +60,11 @@ def _div_mode_dtypes(rounding_mode):
 )
 @pytest.mark.parametrize("rounding_mode", [None, "trunc", "floor"])
 def test_div_tensor_mode(rounding_mode):
-    dtypes = [torch.float32] if rounding_mode == "trunc" else consts.FLOAT_DTYPES
     bench = base.GenericBenchmark(
         op_name="div_tensor_mode",
         input_fn=_div_tensor_mode_input_fn,
         torch_op=lambda a, b: torch.div(a, b, rounding_mode=rounding_mode),
         dtypes=_div_mode_dtypes(rounding_mode),
-        dtypes=dtypes,
     )
     bench.run()
 
@@ -77,7 +75,6 @@ def test_div_tensor_mode(rounding_mode):
 )
 @pytest.mark.parametrize("rounding_mode", [None, "trunc", "floor"])
 def test_div_tensor_mode_inplace(rounding_mode):
-    dtypes = [torch.float32] if rounding_mode == "trunc" else consts.FLOAT_DTYPES
     bench = base.GenericBenchmark(
         op_name="div_tensor_mode_",
         input_fn=_div_tensor_mode_input_fn,
@@ -114,7 +111,6 @@ def test_div_scalar_mode_inplace(rounding_mode):
         input_fn=_div_scalar_mode_input_fn,
         torch_op=lambda a, b: a.div_(b, rounding_mode=rounding_mode),
         dtypes=_div_mode_dtypes(rounding_mode),
-        dtypes=dtypes,
         is_inplace=True,
     )
     bench.run()

--- a/tests/test_div.py
+++ b/tests/test_div.py
@@ -43,6 +43,169 @@ def test_div_tensor_tensor_(shape, dtype):
     utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True)
 
 
+def _make_nonzero_float_tensor(shape, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    return torch.where(inp >= 0, inp + 0.1, inp - 0.1)
+
+
+def _make_nonzero_int_tensor(shape, dtype):
+    inp = torch.randint(-100, 100, shape, dtype=dtype, device="cpu").to(
+        flag_gems.device
+    )
+    return torch.where(inp == 0, 1, inp)
+
+
+DIV_MODE_FLOAT_CASES = (
+    [(None, dtype) for dtype in utils.FLOAT_DTYPES]
+    + [("floor", dtype) for dtype in utils.FLOAT_DTYPES]
+    + [("trunc", torch.float32)]
+)
+
+
+# div.Tensor_mode with rounding_mode keyword
+@pytest.mark.div_tensor_mode
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("rounding_mode,dtype", DIV_MODE_FLOAT_CASES)
+def test_div_tensor_mode_float(shape, rounding_mode, dtype):
+    inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    inp2 = _make_nonzero_float_tensor(shape, dtype)
+    ref_inp1 = utils.to_reference(inp1, False)
+    ref_inp2 = utils.to_reference(inp2, False)
+
+    ref_out = torch.div(ref_inp1, ref_inp2, rounding_mode=rounding_mode)
+    with flag_gems.use_gems():
+        res_out = torch.div(inp1, inp2, rounding_mode=rounding_mode)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True)
+
+
+@pytest.mark.div_tensor_mode
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("rounding_mode", ["trunc", "floor"])
+@pytest.mark.parametrize("dtype", utils.INT_DTYPES)
+def test_div_tensor_mode_int(shape, rounding_mode, dtype):
+    inp1 = torch.randint(-100, 100, shape, dtype=dtype, device="cpu").to(
+        flag_gems.device
+    )
+    inp2 = _make_nonzero_int_tensor(shape, dtype)
+    ref_inp1 = utils.to_reference(inp1, False)
+    ref_inp2 = utils.to_reference(inp2, False)
+
+    ref_out = torch.div(ref_inp1, ref_inp2, rounding_mode=rounding_mode)
+    with flag_gems.use_gems():
+        res_out = torch.div(inp1, inp2, rounding_mode=rounding_mode)
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+# div_.Tensor_mode with rounding_mode keyword
+@pytest.mark.div_tensor_mode_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("rounding_mode,dtype", DIV_MODE_FLOAT_CASES)
+def test_div_tensor_mode_float_(shape, rounding_mode, dtype):
+    inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    inp2 = _make_nonzero_float_tensor(shape, dtype)
+    ref_inp1 = utils.to_reference(inp1.clone(), False)
+    ref_inp2 = utils.to_reference(inp2, False)
+
+    ref_out = ref_inp1.div_(ref_inp2, rounding_mode=rounding_mode)
+    with flag_gems.use_gems():
+        res_out = inp1.div_(inp2, rounding_mode=rounding_mode)
+
+    assert res_out is inp1
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True)
+
+
+@pytest.mark.div_tensor_mode_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("rounding_mode", ["trunc", "floor"])
+@pytest.mark.parametrize("dtype", utils.INT_DTYPES)
+def test_div_tensor_mode_int_(shape, rounding_mode, dtype):
+    inp1 = torch.randint(-100, 100, shape, dtype=dtype, device="cpu").to(
+        flag_gems.device
+    )
+    inp2 = _make_nonzero_int_tensor(shape, dtype)
+    ref_inp1 = utils.to_reference(inp1.clone(), False)
+    ref_inp2 = utils.to_reference(inp2, False)
+
+    ref_out = ref_inp1.div_(ref_inp2, rounding_mode=rounding_mode)
+    with flag_gems.use_gems():
+        res_out = inp1.div_(inp2, rounding_mode=rounding_mode)
+
+    assert res_out is inp1
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+# div.Scalar_mode with rounding_mode keyword
+@pytest.mark.div_scalar_mode
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("rounding_mode,dtype", DIV_MODE_FLOAT_CASES)
+def test_div_scalar_mode_float(shape, rounding_mode, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    scalar = -2.5
+    ref_inp = utils.to_reference(inp, False)
+
+    ref_out = torch.div(ref_inp, scalar, rounding_mode=rounding_mode)
+    with flag_gems.use_gems():
+        res_out = torch.div(inp, scalar, rounding_mode=rounding_mode)
+
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True)
+
+
+@pytest.mark.div_scalar_mode
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("rounding_mode", ["trunc", "floor"])
+@pytest.mark.parametrize("dtype", utils.INT_DTYPES)
+def test_div_scalar_mode_int(shape, rounding_mode, dtype):
+    inp = torch.randint(-100, 100, shape, dtype=dtype, device="cpu").to(
+        flag_gems.device
+    )
+    scalar = -3
+    ref_inp = utils.to_reference(inp, False)
+
+    ref_out = torch.div(ref_inp, scalar, rounding_mode=rounding_mode)
+    with flag_gems.use_gems():
+        res_out = torch.div(inp, scalar, rounding_mode=rounding_mode)
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+# div_.Scalar_mode with rounding_mode keyword
+@pytest.mark.div_scalar_mode_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("rounding_mode,dtype", DIV_MODE_FLOAT_CASES)
+def test_div_scalar_mode_float_(shape, rounding_mode, dtype):
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    scalar = -2.5
+    ref_inp = utils.to_reference(inp.clone(), False)
+
+    ref_out = ref_inp.div_(scalar, rounding_mode=rounding_mode)
+    with flag_gems.use_gems():
+        res_out = inp.div_(scalar, rounding_mode=rounding_mode)
+
+    assert res_out is inp
+    utils.gems_assert_close(res_out, ref_out, dtype, equal_nan=True)
+
+
+@pytest.mark.div_scalar_mode_
+@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
+@pytest.mark.parametrize("rounding_mode", ["trunc", "floor"])
+@pytest.mark.parametrize("dtype", utils.INT_DTYPES)
+def test_div_scalar_mode_int_(shape, rounding_mode, dtype):
+    inp = torch.randint(-100, 100, shape, dtype=dtype, device="cpu").to(
+        flag_gems.device
+    )
+    scalar = -3
+    ref_inp = utils.to_reference(inp.clone(), False)
+
+    ref_out = ref_inp.div_(scalar, rounding_mode=rounding_mode)
+    with flag_gems.use_gems():
+        res_out = inp.div_(scalar, rounding_mode=rounding_mode)
+
+    assert res_out is inp
+    utils.gems_assert_equal(res_out, ref_out)
+
+
 # div.Tensor with true_divide
 @pytest.mark.div_tensor
 @pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)

--- a/tests/test_div.py
+++ b/tests/test_div.py
@@ -67,15 +67,6 @@ DIV_MODE_FLOAT_CASES = (
 @pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
 @pytest.mark.parametrize("rounding_mode,dtype", DIV_MODE_FLOAT_CASES)
 def test_div_tensor_mode_float(shape, rounding_mode, dtype):
-# div.Tensor_mode with rounding_mode keyword
-@pytest.mark.div_tensor_mode
-@pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
-@pytest.mark.parametrize("rounding_mode", [None, "trunc", "floor"])
-@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
-def test_div_tensor_mode_float(shape, rounding_mode, dtype):
-    if rounding_mode == "trunc" and dtype != torch.float32:
-        pytest.skip("tl.math.div_rz only supports float32/float64")
-
     inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     inp2 = _make_nonzero_float_tensor(shape, dtype)
     ref_inp1 = utils.to_reference(inp1, False)
@@ -112,12 +103,6 @@ def test_div_tensor_mode_int(shape, rounding_mode, dtype):
 @pytest.mark.parametrize("shape", utils.POINTWISE_SHAPES)
 @pytest.mark.parametrize("rounding_mode,dtype", DIV_MODE_FLOAT_CASES)
 def test_div_tensor_mode_float_(shape, rounding_mode, dtype):
-@pytest.mark.parametrize("rounding_mode", [None, "trunc", "floor"])
-@pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
-def test_div_tensor_mode_float_(shape, rounding_mode, dtype):
-    if rounding_mode == "trunc" and dtype != torch.float32:
-        pytest.skip("tl.math.div_rz only supports float32/float64")
-
     inp1 = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     inp2 = _make_nonzero_float_tensor(shape, dtype)
     ref_inp1 = utils.to_reference(inp1.clone(), False)


### PR DESCRIPTION
### PR Category
OP Test

### Type of Change
Other

### Description
add tests & benchmark of div_scalar_mode_,div_scalar_mode

### Issue
closes: #4061 

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
benchmark on H20 HBM3
```
FlagGems/benchmark# pytest -s -m div_scalar_mode_
================================ test session starts ================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.13.0, xdoctest-1.0.2, rerunfailures-15.1, hypothesis-6.130.8, xdist-3.6.1, flakefinder-1.1.0, shard-0.1.2
collecting 228 items                                                                WARNING 07-06 08:38:56 [interface.py:869] Current platform cuda does not have '_pytestfixturefunction' attribute.
WARNING 07-06 08:38:56 [interface.py:869] Current platform cuda does not have '_pytestfixturefunction' attribute.
collected 842 items / 839 deselected / 3 selected                                   
Running 3 items in this shard

test_div.py 
Operator: div_scalar_mode_  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.238656            1.405952               0.881          [torch.Size([1073741824]), -2.5]
SUCCESS               0.005088            0.016224               0.314          [torch.Size([64, 64]), -2.5]
SUCCESS               0.024416            0.028480               0.857          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.024480            0.028512               0.859          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               1.238640            1.405952               0.881          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               0.313280            0.349632               0.896          [torch.Size([268435456]), -2.5]
SUCCESS               0.005184            0.014496               0.358          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.008096            0.015808               0.512          [torch.Size([10000, 256]), -2.5]
SUCCESS               0.758160            0.853904               0.888          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.005088            0.015104               0.337          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.008256            0.016000               0.516          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               0.758496            0.853920               0.888          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode_  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.349152            2.471296               0.951          [torch.Size([1073741824]), -2.5]
SUCCESS               0.005120            0.015392               0.333          [torch.Size([64, 64]), -2.5]
SUCCESS               0.041952            0.043440               0.966          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.042144            0.043536               0.968          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               2.349760            2.471152               0.951          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               0.590672            0.614912               0.961          [torch.Size([268435456]), -2.5]
SUCCESS               0.005216            0.015872               0.329          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.011008            0.015648               0.703          [torch.Size([10000, 256]), -2.5]
SUCCESS               1.436976            1.506720               0.954          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.005216            0.014432               0.361          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.011008            0.014624               0.753          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               1.437104            1.506576               0.954          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode_  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.238880            1.407232               0.880          [torch.Size([1073741824]), -2.5]
SUCCESS               0.004928            0.014112               0.349          [torch.Size([64, 64]), -2.5]
SUCCESS               0.024448            0.028640               0.854          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.024416            0.028672               0.852          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               1.238848            1.407168               0.880          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               0.313536            0.349824               0.896          [torch.Size([268435456]), -2.5]
SUCCESS               0.005248            0.014400               0.364          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.008128            0.014496               0.561          [torch.Size([10000, 256]), -2.5]
SUCCESS               0.758144            0.854544               0.887          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.005088            0.014880               0.342          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.008224            0.015200               0.541          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               0.758240            0.854592               0.887          [torch.Size([100, 65536, 100]), -2.5]

.
Operator: div_scalar_mode_  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.348960            3.179920               0.739          [torch.Size([1073741824]), -2.5]
SUCCESS               0.004992            0.013024               0.383          [torch.Size([64, 64]), -2.5]
SUCCESS               0.042016            0.059552               0.706          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.042176            0.059616               0.707          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               2.348352            3.181600               0.738          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               0.590416            0.805216               0.733          [torch.Size([268435456]), -2.5]
SUCCESS               0.005152            0.013280               0.388          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.011136            0.014688               0.758          [torch.Size([10000, 256]), -2.5]
SUCCESS               1.436496            1.986752               0.723          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.005120            0.013056               0.392          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.011232            0.014560               0.771          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               1.436864            1.986592               0.723          [torch.Size([100, 65536, 100]), -2.5]

.
Operator: div_scalar_mode_  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.611472            5.340064               0.302          [torch.Size([1073741824]), -2.5]
SUCCESS               0.005536            0.012736               0.435          [torch.Size([64, 64]), -2.5]
SUCCESS               0.031328            0.082656               0.379          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.031104            0.082496               0.377          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               1.611536            5.339664               0.302          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               0.407552            1.347680               0.302          [torch.Size([268435456]), -2.5]
SUCCESS               0.005792            0.012672               0.457          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.009824            0.017696               0.555          [torch.Size([10000, 256]), -2.5]
SUCCESS               0.986016            3.341792               0.295          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.005792            0.012480               0.464          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.009728            0.017696               0.550          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               0.985952            3.341760               0.295          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode_  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.361888            5.303696               0.445          [torch.Size([1073741824]), -2.5]
SUCCESS               0.005568            0.012256               0.454          [torch.Size([64, 64]), -2.5]
SUCCESS               0.042400            0.081344               0.521          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.042720            0.081536               0.524          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               2.361888            5.303664               0.445          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               0.594112            1.340032               0.443          [torch.Size([268435456]), -2.5]
SUCCESS               0.006112            0.012384               0.494          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.011456            0.017792               0.644          [torch.Size([10000, 256]), -2.5]
SUCCESS               1.445024            3.318592               0.435          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.006112            0.012576               0.486          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.011456            0.017824               0.643          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               1.444960            3.317152               0.436          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode_  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.741744            5.261440               0.331          [torch.Size([1073741824]), -2.5]
SUCCESS               0.005632            0.012960               0.435          [torch.Size([64, 64]), -2.5]
SUCCESS               0.033408            0.082560               0.405          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.033312            0.082464               0.404          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               1.741888            5.263008               0.331          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               0.440352            1.327456               0.332          [torch.Size([268435456]), -2.5]
SUCCESS               0.005920            0.012320               0.481          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.010080            0.017728               0.569          [torch.Size([10000, 256]), -2.5]
SUCCESS               1.065760            3.293088               0.324          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.005952            0.012384               0.481          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.010080            0.017728               0.569          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               1.065856            3.293152               0.324          [torch.Size([100, 65536, 100]), -2.5]

.

=================== 3 passed, 839 deselected in 153.11s (0:02:33) ===================
```
```
FlagGems/benchmark# pytest -s -m div_scalar_mode
================================ test session starts ================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.13.0, xdoctest-1.0.2, rerunfailures-15.1, hypothesis-6.130.8, xdist-3.6.1, flakefinder-1.1.0, shard-0.1.2
collecting 228 items                                                                WARNING 07-06 08:38:58 [interface.py:869] Current platform cuda does not have '_pytestfixturefunction' attribute.
WARNING 07-06 08:38:58 [interface.py:869] Current platform cuda does not have '_pytestfixturefunction' attribute.
collected 842 items / 839 deselected / 3 selected                                   
Running 3 items in this shard

test_div.py 
Operator: div_scalar_mode  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.253024            1.404768               0.892          [torch.Size([1073741824]), -2.5]
SUCCESS               0.005184            0.029376               0.176          [torch.Size([64, 64]), -2.5]
SUCCESS               0.025504            0.040352               0.632          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.025600            0.039712               0.645          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               1.302048            1.453968               0.896          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               0.326368            0.351648               0.928          [torch.Size([268435456]), -2.5]
SUCCESS               0.005280            0.028512               0.185          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.008576            0.029376               0.292          [torch.Size([10000, 256]), -2.5]
SUCCESS               0.799616            0.915504               0.873          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.005376            0.027808               0.193          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.008544            0.029344               0.291          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               0.813440            0.909376               0.895          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.357408            2.487488               0.948          [torch.Size([1073741824]), -2.5]
SUCCESS               0.005152            0.029632               0.174          [torch.Size([64, 64]), -2.5]
SUCCESS               0.043168            0.049920               0.865          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.042496            0.050496               0.842          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               2.348736            2.481088               0.947          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               0.643712            0.627296               1.026          [torch.Size([268435456]), -2.5]
SUCCESS               0.005408            0.028960               0.187          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.011424            0.029760               0.384          [torch.Size([10000, 256]), -2.5]
SUCCESS               1.447392            1.510112               0.958          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.005408            0.028160               0.192          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.011328            0.029152               0.389          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               1.444624            1.528032               0.945          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.286624            1.448384               0.888          [torch.Size([1073741824]), -2.5]
SUCCESS               0.005184            0.029824               0.174          [torch.Size([64, 64]), -2.5]
SUCCESS               0.025536            0.038976               0.655          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.025600            0.039968               0.641          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               1.287552            1.443936               0.892          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               0.325952            0.352000               0.926          [torch.Size([268435456]), -2.5]
SUCCESS               0.005248            0.028576               0.184          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.008576            0.029120               0.295          [torch.Size([10000, 256]), -2.5]
SUCCESS               0.789568            0.907408               0.870          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.005376            0.028832               0.186          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.008480            0.029376               0.289          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               0.788896            0.893760               0.883          [torch.Size([100, 65536, 100]), -2.5]

.
Operator: div_scalar_mode  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.349568            3.017568               0.779          [torch.Size([1073741824]), -2.5]
SUCCESS               0.005280            0.026912               0.196          [torch.Size([64, 64]), -2.5]
SUCCESS               0.043040            0.053808               0.800          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.042592            0.053728               0.793          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               2.344896            3.056864               0.767          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               0.592464            0.770896               0.769          [torch.Size([268435456]), -2.5]
SUCCESS               0.005408            0.026464               0.204          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.011392            0.026976               0.422          [torch.Size([10000, 256]), -2.5]
SUCCESS               1.439856            1.888352               0.762          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.005312            0.026368               0.201          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.011488            0.027136               0.423          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               1.439712            1.909440               0.754          [torch.Size([100, 65536, 100]), -2.5]

.
Operator: div_scalar_mode  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.381824            5.594528               0.426          [torch.Size([1073741824]), -2.5]
SUCCESS               0.006368            0.026496               0.240          [torch.Size([64, 64]), -2.5]
SUCCESS               0.043712            0.086624               0.505          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.043808            0.086624               0.506          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               2.381520            5.594528               0.426          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               0.600480            1.411904               0.425          [torch.Size([268435456]), -2.5]
SUCCESS               0.006464            0.025888               0.250          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.012224            0.026240               0.466          [torch.Size([10000, 256]), -2.5]
SUCCESS               1.456352            3.497664               0.416          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.006400            0.026112               0.245          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.012160            0.027072               0.449          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               1.456768            3.497504               0.417          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.631008            5.567488               0.473          [torch.Size([1073741824]), -2.5]
SUCCESS               0.006016            0.026336               0.228          [torch.Size([64, 64]), -2.5]
SUCCESS               0.044672            0.085280               0.524          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.044448            0.085312               0.521          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               2.581040            5.566992               0.464          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               0.736224            1.406976               0.523          [torch.Size([268435456]), -2.5]
SUCCESS               0.006176            0.026368               0.234          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.012128            0.028000               0.433          [torch.Size([10000, 256]), -2.5]
SUCCESS               1.656304            3.479072               0.476          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.006432            0.025664               0.251          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.012192            0.027264               0.447          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               1.612848            3.478848               0.464          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               2.647568            5.513824               0.480          [torch.Size([1073741824]), -2.5]
SUCCESS               0.006304            0.026496               0.238          [torch.Size([64, 64]), -2.5]
SUCCESS               0.048064            0.086592               0.555          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.048096            0.086560               0.556          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               2.647168            5.514272               0.480          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               0.666816            1.391072               0.479          [torch.Size([268435456]), -2.5]
SUCCESS               0.006560            0.026144               0.251          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.012704            0.026880               0.473          [torch.Size([10000, 256]), -2.5]
SUCCESS               1.618656            3.446880               0.470          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.006464            0.026080               0.248          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.012736            0.027104               0.470          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               1.618784            3.447152               0.470          [torch.Size([100, 65536, 100]), -2.5]

.

=================== 3 passed, 839 deselected in 156.48s (0:02:36) ===================
```

