### PR TITLE
Optimize min single-dim reduction with inner/non-inner kernels

### DIFF
--- a/src/flag_gems/ops/min.py
+++ b/src/flag_gems/ops/min.py
@@ -8,7 +8,7 @@ import triton.language as tl
 
 from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
-from flag_gems.utils import dim_compress, libentry, libtuner
+from flag_gems.utils import libentry, libtuner
 from flag_gems.utils import triton_lang_extension as ext
 from flag_gems.utils.limits import get_dtype_max
 
@@ -96,6 +96,128 @@ def min_kernel(
     tl.store(out_index_ptrs, argmin_values, mask=mask1)
 
 
+@libentry()
+@triton.heuristics(runtime.get_heuristic_config("softmax_non_inner"))
+@triton.jit
+def min_dim_kernel_non_inner(
+    inp,
+    out_value,
+    out_index,
+    M,
+    N,
+    K,
+    TILE_K: tl.constexpr,
+    TILE_N: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    # Split the input into (M, N, K) and reduce over N with a strided read,
+    # avoiding the dim_compress copy. Ties resolve to the lowest index,
+    # matching torch.
+    pid_m = ext.program_id(0)
+    pid_k = ext.program_id(1)
+    k_offset = pid_k * TILE_K + tl.arange(0, TILE_K)
+
+    if tl.constexpr(inp.dtype.element_ty == tl.float16) or tl.constexpr(
+        inp.dtype.element_ty == tl.bfloat16
+    ):
+        cdtype = tl.float32
+    else:
+        cdtype = inp.dtype.element_ty
+
+    max_value = get_dtype_max(cdtype)
+
+    if ONE_TILE_PER_CTA:
+        n_offset = tl.arange(0, TILE_N)
+        offset = pid_m * N * K + n_offset[:, None] * K + k_offset
+        mask = k_offset < K and n_offset[:, None] < N
+        inp_vals = tl.load(inp + offset, mask=mask, other=max_value)
+        local_min, local_argmin = tl.min(
+            inp_vals, 0, return_indices=True, return_indices_tie_break_left=True
+        )
+        offset_index = pid_m * K + k_offset
+        mask1 = k_offset < K
+        tl.store(out_value + offset_index, local_min, mask=mask1)
+        tl.store(out_index + offset_index, local_argmin, mask=mask1)
+    else:
+        min_values = tl.full([TILE_K], dtype=cdtype, value=max_value)
+        argmin_values = tl.full([TILE_K], dtype=tl.int64, value=0)
+        for start_n in range(0, N, TILE_N):
+            n_offset = start_n + tl.arange(0, TILE_N)
+            offset = pid_m * N * K + n_offset[:, None] * K + k_offset
+            mask = k_offset < K and n_offset[:, None] < N
+            inp_vals = tl.load(inp + offset, mask=mask, other=max_value)
+            local_min, local_argmin = tl.min(
+                inp_vals, 0, return_indices=True, return_indices_tie_break_left=True
+            )
+            update = local_min < min_values
+            min_values = tl.where(update, local_min, min_values)
+            argmin_values = tl.where(update, start_n + local_argmin, argmin_values)
+        offset_index = pid_m * K + k_offset
+        mask1 = k_offset < K
+        tl.store(out_value + offset_index, min_values, mask=mask1)
+        tl.store(out_index + offset_index, argmin_values, mask=mask1)
+
+
+@libentry()
+@triton.heuristics(runtime.get_heuristic_config("softmax_inner"))
+@triton.jit
+def min_dim_kernel_inner(
+    inp,
+    out_value,
+    out_index,
+    M,
+    N,
+    TILE_N: tl.constexpr,
+    ONE_TILE_PER_CTA: tl.constexpr,
+):
+    pid_m = ext.program_id(0)
+    dtype = inp.type.element_ty
+    max_value = get_dtype_max(dtype)
+
+    if ONE_TILE_PER_CTA:
+        n_offset = tl.arange(0, TILE_N)
+        offset = pid_m * N + n_offset
+        mask = n_offset < N
+        inp_vals = tl.load(inp + offset, mask=mask, other=max_value)
+        local_min, local_argmin = tl.min(
+            inp_vals, 0, return_indices=True, return_indices_tie_break_left=True
+        )
+        tl.store(out_value + pid_m, local_min)
+        tl.store(out_index + pid_m, local_argmin)
+    else:
+        min_values = max_value
+        argmin_values = 0
+        loop_time = N // TILE_N
+        remainder = N % TILE_N
+        for start_n in range(0, loop_time):
+            n_offset = start_n * TILE_N + tl.arange(0, TILE_N)
+            offset = pid_m * N + n_offset
+            inp_vals = tl.load(inp + offset)
+            local_min, local_argmin = tl.min(
+                inp_vals, 0, return_indices=True, return_indices_tie_break_left=True
+            )
+            update = local_min < min_values
+            min_values = tl.where(update, local_min, min_values)
+            argmin_values = tl.where(
+                update, start_n * TILE_N + local_argmin, argmin_values
+            )
+        if remainder:
+            n_offset = loop_time * TILE_N + tl.arange(0, TILE_N)
+            offset = pid_m * N + n_offset
+            mask = n_offset < N
+            inp_vals = tl.load(inp + offset, mask=mask, other=max_value)
+            local_min, local_argmin = tl.min(
+                inp_vals, 0, return_indices=True, return_indices_tie_break_left=True
+            )
+            update = local_min < min_values
+            min_values = tl.where(update, local_min, min_values)
+            argmin_values = tl.where(
+                update, loop_time * TILE_N + local_argmin, argmin_values
+            )
+        tl.store(out_value + pid_m, min_values)
+        tl.store(out_index + pid_m, argmin_values)
+
+
 def min(inp):
     logger.debug("GEMS MIN")
     M = inp.numel()
@@ -118,10 +240,20 @@ def min_dim(inp, dim=None, keepdim=False):
     assert dim >= -inp.ndim and dim < inp.ndim, "Invalid dim"
     shape = list(inp.shape)
     dim = dim % inp.ndim
-    inp = dim_compress(inp, dim)
+
+    # Single-dim reduction: split into (M, N, K) and reduce over N with a
+    # strided kernel, avoiding the dim_compress copy. K == 1 means the reduced
+    # dim is innermost (contiguous); K > 1 means it is a middle or outer dim,
+    # where the copy used to dominate the runtime.
     N = shape[dim]
+    if N == 0:
+        # Reducing over an empty dimension has no minimum; torch raises here.
+        raise IndexError(
+            "min(): Expected reduction dim to have non-zero size."
+        )
+    M = math.prod(shape[:dim])
+    K = math.prod(shape[dim + 1 :])
     shape[dim] = 1
-    M = inp.numel() // N
 
     out_value = torch.empty(shape, dtype=inp.dtype, device=inp.device)
     out_index = torch.empty(shape, dtype=torch.int64, device=inp.device)
@@ -130,9 +262,14 @@ def min_dim(inp, dim=None, keepdim=False):
         out_value = torch.squeeze(out_value, dim)
         out_index = torch.squeeze(out_index, dim)
 
-    grid = lambda meta: (triton.cdiv(M, meta["BLOCK_M"]),)
+    inp = inp.contiguous()
     with torch_device_fn.device(inp.device):
-        min_kernel[grid](inp, out_value, out_index, M, N)
+        if K == 1:
+            grid = lambda meta: (M, 1, 1)
+            min_dim_kernel_inner[grid](inp, out_value, out_index, M, N)
+        else:
+            grid = lambda meta: (M, triton.cdiv(K, meta["TILE_K"]), 1)
+            min_dim_kernel_non_inner[grid](inp, out_value, out_index, M, N, K)
     Min_out = namedtuple("min", ["values", "indices"])
     out = Min_out(values=out_value, indices=out_index)
     return out

--- a/tests/test_min.py
+++ b/tests/test_min.py
@@ -73,3 +73,30 @@ def test_min_dim(shape, dim, keepdim, dtype):
 
     utils.gems_assert_equal(res_out_index, ref_out_index)
     utils.gems_assert_equal(res_out_value, ref_out_value)
+
+
+@pytest.mark.min_dim
+@pytest.mark.parametrize(
+    "shape, dim",
+    [
+        ((4, 8, 4096), 1),  # non-inner, multi-N-tile
+        ((4, 4096, 8), 1),  # non-inner, multi-N-tile with small K
+        ((8, 4096), 1),  # inner, multi-N-tile
+        ((4096, 8), 0),  # non-inner, large M
+        ((4096, 4096), 0),  # non-inner, multi-N-tile and multi-K-tile
+    ],
+)
+@pytest.mark.parametrize("keepdim", [True, False])
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_min_dim_multi_tile(shape, dim, keepdim, dtype):
+    # Larger shapes that exercise the multi-tile reduction loops in the inner
+    # and non-inner kernels, which the small default shapes do not reach.
+    inp = torch.randn(shape, dtype=dtype, device=flag_gems.device)
+    ref_inp = utils.to_reference(inp)
+
+    ref_out_value, ref_out_index = torch.min(ref_inp, dim=dim, keepdim=keepdim)
+    with flag_gems.use_gems():
+        res_out_value, res_out_index = torch.min(inp, dim=dim, keepdim=keepdim)
+
+    utils.gems_assert_equal(res_out_value, ref_out_value)
+    utils.gems_assert_equal(res_out_index, ref_out_index)


### PR DESCRIPTION
### PR Category

ops

### Type of Change

Performance Optimization

### Description

Optimize `torch.min(x, dim=d)` for a single reduction dimension by adding native inner and non-inner Triton kernels, the same split already merged for `sum`, `mean`, `std`, and the amax/amin work. Unlike those, `min` returns both values and indices, so the kernels produce both in one pass.

The old single-dim path called `dim_compress`, which permutes the reduced dimension to the innermost position and copies the whole tensor before reducing. For a non-inner reduction (a middle or outer dim) that copy reads and writes the entire tensor once just to reorder it, and it dominated the runtime.

The new path splits the input into `(M, N, K)` and reduces over `N` in place:
- `K == 1` (reduced dim is innermost, contiguous) uses a 1D inner kernel.
- `K > 1` (middle or outer dim) uses a 2D kernel that tiles `N` and `K` and reads with the natural stride, so no copy is needed.

Both the min value and its index come from `tl.min(..., return_indices=True, return_indices_tie_break_left=True)`, and ties resolve to the lowest index to match torch. Across N tiles the update uses a strict comparison so the earlier index wins on ties.

A note on the heuristics: this reuses the `softmax_inner`/`softmax_non_inner` tile configs (as amax/amin do) rather than `argmax_*`, because those give power-of-2 tile sizes for every N.

### Performance

A100, fp16, `torch/gems` latency ratio (higher is better, 1.0 means parity with eager):

| shape | dim | before | after |
|-------|-----|-------:|------:|
| (4096, 4096) | 0 | 0.40x | 0.59x |
| (8192, 2048) | 0 | 0.47x | 0.94x |
| (8, 512, 512) | 1 | 0.34x | 0.60x |
| (4, 4096, 8) | 1 | 0.13x | 0.24x |
| (4096, 4096) | 1 | 0.40x | 0.43x |

Every shape improves. The non-inner reductions that were 3-8x slower than eager move toward parity.

### Testing

- `pytest tests/test_min.py`: all pass, including a new `test_min_dim_multi_tile` covering the multi-N-tile and multi-K-tile paths (N=4096, K=4096) that the small default shapes do not reach.
- Checked both values and indices against `torch.min` across float16/bfloat16/float32/int32, 2D and 3D shapes, every single dim, and both keepdim settings. Tie-breaking matches torch (lowest index on equal values), negative dims work, and empty-dim behavior matches torch (a zero-size reduction dim raises, an empty spectator dim returns an empty result).
- `flake8` clean.

### Progress

- [x] Change is fully covered by a UT.
