### PR TITLE
Ship test and benchmark suites in the wheel

### DIFF
--- a/benchmark/test_blas_perf_parallel.py
+++ b/benchmark/test_blas_perf_parallel.py
@@ -14,9 +14,11 @@ import torch
 import yaml
 
 import flag_gems
-from benchmark.base import Benchmark, GenericBenchmark2DOnly
-from benchmark.conftest import Config, emit_record_logger
-from benchmark.consts import (
+
+from . import consts
+from .base import Benchmark, GenericBenchmark2DOnly
+from .conftest import Config, emit_record_logger
+from .consts import (
     COMPLEX_DTYPES,
     DEFAULT_METRICS,
     FLOAT_DTYPES,
@@ -26,8 +28,6 @@ from benchmark.consts import (
     OperationAttribute,
     model_shapes,
 )
-
-from . import consts
 
 try:
     from vllm.model_executor.layers.quantization.utils.fp8_utils import (

--- a/benchmark/test_fp8_fp4_mega_moe.py
+++ b/benchmark/test_fp8_fp4_mega_moe.py
@@ -13,9 +13,68 @@ except ImportError:
     SM100_AVAILABLE = False
 
 from flag_gems.fused.fp8_fp4_mega_moe import fp8_fp4_mega_moe_torch_ref
-from tests.test_fp8_fp4_mega_moe import _build_inputs, _has_native_fp8
 
 from . import base
+
+
+# FP8/FP4 input builders, kept local so the benchmark does not depend on the
+# tests package. Mirrors the helpers in tests/test_fp8_fp4_mega_moe.py.
+def _has_native_fp8():
+    return torch.cuda.is_available() and torch.cuda.get_device_capability()[0] >= 9
+
+
+def _pack_fp4_e2m1(x):
+    ax = x.abs()
+    code = torch.zeros_like(x, dtype=torch.uint8)
+    for boundary in (0.25, 0.75, 1.25, 1.75, 2.5, 3.5, 5.0):
+        code += (ax > boundary).to(torch.uint8)
+    code |= ((x < 0) & (code != 0)).to(torch.uint8) << 3
+    packed = (code[..., 0::2] & 0x0F) | ((code[..., 1::2] & 0x0F) << 4)
+    return packed.contiguous().view(torch.int8)
+
+
+def _quantize_fp4(x):
+    groups = x.float().view(*x.shape[:-1], x.shape[-1] // 32, 32)
+    scale = groups.abs().amax(dim=-1).clamp_min(1e-4) / 6.0
+    x_scaled = (groups / scale.unsqueeze(-1)).reshape_as(x.float())
+    return _pack_fp4_e2m1(x_scaled), scale.contiguous()
+
+
+def _quantize_fp8(x):
+    fp8_dtype = torch.float8_e4m3fn
+    fp8_max = torch.finfo(fp8_dtype).max
+    groups = x.float().view(x.shape[0], x.shape[1] // 32, 32)
+    scale = groups.abs().amax(dim=-1).clamp_min(1e-4) / fp8_max
+    x_scaled = (groups / scale.unsqueeze(-1)).reshape_as(x.float())
+    x_fp8 = x_scaled.clamp(-fp8_max, fp8_max).to(fp8_dtype)
+    return x_fp8, scale.contiguous()
+
+
+def _build_inputs(num_tokens, hidden, intermediate, num_experts, top_k, device):
+    """Build FP8/FP4 inputs for the functional local MegaMoE interface."""
+    torch.manual_seed(42)
+
+    x = torch.randn((num_tokens, hidden), device=device, dtype=torch.bfloat16)
+    l1 = torch.randn(
+        (num_experts, 2 * intermediate, hidden),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+    l2 = torch.randn(
+        (num_experts, hidden, intermediate),
+        device=device,
+        dtype=torch.bfloat16,
+    )
+
+    x_fp8, x_scale = _quantize_fp8(x)
+    l1_fp4, l1_scale = _quantize_fp4(l1)
+    l2_fp4, l2_scale = _quantize_fp4(l2)
+
+    scores = torch.randn((num_tokens, num_experts), device=device, dtype=torch.float32)
+    topk_weights, topk_idx = torch.topk(scores, top_k, dim=-1)
+    topk_weights = torch.softmax(topk_weights, dim=-1)
+
+    return x_fp8, x_scale, topk_idx, topk_weights, l1_fp4, l1_scale, l2_fp4, l2_scale
 
 
 class FP8FP4MegaMoEBenchmark(base.Benchmark):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,9 +188,9 @@ Documentation = "https://flagos-ai.github.io/FlagGems"
 [project.scripts]
 flaggems-setup = "flag_gems._setup:main"
 
-[tool.setuptools.packages.find]
-
-where = ["src"]
+# Package discovery (including shipping the tests/ and benchmark/ suites under
+# collision-safe names) is defined in setup.py, so it is intentionally omitted
+# here — declaring `packages` in both places is an error.
 
 [tool.setuptools.package-data]
 

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,36 @@
+"""Build-time package configuration for flag_gems.
+
+This shim exists only to ship the operator test and benchmark suites inside the
+wheel under collision-safe, importable names — without moving them on disk:
+
+  tests/     -> flaggems_tests
+  benchmark/ -> flaggems_benchmark
+
+All project metadata (name, version, dependencies, …) lives in ``pyproject.toml``
+under ``[project]``; this file intentionally sets *only* ``packages`` and
+``package_dir`` (fields that PEP 621 does not own), so there is no metadata
+conflict. It is consumed by the setuptools build backend (PEP 517); the legacy
+``python setup.py install`` path is never used by pip/uv.
+
+Note: on ``master`` the declared backend is scikit-build-core, which ignores this
+file. The released wheel is built by ``.github/workflows/release.yaml`` after it
+patches the backend to ``setuptools.build_meta`` — that build honors this shim.
+"""
+
+from setuptools import find_packages, setup
+
+setup(
+    package_dir={
+        "": "src",
+        "flaggems_tests": "tests",
+        "flaggems_benchmark": "benchmark",
+    },
+    packages=(
+        find_packages("src")
+        + ["flaggems_tests", *(f"flaggems_tests.{p}" for p in find_packages("tests"))]
+        + [
+            "flaggems_benchmark",
+            *(f"flaggems_benchmark.{p}" for p in find_packages("benchmark")),
+        ]
+    ),
+)


### PR DESCRIPTION
## What & why

The FlagGems wheel currently ships only `flag_gems`; the operator `tests/` and `benchmark/` suites are left out, so they cannot be run against a **wheel-installed** `flag_gems`. (The `test` extra only installs *dependencies* — pytest, scipy, … — it never bundles files.)

This packages both suites into the wheel under **collision-safe** import names so they can be run post-install, e.g. `pytest --pyargs flaggems_tests`:

```
tests/      -> flaggems_tests
benchmark/  -> flaggems_benchmark
```

## Changes

- **`setup.py` (new)** — remaps the two top-level dirs via `package_dir` while `find_packages("src")` still auto-discovers all of `flag_gems`. It sets **only** `packages`/`package_dir` (never `[project]`-owned fields), so `pyproject.toml` metadata is untouched and pip/uv still build via PEP 517 — the legacy `python setup.py install` path is not involved.
- **`pyproject.toml`** — remove `[tool.setuptools.packages.find]` (declaring `packages` in two places is an error; `setup.py` owns discovery now). The build-backend line is unchanged.
- **`benchmark/` self-containment** — `test_blas_perf_parallel.py` absolute `from benchmark.*` imports → relative; `test_fp8_fp4_mega_moe.py` no longer imports helpers from the `tests` package — the FP8/FP4 input builders are inlined locally.

## Non-breaking

On-disk directory names are unchanged, so source-based `pytest tests/…` / `pytest benchmark/…` and all CI (which installs from source) are unaffected; `pip`/`uv install flag_gems` is unaffected (wheels don't execute `setup.py`).

Note: on `master` the declared backend is scikit-build-core, which ignores `setup.py`; the released wheel is built by `release.yaml` after it patches the backend to `setuptools.build_meta`, which honors the shim. Once the repo migrates to the setuptools/split build it is honored universally.

## Verification

Built the wheel via the release path (backend patched to setuptools):
- Wheel top-level: `flag_gems` (intact), `flaggems_tests`, `flaggems_benchmark` — collision-safe names, no bare `tests/`/`benchmark/` leak.
- Fresh venv `--no-deps` install: `import flaggems_tests` / `import flaggems_benchmark` succeed; relative-import targets resolve in-package.
- Re-scan confirms zero `benchmark`↔`tests` cross-imports in either tree.

## Follow-ups (deferred, non-breaking)

- Ship `pytest.ini` marker config inside the package so `pytest --pyargs flaggems_tests` sees registered markers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
