### PR TITLE
[KernelGen][Mthreads] Fix swiglu: accuracy_fail

### DIFF
--- a/benchmark/test_swiglu.py
+++ b/benchmark/test_swiglu.py
@@ -20,6 +20,18 @@ except ImportError:
     GEMS_OP = None
 
 
+def te_swiglu_op(input_tensor, quantizer=None):
+    # TransformerEngine's swiglu requires a 2-D input on some backends (e.g. musa),
+    # while FlagGems supports arbitrary shapes by flattening to 2-D internally.
+    # Collapse the leading dims before calling tex.swiglu and restore the output
+    # shape so the comparison stays valid across vendors.
+    shape = input_tensor.shape
+    last_dim = shape[-1]
+    ref_input = input_tensor.view(-1, last_dim)
+    out = TE_OP(ref_input, quantizer)
+    return out.view(*shape[:-1], last_dim // 2)
+
+
 @pytest.mark.swiglu
 @pytest.mark.skipif(not TE_AVAILABLE, reason="TransformerEngine not installed")
 @pytest.mark.skipif(TE_OP is None, reason="'swilu' not found in TransformerEngine")
@@ -27,7 +39,7 @@ except ImportError:
 def test_swiglu():
     bench = base.TexGluForwardBenchmark(
         op_name="swiglu",
-        torch_op=TE_OP,
+        torch_op=te_swiglu_op,
         gems_op=GEMS_OP,
         dtypes=consts.FLOAT_DTYPES,
     )

--- a/tests/test_swiglu.py
+++ b/tests/test_swiglu.py
@@ -42,7 +42,15 @@ def test_swiglu(shape: tuple[int, ...], dtype: torch.dtype):
 
     input_tensor = generate_input(shape, dtype, device)
 
-    te_forward = tex.swiglu(input_tensor, quantizer=None).to(device)
+    # TransformerEngine's swiglu requires a 2-D input on some backends (e.g. musa),
+    # while FlagGems supports arbitrary shapes by flattening to 2-D internally.
+    # Reshape the reference input to 2-D and restore the original output shape so
+    # the comparison stays valid across vendors.
+    last_dim = shape[-1]
+    H = last_dim // 2
+    ref_input = input_tensor.view(-1, last_dim)
+    te_forward = tex.swiglu(ref_input, quantizer=None).to(device)
+    te_forward = te_forward.view(*shape[:-1], H)
     te_forward = utils.to_reference(te_forward)
 
     with flag_gems.use_gems():


### PR DESCRIPTION
## Summary
- **Operator:** swiglu
- **Error type:** accuracy_fail
- **Root cause:** The flag_gems.swiglu operator is numerically correct for all shapes/dtypes; the failures originated in the test's reference, where TransformerEngine's tex.swiglu on the musa backend requires a strictly 2-D input but the test passed non-2-D shapes (1-D/3-D/4-D) directly, raising 'cast_gated: input.data.shape.size() == 2' before any accuracy assertion.
- **Fix:** Reshape the reference input to 2-D (view(-1, last_dim)) before calling tex.swiglu, then reshape the output back to (*shape[:-1], H), mirroring the operator's internal flatten. Portable across vendors (NVIDIA TE also expects 2-D). Additionally wrapped the TE reference in the benchmark (te_swiglu_op) to flatten to 2-D so the benchmark runs on musa, matching the accuracy test fix.
- **Files modified:**
  - `tests/test_swiglu.py`
  - `benchmark/test_swiglu.py`

## Verification
- Accuracy test: 36/36 passed
- Benchmark: passed
- Format check: passed

## Test Plan
- [ ] `pytest -m 'swiglu' tests/ --ref cpu -vs`
- [ ] `pytest -m 'swiglu' benchmark/ --level core --record log`

## Issue
- WEEKTEST-564
