### PR TITLE
Fix 565-internal: trunc_divide accuracy_fail on mthreads (MTT S5000)

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -8,6 +8,16 @@ from .argmin import argmin
 from .batch_norm import batch_norm, batch_norm_backward
 from .celu import celu
 from .conv2d import conv2d
+from .div import (
+    div_mode,
+    div_mode_,
+    floor_divide,
+    floor_divide_,
+    true_divide,
+    true_divide_,
+    trunc_divide,
+    trunc_divide_,
+)
 from .dropout import dropout, dropout_backward
 from .gather import gather, gather_backward
 from .index_add import index_add, index_add_
@@ -64,8 +74,16 @@ __all__ = [
     "celu",
     # "celu_",
     "conv2d",
+    "div_mode",
+    "div_mode_",
     "dropout",
     "dropout_backward",
+    "floor_divide",
+    "floor_divide_",
+    "true_divide",
+    "true_divide_",
+    "trunc_divide",
+    "trunc_divide_",
     "gather",
     "gather_backward",
     "index_add",

--- a/src/flag_gems/runtime/backend/_mthreads/ops/div.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/div.py
@@ -1,0 +1,260 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+div_rn = tl_extra_shim.div_rn
+div_rz = tl_extra_shim.div_rz
+fmod = tl_extra_shim.fmod
+trunc = tl_extra_shim.trunc
+
+
+@pointwise_dynamic(promotion_methods=[(0, 1, "INT_TO_FLOAT")])
+@triton.jit
+def true_div_func(x, y):
+    return x / y
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "INT_TO_FLOAT")])
+@triton.jit
+def true_div_func_tensor_scalar(x, y):
+    return x / y
+
+
+@pointwise_dynamic(is_tensor=[False, True], promotion_methods=[(0, 1, "INT_TO_FLOAT")])
+@triton.jit
+def true_div_func_scalar_tensor(x, y):
+    return x / y
+
+
+def true_divide(A, B):
+    logger.debug("GEMS_MTHREADS TRUE_DIVIDE")
+    if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
+        return true_div_func(A, B)
+    elif isinstance(A, torch.Tensor):
+        return true_div_func_tensor_scalar(A, B)
+    elif isinstance(B, torch.Tensor):
+        return true_div_func_scalar_tensor(A, B)
+    else:
+        # Both scalar
+        return torch.tensor(A / B)
+
+
+def true_divide_(A, B):
+    logger.debug("GEMS_MTHREADS TRUE_DIVIDE_")
+    if isinstance(B, torch.Tensor):
+        return true_div_func(A, B, out0=A)
+    else:
+        return true_div_func_tensor_scalar(A, B, out0=A)
+
+
+# NOTE: On mthreads, the libdevice ``div_rz`` (round-toward-zero division) intrinsic
+# occasionally yields a quotient that is off by one in the integer part (e.g. it
+# returns -29790022 instead of -29790024 for -0.315/1.057e-08), so wrapping it in
+# ``trunc`` produces the wrong truncated integer. PyTorch's CPU ``div(...,
+# rounding_mode="trunc")`` matches ``trunc(x / y)`` computed with round-to-nearest
+# division, which on this backend is provided by ``div_rn``. Use that instead so the
+# result is bit-for-bit identical to the reference.
+@pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def trunc_div_func(x, y):
+    return trunc(div_rn(x, y))
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def trunc_div_func_tensor_scalar(x, y):
+    return trunc(div_rn(x, tl.cast(y, x.dtype)))
+
+
+@pointwise_dynamic(is_tensor=[False, True], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def trunc_div_func_scalar_tensor(x, y):
+    return trunc(div_rn(tl.cast(x, y.dtype), y))
+
+
+# Integer truncation division: Triton's // on integers is C-style (truncates toward zero)
+@pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def trunc_div_int_func(x, y):
+    return x // y
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def trunc_div_int_func_tensor_scalar(x, y):
+    return x // y
+
+
+@pointwise_dynamic(is_tensor=[False, True], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def trunc_div_int_func_scalar_tensor(x, y):
+    return x // y
+
+
+def trunc_divide(A, B):
+    logger.debug("GEMS_MTHREADS TRUNC_DIVIDE")
+    # Integer types: use dedicated int kernels (Triton // is C-style truncation)
+    if isinstance(A, torch.Tensor) and not A.is_floating_point():
+        if isinstance(B, torch.Tensor):
+            return trunc_div_int_func(A, B)
+        else:
+            return trunc_div_int_func_tensor_scalar(A, B)
+    if isinstance(B, torch.Tensor) and not B.is_floating_point():
+        return trunc_div_int_func_scalar_tensor(A, B)
+    if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
+        return trunc_div_func(A, B)
+    elif isinstance(A, torch.Tensor):
+        return trunc_div_func_tensor_scalar(A, B)
+    elif isinstance(B, torch.Tensor):
+        return trunc_div_func_scalar_tensor(A, B)
+    else:
+        # Both scalar
+        return torch.tensor(A / B)
+
+
+def trunc_divide_(A, B):
+    logger.debug("GEMS_MTHREADS TRUNC_DIVIDE_")
+    # Integer types: use dedicated int kernels (Triton // is C-style truncation)
+    if not A.is_floating_point():
+        if isinstance(B, torch.Tensor):
+            return trunc_div_int_func(A, B, out0=A)
+        else:
+            return trunc_div_int_func_tensor_scalar(A, B, out0=A)
+    if isinstance(B, torch.Tensor):
+        return trunc_div_func(A, B, out0=A)
+    else:
+        return trunc_div_func_tensor_scalar(A, B, out0=A)
+
+
+@triton.jit
+def _int_floordiv(x, y):
+    # TODO: request Triton to add an integer remainder builtin
+    # The semantic of Triton floordiv differs from Pytorch/Numpy
+    # Triton floordiv equates to
+    #     (x - np.fmod(x, y)) / y
+    # whereas Pytorch floordiv is
+    #     (x - np.remainder(x, y)) y
+    # The results show a one off difference when
+    #     C1) x and y have opposite signs
+    # and C2) x is not multiples of y.
+    # Apart from the above, there's an erroneous case x // 0 returns -1
+    # whereas in Pytorch x // 0 returns -1 if x >=0 and -2 if x < 0
+    # but this special case is coalesced into the c1 and c2 check so
+    # there's extra handling.
+    r = x % y
+    c1 = r != 0
+    c2 = (x < 0) ^ (y < 0)
+    return tl.where(c1 & c2, x // y - 1, x // y)
+
+
+# TO be consistent with python, numpy and torch, we have to implement it in the
+# following way.
+# CPython
+# https://github.com/python/cpython/blob/ace008c531dd685a30c1dd68f9b5ba35f20171cf/Objects/floatobject.c#L636
+# numpy
+# https://github.com/numpy/numpy/blob/a4ad142aa1282a77bbb05acd706cb57c9cc29846/numpy/_core/src/npymath/npy_math_internal.h.src#L532
+# torch
+# https://github.com/pytorch/pytorch/blob/d6d9183456cd07ca0b361a194b98c2fb196e7c36/c10/util/generic_math.h#L23
+@triton.jit
+def _float_floordiv(x, y):
+    # NOTE: fmod's sign is the same as the dividend
+    remainder = fmod(x, y)
+    imperfect = remainder != 0.0
+    different_sign = (x < 0) ^ (y < 0)
+
+    # NOTE: we have to use div_rn explicitly here
+    q = div_rn(x - remainder, y)
+    q = tl.where(imperfect & different_sign, q - 1, q)
+
+    floor_q = tl.math.floor(q)
+    c = q - floor_q > 0.5
+    floor_q = tl.where(c, floor_q + 1.0, floor_q)
+
+    q_is_zeros = q == 0.0
+    floor_q = tl.where(q_is_zeros, tl.where(different_sign, -0.0, 0.0), floor_q)
+
+    is_div_by_zero = y == 0.0
+    float_division = x / y
+    out = tl.where(is_div_by_zero, float_division, floor_q)
+    return out
+
+
+@pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def floor_div_func(x, y):
+    if x.type.scalar.is_int() & y.type.scalar.is_int():
+        return _int_floordiv(x, y)
+    else:
+        return _float_floordiv(x, y)
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def floor_div_func_tensor_scalar(x, y):
+    if x.type.scalar.is_int() & y.type.scalar.is_int():
+        return _int_floordiv(x, y)
+    else:
+        return _float_floordiv(x, y)
+
+
+@pointwise_dynamic(is_tensor=[False, True], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def floor_div_func_scalar_tensor(x, y):
+    if x.type.scalar.is_int() & y.type.scalar.is_int():
+        return _int_floordiv(x, y)
+    else:
+        return _float_floordiv(x, y)
+
+
+def floor_divide(A, B):
+    logger.debug("GEMS_MTHREADS FLOOR_DIVIDE")
+    if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
+        return floor_div_func(A, B)
+    elif isinstance(A, torch.Tensor):
+        return floor_div_func_tensor_scalar(A, B)
+    elif isinstance(B, torch.Tensor):
+        return floor_div_func_scalar_tensor(A, B)
+    else:
+        # Both scalar
+        return torch.tensor(A // B)
+
+
+def floor_divide_(A, B):
+    logger.debug("GEMS_MTHREADS FLOOR_DIVIDE_")
+    if isinstance(B, torch.Tensor):
+        return floor_div_func(A, B, out0=A)
+    else:
+        return floor_div_func_tensor_scalar(A, B, out0=A)
+
+
+def div_mode(A, B, rounding_mode=None):
+    logger.debug("GEMS_MTHREADS DIV_MODE")
+    if rounding_mode is None:
+        return true_divide(A, B)
+    elif rounding_mode == "trunc":
+        return trunc_divide(A, B)
+    elif rounding_mode == "floor":
+        return floor_divide(A, B)
+    else:
+        msg = f"div expected rounding_mode to be one of None, 'trunc', or 'floor' but found {rounding_mode}."
+        raise ValueError(msg)
+
+
+def div_mode_(A, B, rounding_mode=None):
+    logger.debug("GEMS_MTHREADS DIV_MODE_")
+    if rounding_mode is None:
+        return true_divide_(A, B)
+    elif rounding_mode == "trunc":
+        return trunc_divide_(A, B)
+    elif rounding_mode == "floor":
+        return floor_divide_(A, B)
+    else:
+        msg = f"div expected rounding_mode to be one of None, 'trunc', or 'floor' but found {rounding_mode}."
+        raise ValueError(msg)


### PR DESCRIPTION
## Summary

Fixes issue **565-internal** (`trunc_divide`) — `accuracy_fail` on the **mthreads / MUSA** backend (MTT S5000).

## Root cause

On mthreads, the shared trunc_divide kernel computes trunc(div_rz(x,y)), but the libdevice div_rz intrinsic (__mt_div_rtz_f32) occasionally returns a quotient off by one in the integer part, so trunc() yields the wrong truncated integer for certain float32 pairs.

## Fix

Added a mthreads-specific override (src/flag_gems/runtime/backend/_mthreads/ops/div.py) that uses trunc(div_rn(x,y)) (round-to-nearest division) instead of div_rz, matching PyTorch CPU trunc-div semantics; exported the div functions in _mthreads/ops/__init__.py so SpecOpRegistrar auto-applies them for mthreads only.

## Files modified

- `src/flag_gems/runtime/backend/_mthreads/ops/div.py`
- `src/flag_gems/runtime/backend/_mthreads/ops/__init__.py`

## Verification

- Accuracy: `pytest -m 'trunc_divide' tests/ --ref cpu` → PASS
- Benchmark: `pytest -m 'trunc_divide' benchmark/ --level core` → PASS
- Format: black / isort / flake8 → PASS

## Notes

Shared ops/ code was left untouched per backend-isolation rules; only a mthreads override was added. The fix was validated against 50M random float32 pairs (0 mismatches vs torch CPU trunc-div).

> Issue ID `565-internal` is an **internal** tracking number (suffix `-internal`), not a GitHub issue number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
