### PR TITLE
[KernelGen][Mthreads] Fix reciprocal_: accuracy_fail

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -34,6 +34,7 @@ from .rand_like import rand_like
 from .randn import randn
 from .randn_like import randn_like
 from .randperm import randperm
+from .reciprocal import reciprocal, reciprocal_
 from .repeat import repeat
 from .repeat_interleave import (
     repeat_interleave_self_int,
@@ -102,6 +103,8 @@ __all__ = [
     "repeat_interleave_self_int",
     "repeat_interleave_self_tensor",
     "repeat_interleave_tensor",
+    "reciprocal",
+    "reciprocal_",
     "resolve_conj",
     "sort",
     "sort_stable",

--- a/src/flag_gems/runtime/backend/_mthreads/ops/reciprocal.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/reciprocal.py
@@ -1,0 +1,38 @@
+import logging
+
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+
+logger = logging.getLogger(
+    f'flag_gems.runtime.backend._mthreads.ops.{__name__.split(".")[-1]}'
+)
+
+
+@pointwise_dynamic(promotion_methods=[(0, "INT_TO_FLOAT")])
+@triton.jit
+def reciprocal_func(x):
+    y = 1.0 / x.to(tl.float32)
+    # The mthreads backend saturates fp16 results that exceed the finite
+    # range to 65504.0 instead of producing +/-inf like PyTorch, so restore
+    # the IEEE-754 overflow semantics for float16 outputs.
+    if tl.constexpr(x.dtype == tl.float16):
+        pos_overflow = y >= 65504.0
+        neg_overflow = y <= -65504.0
+        y = tl.where(
+            pos_overflow,
+            float("inf"),
+            tl.where(neg_overflow, float("-inf"), y),
+        )
+    return y
+
+
+def reciprocal(A):
+    logger.debug("GEMS_MTHREADS RECIPROCAL")
+    return reciprocal_func(A)
+
+
+def reciprocal_(A):
+    logger.debug("GEMS_MTHREADS RECIPROCAL_")
+    return reciprocal_func(A, out0=A)


### PR DESCRIPTION
## Summary
- **Operator:** reciprocal_
- **Error type:** accuracy_fail
- **Root cause:** On the mthreads backend, the Triton compiler saturates float16 results that exceed the finite range to 65504.0 instead of producing +/-inf like PyTorch/IEEE-754. For reciprocal_ of a small fp16 subnormal (e.g. 60*2^-24 ~= 3.58e-06), 1/x ~= 279620 overflows fp16, so the kernel returned 65504.0 while the CPU float64 reference rounds to inf, failing gems_assert_close with equal_nan=True.
- **Fix:** Added a mthreads backend override (src/flag_gems/runtime/backend/_mthreads/ops/reciprocal.py) for reciprocal and reciprocal_ using pointwise_dynamic, with an explicit overflow guard that maps float16 results whose magnitude >= 65504.0 back to +/-inf, restoring IEEE-754 overflow semantics to match the PyTorch reference. Registered the functions in the mthreads ops __init__.py.
- **Files modified:**
  - `src/flag_gems/runtime/backend/_mthreads/ops/__init__.py`
  - `src/flag_gems/runtime/backend/_mthreads/ops/reciprocal.py`

## Verification
- Accuracy test: 18/18 passed
- Benchmark: passed
- Format check: passed

## Test Plan
- [ ] `pytest -m 'reciprocal_' tests/ --ref cpu -vs`
- [ ] `pytest -m 'reciprocal_' benchmark/ --level core --record log`

## Issue
- WEEKTEST-554
