### PR TITLE
docs: update installation guide for setup.sh workflow

### DIFF
--- a/docs/content/en/getting-started/install.md
+++ b/docs/content/en/getting-started/install.md
@@ -6,25 +6,18 @@ weight: 20
 
 ## 1. Prerequisites
 
-- You have to ensure that the kernel driver and user-space SDK/toolkits for
+- You must ensure that the kernel driver and user-space SDK/toolkits for
   your hardware have been installed and configured properly.
-  This applies to both the NVIDIA platforms and other AI accelerator hardwares.
-
-- You have to ensure that a proper Python version has been installed on your node.
-  The currently recommended version is Python 3.10. This may change in the future
-  and there could be other version constraints if you are working
-  on a [non-NVIDIA platform](/FlagGems/usage/non-nvidia/).
-
-- You have to install [PyTorch](https://github.com/pytorch/pytorch),
-  [Triton](https://github.com/triton-lang/triton) before installing *FlagGems*.
-
-  You may need to install the *custom* PyTorch, Triton or vLLM libraries that
-  are tailered for your hardware if you are running *FlagGems* and your workload
-  on a [non-NVIDIA platform](/FlagGems/usage/non-nvidia/).
+  This applies to both NVIDIA platforms and other AI accelerator hardware.
 
 - If you are trying out [the integration with vLLM](/FlagGems/usage/frameworks/#vllm),
   you will need to install [vLLM](https://github.com/vllm-project/vllm)
   or its vendor-customized version if any.
+
+> [!NOTE]
+> You do **not** need to manually install Python, PyTorch, or Triton.
+> The `setup.sh` script handles all of these automatically based on the
+> backend you choose.
 
 ## 2. Install from PyPI
 
@@ -45,9 +38,6 @@ pip install flag_gems
 
 ## 3. Build and install from source {#install-from-source}
 
-*FlagGems* can be built and installed from source just like any other
-open source software.
-
 ### 3.1. Clone the source
 
 ```shell
@@ -55,251 +45,140 @@ git clone https://github.com/flagos-ai/FlagGems
 cd FlagGems/
 ```
 
-### 3.2. Install FlagTree
+### 3.2. Run setup.sh
 
-If you want to use the vanilla Triton compiler instead of *FlagTree*, you can skip this step.
+The `setup.sh` script is the recommended way to install FlagGems from source.
+It reads all configuration from `src/flag_gems/backends.yaml` and automatically:
 
-[FlagTree](https://github.com/flagos-ai/flagtree/) is an open source,
-unified compiler for multiple AI platforms. Please make sure you have
-read the environment requirements from the FlagTree project before
-installing it.
-
-The `requirements_<backend>.txt` files include both FlagTree and the build
-dependencies (such as `scikit-build-core`, `pybind11`, `ninja`, and `cmake`).
-You can install them together with one command.
+- Installs [uv](https://github.com/astral-sh/uv) (if not present)
+- Installs the correct Python version for your backend
+- Creates a virtual environment (`.venv/`)
+- Installs build tools, PyTorch, and vendor-specific dependencies
+- Installs FlagGems with the appropriate extras
+- Installs a compiler ([FlagTree](https://github.com/flagos-ai/flagtree/) or Triton)
+- Installs test dependencies
+- Writes backend environment variables into `.venv/bin/activate`
 
 ```shell
-pip install -r requirements/requirements_nvidia.txt
+./setup.sh <backend>
+```
+
+For example:
+
+```shell
+# NVIDIA CUDA 12.8
+./setup.sh nvidia-cuda128
+
+# Huawei Ascend CANN 9.0.0
+./setup.sh ascend-cann900
+
+# MetaX MACA
+./setup.sh metax
+```
+
+To see available backends:
+
+```shell
+./setup.sh invalid  # prints the list of available backends
+```
+
+After setup completes, activate the environment and start working:
+
+```shell
+source .venv/bin/activate
+pytest tests/test_abs.py -vs
 ```
 
 > [!TIP]
 > **Tips**
 >
-> - For [non-NVIDIA platforms](/FlagGems/usage/non-nvidia/), you
->   **have to** use different `requirements_<backend>.txt` under
->   the `requirements/` directory.
-> - There are on-going efforts to simplify this step. Stay tuned.
+> - The environment variables for your backend are automatically included
+>   in `.venv/bin/activate`. No separate environment setup step is needed.
+> - By default, FlagTree is installed as the compiler when available.
+>   To use vanilla Triton instead, set `COMPILER=triton` before running setup.sh:
+>   ```shell
+>   COMPILER=triton ./setup.sh nvidia-cuda128
+>   ```
 
-### 3.3. Install the package
+### 3.3. Editable install (for development)
 
-FlagGems can be installed either a pure Python package or a package with C++ extensions.
-The C++ extensions are  still an experimental feature, so please make sure
-you have conducted some assessments before using them in production environments.
-
-#### 3.3.1 Install with C++ extension
-
-If you are NOT enabling the C++ wrapped operators, you can skip to the next step.
-
-To build and install the C++ extensions in *FlagGems*, the CMake option
-`-DFLAGGEMS_BUILD_C_EXTENSION=ON` must be specified during installation.
-This can be done by passing arguments to CMake via the `SKBUILD_CMAKE_ARGS` or
-the `CMAKE_ARGS` environment variable.
-The following command installs the `flag_gems` package in an editable mode,
-while enabling the C++ extensions using the `CMAKE_ARGS` environment variable:
+If you are working on the *FlagGems* project (e.g. developing new operators),
+you can perform an editable install so that changes to the Python source take
+effect immediately without reinstalling:
 
 ```shell
-CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DCMAKE_BUILD_TYPE=Release" \
-pip install -v -e .
+source .venv/bin/activate
+uv pip install --no-build-isolation -e .
 ```
-
-> [!TIP]
-> It is recommended to explicitly set `-DCMAKE_BUILD_TYPE=Release`.
-> Without an explicit build type, neither `libtriton_jit` nor FlagGems's
-> own C++ code will be built with compiler optimizations targeted at the
-> selected platform (`-O3 -DNDEBUG` etc.), which makes the C++ wrapper
-> execution noticeably slower and drags down the overall performance of
-> the C++ wrapped operators.
 
 > [!NOTE]
-> If the build fails (e.g. dependency conflicts or pip cannot locate an
-> already-installed PyTorch), add `--no-build-isolation` to the
-> `pip install` command so that pip reuses the PyTorch and the build
-> dependencies from `requirements_<backend>.txt` already installed in
-> your environment. See [§4.2 Build isolation](#build-isolation) for
-> more details.
+> `setup.sh` already installs FlagGems in non-editable mode. Run the command
+> above **after** `setup.sh` completes if you want to switch to editable mode.
+> The `--no-build-isolation` flag reuses the build tools already in the venv.
 
-The above command builds for the default **CUDA** backend. To build for
-a different backend or to enable the pointwise dynamic C++ module,
-pass the corresponding CMake options. Below are examples for each
-supported platform:
+### 3.4. C++ extensions (optional)
 
-**NVIDIA CUDA (with pointwise dynamic C++ support)**
+To build with C++ wrapped operators, set `ENABLE_CPP=1`:
 
 ```shell
-CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DCMAKE_BUILD_TYPE=Release" \
-pip install -v -e .
+ENABLE_CPP=1 ./setup.sh nvidia-cuda128
 ```
 
-**Iluvatar CoreX (IX)**
+This sets the appropriate `CMAKE_ARGS` for your backend automatically.
+C++ extensions are still experimental — please assess before using in production.
 
-```shell
-export LIBRARY_PATH=<corex-install-dir>/lib64:$LIBRARY_PATH
-#export LIBRARY_PATH=/usr/local/corex/lib64:$LIBRARY_PATH
-CMAKE_ARGS="-DFLAGGEMS_BACKEND=IX -DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DCMAKE_BUILD_TYPE=Release" \
-pip install -v -e .
-```
-
-**Moore Threads (MUSA)**
-
-```shell
-export MUSA_HOME=<musa-install-dir>
-#export MUSA_HOME=/usr/local/musa-xxx
-CMAKE_ARGS="-DFLAGGEMS_BACKEND=MUSA -DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DCMAKE_BUILD_TYPE=Release" \
-pip install -e .
-```
-
-**Huawei Ascend (NPU)**
-
-```shell
-CMAKE_ARGS="-DFLAGGEMS_BACKEND=NPU -DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DCMAKE_BUILD_TYPE=Release" \
-pip install -e .
-```
-
-Note that the above commands install the
-[libtriton_jit library](https://github.com/flagos-ai/libtriton_jit)
-by cloning its GIT repository and installing it from source.
-
-For more detailed discussions about the command line options, you can
-check the following sections:
-
-- [CMake options](#cmake-options).
-- [pip options](#pip-options).
-- [build isolation](#build-isolation)
-- [installing libtriton_jit](#libtriton-jit)
-
-#### 3.3.2 Install the Python package only
-
-You can install *flag_gems* as a pure Python package.
-If you are using *FlagGems* as is with no intent to customize it,
-you can install the package to your Python environment:
-
-```shell
-pip install .
-```
-
-This is similar to what `pip install flag_gems` does.
-The only difference is that you are instaling the package from its source
-rather than a prebuilt Python wheel distribution.
-
-If you are working on the *FlagGems* project, e.g. developing new operators
-or performing some similar development/testing works, you can perform an
-_editable_ install by specifying `-e` to the command line as shown below:
-
-```shell
-pip install -e .
-```
-
-Check the [pip options reference](#pip-options) for more information
-about some common `pip` options.
+For manual control over CMake options, see the [CMake options reference](#cmake-options).
 
 ## 4. References
 
-### 4.1 Frequently used `pip` options  {#pip-options}
+### 4.1 Available backends
 
-Some commonly used `pip` options are:
+The full list of supported backends is defined in `src/flag_gems/backends.yaml`.
+Each backend specifies:
 
-1. `-v`: show the log of the configuration and building process;
+- Python version
+- PyTorch and vendor-specific dependencies
+- Triton / FlagTree compiler packages
+- Runtime environment variables
 
-1. `-e`: create an editable installation. Note that in an editable installation,
-   the C++ section (headers, libraries, cmake package files) is installed
-   to the `site-packages` directory, while the Python code remains in
-   the current repository with a loader installed in the `site-packages`
-   directory to find it.
+### 4.2 Environment variables {#env-vars}
 
-   For more details about this installation modes, please refer to the
-   `scikit-build-core`'s [documentation](https://scikit-build-core.readthedocs.io/en/latest/configuration/index.html#editable-installs).
+The `COMPILER` environment variable controls which compiler to use:
 
-1. `--no-build-isolation`：Do not to create a separate virtual environment
-   (aka. virtualenv or venv for short)  to build the project.
-   This is commonly used with an editable installation.
-   Note that when building without isolation, you have to install
-   the build dependencies manually. Check [build isolation](#build-isolation)
-   for more details.
+| Value | Behavior |
+|-------|----------|
+| _(unset)_ | Auto: FlagTree if available, otherwise Triton |
+| `flagtree` | Use FlagTree |
+| `triton` | Use vendor Triton |
 
-1. `--no-deps`: Do not install package dependencies.
-   This can be useful when you do not want the dependencies to be updated.
+The `ENABLE_CPP` environment variable enables C++ extensions:
 
-### 4.2 Build isolation  {#build-isolation}
+| Value | Behavior |
+|-------|----------|
+| _(unset or 0)_ | Python-only installation (default) |
+| `1` | Build C++ wrapped operators |
 
-Following the community recommendations for build frontends in
-[PEP 517](https://peps.python.org/pep-0517/#recommendations-for-build-frontends-non-normative),
-`pip` or other modern build frontends uses an isolated environment to build packages.
-This involves creating a virtual environment and installing the build requirements in it
-before building the package.
+### 4.3 CMake options {#cmake-options}
 
-If you do not want build isolation (often in the case with editable installation),
-you can pass `--no-build-isolation` flag to `pip install`.
-In this case, the installer will attempt to reuse any existing, compatible
-packages when it identifies a dependency to install.
-This means you will need
-to install `build-requirements` in your current environment beforehand.
-Check the `[build-system.requires]` section in the `pyproject.toml` file and
-install the required packages.
+When building with C++ extensions (`ENABLE_CPP=1`), the following CMake
+options are set automatically by `setup.sh`. For manual builds, you can
+pass them via the `CMAKE_ARGS` environment variable.
 
-### 4.3 About CMake options  {#cmake-options}
-
-As mentioned before, you can enable the C++ extensions when building/installing
-`flag_gems` by passing arguments to CMake via the `SKBUILD_CMAKE_ARGS` or
-the `CMAKE_ARGS` environment variable.
-Note that, for the environment variable `SKBUILD_CMAKE_ARGS`, multiple options
-are separated by semicolons (`;`), whereas for `CMAKE_ARGS`, they are separated by spaces.
-This relates to the difference between `scikit-build-core` and its predecessor,
-`scikit-build`.
-
-The CMake options for configuring `flag_gems` are listed below:
-
-<table>
-<thead>
-<tr>
-  <th>Option</th><th>Description</th><th>Default Value</th>
-<tr>
-</thead>
-<tbody>
-<tr>
-  <td><code>FLAGGEMS_USE_EXTERNAL_TRITON_JIT</code></td>
-  <td>Whether to use external <a href="#libtriton-jit">Triton JIT library</a>.</td>
-  <td><code>OFF</code></td>
-</tr>
-<tr>                                      |
-  <td><code>FLAGGEMS_USE_EXTERNAL_PYBIND11</code></td>
-  <td>Whether to use external `pybind11` library.</td>
-  <td><code>ON</code></td>
-</tr>
-<tr>                                      |
-  <td><code>FLAGGEMS_BUILD_C_EXTENSIONS</code></td>
-  <td>Whether to build C++ extension. This is recommended when installed in development mode.</td>
-  <td><code>ON</code></td>
-</tr>
-<tr>
-  <td><code>FLAGGEMS_BUILD_CTESTS</code></td>
-  <td>Whether to build C++ unit tests.</td>
-  <td>same as <code>FLAGGEMS_BUILD_C_EXTENSIONS</code></td>
-</tr>
-<tr>
-  <td><code>FLAGGEMS_INSTALL</code></td>
-  <td>Whether to install FlagGems's cmake package.
-      Recommended for development mode installation.</td>
-  <td>ON</td>
-</tr>
-<tr>
-  <td><code>FLAGGEMS_BACKEND</code></td>
-  <td>Target backend for building. Valid values are <code>CUDA</code>,
-      <code>IX</code>, <code>MUSA</code>, and <code>NPU</code>.</td>
-  <td><code>CUDA</code></td>
-</tr>
-<tr>
-  <td><code>FLAGGEMS_BUILD_POINTWISE_DYNAMIC_CPP</code></td>
-  <td>Whether to build the pointwise dynamic C++ support module.</td>
-  <td><code>OFF</code></td>
-</tr>
-</tbody>
-</table>
+| Option | Description | Default |
+|--------|-------------|---------|
+| `FLAGGEMS_BUILD_C_EXTENSIONS` | Build C++ extensions | `OFF` |
+| `FLAGGEMS_BACKEND` | Target backend (`CUDA`, `IX`, `MUSA`, `NPU`, `GCU`) | `CUDA` |
+| `FLAGGEMS_BUILD_CTESTS` | Build C++ unit tests | same as `FLAGGEMS_BUILD_C_EXTENSIONS` |
+| `FLAGGEMS_INSTALL` | Install CMake package | `ON` |
+| `FLAGGEMS_USE_EXTERNAL_TRITON_JIT` | Use external Triton JIT library | `OFF` |
+| `FLAGGEMS_USE_EXTERNAL_PYBIND11` | Use external pybind11 | `ON` |
+| `FLAGGEMS_BUILD_POINTWISE_DYNAMIC_CPP` | Build pointwise dynamic C++ module | `OFF` |
 
 ### 4.4 `scikit-build-core` options {#scikit-build-core-options}
 
-The `scikit-build-core` tool is a build-backend that bridges the CMake
+The `scikit-build-core` tool is a build-backend that bridges CMake
 and the Python build system, making it easier to create Python modules with CMake.
-Some commonly used environemnt variables for configuring `scikit-build-core` inlcude:
+Some commonly used environment variables for configuring `scikit-build-core` include:
 
 1. `SKBUILD_CMAKE_BUILD_TYPE`, used to configure the build type of the project.
    Valid values are `Release`, `Debug`, `RelWithDebInfo` and `MinSizeRel`;
@@ -307,19 +186,20 @@ Some commonly used environemnt variables for configuring `scikit-build-core` inl
 1. `SKBUILD_BUILD_DIR`, which configures the build directory of the project.
    The default value is `build/{cache_tag}`, which is defined in `pyproject.toml`.
 
-### 4.5 The `libtriton_jit` library  {#libtriton-jit}
+Note that for the environment variable `SKBUILD_CMAKE_ARGS`, multiple options
+are separated by semicolons (`;`), whereas for `CMAKE_ARGS`, they are separated
+by spaces.
+
+### 4.5 The `libtriton_jit` library {#libtriton-jit}
 
 The C++ extension of FlagGems depends on [TritonJIT](https://github.com/flagos-ai/libtriton_jit/),
-which is a library that implements a Triton JIT runtime in C++
-and enables calling Triton JIT functions from C++ code.
-If you are building/inistalling `flag_gems` with an external TritonJIT,
-you should build and install it as a precondition and then
-pass the option `-DTritonJIT_ROOT=<install path>` to CMake.
+a library that implements a Triton JIT runtime in C++ and enables calling
+Triton JIT functions from C++ code.
 
-For example, the following command triggers an editable installation
-with external *Triton JIT* installed  at `/usr/local/lib/libtriton_jit`:
+If you are building with an external TritonJIT, build and install it first,
+then pass `-DTritonJIT_ROOT=<install path>` to CMake:
 
 ```shell
 CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_USE_EXTERNAL_TRITON_JIT=ON -DTritonJIT_ROOT=/usr/local/lib/libtriton_jit" \
-pip install -v -e .
+ENABLE_CPP=1 ./setup.sh nvidia-cuda128
 ```


### PR DESCRIPTION
Rewrite the English installation docs to reflect the current `setup.sh`-based workflow.

### Key changes

- Remove manual Python/PyTorch/Triton prerequisites — `setup.sh` handles all of these
- Add `setup.sh` as the primary source installation method
- Document `COMPILER` and `ENABLE_CPP` environment variables
- Simplify C++ extensions section (`ENABLE_CPP=1 ./setup.sh`)
- Note that env vars are auto-written to `.venv/bin/activate`
- Remove references to obsolete `requirements/*.txt` files
- Keep PyPI install and CMake/libtriton_jit reference sections

Chinese docs update will follow in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)