### PR TITLE
Fix 560-internal: atan2_out accuracy_fail on mthreads (MTT S5000)

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -5,6 +5,7 @@ from .amax import amax
 from .any import any, any_dim, any_dims
 from .arange import arange, arange_start
 from .argmin import argmin
+from .atan2 import atan2, atan2_out
 from .batch_norm import batch_norm, batch_norm_backward
 from .celu import celu
 from .conv2d import conv2d
@@ -59,6 +60,8 @@ __all__ = [
     "arange",
     "arange_start",
     "argmin",
+    "atan2",
+    "atan2_out",
     "batch_norm",
     "batch_norm_backward",
     "celu",

--- a/src/flag_gems/runtime/backend/_mthreads/ops/atan2.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/atan2.py
@@ -1,0 +1,52 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+_atan = tl_extra_shim.atan
+_isnan = tl_extra_shim.isnan
+
+
+@pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def atan2_kernel(x, y):
+    # x = input (y-coord), y = other (x-coord); compute atan2(x, y).
+    # The mthreads libdevice atan2 intrinsic (`__nv_atan2f`) crashes the llc
+    # instruction selector for half-precision inputs whenever a tile is
+    # partially filled (e.g. numel not aligned to the tile size). Rebuild
+    # atan2 from the single-argument atan, which lowers correctly, plus the
+    # standard quadrant correction.
+    xf = x.to(tl.float32)
+    yf = y.to(tl.float32)
+    pi = 3.141592653589793
+    half_pi = 1.5707963267948966
+    ratio = tl.where(yf != 0.0, xf / yf, 0.0)
+    a = _atan(ratio)
+    out = tl.where(
+        yf > 0.0,
+        a,
+        tl.where(
+            yf < 0.0,
+            tl.where(xf >= 0.0, a + pi, a - pi),
+            tl.where(xf > 0.0, half_pi, tl.where(xf < 0.0, -half_pi, 0.0)),
+        ),
+    )
+    nan_mask = (_isnan(xf) | _isnan(yf)).to(tl.int1)
+    out = tl.where(nan_mask, float("nan"), out)
+    return out
+
+
+def atan2(input, other):
+    logger.debug("GEMS_MTHREADS ATAN2")
+    return atan2_kernel(input, other)
+
+
+def atan2_out(input, other, out):
+    logger.debug("GEMS_MTHREADS ATAN2_OUT")
+    return atan2_kernel(input, other, out0=out)


### PR DESCRIPTION
## Summary

Fixes issue **560-internal** (`atan2_out`) — `accuracy_fail` on the **mthreads / MUSA** backend (MTT S5000).

## Root cause

The default atan2 kernel calls the mthreads libdevice atan2 intrinsic (__nv_atan2f), which crashes the llc instruction selector (segfault, exit -11) for half-precision inputs whenever a tile is partially filled (numel not tile-aligned, e.g. numel==1 or 255/257), surfacing as a RuntimeError for the affected fp16 test cases.

## Fix

Added a mthreads-specific override that rebuilds atan2 from the single-argument atan intrinsic (which lowers correctly) plus the standard quadrant correction (atan(y/x) with +/-pi shifts and +/-pi/2 for x==0) and explicit NaN propagation, avoiding the crashing atan2 intrinsic entirely.

## Files modified

- `src/flag_gems/runtime/backend/_mthreads/ops/atan2.py`
- `src/flag_gems/runtime/backend/_mthreads/ops/__init__.py`

## Verification

- Accuracy: `pytest -m 'atan2_out' tests/ --ref cpu` → PASS
- Benchmark: `pytest -m 'atan2_out' benchmark/ --level core` → PASS
- Format: black / isort / flake8 → PASS

## Notes

Only the mthreads backend was affected; bf16 and fp32 dtypes passed on master because they lower through a different (unrolled __mt_atan2_f32) IR path that does not crash. The override is registered via SpecOpRegistrar and only affects the mthreads backend; shared code under src/flag_gems/ops/ was not modified.

> Issue ID `560-internal` is an **internal** tracking number (suffix `-internal`), not a GitHub issue number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
