### PR TITLE
[KernelGen][Mthreads] Fix trunc_divide_: accuracy_fail

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/__init__.py
@@ -8,6 +8,7 @@ from .argmin import argmin
 from .batch_norm import batch_norm, batch_norm_backward
 from .celu import celu
 from .conv2d import conv2d
+from .div import div_mode, div_mode_
 from .dropout import dropout, dropout_backward
 from .gather import gather, gather_backward
 from .index_add import index_add, index_add_
@@ -64,6 +65,8 @@ __all__ = [
     "celu",
     # "celu_",
     "conv2d",
+    "div_mode",
+    "div_mode_",
     "dropout",
     "dropout_backward",
     "gather",

--- a/src/flag_gems/runtime/backend/_mthreads/ops/div.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/div.py
@@ -1,0 +1,315 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.utils import pointwise_dynamic
+from flag_gems.utils.pointwise_dynamic import ComplexMode
+from flag_gems.utils.triton_lang_extension import div_rn, fmod, trunc
+
+logger = logging.getLogger(__name__)
+
+
+@pointwise_dynamic(
+    is_tensor=[True, True, True, True],
+    num_outputs=2,
+    promotion_methods=[
+        (0, 1, 2, 3, "INT_TO_FLOAT"),
+        (0, 1, 2, 3, "INT_TO_FLOAT"),
+    ],
+)
+@triton.jit
+def div_complex_kernel(ar, ai, br, bi):
+    # Smith's method: avoid overflow by dividing by the larger component
+    abs_br = tl.abs(br)
+    abs_bi = tl.abs(bi)
+    use_br = abs_br >= abs_bi
+
+    # When |br| >= |bi|: ratio = bi/br, denom = br + bi*ratio
+    ratio1 = tl.where(br == 0, 0.0, bi / br)
+    denom1 = br + bi * ratio1
+    real1 = (ar + ai * ratio1) / denom1
+    imag1 = (ai - ar * ratio1) / denom1
+
+    # When |bi| > |br|: ratio = br/bi, denom = bi + br*ratio
+    ratio2 = tl.where(bi == 0, 0.0, br / bi)
+    denom2 = bi + br * ratio2
+    real2 = (ar * ratio2 + ai) / denom2
+    imag2 = (ai * ratio2 - ar) / denom2
+
+    real = tl.where(use_br, real1, real2)
+    imag = tl.where(use_br, imag1, imag2)
+    return real, imag
+
+
+@pointwise_dynamic(promotion_methods=[(0, 1, "INT_TO_FLOAT")])
+@triton.jit
+def true_div_func(x, y):
+    return x / y
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "INT_TO_FLOAT")])
+@triton.jit
+def true_div_func_tensor_scalar(x, y):
+    return x / y
+
+
+@pointwise_dynamic(is_tensor=[False, True], promotion_methods=[(0, 1, "INT_TO_FLOAT")])
+@triton.jit
+def true_div_func_scalar_tensor(x, y):
+    return x / y
+
+
+# Register complex support
+true_div_func.register_complex(mode=ComplexMode.CROSS, cross_kernel=div_complex_kernel)
+true_div_func_tensor_scalar.register_complex(
+    mode=ComplexMode.CROSS, tensorize_scalars=True, fallback_target=true_div_func
+)
+true_div_func_scalar_tensor.register_complex(
+    mode=ComplexMode.CROSS, tensorize_scalars=True, fallback_target=true_div_func
+)
+
+
+def true_divide(A, B):
+    logger.debug("GEMS MTHREADS TRUE_DIVIDE")
+    if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
+        return true_div_func(A, B)
+    elif isinstance(A, torch.Tensor):
+        return true_div_func_tensor_scalar(A, B)
+    elif isinstance(B, torch.Tensor):
+        return true_div_func_scalar_tensor(A, B)
+    else:
+        # Both scalar
+        return torch.tensor(A / B)
+
+
+def true_divide_out(A, B, out):
+    logger.debug("GEMS MTHREADS TRUE_DIVIDE OUT")
+    if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
+        return true_div_func(A, B, out0=out)
+    elif isinstance(A, torch.Tensor):
+        return true_div_func_tensor_scalar(A, B, out0=out)
+    elif isinstance(B, torch.Tensor):
+        return true_div_func_scalar_tensor(A, B, out0=out)
+    else:
+        # Both scalar
+        return torch.tensor(A / B) if out is None else out.fill_(A / B)
+
+
+def true_divide_(A, B):
+    logger.debug("GEMS MTHREADS TRUE_DIVIDE_")
+    if isinstance(B, torch.Tensor):
+        return true_div_func(A, B, out0=A)
+    else:
+        return true_div_func_tensor_scalar(A, B, out0=A)
+
+
+# NOTE: torch's trunc-division is the correctly-rounded (round-to-nearest)
+# quotient truncated toward zero. mthreads' plain `x / y` and `div_rz` can both
+# drift ~1 ULP from the correctly-rounded result (and div_rz additionally
+# rounds toward zero before trunc), so neither matches torch on fp32. `div_rn`
+# maps to the round-to-nearest division intrinsic, and trunc() of that matches
+# torch's trunc-division exactly on fp32.
+@pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def trunc_div_func(x, y):
+    return trunc(div_rn(x, y))
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def trunc_div_func_tensor_scalar(x, y):
+    return trunc(div_rn(x, tl.cast(y, x.dtype)))
+
+
+@pointwise_dynamic(is_tensor=[False, True], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def trunc_div_func_scalar_tensor(x, y):
+    return trunc(div_rn(tl.cast(x, y.dtype), y))
+
+
+# Integer truncation division: Triton's // on integers is C-style (truncates toward zero)
+@pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def trunc_div_int_func(x, y):
+    return x // y
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def trunc_div_int_func_tensor_scalar(x, y):
+    return x // y
+
+
+@pointwise_dynamic(is_tensor=[False, True], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def trunc_div_int_func_scalar_tensor(x, y):
+    return x // y
+
+
+def trunc_divide(A, B):
+    logger.debug("GEMS MTHREADS TRUNC_DIVIDE")
+    # Integer types: use dedicated int kernels (Triton // is C-style truncation)
+    if isinstance(A, torch.Tensor) and not A.is_floating_point():
+        if isinstance(B, torch.Tensor):
+            return trunc_div_int_func(A, B)
+        else:
+            return trunc_div_int_func_tensor_scalar(A, B)
+    if isinstance(B, torch.Tensor) and not B.is_floating_point():
+        return trunc_div_int_func_scalar_tensor(A, B)
+    if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
+        return trunc_div_func(A, B)
+    elif isinstance(A, torch.Tensor):
+        return trunc_div_func_tensor_scalar(A, B)
+    elif isinstance(B, torch.Tensor):
+        return trunc_div_func_scalar_tensor(A, B)
+    else:
+        # Both scalar
+        return torch.tensor(A / B)
+
+
+def trunc_divide_(A, B):
+    logger.debug("GEMS MTHREADS TRUNC_DIVIDE_")
+    # Integer types: use dedicated int kernels (Triton // is C-style truncation)
+    if not A.is_floating_point():
+        if isinstance(B, torch.Tensor):
+            return trunc_div_int_func(A, B, out0=A)
+        else:
+            return trunc_div_int_func_tensor_scalar(A, B, out0=A)
+    if isinstance(B, torch.Tensor):
+        return trunc_div_func(A, B, out0=A)
+    else:
+        return trunc_div_func_tensor_scalar(A, B, out0=A)
+
+
+@triton.jit
+def _int_floordiv(x, y):
+    # TODO: request Triton to add an integer remainder builtin
+    # The semantic of Triton floordiv differs from Pytorch/Numpy
+    # Triton floordiv equates to
+    #     (x - np.fmod(x, y)) / y
+    # whereas Pytorch floordiv is
+    #     (x - np.remainder(x, y)) y
+    # The results show a one off difference when
+    #     C1) x and y have opposite signs
+    # and C2) x is not multiples of y.
+    # Apart from the above, there's an erroneous case x // 0 returns -1
+    # whereas in Pytorch x // 0 returns -1 if x >=0 and -2 if x < 0
+    # but this special case is coalesced into the c1 and c2 check so
+    # there's extra handling.
+    r = x % y
+    c1 = r != 0
+    c2 = (x < 0) ^ (y < 0)
+    return tl.where(c1 & c2, x // y - 1, x // y)
+
+
+# TO be consistent with python, numpy and torch, we have to implement it in the
+# following way.
+# CPython
+# https://github.com/python/cpython/blob/ace008c531dd685a30c1dd68f9b5ba35f20171cf/Objects/floatobject.c#L636
+# numpy
+# https://github.com/numpy/numpy/blob/a4ad142aa1282a77bbb05acd706cb57c9cc29846/numpy/_core/src/npymath/npy_math_internal.h.src#L532
+# torch
+# https://github.com/pytorch/pytorch/blob/d6d9183456cd07ca0b361a194b98c2fb196e7c36/c10/util/generic_math.h#L23
+@triton.jit
+def _float_floordiv(x, y):
+    # Cast to float32 for fmod/div_rn which only support fp32/fp64 on CUDA
+    orig_dtype = x.dtype
+    x_fp32 = x.to(tl.float32)
+    y_fp32 = y.to(tl.float32)
+
+    # NOTE: fmod's sign is the same as the dividend
+    remainder = fmod(x_fp32, y_fp32)
+    imperfect = remainder != 0.0
+    different_sign = (x_fp32 < 0) ^ (y_fp32 < 0)
+
+    # NOTE: we have to use div_rn explicitly here
+    q = div_rn(x_fp32 - remainder, y_fp32)
+    q = tl.where(imperfect & different_sign, q - 1, q)
+
+    floor_q = tl.math.floor(q)
+    c = q - floor_q > 0.5
+    floor_q = tl.where(c, floor_q + 1.0, floor_q)
+
+    q_is_zeros = q == 0.0
+    floor_q = tl.where(q_is_zeros, tl.where(different_sign, -0.0, 0.0), floor_q)
+
+    is_div_by_zero = y_fp32 == 0.0
+    float_division = x_fp32 / y_fp32
+    out = tl.where(is_div_by_zero, float_division, floor_q)
+    return out.to(orig_dtype)
+
+
+@pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def floor_div_func(x, y):
+    if x.type.scalar.is_int() & y.type.scalar.is_int():
+        return _int_floordiv(x, y)
+    else:
+        return _float_floordiv(x, y)
+
+
+@pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def floor_div_func_tensor_scalar(x, y):
+    if x.type.scalar.is_int() & y.type.scalar.is_int():
+        return _int_floordiv(x, y)
+    else:
+        return _float_floordiv(x, y)
+
+
+@pointwise_dynamic(is_tensor=[False, True], promotion_methods=[(0, 1, "DEFAULT")])
+@triton.jit
+def floor_div_func_scalar_tensor(x, y):
+    if x.type.scalar.is_int() & y.type.scalar.is_int():
+        return _int_floordiv(x, y)
+    else:
+        return _float_floordiv(x, y)
+
+
+def floor_divide(A, B):
+    logger.debug("GEMS MTHREADS FLOOR_DIVIDE")
+    if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
+        return floor_div_func(A, B)
+    elif isinstance(A, torch.Tensor):
+        return floor_div_func_tensor_scalar(A, B)
+    elif isinstance(B, torch.Tensor):
+        return floor_div_func_scalar_tensor(A, B)
+    else:
+        # Both scalar
+        return torch.tensor(A // B)
+
+
+def floor_divide_(A, B):
+    logger.debug("GEMS MTHREADS FLOOR_DIVIDE_")
+    if isinstance(B, torch.Tensor):
+        return floor_div_func(A, B, out0=A)
+    else:
+        return floor_div_func_tensor_scalar(A, B, out0=A)
+
+
+def div_mode(A, B, rounding_mode=None):
+    logger.debug("GEMS MTHREADS DIV_MODE")
+    if rounding_mode is None:
+        return true_divide(A, B)
+    elif rounding_mode == "trunc":
+        return trunc_divide(A, B)
+    elif rounding_mode == "floor":
+        return floor_divide(A, B)
+    else:
+        msg = f"div expected rounding_mode to be one of None, 'trunc', or 'floor' but found {rounding_mode}."
+        raise ValueError(msg)
+
+
+def div_mode_(A, B, rounding_mode=None):
+    logger.debug("GEMS MTHREADS DIV_MODE_")
+    if rounding_mode is None:
+        return true_divide_(A, B)
+    elif rounding_mode == "trunc":
+        return trunc_divide_(A, B)
+    elif rounding_mode == "floor":
+        return floor_divide_(A, B)
+    else:
+        msg = f"div expected rounding_mode to be one of None, 'trunc', or 'floor' but found {rounding_mode}."
+        raise ValueError(msg)


### PR DESCRIPTION
## Summary
- **Operator:** trunc_divide_
- **Error type:** accuracy_fail
- **Root cause:** On mthreads, the shared trunc_divide kernel used trunc(div_rz(x,y)), but div_rz maps to the round-toward-zero division intrinsic, which drifts ~1 ULP from torch's correctly-rounded (round-to-nearest) fp32 quotient before truncation. On inputs where the exact quotient lands just below an integer (e.g. -109.99999), div_rz rounds toward zero to -110 and trunc gives -110, while torch's CPU ref gives -109, producing rare off-by-one mismatches.
- **Fix:** Added an mthreads-specific override (_mthreads/ops/div.py exporting div_mode/div_mode_) whose trunc_div_func kernels compute trunc(div_rn(x,y)) instead — div_rn maps to the round-to-nearest division intrinsic, so trunc() of its result matches torch's trunc-division exactly on fp32. Integer and other div paths are preserved from the shared implementation.
- **Files modified:**
  - `src/flag_gems/runtime/backend/_mthreads/ops/div.py`
  - `src/flag_gems/runtime/backend/_mthreads/ops/__init__.py`

## Verification
- Accuracy test: 6/6 passed
- Benchmark: passed
- Format check: passed

## Test Plan
- [ ] `pytest -m 'trunc_divide_' tests/ --ref cpu -vs`
- [ ] `pytest -m 'trunc_divide_' benchmark/ --level core --record log`

## Issue
- WEEKTEST-566
