### PR TITLE
Fix 558-internal: linear accuracy_fail on mthreads (MTT S5000)

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_mthreads/tune_configs.yaml
@@ -89,6 +89,59 @@ addmm:
       BLOCK_SIZE_K: 32
     num_stages: 1
     num_warps: 4
+linear:
+  # The NVIDIA default's first config (BLOCK_SIZE 128x256x64, num_stages=3) fails to
+  # compile for fp32 on MUSA (Triton Error [MUSA]: invalid argument during autotune).
+  # num_stages=2 keeps the tile size but fits the MUSA fp32 pipeline; the remaining
+  # configs are unchanged from the NVIDIA default and safe across all dtypes.
+  - META:
+      BLOCK_SIZE_M: 128
+      BLOCK_SIZE_N: 256
+      BLOCK_SIZE_K: 64
+    num_stages: 2
+    num_warps: 8
+  - META:
+      BLOCK_SIZE_M: 64
+      BLOCK_SIZE_N: 256
+      BLOCK_SIZE_K: 32
+    num_stages: 4
+    num_warps: 4
+  - META:
+      BLOCK_SIZE_M: 128
+      BLOCK_SIZE_N: 128
+      BLOCK_SIZE_K: 32
+    num_stages: 4
+    num_warps: 4
+  - META:
+      BLOCK_SIZE_M: 128
+      BLOCK_SIZE_N: 64
+      BLOCK_SIZE_K: 32
+    num_stages: 4
+    num_warps: 4
+  - META:
+      BLOCK_SIZE_M: 64
+      BLOCK_SIZE_N: 128
+      BLOCK_SIZE_K: 32
+    num_stages: 4
+    num_warps: 4
+  - META:
+      BLOCK_SIZE_M: 128
+      BLOCK_SIZE_N: 32
+      BLOCK_SIZE_K: 32
+    num_stages: 4
+    num_warps: 4
+  - META:
+      BLOCK_SIZE_M: 64
+      BLOCK_SIZE_N: 32
+      BLOCK_SIZE_K: 32
+    num_stages: 5
+    num_warps: 2
+  - META:
+      BLOCK_SIZE_M: 32
+      BLOCK_SIZE_N: 64
+      BLOCK_SIZE_K: 32
+    num_stages: 5
+    num_warps: 2
 cross_entropy_loss:
   - META:
       BLOCK_C: 256


### PR DESCRIPTION
## Summary

Fixes issue **558-internal** (`linear`) — `accuracy_fail` on the **mthreads / MUSA** backend (MTT S5000).

## Root cause

The linear operator had no mthreads-specific autotune config, so it used the NVIDIA default set whose first tile (128x256x64, num_stages=3) fails to compile for fp32 on MUSA ('Triton Error [MUSA]: invalid argument' during the pipelined tl.dot loop), crashing the benchmark.

## Fix

Added a linear override in _mthreads/tune_configs.yaml: changed the first config's num_stages from 3 to 2 (keeping the tile size, which fits the MUSA fp32 pipeline) and reused the remaining NVIDIA configs unchanged; all dtypes/shapes now run successfully.

## Files modified

- `src/flag_gems/runtime/backend/_mthreads/tune_configs.yaml`

## Verification

- Accuracy: `pytest -m 'linear' tests/ --ref cpu` → PASS
- Benchmark: `pytest -m 'linear' benchmark/ --level core` → PASS
- Format: black / isort / flake8 → PASS

## Notes

Backend-isolation respected: only the mthreads tune_configs.yaml override was modified; shared ops/linear.py code was not touched. Only a YAML file changed (no .py lint needed). Autotune DB cache was cleared before final verification to ensure configs reload from the patched YAML.

> Issue ID `558-internal` is an **internal** tracking number (suffix `-internal`), not a GitHub issue number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
