### PR TITLE
command.yaml: use COMPILER=triton for h100 runner

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -76,8 +76,11 @@ jobs:
               # profile (cuda133 requires a newer driver). Note: nvcc is not on
               # PATH in this node's container (cuda at /usr/local/cuda-12.9);
               # C++ extension builds may need PATH/CUDA_HOME set.
+              # This node's container glibc is too old for FlagTree
+              # (needs GLIBC 2.38), so use upstream Triton instead.
               VENDOR="nvidia"
               BACKEND="nvidia-cuda128"
+              echo "COMPILER=triton" >> $GITHUB_ENV
               ;;
             cann850)
               VENDOR="ascend"


### PR DESCRIPTION
## Use `COMPILER=triton` for the h100 runner

`/test silu:h100` failed at `import triton`:
```
ImportError: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found
(required by .../site-packages/triton/_C/libtriton.so)
```
The h100 runner's container has an older glibc than the FlagTree build requires (GLIBC 2.38). `setup.sh` reads the `COMPILER` env var (`flagtree` | `triton`; defaults to FlagTree when available). This PR sets `COMPILER=triton` in the `h100` case of `command.yaml`'s `resolve-vendor`, so setup installs upstream Triton (`triton==3.6.0`, from `backends.yaml`) instead of FlagTree.

Scoped to h100 only — it's a per-node property (that container's glibc), set right next to the per-node `BACKEND`. Other runners (h20/a100/...) keep the default FlagTree.

Workaround until FlagTree is rebuilt against an older glibc baseline; then this line can be removed.

---
This PR was written in part with the assistance of generative AI.
