### PR TITLE
feat: add unified Containerfile and build.py for all backends

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,0 +1,107 @@
+# ============================================================
+# FlagGems — unified container image
+#
+# A single Containerfile for all backends. Backend-specific
+# settings are passed as --build-arg by container/build.py,
+# which reads container/configs.yaml and backends.yaml.
+# ============================================================
+
+ARG BASE_IMAGE
+ARG EXTRA_PYPI="https://mirrors.aliyun.com/pypi/simple"
+ARG INCLUDE_TESTS=true
+
+# ── Internal build arguments (set by build.py) ────────────────
+ARG PYTHON_VERSION=3.12
+ARG FLAGOS_PYPI=""
+ARG EXTRAS_GROUP=""
+ARG POST_INSTALL=""
+ARG PRE_INSTALL=""
+
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 1 — builder
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS builder
+
+ARG PYTHON_VERSION
+ARG FLAGOS_PYPI
+ARG EXTRA_PYPI
+ARG EXTRAS_GROUP
+ARG POST_INSTALL
+ARG INCLUDE_TESTS
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── Install uv ────────────────────────────────────────────────
+RUN curl -LsSf https://astral.sh/uv/install.sh \
+    | env UV_INSTALL_DIR=/usr/local/bin sh
+
+# ── Create virtual environment ─────────────────────────────────
+RUN uv venv /flagos --python ${PYTHON_VERSION} --relocatable
+ENV VIRTUAL_ENV=/flagos \
+    PATH="/flagos/bin:${PATH}"
+
+# ── Python build dependencies ─────────────────────────────────
+RUN uv pip install --no-cache-dir \
+        "setuptools>=64.0,<80.0" \
+        "scikit-build-core==0.12.2" \
+        "pybind11==3.0.3" \
+        "cmake>=3.20,<4.0" \
+        "ninja==1.13.0" \
+        "pip"
+
+# ── Build FlagGems ─────────────────────────────────────────────
+WORKDIR /build
+COPY . /build/FlagGems
+WORKDIR /build/FlagGems
+
+RUN uv pip install --no-cache-dir ".[$EXTRAS_GROUP]" \
+      --default-index ${FLAGOS_PYPI} \
+      --index ${EXTRA_PYPI} \
+      --trusted-host resource.flagos.net \
+      --trusted-host mirrors.aliyun.com
+
+# ── Post-install (e.g. triton_ascend) ──────────────────────────
+RUN if [ -n "${POST_INSTALL}" ]; then \
+      sh -c "${POST_INSTALL}"; \
+    fi
+
+# ── Test dependencies ──────────────────────────────────────────
+RUN uv pip install --no-cache-dir ".[test]" \
+      --index ${EXTRA_PYPI} \
+      --trusted-host mirrors.aliyun.com
+
+# ── Copy test suite ───────────────────────────────────────────
+RUN mkdir -p /app && \
+    if [ "${INCLUDE_TESTS}" = "true" ]; then \
+      cp -r /build/FlagGems/tests /app/tests \
+      && cp -r /build/FlagGems/benchmark /app/benchmark \
+      && cp /build/FlagGems/pytest.ini /app; \
+    fi
+
+
+# ════════════════════════════════════════════════════════════════
+#  Stage 2 — runtime
+# ════════════════════════════════════════════════════════════════
+FROM ${BASE_IMAGE} AS runtime
+
+ARG PRE_INSTALL
+ARG DEBIAN_FRONTEND=noninteractive
+
+# ── Pre-install (e.g. SDK tarballs) ────────────────────────────
+RUN if [ -n "${PRE_INSTALL}" ]; then \
+      sh -c "${PRE_INSTALL}"; \
+    fi
+
+# ── Copy uv and venv from builder ─────────────────────────────
+COPY --from=builder /usr/local/bin/uv /usr/local/bin/uv
+COPY --from=builder /root/.local/share/uv /root/.local/share/uv
+COPY --from=builder /flagos /flagos
+
+# ── Copy tests and benchmarks ─────────────────────────────────
+COPY --from=builder /app /app
+
+ENV VIRTUAL_ENV=/flagos \
+    PATH="/flagos/bin:${PATH}"
+
+WORKDIR /app
+ENTRYPOINT ["bash"]

--- a/container/build.py
+++ b/container/build.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python3
+"""Build FlagGems container images.
+
+Reads container/configs.yaml and src/flag_gems/backends.yaml to resolve
+build arguments, then invokes `docker build` with the appropriate
+--build-arg values.
+
+Usage:
+    python container/build.py <backend-key> [options]
+
+Examples:
+    python container/build.py nvidia-cuda128 --dry-run
+    python container/build.py ascend-cann900 --tag latest --push
+    python container/build.py metax --base-image my-registry/metax:custom
+"""
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+
+def find_project_root() -> Path:
+    """Walk up from this script to find the project root (has pyproject.toml)."""
+    d = Path(__file__).resolve().parent.parent
+    if (d / "pyproject.toml").exists():
+        return d
+    cwd = Path.cwd()
+    if (cwd / "pyproject.toml").exists():
+        return cwd
+    sys.exit("Error: cannot locate project root (pyproject.toml not found)")
+
+
+def load_yaml(path: Path) -> dict:
+    with open(path) as f:
+        return yaml.safe_load(f)
+
+
+def resolve_backend(backend_arg: str, configs: dict):
+    """Resolve user input to (backends_yaml_key, variant).
+
+    configs.yaml maps vendor → [variants]. For multi-variant vendors
+    (nvidia, ascend), the backends.yaml key is "{vendor}-{variant}"
+    (e.g. "nvidia-cuda128"). For single-variant vendors (cambricon),
+    the backends.yaml key is just the vendor name (e.g. "cambricon").
+
+    Returns (backends_yaml_key, variant_suffix) where variant_suffix
+    is used for the base image name.
+    """
+    cfg_backends = configs.get("backends", {})
+
+    # Try matching "{vendor}-{variant}" against the input
+    for vendor, variants in cfg_backends.items():
+        for variant in variants:
+            full = f"{vendor}-{variant}"
+            if backend_arg == full:
+                # Multi-variant: backends.yaml key is the full name
+                return full, variant
+            if backend_arg == vendor and len(variants) == 1:
+                # Single-variant shorthand: just the vendor name
+                return vendor, variant
+
+    # Try matching vendor name with multiple variants
+    if backend_arg in cfg_backends:
+        variants = cfg_backends[backend_arg]
+        if len(variants) > 1:
+            names = [f"{backend_arg}-{v}" for v in variants]
+            sys.exit(
+                f"Error: '{backend_arg}' has multiple variants: " f"{', '.join(names)}"
+            )
+
+    sys.exit(f"Error: '{backend_arg}' not found in configs.yaml backends")
+
+
+def resolve_base_image(variant: str, configs: dict) -> str:
+    """Derive base image name: {prefix}-{variant}:{tag}."""
+    prefix = configs.get("base_image_prefix", "flagos-base")
+    tag = configs.get("base_image_tag", "latest")
+    return f"{prefix}-{variant}:{tag}"
+
+
+def resolve_build_args(
+    backend_key: str,
+    variant: str,
+    configs: dict,
+    backends: dict,
+    *,
+    base_image_override: str | None = None,
+    extra_pypi_override: str | None = None,
+    include_tests_override: str | None = None,
+) -> dict[str, str]:
+    """Resolve all docker build-arg values for a given backend."""
+
+    backend_info = backends.get("backends", {}).get(backend_key)
+    if backend_info is None:
+        sys.exit(f"Error: '{backend_key}' not found in backends.yaml")
+
+    vendor = backend_key.split("-")[0]
+    pypi_base = backends.get("pypi_base", "")
+    mirror = backends.get("mirror", "https://mirrors.aliyun.com/pypi/simple")
+
+    args = {
+        "BASE_IMAGE": base_image_override or resolve_base_image(variant, configs),
+        "PYTHON_VERSION": backend_info.get("python", "3.12"),
+        "FLAGOS_PYPI": pypi_base.format(vendor=vendor) if pypi_base else "",
+        "EXTRA_PYPI": extra_pypi_override or mirror,
+        "EXTRAS_GROUP": backend_key,
+        "INCLUDE_TESTS": include_tests_override or "true",
+    }
+
+    # Optional hooks from backends.yaml
+    for key in ("pre_install", "post_install"):
+        val = backend_info.get(key, "")
+        if isinstance(val, str):
+            val = val.strip()
+        if val:
+            args[key.upper()] = val
+
+    return args
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Build FlagGems container images",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "backend",
+        help="Backend key (e.g. nvidia-cuda128, ascend-cann900, metax)",
+    )
+    parser.add_argument("--base-image", help="Override base image")
+    parser.add_argument("--extra-pypi", help="Override extra PyPI mirror URL")
+    parser.add_argument(
+        "--include-tests",
+        choices=["true", "false"],
+        help="Override whether to include tests",
+    )
+    parser.add_argument("--tag", "-t", help="Image tag")
+    parser.add_argument("--push", action="store_true", help="Push after building")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="Print command without executing"
+    )
+
+    args = parser.parse_args()
+
+    project_root = find_project_root()
+    configs = load_yaml(project_root / "container" / "configs.yaml")
+    backends = load_yaml(project_root / "src" / "flag_gems" / "backends.yaml")
+    containerfile = project_root / "container" / "Containerfile"
+
+    if not containerfile.exists():
+        sys.exit(f"Error: {containerfile} not found")
+
+    backend_key, variant = resolve_backend(args.backend, configs)
+
+    build_args = resolve_build_args(
+        backend_key,
+        variant,
+        configs,
+        backends,
+        base_image_override=args.base_image,
+        extra_pypi_override=args.extra_pypi,
+        include_tests_override=args.include_tests,
+    )
+
+    tag = args.tag or f"flaggems-{backend_key}:latest"
+
+    cmd = ["docker", "build"]
+    for key, value in build_args.items():
+        cmd.extend(["--build-arg", f"{key}={value}"])
+    cmd.extend(["-f", str(containerfile), "-t", tag, str(project_root)])
+
+    if args.dry_run:
+        print("Would run:")
+        print("  " + " \\\n    ".join(cmd))
+        print()
+        print("Build args:")
+        for k, v in build_args.items():
+            print(f"  {k}={v}")
+        return
+
+    print(f"Building {tag}...")
+    result = subprocess.run(cmd)
+    if result.returncode != 0:
+        sys.exit(f"docker build failed with exit code {result.returncode}")
+
+    if args.push:
+        print(f"Pushing {tag}...")
+        result = subprocess.run(["docker", "push", tag])
+        if result.returncode != 0:
+            sys.exit(f"docker push failed with exit code {result.returncode}")
+
+    print(f"Done: {tag}")
+
+
+if __name__ == "__main__":
+    main()

--- a/container/configs.yaml
+++ b/container/configs.yaml
@@ -1,65 +1,48 @@
 # Container build configuration for FlagGems images.
 #
-# This file defines container-specific settings (base images, system packages,
-# runtime packages) for each backend. Dependency, compiler, and build hook
-# information (pre_install, post_install) comes from backends.yaml.
+# Base image name is derived as:
+#   {base_image_prefix}-{variant}:{base_image_tag}
+#
+# The "backends" section maps vendor → list of variants.
+# Each variant combined with its vendor forms the backend key
+# used in backends.yaml (e.g. vendor "nvidia" + variant "cuda128"
+# → backend key "nvidia-cuda128").
+#
+# For single-variant vendors, the variant doubles as the image suffix
+# (e.g. vendor "cambricon" + variant "neuware4.4.3"
+# → base image "flagos-base-neuware4.4.3:2.1.0"
+# → backend key "cambricon").
 #
 # Usage:
 #   python container/build.py <backend> [--dry-run] [--push]
 
-defaults:
-  extra_pypi: "https://mirrors.aliyun.com/pypi/simple"
-  include_tests: true
-  system_packages: ""
-  runtime_packages: ""
+base_image_prefix: "flagos-base"
+base_image_tag: "2.1.0"
 
-images:
-  nvidia-cuda128:
-    base_image: "flagos-base-cuda128:2.1.0"
-
-  nvidia-cuda133:
-    base_image: "flagos-base-cuda133:2.1.0"
-
-  ascend-cann850:
-    base_image: "ascend-cann:8.5.0"
-
-  ascend-cann900:
-    base_image: "ascend-cann:9.0.0"
-
+backends:
+  nvidia:
+    - cuda12.8
+    - cuda13.3
+  ascend:
+    - cann8.5.0
+    - cann9.0.0
   cambricon:
-    base_image: "cambricon-neuware:4.4.3"
-
+    - neuware4.4.3
   enflame:
-    base_image: "enflame-tops:1.9.10"
-    system_packages: "curl build-essential ca-certificates"
-
+    - tops1.9.10
   hygon:
-    base_image: "hygon-dtk:26.04"
-    system_packages: "curl build-essential ca-certificates"
-
+    - dtk26.04
   iluvatar:
-    base_image: "iluvatar-corex:4.4.0"
-
+    - corex4.4.0
   kunlunxin:
-    base_image: "kunlunxin-xre:5.29.0"
-    system_packages: "curl build-essential ca-certificates"
-
+    - xre5.29.0
   metax:
-    base_image: "metax-maca:3.7.2.1"
-
+    - maca3.7.2.1
   mthreads:
-    base_image: "mthreads-musa:4.3.6"
-    system_packages: "curl build-essential ca-certificates libnuma-dev"
-    runtime_packages: "libelf1 libnuma-dev libgfortran5 libpython3-dev libopenmpi-dev openmpi-bin"
-
-  spacemit:
-    base_image: "spacemit-base:latest"
-
+    - musa4.3.6
   sunrise:
-    base_image: "sunrise-base:latest"
-
+    - tangrt1.2.0
   thead:
-    base_image: "thead-base:latest"
-
+    - ppu2.0.0
   tsingmicro:
-    base_image: "tsingmicro-tsm:260604"
+    - tsm260604


### PR DESCRIPTION
## Summary

Single parametrized Containerfile replaces 12+ hand-written containerfiles. `build.py` reads `container/configs.yaml` (base images) and `backends.yaml` (python version, pypi index, hooks) to resolve `docker build-arg` values.

## Changes

- **`container/Containerfile`** — unified two-stage build template using ARGs for all backend differences
- **`container/build.py`** — reads YAML configs, resolves build-arg values, invokes `docker build`
- **`container/configs.yaml`** — simplified to vendor → SDK variant mapping with common base image naming

## Usage

```bash
python container/build.py nvidia-cuda128 --dry-run
python container/build.py ascend-cann900 --tag latest --push
python container/build.py metax --base-image my-registry/metax:custom
```

## Base image naming convention

`{prefix}-{variant}:{tag}`, e.g. `flagos-base-cuda128:2.1.0`, `flagos-base-maca3.7.2.1:2.1.0`