### PR TITLE
Fix Ascend env sourcing: unify path and add error tolerance

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -238,7 +238,7 @@ for k, v in b.get('env', {}).items():
     lines.append(f'export {k}={v}')
 
 for script in b.get('env_source', []):
-    lines.append(f'[ -f {script} ] && source {script}')
+    lines.append(f'[ -f {script} ] && source {script} || true')
 
 lines.append('# --- end FlagGems environment ---')
 

--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -65,8 +65,7 @@ backends:
     triton: triton-ascend==3.2.0
     flagtree: flagtree==0.6.0+ascend3.2
     env_source:
-      - /usr/local/Ascend/ascend-toolkit/set_env.sh
-      - /usr/local/Ascend/toolbox/set_env.sh
+      - /usr/local/Ascend/cann/set_env.sh
     deps:
       - torch==2.9.0+cpu
       - torch-npu==2.9.0
@@ -77,8 +76,7 @@ backends:
     triton: triton==3.5.0
     flagtree: flagtree==0.6.0+ascend3.5
     env_source:
-      - /usr/local/Ascend/ascend-toolkit/set_env.sh
-      - /usr/local/Ascend/toolbox/set_env.sh
+      - /usr/local/Ascend/cann/set_env.sh
     post_install:
       - triton_ascend==3.2.1
     deps:

--- a/tools/env.sh
+++ b/tools/env.sh
@@ -21,11 +21,8 @@ export PYTHONPATH="${PYTHONPATH:-}"
 case $BACKEND in
   ascend|ascend-cann850|ascend-cann900)
     # This script is provided by the Huawei Ascend CANN toolkit installation.
-    if [ -f /usr/local/Ascend/ascend-toolkit/set_env.sh ]; then
-      source /usr/local/Ascend/ascend-toolkit/set_env.sh
-    fi
-    if [ -f /usr/local/Ascend/toolbox/set_env.sh ]; then
-      source /usr/local/Ascend/toolbox/set_env.sh
+    if [ -f /usr/local/Ascend/cann/set_env.sh ]; then
+      source /usr/local/Ascend/cann/set_env.sh || true
     fi
 
     # TODO: Check if this is necessary


### PR DESCRIPTION
## Problem

`gpu_check_ascend.sh` fails on CI (ctyun-25/26) with exit code 1 before any debug output prints. Root cause: `.venv/bin/activate` sources Ascend's `set_env.sh` which has internal commands that return non-zero. Under GitHub Actions' `set -e`, this aborts the entire step.

## Fix

- **backends.yaml**: Unify `env_source` to `/usr/local/Ascend/cann/set_env.sh` (present on both cann850 and cann900 nodes); remove `toolbox/set_env.sh`
- **setup.sh**: Add `|| true` when writing `env_source` into `.venv/bin/activate`
- **tools/env.sh**: Same path change + `|| true`

🤖 Generated with [Claude Code](https://claude.com/claude-code)