### PR TITLE
Fix environment setting for Kunlunxin

### DIFF
--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -138,7 +138,8 @@ backends:
     triton: triton==3.0.0+a48aedef
     flagtree: flagtree==0.5.1+xpu3.0
     env:
-      LD_LIBRARY_PATH: /xcudart/lib:/usr/local/cuda/lib64
+      PATH: /usr/local/xpu/bin:$PATH
+      LD_LIBRARY_PATH: /usr/local/xcudart/lib:/usr/local/xpu/lib:/usr/local/cuda/lib64
     deps:
       - apex==0.1
       - benchflow==1.0.0


### PR DESCRIPTION
### PR Category

Other

### Type of Change

Bug Fix

### Description

We were not exporting the LD_LIBRARY_PATH correctly when running on Kunlunxin. This PR fixes the problem.