### PR TITLE
Fix post_install: use full shell commands with eval

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -120,9 +120,10 @@ post_uninstall = []
 for item in b.get('post_install', []):
     if isinstance(item, dict) and 'uninstall' in item:
         post_uninstall.append(item['uninstall'])
-    else:
+    elif isinstance(item, str):
         post_install.append(item)
-print(f'POST_INSTALL=\"{\" \".join(post_install)}\"')
+# Use | as separator to handle commands with spaces
+print(f'POST_INSTALL=\"{\"|\".join(post_install)}\"')
 print(f'POST_UNINSTALL=\"{\" \".join(post_uninstall)}\"')
 ")
 
@@ -201,9 +202,12 @@ fi
 
 # ── Vendor-specific post-install ──────────────────────────────
 if [ -n "${POST_INSTALL}" ]; then
-  for pkg in ${POST_INSTALL}; do
-    printf "Post-install: ${pkg} ..."
-    uv pip install -q "${pkg}" --default-index "${FLAGOS_PYPI}" || fail
+  IFS='|' read -ra POST_CMDS <<< "${POST_INSTALL}"
+  for cmd in "${POST_CMDS[@]}"; do
+    cmd=$(echo "$cmd" | xargs)  # trim whitespace
+    [ -z "$cmd" ] && continue
+    printf "Post-install: ${cmd} ..."
+    eval "${cmd}" || fail
     ok
   done
 fi

--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -80,7 +80,7 @@ backends:
       - /usr/local/Ascend/ascend-toolkit/set_env.sh
       - /usr/local/Ascend/toolbox/set_env.sh
     post_install:
-      - triton_ascend==3.2.1
+      - uv pip install --no-cache-dir --default-index ${FLAGOS_PYPI} --index ${MIRROR} triton_ascend==3.2.1
     deps:
       - torch==2.10.0+cpu
       - torch-npu==2.10.0


### PR DESCRIPTION
## Problem

After #4674 changed `post_install` from a folded string to a package list, `triton_ascend==3.2.1` installation fails because its transitive dependency (`attrs`) is not available in the vendor-only PyPI index:

```
Because attrs was not found in the package registry and
triton-ascend==3.2.1 depends on attrs==24.2.0, we can conclude that
triton-ascend==3.2.1 cannot be used.
```

## Fix

`post_install` items need to be **full shell commands** (not just package names) because some packages require specific index configurations.

### backends.yaml
```yaml
post_install:
  - uv pip install --no-cache-dir --default-index ${FLAGOS_PYPI} --index ${MIRROR} triton_ascend==3.2.1
```

### setup.sh
- Python parser outputs commands joined by `|` separator (handles spaces)
- Bash handler uses `eval` to execute each command, expanding variables like `${FLAGOS_PYPI}` and `${MIRROR}` at runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)