### PR TITLE
Fix uv detection by adding ~/.local/bin to PATH before check

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -45,18 +45,18 @@ UV_VERSION="0.11.22"
 UV_MIRROR="https://resource.flagos.net/repository/flagos-filestore/utils"
 
 printf "Checking uv ..."
+export HOME=$(eval echo ~"$(whoami)")
+export PATH="$HOME/.local/bin:$PATH"
 if command -v uv &>/dev/null; then
   printf " $(uv --version)"
   ok
 else
   printf " not found, installing ...\n"
-  export HOME=$(eval echo ~"$(whoami)")
   ARCH=$(uname -m)
   mkdir -p "$HOME/.local/bin"
   curl -sSf "${UV_MIRROR}/uv-${ARCH}-${UV_VERSION}-linux-gnu.tar.gz" \
     | tar xz -C "$HOME/.local/bin" 2>/dev/null \
     || { curl -LsSf https://astral.sh/uv/install.sh | sh; }
-  export PATH="$HOME/.local/bin:$PATH"
   # Persist PATH for subsequent GitHub Actions steps
   [ -n "${GITHUB_PATH:-}" ] && echo "$HOME/.local/bin" >> "$GITHUB_PATH"
   command -v uv &>/dev/null || { printf "uv installation"; fail; }


### PR DESCRIPTION
## Problem

`setup.sh` adds `$HOME/.local/bin` to PATH only *after* installing uv (inside the `else` branch). If uv was already installed there from a previous run, `command -v uv` fails to find it and triggers a redundant reinstall every time.

## Fix

Move `export HOME=...` and `export PATH="$HOME/.local/bin:$PATH"` before the `if command -v uv` check, so previously installed uv is detected correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)