### PR TITLE
Fix 559-internal: atan2 accuracy_fail on mthreads (MTT S5000)

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -5,6 +5,7 @@ from .amax import amax
 from .any import any, any_dim, any_dims
 from .arange import arange, arange_start
 from .argmin import argmin
+from .atan2 import atan2, atan2_out
 from .batch_norm import batch_norm, batch_norm_backward
 from .celu import celu
 from .conv2d import conv2d
@@ -59,6 +60,8 @@ __all__ = [
     "arange",
     "arange_start",
     "argmin",
+    "atan2",
+    "atan2_out",
     "batch_norm",
     "batch_norm_backward",
     "celu",

--- a/src/flag_gems/runtime/backend/_mthreads/ops/atan2.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/atan2.py
@@ -1,0 +1,50 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic, tl_extra_shim
+
+# The mthreads llc backend crashes (SIGSEGV in SelectionDAG) while lowering the
+# libdevice `atan2` intrinsic, so atan2 is reconstructed from the working `atan`
+# and `sqrt` primitives via the half-angle identity atan2(Y, X) = 2 * atan(t),
+# where t = tan(theta/2) is computed with the numerically stable form per
+# half-plane (see the kernel below). `input` is Y and `other` is X, matching
+# torch.atan2(input, other).
+_atan = tl_extra_shim.atan
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+
+@pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def atan2_kernel(input, other):
+    y = input.to(tl.float32)
+    x = other.to(tl.float32)
+    r = tl.sqrt(x * x + y * y)
+    # Half-angle identity atan2(Y, X) = 2 * atan(tan(theta/2)). Two equivalent
+    # forms of tan(theta/2) are used, picking the one without catastrophic
+    # cancellation for each half-plane:
+    #   x >= 0 -> t = Y / (r + X)   (r + X never cancels)
+    #   x <  0 -> t = (r - X) / Y   (r - X never cancels; Y != 0 except on the
+    #                                negative real axis, where it yields +/-inf
+    #                                -> +/-pi, which is correct)
+    pos = x >= 0.0
+    t_pos = y / (r + x)
+    t_neg = (r - x) / y
+    t = tl.where(pos, t_pos, t_neg)
+    ang = 2.0 * _atan(t)
+    # atan2(+/-0, 0) is defined as 0; the (0, 0) case produces nan above.
+    return tl.where((x == 0.0) & (y == 0.0), 0.0, ang)
+
+
+def atan2(input, other):
+    logger.debug("GEMS_MTHREADS ATAN2")
+    return atan2_kernel(input, other)
+
+
+def atan2_out(input, other, out):
+    logger.debug("GEMS_MTHREADS ATAN2_OUT")
+    return atan2_kernel(input, other, out0=out)


### PR DESCRIPTION
## Summary

Fixes issue **559-internal** (`atan2`) — `accuracy_fail` on the **mthreads / MUSA** backend (MTT S5000).

## Root cause

The default atan2 implementation uses the libdevice atan2 intrinsic, which crashes the mthreads llc compiler (SIGSEGV in SelectionDAG) during lowering, so the operator failed to compile.

## Fix

Added a mthreads-only override that reconstructs atan2 from the working atan+sqrt primitives via the half-angle identity atan2(Y,X)=2*atan(tan(theta/2)), using the numerically stable form per half-plane to avoid fp32 cancellation on the negative real axis, with a (0,0)->0 guard.

## Files modified

- `src/flag_gems/runtime/backend/_mthreads/ops/atan2.py`
- `src/flag_gems/runtime/backend/_mthreads/ops/__init__.py`

## Verification

- Accuracy: `pytest -m 'atan2' tests/ --ref cpu` → PASS
- Benchmark: `pytest -m 'atan2' benchmark/ --level core` → PASS
- Format: black / isort / flake8 → PASS

## Notes

Shared code under src/flag_gems/ops/ was not modified; fix is isolated to the mthreads backend override, consistent with the multi-backend override mechanism.

> Issue ID `559-internal` is an **internal** tracking number (suffix `-internal`), not a GitHub issue number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
