### PR TITLE
[Hygon] fix mm float64 accumulation

### DIFF
--- a/src/flag_gems/runtime/backend/_hygon/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_hygon/ops/mm.py
@@ -50,6 +50,7 @@ def mm_kernel(
     BLOCK_N: tl.constexpr,
     BLOCK_K: tl.constexpr,
     GROUP_M: tl.constexpr,
+    IS_FP64: tl.constexpr = False,
 ):
     pid = ext.program_id(0)
 
@@ -83,7 +84,10 @@ def mm_kernel(
     prev_k_mult = tl.cdiv(K, BLOCK_K) * BLOCK_K - BLOCK_K
 
     # accumulator
-    accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
+    if IS_FP64:
+        accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float64)
+    else:
+        accumulator = tl.zeros((BLOCK_M, BLOCK_N), dtype=tl.float32)
 
     # --------------------------
     # main K loop
@@ -102,7 +106,10 @@ def mm_kernel(
             a = a.to(c_ptr.dtype.element_ty)
             b = b.to(c_ptr.dtype.element_ty)
 
-        accumulator += tl.dot(a, b, out_dtype=tl.float32, allow_tf32=False)
+        if IS_FP64:
+            accumulator += tl.dot(a, b, out_dtype=tl.float64, allow_tf32=False)
+        else:
+            accumulator += tl.dot(a, b, out_dtype=tl.float32, allow_tf32=False)
 
     # --------------------------
     # loop peel
@@ -110,20 +117,35 @@ def mm_kernel(
     rk = prev_k_mult + offs_k
     mask_k = rk < K
 
-    a = tl.load(
-        a_ptr + (offs_am_cont[:, None] * stride_am + rk[None, :] * stride_ak),
-        mask=mask_k[None, :],
-    )
-    b = tl.load(
-        b_ptr + (rk[:, None] * stride_bk + offs_bn_cont[None, :] * stride_bn),
-        mask=mask_k[:, None],
-    )
+    if IS_FP64:
+        a = tl.load(
+            a_ptr + (offs_am_cont[:, None] * stride_am + rk[None, :] * stride_ak),
+            mask=mask_k[None, :],
+            other=0.0,
+        )
+        b = tl.load(
+            b_ptr + (rk[:, None] * stride_bk + offs_bn_cont[None, :] * stride_bn),
+            mask=mask_k[:, None],
+            other=0.0,
+        )
+    else:
+        a = tl.load(
+            a_ptr + (offs_am_cont[:, None] * stride_am + rk[None, :] * stride_ak),
+            mask=mask_k[None, :],
+        )
+        b = tl.load(
+            b_ptr + (rk[:, None] * stride_bk + offs_bn_cont[None, :] * stride_bn),
+            mask=mask_k[:, None],
+        )
 
     if a.dtype != b.dtype:
         a = a.to(c_ptr.dtype.element_ty)
         b = b.to(c_ptr.dtype.element_ty)
 
-    accumulator += tl.dot(a, b, out_dtype=tl.float32, allow_tf32=False)
+    if IS_FP64:
+        accumulator += tl.dot(a, b, out_dtype=tl.float64, allow_tf32=False)
+    else:
+        accumulator += tl.dot(a, b, out_dtype=tl.float32, allow_tf32=False)
 
     # cast to output dtype
     accumulator = accumulator.to(c_ptr.dtype.element_ty)
@@ -141,7 +163,7 @@ def mm_kernel(
     tl.store(c_ptr, accumulator, mask=mask_store)
 
 
-_ordered_datatypes = [torch.float16, torch.bfloat16, torch.float32]
+_ordered_datatypes = [torch.float16, torch.bfloat16, torch.float32, torch.float64]
 
 
 def get_higher_dtype(a, b):
@@ -198,6 +220,7 @@ def mm(a, b):
             num_stages=1,
             num_warps=4,
             num_ldmatrixes=0,
+            IS_FP64=a.dtype == torch.float64,
         )
     return c
 
@@ -240,5 +263,6 @@ def mm_out(a, b, *, out):
             num_stages=1,
             num_warps=4,
             num_ldmatrixes=0,
+            IS_FP64=a.dtype == torch.float64,
         )
     return c


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description
Fix the Hygon-specific `mm` kernel for float64 inputs.

The kernel previously initialized the loop-carried accumulator as `tl.float32` while float64 inputs can produce float64 dot results, which may trigger a dtype mismatch in the Hygon fp64 `mm` path. This change adds an `IS_FP64` kernel flag, uses a `tl.float64` accumulator for float64 inputs, and keeps the existing fp32 accumulation path unchanged for other dtypes.

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
No benchmark added. This only changes the Hygon float64 `mm` path; existing non-fp64 paths are unchanged.