### PR TITLE
Fix ascend-cann900 post_install format in backends.yaml

### DIFF
--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -79,9 +79,8 @@ backends:
     env_source:
       - /usr/local/Ascend/ascend-toolkit/set_env.sh
       - /usr/local/Ascend/toolbox/set_env.sh
-    post_install: >-
-      uv pip install --no-cache-dir --index ${FLAGOS_PYPI}
-      "triton_ascend==3.2.1"
+    post_install:
+      - triton_ascend==3.2.1
     deps:
       - torch==2.10.0+cpu
       - torch-npu==2.10.0


### PR DESCRIPTION
## Problem

`post_install` for ascend-cann900 uses a YAML folded string (`>-`), but `setup.sh`'s Python parser iterates it character-by-character, producing garbled output like `t: command not found`.

## Fix

Change from folded string to list format (consistent with how `setup.sh` processes `post_install`):

```yaml
# Before
post_install: >-
  uv pip install --no-cache-dir --index ${FLAGOS_PYPI}
  "triton_ascend==3.2.1"

# After
post_install:
  - triton_ascend==3.2.1
```

`setup.sh` handles the install command — `post_install` only needs the package specifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)