### PR TITLE
Unify vendor/backend naming across CI workflows

### DIFF
--- a/.github/actions/setup-flaggems/action.yml
+++ b/.github/actions/setup-flaggems/action.yml
@@ -2,8 +2,8 @@ name: "Setup FlagGems"
 description: "Run setup.sh for a vendor and optionally check GPU availability"
 
 inputs:
-  vendor:
-    description: "FlagGems backend name (e.g. nvidia-cuda133, mthreads, ascend-cann900)"
+  backend:
+    description: "FlagGems backend label (e.g. nvidia-cuda133, mthreads-musa520, ascend-cann900)"
     required: true
   gpu_check_script:
     description: "Path to GPU check script (leave empty to skip)"
@@ -15,10 +15,10 @@ runs:
   steps:
     - name: Setup FlagGems
       shell: bash
-      run: ./setup.sh ${{ inputs.vendor }}
+      run: ./setup.sh ${{ inputs.backend }}
 
     - name: Install vllm (nvidia only)
-      if: startsWith(inputs.vendor, 'nvidia')
+      if: startsWith(inputs.backend, 'nvidia')
       shell: bash
       env:
         VLLM_VERSION: "0.21.0"

--- a/.github/backends.json
+++ b/.github/backends.json
@@ -1,90 +1,90 @@
 [
   {
-    "vendor": "ascend-cann850",
+    "backend": "ascend-cann850",
     "runner_label": "ascend",
     "label": "vendor/Ascend",
     "gpu_check": "tools/gpu_check_ascend.sh",
     "enabled": true
   },
   {
-    "vendor": "enflame",
+    "backend": "enflame",
     "runner_label": "enflame",
     "label": "vendor/Enflame",
     "gpu_check": "",
     "enabled": true
   },
   {
-    "vendor": "hygon",
+    "backend": "hygon",
     "runner_label": "hygon",
     "label": "vendor/Hygon",
     "gpu_check": "tools/gpu_check_hygon.sh",
     "enabled": true
   },
   {
-    "vendor": "iluvatar",
+    "backend": "iluvatar",
     "runner_label": "iluvatar",
     "label": "vendor/Iluvatar",
     "gpu_check": "tools/gpu_check_iluvatar.sh",
     "enabled": true
   },
   {
-    "vendor": "kunlunxin",
+    "backend": "kunlunxin",
     "runner_label": "kunlunxin",
     "label": "vendor/Kunlunxin",
     "gpu_check": "tools/gpu_check_kunlunxin.sh",
     "enabled": true
   },
   {
-    "vendor": "metax",
+    "backend": "metax",
     "runner_label": "metax",
     "label": "vendor/MetaX",
     "gpu_check": "tools/gpu_check_metax.sh",
     "enabled": true
   },
   {
-    "vendor": "mthreads",
+    "backend": "mthreads-musa520",
     "runner_label": "mthreads",
     "label": "vendor/MooreThreads",
     "gpu_check": "tools/gpu_check_mthreads.sh",
     "enabled": true
   },
   {
-    "vendor": "nvidia-cuda128",
+    "backend": "nvidia-cuda128",
     "runner_label": "h20-cu128",
     "label": "vendor/NVIDIA",
     "gpu_check": "tools/gpu_check_nvidia.sh",
     "enabled": false
   },
   {
-    "vendor": "nvidia-cuda133",
+    "backend": "nvidia-cuda133",
     "runner_label": "h20",
     "label": "vendor/NVIDIA",
     "gpu_check": "tools/gpu_check_nvidia.sh",
     "enabled": true
   },
   {
-    "vendor": "spacemit",
+    "backend": "spacemit",
     "runner_label": "spacemit",
     "label": "vendor/SpaceMit",
     "gpu_check": "",
     "enabled": true
   },
   {
-    "vendor": "sunrise",
+    "backend": "sunrise",
     "runner_label": "sunrise",
     "label": "vendor/Sunrise",
     "gpu_check": "",
     "enabled": true
   },
   {
-    "vendor": "thead",
+    "backend": "thead",
     "runner_label": "thead",
     "label": "vendor/Thead",
     "gpu_check": "tools/gpu_check_thead.sh",
     "enabled": true
   },
   {
-    "vendor": "tsingmicro",
+    "backend": "tsingmicro",
     "runner_label": "tsingmicro",
     "label": "vendor/TsingMicro",
     "gpu_check": "tools/gpu_check_tsingmicro.sh",

--- a/.github/workflows/backend-test.yaml
+++ b/.github/workflows/backend-test.yaml
@@ -4,8 +4,8 @@ name: Backend Test
 on:
   workflow_call:
     inputs:
-      vendor:
-        description: 'GEMS_VENDOR value (e.g. iluvatar, ascend, mthreads)'
+      backend:
+        description: 'FlagGems backend label (e.g. nvidia-cuda133, mthreads-musa520, ascend-cann900)'
         required: true
         type: string
       runner_label:
@@ -44,7 +44,7 @@ jobs:
     runs-on: ${{ inputs.runner_label }}
     concurrency:
       group: >-
-        op-test-${{ inputs.vendor }}-${{ github.event.pull_request.number || github.ref }}
+        op-test-${{ inputs.backend }}-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -52,7 +52,7 @@ jobs:
       - uses: ./.github/actions/checkout-retry
       - uses: ./.github/actions/setup-flaggems
         with:
-          vendor: ${{ inputs.vendor }}
+          backend: ${{ inputs.backend }}
           gpu_check_script: ${{ inputs.gpu_check_script }}
 
       - name: Test alpha ops
@@ -61,7 +61,7 @@ jobs:
           CHANGED_FILES: ${{ inputs.changed_files }}
         shell: bash
         run: |
-          bash ${{ inputs.test_script }} ${{ inputs.vendor }} ${{ inputs.pr_id }}
+          bash ${{ inputs.test_script }} ${{ inputs.backend }} ${{ inputs.pr_id }}
       - name: Run backend tests
         if: ${{ inputs.test_script == '' }}
         shell: bash

--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -80,6 +80,10 @@ jobs:
               VENDOR="ascend"
               BACKEND="ascend-cann900"
               ;;
+            mthreads)
+              VENDOR="mthreads"
+              BACKEND="mthreads-musa520"
+              ;;
             *)
               VENDOR="${RUNNER_LABEL}"
               BACKEND="${RUNNER_LABEL}"
@@ -118,7 +122,7 @@ jobs:
 
       - uses: ./.github/actions/setup-flaggems
         with:
-          vendor: ${{ env.BACKEND }}
+          backend: ${{ env.BACKEND }}
           gpu_check_script: tools/gpu_check_${{ env.VENDOR }}.sh
 
       - id: run-tests

--- a/.github/workflows/unittest.yaml
+++ b/.github/workflows/unittest.yaml
@@ -75,9 +75,9 @@ jobs:
             const labels = JSON.parse(${{ steps.get-labels.outputs.result }} || '[]');
             const filtered = backends.filter(b => b.enabled && labels.includes(b.label));
             const matrix = {
-              vendor: filtered.map(b => b.vendor),
+              backend: filtered.map(b => b.backend),
               include: filtered.map(b => ({
-                vendor: b.vendor,
+                backend: b.backend,
                 runner_label: b.runner_label,
                 gpu_check: b.gpu_check
               }))
@@ -139,13 +139,13 @@ jobs:
 
   backend-tests:
     needs: preprocess
-    if: fromJSON(needs.preprocess.outputs.backend_matrix).vendor[0] != null
+    if: fromJSON(needs.preprocess.outputs.backend_matrix).backend[0] != null
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.preprocess.outputs.backend_matrix) }}
     uses: ./.github/workflows/backend-test.yaml
     with:
-      vendor: ${{ matrix.vendor }}
+      backend: ${{ matrix.backend }}
       runner_label: ${{ matrix.runner_label }}
       gpu_check_script: ${{ matrix.gpu_check }}
       changed_files: ${{ join(needs.preprocess.outputs.changed_files, ' ') }}
@@ -160,7 +160,7 @@ jobs:
     if: contains(needs.preprocess.outputs.labels, 'ops/alpha')
     uses: ./.github/workflows/backend-test.yaml
     with:
-      vendor: nvidia-cuda133
+      backend: nvidia-cuda133
       runner_label: h20
       gpu_check_script: tools/gpu_check_nvidia.sh
       test_script: tools/test-op-experimental.sh


### PR DESCRIPTION
## Problem

CI workflows conflate 'vendor' (e.g. `mthreads`) with 'backend' (e.g. `mthreads-musa520`). `setup.sh` requires a full backend label, but the mthreads workflow passed the bare vendor name `mthreads`, causing setup to fail with 'unknown backend'.

## Definitions

- **vendor**: hardware vendor name (e.g. `nvidia`, `ascend`, `mthreads`)
- **backend**: full backend label from `backends.yaml` (e.g. `nvidia-cuda133`, `ascend-cann900`, `mthreads-musa520`)

## Changes

| File | Change |
|------|--------|
| `.github/backends.json` | Rename `vendor` → `backend`; update `mthreads` → `mthreads-musa520` |
| `backend-test.yaml` | Rename input `vendor` → `backend` |
| `setup-flaggems/action.yml` | Rename input `vendor` → `backend` |
| `unittest.yaml` | Update matrix keys and references |
| `command.yaml` | Pass `backend:` to setup-flaggems; add `mthreads` case to resolve-vendor |

---
This PR was written in part with the assistance of generative AI.