### PR TITLE
Fix negative op on non-CUDA backends (e.g. MUSA)

### DIFF
--- a/src/flag_gems/ops/negative.py
+++ b/src/flag_gems/ops/negative.py
@@ -34,7 +34,6 @@ def negative_kernel(x_ptr, out_ptr, n_elements, BLOCK_SIZE: tl.constexpr):
 
 
 def _launch_negative(x: torch.Tensor, out: torch.Tensor):
-    assert x.is_cuda and out.is_cuda, "Tensors must be on CUDA device"
     assert x.dtype == out.dtype, "Input and output must have the same dtype"
     assert (
         x.numel() == out.numel()


### PR DESCRIPTION
## Problem

`negative` operator fails on Mthreads (MUSA) and other non-CUDA backends with:
```
AssertionError: Tensors must be on CUDA device
```

`tensor.is_cuda` returns `False` on MUSA/MetaX/Iluvatar devices. The assert is overly restrictive — the Triton kernel works on any Triton-supported device.

## Fix

Remove `assert x.is_cuda and out.is_cuda`.

## Verification

### Accuracy (all 18/18 passed)

| Backend | Device | Result |
|---------|--------|--------|
| NVIDIA H20 | CUDA 13.3 | 18/18 ✅ |
| Iluvatar BI-V150 | CoreX 4.4.0 | 18/18 ✅ |
| Mthreads S5000 | MUSA 5.2.0 | 18/18 ✅ |
| MetaX C500 | MACA 3.7.2 | 18/18 ✅ |

### Performance (speedup vs torch)

| Backend | fp16 | fp32 | bf16 |
|---------|------|------|------|
| NVIDIA H20 | 1.03–1.10 | 1.00–1.01 | 1.00–1.03 |
| Iluvatar BI-V150 | 1.04–1.07 | 1.00–1.02 | 1.04–1.07 |
| Mthreads S5000 | 0.99–1.02 | 0.88–1.03 | 0.97–1.01 |
| MetaX C500 | 0.95–1.01 | 1.00–1.01 | 0.97–1.02 |

Related: #4223

🤖 Generated with [Claude Code](https://claude.com/claude-code)