### PR TITLE
feat: integrate env vars into backends.yaml, auto-write to activate

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -91,7 +91,7 @@ uv pip install -q \
   "pybind11==3.0.3" \
   "cmake>=3.20,<4" \
   "ninja==1.13.0" \
-  "PyYAML>=6.0" \
+  "PyYAML==6.0.3" \
   --index "${MIRROR}" \
   || fail
 ok
@@ -228,4 +228,31 @@ printf "Installing test dependencies ..."
 uv pip install -q ".[test]" --index "${MIRROR}" || fail
 ok
 
+# ── Write env into .venv/bin/activate ────────────────────────
+# So that `source .venv/bin/activate` sets up the full environment.
+printf "Writing environment to .venv/bin/activate ..."
+python3 -c "
+import yaml
+
+cfg = yaml.safe_load(open('${BACKENDS_YAML}'))
+b = cfg['backends']['${BACKEND}']
+
+lines = []
+lines.append('')
+lines.append('# --- FlagGems environment (${BACKEND}) ---')
+
+for k, v in b.get('env', {}).items():
+    lines.append(f'export {k}={v}')
+
+for script in b.get('env_source', []):
+    lines.append(f'[ -f {script} ] && source {script}')
+
+lines.append('# --- end FlagGems environment ---')
+
+with open('.venv/bin/activate', 'a') as f:
+    f.write('\n'.join(lines) + '\n')
+" || fail
+ok
+
 printf "\n${GREEN}FlagGems setup complete for ${BACKEND}${NC}\n"
+printf "Run: ${GREEN}source .venv/bin/activate${NC}\n"

--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -21,6 +21,13 @@
 #
 # "triton:" — vendor-specific Triton packages for this backend
 # "flagtree:" — FlagTree package for this backend (preferred)
+#
+# "env:" — environment variables to export (key: value pairs).
+#   Written into .venv/bin/activate by setup.sh so that
+#   `source .venv/bin/activate` sets up the full environment.
+#
+# "env_source:" — vendor scripts to source (list of paths).
+#   Each script is sourced if it exists.
 
 pypi_base: "https://resource.flagos.net/repository/flagos-pypi-{vendor}/simple"
 mirror: "https://mirrors.aliyun.com/pypi/simple"
@@ -31,6 +38,9 @@ backends:
     cmake_backend: CUDA
     triton: triton==3.6.0
     flagtree: flagtree==0.6.0
+    env:
+      PATH: /usr/local/cuda/bin:$PATH
+      LD_LIBRARY_PATH: /usr/local/cuda/lib64:$LD_LIBRARY_PATH
     deps:
       - torch==2.10.0+cu128
       - torchaudio==2.10.0+cu128
@@ -41,6 +51,9 @@ backends:
     cmake_backend: CUDA
     triton: triton==3.6.0
     flagtree: flagtree==0.6.0
+    env:
+      PATH: /usr/local/cuda/bin:$PATH
+      LD_LIBRARY_PATH: /usr/local/cuda/lib64:$LD_LIBRARY_PATH
     deps:
       - torch==2.11.0+cu130
       - torchaudio==2.11.0+cu130
@@ -51,6 +64,9 @@ backends:
     cmake_backend: NPU
     triton: triton-ascend==3.2.0
     flagtree: flagtree==0.6.0+ascend3.2
+    env_source:
+      - /usr/local/Ascend/ascend-toolkit/set_env.sh
+      - /usr/local/Ascend/toolbox/set_env.sh
     deps:
       - torch==2.9.0+cpu
       - torch-npu==2.9.0
@@ -58,10 +74,11 @@ backends:
   ascend-cann900:
     python: "3.11"
     cmake_backend: NPU
-    triton:
-      - triton==3.5.0
-      - triton-ascend==3.2.1
+    triton: triton==3.5.0
     flagtree: flagtree==0.6.0+ascend3.5
+    env_source:
+      - /usr/local/Ascend/ascend-toolkit/set_env.sh
+      - /usr/local/Ascend/toolbox/set_env.sh
     post_install: >-
       uv pip install --no-cache-dir --index ${FLAGOS_PYPI}
       "triton_ascend==3.2.1"
@@ -72,6 +89,9 @@ backends:
   cambricon:
     python: "3.10"
     triton: triton==3.2.0+mlu1.7.2
+    env:
+      PATH: /usr/local/neuware/bin:$PATH
+      LD_LIBRARY_PATH: /usr/local/neuware/lib64:$LD_LIBRARY_PATH
     deps:
       - cambricon_dali==0.13.0
       - torch==2.7.1+cpu
@@ -83,6 +103,8 @@ backends:
     cmake_backend: GCU
     triton: triton-gcu==3.6.0+1.0.20260521.cc.1.9.10
     flagtree: flagtree==0.6.0+enflame3.6
+    env:
+      LD_LIBRARY_PATH: /opt/OpenCloudOS/gcc-toolset-14/root/usr/lib64:$LD_LIBRARY_PATH
     deps:
       - pyefml==1.9.10
       - torch==2.10.0+cpu
@@ -95,6 +117,8 @@ backends:
     python: "3.10"
     triton: triton==3.3.0+das.opt1.dtk2604.torch290
     flagtree: flagtree==0.5.1+hcu3.1
+    env_source:
+      - /opt/dtk-26.04/env.sh
     deps:
       - torch==2.9.0+das.opt1.dtk2604
 
@@ -103,6 +127,10 @@ backends:
     cmake_backend: IX
     triton: triton==3.1.0+corex.4.4.0
     # flagtree==0.5.1+iluvatar3.1 — plugin loading bug in venv, disabled for now
+    env:
+      COREX_ROOT: /usr/local/corex
+      PATH: $COREX_ROOT/bin:$PATH
+      LD_LIBRARY_PATH: $COREX_ROOT/lib:$LD_LIBRARY_PATH
     deps:
       - torch==2.7.1+corex.4.4.0
       - torchaudio==2.7.1+corex.4.4.0
@@ -112,6 +140,8 @@ backends:
     python: "3.10"
     triton: triton==3.0.0+a48aedef
     flagtree: flagtree==0.5.1+xpu3.0
+    env:
+      LD_LIBRARY_PATH: /xcudart/lib:/usr/local/cuda/lib64
     deps:
       - apex==0.1
       - benchflow==1.0.0
@@ -133,6 +163,9 @@ backends:
     python: "3.12"
     triton: triton==3.0.0+metax3.7.2.0
     flagtree: flagtree==3.1.0+metax3.7.2.0
+    env:
+      MACA_PATH: /opt/maca
+      LD_LIBRARY_PATH: $MACA_PATH/lib:$MACA_PATH/mxgpu_llvm/lib:$LD_LIBRARY_PATH
     deps:
       - torch==2.8.0+metax3.7.2.0
       - torchaudio==2.4.1+metax3.7.2.0
@@ -144,6 +177,10 @@ backends:
     cmake_backend: MUSA
     triton: triton==3.6.0+git89458660
     flagtree: flagtree==0.6.0+mthreads3.6
+    env:
+      MUSA_HOME: /usr/local/musa
+      PATH: $MUSA_HOME/bin:$PATH
+      LD_LIBRARY_PATH: $VIRTUAL_ENV/lib:$MUSA_HOME/lib:$LD_LIBRARY_PATH
     deps:
       - torch==2.9.0+musa.4.3.6
       - torch_musa==2.9.0
@@ -159,6 +196,8 @@ backends:
     python: "3.10"
     triton: triton==3.4.0.6+gite4f6d6e4
     # flagtree==0.4.0+sunrise3.4 — requires GLIBC_2.39, unavailable on current system
+    env:
+      LD_LIBRARY_PATH: /usr/local/tangrt/targets/linux-x86_64/lib:$LD_LIBRARY_PATH
     deps:
       - torch==2.11.0+cpu
       - torchaudio==2.11.0+cpu
@@ -168,6 +207,8 @@ backends:
   thead:
     python: "3.12"
     triton: triton==3.5.0+ppu2.0.0.oe
+    env_source:
+      - /usr/local/PPU_SDK/envsetup.sh
     deps:
       - torch==2.9.0+ppu2.0.0.oe
 
@@ -175,6 +216,14 @@ backends:
     python: "3.10"
     triton: triton==3.3.0+gitfe2a28fa
     flagtree: flagtree==0.5.0.post20260612+git705a4064
+    env:
+      TX8_DEPS_ROOT: /opt/tx8_deps
+      LLVM_SYSPATH: /opt/llvm
+      LLVM_BINARY_DIR: ${LLVM_SYSPATH}/bin
+      PYTHONPATH: ${LLVM_SYSPATH}/python_packages/mlir_core
+      LD_LIBRARY_PATH: /usr/local/kuiper/lib:/usr/local/kuiper/tsm8-profiler/lib:${TX8_DEPS_ROOT}/lib:${LD_LIBRARY_PATH}
+      USE_TORCH_XLA: "0"
+      TORCH_COMPILE_DISABLE: "1"
     deps:
       - torch==2.7.0+cpu
       - torchvision==0.22.0+cpu

--- a/tools/env.sh
+++ b/tools/env.sh
@@ -95,7 +95,7 @@ case $BACKEND in
     export USE_TORCH_XLA=0
     # Torch compiler is not supported on TsingMicro, and in particular,
     # it is not used for inference scenario
-    export TORCH_COMPILE_DIABLE=1
+    export TORCH_COMPILE_DISABLE=1
 
     # if [ -n "${USE_TRITON}" ]; then
     #   export PYTHONPATH=$SITE_PACKAGES/triton/backends/tsingmicro/llvm/python_packages/mlir_core


### PR DESCRIPTION
## Summary

Add `env` and `env_source` fields to `backends.yaml` so that `setup.sh` can write vendor environment variables directly into `.venv/bin/activate`.

## Before

```bash
./setup.sh metax
source .venv/bin/activate
source tools/env.sh metax    # ← extra step
pytest tests/test_abs.py
```

## After

```bash
./setup.sh metax
source .venv/bin/activate    # env vars included automatically
pytest tests/test_abs.py
```

## Changes

- **`backends.yaml`**: Add `env:` (key-value exports) and `env_source:` (vendor scripts to source) per backend
- **`setup.sh`**: Append env setup to `.venv/bin/activate` after installation
- **`tools/env.sh`**: Fix `TORCH_COMPILE_DIABLE` typo → `TORCH_COMPILE_DISABLE`

`tools/env.sh` is kept for build-time use within `setup.sh` itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)