### PR TITLE
Always persist uv PATH to GITHUB_PATH

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -56,12 +56,12 @@ else
   curl -sSf "${UV_MIRROR}/uv-${ARCH}-${UV_VERSION}-linux-gnu.tar.gz" \
     | tar xz -C "$HOME/.local/bin" 2>/dev/null \
     || { curl -LsSf https://astral.sh/uv/install.sh | sh; }
-  # Persist PATH for subsequent GitHub Actions steps
-  [ -n "${GITHUB_PATH:-}" ] && echo "$HOME/.local/bin" >> "$GITHUB_PATH"
   command -v uv &>/dev/null || { printf "uv installation"; fail; }
   printf "Installed $(uv --version)"
   ok
 fi
+# Persist PATH for subsequent GitHub Actions steps
+[ -n "${GITHUB_PATH:-}" ] && echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
 # ── Install Python via uv ────────────────────────────────────
 printf "Installing Python ${PYTHON_VERSION} ..."


### PR DESCRIPTION
## Problem

`setup-flaggems` action's vllm install step fails with `uv: command not found` on h20, even though `setup.sh` found uv successfully.

`GITHUB_PATH` was only written when uv was freshly installed (inside the `else` branch). When uv already exists at `$HOME/.local/bin/uv`, the path was never persisted for subsequent steps.

## Fix

Move `GITHUB_PATH` write outside the if/else block — always persist `$HOME/.local/bin` regardless of whether uv was found or installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)