### PR TITLE
Fix uv not found in subsequent CI steps

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -57,6 +57,8 @@ else
     | tar xz -C "$HOME/.local/bin" 2>/dev/null \
     || { curl -LsSf https://astral.sh/uv/install.sh | sh; }
   export PATH="$HOME/.local/bin:$PATH"
+  # Persist PATH for subsequent GitHub Actions steps
+  [ -n "${GITHUB_PATH:-}" ] && echo "$HOME/.local/bin" >> "$GITHUB_PATH"
   command -v uv &>/dev/null || { printf "uv installation"; fail; }
   printf "Installed $(uv --version)"
   ok


### PR DESCRIPTION
## Problem

`setup.sh` installs `uv` to `$HOME/.local/bin` and exports `PATH`, but this only affects the current shell. Subsequent GitHub Actions steps (e.g. the vllm install step in `setup-flaggems` action) run in a new shell and get:

```
/home/secure/actions-runner/_work/_temp/xxx.sh: line 3: uv: command not found
```

## Fix

When running in CI (`$GITHUB_PATH` is set), write `$HOME/.local/bin` to `$GITHUB_PATH` so the path persists across steps.

```bash
[ -n "${GITHUB_PATH:-}" ] && echo "$HOME/.local/bin" >> "$GITHUB_PATH"
```