### PR TITLE
Fix 552-internal: bincount benchmark_fail on mthreads (MTT S5000)

### DIFF
--- a/benchmark/test_bincount.py
+++ b/benchmark/test_bincount.py
@@ -47,11 +47,19 @@ def bincount_weighted_input_fn(shape, dtype, device):
 
 @pytest.mark.bincount
 def test_bincount_weighted():
+    # Native torch.bincount on mthreads does not upcast fp16/bfloat16 weights
+    # (raises "expected scalar type Float but found Half"), so the baseline
+    # can only be measured for float32 on this backend.
+    if flag_gems.vendor_name == "mthreads":
+        dtypes = [torch.float32]
+    else:
+        dtypes = consts.FLOAT_DTYPES
+
     bench = base.GenericBenchmark(
         input_fn=bincount_weighted_input_fn,
         op_name="bincount_weighted",
         torch_op=torch.bincount,
-        dtypes=consts.FLOAT_DTYPES,
+        dtypes=dtypes,
     )
     bench.set_gems(flag_gems.bincount)
     bench.run()


### PR DESCRIPTION
## Summary

Fixes issue **552-internal** (`bincount`) — `benchmark_fail` on the **mthreads / MUSA** backend (MTT S5000).

## Root cause

The test_bincount_weighted benchmark measured the native torch.bincount baseline across fp16/fp32/bf16 weights, but on the mthreads/MUSA backend native torch.bincount does not upcast fp16/bf16 weights and raises 'expected scalar type Float but found Half' before the gems op is ever timed.

## Fix

Restricted the benchmark's weighted dtypes to float32 on the mthreads backend (matching the existing avg_pool2d_backward/batch_norm_backward precedent) while keeping FLOAT_DTYPES for other backends; the shared operator code already correctly upcasts fp16/bf16 weights and was not modified.

## Files modified

- `benchmark/test_bincount.py`

## Verification

- Accuracy: `pytest -m 'bincount' tests/ --ref cpu` → PASS
- Benchmark: `pytest -m 'bincount' benchmark/ --level core` → PASS
- Format: black / isort / flake8 → PASS

## Notes

Operator source (src/flag_gems/ops/bincount.py) was already correct: it upcasts fp16/bf16 weights to fp32 for atomic_add and casts back. No operator override was needed in _mthreads/ops. Fix is benchmark-only, following the existing vendor-conditional dtype restriction pattern used by avg_pool2d_backward and batch_norm_backward.

> Issue ID `552-internal` is an **internal** tracking number (suffix `-internal`), not a GitHub issue number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
