### PR TITLE
[KernelGen][Mthreads] Fix geglu: accuracy_fail

### DIFF
--- a/benchmark/test_geglu.py
+++ b/benchmark/test_geglu.py
@@ -20,6 +20,18 @@ except ImportError:
     GEMS_OP = None
 
 
+def te_geglu_op(input_tensor, quantizer=None):
+    # TransformerEngine's geglu only accepts 2-D input on some backends (e.g. musa),
+    # while FlagGems supports arbitrary shapes by flattening to 2-D internally.
+    # Flatten to 2-D for the reference and reshape the result back to the expected
+    # output shape so the comparison stays valid across vendors.
+    shape = input_tensor.shape
+    last_dim = shape[-1]
+    ref_input = input_tensor.reshape(-1, last_dim)
+    out = TE_OP(ref_input, quantizer)
+    return out.reshape(*shape[:-1], last_dim // 2)
+
+
 @pytest.mark.geglu
 @pytest.mark.skipif(not TE_AVAILABLE, reason="TransformerEngine not installed")
 @pytest.mark.skipif(TE_OP is None, reason="'geglu' not found in TransformerEngine")
@@ -27,7 +39,7 @@ except ImportError:
 def test_geglu():
     bench = base.TexGluForwardBenchmark(
         op_name="geglu",
-        torch_op=TE_OP,
+        torch_op=te_geglu_op,
         gems_op=GEMS_OP,
         dtypes=consts.FLOAT_DTYPES,
     )

--- a/tests/test_geglu.py
+++ b/tests/test_geglu.py
@@ -20,8 +20,12 @@ except ImportError:
 def test_geglu(shape, dtype):
     input_tensor = torch.randn(shape, dtype=dtype, device=flag_gems.device)
 
-    ref_out = tex.geglu(input_tensor, None)
-    ref_out = utils.to_reference(ref_out)
+    H = shape[-1] // 2
+    M = input_tensor.numel() // (2 * H)
+    # TransformerEngine's geglu only accepts 2D input; flatten to 2D for the
+    # reference and reshape the result back to the expected output shape.
+    ref_out = tex.geglu(input_tensor.reshape(M, 2 * H), None)
+    ref_out = utils.to_reference(ref_out).reshape(*shape[:-1], H)
 
     with flag_gems.use_gems():
         res_out = flag_gems.geglu(input_tensor)


### PR DESCRIPTION
## Summary
- **Operator:** geglu
- **Error type:** accuracy_fail
- **Root cause:** The test passed the N-D input tensor directly to TransformerEngine's tex.geglu as the reference, but TE's geglu (mthreads build) asserts input must be strictly 2D, so every non-2D shape crashed in the reference before reaching the operator. The FlagGems geglu operator itself is correct.
- **Fix:** In tests/test_geglu.py, flatten the input to 2D before calling tex.geglu for the reference, then reshape the reference output back to the expected (..., H) shape. No operator code change needed. Additionally wrapped the TE reference in the benchmark (te_geglu_op) to flatten to 2-D so the benchmark runs on musa, matching the accuracy test fix.
- **Files modified:**
  - `tests/test_geglu.py`
  - `benchmark/test_geglu.py`

## Verification
- Accuracy test: 15/15 passed
- Benchmark: passed
- Format check: passed

## Test Plan
- [ ] `pytest -m 'geglu' tests/ --ref cpu -vs`
- [ ] `pytest -m 'geglu' benchmark/ --level core --record log`

## Issue
- WEEKTEST-562
