### PR TITLE
Only run post_install in triton mode

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -199,11 +199,11 @@ if [ "${COMPILER}" != "flagtree" ] && [ "${COMPILER}" != "triton" ]; then
   exit 1
 fi
 
-# ── Vendor-specific post-install ──────────────────────────────
-if [ -n "${POST_INSTALL}" ]; then
+# ── Vendor-specific post-install (triton mode only) ──────────
+if [ -n "${POST_INSTALL}" ] && [ "${COMPILER}" = "triton" ]; then
   for pkg in ${POST_INSTALL}; do
     printf "Post-install: ${pkg} ..."
-    uv pip install -q "${pkg}" --default-index "${FLAGOS_PYPI}" || fail
+    uv pip install -q "${pkg}" --default-index "${FLAGOS_PYPI}" --index "${MIRROR}" || fail
     ok
   done
 fi


### PR DESCRIPTION
## Problem

On ascend-cann900, `post_install` installs `triton_ascend==3.2.1` which conflicts with FlagTree's triton backend:

```
ModuleNotFoundError: No module named 'triton._C.libtriton.ascend';
'triton._C.libtriton' is not a package
```

FlagTree replaces the triton package entirely — installing triton_ascend on top of it breaks the import chain.

## Fix

- Only execute `post_install` when `COMPILER=triton` (default is flagtree, which doesn't need triton_ascend)
- Also add `--index ${MIRROR}` so transitive deps (e.g. `attrs`) can be resolved from the public mirror

🤖 Generated with [Claude Code](https://claude.com/claude-code)