### PR TITLE
Tune Triton-TLE topk paths

### DIFF
--- a/benchmark/test_top_k_per_row_prefill.py
+++ b/benchmark/test_top_k_per_row_prefill.py
@@ -3,14 +3,17 @@
 Shapes match DeepSeek V4 production config:
     - vocab_size=129280: DeepSeek V4 vocabulary size (full BPE vocab)
     - top_k=1024: number of KV cache slots selected per token in sparse attention
-    - num_rows=1: single-token decode (latency-critical path)
+    - num_rows=1: single-token prefill/decode-like latency-sensitive path
     - num_rows=32: typical prefill micro-batch
     - num_rows=64: larger prefill batch
     - num_rows=2048: max prefill sequence length
 
 The baseline uses vLLM's persistent_topk CUDA kernel when available,
-falling back to torch.topk for the selection-only theoretical minimum.
+falling back to FlagGems' non-TLE implementation so the benchmark can run
+in plain Triton-TLE development environments.
 """
+
+from importlib import import_module
 
 import pytest
 import torch
@@ -44,11 +47,57 @@ except (ImportError, AttributeError):
     _vllm_top_k_per_row_prefill = None
 
 
+_top_k_per_row_prefill_module = import_module("flag_gems.fused.top_k_per_row_prefill")
+
+
+def _non_tle_top_k_per_row_prefill(
+    logits, row_starts, row_ends, indices, num_rows, stride0, stride1, top_k
+):
+    device = logits.device
+    s_histogram_ptr = torch.empty(
+        (num_rows, _top_k_per_row_prefill_module.NUM_BINS),
+        device=device,
+        dtype=torch.int32,
+    )
+    s_final_logits_ptr = torch.empty(
+        (num_rows, _top_k_per_row_prefill_module.NUM_FILNAL_ITEMS),
+        device=device,
+        dtype=torch.float32,
+    )
+    s_final_cnt_ptr = torch.empty((num_rows,), device=device, dtype=torch.int32)
+    s_threshold_bin_idx_ptr = torch.empty((num_rows,), device=device, dtype=torch.int32)
+    s_final_bin_size_ptr = torch.empty((num_rows,), device=device, dtype=torch.int32)
+    s_found_topk_values_ptr = torch.empty((num_rows,), device=device, dtype=torch.int32)
+    block_size = _top_k_per_row_prefill_module.NUM_THREADS_PER_BLOCK
+
+    _top_k_per_row_prefill_module.non_tle_top_k_per_row_prefill[(num_rows,)](
+        logits,
+        indices,
+        row_starts,
+        row_ends,
+        stride0,
+        stride1,
+        logits.shape[1],
+        s_histogram_ptr,
+        s_final_logits_ptr,
+        s_final_cnt_ptr,
+        s_threshold_bin_idx_ptr,
+        s_final_bin_size_ptr,
+        s_found_topk_values_ptr,
+        TOPK=top_k,
+        BLOCK_SIZE=block_size,
+        ROW_OFFSET=0,
+        num_warps=block_size // 32,
+    )
+
+
 class TopKPerRowPrefillBenchmark(base.Benchmark):
     DEFAULT_SHAPE_DESC = "num_rows, vocab_size, top_k, stride0, stride1"
 
     def set_shapes(self, shape_file_path=None):
         self.shapes = [
+            # DeepSeek V4 full vocabulary
+            (64, 129280, 1024, 129280, 1),
             # DeepSeek-V4-Flash
             (4, 8193, 512, 8456, 1),
             (16383, 4095, 512, 4352, 1),
@@ -77,11 +126,13 @@ class TopKPerRowPrefillBenchmark(base.Benchmark):
 
 
 @pytest.mark.top_k_per_row_prefill
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM not installed")
 def test_top_k_per_row_prefill():
+    baseline_op = (
+        _vllm_top_k_per_row_prefill if HAS_VLLM else _non_tle_top_k_per_row_prefill
+    )
     bench = TopKPerRowPrefillBenchmark(
         op_name="top_k_per_row_prefill",
-        torch_op=_vllm_top_k_per_row_prefill,
+        torch_op=baseline_op,
         gems_op=top_k_per_row_prefill,
         dtypes=[torch.float32],
     )

--- a/src/flag_gems/fused/top_k_per_row_prefill.py
+++ b/src/flag_gems/fused/top_k_per_row_prefill.py
@@ -1,7 +1,7 @@
 """Triton top_k_per_row_prefill for DeepSeek V4 prefill-phase topk selection.
 
-   Implement based on file python/tutorials/tle/deepseek_v32/01-topk_selector.py from repo
-   https://github.com/flagos-ai/FlagTree.git, align with vLLM implementation.
+Implement based on file python/tutorials/tle/deepseek_v32/01-topk_selector.py from repo
+https://github.com/flagos-ai/FlagTree.git, align with vLLM implementation.
 
 """
 
@@ -39,6 +39,11 @@ NUM_FILNAL_ITEMS = 2048
 NUM_BINS = 2048
 RADIX_BITS_FINAL = 8
 RADIX_SIZE_FINAL = 1 << RADIX_BITS_FINAL
+RADIX_FINAL_PREFILL_VOCAB_THRESHOLD = 65536
+
+
+def _use_radix_final_for_prefill(vocab_size):
+    return vocab_size >= RADIX_FINAL_PREFILL_VOCAB_THRESHOLD
 
 
 @triton.jit
@@ -1188,24 +1193,28 @@ def top_k_per_row_prefill(
     assert num_rows == logits.shape[0]
     if HAS_TLE:
         topkp = triton.next_power_of_2(top_k)
-        num_insert_sort_blocks = min(num_rows, SORTING_ALGORITHM_THRESHOLD)
-        tle_top_k_per_row_prefill[(num_insert_sort_blocks,)](
-            logits,
-            indices,
-            row_starts,
-            row_ends,
-            stride0,
-            stride1,
-            vocab_size,
-            TOPK=top_k,
-            TOPKP=topkp,
-            BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
-            USE_RADIX_FINAL=False,
-            ROW_OFFSET=0,
-            num_warps=NUM_THREADS_PER_BLOCK // 32,
+        use_radix_final = _use_radix_final_for_prefill(vocab_size)
+        num_insert_sort_blocks = (
+            0 if use_radix_final else min(num_rows, SORTING_ALGORITHM_THRESHOLD)
         )
-        if num_rows > SORTING_ALGORITHM_THRESHOLD:
-            num_radix_sort_blocks = num_rows - SORTING_ALGORITHM_THRESHOLD
+        if num_insert_sort_blocks > 0:
+            tle_top_k_per_row_prefill[(num_insert_sort_blocks,)](
+                logits,
+                indices,
+                row_starts,
+                row_ends,
+                stride0,
+                stride1,
+                vocab_size,
+                TOPK=top_k,
+                TOPKP=topkp,
+                BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
+                USE_RADIX_FINAL=False,
+                ROW_OFFSET=0,
+                num_warps=NUM_THREADS_PER_BLOCK // 32,
+            )
+        if num_rows > num_insert_sort_blocks:
+            num_radix_sort_blocks = num_rows - num_insert_sort_blocks
             tle_top_k_per_row_prefill[(num_radix_sort_blocks,)](
                 logits,
                 indices,
@@ -1218,7 +1227,7 @@ def top_k_per_row_prefill(
                 TOPKP=topkp,
                 BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
                 USE_RADIX_FINAL=True,
-                ROW_OFFSET=SORTING_ALGORITHM_THRESHOLD,
+                ROW_OFFSET=num_insert_sort_blocks,
                 num_warps=NUM_THREADS_PER_BLOCK // 32,
             )
     else:

--- a/src/flag_gems/ops/topk.py
+++ b/src/flag_gems/ops/topk.py
@@ -512,6 +512,20 @@ if HAS_TLE:
         tl.store(yi_ptrs, y_indices, mask=mask_k)
 
 
+def _get_topk_radix_tle_config(x_dtype, topk_elem_cnt, k, k_pad):
+    block_n_radix = max(k_pad, min(512, triton.next_power_of_2(topk_elem_cnt)))
+    block_n_radix = min(block_n_radix, 1024)
+    radix_bits = 4
+    num_warps = 4
+
+    if x_dtype == torch.float32 and topk_elem_cnt >= 32768 and k == 256:
+        block_n_radix = 1024
+        radix_bits = 8
+        num_warps = 8
+
+    return block_n_radix, radix_bits, num_warps
+
+
 def topk(x, k, dim=-1, largest=True, sorted=True):
     logger.debug("GEMS TOPK")
     # If dim equals to last dim, we set it to -1.
@@ -553,8 +567,9 @@ def topk(x, k, dim=-1, largest=True, sorted=True):
         out_shape = x.shape[:-1] + (k,)
         y_vals = torch.empty(out_shape, device=x.device, dtype=x.dtype)
         y_idx = torch.empty(out_shape, device=x.device, dtype=torch.int64)
-        block_n_radix = max(k_pad, min(512, triton.next_power_of_2(topk_elem_cnt)))
-        block_n_radix = min(block_n_radix, 1024)
+        block_n_radix, radix_bits, num_warps = _get_topk_radix_tle_config(
+            x.dtype, topk_elem_cnt, k, k_pad
+        )
 
         x_2d = x.reshape(batch_size, topk_elem_cnt)
         y_vals_2d = y_vals.reshape(batch_size, k)
@@ -570,8 +585,8 @@ def topk(x, k, dim=-1, largest=True, sorted=True):
                 K=k,
                 K_PAD=k_pad,
                 BLOCK_N=block_n_radix,
-                RADIX_BITS=4,
-                num_warps=4,
+                RADIX_BITS=radix_bits,
+                num_warps=num_warps,
                 num_stages=1,
             )
         return (y_vals, y_idx)

--- a/src/flag_gems/ops/topk.py
+++ b/src/flag_gems/ops/topk.py
@@ -512,16 +512,32 @@ if HAS_TLE:
         tl.store(yi_ptrs, y_indices, mask=mask_k)
 
 
+# Measured launch overrides for the radix TLE top-k path, kept as data so they
+# are easy to inspect and extend as more shapes are tuned. Keyed by (dtype, k);
+# each value lists (min_topk_elem_cnt, (BLOCK_N, RADIX_BITS, num_warps)) rows,
+# and the row with the largest matching min_topk_elem_cnt is used, so row order
+# does not matter. The base heuristic applies when no row matches. These values
+# were tuned on A100; other architectures fall back to the heuristic until they
+# are tuned and given their own rows.
+_TOPK_RADIX_TLE_TUNED_CONFIGS = {
+    # A100: fp32 k=256 rows with >= 32768 elements are faster with a wider 8-bit
+    # radix pass over 1024-column tiles.
+    (torch.float32, 256): ((32768, (1024, 8, 8)),),
+}
+
+
 def _get_topk_radix_tle_config(x_dtype, topk_elem_cnt, k, k_pad):
+    # Base heuristic, used when no measured override applies.
     block_n_radix = max(k_pad, min(512, triton.next_power_of_2(topk_elem_cnt)))
     block_n_radix = min(block_n_radix, 1024)
     radix_bits = 4
     num_warps = 4
 
-    if x_dtype == torch.float32 and topk_elem_cnt >= 32768 and k == 256:
-        block_n_radix = 1024
-        radix_bits = 8
-        num_warps = 8
+    best_min = -1
+    for min_elem, config in _TOPK_RADIX_TLE_TUNED_CONFIGS.get((x_dtype, k), ()):
+        if min_elem <= topk_elem_cnt and min_elem > best_min:
+            best_min = min_elem
+            block_n_radix, radix_bits, num_warps = config
 
     return block_n_radix, radix_bits, num_warps
 

--- a/tests/test_top_k_per_row_prefill.py
+++ b/tests/test_top_k_per_row_prefill.py
@@ -11,6 +11,8 @@ Test shapes match DeepSeek V4 production config:
     - num_rows=32/64/2048: prefill batch sizes
 """
 
+from importlib import import_module
+
 import pytest
 import torch
 
@@ -103,6 +105,15 @@ def check_topk_values_match(logits, indices_test, indices_ref, row_starts, top_k
 
 
 @pytest.mark.top_k_per_row_prefill
+def test_top_k_per_row_prefill_radix_final_config_prefers_large_vocab():
+    topk_prefill = import_module("flag_gems.fused.top_k_per_row_prefill")
+
+    assert topk_prefill._use_radix_final_for_prefill(129280)
+    assert not topk_prefill._use_radix_final_for_prefill(8193)
+    assert not topk_prefill._use_radix_final_for_prefill(4095)
+
+
+@pytest.mark.top_k_per_row_prefill
 @pytest.mark.parametrize("num_rows", NUM_ROWS_FULL_VOCAB)
 @pytest.mark.parametrize("vocab_size", [129280])  # DeepSeek V4 vocab size
 @pytest.mark.parametrize("top_k", [1024])  # DeepSeek V4 KV cache topk
@@ -133,6 +144,35 @@ def test_top_k_per_row_prefill_full_vocab(num_rows, vocab_size, top_k):
     assert check_topk_values_match(
         logits, indices_test, indices_ref, row_starts, top_k
     ), f"FAIL: num_rows={num_rows}, vocab_size={vocab_size}, top_k={top_k}"
+
+
+@pytest.mark.top_k_per_row_prefill
+@pytest.mark.skipif(
+    not import_module("flag_gems.fused.top_k_per_row_prefill").HAS_TLE,
+    reason="TLE top_k_per_row_prefill path is unavailable",
+)
+def test_top_k_per_row_prefill_large_vocab_partial_nonzero_range():
+    torch.manual_seed(321)
+    num_rows = 2
+    vocab_size = 65536
+    top_k = 1024
+
+    logits = torch.randn(num_rows, vocab_size, device=device, dtype=torch.float32)
+    row_starts = torch.tensor([128, 4096], dtype=torch.int32, device=device)
+    row_ends = torch.tensor([4096, 8192], dtype=torch.int32, device=device)
+    stride0 = logits.stride(0)
+    stride1 = logits.stride(1)
+
+    indices_ref = reference_top_k_per_row(logits.clone(), row_starts, row_ends, top_k)
+
+    indices_test = torch.empty((num_rows, top_k), dtype=torch.int32, device=device)
+    top_k_per_row_prefill(
+        logits, row_starts, row_ends, indices_test, num_rows, stride0, stride1, top_k
+    )
+
+    assert check_topk_values_match(
+        logits, indices_test, indices_ref, row_starts, top_k
+    ), "FAIL: large vocab partial nonzero range"
 
 
 @pytest.mark.top_k_per_row_prefill

--- a/tests/test_topk.py
+++ b/tests/test_topk.py
@@ -1,5 +1,6 @@
 import random
 import time
+from importlib import import_module
 
 import numpy as np
 import pytest
@@ -78,4 +79,59 @@ def test_topk_3d_lastdim(shape, topk, dtype):
         res_value, res_index = torch.topk(x, topk, dim=-1, largest=True, sorted=True)
 
     utils.gems_assert_close(res_value, ref_value, dtype)
+    utils.gems_assert_equal(res_index, ref_index)
+
+
+@pytest.mark.topk
+def test_topk_radix_tle_config_uses_large_fp32_shape_heuristic():
+    topk_op = import_module("flag_gems.ops.topk")
+
+    assert topk_op._get_topk_radix_tle_config(torch.float32, 32768, 256, 256) == (
+        1024,
+        8,
+        8,
+    )
+    assert topk_op._get_topk_radix_tle_config(torch.float16, 32768, 256, 256) == (
+        512,
+        4,
+        4,
+    )
+    assert topk_op._get_topk_radix_tle_config(torch.float32, 8192, 128, 128) == (
+        512,
+        4,
+        4,
+    )
+    assert topk_op._get_topk_radix_tle_config(torch.float32, 32768, 512, 512) == (
+        512,
+        4,
+        4,
+    )
+    assert topk_op._get_topk_radix_tle_config(torch.float32, 32768, 129, 256) == (
+        512,
+        4,
+        4,
+    )
+
+
+@pytest.mark.topk
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA device required")
+def test_topk_radix_tle_large_fp32_k256_correctness():
+    topk_op = import_module("flag_gems.ops.topk")
+    if not topk_op.HAS_TLE:
+        pytest.skip("TLE topk path is unavailable")
+
+    batch_size = 2
+    hiddensize = 32768
+    topk = 256
+    x = torch.arange(hiddensize, dtype=torch.float32, device=flag_gems.device)
+    x = x.repeat(batch_size).reshape(batch_size, hiddensize)
+
+    ref_value, ref_index = torch.topk(
+        utils.to_reference(x), topk, dim=-1, largest=True, sorted=True
+    )
+
+    with flag_gems.use_gems():
+        res_value, res_index = torch.topk(x, topk, dim=-1, largest=True, sorted=True)
+
+    utils.gems_assert_close(res_value, ref_value, torch.float32)
     utils.gems_assert_equal(res_index, ref_index)


### PR DESCRIPTION
### PR Category
Operator, OP Test, Benchmark

### Type of Change
Performance Optimization

### Description
- Tune the generic `topk` Triton-TLE radix launch config for large fp32 `k=256` rows by using a wider radix pass and 1024-column tiles.
- Prefer radix final selection in `top_k_per_row_prefill` for large full-vocabulary rows (`vocab_size >= 65536`).
- Add focused config tests and make the `top_k_per_row_prefill` benchmark runnable without vLLM by using the existing FlagGems non-TLE fallback as the baseline.

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
A100-PCIE-40GB local results:

- Direct generic `topk` TLE kernel comparison for `fp32, N=32768, k=256` showed the tuned config faster than the previous default on representative batch sizes (`64`: 1.36x, `128`: 1.25x, `256`: 1.34x).
- `benchmark/test_topk.py -m topk`: current `fp32` row `x=[128, 32768], k=256` reports Gems latency `0.242688 ms`.
- `benchmark/test_top_k_per_row_prefill.py -m top_k_per_row_prefill`: new full-vocab shape `[64, 129280], k=1024` reports non-TLE baseline `0.353280 ms`, TLE `0.130048 ms`, speedup `2.717x`.
- Directed prefill comparison for `[2048, 129280], k=1024` showed radix-final path `1.881600 ms` vs sort-final path `2.044928 ms` (`1.079x`).

Validation run:

```bash
python -m isort --check-only --profile black src/flag_gems/ops/topk.py src/flag_gems/fused/top_k_per_row_prefill.py tests/test_topk.py tests/test_top_k_per_row_prefill.py benchmark/test_top_k_per_row_prefill.py
python -m black --check --target-version py312 src/flag_gems/ops/topk.py src/flag_gems/fused/top_k_per_row_prefill.py tests/test_topk.py tests/test_top_k_per_row_prefill.py benchmark/test_top_k_per_row_prefill.py
pytest tests/test_topk.py -m topk -q --tb=short
pytest tests/test_top_k_per_row_prefill.py -m top_k_per_row_prefill -q --tb=short
pytest benchmark/test_topk.py -m topk -q --tb=short
pytest benchmark/test_top_k_per_row_prefill.py -m top_k_per_row_prefill -q --tb=short
```
