### PR TITLE
Add scalar tensor op

### DIFF
--- a/benchmark/test_scalar_tensor.py
+++ b/benchmark/test_scalar_tensor.py
@@ -1,0 +1,16 @@
+import pytest
+import torch
+
+from . import base
+
+
+def _input_fn(shape, dtype, device):
+    yield {"s": 0.01, "dtype": dtype, "device": device},
+
+
+@pytest.mark.scalar_tensor
+def test_scalar_tensor():
+    bench = base.GenericBenchmark(
+        op_name="scalar_tensor", input_fn=_input_fn, torch_op=torch.scalar_tensor
+    )
+    bench.run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -7134,6 +7134,18 @@ ops:
     stages:
       - beta: '5.0'
       - stable: '5.3'
+  - id: scalar_tensor
+    description: |
+      Creates a 0-dimensional (scalar) tensor from a Python numeric value.
+      The tensor's dtype can be specified, otherwise inferred from the input value.
+    for:
+      - scalar_tensor
+    labels:
+      - aten
+    kind:
+      - Tensor
+    stages:
+      - alpha: '5.4'
   - id: sigmoid
     description: Computes the expit (also known as the logistic sigmoid function) of the elements of `input`.
     for:

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -631,6 +631,7 @@ _FULL_CONFIG = (
     ("scatter_reduce.two", scatter_reduce),
     ("scatter_reduce.two_out", scatter_reduce_out),
     ("scatter_reduce_.two", scatter_reduce_),
+    ("scalar_tensor", scalar_tensor),
     ("searchsorted.Scalar", searchsorted_scalar),
     ("searchsorted.Scalar_out", searchsorted_scalar_out),
     ("searchsorted.Tensor", searchsorted),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -416,6 +416,7 @@ from flag_gems.ops.rrelu_with_noise_backward import rrelu_with_noise_backward
 from flag_gems.ops.rrelu_with_noise_functional import rrelu_with_noise_functional
 from flag_gems.ops.rsqrt import rsqrt, rsqrt_
 from flag_gems.ops.rsub import rsub_scalar, rsub_tensor
+from flag_gems.ops.scalar_tensor import scalar_tensor
 from flag_gems.ops.scaled_grouped_mm import scaled_grouped_mm
 from flag_gems.ops.scaled_mm import scaled_mm, scaled_mm_out
 from flag_gems.ops.scaled_softmax import scaled_softmax_backward, scaled_softmax_forward
@@ -1111,6 +1112,7 @@ __all__ = [
     "softplus_backward",
     "softshrink",
     "softshrink_out",
+    "scalar_tensor",
     "sort",
     "sort_stable",
     "special_chebyshev_polynomial_v",

--- a/src/flag_gems/ops/scalar_tensor.py
+++ b/src/flag_gems/ops/scalar_tensor.py
@@ -1,0 +1,26 @@
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+
+logger = logging.getLogger(__name__)
+
+
+@triton.jit
+def scalar_tensor_kernel(out, value_scalar):
+    tl.store(out, value_scalar)
+
+
+def scalar_tensor(s, *, dtype=None, layout=None, device=None, pin_memory=None):
+    logger.debug("GEMS SCALAR_TENSOR")
+    out = torch.empty(
+        (), dtype=dtype, layout=layout, device=device, pin_memory=pin_memory
+    )
+    if dtype == torch.bool:
+        s = bool(s)
+    with torch_device_fn.device(out.device):
+        scalar_tensor_kernel[(1,)](out, s)
+    return out

--- a/tests/test_scalar_tensor.py
+++ b/tests/test_scalar_tensor.py
@@ -1,0 +1,26 @@
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+device = flag_gems.device
+
+
+@pytest.mark.scalar_tensor
+@pytest.mark.parametrize(
+    "dtype", utils.BOOL_TYPES + utils.INT_DTYPES + utils.FLOAT_DTYPES
+)
+@pytest.mark.parametrize("fill_value", [0.01, 2, 0, -1, True, False])
+def test_scalar_tensor(dtype, fill_value):
+    # with dtype
+    ref_out = torch.scalar_tensor(
+        fill_value, dtype=dtype, device="cpu" if cfg.TO_CPU else device
+    )
+
+    with flag_gems.use_gems():
+        res_out = torch.scalar_tensor(fill_value, dtype=dtype, device=flag_gems.device)
+
+    utils.gems_assert_equal(res_out, ref_out)

--- a/tests/test_scalar_tensor.py
+++ b/tests/test_scalar_tensor.py
@@ -15,7 +15,6 @@ device = flag_gems.device
 )
 @pytest.mark.parametrize("fill_value", [0.01, 2, 0, -1, True, False])
 def test_scalar_tensor(dtype, fill_value):
-    # with dtype
     ref_out = torch.scalar_tensor(
         fill_value, dtype=dtype, device="cpu" if cfg.TO_CPU else device
     )


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator
### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
New Feature
### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
```
benchmark/test_scalar_tensor.py::test_scalar_tensor 
Operator: scalar_tensor  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.004640            0.004560               1.018          {'s': 0.01, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.004704            0.004800               0.980          {'s': 0.01, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.004704            0.004800               0.980          {'s': 0.01, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.004640            0.004448               1.043          {'s': 0.01, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.004672            0.004800               0.973          {'s': 0.01, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.004672            0.004448               1.050          {'s': 0.01, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.004864            0.004480               1.086          {'s': 0.01, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.004864            0.004512               1.078          {'s': 0.01, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.004640            0.004544               1.021          {'s': 0.01, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.004608            0.004448               1.036          {'s': 0.01, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.004864            0.004768               1.020          {'s': 0.01, 'dtype': torch.float16, 'device': 'cuda'}
SUCCESS               0.004864            0.004448               1.094          {'s': 0.01, 'dtype': torch.float16, 'device': 'cuda'}


Operator: scalar_tensor  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.004608            0.004608               1.000          {'s': 0.01, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.004864            0.004448               1.094          {'s': 0.01, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.004544            0.004544               1.000          {'s': 0.01, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.004704            0.004800               0.980          {'s': 0.01, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.004704            0.004480               1.050          {'s': 0.01, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.004704            0.004608               1.021          {'s': 0.01, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.004640            0.004544               1.021          {'s': 0.01, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.004576            0.004768               0.960          {'s': 0.01, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.004832            0.004544               1.063          {'s': 0.01, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.004672            0.004608               1.014          {'s': 0.01, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.004672            0.004768               0.980          {'s': 0.01, 'dtype': torch.float32, 'device': 'cuda'}
SUCCESS               0.004640            0.004544               1.021          {'s': 0.01, 'dtype': torch.float32, 'device': 'cuda'}


Operator: scalar_tensor  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.004864            0.004768               1.020          {'s': 0.01, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.004640            0.004544               1.021          {'s': 0.01, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.004832            0.004480               1.079          {'s': 0.01, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.004672            0.004544               1.028          {'s': 0.01, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.004672            0.004544               1.028          {'s': 0.01, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.004640            0.004608               1.007          {'s': 0.01, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.004864            0.004512               1.078          {'s': 0.01, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.004704            0.004768               0.987          {'s': 0.01, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.004544            0.004544               1.000          {'s': 0.01, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.004640            0.004512               1.028          {'s': 0.01, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.004704            0.004768               0.987          {'s': 0.01, 'dtype': torch.bfloat16, 'device': 'cuda'}
SUCCESS               0.004864            0.004448               1.094          {'s': 0.01, 'dtype': torch.bfloat16, 'device': 'cuda'}
```


### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
