### PR TITLE
[KernelGen][Mthreads] Fix reglu: accuracy_fail

### DIFF
--- a/benchmark/test_reglu.py
+++ b/benchmark/test_reglu.py
@@ -16,12 +16,23 @@ except ImportError:
     TE_OP = None
 
 
+def te_reglu_op(input_tensor, quantizer=None):
+    # TransformerEngine's reglu kernel only accepts 2-D inputs on this backend
+    # (its cast_gated kernel asserts input.data.shape.size() == 2), so collapse
+    # all leading dims before calling it and restore the output shape afterwards.
+    shape = input_tensor.shape
+    last_dim = shape[-1]
+    input_2d = input_tensor.contiguous().view(-1, last_dim)
+    out = TE_OP(input_2d, quantizer)
+    return out.view(*shape[:-1], last_dim // 2)
+
+
 @pytest.mark.reglu
 @pytest.mark.skipif(TE_OP is None, reason="TransformerEngine not installed")
 def test_reglu():
     bench = base.TexGluForwardBenchmark(
         op_name="reglu",
-        torch_op=TE_OP,
+        torch_op=te_reglu_op,
         gems_op=flag_gems.reglu,
         dtypes=consts.FLOAT_DTYPES,
     )

--- a/tests/test_reglu.py
+++ b/tests/test_reglu.py
@@ -13,6 +13,17 @@ except ImportError:
     TE_AVAILABLE = False
 
 
+def te_reglu_ref(input_tensor):
+    # TransformerEngine's reglu kernel on this backend only accepts 2-D inputs
+    # (its cast_gated kernel asserts input.data.shape.size() == 2), so collapse
+    # all leading dims before calling it and restore the output shape afterwards.
+    shape = input_tensor.shape
+    last_dim = shape[-1]
+    input_2d = input_tensor.contiguous().view(-1, last_dim)
+    ref_out = tex.reglu(input_2d, None)
+    return ref_out.view(*shape[:-1], last_dim // 2)
+
+
 @pytest.mark.reglu
 @pytest.mark.parametrize("shape", utils.GLU_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
@@ -20,7 +31,7 @@ except ImportError:
 def test_reglu(shape, dtype):
     input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
 
-    ref_out = tex.reglu(input_tensor, None)
+    ref_out = te_reglu_ref(input_tensor)
     ref_out = utils.to_reference(ref_out)
     with flag_gems.use_gems():
         res_out = flag_gems.reglu(input_tensor)


### PR DESCRIPTION
## Summary
- **Operator:** reglu
- **Error type:** accuracy_fail
- **Root cause:** The FlagGems reglu kernel is correct; the failures came from the reference path. TransformerEngine's reglu kernel on the mthreads backend only accepts 2-D inputs (its cast_gated kernel asserts input.data.shape.size() == 2), so calling tex.reglu on 1-D/3-D/4-D/5-D test shapes crashed, failing 12 of 15 accuracy cases and the benchmark.
- **Fix:** Wrapped the TE reference call in the accuracy test (te_reglu_ref helper) and in the benchmark (te_reglu_op wrapper) to flatten leading dims into a 2-D tensor before invoking tex.reglu and restore the original output shape afterwards. No operator source code was changed.
- **Files modified:**
  - `tests/test_reglu.py`
  - `benchmark/test_reglu.py`

## Verification
- Accuracy test: 15/15 passed
- Benchmark: passed
- Format check: passed

## Test Plan
- [ ] `pytest -m 'reglu' tests/ --ref cpu -vs`
- [ ] `pytest -m 'reglu' benchmark/ --level core --record log`

## Issue
- WEEKTEST-563
