### PR TITLE
chore: remove requirements/ — superseded by backends.yaml

### DIFF
--- a/requirements/requirements_aipu.txt
+++ b/requirements/requirements_aipu.txt
@@ -1,8 +1,0 @@
---index-url https://resource.flagos.net/repository/flagos-pypi-hosted/simple
---extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
---trusted-host resource.flagos.net pypi.tuna.tsinghua.edu.cn
-flagtree==0.5.0+aipu3.3
-scikit-build-core>=0.11
-pybind11
-ninja
-cmake

--- a/requirements/requirements_ascend.txt
+++ b/requirements/requirements_ascend.txt
@@ -1,8 +1,0 @@
---index-url https://resource.flagos.net/repository/flagos-pypi-hosted/simple
---extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
---trusted-host resource.flagos.net pypi.tuna.tsinghua.edu.cn
-flagtree==0.5.0+ascend3.2
-scikit-build-core>=0.11
-pybind11
-ninja
-cmake

--- a/requirements/requirements_enflame.txt
+++ b/requirements/requirements_enflame.txt
@@ -1,8 +1,0 @@
---index-url https://resource.flagos.net/repository/flagos-pypi-hosted/simple
---extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
---trusted-host resource.flagos.net pypi.tuna.tsinghua.edu.cn
-flagtree==0.5.0+enflame3.5
-scikit-build-core>=0.11
-pybind11
-ninja
-cmake

--- a/requirements/requirements_hcu.txt
+++ b/requirements/requirements_hcu.txt
@@ -1,8 +1,0 @@
---index-url https://resource.flagos.net/repository/flagos-pypi-hosted/simple
---extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
---trusted-host resource.flagos.net pypi.tuna.tsinghua.edu.cn
-flagtree==0.5.1+hcu3.1
-scikit-build-core>=0.11
-pybind11
-ninja
-cmake

--- a/requirements/requirements_iluvatar.txt
+++ b/requirements/requirements_iluvatar.txt
@@ -1,8 +1,0 @@
---index-url https://resource.flagos.net/repository/flagos-pypi-hosted/simple
---extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
---trusted-host resource.flagos.net pypi.tuna.tsinghua.edu.cn
-flagtree==0.5.1+iluvatar3.1
-scikit-build-core>=0.11
-pybind11
-ninja
-cmake

--- a/requirements/requirements_metax.txt
+++ b/requirements/requirements_metax.txt
@@ -1,8 +1,0 @@
---index-url https://resource.flagos.net/repository/flagos-pypi-hosted/simple
---extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
---trusted-host resource.flagos.net pypi.tuna.tsinghua.edu.cn
-flagtree==0.5.1+metax3.0
-scikit-build-core>=0.11
-pybind11
-ninja
-cmake

--- a/requirements/requirements_mthreads.txt
+++ b/requirements/requirements_mthreads.txt
@@ -1,8 +1,0 @@
---index-url https://resource.flagos.net/repository/flagos-pypi-hosted/simple
---extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
---trusted-host resource.flagos.net pypi.tuna.tsinghua.edu.cn
-flagtree==0.5.1+mthreads3.1
-scikit-build-core>=0.11
-pybind11
-ninja
-cmake

--- a/requirements/requirements_nvidia.txt
+++ b/requirements/requirements_nvidia.txt
@@ -1,9 +1,0 @@
---index-url https://resource.flagos.net/repository/flagos-pypi-hosted/simple
---extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
---trusted-host resource.flagos.net pypi.tuna.tsinghua.edu.cn
-torch>=2.2.0
-flagtree==0.5.0
-scikit-build-core>=0.11
-pybind11
-ninja
-cmake

--- a/requirements/requirements_sunrise.txt
+++ b/requirements/requirements_sunrise.txt
@@ -1,8 +1,0 @@
---index-url https://resource.flagos.net/repository/flagos-pypi-hosted/simple
---extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
---trusted-host resource.flagos.net pypi.tuna.tsinghua.edu.cn
-flagtree==0.4.0+sunrise3.4
-scikit-build-core>=0.11
-pybind11
-ninja
-cmake

--- a/requirements/requirements_tsingmicro.txt
+++ b/requirements/requirements_tsingmicro.txt
@@ -1,8 +1,0 @@
---index-url https://resource.flagos.net/repository/flagos-pypi-hosted/simple
---extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
---trusted-host resource.flagos.net pypi.tuna.tsinghua.edu.cn
-flagtree==0.5.0+tsingmicro3.3
-scikit-build-core>=0.11
-pybind11
-ninja
-cmake

--- a/requirements/requirements_xpu.txt
+++ b/requirements/requirements_xpu.txt
@@ -1,8 +1,0 @@
---index-url https://resource.flagos.net/repository/flagos-pypi-hosted/simple
---extra-index-url https://pypi.tuna.tsinghua.edu.cn/simple
---trusted-host resource.flagos.net pypi.tuna.tsinghua.edu.cn
-flagtree==0.3.0rc2+xpu3.0
-scikit-build-core>=0.11
-pybind11
-ninja
-cmake


### PR DESCRIPTION
The `requirements/*.txt` files are no longer used anywhere. Dependency information is now managed in `src/flag_gems/backends.yaml` and `pyproject.toml`.

No references remain in `setup.sh`, CI workflows, or documentation.

The requirements have no risk of deprecation since we have a tighter control of dependencies and their versions. Even warnings from dependabot can be ignored.