### PR TITLE
Fix setup.sh and env.sh for set -u compatibility

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -45,8 +45,7 @@ UV_VERSION="0.11.22"
 UV_MIRROR="https://resource.flagos.net/repository/flagos-filestore/utils"
 
 printf "Checking uv ..."
-export HOME=$(eval echo ~"$(whoami)")
-export PATH="$HOME/.local/bin:$PATH"
+export PATH="${HOME}/.local/bin:$PATH"
 if command -v uv &>/dev/null; then
   printf " $(uv --version)"
   ok

--- a/tools/env.sh
+++ b/tools/env.sh
@@ -16,6 +16,7 @@ export C_INCLUDE_PATH="${C_INCLUDE_PATH:-}"
 export CPLUS_INCLUDE_PATH="${CPLUS_INCLUDE_PATH:-}"
 export LD_LIBRARY_PATH="${LD_LIBRARY_PATH:-}"
 export LIBRARY_PATH="${LIBRARY_PATH:-}"
+export PYTHONPATH="${PYTHONPATH:-}"
 
 case $BACKEND in
   ascend|ascend-cann850|ascend-cann900)


### PR DESCRIPTION
## Problems

1. **setup.sh**: Unnecessary `export HOME=$(eval echo ~"$(whoami)")` — `HOME` is always already set
2. **env.sh**: Ascend's `set_env.sh` appends to `PYTHONPATH` without guarding, causing `unbound variable` error under `set -u`

## Fixes

- **setup.sh**: Remove `export HOME` line, use `${HOME}` directly
- **env.sh**: Add `export PYTHONPATH="${PYTHONPATH:-}"` to the existing guard block

Fixes the CI failure: https://github.com/flagos-ai/FlagGems/actions/runs/29102790559/job/86395685764

🤖 Generated with [Claude Code](https://claude.com/claude-code)