### PR TITLE
Fix 561-internal: fill_scalar_ accuracy_fail on mthreads (MTT S5000)

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -9,6 +9,7 @@ from .batch_norm import batch_norm, batch_norm_backward
 from .celu import celu
 from .conv2d import conv2d
 from .dropout import dropout, dropout_backward
+from .fill import fill_tensor, fill_tensor_, fill_tensor_out
 from .gather import gather, gather_backward
 from .index_add import index_add, index_add_
 from .index_put import _index_put_impl_, index_put, index_put_
@@ -66,6 +67,9 @@ __all__ = [
     "conv2d",
     "dropout",
     "dropout_backward",
+    "fill_tensor",
+    "fill_tensor_",
+    "fill_tensor_out",
     "gather",
     "gather_backward",
     "index_add",

--- a/src/flag_gems/runtime/backend/_mthreads/ops/fill.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/fill.py
@@ -1,0 +1,69 @@
+import logging
+
+import torch
+
+from flag_gems.ops.fill import (
+    fill_scalar,
+    fill_scalar_,
+    fill_scalar_out,
+    fill_tensor_func,
+)
+from flag_gems.runtime import torch_device_fn
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+
+def _value_on_device(value):
+    """Whether ``value`` resides on the GPU (musa) device.
+
+    ``Tensor.is_cuda`` is unreliable on the mthreads backend: importing
+    ``transformer_engine`` monkeypatches it to ``True`` for *every* tensor
+    (including CPU ones), which makes the original ``not value.is_cuda``
+    guard in the shared implementation misroute a CPU scalar value into the
+    tensor kernel and crash with "Pointer argument ... cannot be accessed
+    from Triton (cpu tensor?)". ``is_musa`` is not affected, so use it.
+    """
+    return value.is_musa
+
+
+def fill_tensor(input, value):
+    if not _value_on_device(value):
+        return fill_scalar(input, value.item())
+    logger.debug("GEMS MTHREADS FILL (Dynamic)")
+    if value.ndim != 0:
+        raise RuntimeError(
+            f"fill_ only supports 0-dimension value tensor but got tensor with {value.ndim} dimensions."
+        )
+    out = torch.empty_like(input)
+    with torch_device_fn.device(input.device):
+        return fill_tensor_func(input, value, out0=out)
+
+
+def fill_tensor_out(input, value, *, out=None):
+    logger.debug("GEMS MTHREADS FILL_TENSOR_OUT")
+    if out is None:
+        return fill_tensor(input, value)
+    if not _value_on_device(value):
+        return fill_scalar_out(input, value.item(), out=out)
+    if value.ndim != 0:
+        raise RuntimeError(
+            f"fill_ only supports 0-dimension value tensor but got tensor with {value.ndim} dimensions."
+        )
+    with torch_device_fn.device(input.device):
+        fill_tensor_func(input, value, out0=out)
+    return out
+
+
+def fill_tensor_(self, value):
+    if not _value_on_device(value):
+        return fill_scalar_(self, value.item())
+    logger.debug("GEMS MTHREADS FILL_TENSOR_")
+    if value.ndim != 0:
+        raise RuntimeError(
+            f"fill_ only supports 0-dimension value tensor but got tensor with {value.ndim} dimensions."
+        )
+    with torch_device_fn.device(self.device):
+        fill_tensor_func(self, value, out0=self)
+    return self


### PR DESCRIPTION
## Summary

Fixes issue **561-internal** (`fill_scalar_`) — `accuracy_fail` on the **mthreads / MUSA** backend (MTT S5000).

## Root cause

transformer_engine (imported at test collection via tests/test_dgeglu.py) monkeypatches torch.Tensor.is_cuda to True for all tensors including CPU ones, so the shared fill.py guard `if not value.is_cuda` misroutes a CPU scalar value into the tensor kernel and crashes with 'Pointer argument cannot be accessed from Triton (cpu tensor?)'.

## Fix

Added a mthreads backend override of fill_tensor/fill_tensor_out/fill_tensor_ that checks value.is_musa instead of value.is_cuda, correctly routing CPU scalar values to the scalar kernel while leaving the musa-tensor path unchanged.

## Files modified

- `src/flag_gems/runtime/backend/_mthreads/ops/fill.py`
- `src/flag_gems/runtime/backend/_mthreads/ops/__init__.py`

## Verification

- Accuracy: `pytest -m 'fill_scalar_' tests/ --ref cpu` → PASS
- Benchmark: `pytest -m 'fill_scalar_' benchmark/ --level core` → PASS
- Format: black / isort / flake8 → PASS

## Notes

Failure was order-dependent: standalone tests/test_fill.py passed (TE not imported), but the full tests/ tree failed 45 sliced_view cases. All 372 fill tests pass after the fix. No shared ops/ code modified; fix isolated to the mthreads backend override.

> Issue ID `561-internal` is an **internal** tracking number (suffix `-internal`), not a GitHub issue number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
