### PR TITLE
Tune decode top-k split path for A100

### DIFF
--- a/benchmark/test_top_k_per_row_decode.py
+++ b/benchmark/test_top_k_per_row_decode.py
@@ -47,6 +47,20 @@ except (ImportError, AttributeError):
     _vllm_top_k_per_row_decode = None
 
 
+def _torch_top_k_per_row_decode(
+    logits, next_n, seq_lens, indices, num_rows, stride0, stride1, top_k
+):
+    for i in range(num_rows):
+        batch_id = i // next_n
+        batch_offset = i % next_n
+        row_len = int(seq_lens[batch_id].item()) - next_n + batch_offset + 1
+        k = min(top_k, row_len)
+        _, topk_idx = torch.topk(logits[i, :row_len], k, largest=True, sorted=False)
+        indices[i, :k] = topk_idx.to(torch.int32)
+        if k < top_k:
+            indices[i, k:] = -1
+
+
 class TopKPerRowDecodeBenchmark(base.Benchmark):
     DEFAULT_SHAPE_DESC = "num_rows, vocab_size, next_n, top_k, stride0, stride1"
 
@@ -64,6 +78,10 @@ class TopKPerRowDecodeBenchmark(base.Benchmark):
             (4, 262144, 1, 512, 262144, 1),
             (8, 262144, 1, 512, 262144, 1),
             (24, 262144, 1, 512, 262144, 1),
+            # Medium vocab shapes exercise the split decode path tuned for A100.
+            (1, 129280, 1, 512, 129280, 1),
+            (16, 129280, 1, 512, 129280, 1),
+            (64, 129280, 1, 1024, 129280, 1),
         ]
 
     def get_input_iter(self, dtype):
@@ -97,11 +115,11 @@ class TopKPerRowDecodeBenchmark(base.Benchmark):
 
 
 @pytest.mark.top_k_per_row_decode
-@pytest.mark.skipif(not HAS_VLLM, reason="vLLM not installed")
 def test_top_k_per_row_decode():
+    baseline = _vllm_top_k_per_row_decode if HAS_VLLM else _torch_top_k_per_row_decode
     bench = TopKPerRowDecodeBenchmark(
         op_name="top_k_per_row_decode",
-        torch_op=_vllm_top_k_per_row_decode,
+        torch_op=baseline,
         gems_op=top_k_per_row_decode,
         dtypes=[torch.float32],
     )

--- a/src/flag_gems/fused/top_k_per_row_decode.py
+++ b/src/flag_gems/fused/top_k_per_row_decode.py
@@ -1,7 +1,7 @@
 """Triton top_k_per_row_decode for DeepSeek V4 decode-phase topk selection.
 
-   Implement based on file python/tutorials/tle/deepseek_v32/01-topk_selector.py from repo
-   https://github.com/flagos-ai/FlagTree.git, align with vLLM implementation.
+Implement based on file python/tutorials/tle/deepseek_v32/01-topk_selector.py from repo
+https://github.com/flagos-ai/FlagTree.git, align with vLLM implementation.
 
 """
 
@@ -34,11 +34,29 @@ SORTING_ALGORITHM_THRESHOLD = 12288
 SPLIT_WORK_THRESHOLD = 200 * 1000
 NUM_THREADS_PER_BLOCK = 512
 MULTIPLE_BLOCKS_PER_ROW_CONFIG = 10
+MEDIUM_VOCAB_SPLIT_WORK_THRESHOLD = 100 * 1000
+MEDIUM_VOCAB_SPLIT_TOPK_THRESHOLD = 512
+MEDIUM_VOCAB_MANY_ROWS_THRESHOLD = 64
+MEDIUM_VOCAB_MULTIPLE_BLOCKS_PER_ROW_CONFIG = 10
+MEDIUM_VOCAB_MANY_ROWS_MULTIPLE_BLOCKS_PER_ROW_CONFIG = 4
 NUM_THREADS_PER_BLOCK_MERGE = 1024
 NUM_FILNAL_ITEMS = 2048
 NUM_BINS = 2048
 RADIX_BITS_FINAL = 8
 RADIX_SIZE_FINAL = 1 << RADIX_BITS_FINAL
+
+
+def _get_decode_split_blocks(num_rows, vocab_size, top_k):
+    if vocab_size >= SPLIT_WORK_THRESHOLD:
+        return MULTIPLE_BLOCKS_PER_ROW_CONFIG
+    if (
+        vocab_size >= MEDIUM_VOCAB_SPLIT_WORK_THRESHOLD
+        and top_k >= MEDIUM_VOCAB_SPLIT_TOPK_THRESHOLD
+    ):
+        if num_rows >= MEDIUM_VOCAB_MANY_ROWS_THRESHOLD:
+            return MEDIUM_VOCAB_MANY_ROWS_MULTIPLE_BLOCKS_PER_ROW_CONFIG
+        return MEDIUM_VOCAB_MULTIPLE_BLOCKS_PER_ROW_CONFIG
+    return 1
 
 
 @triton.jit
@@ -1226,7 +1244,8 @@ def top_k_per_row_decode(
     use_radix_final = vocab_size >= SORTING_ALGORITHM_THRESHOLD
     if HAS_TLE:
         topkp = triton.next_power_of_2(top_k)
-        if vocab_size < SPLIT_WORK_THRESHOLD:
+        split_blocks = _get_decode_split_blocks(num_rows, vocab_size, top_k)
+        if split_blocks == 1:
             tle_top_k_per_row_decode[(num_rows,)](
                 logits,
                 indices,
@@ -1242,26 +1261,26 @@ def top_k_per_row_decode(
                 BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
                 USE_RADIX_FINAL=use_radix_final,
                 MULTIPLE_BLOCKS_PER_ROW=False,
-                MULTIPLE_BLOCKS_NUM=1,
+                MULTIPLE_BLOCKS_NUM=split_blocks,
                 MERGE_BLOCKS=False,
                 num_warps=NUM_THREADS_PER_BLOCK // 32,
             )
         else:
             device = logits.device
             out_indices_aux = torch.empty(
-                (num_rows, MULTIPLE_BLOCKS_PER_ROW_CONFIG, top_k),
+                (num_rows, split_blocks, top_k),
                 device=device,
                 dtype=torch.int32,
             )
             out_logits_aux = torch.empty(
-                (num_rows, MULTIPLE_BLOCKS_PER_ROW_CONFIG, top_k),
+                (num_rows, split_blocks, top_k),
                 device=device,
                 dtype=torch.float32,
             )
             tle_top_k_per_row_decode[
                 (
                     num_rows,
-                    MULTIPLE_BLOCKS_PER_ROW_CONFIG,
+                    split_blocks,
                 )
             ](
                 logits,
@@ -1278,7 +1297,7 @@ def top_k_per_row_decode(
                 BLOCK_SIZE=NUM_THREADS_PER_BLOCK,
                 USE_RADIX_FINAL=use_radix_final,
                 MULTIPLE_BLOCKS_PER_ROW=True,
-                MULTIPLE_BLOCKS_NUM=MULTIPLE_BLOCKS_PER_ROW_CONFIG,
+                MULTIPLE_BLOCKS_NUM=split_blocks,
                 MERGE_BLOCKS=False,
                 num_warps=NUM_THREADS_PER_BLOCK // 32,
             )
@@ -1287,9 +1306,9 @@ def top_k_per_row_decode(
                 indices,
                 seq_lens,
                 next_n,
-                MULTIPLE_BLOCKS_PER_ROW_CONFIG * top_k,
+                split_blocks * top_k,
                 1,
-                MULTIPLE_BLOCKS_PER_ROW_CONFIG * top_k,
+                split_blocks * top_k,
                 None,
                 out_indices_aux,
                 TOPK=top_k,
@@ -1297,7 +1316,7 @@ def top_k_per_row_decode(
                 BLOCK_SIZE=NUM_THREADS_PER_BLOCK_MERGE,
                 USE_RADIX_FINAL=use_radix_final,
                 MULTIPLE_BLOCKS_PER_ROW=False,
-                MULTIPLE_BLOCKS_NUM=MULTIPLE_BLOCKS_PER_ROW_CONFIG,
+                MULTIPLE_BLOCKS_NUM=split_blocks,
                 MERGE_BLOCKS=True,
                 num_warps=NUM_THREADS_PER_BLOCK_MERGE // 32,
             )

--- a/src/flag_gems/fused/top_k_per_row_decode.py
+++ b/src/flag_gems/fused/top_k_per_row_decode.py
@@ -46,11 +46,15 @@ RADIX_BITS_FINAL = 8
 RADIX_SIZE_FINAL = 1 << RADIX_BITS_FINAL
 
 
-def _get_decode_split_blocks(num_rows, vocab_size, top_k):
+def _get_decode_split_blocks(num_rows, vocab_size, top_k, stride1):
     if vocab_size >= SPLIT_WORK_THRESHOLD:
         return MULTIPLE_BLOCKS_PER_ROW_CONFIG
+    # The medium-vocab split path is only enabled for contiguous rows
+    # (stride1 == 1). For strided rows the multi-block kernel would offset by
+    # an unscaled row_start, so keep those on the safe single-block path.
     if (
-        vocab_size >= MEDIUM_VOCAB_SPLIT_WORK_THRESHOLD
+        stride1 == 1
+        and vocab_size >= MEDIUM_VOCAB_SPLIT_WORK_THRESHOLD
         and top_k >= MEDIUM_VOCAB_SPLIT_TOPK_THRESHOLD
     ):
         if num_rows >= MEDIUM_VOCAB_MANY_ROWS_THRESHOLD:
@@ -1244,7 +1248,7 @@ def top_k_per_row_decode(
     use_radix_final = vocab_size >= SORTING_ALGORITHM_THRESHOLD
     if HAS_TLE:
         topkp = triton.next_power_of_2(top_k)
-        split_blocks = _get_decode_split_blocks(num_rows, vocab_size, top_k)
+        split_blocks = _get_decode_split_blocks(num_rows, vocab_size, top_k, stride1)
         if split_blocks == 1:
             tle_top_k_per_row_decode[(num_rows,)](
                 logits,

--- a/tests/test_top_k_per_row_decode.py
+++ b/tests/test_top_k_per_row_decode.py
@@ -5,6 +5,8 @@ Uses value-based comparison (sorted selected values must match) to handle
 non-deterministic tie-breaking between implementations.
 """
 
+from importlib import import_module
+
 import pytest
 import torch
 
@@ -19,6 +21,18 @@ pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="CUDA device required",
 )
+
+
+@pytest.mark.top_k_per_row_decode
+def test_top_k_per_row_decode_split_config_uses_medium_vocab_path():
+    decode_op = import_module("flag_gems.fused.top_k_per_row_decode")
+
+    assert decode_op._get_decode_split_blocks(1, 32768, 1024) == 1
+    assert decode_op._get_decode_split_blocks(16, 65536, 1024) == 1
+    assert decode_op._get_decode_split_blocks(1, 129280, 512) == 10
+    assert decode_op._get_decode_split_blocks(16, 129280, 1024) == 10
+    assert decode_op._get_decode_split_blocks(64, 129280, 1024) == 4
+    assert decode_op._get_decode_split_blocks(1, 262144, 512) == 10
 
 
 # --- Shape configuration with QUICK_MODE support ---

--- a/tests/test_top_k_per_row_decode.py
+++ b/tests/test_top_k_per_row_decode.py
@@ -5,8 +5,6 @@ Uses value-based comparison (sorted selected values must match) to handle
 non-deterministic tie-breaking between implementations.
 """
 
-from importlib import import_module
-
 import pytest
 import torch
 
@@ -21,18 +19,6 @@ pytestmark = pytest.mark.skipif(
     not torch.cuda.is_available(),
     reason="CUDA device required",
 )
-
-
-@pytest.mark.top_k_per_row_decode
-def test_top_k_per_row_decode_split_config_uses_medium_vocab_path():
-    decode_op = import_module("flag_gems.fused.top_k_per_row_decode")
-
-    assert decode_op._get_decode_split_blocks(1, 32768, 1024) == 1
-    assert decode_op._get_decode_split_blocks(16, 65536, 1024) == 1
-    assert decode_op._get_decode_split_blocks(1, 129280, 512) == 10
-    assert decode_op._get_decode_split_blocks(16, 129280, 1024) == 10
-    assert decode_op._get_decode_split_blocks(64, 129280, 1024) == 4
-    assert decode_op._get_decode_split_blocks(1, 262144, 512) == 10
 
 
 # --- Shape configuration with QUICK_MODE support ---
@@ -157,6 +143,27 @@ def test_top_k_per_row_decode_partial_seqlen(vocab_size, top_k, seq_len):
 
     logits, next_n, seq_lens, indices, num_rows, s0, s1, k = _make_inputs(
         batch_size, vocab_size, top_k, seq_len=seq_len
+    )
+    logits_ref = logits.clone()
+    indices_ref = torch.zeros_like(indices)
+
+    top_k_per_row_decode(logits, next_n, seq_lens, indices, num_rows, s0, s1, k)
+    ref_fn(logits_ref, next_n, seq_lens, indices_ref, num_rows, s0, s1, k)
+
+    assert check_topk_values_match(logits, indices, indices_ref, top_k)
+
+
+@pytest.mark.top_k_per_row_decode
+def test_top_k_per_row_decode_medium_vocab_many_rows_split_correctness():
+    """Covers the 4-block medium-vocab split/merge path."""
+    torch.manual_seed(789)
+    batch_size = 64
+    vocab_size = 129280
+    top_k = 512
+    ref_fn = _vllm_top_k_per_row_decode if HAS_VLLM else _torch_topk_ref
+
+    logits, next_n, seq_lens, indices, num_rows, s0, s1, k = _make_inputs(
+        batch_size, vocab_size, top_k
     )
     logits_ref = logits.clone()
     indices_ref = torch.zeros_like(indices)

--- a/tests/test_top_k_per_row_decode_config.py
+++ b/tests/test_top_k_per_row_decode_config.py
@@ -4,9 +4,22 @@ from importlib import import_module
 def test_top_k_per_row_decode_split_config_uses_medium_vocab_path():
     decode_op = import_module("flag_gems.fused.top_k_per_row_decode")
 
-    assert decode_op._get_decode_split_blocks(1, 32768, 1024) == 1
-    assert decode_op._get_decode_split_blocks(16, 65536, 1024) == 1
-    assert decode_op._get_decode_split_blocks(1, 129280, 512) == 10
-    assert decode_op._get_decode_split_blocks(16, 129280, 1024) == 10
-    assert decode_op._get_decode_split_blocks(64, 129280, 1024) == 4
-    assert decode_op._get_decode_split_blocks(1, 262144, 512) == 10
+    # Contiguous rows (stride1 == 1): medium-vocab split heuristic applies.
+    assert decode_op._get_decode_split_blocks(1, 32768, 1024, 1) == 1
+    assert decode_op._get_decode_split_blocks(16, 65536, 1024, 1) == 1
+    assert decode_op._get_decode_split_blocks(1, 129280, 512, 1) == 10
+    assert decode_op._get_decode_split_blocks(16, 129280, 1024, 1) == 10
+    assert decode_op._get_decode_split_blocks(64, 129280, 1024, 1) == 4
+    assert decode_op._get_decode_split_blocks(1, 262144, 512, 1) == 10
+
+
+def test_top_k_per_row_decode_split_config_skips_medium_vocab_for_strided():
+    decode_op = import_module("flag_gems.fused.top_k_per_row_decode")
+
+    # Strided rows (stride1 != 1) must stay on the single-block path for the
+    # medium-vocab range, since the multi-block kernel mis-addresses strided
+    # rows past the first block. The >= SPLIT_WORK_THRESHOLD range keeps its
+    # pre-existing behavior and is intentionally not guarded here.
+    assert decode_op._get_decode_split_blocks(16, 129280, 1024, 2) == 1
+    assert decode_op._get_decode_split_blocks(64, 129280, 1024, 2) == 1
+    assert decode_op._get_decode_split_blocks(1, 129280, 512, 8) == 1

--- a/tests/test_top_k_per_row_decode_config.py
+++ b/tests/test_top_k_per_row_decode_config.py
@@ -1,0 +1,12 @@
+from importlib import import_module
+
+
+def test_top_k_per_row_decode_split_config_uses_medium_vocab_path():
+    decode_op = import_module("flag_gems.fused.top_k_per_row_decode")
+
+    assert decode_op._get_decode_split_blocks(1, 32768, 1024) == 1
+    assert decode_op._get_decode_split_blocks(16, 65536, 1024) == 1
+    assert decode_op._get_decode_split_blocks(1, 129280, 512) == 10
+    assert decode_op._get_decode_split_blocks(16, 129280, 1024) == 10
+    assert decode_op._get_decode_split_blocks(64, 129280, 1024) == 4
+    assert decode_op._get_decode_split_blocks(1, 262144, 512) == 10


### PR DESCRIPTION
## Summary
- add an A100-focused split-block heuristic for medium-vocab `top_k_per_row_decode` workloads
- keep the existing large-vocab split path unchanged while enabling split for `vocab_size >= 100000` and `top_k >= 512`
- add a config-selection test and make the decode benchmark runnable without vLLM via a PyTorch fallback

## A100 old vs new heuristic
Measured on NVIDIA A100-PCIE-40GB with TLE enabled:

| shape `(rows, vocab, k)` | old | new | speedup |
| --- | ---: | ---: | ---: |
| `(1, 129280, 512)` | 0.123843 ms | 0.060580 ms | 2.044x |
| `(16, 129280, 512)` | 0.128635 ms | 0.070820 ms | 1.816x |
| `(64, 129280, 512)` | 0.180163 ms | 0.127611 ms | 1.412x |
| `(1, 129280, 1024)` | 0.128164 ms | 0.077967 ms | 1.644x |
| `(16, 129280, 1024)` | 0.131850 ms | 0.114749 ms | 1.149x |
| `(64, 129280, 1024)` | 0.184238 ms | 0.134820 ms | 1.367x |

Boundary checks stayed effectively unchanged: `(16, 65536, 1024)` 0.98x, `(64, 65536, 1024)` 0.99x, `(64, 262144, 512)` 1.00x.

## Benchmark
`python -m pytest benchmark/test_top_k_per_row_decode.py -m top_k_per_row_decode -s --tb=short`

Selected rows from the fallback benchmark:
- `[1, 129280], k=512`: Torch 0.147456 ms, Gems 0.036864 ms, 4.000x
- `[16, 129280], k=512`: Torch 2.224640 ms, Gems 0.049152 ms, 45.260x
- `[64, 129280], k=1024`: Torch 8.282624 ms, Gems 0.103424 ms, 80.084x

## Tests
- `python -m isort --check-only --profile black src/flag_gems/fused/top_k_per_row_decode.py tests/test_top_k_per_row_decode.py benchmark/test_top_k_per_row_decode.py`
- `python -m black --check --target-version py312 src/flag_gems/fused/top_k_per_row_decode.py tests/test_top_k_per_row_decode.py benchmark/test_top_k_per_row_decode.py`
- `python -m pytest tests/test_top_k_per_row_decode.py -m top_k_per_row_decode -q --tb=short`
- `python -m pytest benchmark/test_top_k_per_row_decode.py -m top_k_per_row_decode -q --tb=short`


## Update: strided-row safety

Follow-up review noted that the new medium-vocab split heuristic could route
non-contiguous (`stride1 != 1`) rows into the multi-block kernel, whose split
blocks offset by an unscaled `row_start` and would read the wrong columns past
the first block for strided inputs. The medium-vocab split path is now gated on
`stride1 == 1`, so strided rows stay on the safe single-block path. The
pre-existing `>= SPLIT_WORK_THRESHOLD` range is unchanged. A config test covers
the strided fallback.


## Update: strided-row safety

Follow-up review noted that the new medium-vocab split heuristic could route
non-contiguous (`stride1 != 1`) rows into the multi-block kernel, whose split
blocks offset by an unscaled `row_start` and would read the wrong columns past
the first block for strided inputs. The medium-vocab split path is now gated on
`stride1 == 1`, so strided rows stay on the safe single-block path. The
pre-existing `>= SPLIT_WORK_THRESHOLD` range is unchanged. A config test covers
the strided fallback.
