### PR TITLE
Cache type_promotion in the pointwise_dynamic hot path

### DIFF
--- a/src/flag_gems/utils/type_utils.py
+++ b/src/flag_gems/utils/type_utils.py
@@ -1,13 +1,83 @@
+import threading
+from collections import OrderedDict
+
 import torch
 from torch._prims_common import ELEMENTWISE_TYPE_PROMOTION_KIND, elementwise_dtypes
 
+# Elementwise type promotion is a pure function of a small, cheap descriptor of
+# the operands, so pointwise_dynamic recomputes the same result on every launch.
+# Cache it to skip the torch._prims_common machinery on the hot path.
+#
+# What the result depends on (verified against elementwise_dtypes): the promotion
+# kind, each tensor operand's dtype and whether it is 0-dim (torch treats a 0-dim
+# tensor like a scalar), each python scalar operand's category (bool / int /
+# float / complex, never its value), and torch.get_default_dtype() -- a floating
+# or complex result can fall back to the default dtype, and INT_TO_FLOAT converts
+# integer results using it, so the default dtype is always part of the key. It
+# does NOT depend on device, values, non-scalar shape, strides, layout,
+# requires_grad, or grad mode.
+
+_TENSOR = "T"
+_SCALAR = "S"
+# Only these exact python scalar types are canonicalized; anything else falls
+# back to the uncached path so we never risk a wrong or unbounded key.
+_SCALAR_TYPES = (bool, int, float, complex)
+
+
+def _operand_descriptors(args):
+    """Return a hashable tuple describing the operands, or None if any operand
+    is outside the canonicalized fast-path domain (tensor / plain python scalar
+    / None)."""
+    descriptors = []
+    for a in args:
+        if isinstance(a, torch.Tensor):
+            descriptors.append((_TENSOR, a.dtype, a.ndim == 0))
+        elif a is None:
+            # torch ignores None operands in promotion.
+            continue
+        elif type(a) in _SCALAR_TYPES:
+            # bool is a subclass of int, so key on the exact type; the value
+            # never affects promotion.
+            descriptors.append((_SCALAR, type(a)))
+        else:
+            return None
+    return tuple(descriptors)
+
+
+# Bounded LRU cache from (kind, default_dtype, operand descriptors) to the
+# promotion result, guarded by a lock so it stays correct under threaded use.
+_promotion_cache = OrderedDict()
+_promotion_cache_lock = threading.Lock()
+_PROMOTION_CACHE_MAXSIZE = 1024
+
 
 def type_promotion(*args, type_promotion: ELEMENTWISE_TYPE_PROMOTION_KIND):
-    computation_dtype, result_dtype = elementwise_dtypes(
-        *args,
-        type_promotion_kind=type_promotion,
-    )
-    return computation_dtype, result_dtype
+    descriptors = _operand_descriptors(args)
+    if descriptors is None:
+        # An operand outside the supported fast-path domain; compute directly.
+        return elementwise_dtypes(*args, type_promotion_kind=type_promotion)
+
+    default_dtype = torch.get_default_dtype()
+    key = (type_promotion, default_dtype, descriptors)
+    with _promotion_cache_lock:
+        cached = _promotion_cache.get(key)
+        if cached is not None:
+            _promotion_cache.move_to_end(key)  # mark most-recently-used
+            return cached
+
+    result = elementwise_dtypes(*args, type_promotion_kind=type_promotion)
+
+    # Only cache if the default dtype did not change while we were computing:
+    # otherwise `result` may reflect a different default than `key` records, and
+    # storing it would poison the entry for the original default. (This closes a
+    # race with a concurrent torch.set_default_dtype.)
+    if torch.get_default_dtype() == default_dtype:
+        with _promotion_cache_lock:
+            _promotion_cache[key] = result
+            _promotion_cache.move_to_end(key)
+            if len(_promotion_cache) > _PROMOTION_CACHE_MAXSIZE:
+                _promotion_cache.popitem(last=False)  # evict least-recently-used
+    return result
 
 
 _accumulator_dtype_map = {


### PR DESCRIPTION
### PR Category

Performance Optimization

### Type of Change

Performance Optimization

### Description

`type_promotion()` calls `torch._prims_common.elementwise_dtypes` on every `pointwise_dynamic` launch. That call is pure with respect to a small, cheap descriptor of the operands, so it recomputes the same result every time and is a measurable slice of the fixed per-call CPU overhead. This caches it.

The result depends only on (verified against `elementwise_dtypes`):
- the promotion kind,
- each tensor operand's dtype and whether it is 0-dim (torch treats a 0-dim tensor like a scalar),
- each python scalar operand's category (`bool` / `int` / `float` / `complex`, never its value),
- `torch.get_default_dtype()` -- a floating/complex result, or an `INT_TO_FLOAT` conversion, can fall back to the default dtype, so it is **always** part of the key.

It does **not** depend on device, values, non-scalar shape, strides, layout, `requires_grad`, or grad mode (all checked).

Safety of the key:
- Operands outside the canonicalized domain (anything other than a tensor, a plain python scalar, or `None`) bypass the cache entirely and go straight to `elementwise_dtypes`, so behavior is never changed and no unhashable key is ever built.
- The cache keys on scalar **category**, not value, so a stream of varying scalars (`1`, `2`, `3`, ...) does not grow it.
- Bounded at `maxsize=1024`.

This is independent of #4827 (which caches `heuristics_for_tile_size`); both are small pieces of reducing the `pointwise_dynamic` per-call overhead described in #4812.

### Performance

A100, sigmoid `4096` fp16, per-call wall time (min of repeated timed blocks):

| | per-call |
|---|---:|
| baseline | ~64.9 us |
| with cache | ~58.3 us |

~6.6 us / ~10%, independent of tensor size, benefiting all `pointwise_dynamic` operators.

### Testing

- `pytest tests/test_pointwise_type_promotion.py`: 150 passed.
- Verified the cached result matches `elementwise_dtypes` across 205 combinations of promotion kind x dtype x 0-dim x scalar category x two-tensor mixes x `None`, with 0 mismatches.
- Verified the three key-correctness properties directly: changing `torch.set_default_dtype` invalidates stale entries (including the integer-only `INT_TO_FLOAT` case); an unsupported operand bypasses the cache instead of crashing; 500 distinct scalar values collapse to a single cache entry.
- `pre-commit` (black, flake8, isort) clean.

### Issue

Part of #4812.
