### PR TITLE
chore: remove tools/env.sh from CI workflows

### DIFF
--- a/.github/actions/setup-flaggems/action.yml
+++ b/.github/actions/setup-flaggems/action.yml
@@ -48,7 +48,7 @@ runs:
       if: inputs.gpu_check_script != ''
       shell: bash
       run: |
-        source tools/env.sh ${{ inputs.vendor }}
+        source .venv/bin/activate
         GPU_OUTPUT=$(bash ${{ inputs.gpu_check_script }})
         echo "$GPU_OUTPUT"
         AVAILABLE_GPUS=$(echo "$GPU_OUTPUT" | grep "^Available GPUs:" | cut -d: -f2 | tr -d ' ')

--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -69,5 +69,4 @@ jobs:
           CHANGED_FILES: ${{ inputs.changed_files }}
         run: |
           source .venv/bin/activate
-          source tools/env.sh ${{ inputs.vendor }}
           tools/test-op.sh ${{ inputs.pr_id }}

--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -129,7 +129,6 @@ jobs:
           EXISTING_OP: ${{ needs.preprocess.outputs.existing }}
         run: |
           source .venv/bin/activate
-          source tools/env.sh ${BACKEND}
           tools/run_tests.py --ops ${{ needs.preprocess.outputs.op }} \
             --gpus "${AVAILABLE_GPUS}" \
             --dump-output \

--- a/.github/workflows/random-test.yaml
+++ b/.github/workflows/random-test.yaml
@@ -93,7 +93,6 @@ jobs:
         shell: bash
         run: |
           source .venv/bin/activate
-          source tools/env.sh ${BACKEND}
           tools/run_tests.py --ops ${{ inputs.operators }} --gpus ${{ inputs.gpus }}
 
       - name: Upload results


### PR DESCRIPTION
Since #4633, `setup.sh` writes backend environment variables into `.venv/bin/activate`. The separate `source tools/env.sh` step is no longer needed.

### Changes

- `backend-test.yaml`: remove `source tools/env.sh`
- `random-test.yaml`: remove `source tools/env.sh`
- `command.yaml`: remove `source tools/env.sh`
- `setup-flaggems/action.yml`: GPU check now uses `source .venv/bin/activate` instead of `source tools/env.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)