### PR TITLE
[KernelGen][Mthreads] Fix linear: accuracy_fail

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_mthreads/tune_configs.yaml
@@ -89,6 +89,59 @@ addmm:
       BLOCK_SIZE_K: 32
     num_stages: 1
     num_warps: 4
+linear:
+  # The NVIDIA default's first config (BLOCK_SIZE 128x256x64, num_stages=3) fails to
+  # compile for fp32 on MUSA (Triton Error [MUSA]: invalid argument during autotune).
+  # num_stages=2 keeps the tile size but fits the MUSA fp32 pipeline; the remaining
+  # configs are unchanged from the NVIDIA default and safe across all dtypes.
+  - META:
+      BLOCK_SIZE_M: 128
+      BLOCK_SIZE_N: 256
+      BLOCK_SIZE_K: 64
+    num_stages: 2
+    num_warps: 8
+  - META:
+      BLOCK_SIZE_M: 64
+      BLOCK_SIZE_N: 256
+      BLOCK_SIZE_K: 32
+    num_stages: 4
+    num_warps: 4
+  - META:
+      BLOCK_SIZE_M: 128
+      BLOCK_SIZE_N: 128
+      BLOCK_SIZE_K: 32
+    num_stages: 4
+    num_warps: 4
+  - META:
+      BLOCK_SIZE_M: 128
+      BLOCK_SIZE_N: 64
+      BLOCK_SIZE_K: 32
+    num_stages: 4
+    num_warps: 4
+  - META:
+      BLOCK_SIZE_M: 64
+      BLOCK_SIZE_N: 128
+      BLOCK_SIZE_K: 32
+    num_stages: 4
+    num_warps: 4
+  - META:
+      BLOCK_SIZE_M: 128
+      BLOCK_SIZE_N: 32
+      BLOCK_SIZE_K: 32
+    num_stages: 4
+    num_warps: 4
+  - META:
+      BLOCK_SIZE_M: 64
+      BLOCK_SIZE_N: 32
+      BLOCK_SIZE_K: 32
+    num_stages: 5
+    num_warps: 2
+  - META:
+      BLOCK_SIZE_M: 32
+      BLOCK_SIZE_N: 64
+      BLOCK_SIZE_K: 32
+    num_stages: 5
+    num_warps: 2
 cross_entropy_loss:
   - META:
       BLOCK_C: 256


### PR DESCRIPTION
## Summary
- **Operator:** linear
- **Error type:** accuracy_fail
- **Root cause:** The linear operator had no mthreads-specific autotune config, so it used the NVIDIA default set whose first tile (128x256x64, num_stages=3) fails to compile for fp32 on MUSA ('Triton Error [MUSA]: invalid argument' during the pipelined tl.dot loop), crashing the benchmark.
- **Fix:** Added a linear override in _mthreads/tune_configs.yaml: changed the first config's num_stages from 3 to 2 (keeping the tile size, which fits the MUSA fp32 pipeline) and reused the remaining NVIDIA configs unchanged; all dtypes/shapes now run successfully.
- **Files modified:**
  - `src/flag_gems/runtime/backend/_mthreads/tune_configs.yaml`

## Verification
- Accuracy test: 12/12 passed
- Benchmark: passed
- Format check: passed

## Test Plan
- [ ] `pytest -m 'linear' tests/ --ref cpu -vs`
- [ ] `pytest -m 'linear' benchmark/ --level core --record log`

## Issue
- WEEKTEST-558
