### PR TITLE
Debug ascend gpu_check failure; remove HOME override from command.yaml

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -96,8 +96,6 @@ jobs:
         env:
           GH_VERSION: "2.95.0"
         run: |
-          export HOME=$(eval echo ~"$(whoami)")
-          echo "HOME=${HOME}" >> $GITHUB_ENV
           GH_DIR="${HOME}/.local/bin"
           if command -v gh &>/dev/null; then
             echo "gh already available: $(gh --version | head -1)"

--- a/tools/gpu_check_ascend.sh
+++ b/tools/gpu_check_ascend.sh
@@ -5,10 +5,24 @@ mem_threshold=30000     # Minimum free memory required (MB)
 sleep_time=120          # Wait time between retries (seconds)
 max_wait=600           # Maximum total wait time (seconds)
 
-# Get the number of NPU chips from npu-smi info output
-npu_smi_output=$(npu-smi info)
+# Debug: environment info
+echo "[DEBUG] PATH=$PATH"
+echo "[DEBUG] USER=$(whoami)"
+echo "[DEBUG] HOME=$HOME"
+echo "[DEBUG] which npu-smi: $(which npu-smi 2>&1)"
+echo "[DEBUG] npu-smi version:"
+npu-smi -v 2>&1 || true
+echo ""
 
-if [ $? -ne 0 ]; then
+# Get the number of NPU chips from npu-smi info output
+echo "[DEBUG] Running: npu-smi info"
+npu_smi_output=$(npu-smi info 2>&1)
+npu_smi_rc=$?
+echo "[DEBUG] npu-smi info exit code: $npu_smi_rc"
+
+if [ $npu_smi_rc -ne 0 ]; then
+    echo "[DEBUG] npu-smi info output:"
+    echo "$npu_smi_output"
     echo "Failed to run npu-smi. Please check if npu-smi is installed and working correctly."
     exit 1
 fi


### PR DESCRIPTION
## Purpose

Diagnose why `gpu_check_ascend.sh` fails on the CI runner (ctyun-25) but works on hw25/hw26.

## Changes

### gpu_check_ascend.sh
Add debug logging before `npu-smi info` call:
- PATH, USER, HOME
- `which npu-smi`
- `npu-smi -v`
- Exit code and stderr of `npu-smi info`

### command.yaml
Remove the `export HOME=...` + `echo HOME >> $GITHUB_ENV` in the setup-gh step. This was unnecessarily overriding HOME for all subsequent steps and may be interfering with environment setup.

## Next steps

Once we see the debug output from a CI run, we'll know the root cause and can apply the proper fix (and remove the debug logging).

🤖 Generated with [Claude Code](https://claude.com/claude-code)