### PR TITLE
feat: add FA3 varlen flash attention on Hopper (Triton + libtuner)

### DIFF
--- a/benchmark/test_flash_attn_varlen_fa3_func.py
+++ b/benchmark/test_flash_attn_varlen_fa3_func.py
@@ -1,0 +1,359 @@
+from typing import Any, List, Optional, Tuple
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import base, utils
+from .test_flash_attn_varlen_func import make_paged_kv_cache
+
+vendor_name = flag_gems.vendor_name
+
+
+def _is_hopper() -> bool:
+    return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 9
+
+
+def _fa3_call_args(
+    q,
+    k,
+    v,
+    max_q,
+    cu_q,
+    max_k,
+    cu_k,
+    seqused_k,
+    scale,
+    causal,
+    block_table,
+    out,
+):
+    return (
+        q,
+        k,
+        v,
+        max_q,
+        cu_q,
+        max_k,
+        cu_k,
+        seqused_k,
+        None,
+        0.0,
+        scale,
+        causal,
+        [-1, -1],
+        0.0,
+        None,
+        False,
+        False,
+        block_table,
+        False,
+        out,
+        None,
+        None,
+        None,
+        None,
+        {"fa_version": 3},
+    )
+
+
+# name, paged, seq_lens, nh_q, nh_k, head_dim, causal
+_HOPPER_CONFIGS = [
+    ("prefill_b4_s2k_d128_mha", False, [(2048, 2048)] * 4, 32, 32, 128, True),
+    ("prefill_b4_s4k_d128_mha", False, [(4096, 4096)] * 4, 32, 32, 128, True),
+    ("prefill_b4_s8k_d128_mha", False, [(8192, 8192)] * 4, 32, 32, 128, True),
+    ("prefill_b2_s16k_d128_mha", False, [(16384, 16384)] * 2, 32, 32, 128, True),
+    ("prefill_b4_s4k_d128_gqa4", False, [(4096, 4096)] * 4, 32, 8, 128, True),
+    ("prefill_b4_s8k_d128_gqa4", False, [(8192, 8192)] * 4, 32, 8, 128, True),
+    ("prefill_b8_s2k_d64_mha", False, [(2048, 2048)] * 8, 16, 16, 64, False),
+    ("decode_b16_kv1k_d128_gqa4", False, [(1, 1024)] * 16, 32, 8, 128, True),
+    ("decode_b8_kv1k_d192_gqa4", False, [(1, 1024)] * 8, 32, 8, 192, True),
+    ("decode_b8_kv1k_d256_gqa4", False, [(1, 1024)] * 8, 32, 8, 256, True),
+    (
+        "decode_b16_mixed_d128_gqa4",
+        False,
+        [(1, 512), (1, 1024), (1, 2048), (1, 4096)] * 4,
+        32,
+        8,
+        128,
+        True,
+    ),
+    ("decode_b32_kv2k_d128_gqa4", False, [(1, 2048)] * 32, 32, 8, 128, True),
+    (
+        "varlen_mixed_d128_gqa4",
+        False,
+        [(2048, 2048), (1, 4096), (1, 4096), (1024, 1024), (1, 8192), (1, 1024)],
+        32,
+        8,
+        128,
+        True,
+    ),
+    (
+        "varlen_serve_b32_1pf_31dec_d128_gqa4",
+        False,
+        [(2048, 2048)] + [(1, 1024 + 64 * i) for i in range(31)],
+        32,
+        8,
+        128,
+        True,
+    ),
+    (
+        "varlen_longtail_d128_gqa4",
+        False,
+        [(16384, 16384)] + [(256, 256)] * 16,
+        32,
+        8,
+        128,
+        True,
+    ),
+    (
+        "paged_decode_b16_kvmix_bs16_d128_gqa4",
+        True,
+        [(1, 1024 + 256 * i) for i in range(16)],
+        32,
+        8,
+        128,
+        True,
+    ),
+    (
+        "paged_decode_b8_bs16_d192_gqa4",
+        True,
+        [(1, 1024 + 128 * i) for i in range(8)],
+        32,
+        8,
+        192,
+        True,
+    ),
+    (
+        "paged_decode_b8_bs16_d256_gqa4",
+        True,
+        [(1, 1024 + 128 * i) for i in range(8)],
+        32,
+        8,
+        256,
+        True,
+    ),
+    (
+        "paged_decode_b64_bs16_d128_gqa4",
+        True,
+        [(1, 512 + 128 * i) for i in range(64)],
+        32,
+        8,
+        128,
+        True,
+    ),
+    (
+        "paged_serve_b32_1pf_31dec_bs16_d128_gqa4",
+        True,
+        [(2048, 2048)] + [(1, 1024 + 96 * i) for i in range(31)],
+        32,
+        8,
+        128,
+        True,
+    ),
+    ("paged_uniform_b4_s4k_bs16_d128_mha", True, [(4096, 4096)] * 4, 32, 32, 128, True),
+]
+
+
+class FlashAttnVarlenFa3Benchmark(base.Benchmark):
+    """benchmark for flash_attn_varlen_func (FA3, Hopper only)"""
+
+    def set_shapes(self, shape_file_path: Optional[List[Any]] = None):
+        all_cu_seqlens_q = [
+            (0, 512),
+            (0, 1, 2, 72),
+            tuple(range(0, 45))
+            + (105, 121, 137, 153, 169, 185, 201, 217, 233, 249, 265),
+            tuple(range(0, 196)) + (211, 226, 240, 253, 265),
+        ]
+        all_seqused_k = [
+            (512,),
+            (1, 1, 70),
+            (515,) + (514,) * 20 + (513,) * 20 + (512,) * 14,
+            (2333,)
+            + (2331,) * 20
+            + (2330,) * 20
+            + (2329,) * 14
+            + (2328,) * 18
+            + (2327,) * 15
+            + (2326,) * 17
+            + (2325,) * 18
+            + (2324,) * 21
+            + (2323,) * 22
+            + (2322,) * 24
+            + (2321,) * 5
+            + (2320, 2319, 2318, 2317, 2316),
+        ]
+        qwen_configs = [
+            ("qwen", cu_seqlens_q, seqused_k)
+            for cu_seqlens_q, seqused_k in zip(all_cu_seqlens_q, all_seqused_k)
+        ]
+        self.shapes = qwen_configs + _HOPPER_CONFIGS
+
+    def get_input_iter(self, dtype):
+        for config in self.shapes:
+            yield self.flash_attn_varlen_fa3_input_fn(config, dtype, self.device)
+
+    def flash_attn_varlen_fa3_input_fn(self, config, dtype, device):
+        if config[0] == "qwen":
+            _, cu_query_lens, seqused_k = config
+            num_query_heads, num_kv_heads = 16, 8
+            head_size, block_size, num_blocks = 128, 16, 2000
+            causal = True
+
+            num_seqs = len(cu_query_lens) - 1
+            max_query_len = max(
+                x - y for x, y in zip(cu_query_lens[1:], cu_query_lens[:-1])
+            )
+            max_kv_len = max(seqused_k)
+            scale = head_size**-0.5
+
+            with torch.device(device):
+                query = torch.randn(
+                    cu_query_lens[-1],
+                    num_query_heads,
+                    head_size,
+                    dtype=dtype,
+                    device=device,
+                )
+                out = torch.empty_like(query)
+                key_cache, value_cache = make_paged_kv_cache(
+                    num_blocks,
+                    block_size,
+                    num_kv_heads,
+                    head_size,
+                    dtype=dtype,
+                    device=device,
+                    non_contiguous=False,
+                )
+                cu_query_lens = torch.tensor(
+                    cu_query_lens, dtype=torch.int32, device=device
+                )
+                seqused_k = torch.tensor(seqused_k, dtype=torch.int32, device=device)
+                max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+                block_tables = torch.randint(
+                    0,
+                    num_blocks,
+                    (num_seqs, max_num_blocks_per_seq),
+                    dtype=torch.int32,
+                    device=device,
+                )
+
+            return _fa3_call_args(
+                query,
+                key_cache,
+                value_cache,
+                max_query_len,
+                cu_query_lens,
+                max_kv_len,
+                None,
+                seqused_k,
+                scale,
+                causal,
+                block_tables,
+                out,
+            )
+
+        _, paged, seq_lens, num_query_heads, num_kv_heads, head_size, causal = config
+        cu_q, cu_k = [0], [0]
+        for q_len, k_len in seq_lens:
+            cu_q.append(cu_q[-1] + q_len)
+            cu_k.append(cu_k[-1] + k_len)
+        max_query_len = max(q for q, _ in seq_lens)
+        max_kv_len = max(k for _, k in seq_lens)
+        scale = head_size**-0.5
+
+        with torch.device(device):
+            query = torch.randn(
+                cu_q[-1], num_query_heads, head_size, dtype=dtype, device=device
+            ) * 0.5
+            out = torch.empty_like(query)
+            cu_query_lens = torch.tensor(cu_q, dtype=torch.int32, device=device)
+
+            if paged:
+                block_size = 16
+                blocks_per_req = [
+                    (k_len + block_size - 1) // block_size for _, k_len in seq_lens
+                ]
+                max_blocks_per_req = max(blocks_per_req)
+                total_virtual_blocks = sum(blocks_per_req)
+                num_physical_blocks = max(1, int(total_virtual_blocks * 1.5))
+                perm = torch.randperm(num_physical_blocks, device=device)[
+                    :total_virtual_blocks
+                ]
+                block_tables = torch.zeros(
+                    (len(seq_lens), max_blocks_per_req),
+                    dtype=torch.int32,
+                    device=device,
+                )
+                offset = 0
+                for req_idx, n_blocks in enumerate(blocks_per_req):
+                    block_tables[req_idx, :n_blocks] = perm[offset : offset + n_blocks]
+                    offset += n_blocks
+                key_cache = torch.randn(
+                    num_physical_blocks,
+                    block_size,
+                    num_kv_heads,
+                    head_size,
+                    dtype=dtype,
+                    device=device,
+                ) * 0.5
+                value_cache = torch.randn_like(key_cache)
+                seqused_k = torch.tensor(
+                    [k for _, k in seq_lens], dtype=torch.int32, device=device
+                )
+                cu_seqlens_k = None
+            else:
+                key_cache = torch.randn(
+                    cu_k[-1], num_kv_heads, head_size, dtype=dtype, device=device
+                ) * 0.5
+                value_cache = torch.randn_like(key_cache)
+                cu_seqlens_k = torch.tensor(cu_k, dtype=torch.int32, device=device)
+                seqused_k = None
+                block_tables = None
+
+        return _fa3_call_args(
+            query,
+            key_cache,
+            value_cache,
+            max_query_len,
+            cu_query_lens,
+            max_kv_len,
+            cu_seqlens_k,
+            seqused_k,
+            scale,
+            causal,
+            block_tables,
+            out,
+        )
+
+
+@pytest.mark.skipif(not _is_hopper(), reason="FA3 requires Hopper GPU (sm_90+)")
+@pytest.mark.skipif(
+    utils.SkipVersion("vllm", "<0.9"),
+    reason="vLLM version prior to 0.9 does not include the flash_attn_varlen_func API.",
+)
+@pytest.mark.skipif(
+    utils.SkipVersion("torch", "<2.7"),
+    reason="Torch version prior to 2.7 is not compatible with VLLM.",
+)
+@pytest.mark.skipif(vendor_name == "hygon", reason="Not working")
+@pytest.mark.skipif(vendor_name == "cambricon", reason="Not supported")
+@pytest.mark.flash_attn_varlen_func
+def test_flash_attn_varlen_fa3_func(monkeypatch):
+    monkeypatch.setenv("VLLM_CONFIGURE_LOGGING", "0")
+
+    from vllm.vllm_flash_attn.flash_attn_interface import flash_attn_varlen_func as _vllm_fa
+
+    def vllm_fa3(*args, **kwargs):
+        kwargs.pop("fa_version", None)
+        return _vllm_fa(*args, fa_version=3, **kwargs)
+
+    bench = FlashAttnVarlenFa3Benchmark(
+        op_name="flash_attn_varlen_fa3_func",
+        torch_op=vllm_fa3,
+        gems_op=flag_gems.flash_attn_varlen_func,
+        dtypes=[torch.float16, torch.bfloat16],
+    )
+    bench.run()

--- a/benchmark/test_flash_attn_varlen_fa3_func.py
+++ b/benchmark/test_flash_attn_varlen_fa3_func.py
@@ -265,9 +265,12 @@ class FlashAttnVarlenFa3Benchmark(base.Benchmark):
         scale = head_size**-0.5
 
         with torch.device(device):
-            query = torch.randn(
-                cu_q[-1], num_query_heads, head_size, dtype=dtype, device=device
-            ) * 0.5
+            query = (
+                torch.randn(
+                    cu_q[-1], num_query_heads, head_size, dtype=dtype, device=device
+                )
+                * 0.5
+            )
             out = torch.empty_like(query)
             cu_query_lens = torch.tensor(cu_q, dtype=torch.int32, device=device)
 
@@ -291,23 +294,29 @@ class FlashAttnVarlenFa3Benchmark(base.Benchmark):
                 for req_idx, n_blocks in enumerate(blocks_per_req):
                     block_tables[req_idx, :n_blocks] = perm[offset : offset + n_blocks]
                     offset += n_blocks
-                key_cache = torch.randn(
-                    num_physical_blocks,
-                    block_size,
-                    num_kv_heads,
-                    head_size,
-                    dtype=dtype,
-                    device=device,
-                ) * 0.5
+                key_cache = (
+                    torch.randn(
+                        num_physical_blocks,
+                        block_size,
+                        num_kv_heads,
+                        head_size,
+                        dtype=dtype,
+                        device=device,
+                    )
+                    * 0.5
+                )
                 value_cache = torch.randn_like(key_cache)
                 seqused_k = torch.tensor(
                     [k for _, k in seq_lens], dtype=torch.int32, device=device
                 )
                 cu_seqlens_k = None
             else:
-                key_cache = torch.randn(
-                    cu_k[-1], num_kv_heads, head_size, dtype=dtype, device=device
-                ) * 0.5
+                key_cache = (
+                    torch.randn(
+                        cu_k[-1], num_kv_heads, head_size, dtype=dtype, device=device
+                    )
+                    * 0.5
+                )
                 value_cache = torch.randn_like(key_cache)
                 cu_seqlens_k = torch.tensor(cu_k, dtype=torch.int32, device=device)
                 seqused_k = None
@@ -344,7 +353,9 @@ class FlashAttnVarlenFa3Benchmark(base.Benchmark):
 def test_flash_attn_varlen_fa3_func(monkeypatch):
     monkeypatch.setenv("VLLM_CONFIGURE_LOGGING", "0")
 
-    from vllm.vllm_flash_attn.flash_attn_interface import flash_attn_varlen_func as _vllm_fa
+    from vllm.vllm_flash_attn.flash_attn_interface import (
+        flash_attn_varlen_func as _vllm_fa,
+    )
 
     def vllm_fa3(*args, **kwargs):
         kwargs.pop("fa_version", None)

--- a/benchmark/test_flash_attn_varlen_fa3_func.py
+++ b/benchmark/test_flash_attn_varlen_fa3_func.py
@@ -1,4 +1,4 @@
-from typing import Any, List, Optional, Tuple
+from typing import Any, List, Optional
 
 import pytest
 import torch

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -9,7 +9,7 @@ import triton.language as tl
 
 from flag_gems import runtime
 from flag_gems.config import use_c_extension
-from flag_gems.ops.flash_api import mha_fwd, mha_varlan_fwd, mha_varlan_fwd_opt
+from flag_gems.ops.flash_api import mha_fwd, mha_varlan_fwd, mha_varlan_fwd_fa3, mha_varlan_fwd_opt
 from flag_gems.ops.flash_kernel import keep
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry, libtuner
@@ -1285,11 +1285,12 @@ def flash_attn_varlen_func(
             logsumexp of each row of the matrix QK^T * scaling (e.g., log of the softmax
             normalization factor).
     """
-    if fa_version != 2:
-        raise RuntimeError("Only FA2 is implemented.")
+    if fa_version not in (2, 3):
+        raise RuntimeError(f"fa_version {fa_version} is not supported. Use 2 or 3.")
     if num_splits > 0:
         raise RuntimeError("num_splits > 0 is not implemented in GEMS.")
     if use_c_extension:
+        assert fa_version == 2, "FA3 varlen is not supported in C extension"
         logger.debug("GEMS FLASH_ATTN_VARLEN_FUNC(C EXTENSION)")
         with torch_device_fn.device(q.device):
             out_cpp, softmax_lse = torch.ops.flag_gems.flash_attn_varlen_func(
@@ -1333,12 +1334,17 @@ def flash_attn_varlen_func(
         assert (
             cu_seqlens_k is None or seqused_k is None
         ), "cu_seqlens_k and seqused_k cannot be provided at the same time"
-        assert (
-            block_table is None or seqused_k is not None
-        ), "seqused_k must be provided if block_table is provided"
+        if block_table is not None:
+            if fa_version == 3:
+                assert (
+                    seqused_k is not None or cu_seqlens_k is not None
+                ), "seqused_k or cu_seqlens_k must be provided if block_table is provided"
+            else:
+                assert (
+                    seqused_k is not None
+                ), "seqused_k must be provided if block_table is provided"
         if softmax_scale is None:
             softmax_scale = q.shape[-1] ** (-0.5)
-        # custom op does not support non-tuple input
         if window_size is None:
             real_window_size = (-1, -1)
         else:
@@ -1352,31 +1358,59 @@ def flash_attn_varlen_func(
         max_seqlen_k = (
             max_seqlen_k.item() if hasattr(max_seqlen_k, "item") else max_seqlen_k
         )
-        out, q, k, v, softmax_lse, *_ = mha_varlan_fwd(
-            q,
-            k,
-            v,
-            out,
-            cu_seqlens_q,
-            # cu_seqlens_k not used since we use seqused_k, but flash_api.cpp
-            # still wants it so we pass all zeros
-            dummy_cu_seqlens_k if cu_seqlens_k is None else cu_seqlens_k,
-            seqused_k,
-            None,
-            block_table,
-            alibi_slopes,
-            max_seqlen_q,
-            max_seqlen_k,
-            dropout_p,
-            softmax_scale,
-            False,
-            causal,
-            real_window_size[0],
-            real_window_size[1],
-            softcap,
-            return_softmax_lse and dropout_p > 0,
-            None,
-        )
+
+        if fa_version == 3:
+            assert alibi_slopes is None, "alibi_slopes is not supported in FA3."
+            logger.debug("GEMS FLASH_ATTN_VARLEN_FUNC FA3")
+            out, q, k, v, softmax_lse, *_ = mha_varlan_fwd_fa3(
+                q,
+                k,
+                v,
+                out,
+                cu_seqlens_q,
+                dummy_cu_seqlens_k if cu_seqlens_k is None else cu_seqlens_k,
+                seqused_k,
+                None,           # leftpad_k
+                block_table,
+                max_seqlen_q,
+                max_seqlen_k,
+                softmax_scale,
+                causal,
+                real_window_size[0],
+                real_window_size[1],
+                softcap,
+                False,          # return_softmax
+                None,           # gen
+                q_descale=q_descale,
+                k_descale=k_descale,
+                v_descale=v_descale,
+            )
+        else:
+            out, q, k, v, softmax_lse, *_ = mha_varlan_fwd(
+                q,
+                k,
+                v,
+                out,
+                cu_seqlens_q,
+                # cu_seqlens_k not used since we use seqused_k, but flash_api.cpp
+                # still wants it so we pass all zeros
+                dummy_cu_seqlens_k if cu_seqlens_k is None else cu_seqlens_k,
+                seqused_k,
+                None,
+                block_table,
+                alibi_slopes,
+                max_seqlen_q,
+                max_seqlen_k,
+                dropout_p,
+                softmax_scale,
+                False,
+                causal,
+                real_window_size[0],
+                real_window_size[1],
+                softcap,
+                return_softmax_lse and dropout_p > 0,
+                None,
+            )
 
     return (out, softmax_lse) if return_softmax_lse else out
 

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -9,7 +9,12 @@ import triton.language as tl
 
 from flag_gems import runtime
 from flag_gems.config import use_c_extension
-from flag_gems.ops.flash_api import mha_fwd, mha_varlan_fwd, mha_varlan_fwd_fa3, mha_varlan_fwd_opt
+from flag_gems.ops.flash_api import (
+    mha_fwd,
+    mha_varlan_fwd,
+    mha_varlan_fwd_fa3,
+    mha_varlan_fwd_opt,
+)
 from flag_gems.ops.flash_kernel import keep
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils import libentry, libtuner
@@ -1370,7 +1375,7 @@ def flash_attn_varlen_func(
                 cu_seqlens_q,
                 dummy_cu_seqlens_k if cu_seqlens_k is None else cu_seqlens_k,
                 seqused_k,
-                None,           # leftpad_k
+                None,  # leftpad_k
                 block_table,
                 max_seqlen_q,
                 max_seqlen_k,
@@ -1379,8 +1384,8 @@ def flash_attn_varlen_func(
                 real_window_size[0],
                 real_window_size[1],
                 softcap,
-                False,          # return_softmax
-                None,           # gen
+                False,  # return_softmax
+                None,  # gen
                 q_descale=q_descale,
                 k_descale=k_descale,
                 v_descale=v_descale,

--- a/src/flag_gems/ops/flash_api.py
+++ b/src/flag_gems/ops/flash_api.py
@@ -1136,61 +1136,38 @@ def mha_varlan_fwd_fa3(
 
         args_tuple = tuple(getattr(params, slot) for slot in params.__slots__)
 
-        total_rows = total_q * num_heads
-        num_sms = torch_device_fn.get_device_properties(
-            flag_gems.device
-        ).multi_processor_count
-        avg_rows_per_cta = min(total_q / batch_size, total_rows / num_sms)
-        if avg_rows_per_cta > 64:
-            varlen_fwd_config_str = "mha_block_128"
-        elif avg_rows_per_cta > 32:
-            varlen_fwd_config_str = "mha_block_64"
-        elif avg_rows_per_cta > 16:
-            varlen_fwd_config_str = "mha_block_32"
-        else:
-            varlen_fwd_config_str = "mha_block_16"
-
-        cfg = runtime.get_heuristic_config(varlen_fwd_config_str)
-        block_m = cfg["BLOCK_M"](args_tuple)
         h_hk_ratio = num_heads // num_heads_k
-        pack_gqa = _get_pack_gqa_fa3(
-            num_heads,
-            num_heads_k,
-            max_seqlen_q,
-            block_m,
-            is_paged=is_paged,
-        )
-        if pack_gqa:
-            grid = lambda args, _hh=h_hk_ratio, _bs=batch_size, _hk=num_heads_k: (
-                triton.cdiv(max_seqlen_q * _hh, args["BLOCK_M"]),
-                _bs,
-                _hk,
+
+        def grid(meta):
+            block_m = meta["BLOCK_M"]
+            pack_gqa = _get_pack_gqa_fa3(
+                num_heads,
+                num_heads_k,
+                max_seqlen_q,
+                block_m,
+                is_paged=is_paged,
             )
-        else:
-            grid = lambda args, _bs=batch_size, _nh=num_heads: (
-                triton.cdiv(max_seqlen_q, args["BLOCK_M"]),
-                _bs,
-                _nh,
+            if pack_gqa:
+                return (
+                    triton.cdiv(max_seqlen_q * h_hk_ratio, block_m),
+                    batch_size,
+                    num_heads_k,
+                )
+            return (
+                triton.cdiv(max_seqlen_q, block_m),
+                batch_size,
+                num_heads,
             )
-        kernel = flash_varlen_fwd_fa3_kernel[grid]
-        cfg_params = {
-            "BLOCK_M": block_m,
-            "BLOCK_N": cfg["BLOCK_N"](args_tuple),
-            "BLOCK_K": triton.next_power_of_2(head_size),
-            "num_warps": cfg["num_warps"](args_tuple),
-            "num_stages": cfg["num_stages"](args_tuple),
-            "HAS_DESCALE": False,
-            "qk_descale": 1.0,
-            "v_descale": 1.0,
-            "IS_HOPPER": True,
-            "PACK_GQA": pack_gqa,
-        }
 
         def _alloc_fn(size: int, align: int, _stream):
             return torch.empty(size, dtype=torch.int8, device=q_device)
 
         triton.set_allocator(_alloc_fn)
-        kernel(*args_tuple, **cfg_params)
+        flash_varlen_fwd_fa3_kernel[grid](
+            *args_tuple,
+            qk_descale=1.0,
+            v_descale=1.0,
+        )
 
         unused = None
     return out, q, k, v, lse, None, unused, None

--- a/src/flag_gems/ops/flash_api.py
+++ b/src/flag_gems/ops/flash_api.py
@@ -12,8 +12,10 @@ from flag_gems.ops.flash_kernel import (
     flash_fwd_kernel,
     flash_fwd_splitkv_combine_kernel,
     flash_fwd_splitkv_kernel,
+    flash_varlen_fwd_fa3_kernel,
     flash_varlen_fwd_kernel,
 )
+
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils.random_utils import philox_backend_seed_offset
 
@@ -929,6 +931,269 @@ def mha_varlan_fwd_opt(
         # unused = torch.empty((), dtype=torch.int64, device=q_device)
         unused = None
     return out, q, k, v, lse, philox_args, unused, p
+
+
+def _is_hopper():
+    return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 9
+
+
+def _should_pack_gqa_kernel(varlen_q, seqlen_q, qhead_per_khead, block_m):
+    """Mirror hopper/heuristics.h::should_pack_gqa."""
+    if varlen_q:
+        return True
+
+    def _round_up(a, b):
+        return (a + b - 1) // b * b
+
+    nopack_eff = float(seqlen_q) / float(_round_up(seqlen_q, block_m))
+    pack_eff = float(seqlen_q * qhead_per_khead) / float(
+        _round_up(seqlen_q * qhead_per_khead, block_m)
+    )
+    return nopack_eff < 0.9 * pack_eff
+
+
+def _get_pack_gqa_fa3(
+    num_heads,
+    num_heads_k,
+    max_seqlen_q,
+    block_m,
+    *,
+    is_paged,
+):
+    """Kernel-side packGQA policy for flash_varlen_fwd_fa3_kernel."""
+    if num_heads == num_heads_k:
+        return False
+    if is_paged:
+        return True
+    qhead_per_khead = num_heads // num_heads_k
+    return _should_pack_gqa_kernel(True, max_seqlen_q, qhead_per_khead, block_m)
+
+
+def mha_varlan_fwd_fa3(
+    q,
+    k,
+    v,
+    out,
+    cu_seqlens_q,
+    cu_seqlens_k,
+    seqused_k,
+    leftpad_k,
+    page_table,
+    max_seqlen_q,
+    max_seqlen_k,
+    softmax_scale,
+    is_causal,
+    window_size_left,
+    window_size_right,
+    softcap,
+    return_softmax,
+    gen,
+    q_descale=None,
+    k_descale=None,
+    v_descale=None,
+):
+    """FA3-style varlen forward on Hopper."""
+    CHECK_DEVICE(q), CHECK_DEVICE(k), CHECK_DEVICE(v)
+    assert _is_hopper(), "FA3 varlen requires Hopper GPU (sm_90+)"
+    q_device = q.device
+    q_dtype = q.dtype
+    assert q_dtype in (torch.float16, torch.bfloat16), \
+        "FlashAttention FA3 only supports fp16 and bf16"
+    assert q_dtype == k.dtype and q_dtype == v.dtype
+    assert q.stride(-1) == 1 and k.stride(-1) == 1 and v.stride(-1) == 1
+    assert cu_seqlens_q.dtype == torch.int32 and cu_seqlens_q.is_contiguous()
+    assert leftpad_k is None, "leftpad_k is not supported."
+
+    is_paged = page_table is not None
+    if not is_paged:
+        page_table = torch.empty((0, 0), device=q_device, dtype=torch.int32)
+
+    total_q, num_heads, head_size = q.size()
+    num_heads_k = k.size(2) if is_paged else k.size(1)
+    batch_size = cu_seqlens_q.numel() - 1
+    block_size = k.size(1) if is_paged else 1
+    num_pages = k.size(0) if is_paged else 0
+    k_batch_size = num_pages
+    page_table_batch_stride = page_table.stride(0)
+
+    assert k.size() == v.size()
+    assert cu_seqlens_q.size() == (batch_size + 1,)
+
+    if out is not None:
+        assert out.stride(-1) == 1 and out.dtype == q.dtype
+        assert out.size() == (total_q, num_heads, head_size)
+
+    if seqused_k is not None:
+        assert seqused_k.is_contiguous()
+        assert seqused_k.size() == (batch_size,)
+
+    if max_seqlen_q == 1:
+        is_causal = False
+    if is_causal:
+        window_size_right = 0
+    if window_size_left >= max_seqlen_k:
+        window_size_left = -1
+    if window_size_right >= max_seqlen_k:
+        window_size_right = -1
+    is_local = window_size_left >= 0
+
+    assert softcap == 0.0, "softcap is not supported in FA3"
+    assert not is_local, "sliding window is not supported in FA3"
+    assert q_descale is None and k_descale is None and v_descale is None, \
+        "FP8 descale is not supported in FA3"
+    if is_paged:
+        assert seqused_k is not None, "paged FA3 varlen requires seqused_k"
+    else:
+        assert cu_seqlens_k is not None, "non-paged FA3 varlen requires cu_seqlens_k"
+
+    q_batch_stride = 0
+    k_batch_stride = 0
+    v_batch_stride = 0
+    o_batch_stride = 0
+    total_q = q.size(0)
+
+    assert head_size <= 256, "head dimension at most 256"
+    assert head_size % 8 == 0
+
+    round_multiple = lambda x, m: (x + m - 1) // m * m
+    head_size_rounded = round_multiple(head_size, 32) if head_size <= 192 else 256
+    seqlen_q_rounded = round_multiple(max_seqlen_q, 128)
+    seqlen_k_rounded = round_multiple(max_seqlen_k, 32)
+
+    M_LOG2E = 1.4426950408889634074
+    is_softcap = False
+    adjusted_softcap = 0.0
+    adjusted_scale_softmax = softmax_scale
+    adjusted_scale_softmax_log2e = softmax_scale * M_LOG2E
+
+    with torch_device_fn.device(q_device):
+        if out is None:
+            out = torch.empty_like(q, dtype=v.dtype)
+
+        lse = torch.empty((num_heads, total_q), dtype=torch.float, device=q_device)
+
+        params = fwd_params(
+            q,
+            k,
+            v,
+            out,
+            None,
+            lse,
+            q.stride(-3),
+            k.stride(-3),
+            v.stride(-3),
+            q.stride(-2),
+            k.stride(-2),
+            v.stride(-2),
+            out.stride(-3),
+            out.stride(-2),
+            q_batch_stride,
+            k_batch_stride,
+            v_batch_stride,
+            o_batch_stride,
+            cu_seqlens_q is not None,
+            cu_seqlens_q,
+            cu_seqlens_k is not None,
+            cu_seqlens_k,
+            seqused_k is not None,
+            seqused_k,
+            batch_size,
+            k_batch_size,
+            num_heads,
+            num_heads_k,
+            num_heads // num_heads_k,
+            max_seqlen_q,
+            max_seqlen_k,
+            seqlen_q_rounded,
+            seqlen_k_rounded,
+            head_size,
+            head_size_rounded,
+            is_softcap,
+            adjusted_softcap,
+            adjusted_scale_softmax,
+            adjusted_scale_softmax_log2e,
+            False,
+            1.0,
+            1.0,
+            255,
+            torch.empty((2,), dtype=torch.int64, device=q_device),
+            False,
+            is_causal,
+            is_local,
+            window_size_left,
+            window_size_right,
+            False,
+            is_paged,
+            False,
+            None,
+            0,
+            total_q,
+            page_table,
+            page_table_batch_stride,
+            block_size,
+            k.stride(0) if is_paged else 0,
+        )
+
+        args_tuple = tuple(getattr(params, slot) for slot in params.__slots__)
+
+        total_rows = total_q * num_heads
+        num_sms = torch_device_fn.get_device_properties(
+            flag_gems.device
+        ).multi_processor_count
+        avg_rows_per_cta = min(total_q / batch_size, total_rows / num_sms)
+        if avg_rows_per_cta > 64:
+            varlen_fwd_config_str = "mha_block_128"
+        elif avg_rows_per_cta > 32:
+            varlen_fwd_config_str = "mha_block_64"
+        elif avg_rows_per_cta > 16:
+            varlen_fwd_config_str = "mha_block_32"
+        else:
+            varlen_fwd_config_str = "mha_block_16"
+
+        cfg = runtime.get_heuristic_config(varlen_fwd_config_str)
+        block_m = cfg["BLOCK_M"](args_tuple)
+        h_hk_ratio = num_heads // num_heads_k
+        pack_gqa = _get_pack_gqa_fa3(
+            num_heads,
+            num_heads_k,
+            max_seqlen_q,
+            block_m,
+            is_paged=is_paged,
+        )
+        if pack_gqa:
+            grid = lambda args, _hh=h_hk_ratio, _bs=batch_size, _hk=num_heads_k: (
+                triton.cdiv(max_seqlen_q * _hh, args["BLOCK_M"]),
+                _bs,
+                _hk,
+            )
+        else:
+            grid = lambda args, _bs=batch_size, _nh=num_heads: (
+                triton.cdiv(max_seqlen_q, args["BLOCK_M"]),
+                _bs,
+                _nh,
+            )
+        kernel = flash_varlen_fwd_fa3_kernel[grid]
+        cfg_params = {
+            "BLOCK_M": block_m,
+            "BLOCK_N": cfg["BLOCK_N"](args_tuple),
+            "BLOCK_K": triton.next_power_of_2(head_size),
+            "num_warps": cfg["num_warps"](args_tuple),
+            "num_stages": cfg["num_stages"](args_tuple),
+            "HAS_DESCALE": False,
+            "qk_descale": 1.0,
+            "v_descale": 1.0,
+            "IS_HOPPER": True,
+            "PACK_GQA": pack_gqa,
+        }
+
+        def _alloc_fn(size: int, align: int, _stream):
+            return torch.empty(size, dtype=torch.int8, device=q_device)
+
+        triton.set_allocator(_alloc_fn)
+        kernel(*args_tuple, **cfg_params)
+
+        unused = None
+    return out, q, k, v, lse, None, unused, None
 
 
 def mha_fwd(

--- a/src/flag_gems/ops/flash_api.py
+++ b/src/flag_gems/ops/flash_api.py
@@ -15,7 +15,6 @@ from flag_gems.ops.flash_kernel import (
     flash_varlen_fwd_fa3_kernel,
     flash_varlen_fwd_kernel,
 )
-
 from flag_gems.runtime import torch_device_fn
 from flag_gems.utils.random_utils import philox_backend_seed_offset
 
@@ -997,8 +996,10 @@ def mha_varlan_fwd_fa3(
     assert _is_hopper(), "FA3 varlen requires Hopper GPU (sm_90+)"
     q_device = q.device
     q_dtype = q.dtype
-    assert q_dtype in (torch.float16, torch.bfloat16), \
-        "FlashAttention FA3 only supports fp16 and bf16"
+    assert q_dtype in (
+        torch.float16,
+        torch.bfloat16,
+    ), "FlashAttention FA3 only supports fp16 and bf16"
     assert q_dtype == k.dtype and q_dtype == v.dtype
     assert q.stride(-1) == 1 and k.stride(-1) == 1 and v.stride(-1) == 1
     assert cu_seqlens_q.dtype == torch.int32 and cu_seqlens_q.is_contiguous()
@@ -1039,8 +1040,9 @@ def mha_varlan_fwd_fa3(
 
     assert softcap == 0.0, "softcap is not supported in FA3"
     assert not is_local, "sliding window is not supported in FA3"
-    assert q_descale is None and k_descale is None and v_descale is None, \
-        "FP8 descale is not supported in FA3"
+    assert (
+        q_descale is None and k_descale is None and v_descale is None
+    ), "FP8 descale is not supported in FA3"
     if is_paged:
         assert seqused_k is not None, "paged FA3 varlen requires seqused_k"
     else:

--- a/src/flag_gems/ops/flash_kernel.py
+++ b/src/flag_gems/ops/flash_kernel.py
@@ -1,4 +1,3 @@
-import torch
 import triton
 import triton.language as tl
 

--- a/src/flag_gems/ops/flash_kernel.py
+++ b/src/flag_gems/ops/flash_kernel.py
@@ -3,7 +3,7 @@ import triton
 import triton.language as tl
 
 from flag_gems import runtime
-from flag_gems.utils import libentry, tl_extra_shim
+from flag_gems.utils import libentry, libtuner, tl_extra_shim
 
 
 @triton.jit
@@ -1731,21 +1731,64 @@ def flash_varlen_fwd_kernel(
 
 
 # ---------------------------------------------------------------------------
-# FA3 varlen forward kernel (Hopper, packGQA)
+# FA3 varlen forward kernel (Hopper Triton path, libtuner)
 # ---------------------------------------------------------------------------
 
 
-# ---------------------------------------------------------------------------
-# FA3 varlen forward kernel (gluon launch path)
-#
-# Same algorithm as flash_varlen_fwd_fa3_kernel.  Differs only in TMA policy:
-#   - non-paged Hopper uses tl.make_tensor_descriptor even with cu_seqlens_k
-#   - warp_specialize is disabled when K bounds are runtime-derived, because
-#     TaskIdPropagation cannot track loop-body descriptor bases
-# ---------------------------------------------------------------------------
+def fa3_varlen_heur_block_k(args):
+    return triton.next_power_of_2(args["d"])
+
+
+def fa3_varlen_pack_gqa_heur(args):
+    """Mirror flash_api._get_pack_gqa_fa3 / _should_pack_gqa_kernel(varlen_q=True)."""
+    num_heads = args["h"]
+    num_heads_k = args["hk"]
+    if num_heads == num_heads_k:
+        return False
+    if args["is_paged"]:
+        return True
+    # varlen non-paged GQA: _should_pack_gqa_kernel returns True when varlen_q=True
+    return True
+
+
+def _fa3_varlen_target_block_m(nargs):
+    total_q = nargs["total_q"]
+    batch_size = nargs["b"]
+    num_heads = nargs["h"]
+    total_rows = total_q * num_heads
+    num_sms = runtime.torch_device_fn.get_device_properties(
+        runtime.device
+    ).multi_processor_count
+    avg_rows_per_cta = min(total_q / max(batch_size, 1), total_rows / num_sms)
+    if avg_rows_per_cta > 64:
+        return 128
+    if avg_rows_per_cta > 32:
+        return 64
+    if avg_rows_per_cta > 16:
+        return 32
+    return 16
+
+
+def prune_fa3_varlen_configs(configs, nargs, **kwargs):
+    target_bm = _fa3_varlen_target_block_m(nargs)
+    pruned = [cfg for cfg in configs if cfg.kwargs["BLOCK_M"] == target_bm]
+    return pruned or configs
 
 
 @libentry()
+@libtuner(
+    configs=runtime.get_tuned_config("attention_fa3_varlen"),
+    key=["d", "seqlen_q", "is_paged"],
+    prune_configs_by={"early_config_prune": prune_fa3_varlen_configs},
+)
+@triton.heuristics(
+    values={
+        "BLOCK_K": fa3_varlen_heur_block_k,
+        "PACK_GQA": fa3_varlen_pack_gqa_heur,
+        "HAS_DESCALE": lambda args: False,
+        "IS_HOPPER": lambda args: True,
+    }
+)
 @triton.jit(
     do_not_specialize=[
         "q_batch_stride",

--- a/src/flag_gems/ops/flash_kernel.py
+++ b/src/flag_gems/ops/flash_kernel.py
@@ -1,3 +1,4 @@
+import torch
 import triton
 import triton.language as tl
 
@@ -172,6 +173,87 @@ def apply_mask(
             S = tl.where(col_idx[None, :] >= max_seqlen_k, float("-inf"), S)
 
     return S
+
+
+@triton.jit
+def load_q_tile_pack_gqa(
+    q_ptr,
+    q_offset,
+    q_row_stride,
+    q_head_stride,
+    m_block,
+    hid,
+    q_len,
+    d,
+    h_hk_ratio: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    packed_rows = m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+    token_idx = packed_rows // h_hk_ratio
+    q_heads = hid * h_hk_ratio + (packed_rows % h_hk_ratio)
+    d_offs = tl.arange(0, BLOCK_K)
+    q_ptrs = (
+        q_ptr
+        + q_offset
+        + token_idx[:, None] * q_row_stride
+        + q_heads[:, None] * q_head_stride
+        + d_offs[None, :]
+    )
+    q_packed_len = q_len * h_hk_ratio
+    mask = (packed_rows[:, None] < q_packed_len) & (d_offs[None, :] < d)
+    return tl.load(q_ptrs, mask=mask, other=0.0)
+
+
+@triton.jit
+def store_o_tile_pack_gqa(
+    o_ptr,
+    o_offset,
+    o_row_stride,
+    o_head_stride,
+    m_block,
+    hid,
+    q_len,
+    d,
+    h_hk_ratio: tl.constexpr,
+    out,
+    BLOCK_M: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    packed_rows = m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+    token_idx = packed_rows // h_hk_ratio
+    q_heads = hid * h_hk_ratio + (packed_rows % h_hk_ratio)
+    d_offs = tl.arange(0, BLOCK_K)
+    o_ptrs = (
+        o_ptr
+        + o_offset
+        + token_idx[:, None] * o_row_stride
+        + q_heads[:, None] * o_head_stride
+        + d_offs[None, :]
+    )
+    q_packed_len = q_len * h_hk_ratio
+    mask = (packed_rows[:, None] < q_packed_len) & (d_offs[None, :] < d)
+    tl.store(o_ptrs, out, mask=mask)
+
+
+@triton.jit
+def store_lse_tile_pack_gqa(
+    softmax_lse_ptr,
+    total_q,
+    lse_offset,
+    m_block,
+    hid,
+    q_len,
+    h_hk_ratio: tl.constexpr,
+    lse,
+    BLOCK_M: tl.constexpr,
+):
+    packed_rows = m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+    token_idx = packed_rows // h_hk_ratio
+    q_heads = hid * h_hk_ratio + (packed_rows % h_hk_ratio)
+    lse_ptrs = softmax_lse_ptr + q_heads * total_q + lse_offset + token_idx
+    mask = packed_rows < q_len * h_hk_ratio
+    tl.store(lse_ptrs, lse, mask=mask)
 
 
 @triton.jit
@@ -1645,3 +1727,404 @@ def flash_varlen_fwd_kernel(
         lse,
         mask=lse_row_offset < (lse_offset + q_len),
     )
+
+
+
+# ---------------------------------------------------------------------------
+# FA3 varlen forward kernel (Hopper, packGQA)
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# FA3 varlen forward kernel (gluon launch path)
+#
+# Same algorithm as flash_varlen_fwd_fa3_kernel.  Differs only in TMA policy:
+#   - non-paged Hopper uses tl.make_tensor_descriptor even with cu_seqlens_k
+#   - warp_specialize is disabled when K bounds are runtime-derived, because
+#     TaskIdPropagation cannot track loop-body descriptor bases
+# ---------------------------------------------------------------------------
+
+
+@libentry()
+@triton.jit(
+    do_not_specialize=[
+        "q_batch_stride",
+        "k_batch_stride",
+        "v_batch_stride",
+        "o_batch_stride",
+        "b",
+        "bk",
+        "seqlen_q",
+        "seqlen_k",
+        "seqlen_q_rounded",
+        "seqlen_k_rounded",
+        "total_q",
+        "qk_descale",
+        "v_descale",
+    ]
+)
+def flash_varlen_fwd_fa3_kernel(
+    q_ptr,
+    k_ptr,
+    v_ptr,
+    o_ptr,
+    p_ptr,
+    softmax_lse_ptr,
+    q_row_stride,
+    k_row_stride,
+    v_row_stride,
+    q_head_stride,
+    k_head_stride,
+    v_head_stride,
+    o_row_stride,
+    o_head_stride,
+    q_batch_stride,
+    k_batch_stride,
+    v_batch_stride,
+    o_batch_stride,
+    is_cu_seqlens_q: tl.constexpr,
+    cu_seqlens_q_ptr,
+    is_cu_seqlens_k: tl.constexpr,
+    cu_seqlens_k_ptr,
+    is_seqused_k: tl.constexpr,
+    seqused_k_ptr,
+    # sizes
+    b,
+    bk,
+    h: tl.constexpr,
+    hk: tl.constexpr,
+    h_hk_ratio: tl.constexpr,
+    seqlen_q,
+    seqlen_k,
+    seqlen_q_rounded,
+    seqlen_k_rounded,
+    d: tl.constexpr,
+    d_rounded: tl.constexpr,
+    # scaling factors
+    is_softcap: tl.constexpr,
+    softcap: tl.constexpr,
+    scale_softmax: tl.constexpr,
+    scale_softmax_log2: tl.constexpr,
+    # dropout (unsupported in FA3, kept for fwd_params compat)
+    is_dropout: tl.constexpr,
+    p_dropout: tl.constexpr,
+    rp_dropout: tl.constexpr,
+    p_dropout_in_uint8_t: tl.constexpr,
+    philox_args,
+    return_softmax: tl.constexpr,
+    # causal / swa
+    is_causal: tl.constexpr,
+    is_local: tl.constexpr,
+    window_size_left: tl.constexpr,
+    window_size_right: tl.constexpr,
+    seqlenq_ngroups_swapped: tl.constexpr,
+    is_paged: tl.constexpr,
+    # alibi slot (not used in FA3, kept for fwd_params compat)
+    is_alibi: tl.constexpr,
+    alibi_slopes_ptr,
+    alibi_slopes_batch_stride: tl.constexpr,
+    # block table
+    total_q,
+    page_table_ptr,
+    page_table_batch_stride: tl.constexpr,
+    block_size: tl.constexpr,
+    k_page_stride,
+    # FA3-specific
+    HAS_DESCALE: tl.constexpr,
+    qk_descale,
+    v_descale,
+    IS_HOPPER: tl.constexpr,
+    PACK_GQA: tl.constexpr,
+    # tile sizes
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    num_warps: tl.constexpr,
+    num_stages: tl.constexpr,
+):
+    m_block = tl.program_id(0)
+    bid     = tl.program_id(1)
+    hid     = tl.program_id(2)
+    if is_cu_seqlens_q:
+        q_eos = tl.load(cu_seqlens_q_ptr + bid + 1).to(tl.int32)
+        q_bos = tl.load(cu_seqlens_q_ptr + bid).to(tl.int32)
+        q_len = q_eos - q_bos
+        q_offset   = q_bos * q_row_stride
+        o_offset   = q_bos * o_row_stride
+        lse_offset = q_bos
+    else:
+        q_len      = seqlen_q
+        q_offset   = bid * q_batch_stride
+        o_offset   = bid * o_batch_stride
+        lse_offset = bid * seqlen_q
+
+    if is_cu_seqlens_k:
+        k_eos = tl.load(cu_seqlens_k_ptr + bid + 1).to(tl.int32)
+        k_bos = tl.load(cu_seqlens_k_ptr + bid).to(tl.int32)
+        k_len_cache = k_eos - k_bos
+    else:
+        k_bos       = 0
+        k_len_cache = seqlen_k
+
+    if is_seqused_k:
+        k_len = tl.load(seqused_k_ptr + bid).to(tl.int32)
+    else:
+        k_len = k_len_cache
+
+    q_packed_len = q_len * h_hk_ratio
+    if PACK_GQA:
+        if m_block * BLOCK_M >= q_packed_len:
+            return
+    else:
+        if m_block * BLOCK_M >= q_len:
+            return
+
+    is_even_mn: tl.constexpr = False
+
+    use_hopper_tma: tl.constexpr = IS_HOPPER and not is_paged
+    use_hopper_tma_qo: tl.constexpr = use_hopper_tma and not PACK_GQA
+    use_warp_specialize: tl.constexpr = (
+        use_hopper_tma and not is_cu_seqlens_k and not is_seqused_k
+    )
+
+    if PACK_GQA:
+        q_row_start = (m_block * BLOCK_M) // h_hk_ratio
+        q_row_bound = tl.minimum((m_block + 1) * BLOCK_M, q_packed_len) // h_hk_ratio
+    else:
+        q_row_start = m_block * BLOCK_M
+        q_row_bound = (m_block + 1) * BLOCK_M
+
+    if is_local:
+        n_block_min = tl.maximum(
+            0,
+            (q_row_start + k_len - q_len - window_size_left) // BLOCK_N,
+        )
+    else:
+        n_block_min = 0
+
+    n_block_max = tl.cdiv(k_len, BLOCK_N)
+    if is_causal or is_local:
+        n_block_max = tl.minimum(
+            n_block_max,
+            tl.cdiv(
+                q_row_bound + k_len - q_len + window_size_right,
+                BLOCK_N,
+            ),
+        )
+
+    if PACK_GQA:
+        kv_hid = hid
+    else:
+        kv_hid = hid // h_hk_ratio
+    q_row_offset = hid * q_head_stride if not PACK_GQA else 0
+    k_row_offset = kv_hid * k_head_stride
+
+    if is_paged:
+        page_table_ptr += bid * page_table_batch_stride
+    k_ptr_base = k_ptr + k_row_offset
+    v_ptr_base = v_ptr + k_row_offset
+
+    if PACK_GQA:
+        bQ = load_q_tile_pack_gqa(
+            q_ptr, q_offset, q_row_stride, q_head_stride,
+            m_block, hid, q_len, d, h_hk_ratio, BLOCK_M, BLOCK_K,
+        )
+    elif use_hopper_tma_qo:
+        desc_q = tl.make_tensor_descriptor(
+            q_ptr + q_offset + q_row_offset,
+            shape=[q_len, d],
+            strides=[q_row_stride, 1],
+            block_shape=[BLOCK_M, BLOCK_K],
+        )
+        bQ = desc_q.load([m_block * BLOCK_M, 0])
+    else:
+        gQ = tl.make_block_ptr(
+            base=q_ptr + q_offset + q_row_offset,
+            shape=(q_len, d),
+            strides=(q_row_stride, 1),
+            offsets=(m_block * BLOCK_M, 0),
+            block_shape=(BLOCK_M, BLOCK_K),
+            order=(1, 0),
+        )
+        bQ = tl.load(gQ, boundary_check=(0, 1))
+
+    acc_    = tl.zeros((BLOCK_M, BLOCK_K), dtype=tl.float32)
+    rowmax_ = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
+    rowsum_ = tl.zeros([BLOCK_M], dtype=tl.float32)
+
+    row_idx = m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+    if PACK_GQA:
+        mask_row_idx = row_idx // h_hk_ratio
+    else:
+        mask_row_idx = row_idx
+
+    if not is_causal and not is_local:
+        n_masking_steps = 1
+    elif is_even_mn:
+        n_masking_steps = tl.cdiv(BLOCK_M, BLOCK_N)
+    else:
+        n_masking_steps = tl.cdiv(BLOCK_M, BLOCK_N) + 1
+    n_masking_steps = tl.minimum(n_block_max - n_block_min, n_masking_steps)
+
+    if use_hopper_tma:
+        k_ptr_seq = k_ptr_base + k_bos * k_row_stride
+        v_ptr_seq = v_ptr_base + k_bos * k_row_stride
+        desc_k = tl.make_tensor_descriptor(
+            k_ptr_seq,
+            shape=[k_len, d],
+            strides=[k_row_stride, 1],
+            block_shape=[BLOCK_N, BLOCK_K],
+        )
+        desc_v = tl.make_tensor_descriptor(
+            v_ptr_seq,
+            shape=[k_len, d],
+            strides=[v_row_stride, 1],
+            block_shape=[BLOCK_N, BLOCK_K],
+        )
+
+    n_block = n_block_max - 1
+    for step in tl.range(0, n_masking_steps):
+        col_idx = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
+        if is_paged:
+            bK, bV = load_from_kvcache(
+                col_idx, k_len, page_table_ptr, k_ptr_base, v_ptr_base,
+                block_size, d, k_row_stride,
+                BLOCK_K=BLOCK_K, k_page_stride=k_page_stride, boundary_check=True,
+            )
+        else:
+            start_n = n_block * BLOCK_N
+            if use_hopper_tma:
+                bK = tl.trans(desc_k.load([start_n, 0]))
+                bV = desc_v.load([start_n, 0])
+            else:
+                k_ptr_seq = k_ptr_base + k_bos * k_row_stride
+                v_ptr_seq = v_ptr_base + k_bos * k_row_stride
+                gK = tl.make_block_ptr(
+                    base=k_ptr_seq, shape=(k_len, d),
+                    strides=(k_row_stride, 1), offsets=(start_n, 0),
+                    block_shape=(BLOCK_N, BLOCK_K), order=(0, 1),
+                )
+                gV = tl.make_block_ptr(
+                    base=v_ptr_seq, shape=(k_len, d),
+                    strides=(v_row_stride, 1), offsets=(start_n, 0),
+                    block_shape=(BLOCK_N, BLOCK_K), order=(0, 1),
+                )
+                bK = tl.trans(tl.load(gK, boundary_check=(0, 1)))
+                bV = tl.load(gV, boundary_check=(0, 1))
+
+        S = tl.dot(bQ, bK, out_dtype=tl.float32)
+        if HAS_DESCALE:
+            S *= qk_descale
+        S = apply_softcap(S, softcap, is_softcap)
+        S = apply_mask(
+            S, col_idx, mask_row_idx, q_len, k_len,
+            window_size_left, window_size_right,
+            is_even_mn=False, is_causal=is_causal, is_local=is_local,
+        )
+        acc_, P, rowmax_, rowsum_ = softmax_rescale(
+            acc_, S, rowmax_, rowsum_,
+            softmax_scale_log2e=scale_softmax_log2, is_border=True,
+        )
+        P = P.to(q_ptr.type.element_ty)
+        acc_ = tl.dot(P, bV, acc_)
+        if HAS_DESCALE:
+            acc_ *= v_descale
+        n_block -= 1
+
+    for n_block in tl.range(
+        n_block_max - n_masking_steps - 1, n_block_min - 1, step=-1,
+        num_stages=num_stages,
+        warp_specialize=use_warp_specialize,
+    ):
+        col_idx = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
+        if is_paged:
+            bK, bV = load_from_kvcache(
+                col_idx, k_len, page_table_ptr, k_ptr_base, v_ptr_base,
+                block_size, d, k_row_stride,
+                BLOCK_K=BLOCK_K, k_page_stride=k_page_stride,
+            )
+        else:
+            start_n = n_block * BLOCK_N
+            if use_hopper_tma:
+                bK = tl.trans(desc_k.load([start_n, 0]))
+                bV = desc_v.load([start_n, 0])
+            else:
+                k_ptr_seq = k_ptr_base + k_bos * k_row_stride
+                v_ptr_seq = v_ptr_base + k_bos * k_row_stride
+                gK = tl.make_block_ptr(
+                    base=k_ptr_seq, shape=(k_len, d),
+                    strides=(k_row_stride, 1), offsets=(start_n, 0),
+                    block_shape=(BLOCK_N, BLOCK_K), order=(0, 1),
+                )
+                gV = tl.make_block_ptr(
+                    base=v_ptr_seq, shape=(k_len, d),
+                    strides=(v_row_stride, 1), offsets=(start_n, 0),
+                    block_shape=(BLOCK_N, BLOCK_K), order=(0, 1),
+                )
+                bK = tl.trans(tl.load(gK))
+                bV = tl.load(gV)
+
+        S = tl.dot(bQ, bK, out_dtype=tl.float32)
+        if HAS_DESCALE:
+            S *= qk_descale
+        S = apply_softcap(S, softcap, is_softcap)
+        S = apply_mask(
+            S, col_idx, mask_row_idx, q_len, k_len,
+            window_size_left, window_size_right,
+            is_even_mn=True, is_causal=False, is_local=is_local,
+        )
+        acc_, P, rowmax_, rowsum_ = softmax_rescale(
+            acc_, S, rowmax_, rowsum_,
+            softmax_scale_log2e=scale_softmax_log2, is_border=is_local,
+        )
+        P = P.to(q_ptr.type.element_ty)
+        acc_ = tl.dot(P, bV, acc_)
+        if HAS_DESCALE:
+            acc_ *= v_descale
+
+    lse = tl.where(
+        rowsum_ == 0 | (rowsum_ != rowsum_),
+        float("inf"),
+        rowmax_ * scale_softmax + tl.log(rowsum_),
+    )
+    inv_sum = tl.where(rowsum_ == 0 | (rowsum_ != rowsum_), 1.0, 1.0 / rowsum_)
+    acc_ *= inv_sum[:, None]
+    out = acc_.to(o_ptr.type.element_ty)
+
+    if PACK_GQA:
+        store_o_tile_pack_gqa(
+            o_ptr, o_offset, o_row_stride, o_head_stride,
+            m_block, hid, q_len, d, h_hk_ratio, out, BLOCK_M, BLOCK_K,
+        )
+        store_lse_tile_pack_gqa(
+            softmax_lse_ptr, total_q, lse_offset,
+            m_block, hid, q_len, h_hk_ratio, lse, BLOCK_M,
+        )
+    else:
+        o_row_offset = hid * o_head_stride
+        if use_hopper_tma_qo:
+            desc_o = tl.make_tensor_descriptor(
+                o_ptr + o_offset + o_row_offset,
+                shape=[q_len, d],
+                strides=[o_row_stride, 1],
+                block_shape=[BLOCK_M, BLOCK_K],
+            )
+            desc_o.store([m_block * BLOCK_M, 0], out)
+        else:
+            gO = tl.make_block_ptr(
+                base=o_ptr + o_offset + o_row_offset,
+                shape=(q_len, d),
+                strides=(o_row_stride, 1),
+                offsets=(m_block * BLOCK_M, 0),
+                block_shape=(BLOCK_M, BLOCK_K),
+                order=(1, 0),
+            )
+            tl.store(gO, out, boundary_check=(0, 1))
+
+        softmax_lse_ptr += hid * total_q
+        lse_row_offset = lse_offset + m_block * BLOCK_M + tl.arange(0, BLOCK_M)
+        tl.store(
+            softmax_lse_ptr + lse_row_offset,
+            lse,
+            mask=lse_row_offset < (lse_offset + q_len),
+        )

--- a/src/flag_gems/ops/flash_kernel.py
+++ b/src/flag_gems/ops/flash_kernel.py
@@ -1729,7 +1729,6 @@ def flash_varlen_fwd_kernel(
     )
 
 
-
 # ---------------------------------------------------------------------------
 # FA3 varlen forward kernel (Hopper Triton path, libtuner)
 # ---------------------------------------------------------------------------
@@ -1886,19 +1885,19 @@ def flash_varlen_fwd_fa3_kernel(
     num_stages: tl.constexpr,
 ):
     m_block = tl.program_id(0)
-    bid     = tl.program_id(1)
-    hid     = tl.program_id(2)
+    bid = tl.program_id(1)
+    hid = tl.program_id(2)
     if is_cu_seqlens_q:
         q_eos = tl.load(cu_seqlens_q_ptr + bid + 1).to(tl.int32)
         q_bos = tl.load(cu_seqlens_q_ptr + bid).to(tl.int32)
         q_len = q_eos - q_bos
-        q_offset   = q_bos * q_row_stride
-        o_offset   = q_bos * o_row_stride
+        q_offset = q_bos * q_row_stride
+        o_offset = q_bos * o_row_stride
         lse_offset = q_bos
     else:
-        q_len      = seqlen_q
-        q_offset   = bid * q_batch_stride
-        o_offset   = bid * o_batch_stride
+        q_len = seqlen_q
+        q_offset = bid * q_batch_stride
+        o_offset = bid * o_batch_stride
         lse_offset = bid * seqlen_q
 
     if is_cu_seqlens_k:
@@ -1906,7 +1905,7 @@ def flash_varlen_fwd_fa3_kernel(
         k_bos = tl.load(cu_seqlens_k_ptr + bid).to(tl.int32)
         k_len_cache = k_eos - k_bos
     else:
-        k_bos       = 0
+        k_bos = 0
         k_len_cache = seqlen_k
 
     if is_seqused_k:
@@ -1969,8 +1968,17 @@ def flash_varlen_fwd_fa3_kernel(
 
     if PACK_GQA:
         bQ = load_q_tile_pack_gqa(
-            q_ptr, q_offset, q_row_stride, q_head_stride,
-            m_block, hid, q_len, d, h_hk_ratio, BLOCK_M, BLOCK_K,
+            q_ptr,
+            q_offset,
+            q_row_stride,
+            q_head_stride,
+            m_block,
+            hid,
+            q_len,
+            d,
+            h_hk_ratio,
+            BLOCK_M,
+            BLOCK_K,
         )
     elif use_hopper_tma_qo:
         desc_q = tl.make_tensor_descriptor(
@@ -1991,7 +1999,7 @@ def flash_varlen_fwd_fa3_kernel(
         )
         bQ = tl.load(gQ, boundary_check=(0, 1))
 
-    acc_    = tl.zeros((BLOCK_M, BLOCK_K), dtype=tl.float32)
+    acc_ = tl.zeros((BLOCK_M, BLOCK_K), dtype=tl.float32)
     rowmax_ = tl.full([BLOCK_M], float("-inf"), dtype=tl.float32)
     rowsum_ = tl.zeros([BLOCK_M], dtype=tl.float32)
 
@@ -2030,9 +2038,17 @@ def flash_varlen_fwd_fa3_kernel(
         col_idx = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
         if is_paged:
             bK, bV = load_from_kvcache(
-                col_idx, k_len, page_table_ptr, k_ptr_base, v_ptr_base,
-                block_size, d, k_row_stride,
-                BLOCK_K=BLOCK_K, k_page_stride=k_page_stride, boundary_check=True,
+                col_idx,
+                k_len,
+                page_table_ptr,
+                k_ptr_base,
+                v_ptr_base,
+                block_size,
+                d,
+                k_row_stride,
+                BLOCK_K=BLOCK_K,
+                k_page_stride=k_page_stride,
+                boundary_check=True,
             )
         else:
             start_n = n_block * BLOCK_N
@@ -2043,14 +2059,20 @@ def flash_varlen_fwd_fa3_kernel(
                 k_ptr_seq = k_ptr_base + k_bos * k_row_stride
                 v_ptr_seq = v_ptr_base + k_bos * k_row_stride
                 gK = tl.make_block_ptr(
-                    base=k_ptr_seq, shape=(k_len, d),
-                    strides=(k_row_stride, 1), offsets=(start_n, 0),
-                    block_shape=(BLOCK_N, BLOCK_K), order=(0, 1),
+                    base=k_ptr_seq,
+                    shape=(k_len, d),
+                    strides=(k_row_stride, 1),
+                    offsets=(start_n, 0),
+                    block_shape=(BLOCK_N, BLOCK_K),
+                    order=(0, 1),
                 )
                 gV = tl.make_block_ptr(
-                    base=v_ptr_seq, shape=(k_len, d),
-                    strides=(v_row_stride, 1), offsets=(start_n, 0),
-                    block_shape=(BLOCK_N, BLOCK_K), order=(0, 1),
+                    base=v_ptr_seq,
+                    shape=(k_len, d),
+                    strides=(v_row_stride, 1),
+                    offsets=(start_n, 0),
+                    block_shape=(BLOCK_N, BLOCK_K),
+                    order=(0, 1),
                 )
                 bK = tl.trans(tl.load(gK, boundary_check=(0, 1)))
                 bV = tl.load(gV, boundary_check=(0, 1))
@@ -2060,13 +2082,24 @@ def flash_varlen_fwd_fa3_kernel(
             S *= qk_descale
         S = apply_softcap(S, softcap, is_softcap)
         S = apply_mask(
-            S, col_idx, mask_row_idx, q_len, k_len,
-            window_size_left, window_size_right,
-            is_even_mn=False, is_causal=is_causal, is_local=is_local,
+            S,
+            col_idx,
+            mask_row_idx,
+            q_len,
+            k_len,
+            window_size_left,
+            window_size_right,
+            is_even_mn=False,
+            is_causal=is_causal,
+            is_local=is_local,
         )
         acc_, P, rowmax_, rowsum_ = softmax_rescale(
-            acc_, S, rowmax_, rowsum_,
-            softmax_scale_log2e=scale_softmax_log2, is_border=True,
+            acc_,
+            S,
+            rowmax_,
+            rowsum_,
+            softmax_scale_log2e=scale_softmax_log2,
+            is_border=True,
         )
         P = P.to(q_ptr.type.element_ty)
         acc_ = tl.dot(P, bV, acc_)
@@ -2075,16 +2108,25 @@ def flash_varlen_fwd_fa3_kernel(
         n_block -= 1
 
     for n_block in tl.range(
-        n_block_max - n_masking_steps - 1, n_block_min - 1, step=-1,
+        n_block_max - n_masking_steps - 1,
+        n_block_min - 1,
+        step=-1,
         num_stages=num_stages,
         warp_specialize=use_warp_specialize,
     ):
         col_idx = n_block * BLOCK_N + tl.arange(0, BLOCK_N)
         if is_paged:
             bK, bV = load_from_kvcache(
-                col_idx, k_len, page_table_ptr, k_ptr_base, v_ptr_base,
-                block_size, d, k_row_stride,
-                BLOCK_K=BLOCK_K, k_page_stride=k_page_stride,
+                col_idx,
+                k_len,
+                page_table_ptr,
+                k_ptr_base,
+                v_ptr_base,
+                block_size,
+                d,
+                k_row_stride,
+                BLOCK_K=BLOCK_K,
+                k_page_stride=k_page_stride,
             )
         else:
             start_n = n_block * BLOCK_N
@@ -2095,14 +2137,20 @@ def flash_varlen_fwd_fa3_kernel(
                 k_ptr_seq = k_ptr_base + k_bos * k_row_stride
                 v_ptr_seq = v_ptr_base + k_bos * k_row_stride
                 gK = tl.make_block_ptr(
-                    base=k_ptr_seq, shape=(k_len, d),
-                    strides=(k_row_stride, 1), offsets=(start_n, 0),
-                    block_shape=(BLOCK_N, BLOCK_K), order=(0, 1),
+                    base=k_ptr_seq,
+                    shape=(k_len, d),
+                    strides=(k_row_stride, 1),
+                    offsets=(start_n, 0),
+                    block_shape=(BLOCK_N, BLOCK_K),
+                    order=(0, 1),
                 )
                 gV = tl.make_block_ptr(
-                    base=v_ptr_seq, shape=(k_len, d),
-                    strides=(v_row_stride, 1), offsets=(start_n, 0),
-                    block_shape=(BLOCK_N, BLOCK_K), order=(0, 1),
+                    base=v_ptr_seq,
+                    shape=(k_len, d),
+                    strides=(v_row_stride, 1),
+                    offsets=(start_n, 0),
+                    block_shape=(BLOCK_N, BLOCK_K),
+                    order=(0, 1),
                 )
                 bK = tl.trans(tl.load(gK))
                 bV = tl.load(gV)
@@ -2112,13 +2160,24 @@ def flash_varlen_fwd_fa3_kernel(
             S *= qk_descale
         S = apply_softcap(S, softcap, is_softcap)
         S = apply_mask(
-            S, col_idx, mask_row_idx, q_len, k_len,
-            window_size_left, window_size_right,
-            is_even_mn=True, is_causal=False, is_local=is_local,
+            S,
+            col_idx,
+            mask_row_idx,
+            q_len,
+            k_len,
+            window_size_left,
+            window_size_right,
+            is_even_mn=True,
+            is_causal=False,
+            is_local=is_local,
         )
         acc_, P, rowmax_, rowsum_ = softmax_rescale(
-            acc_, S, rowmax_, rowsum_,
-            softmax_scale_log2e=scale_softmax_log2, is_border=is_local,
+            acc_,
+            S,
+            rowmax_,
+            rowsum_,
+            softmax_scale_log2e=scale_softmax_log2,
+            is_border=is_local,
         )
         P = P.to(q_ptr.type.element_ty)
         acc_ = tl.dot(P, bV, acc_)
@@ -2136,12 +2195,29 @@ def flash_varlen_fwd_fa3_kernel(
 
     if PACK_GQA:
         store_o_tile_pack_gqa(
-            o_ptr, o_offset, o_row_stride, o_head_stride,
-            m_block, hid, q_len, d, h_hk_ratio, out, BLOCK_M, BLOCK_K,
+            o_ptr,
+            o_offset,
+            o_row_stride,
+            o_head_stride,
+            m_block,
+            hid,
+            q_len,
+            d,
+            h_hk_ratio,
+            out,
+            BLOCK_M,
+            BLOCK_K,
         )
         store_lse_tile_pack_gqa(
-            softmax_lse_ptr, total_q, lse_offset,
-            m_block, hid, q_len, h_hk_ratio, lse, BLOCK_M,
+            softmax_lse_ptr,
+            total_q,
+            lse_offset,
+            m_block,
+            hid,
+            q_len,
+            h_hk_ratio,
+            lse,
+            BLOCK_M,
         )
     else:
         o_row_offset = hid * o_head_stride

--- a/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
@@ -25,6 +25,35 @@ attention:
       - 2
       - 3
       - 4
+attention_fa3_varlen:
+  - META:
+      BLOCK_M: 128
+      BLOCK_N: 32
+      num_warps: 4
+      num_stages: 3
+    num_warps: 4
+    num_stages: 3
+  - META:
+      BLOCK_M: 64
+      BLOCK_N: 64
+      num_warps: 4
+      num_stages: 3
+    num_warps: 4
+    num_stages: 3
+  - META:
+      BLOCK_M: 32
+      BLOCK_N: 64
+      num_warps: 4
+      num_stages: 3
+    num_warps: 4
+    num_stages: 3
+  - META:
+      BLOCK_M: 16
+      BLOCK_N: 64
+      num_warps: 4
+      num_stages: 3
+    num_warps: 4
+    num_stages: 3
 attention_bwd:
   - gen: true
     param_map:

--- a/tests/test_flash_attn_varlen_fa3_func.py
+++ b/tests/test_flash_attn_varlen_fa3_func.py
@@ -1,0 +1,307 @@
+from typing import List, Tuple
+
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from .conftest import QUICK_MODE
+
+device = flag_gems.device
+vendor_name = flag_gems.vendor_name
+
+
+def _is_hopper():
+    return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 9
+
+
+if QUICK_MODE:
+    NUM_HEADS = [(8, 2)]
+    HEAD_SIZES = [128]
+    FLOAT_DTYPES = [torch.float16]
+    NUM_BLOCKS = [2048]
+else:
+    NUM_HEADS = [(4, 4), (8, 2), (16, 2)]
+    HEAD_SIZES = [64, 128, 256]
+    FLOAT_DTYPES = [torch.float16, torch.bfloat16]
+    NUM_BLOCKS = [32768, 2048]
+
+
+def ref_paged_attn(
+    query: torch.Tensor,
+    key_cache: torch.Tensor,
+    value_cache: torch.Tensor,
+    query_lens: List[int],
+    kv_lens: List[int],
+    block_tables: torch.Tensor,
+    scale: float,
+) -> torch.Tensor:
+    """Pure-PyTorch reference for paged causal attention."""
+    block_tables_np = block_tables.cpu().numpy()
+    _, block_size, num_kv_heads, head_size = key_cache.shape
+
+    outputs: List[torch.Tensor] = []
+    start_idx = 0
+    for i in range(len(query_lens)):
+        query_len = query_lens[i]
+        kv_len = kv_lens[i]
+        q = query[start_idx : start_idx + query_len].clone() * scale
+
+        num_kv_blocks = (kv_len + block_size - 1) // block_size
+        block_idx = block_tables_np[i, :num_kv_blocks]
+        k = key_cache[block_idx].view(-1, num_kv_heads, head_size)[:kv_len]
+        v = value_cache[block_idx].view(-1, num_kv_heads, head_size)[:kv_len]
+
+        if q.shape[1] != k.shape[1]:
+            ratio = q.shape[1] // k.shape[1]
+            k = torch.repeat_interleave(k, ratio, dim=1)
+            v = torch.repeat_interleave(v, ratio, dim=1)
+
+        attn = torch.einsum("qhd,khd->hqk", q, k)
+        ones = torch.ones(query_len, kv_len, device=q.device)
+        mask = torch.triu(ones, diagonal=kv_len - query_len + 1).bool()
+        attn.masked_fill_(mask, float("-inf"))
+        attn = torch.softmax(attn, dim=-1).to(v.dtype)
+        out = torch.einsum("hqk,khd->qhd", attn, v)
+        outputs.append(out)
+        start_idx += query_len
+
+    return torch.cat(outputs, dim=0)
+
+
+@pytest.mark.flash_attn_varlen_func
+@pytest.mark.skipif(not _is_hopper(), reason="FA3 requires Hopper (sm_90+)")
+@pytest.mark.skipif(vendor_name == "kunlunxin", reason="Not supported")
+@pytest.mark.skipif(vendor_name == "hygon", reason="Not working")
+@pytest.mark.parametrize("seq_lens", [[(1, 1328), (5, 18), (129, 463)]])
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize("block_size", [16, 32])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+@pytest.mark.parametrize("num_blocks", NUM_BLOCKS)
+def test_flash_attn_varlen_fa3_func(
+    seq_lens: List[Tuple[int, int]],
+    num_heads: Tuple[int, int],
+    head_size: int,
+    dtype: torch.dtype,
+    block_size: int,
+    num_blocks: int,
+) -> None:
+    with torch.device(device):
+        utils.init_seed(1234567890)
+
+        num_seqs = len(seq_lens)
+        query_lens = [x[0] for x in seq_lens]
+        kv_lens = [x[1] for x in seq_lens]
+        num_query_heads, num_kv_heads = num_heads
+        assert num_query_heads % num_kv_heads == 0
+
+        max_query_len = max(query_lens)
+        max_kv_len = max(kv_lens)
+        scale = head_size**-0.5
+
+        query = torch.randn(
+            sum(query_lens), num_query_heads, head_size, dtype=dtype
+        )
+        key_cache = torch.randn(
+            num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
+        )
+        value_cache = torch.randn_like(key_cache)
+        cu_query_lens = torch.tensor(
+            [0] + query_lens, dtype=torch.int32, device=device
+        ).cumsum(dim=0, dtype=torch.int32)
+        seqused_k = torch.tensor(kv_lens, dtype=torch.int32, device=device)
+        max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+        block_tables = torch.randint(
+            0,
+            num_blocks,
+            (num_seqs, max_num_blocks_per_seq),
+            dtype=torch.int32,
+            device=device,
+        )
+
+        output = flag_gems.flash_attn_varlen_func(
+            q=query,
+            k=key_cache,
+            v=value_cache,
+            cu_seqlens_q=cu_query_lens,
+            seqused_k=seqused_k,
+            max_seqlen_q=max_query_len,
+            max_seqlen_k=max_kv_len,
+            softmax_scale=scale,
+            causal=True,
+            window_size=(-1, -1),
+            block_table=block_tables,
+            softcap=0,
+            fa_version=3,
+        )
+
+        ref_output = ref_paged_attn(
+            query=query,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            query_lens=query_lens,
+            kv_lens=kv_lens,
+            block_tables=block_tables,
+            scale=scale,
+        )
+
+        msg = f"max_diff={torch.max(torch.abs(output - ref_output))}"
+        torch.testing.assert_close(output, ref_output, atol=2e-2, rtol=1e-2, msg=msg)
+
+
+@pytest.mark.flash_attn_varlen_func
+@pytest.mark.skipif(not _is_hopper(), reason="FA3 requires Hopper (sm_90+)")
+@pytest.mark.skipif(vendor_name == "kunlunxin", reason="Not supported")
+@pytest.mark.skipif(vendor_name == "hygon", reason="Not working")
+@pytest.mark.parametrize("seq_lens", [[(1, 512)] * 32, [(1, 2048)] * 16])
+@pytest.mark.parametrize("num_heads", [(16, 8), (8, 2)])
+@pytest.mark.parametrize("head_size", [128])
+@pytest.mark.parametrize("block_size", [16])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+@pytest.mark.parametrize("num_blocks", [2048])
+def test_flash_attn_varlen_fa3_func_decode(
+    seq_lens: List[Tuple[int, int]],
+    num_heads: Tuple[int, int],
+    head_size: int,
+    dtype: torch.dtype,
+    block_size: int,
+    num_blocks: int,
+) -> None:
+    with torch.device(device):
+        utils.init_seed(42)
+
+        num_seqs = len(seq_lens)
+        query_lens = [x[0] for x in seq_lens]
+        kv_lens = [x[1] for x in seq_lens]
+        num_query_heads, num_kv_heads = num_heads
+        max_query_len = max(query_lens)
+        max_kv_len = max(kv_lens)
+        scale = head_size**-0.5
+
+        query = torch.randn(
+            sum(query_lens), num_query_heads, head_size, dtype=dtype
+        )
+        key_cache = torch.randn(
+            num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
+        )
+        value_cache = torch.randn_like(key_cache)
+        cu_query_lens = torch.tensor(
+            [0] + query_lens, dtype=torch.int32, device=device
+        ).cumsum(dim=0, dtype=torch.int32)
+        seqused_k = torch.tensor(kv_lens, dtype=torch.int32, device=device)
+        max_num_blocks_per_seq = (max_kv_len + block_size - 1) // block_size
+        block_tables = torch.randint(
+            0,
+            num_blocks,
+            (num_seqs, max_num_blocks_per_seq),
+            dtype=torch.int32,
+            device=device,
+        )
+
+        output = flag_gems.flash_attn_varlen_func(
+            q=query,
+            k=key_cache,
+            v=value_cache,
+            cu_seqlens_q=cu_query_lens,
+            seqused_k=seqused_k,
+            max_seqlen_q=max_query_len,
+            max_seqlen_k=max_kv_len,
+            softmax_scale=scale,
+            causal=True,
+            window_size=(-1, -1),
+            block_table=block_tables,
+            softcap=0,
+            fa_version=3,
+        )
+
+        ref_output = ref_paged_attn(
+            query=query,
+            key_cache=key_cache,
+            value_cache=value_cache,
+            query_lens=query_lens,
+            kv_lens=kv_lens,
+            block_tables=block_tables,
+            scale=scale,
+        )
+
+        msg = f"max_diff={torch.max(torch.abs(output - ref_output))}"
+        torch.testing.assert_close(output, ref_output, atol=2e-2, rtol=1e-2, msg=msg)
+
+
+@pytest.mark.flash_attn_varlen_func
+@pytest.mark.skipif(not _is_hopper(), reason="FA3 requires Hopper (sm_90+)")
+@pytest.mark.skipif(vendor_name == "kunlunxin", reason="Not supported")
+@pytest.mark.skipif(vendor_name == "hygon", reason="Not working")
+@pytest.mark.parametrize("seq_lens", [[(512, 512), (256, 256), (128, 128)]])
+@pytest.mark.parametrize("num_heads", NUM_HEADS)
+@pytest.mark.parametrize("head_size", HEAD_SIZES)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_flash_attn_varlen_fa3_func_non_paged(
+    seq_lens: List[Tuple[int, int]],
+    num_heads: Tuple[int, int],
+    head_size: int,
+    dtype: torch.dtype,
+) -> None:
+    """non-paged path: k/v are flat [total_kv, nhead, d] tensors."""
+    with torch.device(device):
+        utils.init_seed(1234567890)
+
+        query_lens = [x[0] for x in seq_lens]
+        kv_lens = [x[1] for x in seq_lens]
+        num_query_heads, num_kv_heads = num_heads
+        assert num_query_heads % num_kv_heads == 0
+
+        max_query_len = max(query_lens)
+        max_kv_len = max(kv_lens)
+        scale = head_size**-0.5
+
+        query = torch.randn(sum(query_lens), num_query_heads, head_size, dtype=dtype)
+        key = torch.randn(sum(kv_lens), num_kv_heads, head_size, dtype=dtype)
+        value = torch.randn_like(key)
+
+        cu_query_lens = torch.tensor(
+            [0] + query_lens, dtype=torch.int32, device=device
+        ).cumsum(dim=0, dtype=torch.int32)
+        cu_kv_lens = torch.tensor(
+            [0] + kv_lens, dtype=torch.int32, device=device
+        ).cumsum(dim=0, dtype=torch.int32)
+
+        output = flag_gems.flash_attn_varlen_func(
+            q=query,
+            k=key,
+            v=value,
+            cu_seqlens_q=cu_query_lens,
+            cu_seqlens_k=cu_kv_lens,
+            max_seqlen_q=max_query_len,
+            max_seqlen_k=max_kv_len,
+            softmax_scale=scale,
+            causal=True,
+            window_size=(-1, -1),
+            softcap=0,
+            fa_version=3,
+        )
+
+        outputs_ref = []
+        q_off, k_off = 0, 0
+        for ql, kl in zip(query_lens, kv_lens):
+            q_i = query[q_off : q_off + ql].clone() * scale
+            k_i = key[k_off : k_off + kl]
+            v_i = value[k_off : k_off + kl]
+            if num_query_heads != num_kv_heads:
+                ratio = num_query_heads // num_kv_heads
+                k_i = torch.repeat_interleave(k_i, ratio, dim=1)
+                v_i = torch.repeat_interleave(v_i, ratio, dim=1)
+            attn = torch.einsum("qhd,khd->hqk", q_i, k_i)
+            ones = torch.ones(ql, kl, device=device)
+            mask = torch.triu(ones, diagonal=kl - ql + 1).bool()
+            attn.masked_fill_(mask, float("-inf"))
+            attn = torch.softmax(attn, dim=-1).to(v_i.dtype)
+            outputs_ref.append(torch.einsum("hqk,khd->qhd", attn, v_i))
+            q_off += ql
+            k_off += kl
+
+        ref_output = torch.cat(outputs_ref, dim=0)
+        msg = f"max_diff={torch.max(torch.abs(output - ref_output))}"
+        torch.testing.assert_close(output, ref_output, atol=2e-2, rtol=1e-2, msg=msg)

--- a/tests/test_flash_attn_varlen_fa3_func.py
+++ b/tests/test_flash_attn_varlen_fa3_func.py
@@ -101,9 +101,7 @@ def test_flash_attn_varlen_fa3_func(
         max_kv_len = max(kv_lens)
         scale = head_size**-0.5
 
-        query = torch.randn(
-            sum(query_lens), num_query_heads, head_size, dtype=dtype
-        )
+        query = torch.randn(sum(query_lens), num_query_heads, head_size, dtype=dtype)
         key_cache = torch.randn(
             num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
         )
@@ -180,9 +178,7 @@ def test_flash_attn_varlen_fa3_func_decode(
         max_kv_len = max(kv_lens)
         scale = head_size**-0.5
 
-        query = torch.randn(
-            sum(query_lens), num_query_heads, head_size, dtype=dtype
-        )
+        query = torch.randn(sum(query_lens), num_query_heads, head_size, dtype=dtype)
         key_cache = torch.randn(
             num_blocks, block_size, num_kv_heads, head_size, dtype=dtype
         )


### PR DESCRIPTION
### PR Category
Operator | OP Test | Benchmark

### Type of Change
New Feature | Performance Optimization

### Description
Add **FA3 varlen** forward attention for Hopper (sm_90+) via Triton kernel `flash_varlen_fwd_fa3_kernel`, integrated into `flash_attn_varlen_func` (`fa_version=3`).

https://github.com/flagos-ai/FlagTree/pull/707

**Scope:**
- Non-paged and paged KV, GQA (`PACK_GQA`), causal prefill & decode
- Launch path: `mha_varlan_fwd_fa3` in `flash_api.py`
- `@libentry` + `@libtuner` with `attention_fa3_varlen` tune configs
- Accuracy tests: `tests/test_flash_attn_varlen_fa3_func.py`
- Benchmark: `benchmark/test_flash_attn_varlen_fa3_func.py` (baseline: **vLLM FA3**)

### Issue
N/A

### Progress
- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance
**Setup:** H800,  `pytest benchmark/test_flash_attn_varlen_fa3_func.py -v -s`  

| vllm (ms) | gems (ms) | speedup | sizedetail |
|----------:|----------:|--------:|:-----------|
| 0.020736 | 0.024576 | 0.844 | paged_medium_or_prefill_tq512_q512_k512_h16_hk8_d128 (float16) |
| 0.014912 | 0.019328 | 0.772 | paged_short_tq72_q70_k70_h16_hk8_d128 (float16) |
| 0.067424 | 0.066208 | 1.018 | paged_mixed_short_tq265_q61_k515_h16_hk8_d128 (float16) |
| 0.539680 | 0.442048 | 1.221 | paged_decodeish_long_k_tq265_q16_k2333_h16_hk8_d128 (float16) |
| 0.369984 | 0.432736 | 0.855 | prefill_b4_s2k_d128_mha (float16) |
| 1.047840 | 1.508576 | 0.695 | prefill_b4_s4k_d128_mha (float16) |
| 3.740480 | 5.559808 | 0.673 | prefill_b4_s8k_d128_mha (float16) |
| 7.089280 | 10.544192 | 0.672 | prefill_b2_s16k_d128_mha (float16) |
| 1.006464 | 1.409760 | 0.714 | prefill_b4_s4k_d128_gqa4 (float16) |
| 3.675264 | 5.393536 | 0.681 | prefill_b4_s8k_d128_gqa4 (float16) |
| 0.378464 | 0.447376 | 0.846 | prefill_b8_s2k_d64_mha (float16) |
| 0.042560 | 0.037152 | 1.146 | decode_b16_kv1k_d128_gqa4 (float16) |
| 0.036912 | 0.035536 | 1.039 | decode_b8_kv1k_d192_gqa4 (float16) |
| 0.044416 | 0.038528 | 1.153 | decode_b8_kv1k_d256_gqa4 (float16) |
| 0.069152 | 0.076672 | 0.902 | decode_b16_mixed_d128_gqa4 (float16) |
| 0.110784 | 0.104032 | 1.065 | decode_b32_kv2k_d128_gqa4 (float16) |
| 0.191936 | 0.312976 | 0.613 | varlen_mixed_d128_gqa4 (float16) |
| 0.175232 | 0.240720 | 0.728 | varlen_serve_b32_1pf_31dec_d128_gqa4 (float16) |
| 3.602448 | 5.476928 | 0.658 | varlen_longtail_d128_gqa4 (float16) |
| 0.089280 | 0.163072 | 0.547 | paged_decode_b16_kvmix_bs16_d128_gqa4 (float16) |
| 0.052928 | 0.099040 | 0.534 | paged_decode_b8_bs16_d192_gqa4 (float16) |
| 0.062304 | 0.097904 | 0.636 | paged_decode_b8_bs16_d256_gqa4 (float16) |
| 0.412096 | 0.499088 | 0.826 | paged_decode_b64_bs16_d128_gqa4 (float16) |
| 0.204672 | 0.442528 | 0.463 | paged_serve_b32_1pf_31dec_bs16_d128_gqa4 (float16) |
| 1.115936 | 1.971648 | 0.566 | paged_uniform_b4_s4k_bs16_d128_mha (float16) |
| 0.020096 | 0.024512 | 0.820 | paged_medium_or_prefill_tq512_q512_k512_h16_hk8_d128 (bfloat16) |
| 0.015296 | 0.019136 | 0.799 | paged_short_tq72_q70_k70_h16_hk8_d128 (bfloat16) |
| 0.067232 | 0.065600 | 1.025 | paged_mixed_short_tq265_q61_k515_h16_hk8_d128 (bfloat16) |
| 0.531392 | 0.441856 | 1.203 | paged_decodeish_long_k_tq265_q16_k2333_h16_hk8_d128 (bfloat16) |
| 0.348656 | 0.430976 | 0.809 | prefill_b4_s2k_d128_mha (bfloat16) |
| 0.998752 | 1.485584 | 0.672 | prefill_b4_s4k_d128_mha (bfloat16) |
| 3.583408 | 5.396640 | 0.664 | prefill_b4_s8k_d128_mha (bfloat16) |
| 6.943296 | 10.309024 | 0.674 | prefill_b2_s16k_d128_mha (bfloat16) |
| 0.967408 | 1.384976 | 0.699 | prefill_b4_s4k_d128_gqa4 (bfloat16) |
| 3.495936 | 5.286912 | 0.661 | prefill_b4_s8k_d128_gqa4 (bfloat16) |
| 0.410256 | 0.445088 | 0.922 | prefill_b8_s2k_d64_mha (bfloat16) |
| 0.042528 | 0.037280 | 1.141 | decode_b16_kv1k_d128_gqa4 (bfloat16) |
| 0.036608 | 0.035520 | 1.031 | decode_b8_kv1k_d192_gqa4 (bfloat16) |
| 0.044160 | 0.038560 | 1.145 | decode_b8_kv1k_d256_gqa4 (bfloat16) |
| 0.068864 | 0.075776 | 0.909 | decode_b16_mixed_d128_gqa4 (bfloat16) |
| 0.110656 | 0.104192 | 1.062 | decode_b32_kv2k_d128_gqa4 (bfloat16) |
| 0.183200 | 0.313728 | 0.584 | varlen_mixed_d128_gqa4 (bfloat16) |
| 0.171168 | 0.238896 | 0.716 | varlen_serve_b32_1pf_31dec_d128_gqa4 (bfloat16) |
| 3.328256 | 5.301248 | 0.628 | varlen_longtail_d128_gqa4 (bfloat16) |
| 0.088864 | 0.162048 | 0.548 | paged_decode_b16_kvmix_bs16_d128_gqa4 (bfloat16) |
| 0.052640 | 0.098880 | 0.532 | paged_decode_b8_bs16_d192_gqa4 (bfloat16) |
| 0.062064 | 0.098752 | 0.628 | paged_decode_b8_bs16_d256_gqa4 (bfloat16) |
| 0.412704 | 0.497920 | 0.829 | paged_decode_b64_bs16_d128_gqa4 (bfloat16) |
| 0.199360 | 0.446208 | 0.447 | paged_serve_b32_1pf_31dec_bs16_d128_gqa4 (bfloat16) |
| 1.085840 | 1.952704 | 0.556 | paged_uniform_b4_s4k_bs16_d128_mha (bfloat16) |