### PR TITLE
Fix cumsum ZeroDivisionError on empty tensor (#4543)

### DIFF
--- a/src/flag_gems/ops/cumsum.py
+++ b/src/flag_gems/ops/cumsum.py
@@ -218,7 +218,14 @@ def cumsum_wrapper(inp, dim=1, dtype=None, out=None):
     for i in range(dim):
         M *= shape[i]
     inp = inp.contiguous()
-    K = inp.numel() // M // N
+
+    # torch.cumsum only enforces the out= dtype when an explicit dtype= is
+    # given (otherwise out may keep its own dtype). Check it up front, before
+    # dtype is defaulted, and even for empty inputs — matching torch.
+    if out is not None and dtype is not None and out.dtype != dtype:
+        raise RuntimeError(
+            f"Expected out tensor to have dtype {dtype}, but got {out.dtype} instead"
+        )
 
     if dtype is None:
         dtype = inp.dtype
@@ -226,6 +233,16 @@ def cumsum_wrapper(inp, dim=1, dtype=None, out=None):
             dtype = torch.int64
     if out is None:
         out = torch.empty_like(inp, dtype=dtype)
+    elif out.shape != inp.shape:
+        # cumsum is shape-preserving, so resize a stale out to the input shape.
+        out.resize_(inp.shape)
+
+    # Empty input: nothing to scan. out now has the right (empty) shape, so
+    # return before the div-by-zero below when a leading/scanned dim is 0.
+    if inp.numel() == 0:
+        return out
+
+    K = inp.numel() // M // N
 
     compute_dtype = out.dtype
     if inp.dtype == torch.float16 or inp.dtype == torch.bfloat16:

--- a/tests/test_cumsum.py
+++ b/tests/test_cumsum.py
@@ -18,6 +18,20 @@ else:
 
 random.seed(time.time() // 100)
 
+# Backends that ship their own cumsum copy still carrying the empty-tensor
+# div-by-zero (issue 4602). Skip the empty-input tests there until those
+# backend overrides get the same fix as the generic implementation.
+_EMPTY_CUMSUM_UNFIXED_VENDORS = {
+    "aipu",
+    "arm",
+    "ascend",
+    "cambricon",
+    "kunlunxin",
+    "sunrise",
+    "enflame",
+    "tsingmicro",
+}
+
 
 @pytest.mark.cumsum
 @pytest.mark.parametrize("shape", CUMSUM_SHAPES)
@@ -71,3 +85,72 @@ def test_cumsum_out(shape, dtype):
         torch.cumsum(inp, dim=dim, out=out)
 
     utils.gems_assert_close(out, ref_out_buf, dtype, reduce_dim=shape[dim])
+
+
+@pytest.mark.cumsum
+@pytest.mark.parametrize(
+    "shape, dim",
+    [((0,), 0), ((0, 5), 1), ((3, 0, 4), 2), ((3, 0, 4), 0), ((2, 0), 0)],
+)
+@pytest.mark.parametrize("dtype", [torch.float32, torch.int32])
+def test_cumsum_empty(shape, dim, dtype):
+    # Issue 4543: cumsum on an empty tensor must not raise (div-by-zero when a
+    # scanned/leading dim is 0). Output should match torch.cumsum in shape/dtype.
+    if flag_gems.vendor_name in _EMPTY_CUMSUM_UNFIXED_VENDORS:
+        pytest.skip(
+            f"{flag_gems.vendor_name} cumsum override still has the empty-tensor "
+            "div-by-zero (issue 4602)"
+        )
+    if dtype in utils.INT_DTYPES:
+        inp = torch.zeros(shape, dtype=dtype, device=flag_gems.device)
+    else:
+        inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp)
+
+    ref_out = torch.cumsum(ref_inp, dim=dim)
+    with flag_gems.use_gems():
+        res_out = torch.cumsum(inp, dim=dim)
+
+    assert res_out.shape == ref_out.shape
+    assert res_out.dtype == ref_out.dtype
+    assert res_out.numel() == 0
+
+
+@pytest.mark.cumsum_out
+@pytest.mark.parametrize("shape, dim", [((0,), 0), ((0, 5), 1)])
+def test_cumsum_out_resizes(shape, dim):
+    # torch.cumsum(..., out=out) resizes an empty (zero-element) out to the
+    # input shape. (Non-empty implicit resize is deprecated in torch, so we
+    # only assert the zero-element contract torch keeps supporting.)
+    if flag_gems.vendor_name in _EMPTY_CUMSUM_UNFIXED_VENDORS:
+        pytest.skip(
+            f"{flag_gems.vendor_name} cumsum override still has the empty-tensor "
+            "div-by-zero (issue 4602)"
+        )
+    inp = torch.randn(shape, dtype=torch.float32, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp, True)
+
+    out = torch.empty(7, dtype=torch.float32, device=flag_gems.device)
+    ref_out = torch.empty(0, dtype=torch.float32, device=ref_inp.device)
+
+    torch.cumsum(ref_inp, dim=dim, out=ref_out)
+    with flag_gems.use_gems():
+        torch.cumsum(inp, dim=dim, out=out)
+
+    assert out.shape == ref_out.shape == inp.shape
+
+
+@pytest.mark.cumsum_out
+def test_cumsum_out_dtype_mismatch_raises():
+    # torch.cumsum raises when an explicit dtype= disagrees with out.dtype,
+    # even for empty inputs. gems should match rather than silently return.
+    if flag_gems.vendor_name in _EMPTY_CUMSUM_UNFIXED_VENDORS:
+        pytest.skip(
+            f"{flag_gems.vendor_name} cumsum override still has the empty-tensor "
+            "div-by-zero (issue 4602)"
+        )
+    inp = torch.empty(0, dtype=torch.float32, device=flag_gems.device)
+    out = torch.empty(0, dtype=torch.float32, device=flag_gems.device)
+    with flag_gems.use_gems():
+        with pytest.raises(RuntimeError):
+            torch.cumsum(inp, dim=0, dtype=torch.float64, out=out)


### PR DESCRIPTION
## What

`torch.cumsum` on an empty tensor raised `ZeroDivisionError` instead of returning an empty tensor like native PyTorch.

Closes #4543.

## Root cause

`cumsum_wrapper` in `src/flag_gems/ops/cumsum.py` computed `K = inp.numel() // M // N` before any empty-input handling. When the leading dims product `M` **or** the scanned dim `N` is `0`, this divides by zero:

- `(0,)`, `dim=0` → `N == 0`
- `(0, 5)`, `dim=1` → `M == 0`
- `(3, 0, 4)`, `dim=2` → `M == 0`

(Some empty shapes like `(3, 0, 4)` `dim=0` happened to survive because `K` became `0` and the col-scan launched an empty grid — but the crashing cases above were unhandled.)

## Fix

1. **Empty input**: return early when `inp.numel() == 0`, after the output is allocated but before the division. Matches `torch.cumsum` (empty tensor of the same shape; integer inputs promoted to `int64`).
2. **`out=` shape**: resize a provided `out` to the input shape (cumsum is shape-preserving), via an explicit `out.resize_()` so no deprecation warning is emitted. The zero-element resize is the behavior torch keeps supporting long-term.
3. **`out=` dtype**: raise `RuntimeError` when an explicit `dtype=` disagrees with `out.dtype`, matching torch. Only enforced when `dtype=` is passed — a default-dtype `out` keeps its own dtype and must not falsely raise (e.g. `int32` input with an `int32` out).

Points 2 and 3 apply on the empty path too, so the empty-input behavior matches torch's full `out=` contract, not just the no-crash requirement.

## Scope: generic implementation only

Several backends ship their own `cumsum` copy (registered in place of the generic one) that still carries this same div-by-zero. Those need per-hardware fixes and validation, tracked separately in #4602. The new tests skip the affected vendors (`aipu`, `arm`, `ascend`, `cambricon`, `kunlunxin`, `sunrise`, `enflame`, `tsingmicro`) until their overrides are fixed, so vendor CI does not go red in the meantime.

## Testing

- `test_cumsum_empty` — crashing and previously-passing empty shapes, float and integer dtypes.
- `test_cumsum_out_resizes` — the empty `out=` resize contract.
- `test_cumsum_out_dtype_mismatch_raises` — explicit `dtype=` vs `out.dtype` mismatch raises.

Verified on an NVIDIA A100 (`vendor_name == "nvidia"`, not skipped), in both default and CPU-reference modes:

```
$ pytest tests/test_cumsum.py -q
53 passed
$ pytest tests/test_cumsum.py --ref cpu -q
53 passed
```

All empty shapes match `torch.cumsum` in shape and dtype. `black` / `isort` / `flake8` clean.