### PR TITLE
Add probe-node workflow to inspect self-hosted runner environment

### DIFF
--- a/.github/workflows/probe-node.yaml
+++ b/.github/workflows/probe-node.yaml
@@ -28,8 +28,32 @@ jobs:
             echo "uname:   $(uname -a)"
             echo "python3: $(python3 --version 2>&1)"
             echo
+
+            echo "=== container / virtualization ==="
+            if [ -f /.dockerenv ]; then
+              echo "container: yes (/.dockerenv present)"
+            elif grep -qaE 'docker|containerd|kubepods|lxc' /proc/1/cgroup 2>/dev/null; then
+              echo "container: yes (cgroup: $(grep -aE 'docker|containerd|kubepods|lxc' /proc/1/cgroup | head -1))"
+            else
+              echo "container: no / undetected"
+            fi
+            echo "systemd-detect-virt: $(systemd-detect-virt 2>/dev/null || echo 'n/a')"
+            echo "pid1: $(cat /proc/1/comm 2>/dev/null || echo '?')"
+            echo
+
+            echo "=== host memory / cgroup limit ==="
+            free -h 2>/dev/null || echo "free: not found"
+            for f in /sys/fs/cgroup/memory.max /sys/fs/cgroup/memory/memory.limit_in_bytes; do
+              [ -r "$f" ] && echo "cgroup mem limit ($f): $(cat "$f")"
+            done
+            echo
+
             echo "=== nvidia-smi ==="
             nvidia-smi 2>&1 || echo "nvidia-smi: not found"
+            echo
+            echo "=== GPU memory (total / used / free, MiB) ==="
+            nvidia-smi --query-gpu=index,name,memory.total,memory.used,memory.free \
+              --format=csv,noheader 2>&1 || echo "nvidia-smi query: not found"
             echo
             echo "=== nvcc --version ==="
             nvcc --version 2>&1 || echo "nvcc: not found"

--- a/.github/workflows/probe-node.yaml
+++ b/.github/workflows/probe-node.yaml
@@ -1,0 +1,39 @@
+name: "probe node"
+
+# Manually probe a self-hosted runner's environment (driver / CUDA / OS) so we
+# can pick the correct backend profile for it (e.g. nvidia-cuda133 vs
+# nvidia-cuda128). Needs only bash on the runner.
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: "Self-hosted runner label to probe (e.g. h100, a100, h20)"
+        required: true
+        default: "h100"
+
+permissions:
+  contents: read
+
+jobs:
+  probe:
+    runs-on: ${{ inputs.runner }}
+    steps:
+      - name: Probe node environment
+        shell: bash
+        run: |
+          {
+            echo "## Node probe: \`${{ inputs.runner }}\`"
+            echo '```'
+            echo "uname:   $(uname -a)"
+            echo "python3: $(python3 --version 2>&1)"
+            echo
+            echo "=== nvidia-smi ==="
+            nvidia-smi 2>&1 || echo "nvidia-smi: not found"
+            echo
+            echo "=== nvcc --version ==="
+            nvcc --version 2>&1 || echo "nvcc: not found"
+            echo
+            echo "=== /usr/local/cuda* ==="
+            ls -d /usr/local/cuda* 2>/dev/null || echo "no /usr/local/cuda*"
+          } | tee -a "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Add a `probe node` workflow to inspect self-hosted runners

A minimal `workflow_dispatch` workflow that runs on a chosen self-hosted runner label and prints its environment, so we can pick the correct backend profile before routing tests to a node (e.g. verify a new **h100** runner's CUDA to choose `nvidia-cuda133` vs `nvidia-cuda128`).

Run it from the Actions tab → "probe node" → Run workflow → enter a runner label (default `h100`). Output goes to the job log and the run's Step Summary.

Reports:
- `uname`, `python3 --version`
- container / virtualization: `/.dockerenv`, `/proc/1/cgroup`, `systemd-detect-virt`, pid1
- host memory (`free -h`) and cgroup memory limit
- `nvidia-smi` (driver + max CUDA) and per-GPU total/used/free memory
- `nvcc --version`, `/usr/local/cuda*`

Needs only `bash` on the runner. Does not touch any existing workflow.

---
This PR was written in part with the assistance of generative AI.
