### PR TITLE
Optimize w8a8_block_fp8_bmm

### DIFF
--- a/src/flag_gems/runtime/backend/_nvidia/hopper/general_ops_hopper_expand.yaml
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/general_ops_hopper_expand.yaml
@@ -315,3 +315,80 @@ mul:
       n_elements: align32
       n_cols: default
       dtype: default
+w8a8_block_fp8_bmm_general:
+  - config:
+    param_map:
+      META:
+        BLOCK_M: block_m
+        BLOCK_N: block_n
+        BLOCK_K: block_k
+        GROUP_M: group_m
+      num_stages: stages
+      num_warps: warps
+    block_m:
+      - 16
+      - 64
+    block_n:
+      - 16
+      - 32
+      - 64
+    block_k:
+      - 128
+    group_m:
+      - 1
+      - 2
+      - 4
+      - 8
+    stages:
+      - 3
+      - 4
+      - 5
+      - 6
+    warps:
+      - 4
+  - strategy:
+      B: default
+      M: align32
+      N: align32
+      K: align32
+      stride_xm: align32
+      stride_yk: align32
+w8a8_block_fp8_bmm_splitk:
+  - config:
+    param_map:
+      META:
+        BLOCK_M: block_m
+        BLOCK_N: block_n
+        BLOCK_K: block_k
+        SPLIT_K: split_k
+      num_stages: stages
+      num_warps: warps
+    block_m:
+      - 8
+      - 16
+      - 64
+    block_n:
+      - 32
+      - 64
+    block_k:
+      - 128
+    split_k:
+      - 2
+      - 4
+      - 8
+      - 16
+      - 32
+    stages:
+      - 2
+      - 3
+      - 4
+    warps:
+      - 4
+      - 8
+  - strategy:
+      B: default
+      M: align32
+      N: align32
+      K: align32
+      stride_xm: align32
+      stride_yk: align32

--- a/src/flag_gems/runtime/backend/_nvidia/hopper/ops/w8a8_block_fp8_bmm.py
+++ b/src/flag_gems/runtime/backend/_nvidia/hopper/ops/w8a8_block_fp8_bmm.py
@@ -2,455 +2,612 @@ from typing import List, Optional
 
 import torch
 import triton
-from triton.experimental import gluon
-from triton.experimental.gluon import language as gl
-from triton.experimental.gluon.language.nvidia.hopper import (
-    fence_async_shared,
-    mbarrier,
-    tma,
-    warpgroup_mma,
-    warpgroup_mma_wait,
-)
-from triton.experimental.gluon.nvidia.hopper import TensorDescriptor
-from triton.language.core import _aggregate as aggregate
+import triton.language as tl
 
 from flag_gems import runtime
 from flag_gems.utils import libentry, libtuner
+from flag_gems.utils.libentry import LibTuner
+from flag_gems.utils.triton_version_utils import has_triton_tle
 
-_TORCH_TO_GL_DTYPE = {
-    torch.float8_e4m3fn: gl.float8e4nv,
-    torch.float8_e5m2: gl.float8e5,
-    torch.bfloat16: gl.bfloat16,
-    torch.float16: gl.float16,
-    torch.float32: gl.float32,
-}
-
-
-def _gl_dtype(t: torch.Tensor):
+if has_triton_tle(3, 6, 0):
     try:
-        return _TORCH_TO_GL_DTYPE[t.dtype]
-    except KeyError as e:
-        raise TypeError(f"Unsupported tensor dtype: {t.dtype}") from e
+        import triton.experimental.tle.language as tle
+
+        HAS_TLE_W8A8_BLOCK_FP8_BMM = True
+    except ImportError:
+        tle = None
+        HAS_TLE_W8A8_BLOCK_FP8_BMM = False
+else:
+    tle = None
+    HAS_TLE_W8A8_BLOCK_FP8_BMM = False
 
 
-@gluon.constexpr_function
-def get_warps_per_cta(BLOCK_M, BLOCK_N, num_warps):
-    warps_per_cta = [4, 1]
-    m = 16
-    while warps_per_cta[0] * warps_per_cta[1] != num_warps:
-        if BLOCK_M > m * warps_per_cta[0]:
-            warps_per_cta[0] *= 2
-        else:
-            warps_per_cta[1] *= 2
-    return warps_per_cta
+def _set_triton_descriptor_allocator(device: torch.device) -> None:
+    def alloc_fn(size: int, align: int, stream):
+        _ = align
+        _ = stream
+        return torch.empty(size, dtype=torch.int8, device=device)
+
+    triton.set_allocator(alloc_fn)
 
 
-@gluon.constexpr_function
-def get_instr_shape_n(BLOCK_M, BLOCK_N, num_warps):
-    m = 16
-    m_reps = triton.cdiv(BLOCK_M, m)
-    n_reps = triton.cdiv(num_warps, m_reps)
-    max_n = max(BLOCK_N // n_reps, 8)
-    n = 256
-    while n > max_n or BLOCK_N % n != 0:
-        n -= 8
-    assert n >= 8, "expected to find a valid n"
-    return n
+def _get_tle_w8a8_block_fp8_bmm_configs():
+    # TLE shared-memory tensors require power-of-two shapes, so stage counts
+    # like 6 cannot compile.  Stage 8 compiles, but hits launch failures on
+    # large DeepSeek-V4 Pro shapes (for example BMM K=7168), so keep the stable
+    # Hopper TLE path on 4 stages for now.
+    return [
+        config
+        for config in runtime.get_tuned_config("w8a8_block_fp8_bmm")
+        if config.num_stages == 4
+    ]
 
 
-@gluon.constexpr_function
-def pick_wgmma_layout(dtype, BLOCK_M, BLOCK_N, num_warps):
-    m = 16
-    k = 256 // dtype.primitive_bitwidth
-    n = get_instr_shape_n(BLOCK_M, BLOCK_N, num_warps)
-    warps_per_cta = get_warps_per_cta(BLOCK_M, BLOCK_N, num_warps)
-    return gl.NVMMADistributedLayout(
-        version=[3, 0],
-        warps_per_cta=warps_per_cta,
-        instr_shape=[m, n, k],
-    )
+def _filter_tle_w8a8_block_fp8_bmm_configs(configs):
+    return [config for config in configs if config.num_stages == 4]
 
 
-@aggregate
-class Config:
-    B: gl.constexpr
-    M: gl.constexpr
-    M_aligned: gl.constexpr
-    N: gl.constexpr
-    K: gl.constexpr
-    BLOCK_M: gl.constexpr
-    BLOCK_N: gl.constexpr
-    BLOCK_K: gl.constexpr
-    TILE_ORDER: gl.constexpr
-    SWAP_AB: gl.constexpr
-    num_warps: gl.constexpr
-    num_stages: gl.constexpr
-    num_sms: gl.constexpr
-    # xs (per-token scale) strides into the caller's [B, M, num_kb] tensor.
-    xs_sB: gl.constexpr
-    xs_sM: gl.constexpr
-    xs_sKb: gl.constexpr
-    # Derived: tile counts.
-    num_m_tiles: gl.constexpr
-    num_n_tiles: gl.constexpr
-    num_k_blocks: gl.constexpr
-    num_tiles_per_batch: gl.constexpr
-    num_tiles: gl.constexpr
+class _TLEW8A8BlockFP8BMMTuner(LibTuner.get("default")):
+    def _keep_tle_configs(self):
+        configs = _filter_tle_w8a8_block_fp8_bmm_configs(self.configs)
+        if not configs:
+            configs = _filter_tle_w8a8_block_fp8_bmm_configs(
+                self._flagtune_default_configs
+            )
+        if configs and len(configs) != len(self.configs):
+            self._set_configs_and_strategy(configs, self.strategy)
+            return True
+        return False
 
-    @gluon.constexpr_function
-    def __init__(
-        self,
-        B,
-        M,
-        M_aligned,
-        N,
-        K,
-        BLOCK_M,
-        BLOCK_N,
-        BLOCK_K,
-        TILE_ORDER,
-        SWAP_AB,
-        num_warps,
-        num_stages,
-        num_sms,
-        xs_sB,
-        xs_sM,
-        xs_sKb,
-    ):
-        self.B = gl.constexpr(B)
-        self.M = gl.constexpr(M)
-        self.M_aligned = gl.constexpr(M_aligned)
-        self.N = gl.constexpr(N)
-        self.K = gl.constexpr(K)
-        self.BLOCK_M = gl.constexpr(BLOCK_M)
-        self.BLOCK_N = gl.constexpr(BLOCK_N)
-        self.BLOCK_K = gl.constexpr(BLOCK_K)
-        self.TILE_ORDER = gl.constexpr(TILE_ORDER)
-        self.SWAP_AB = gl.constexpr(SWAP_AB)
-        self.num_warps = gl.constexpr(num_warps)
-        self.num_stages = gl.constexpr(num_stages)
-        self.num_sms = gl.constexpr(num_sms)
-        self.xs_sB = gl.constexpr(xs_sB)
-        self.xs_sM = gl.constexpr(xs_sM)
-        self.xs_sKb = gl.constexpr(xs_sKb)
-        num_m = M_aligned // BLOCK_M
-        num_n = N // BLOCK_N
-        self.num_m_tiles = gl.constexpr(num_m)
-        self.num_n_tiles = gl.constexpr(num_n)
-        self.num_k_blocks = gl.constexpr(K // BLOCK_K)
-        self.num_tiles_per_batch = gl.constexpr(num_m * num_n)
-        self.num_tiles = gl.constexpr(B * num_m * num_n)
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._keep_tle_configs()
+
+    def apply_flagtune(self):
+        changed = super().apply_flagtune()
+        return self._keep_tle_configs() or changed
 
 
-@aggregate
-class BarrierCounter:
-    index: gl.tensor
-    phase: gl.tensor
-    num_barriers: gl.constexpr
-
-    @gluon.constexpr_function
-    def __init__(self, index, phase, num_barriers):
-        self.index = index
-        self.phase = phase
-        self.num_barriers = gl.constexpr(num_barriers)
-
-    @gluon.must_use_result
-    @gluon.jit
-    def increment(self):
-        if self.num_barriers == 1:
-            return BarrierCounter(gl.to_tensor(0), self.phase ^ 1, self.num_barriers)
-        next_index = self.index + 1
-        rollover = next_index == self.num_barriers
-        index = gl.where(rollover, 0, next_index)
-        phase = gl.where(rollover, self.phase ^ 1, self.phase)
-        return BarrierCounter(index, phase, self.num_barriers)
-
-
-@aggregate
-class Channel:
-    x_smem: gl.shared_memory_descriptor
-    y_smem: gl.shared_memory_descriptor
-    ready_bars: gl.shared_memory_descriptor
-    empty_bars: gl.shared_memory_descriptor
-    num_stages: gl.constexpr
-
-    @gluon.constexpr_function
-    def __init__(self, x_smem, y_smem, ready_bars, empty_bars, num_stages):
-        self.x_smem = x_smem
-        self.y_smem = y_smem
-        self.ready_bars = ready_bars
-        self.empty_bars = empty_bars
-        self.num_stages = gl.constexpr(num_stages)
-
-    @gluon.jit
-    def alloc(
-        BLOCK_M: gl.constexpr,
-        BLOCK_N: gl.constexpr,
-        BLOCK_K: gl.constexpr,
-        x_dtype: gl.constexpr,
-        x_layout: gl.constexpr,
-        y_dtype: gl.constexpr,
-        y_layout: gl.constexpr,
-        num_stages: gl.constexpr,
-        num_warps: gl.constexpr,
-    ):
-        # x: 3D box [1, BLOCK_M, BLOCK_K] (x is permuted/non-contig at the global level).
-        # y: 2D box. xs is loaded directly with gl.load (not staged through smem).
-        x_smem = gl.allocate_shared_memory(
-            x_dtype, [num_stages, 1, BLOCK_M, BLOCK_K], x_layout
-        )
-        y_smem = gl.allocate_shared_memory(
-            y_dtype, [num_stages, BLOCK_N, BLOCK_K], y_layout
-        )
-        ready_bars = gl.allocate_shared_memory(
-            gl.int64, [num_stages, 1], mbarrier.MBarrierLayout()
-        )
-        empty_bars = gl.allocate_shared_memory(
-            gl.int64, [num_stages, 1], mbarrier.MBarrierLayout()
-        )
-        for i in gl.static_range(num_stages):
-            mbarrier.init(ready_bars.index(i), count=1)
-            mbarrier.init(empty_bars.index(i), count=1)
-            mbarrier.arrive(empty_bars.index(i), count=1)
-        return Channel(x_smem, y_smem, ready_bars, empty_bars, num_stages)
-
-    @gluon.jit
-    def release(self):
-        self.x_smem._keep_alive()
-        self.y_smem._keep_alive()
-        for i in gl.static_range(self.num_stages):
-            mbarrier.invalidate(self.ready_bars.index(i))
-            mbarrier.invalidate(self.empty_bars.index(i))
-
-
-@gluon.jit
-def get_tile(tile_id, config):
+@triton.jit
+def _get_tile(
+    tile_id,
+    num_m_tiles: tl.constexpr,
+    num_n_tiles: tl.constexpr,
+    num_tiles_per_batch: tl.constexpr,
+    TILE_ORDER: tl.constexpr,
+):
     # TILE_ORDER: 0 = horizontal (N fastest within batch — favours x reuse across N sweep)
     #             1 = vertical   (M fastest within batch — favours y reuse across M sweep)
-    batch_id = tile_id // config.num_tiles_per_batch
-    local_id = tile_id % config.num_tiles_per_batch
-    if config.TILE_ORDER == 0:
-        m_tile_id = local_id // config.num_n_tiles
-        n_tile_id = local_id % config.num_n_tiles
+    batch_id = tile_id // num_tiles_per_batch
+    local_id = tile_id % num_tiles_per_batch
+    if TILE_ORDER == 0:
+        m_tile_id = local_id // num_n_tiles
+        n_tile_id = local_id % num_n_tiles
     else:
-        n_tile_id = local_id // config.num_m_tiles
-        m_tile_id = local_id % config.num_m_tiles
+        n_tile_id = local_id // num_m_tiles
+        m_tile_id = local_id % num_m_tiles
     return batch_id, m_tile_id, n_tile_id
 
 
-@gluon.jit
-def compute_partition(channel, config, tensors):
-    x_desc, y_desc, xs_ptr, z_desc, ys_ptr = tensors
-    start_pid = gl.program_id(0)
-    counter = BarrierCounter(
-        index=gl.to_tensor(0), phase=gl.to_tensor(0), num_barriers=config.num_stages
-    )
+@triton.jit
+def _tle_w8a8_block_fp8_bmm_compute_partition(
+    x_smem,
+    y_smem,
+    empty_x,
+    empty_y,
+    full_x,
+    full_y,
+    xs_ptr,
+    z_ptr,
+    ys_ptr,
+    xs_sB: tl.constexpr,
+    xs_sM: tl.constexpr,
+    xs_sKb: tl.constexpr,
+    z_sB: tl.constexpr,
+    z_sM: tl.constexpr,
+    z_sN: tl.constexpr,
+    B: tl.constexpr,
+    M: tl.constexpr,
+    M_aligned: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    TILE_ORDER: tl.constexpr,
+    SWAP_AB: tl.constexpr,
+    num_stages: tl.constexpr,
+    num_sms: tl.constexpr,
+):
+    start_pid = tl.program_id(0)
+    num_m_tiles: tl.constexpr = M_aligned // BLOCK_M
+    num_n_tiles: tl.constexpr = N // BLOCK_N
+    num_k_blocks: tl.constexpr = K // BLOCK_K
+    num_tiles_per_batch: tl.constexpr = num_m_tiles * num_n_tiles
+    num_tiles: tl.constexpr = B * num_tiles_per_batch
+    xs_lane = tl.arange(0, BLOCK_M)
 
-    if config.SWAP_AB:
-        mma_layout: gl.constexpr = pick_wgmma_layout(
-            x_desc.dtype, config.BLOCK_N, config.BLOCK_M, num_warps=config.num_warps
+    for tile_id in range(start_pid, num_tiles, num_sms):
+        batch_id, m_tile_id, n_tile_id = _get_tile(
+            tile_id, num_m_tiles, num_n_tiles, num_tiles_per_batch, TILE_ORDER
         )
-        xs_load_layout: gl.constexpr = gl.SliceLayout(0, mma_layout)
-    else:
-        mma_layout: gl.constexpr = pick_wgmma_layout(
-            x_desc.dtype, config.BLOCK_M, config.BLOCK_N, num_warps=config.num_warps
-        )
-        xs_load_layout: gl.constexpr = gl.SliceLayout(1, mma_layout)
-
-    z_smem_layout: gl.constexpr = gl.NVMMASharedLayout.get_default_for(
-        [1, config.BLOCK_M, config.BLOCK_N], z_desc.dtype
-    )
-    z_smem = gl.allocate_shared_memory(
-        z_desc.dtype, [1, config.BLOCK_M, config.BLOCK_N], z_smem_layout
-    )
-
-    # xs in-tile lane indices (one fp32 per token along BLOCK_M).
-    xs_lane = gl.arange(0, config.BLOCK_M, layout=xs_load_layout)
-
-    for tile_id in range(start_pid, config.num_tiles, config.num_sms):
-        batch_id, m_tile_id, n_tile_id = get_tile(tile_id, config)
-        m_start = m_tile_id * config.BLOCK_M
-        n_start = n_tile_id * config.BLOCK_N
+        m_start = m_tile_id * BLOCK_M
+        n_start = n_tile_id * BLOCK_N
         # ys layout matches the scale grid (N/BLOCK_N, K/BLOCK_K); one scale per (n_tile, k_block).
-        ys_base = (batch_id * config.num_n_tiles + n_tile_id) * config.num_k_blocks
+        ys_base = (batch_id * num_n_tiles + n_tile_id) * num_k_blocks
         # xs is the caller's [B, M, num_kb] tensor (strided, possibly non-contig).
         xs_m = m_start + xs_lane
-        xs_mask = xs_m < config.M
-        xs_row_base = batch_id * config.xs_sB + xs_m * config.xs_sM
+        xs_mask = xs_m < M
+        xs_row_base = batch_id * xs_sB + xs_m * xs_sM
 
-        if config.SWAP_AB:
-            partial_zero = gl.zeros(
-                (config.BLOCK_N, config.BLOCK_M), dtype=gl.float32, layout=mma_layout
-            )
-            acc = gl.zeros(
-                (config.BLOCK_N, config.BLOCK_M), dtype=gl.float32, layout=mma_layout
-            )
+        if SWAP_AB:
+            acc = tl.zeros((BLOCK_N, BLOCK_M), dtype=tl.float32)
         else:
-            partial_zero = gl.zeros(
-                (config.BLOCK_M, config.BLOCK_N), dtype=gl.float32, layout=mma_layout
-            )
-            acc = gl.zeros(
-                (config.BLOCK_M, config.BLOCK_N), dtype=gl.float32, layout=mma_layout
-            )
+            acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
 
-        for k in range(0, config.K, config.BLOCK_K):
-            k_block_idx = k // config.BLOCK_K
-            index, phase = counter.index, counter.phase
-            x_slot = channel.x_smem.index(index)  # [1, BLOCK_M, BLOCK_K]
-            y_slot = channel.y_smem.index(index)  # [BLOCK_N, BLOCK_K]
-            ready_bar = channel.ready_bars.index(index)
-            empty_bar = channel.empty_bars.index(index)
-            mbarrier.wait(ready_bar, phase)
+        for k_block_idx in range(0, num_k_blocks):
+            index = k_block_idx % num_stages
+            phase = k_block_idx // num_stages
+            x_slot = x_smem.slot(index).slot(0)  # [BLOCK_M, BLOCK_K]
+            y_slot = y_smem.slot(index)  # [BLOCK_N, BLOCK_K]
+            tle.gpu.barrier_wait(full_x[index], phaseIdx=phase)
+            tle.gpu.barrier_wait(full_y[index], phaseIdx=phase)
 
-            x = x_slot.reshape((config.BLOCK_M, config.BLOCK_K))
-            y = y_slot
-
-            x_s = gl.load(
-                xs_ptr + xs_row_base + k_block_idx * config.xs_sKb,
+            x_s = tl.load(
+                xs_ptr + xs_row_base + k_block_idx * xs_sKb,
                 mask=xs_mask,
                 other=0.0,
             )
-            y_s = gl.load(ys_ptr + ys_base + k_block_idx)
+            y_s = tl.load(ys_ptr + ys_base + k_block_idx)
             xy_s = x_s * y_s
 
-            if config.SWAP_AB:
-                x_t = x.permute((1, 0))
-                partial_async = warpgroup_mma(
-                    y, x_t, partial_zero, use_acc=False, is_async=True
+            if SWAP_AB:
+                partial = tle.gpu.wgmma(
+                    y_slot,
+                    x_slot,
+                    out_dtype=tl.float32,
+                    trans_b=True,
                 )
-                partial = warpgroup_mma_wait(num_outstanding=0, deps=(partial_async,))
+                partial = tle.gpu.wgmma_wait(0, partial)
                 acc = acc + partial * xy_s[None, :]
             else:
-                y_t = y.permute((1, 0))
-                partial_async = warpgroup_mma(
-                    x, y_t, partial_zero, use_acc=False, is_async=True
+                partial = tle.gpu.wgmma(
+                    x_slot,
+                    y_slot,
+                    out_dtype=tl.float32,
+                    trans_b=True,
                 )
-                partial = warpgroup_mma_wait(num_outstanding=0, deps=(partial_async,))
+                partial = tle.gpu.wgmma_wait(0, partial)
                 acc = acc + partial * xy_s[:, None]
 
-            mbarrier.arrive(empty_bar)
-            counter = counter.increment()
+            tle.gpu.barrier_arrive(empty_x[index], phaseIdx=phase)
+            tle.gpu.barrier_arrive(empty_y[index], phaseIdx=phase)
 
-        acc_out = acc.to(z_desc.dtype)
-        if config.SWAP_AB:
-            acc_out = acc_out.permute((1, 0))
-        tma.store_wait(pendings=0)
-        z_smem.reshape((config.BLOCK_M, config.BLOCK_N)).store(acc_out)
-        fence_async_shared()
-        tma.async_copy_shared_to_global(z_desc, [batch_id, m_start, n_start], z_smem)
+        if SWAP_AB:
+            acc_out = tl.trans(acc)
+        else:
+            acc_out = acc
+        offs_m = m_start + tl.arange(0, BLOCK_M)
+        offs_n = n_start + tl.arange(0, BLOCK_N)
+        z_ptrs = (
+            z_ptr + batch_id * z_sB + offs_m[:, None] * z_sM + offs_n[None, :] * z_sN
+        )
+        z_mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+        tl.store(z_ptrs, acc_out, mask=z_mask)
 
-    tma.store_wait(pendings=0)
 
+@triton.jit
+def _tle_w8a8_block_fp8_bmm_load_partition(
+    x_desc,
+    y_desc,
+    x_smem,
+    y_smem,
+    empty_x,
+    empty_y,
+    full_x,
+    full_y,
+    B: tl.constexpr,
+    M: tl.constexpr,
+    M_aligned: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    TILE_ORDER: tl.constexpr,
+    num_stages: tl.constexpr,
+    num_sms: tl.constexpr,
+):
+    start_pid = tl.program_id(0)
+    num_m_tiles: tl.constexpr = M_aligned // BLOCK_M
+    num_n_tiles: tl.constexpr = N // BLOCK_N
+    num_tiles_per_batch: tl.constexpr = num_m_tiles * num_n_tiles
+    num_tiles: tl.constexpr = B * num_tiles_per_batch
 
-@gluon.jit
-def load_partition(channel, config, tensors):
-    x_desc, y_desc, xs_ptr, z_desc, ys_ptr = tensors
-    start_pid = gl.program_id(0)
-    counter = BarrierCounter(
-        index=gl.to_tensor(0), phase=gl.to_tensor(0), num_barriers=config.num_stages
-    )
+    for tile_id in range(start_pid, num_tiles, num_sms):
+        batch_id, m_tile_id, n_tile_id = _get_tile(
+            tile_id, num_m_tiles, num_n_tiles, num_tiles_per_batch, TILE_ORDER
+        )
+        m_start = m_tile_id * BLOCK_M
+        n_start = n_tile_id * BLOCK_N
+        y_row = batch_id * N + n_start
 
-    nbytes: gl.constexpr = (
-        config.BLOCK_M * config.BLOCK_K + config.BLOCK_N * config.BLOCK_K
-    )
-
-    for tile_id in range(start_pid, config.num_tiles, config.num_sms):
-        batch_id, m_tile_id, n_tile_id = get_tile(tile_id, config)
-        m_start = m_tile_id * config.BLOCK_M
-        n_start = n_tile_id * config.BLOCK_N
-
-        y_row = batch_id * config.N + n_start
-
-        for k in range(0, config.K, config.BLOCK_K):
-            index, phase = counter.index, counter.phase
-            x_slot = channel.x_smem.index(index)
-            y_slot = channel.y_smem.index(index)
-            ready_bar = channel.ready_bars.index(index)
-            empty_bar = channel.empty_bars.index(index)
-            mbarrier.wait(empty_bar, phase)
-
-            mbarrier.expect(ready_bar, nbytes)
-            tma.async_copy_global_to_shared(
-                x_desc, [batch_id, m_start, k], ready_bar, x_slot
+        for k_block_idx in range(0, K // BLOCK_K):
+            index = k_block_idx % num_stages
+            phase = k_block_idx // num_stages
+            k_start = k_block_idx * BLOCK_K
+            tle.gpu.barrier_wait(empty_x[index], phaseIdx=phase)
+            tle.gpu.copy(
+                x_desc,
+                x_smem.slot(index),
+                [1, BLOCK_M, BLOCK_K],
+                [batch_id, m_start, k_start],
+                barrier=full_x[index],
             )
-            tma.async_copy_global_to_shared(y_desc, [y_row, k], ready_bar, y_slot)
-
-            counter = counter.increment()
+            tle.gpu.barrier_wait(empty_y[index], phaseIdx=phase)
+            tle.gpu.copy(
+                y_desc,
+                y_smem.slot(index),
+                [BLOCK_N, BLOCK_K],
+                [y_row, k_start],
+                barrier=full_y[index],
+            )
 
 
 @libentry()
 @libtuner(
-    configs=runtime.get_tuned_config("w8a8_block_fp8_bmm"),
+    configs=_get_tle_w8a8_block_fp8_bmm_configs(),
     key=["B", "M_aligned", "N", "K"],
     strategy=["default", "align32", "align32", "align32"],
+    policy=_TLEW8A8BlockFP8BMMTuner,
     flagtune_op_name="w8a8_block_fp8_bmm",
     flagtune_expand_op_name="w8a8_block_fp8_bmm",
 )
-@gluon.jit
+@triton.jit
 def w8a8_block_fp8_bmm_kernel(
     x_desc,
     y_desc,
     xs_ptr,
-    z_desc,
+    z_ptr,
     ys_ptr,
-    xs_sB: gl.constexpr,
-    xs_sM: gl.constexpr,
-    xs_sKb: gl.constexpr,
-    B: gl.constexpr,
-    M: gl.constexpr,
-    M_aligned: gl.constexpr,
-    N: gl.constexpr,
-    K: gl.constexpr,
-    BLOCK_M: gl.constexpr,
-    BLOCK_N: gl.constexpr,
-    BLOCK_K: gl.constexpr,
-    TILE_ORDER: gl.constexpr,
-    SWAP_AB: gl.constexpr,
-    num_warps: gl.constexpr,
-    num_stages: gl.constexpr,
-    num_sms: gl.constexpr,
+    xs_sB: tl.constexpr,
+    xs_sM: tl.constexpr,
+    xs_sKb: tl.constexpr,
+    z_sB: tl.constexpr,
+    z_sM: tl.constexpr,
+    z_sN: tl.constexpr,
+    B: tl.constexpr,
+    M: tl.constexpr,
+    M_aligned: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    TILE_ORDER: tl.constexpr,
+    SWAP_AB: tl.constexpr,
+    X_ELEM_BYTES: tl.constexpr,
+    Y_ELEM_BYTES: tl.constexpr,
+    num_warps: tl.constexpr,
+    num_stages: tl.constexpr,
+    num_sms: tl.constexpr,
 ):
-    config = Config(
-        B=B,
-        M=M,
-        M_aligned=M_aligned,
-        N=N,
-        K=K,
-        BLOCK_M=BLOCK_M,
-        BLOCK_N=BLOCK_N,
-        BLOCK_K=BLOCK_K,
-        TILE_ORDER=TILE_ORDER,
-        SWAP_AB=SWAP_AB,
-        num_warps=num_warps,
-        num_stages=num_stages,
-        num_sms=num_sms,
-        xs_sB=xs_sB,
-        xs_sM=xs_sM,
-        xs_sKb=xs_sKb,
+    _ = num_warps
+    x_smem = tle.gpu.alloc(
+        [num_stages, 1, BLOCK_M, BLOCK_K],
+        dtype=x_desc.dtype,
+        layout=None,
+        scope=tle.gpu.smem,
     )
-    tensors = (x_desc, y_desc, xs_ptr, z_desc, ys_ptr)
-    channel = Channel.alloc(
-        BLOCK_M=BLOCK_M,
-        BLOCK_N=BLOCK_N,
-        BLOCK_K=BLOCK_K,
-        x_dtype=x_desc.dtype,
-        x_layout=gl.constexpr(x_desc.layout),
-        y_dtype=y_desc.dtype,
-        y_layout=gl.constexpr(y_desc.layout),
-        num_stages=num_stages,
-        num_warps=num_warps,
+    y_smem = tle.gpu.alloc(
+        [num_stages, BLOCK_N, BLOCK_K],
+        dtype=y_desc.dtype,
+        layout=None,
+        scope=tle.gpu.smem,
+    )
+    empty_x = tle.gpu.alloc_barriers(
+        num_barriers=num_stages, arrive_count=1, init=tle.gpu.READY
+    )
+    empty_y = tle.gpu.alloc_barriers(
+        num_barriers=num_stages, arrive_count=1, init=tle.gpu.READY
+    )
+    full_x = tle.gpu.alloc_barriers(
+        num_barriers=num_stages,
+        arrive_count=1,
+        expect_bytes=BLOCK_M * BLOCK_K * X_ELEM_BYTES,
+    )
+    full_y = tle.gpu.alloc_barriers(
+        num_barriers=num_stages,
+        arrive_count=1,
+        expect_bytes=BLOCK_N * BLOCK_K * Y_ELEM_BYTES,
     )
 
-    gl.warp_specialize(
+    tle.gpu.warp_specialize(
         [
-            (compute_partition, (channel, config, tensors)),
-            (load_partition, (channel, config, tensors)),
+            (
+                _tle_w8a8_block_fp8_bmm_compute_partition,
+                (
+                    x_smem,
+                    y_smem,
+                    empty_x,
+                    empty_y,
+                    full_x,
+                    full_y,
+                    xs_ptr,
+                    z_ptr,
+                    ys_ptr,
+                    xs_sB,
+                    xs_sM,
+                    xs_sKb,
+                    z_sB,
+                    z_sM,
+                    z_sN,
+                    B,
+                    M,
+                    M_aligned,
+                    N,
+                    K,
+                    BLOCK_M,
+                    BLOCK_N,
+                    BLOCK_K,
+                    TILE_ORDER,
+                    SWAP_AB,
+                    num_stages,
+                    num_sms,
+                ),
+            ),
+            (
+                _tle_w8a8_block_fp8_bmm_load_partition,
+                (
+                    x_desc,
+                    y_desc,
+                    x_smem,
+                    y_smem,
+                    empty_x,
+                    empty_y,
+                    full_x,
+                    full_y,
+                    B,
+                    M,
+                    M_aligned,
+                    N,
+                    K,
+                    BLOCK_M,
+                    BLOCK_N,
+                    BLOCK_K,
+                    TILE_ORDER,
+                    num_stages,
+                    num_sms,
+                ),
+            ),
         ],
         [1],
         [24],
     )
 
-    channel.release()
+
+@libentry()
+@libtuner(
+    configs=runtime.get_tuned_config("w8a8_block_fp8_bmm_splitk"),
+    key=["B", "M", "N", "K", "stride_xm", "stride_yk"],
+    reset_to_zero=["Z"],
+    strategy=["default", "align32", "align32", "align32", "align32", "align32"],
+    warmup=5,
+    rep=5,
+    flagtune_op_name="w8a8_block_fp8_bmm",
+    flagtune_expand_op_name="w8a8_block_fp8_bmm_splitk",
+)
+@triton.jit
+def w8a8_block_fp8_bmm_kernel_splitk(
+    X,
+    Y,
+    XS,
+    Z,
+    YS,
+    B: tl.constexpr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    stride_xb: tl.constexpr,
+    stride_xm: tl.constexpr,
+    stride_xk: tl.constexpr,
+    stride_yb: tl.constexpr,
+    stride_yn: tl.constexpr,
+    stride_yk: tl.constexpr,
+    stride_xsb: tl.constexpr,
+    stride_xsm: tl.constexpr,
+    stride_xsk: tl.constexpr,
+    stride_zb: tl.constexpr,
+    stride_zm: tl.constexpr,
+    stride_zn: tl.constexpr,
+    stride_ysb: tl.constexpr,
+    stride_ysn: tl.constexpr,
+    stride_ysk: tl.constexpr,
+    SCALE_BLOCK_N: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    SPLIT_K: tl.constexpr,
+):
+    pid = tl.program_id(0)
+    pid_k = tl.program_id(1)
+
+    grid_m = tl.cdiv(M, BLOCK_M)
+    grid_n = tl.cdiv(N, BLOCK_N)
+    tiles_per_batch = grid_m * grid_n
+    batch_id = pid // tiles_per_batch
+    local_pid = pid % tiles_per_batch
+    pid_m = local_pid // grid_n
+    pid_n = local_pid % grid_n
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+
+    total_k_iters = tl.cdiv(K, BLOCK_K)
+    k_per_split = tl.cdiv(total_k_iters, SPLIT_K)
+    k_start = pid_k * k_per_split
+    k_end = min((pid_k + 1) * k_per_split, total_k_iters)
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k_iter in range(k_start, k_end):
+        offs_k = k_iter * BLOCK_K + tl.arange(0, BLOCK_K)
+
+        x = tl.load(
+            X
+            + batch_id * stride_xb
+            + offs_m[:, None] * stride_xm
+            + offs_k[None, :] * stride_xk,
+            mask=(offs_m[:, None] < M) & (offs_k[None, :] < K),
+            other=0.0,
+        )
+        y = tl.load(
+            Y
+            + batch_id * stride_yb
+            + offs_n[None, :] * stride_yn
+            + offs_k[:, None] * stride_yk,
+            mask=(offs_k[:, None] < K) & (offs_n[None, :] < N),
+            other=0.0,
+        )
+
+        x_s = tl.load(
+            XS + batch_id * stride_xsb + offs_m * stride_xsm + k_iter * stride_xsk,
+            mask=offs_m < M,
+            other=0.0,
+        )
+        y_s = tl.load(
+            YS
+            + batch_id * stride_ysb
+            + (offs_n // SCALE_BLOCK_N) * stride_ysn
+            + k_iter * stride_ysk,
+            mask=offs_n < N,
+            other=0.0,
+        )
+        acc += tl.dot(x, y, out_dtype=tl.float32) * x_s[:, None] * y_s[None, :]
+
+    z_ptrs = (
+        Z
+        + batch_id * stride_zb
+        + offs_m[:, None] * stride_zm
+        + offs_n[None, :] * stride_zn
+    )
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    if Z.dtype.element_ty == tl.bfloat16:
+        tl.atomic_add(z_ptrs, acc.to(tl.bfloat16), mask=mask)
+    elif Z.dtype.element_ty == tl.float16:
+        tl.atomic_add(z_ptrs, acc.to(tl.float16), mask=mask)
+    else:
+        tl.atomic_add(z_ptrs, acc.to(tl.float32), mask=mask)
+
+
+@libentry()
+@libtuner(
+    configs=runtime.get_tuned_config("w8a8_block_fp8_bmm_general"),
+    key=["B", "M", "N", "K", "stride_xm", "stride_yk"],
+    strategy=["default", "align32", "align32", "align32", "align32", "align32"],
+    warmup=5,
+    rep=5,
+    flagtune_op_name="w8a8_block_fp8_bmm",
+    flagtune_expand_op_name="w8a8_block_fp8_bmm_general",
+)
+@triton.jit
+def w8a8_block_fp8_bmm_kernel_general(
+    X,
+    Y,
+    XS,
+    Z,
+    YS,
+    B: tl.constexpr,
+    M: tl.constexpr,
+    N: tl.constexpr,
+    K: tl.constexpr,
+    stride_xb: tl.constexpr,
+    stride_xm: tl.constexpr,
+    stride_xk: tl.constexpr,
+    stride_yb: tl.constexpr,
+    stride_yn: tl.constexpr,
+    stride_yk: tl.constexpr,
+    stride_xsb: tl.constexpr,
+    stride_xsm: tl.constexpr,
+    stride_xsk: tl.constexpr,
+    stride_zb: tl.constexpr,
+    stride_zm: tl.constexpr,
+    stride_zn: tl.constexpr,
+    stride_ysb: tl.constexpr,
+    stride_ysn: tl.constexpr,
+    stride_ysk: tl.constexpr,
+    SCALE_BLOCK_N: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+    GROUP_M: tl.constexpr,
+):
+    pid = tl.program_id(0).to(tl.int64)
+
+    num_pid_m = tl.cdiv(M, BLOCK_M)
+    num_pid_n = tl.cdiv(N, BLOCK_N)
+    tiles_per_batch = num_pid_m * num_pid_n
+    batch_id = (pid // tiles_per_batch).to(tl.int64)
+    local_pid = pid % tiles_per_batch
+    num_pid_in_group = GROUP_M * num_pid_n
+    group_id = local_pid // num_pid_in_group
+    first_pid_m = group_id * GROUP_M
+    group_size_m = min(num_pid_m - first_pid_m, GROUP_M)
+    local_group_pid = local_pid % num_pid_in_group
+    pid_m = first_pid_m + (local_group_pid % group_size_m)
+    pid_n = local_group_pid // group_size_m
+
+    offs_m = (pid_m * BLOCK_M + tl.arange(0, BLOCK_M)).to(tl.int64)
+    offs_n = (pid_n * BLOCK_N + tl.arange(0, BLOCK_N)).to(tl.int64)
+
+    acc = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    for k_iter in range(0, tl.cdiv(K, BLOCK_K)):
+        offs_k = (k_iter * BLOCK_K + tl.arange(0, BLOCK_K)).to(tl.int64)
+
+        x = tl.load(
+            X
+            + batch_id * stride_xb
+            + offs_m[:, None] * stride_xm
+            + offs_k[None, :] * stride_xk,
+            mask=(offs_m[:, None] < M) & (offs_k[None, :] < K),
+            other=0.0,
+        )
+        y = tl.load(
+            Y
+            + batch_id * stride_yb
+            + offs_n[None, :] * stride_yn
+            + offs_k[:, None] * stride_yk,
+            mask=(offs_k[:, None] < K) & (offs_n[None, :] < N),
+            other=0.0,
+        )
+
+        x_s = tl.load(
+            XS + batch_id * stride_xsb + offs_m * stride_xsm + k_iter * stride_xsk,
+            mask=offs_m < M,
+            other=0.0,
+        )
+        y_s = tl.load(
+            YS
+            + batch_id * stride_ysb
+            + (offs_n // SCALE_BLOCK_N) * stride_ysn
+            + k_iter * stride_ysk,
+            mask=offs_n < N,
+            other=0.0,
+        )
+        acc += tl.dot(x, y, out_dtype=tl.float32) * x_s[:, None] * y_s[None, :]
+
+    z_ptrs = (
+        Z
+        + batch_id * stride_zb
+        + offs_m[:, None] * stride_zm
+        + offs_n[None, :] * stride_zn
+    )
+    mask = (offs_m[:, None] < M) & (offs_n[None, :] < N)
+    if Z.dtype.element_ty == tl.bfloat16:
+        tl.store(z_ptrs, acc.to(tl.bfloat16), mask=mask)
+    elif Z.dtype.element_ty == tl.float16:
+        tl.store(z_ptrs, acc.to(tl.float16), mask=mask)
+    else:
+        tl.store(z_ptrs, acc.to(tl.float32), mask=mask)
 
 
 def w8a8_block_fp8_bmm(
@@ -495,41 +652,100 @@ def w8a8_block_fp8_bmm(
     SWAP_AB = 1 if BLOCK_M < 64 else 0
 
     M_aligned = triton.cdiv(M, BLOCK_M) * BLOCK_M
+    if B == 1 and M < 300 and N < 2112 and K >= 4096:
+        z.zero_()
+        splitk_grid = lambda META: (
+            B * triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+            META["SPLIT_K"],
+        )
+        w8a8_block_fp8_bmm_kernel_splitk[splitk_grid](
+            x,
+            y,
+            xs,
+            z,
+            ys,
+            B=B,
+            M=M,
+            N=N,
+            K=K,
+            stride_xb=x.stride(0),
+            stride_xm=x.stride(1),
+            stride_xk=x.stride(2),
+            stride_yb=y.stride(0),
+            stride_yn=y.stride(1),
+            stride_yk=y.stride(2),
+            stride_xsb=xs.stride(0),
+            stride_xsm=xs.stride(1),
+            stride_xsk=xs.stride(2),
+            stride_zb=z.stride(0),
+            stride_zm=z.stride(1),
+            stride_zn=z.stride(2),
+            stride_ysb=ys.stride(0),
+            stride_ysn=ys.stride(1),
+            stride_ysk=ys.stride(2),
+            SCALE_BLOCK_N=BLOCK_N,
+        )
+        return z
 
-    x_gl_dtype = _gl_dtype(x)
-    y_gl_dtype = _gl_dtype(y)
-    z_gl_dtype = _gl_dtype(z)
+    if not HAS_TLE_W8A8_BLOCK_FP8_BMM:
+        general_grid = lambda META: (
+            B * triton.cdiv(M, META["BLOCK_M"]) * triton.cdiv(N, META["BLOCK_N"]),
+        )
+        w8a8_block_fp8_bmm_kernel_general[general_grid](
+            x,
+            y,
+            xs,
+            z,
+            ys,
+            B=B,
+            M=M,
+            N=N,
+            K=K,
+            stride_xb=x.stride(0),
+            stride_xm=x.stride(1),
+            stride_xk=x.stride(2),
+            stride_yb=y.stride(0),
+            stride_yn=y.stride(1),
+            stride_yk=y.stride(2),
+            stride_xsb=xs.stride(0),
+            stride_xsm=xs.stride(1),
+            stride_xsk=xs.stride(2),
+            stride_zb=z.stride(0),
+            stride_zm=z.stride(1),
+            stride_zn=z.stride(2),
+            stride_ysb=ys.stride(0),
+            stride_ysn=ys.stride(1),
+            stride_ysk=ys.stride(2),
+            SCALE_BLOCK_N=BLOCK_N,
+        )
+        return z
 
-    x_layout = gl.NVMMASharedLayout.get_default_for([1, BLOCK_M, BLOCK_K], x_gl_dtype)
-    x_desc = TensorDescriptor.from_tensor(
-        x, block_shape=[1, BLOCK_M, BLOCK_K], layout=x_layout
-    )
+    from triton.tools.tensor_descriptor import TensorDescriptor
+
+    _set_triton_descriptor_allocator(device)
+    x_desc = TensorDescriptor.from_tensor(x, block_shape=[1, BLOCK_M, BLOCK_K])
 
     assert y.is_contiguous(), "y must be contiguous so it can be viewed as (B*N, K)"
     y_flat = y.view(B * N, K)
-    y_layout = gl.NVMMASharedLayout.get_default_for([BLOCK_N, BLOCK_K], y_gl_dtype)
-    y_desc = TensorDescriptor.from_tensor(
-        y_flat, block_shape=[BLOCK_N, BLOCK_K], layout=y_layout
-    )
+    y_desc = TensorDescriptor.from_tensor(y_flat, block_shape=[BLOCK_N, BLOCK_K])
 
     assert xs.ndim == 3 and xs.shape == (B, M, num_kb)
     xs_sB, xs_sM, xs_sKb = xs.stride()
-
-    z_layout = gl.NVMMASharedLayout.get_default_for([1, BLOCK_M, BLOCK_N], z_gl_dtype)
-    z_desc = TensorDescriptor.from_tensor(
-        z, block_shape=[1, BLOCK_M, BLOCK_N], layout=z_layout
-    )
+    z_sB, z_sM, z_sN = z.stride()
 
     num_sms = torch.cuda.get_device_properties(device).multi_processor_count
     w8a8_block_fp8_bmm_kernel[(num_sms,)](
         x_desc,
         y_desc,
         xs,
-        z_desc,
+        z,
         ys,
         xs_sB=xs_sB,
         xs_sM=xs_sM,
         xs_sKb=xs_sKb,
+        z_sB=z_sB,
+        z_sM=z_sM,
+        z_sN=z_sN,
         B=B,
         M=M,
         M_aligned=M_aligned,
@@ -539,6 +755,8 @@ def w8a8_block_fp8_bmm(
         BLOCK_N=BLOCK_N,
         BLOCK_K=BLOCK_K,
         SWAP_AB=SWAP_AB,
+        X_ELEM_BYTES=x.element_size(),
+        Y_ELEM_BYTES=y.element_size(),
         num_sms=num_sms,
     )
 

--- a/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_nvidia/tune_configs.yaml
@@ -2654,3 +2654,59 @@ compute_global_topk_indices_and_lens:
       TPP: 1
     num_warps: 4
     num_stages: 3
+
+w8a8_block_fp8_bmm_general:
+  - gen: true
+    param_map:
+      META:
+        BLOCK_M: block_m
+        BLOCK_N: block_n
+        BLOCK_K: block_k
+        GROUP_M: group_m
+      num_warps: warps
+      num_stages: stages
+    block_m:
+      - 16
+      - 32
+      - 64
+    block_n:
+      - 32
+      - 64
+    block_k:
+      - 128
+    group_m:
+      - 1
+      - 4
+      - 8
+    warps:
+      - 4
+    stages:
+      - 3
+
+w8a8_block_fp8_bmm_splitk:
+  - gen: true
+    param_map:
+      META:
+        BLOCK_M: block_m
+        BLOCK_N: block_n
+        BLOCK_K: block_k
+        SPLIT_K: split_k
+      num_warps: warps
+      num_stages: stages
+    block_m:
+      - 16
+      - 64
+    block_n:
+      - 32
+      - 64
+    block_k:
+      - 128
+    split_k:
+      - 4
+      - 8
+      - 16
+      - 32
+    warps:
+      - 4
+    stages:
+      - 3

--- a/src/flag_gems/runtime/common.py
+++ b/src/flag_gems/runtime/common.py
@@ -85,6 +85,22 @@ DEFAULT_STRATEGIES = {
         "default",
     ],
     "w8a8_block_fp8_bmm": ["default", "align32", "align32", "align32"],
+    "w8a8_block_fp8_bmm_general": [
+        "default",
+        "align32",
+        "align32",
+        "align32",
+        "align32",
+        "align32",
+    ],
+    "w8a8_block_fp8_bmm_splitk": [
+        "default",
+        "align32",
+        "align32",
+        "align32",
+        "align32",
+        "align32",
+    ],
     "mm_splitk": ["align32", "align32", "align32", "align32", "align32"],
 }
 
@@ -120,6 +136,8 @@ OP_KEY_ORDERS = {
     "w8a8_block_fp8_general_splitk": ["M", "N", "K", "stride_am", "stride_bk"],
     "w8a8_block_fp8_general_tma": ["M", "N", "K", "stride_am", "stride_bk", "dtype"],
     "w8a8_block_fp8_bmm": ["B", "M_aligned", "N", "K"],
+    "w8a8_block_fp8_bmm_general": ["B", "M", "N", "K", "stride_xm", "stride_yk"],
+    "w8a8_block_fp8_bmm_splitk": ["B", "M", "N", "K", "stride_xm", "stride_yk"],
     "mm_splitk": ["M", "N", "K", "stride_am", "stride_bk"],
 }
 

--- a/src/flag_gems/runtime/configs_loader.py
+++ b/src/flag_gems/runtime/configs_loader.py
@@ -304,7 +304,7 @@ class TunedConfigLoader(object):
                 if block * tpp <= 1024
             ]
 
-        if op_name == "w8a8_block_fp8_general":
+        if op_name in ("w8a8_block_fp8_general", "w8a8_block_fp8_bmm_general"):
             return [
                 triton.Config(
                     {
@@ -362,7 +362,7 @@ class TunedConfigLoader(object):
                 for w in ranges["w"]
             ]
 
-        if op_name == "w8a8_block_fp8_general_splitk":
+        if op_name in ("w8a8_block_fp8_general_splitk", "w8a8_block_fp8_bmm_splitk"):
             return [
                 triton.Config(
                     {
@@ -520,6 +520,18 @@ class TunedConfigLoader(object):
             "w8a8_block_fp8_bmm": self._build_single_expand_spec(
                 "w8a8_block_fp8_bmm",
                 expand_yaml_path=self._get_expand_config_path("w8a8_block_fp8_bmm"),
+            ),
+            "w8a8_block_fp8_bmm_general": self._build_single_expand_spec(
+                "w8a8_block_fp8_bmm_general",
+                expand_yaml_path=self._get_expand_config_path(
+                    "w8a8_block_fp8_bmm_general"
+                ),
+            ),
+            "w8a8_block_fp8_bmm_splitk": self._build_single_expand_spec(
+                "w8a8_block_fp8_bmm_splitk",
+                expand_yaml_path=self._get_expand_config_path(
+                    "w8a8_block_fp8_bmm_splitk"
+                ),
             ),
             "mm_splitk": self._build_single_expand_spec("mm_splitk"),
             "sparse_attention": self._build_single_expand_spec("sparse_attention"),


### PR DESCRIPTION
### PR Category

1. Replace the original Gluon implementation of `w8a8_block_fp8_bmm_kernel` with a TLE implementation while maintaining comparable performance.
2. Add a new `w8a8_block_fp8_bmm_general` path.
3. Add a split-K path to improve performance for the **B=1**, **large-K**, **small-M/N** workload.

### Type of Change

Performance Optimization

### Description

This PR refactors the original `w8a8_block_fp8_bmm_kernel` by replacing the Gluon implementation with TLE and introduces two new execution paths:

- `w8a8_block_fp8_bmm_general` for the general case.
- `w8a8_block_fp8_bmm_splitk` for **B=1** workloads with large **K** and relatively small **M/N**, improving kernel performance in this scenario.

The TLE implementation maintains performance comparable to the original Gluon implementation while simplifying the kernel structure.

### Issue

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

- Replacing Gluon with TLE maintains nearly identical performance for the original `w8a8_block_fp8_bmm_kernel` path.

| Implementation | Without CUDA Graph | With CUDA Graph |
| -------------- | -----------------: | --------------: |
| Gluon | 1.088× | 1.514× |
| TLE | 1.146× | 1.423× |

- `w8a8_block_fp8_bmm_splitk`
  - **h=1**: **1.093×** average speedup over DeepGEMM.

- `w8a8_block_fp8_bmm_general`
  - **h=8**: **1.117×** average speedup over DeepGEMM.
  - **h=1**: **1.025×** average speedup over DeepGEMM.