### PR TITLE
docs: update install/cpp/packaging guides for cpp/ wheel split

### DIFF
--- a/docs/content/en/getting-started/install.md
+++ b/docs/content/en/getting-started/install.md
@@ -31,10 +31,22 @@ pip install flag_gems
 > [!INFO]
 > **Info**
 >
-> This Python installation only installs the PyTorch operators implemented
-> in Python from *FlagGems*.
-> To install the C++-wrapped operators, you will have to
-> [build and install from source](#install-from-source).
+> This installs the pure-Python operators from *FlagGems*.
+>
+> To use the C++ wrapped operators (which reduce dispatch overhead for
+> performance-critical paths), you can install a prebuilt native extension
+> wheel via an extra:
+>
+> ```shell
+> pip install "flag-gems[cpp-cuda]"
+> ```
+>
+> This pulls in the matching `flag-gems-cpp-cuda` package from the flagOS
+> PyPI index. Replace `cpp-cuda` with the extension for your vendor:
+> `cpp-musa`, `cpp-npu`, `cpp-gcu`, or `cpp-ix`.
+>
+> If a prebuilt wheel is not available for your platform, see
+> [Build and install from source](#install-from-source).
 
 ## 3. Build and install from source {#install-from-source}
 
@@ -118,16 +130,53 @@ uv pip install --no-build-isolation -e .
 
 ### 3.4. C++ extensions (optional)
 
-To build with C++ wrapped operators, set `ENABLE_CPP=1`:
+FlagGems supports C++ wrapped operators for reduced dispatch overhead on
+performance-critical operations. The C++ extension is a **separate per-vendor
+package** (e.g., `flag-gems-cpp-cuda`) that installs compiled `.so` files into
+the `flag_gems/` namespace alongside the pure-Python operator implementations.
+
+There are two ways to get the C++ extensions:
+
+#### Option A: Build from source with `setup.sh`
 
 ```shell
 ENABLE_CPP=1 ./setup.sh nvidia-cuda128
 ```
 
-This sets the appropriate `CMAKE_ARGS` for your backend automatically.
-C++ extensions are still experimental — please assess before using in production.
+`setup.sh` automatically:
+- Injects the correct vendor name into `cpp/pyproject.toml` via
+  `tools/set_cpp_vendor.sh`
+- Sets the appropriate `CMAKE_ARGS` (`-DFLAGGEMS_BACKEND=...`)
+- Builds and installs the C++ extension from the `cpp/` subdirectory
+
+#### Option B: Manual build from the `cpp/` subdirectory
+
+The C++ extension uses `scikit-build-core` as its build-backend and requires
+CMake, a C++ toolchain, and your vendor's SDK. Build from the `cpp/`
+subdirectory:
+
+```shell
+# Set the vendor name (cuda, musa, npu, gcu, or ix)
+tools/set_cpp_vendor.sh cuda
+
+# Build and install
+CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=CUDA" \
+  uv pip install --no-build-isolation ./cpp
+```
 
 For manual control over CMake options, see the [CMake options reference](#cmake-options).
+
+#### Runtime: enable with `USE_C_EXTENSION`
+
+After installation, set the environment variable to activate C++ paths:
+
+```shell
+export USE_C_EXTENSION=1
+```
+
+Without this, only `torch.ops.flag_gems.*` and the `c_operators` pybind module
+are active; the ATen replacement and `flag_gems.enable()` C++ branches require
+it. See the [C++ usage guide](/FlagGems/usage/cpp/) for details.
 
 ## 4. References
 
@@ -175,6 +224,11 @@ pass them via the `CMAKE_ARGS` environment variable.
 | `FLAGGEMS_BUILD_POINTWISE_DYNAMIC_CPP` | Build pointwise dynamic C++ module | `OFF` |
 
 ### 4.4 `scikit-build-core` options {#scikit-build-core-options}
+
+> [!NOTE]
+> The main `flag-gems` package uses `setuptools` as its build-backend.
+> The `scikit-build-core` tool is used **only for the C++ extension**
+> built from the `cpp/` subdirectory.
 
 The `scikit-build-core` tool is a build-backend that bridges CMake
 and the Python build system, making it easier to create Python modules with CMake.

--- a/docs/content/en/release/packaging.md
+++ b/docs/content/en/release/packaging.md
@@ -8,7 +8,8 @@ weight: 20
 Creating a source or binary distribution is similar to
 [building and installing from source](/FlagGems/getting-started/installation/#install-from-source).
 It involves invoking a build-frontend (such as `pip` or `build`) and pass the command
-to the build-backend (`scikit-build-core` here).
+to the build-backend (`setuptools` for the main `flag-gems` package;
+`scikit-build-core` for the `cpp/` C++ extension package).
 
 ## 1. Using the `build` build frontend
 
@@ -41,7 +42,7 @@ Alternatively, you can build a wheel with `pip`:
 pip wheel --no-build-isolation --no-deps -w dist .
 ```
 
-The environment variables used to configure `scikit-build-core` work in the same way
+The environment variables used to configure `setuptools` work in the same way
 as described in the [installation guide](/FlagGems/getting-started/installation/).
 
 After the binary distribution (wheel) is built, you can use `pip` to install it.
@@ -50,3 +51,31 @@ After the binary distribution (wheel) is built, you can use `pip` to install it.
 cd FlagGems
 python -m build --no-isolation --wheel .
 ```
+
+## 3. Building C++ extension wheels
+
+The C++ wrapped operators are packaged as **per-vendor native extension wheels**
+built from the `cpp/` subdirectory. Each vendor produces a separate package
+(`flag-gems-cpp-cuda`, `flag-gems-cpp-musa`, etc.) that installs its `.so`
+files into the `flag_gems/` namespace.
+
+Before building, inject the vendor name into `cpp/pyproject.toml`:
+
+```shell
+tools/set_cpp_vendor.sh cuda    # or musa, npu, gcu, ix
+```
+
+Then build from the `cpp/` subdirectory. The build requires the vendor's SDK
+and toolchain (CMake, a C++ compiler, and PyTorch for that backend):
+
+```shell
+cd cpp/
+CMAKE_ARGS="-DFLAGGEMS_BACKEND=CUDA" python -m build --no-isolation --wheel .
+```
+
+This produces a platform-specific wheel (e.g.
+`flag_gems_cpp_cuda-x.y.z-cp312-cp312-linux_x86_64.whl`) in `cpp/dist/`.
+
+The environment variables used to configure `scikit-build-core` (see the
+[installation guide](/FlagGems/getting-started/installation/#scikit-build-core-options))
+apply when building from `cpp/`.

--- a/docs/content/en/usage/cpp.md
+++ b/docs/content/en/usage/cpp.md
@@ -32,11 +32,11 @@ In this stack:
 - `libtriton_jit` handles JIT specialization, kernel caching, and backend-specific
   launches (currently supporting **NVIDIA (CUDA)**, **Moore Threads (MUSA)**,
   **Huawei Ascend (NPU)** and **Iluvatar CoreX (IX)**).
-- FlagGems's C++ wrappers (under `lib/`, e.g. `rms_norm.cpp`, `mm.cpp`) implement
+- FlagGems's C++ wrappers (under `cpp/lib/`, e.g. `rms_norm.cpp`, `mm.cpp`) implement
   tensor metadata handling, shape/type promotion, and argument preparation in C++,
   then invoke the Triton kernels through `libtriton_jit::TritonJITFunction`.
 - On top of the wrappers, *FlagGems* ships two Python-facing extension modules
-  (`src/flag_gems/csrc/cstub.cpp` and `src/flag_gems/csrc/aten_patch.cpp`)
+  (`cpp/csrc/cstub.cpp` and `cpp/csrc/aten_patch.cpp`)
   and one installable C++ library target (`FlagGems::operators`), which together
   expose the wrappers through four different invocation paths (see
   [§3. Ways to invoke C++ operators](#3-ways-to-invoke-c-operators)).
@@ -71,28 +71,48 @@ To make the C++ wrapper **fully effective** you need both of the following:
 
 1. **At build/install time: enable the C++ extension and build in Release mode**
 
-   Install from source with at least `-DFLAGGEMS_BUILD_C_EXTENSIONS=ON` and
-   `-DCMAKE_BUILD_TYPE=Release` (the latter ensures both FlagGems itself
-   and the `libtriton_jit` subproject built alongside it are compiled with
-   platform-targeted optimizations; without it the wrapper will be noticeably
-   slower):
+   **Preferred — build from source with `setup.sh`:**
 
    ```shell
+   ENABLE_CPP=1 ./setup.sh nvidia-cuda128
+   ```
+
+   This reads the backend configuration from `backends.yaml`, sets the appropriate
+   CMake arguments, injects the vendor name into `cpp/pyproject.toml`, and builds
+   the C++ extension from the `cpp/` subdirectory.
+
+   **Alternative — install a prebuilt wheel (if available for your vendor):**
+
+   ```shell
+   pip install "flag-gems[cpp-cuda]"
+   ```
+
+   This pulls a prebuilt `flag-gems-cpp-cuda` wheel from the flagOS PyPI index.
+   Replace `cpp-cuda` with your vendor extension: `cpp-musa`, `cpp-npu`,
+   `cpp-gcu`, or `cpp-ix`.
+
+   **Manual — build from the `cpp/` subdirectory:**
+
+   The C++ sources and CMake build system live in `cpp/`. Build with at least
+   `-DFLAGGEMS_BUILD_C_EXTENSIONS=ON` and `-DCMAKE_BUILD_TYPE=Release`:
+
+   ```shell
+   tools/set_cpp_vendor.sh cuda
    CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DCMAKE_BUILD_TYPE=Release" \
-   pip install -v -e .
+   uv pip install --no-build-isolation ./cpp
    ```
 
    > [!NOTE]
-   > If the command above fails, try adding `--no-build-isolation` so
-   > that pip reuses the PyTorch already installed in your environment
-   > and the build dependencies from `requirements_<backend>.txt`.
+   > The C++ extension must target a specific vendor (`-DFLAGGEMS_BACKEND=<...>`).
+   > `tools/set_cpp_vendor.sh` injects the vendor name into `cpp/pyproject.toml`
+   > so the built wheel has the correct package name.
 
    Other useful options:
 
    - `-DFLAGGEMS_BACKEND=<CUDA|IX|MUSA|NPU>`: select the target backend (default `CUDA`);
    - `-DFLAGGEMS_BUILD_POINTWISE_DYNAMIC_CPP=ON`: build the pointwise-dynamic
      operators (`add`, `div`, `fill`);
-   - `-DFLAGGEMS_BUILD_CTESTS=ON`: build the `ctests/` GTest suite
+   - `-DFLAGGEMS_BUILD_CTESTS=ON`: build the `cpp/ctests/` GTest suite
      (the only way to verify the native C++ API in §3.4);
    - `-DFLAGGEMS_USE_EXTERNAL_TRITON_JIT=ON -DTritonJIT_ROOT=<path>`:
      build against an externally installed `libtriton_jit`.
@@ -183,7 +203,7 @@ case and has a different level of dispatcher overhead.
 
 All C++ wrappers are registered as PyTorch *custom ops* under the
 `flag_gems` namespace via `TORCH_LIBRARY(flag_gems, m)` in
-`src/flag_gems/csrc/cstub.cpp`. You can call them explicitly from Python,
+`cpp/csrc/cstub.cpp`. You can call them explicitly from Python,
 bypassing any patching logic or Python-side fall back paths:
 
 ```python
@@ -196,7 +216,7 @@ out    = torch.ops.flag_gems.mm(a, b)
 For a subset of operators, *FlagGems* additionally registers the C++
 implementations directly under the **`aten::` namespace** using
 `TORCH_LIBRARY_IMPL(aten, <dispatch_key>, m)` in
-`src/flag_gems/csrc/aten_patch.cpp`. The dispatch key is chosen by backend:
+`cpp/csrc/aten_patch.cpp`. The dispatch key is chosen by backend:
 
 - `CUDA` for NVIDIA CUDA and Iluvatar CoreX (IX);
 - `PrivateUse1` for Huawei Ascend (NPU) and Moore Threads (MUSA).
@@ -215,7 +235,7 @@ lowest-friction way to accelerate an existing model.
 ### 3.3 Via the `c_operators` pybind module (direct, dispatcher-free)
 
 The same C++ wrappers are also exported through a `PYBIND11_MODULE(c_operators, …)`
-in `src/flag_gems/csrc/cstub.cpp`:
+in `cpp/csrc/cstub.cpp`:
 
 ```python
 from flag_gems import c_operators
@@ -243,7 +263,7 @@ at::Tensor c = flag_gems::mm_tensor(a, b);
 at::Tensor y = flag_gems::rms_norm(x, weight, eps);
 ```
 
-This is exactly what the in-tree GTest suite under `ctests/` uses (e.g.
+This is exactly what the in-tree GTest suite under `cpp/ctests/` uses (e.g.
 `ctests/test_triton_mm.cpp`), and it is the right path when embedding
 FlagGems into a non-Python C++ application or when writing C++ unit tests.
 

--- a/docs/content/zh-cn/getting-started/install.md
+++ b/docs/content/zh-cn/getting-started/install.md
@@ -59,17 +59,41 @@ pip install flag_gems
 > [!INFO]
 > **Info**
 >
-> This Python installation only installs the PyTorch operators implemented
-> in Python from *FlagGems*.
-> To install the C++-wrapped operators, you will have to
-> [build and install from source](#install-from-source).
--->
+> This installs the pure-Python operators from *FlagGems*.
+>
+> To use the C++ wrapped operators (which reduce dispatch overhead for
+> performance-critical paths), you can install a prebuilt native extension
+> wheel via an extra:
+>
+> ```shell
+> pip install "flag-gems[cpp-cuda]"
+> ```
+>
+> This pulls in the matching `flag-gems-cpp-cuda` package from the flagOS
+> PyPI index. Replace `cpp-cuda` with the extension for your vendor:
+> `cpp-musa`, `cpp-npu`, `cpp-gcu`, or `cpp-ix`.
+>
+> If a prebuilt wheel is not available for your platform, see
+> [Build and install from source](#install-from-source).
+>-->
 > [!INFO]
 > **提示**
 >
-> 这种纯 Python 包的安装方式仅安装 *FlagGems* 中用 Python 实现的算子。
-> 如果需要安装 C++ 封装的算子，你必须采用
-> [从源码构建安装](#install-from-source)方式。
+> 上述命令仅安装 *FlagGems* 中纯 Python 实现的算子。
+>
+> 如需使用 C++ 封装的算子（可减少性能关键路径上的 dispatch 开销），
+> 可以通过 extras 安装预构建的原生扩展 wheel：
+>
+> ```shell
+> pip install "flag-gems[cpp-cuda]"
+> ```
+>
+> 该命令会从 flagOS PyPI 仓库拉取匹配的 `flag-gems-cpp-cuda` 包。
+> 请将 `cpp-cuda` 替换为你所使用的硬件对应的扩展：
+> `cpp-musa`、`cpp-npu`、`cpp-gcu` 或 `cpp-ix`。
+>
+> 如果你的平台上没有可用的预构建 wheel，请参阅
+> [从源码构建安装](#install-from-source)。
 
 <!--
 ## 3. Build and install from source {#install-from-source}
@@ -204,26 +228,64 @@ uv pip install --no-build-isolation -e .
 <!--
 ### 3.4. C++ extensions (optional)
 
-To build with C++ wrapped operators, set `ENABLE_CPP=1`:
+FlagGems supports C++ wrapped operators for reduced dispatch overhead on
+performance-critical operations. The C++ extension is a **separate per-vendor
+package** (e.g., `flag-gems-cpp-cuda`) that installs compiled `.so` files into
+the `flag_gems/` namespace alongside the pure-Python operator implementations.
+
+There are two ways to get the C++ extensions:
+
+#### Option A: Build from source with `setup.sh`
 -->
 ### 3.4 C++ 扩展（可选）
 
-如需构建 C++ 封装的算子，设置 `ENABLE_CPP=1`：
+*FlagGems* 通过 C++ 封装算子在性能关键路径上减少 dispatch 开销。
+C++ 扩展是一个**独立的、按硬件供应商区分的包**（如 `flag-gems-cpp-cuda`），
+它将编译好的 `.so` 文件安装到 `flag_gems/` 命名空间下，与纯 Python 算子并列。
+
+C++ 扩展的获取方式有两种：
+
+#### 方式 A：通过 `setup.sh` 从源码构建
 
 ```shell
 ENABLE_CPP=1 ./setup.sh nvidia-cuda128
 ```
 
-<!--
-This sets the appropriate `CMAKE_ARGS` for your backend automatically.
-C++ extensions are still experimental — please assess before using in production.
+`setup.sh` 会自动完成以下操作：
+- 通过 `tools/set_cpp_vendor.sh` 向 `cpp/pyproject.toml` 注入正确的 vendor 标识
+- 设置对应的 `CMAKE_ARGS`（`-DFLAGGEMS_BACKEND=...`）
+- 从 `cpp/` 子目录构建并安装 C++ 扩展
 
+#### 方式 B：在 `cpp/` 子目录中手动构建
+
+C++ 扩展使用 `scikit-build-core` 作为构建后端，需要 CMake、C++ 工具链以及
+对应硬件厂商的 SDK。从 `cpp/` 子目录进行构建：
+
+```shell
+# 设置 vendor 标识（cuda、musa、npu、gcu 或 ix）
+tools/set_cpp_vendor.sh cuda
+
+# 构建并安装
+CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DFLAGGEMS_BACKEND=CUDA" \
+  uv pip install --no-build-isolation ./cpp
+```
+
+<!--
 For manual control over CMake options, see the CMake options reference.
 -->
-此命令会自动为你的后端设置合适的 `CMAKE_ARGS`。
-C++ 扩展仍然是实验性功能，请在生产环境中使用前进行充分评估。
-
 如需手动控制 CMake 选项，请参阅 [CMake 选项参考](#cmake-options)。
+
+#### 运行时：通过 `USE_C_EXTENSION` 启用
+
+安装完成后，设置以下环境变量来激活 C++ 路径：
+
+```shell
+export USE_C_EXTENSION=1
+```
+
+如果不设置该变量，只有 `torch.ops.flag_gems.*` 及 `c_operators` pybind
+模块生效；ATen 替换和 `flag_gems.enable()` 的 C++ 分支仍需此变量。
+详见 [C++ 使用指南](/FlagGems/zh-cn/usage/cpp/)。
 
 <!--
 ## 4. References
@@ -331,6 +393,10 @@ are separated by semicolons (`;`), whereas for `CMAKE_ARGS`, they are separated
 by spaces.
 -->
 ### 4.4 `scikit-build-core` 选项 {#scikit-build-core-options}
+
+> [!NOTE]
+> 主包 `flag-gems` 使用 `setuptools` 作为构建后端。
+> `scikit-build-core` **仅用于**从 `cpp/` 子目录构建的 C++ 扩展。
 
 `scikit-build-core` 是一个构建后端，用来桥接 CMake 和 Python 构建系统，
 简化使用 CMake 构建 Python 模块的过程。

--- a/docs/content/zh-cn/release/packaging.md
+++ b/docs/content/zh-cn/release/packaging.md
@@ -9,13 +9,14 @@ weight: 20
 Creating a source or binary distribution is similar to
 [building and installing from source](/FlagGems/getting-started/installation/#install-from-source).
 It involves invoking a build-frontend (such as `pip` or `build`) and pass the command
-to the build-backend (`scikit-build-core` here).
+to the build-backend (`setuptools` for the main `flag-gems` package;
+`scikit-build-core` for the `cpp/` C++ extension package).
 -->
 # 关于打包与发布
 
 创建源码或二进制发行包的过程类似于基于[源码来构建和安装](/FlagGems/zh-cn/getting-started/installation/#install-from-source)的过程。
 打包过程包括对前端（如 `pip` 或 `build`）的调用以及将命令发送给后端
-（`scikit-build-core`）的动作。
+（主包 `flag-gems` 使用 `setuptools`，`cpp/` C++ 扩展包使用 `scikit-build-core`）。
 
 <!--
 ## 1. Using the `build` build frontend
@@ -72,12 +73,12 @@ pip wheel --no-build-isolation --no-deps -w dist .
 ```
 
 <!--
-The environment variables used to configure `scikit-build-core` work in the same way
+The environment variables used to configure `setuptools` work in the same way
 as described in the [installation guide](/FlagGems/getting-started/installation/).
 
 After the binary distribution (wheel) is built, you can use `pip` to install it.
 -->
-用来配置 `scikit-build-core`
+用来配置 `setuptools`
 的环境变量的工作方式与[安装说明](/FlagGems/zh-cn/getting-started/installation/)文档中的方式一致。
 
 构建二进制包（wheel）的动作完成之后，你可以使用 `pip` 命令来安装。
@@ -86,3 +87,53 @@ After the binary distribution (wheel) is built, you can use `pip` to install it.
 cd FlagGems
 python -m build --no-isolation --wheel .
 ```
+
+<!--
+## 3. Building C++ extension wheels
+
+The C++ wrapped operators are packaged as **per-vendor native extension wheels**
+built from the `cpp/` subdirectory. Each vendor produces a separate package
+(`flag-gems-cpp-cuda`, `flag-gems-cpp-musa`, etc.) that installs its `.so`
+files into the `flag_gems/` namespace.
+
+Before building, inject the vendor name into `cpp/pyproject.toml`:
+-->
+## 3. 构建 C++ 扩展 wheel
+
+C++ 封装算子以**按硬件厂商区分的原生扩展 wheel** 的形式进行打包，
+构建入口为 `cpp/` 子目录。每个厂商对应一个独立的包
+（`flag-gems-cpp-cuda`、`flag-gems-cpp-musa` 等），
+这些包将其 `.so` 文件安装到 `flag_gems/` 命名空间中。
+
+构建之前，先向 `cpp/pyproject.toml` 注入厂商标识：
+
+```shell
+tools/set_cpp_vendor.sh cuda    # 或 musa、npu、gcu、ix
+```
+
+<!--
+Then build from the `cpp/` subdirectory. The build requires the vendor's SDK
+and toolchain (CMake, a C++ compiler, and PyTorch for that backend):
+-->
+然后从 `cpp/` 子目录进行构建。构建需要对应厂商的 SDK 和工具链
+（CMake、C++ 编译器以及该后端的 PyTorch）：
+
+```shell
+cd cpp/
+CMAKE_ARGS="-DFLAGGEMS_BACKEND=CUDA" python -m build --no-isolation --wheel .
+```
+
+<!--
+This produces a platform-specific wheel (e.g.
+`flag_gems_cpp_cuda-x.y.z-cp312-cp312-linux_x86_64.whl`) in `cpp/dist/`.
+
+The environment variables used to configure `scikit-build-core` (see the
+[installation guide](/FlagGems/getting-started/installation/#scikit-build-core-options))
+apply when building from `cpp/`.
+-->
+该命令会在 `cpp/dist/` 目录下生成平台相关的 wheel 包
+（例如 `flag_gems_cpp_cuda-x.y.z-cp312-cp312-linux_x86_64.whl`）。
+
+用于配置 `scikit-build-core` 的环境变量（参见
+[安装说明](/FlagGems/zh-cn/getting-started/installation/#scikit-build-core-options)）
+在从 `cpp/` 构建时适用。

--- a/docs/content/zh-cn/usage/cpp.md
+++ b/docs/content/zh-cn/usage/cpp.md
@@ -46,7 +46,7 @@ Triton JIT 运行时逻辑（参数特化、内核缓存和发射），
 - `libtriton_jit` 负责 JIT 特化、内核缓存以及特定后端的 kernel 发射，
   目前已支持 **NVIDIA（CUDA）**、**摩尔线程（MUSA）**、**华为昇腾（NPU）**
   与**天数智芯（IX）** 四种后端；
-- *FlagGems* 的 C++ 封装算子（位于 `lib/` 目录下，例如 `rms_norm.cpp`、`mm.cpp`）
+- *FlagGems* 的 C++ 封装算子（位于 `cpp/lib/` 目录下，例如 `rms_norm.cpp`、`mm.cpp`）
   以 C++ 实现张量元数据处理、形状/类型提升以及参数准备，最后通过
   `libtriton_jit::TritonJITFunction` 调用 Triton 内核；
 - 在封装算子之上，*FlagGems* 还提供两个面向 Python 的扩展模块
@@ -79,26 +79,49 @@ Triton JIT 运行时逻辑（参数特化、内核缓存和发射），
 
 1. **编译安装时：打开 C++ 扩展并以 Release 构建**
 
-   从源码安装，至少传入 `-DFLAGGEMS_BUILD_C_EXTENSIONS=ON` 与
+   **推荐方式 — 通过 `setup.sh` 从源码构建：**
+
+   ```shell
+   ENABLE_CPP=1 ./setup.sh nvidia-cuda128
+   ```
+
+   `setup.sh` 从 `backends.yaml` 读取后端配置，设置对应的 CMake 参数，
+   向 `cpp/pyproject.toml` 注入 vendor 标识，并从 `cpp/` 子目录构建 C++ 扩展。
+
+   **备选方式 — 安装预构建 wheel（如果你的硬件平台支持）：**
+
+   ```shell
+   pip install "flag-gems[cpp-cuda]"
+   ```
+
+   该命令从 flagOS PyPI 仓库拉取预构建的 `flag-gems-cpp-cuda` wheel。
+   请将 `cpp-cuda` 替换为你的硬件对应的扩展：
+   `cpp-musa`、`cpp-npu`、`cpp-gcu` 或 `cpp-ix`。
+
+   **手动构建 — 从 `cpp/` 子目录：**
+
+   C++ 源码和 CMake 构建系统位于 `cpp/` 子目录下。
+   构建时至少需要传入 `-DFLAGGEMS_BUILD_C_EXTENSIONS=ON` 与
    `-DCMAKE_BUILD_TYPE=Release`（后者保证 FlagGems 与随同构建的
    `libtriton_jit` 都按目标平台开启优化，否则 wrapper 会明显变慢）：
 
    ```shell
+   tools/set_cpp_vendor.sh cuda
    CMAKE_ARGS="-DFLAGGEMS_BUILD_C_EXTENSIONS=ON -DCMAKE_BUILD_TYPE=Release" \
-   pip install -v -e .
+   uv pip install --no-build-isolation ./cpp
    ```
 
    > [!NOTE]
-   > 如果上述命令构建失败，可以尝试加上 `--no-build-isolation`，
-   > 让 pip 复用当前环境中已安装的 PyTorch 以及
-   > `requirements_<backend>.txt` 预装的构建依赖。
+   > C++ 扩展必须指定目标硬件 (`-DFLAGGEMS_BACKEND=<...>`)。
+   > `tools/set_cpp_vendor.sh` 会将 vendor 标识写入 `cpp/pyproject.toml`，
+   > 确保构建出的 wheel 具有正确的包名。
 
    其他可选参数：
 
    - `-DFLAGGEMS_BACKEND=<CUDA|IX|MUSA|NPU>`：选择目标后端（默认 `CUDA`）；
    - `-DFLAGGEMS_BUILD_POINTWISE_DYNAMIC_CPP=ON`：编译 `add`/`div`/`fill`
      这几个 pointwise dynamic 算子；
-   - `-DFLAGGEMS_BUILD_CTESTS=ON`：编译 `ctests/` 下的 GTest 用例
+   - `-DFLAGGEMS_BUILD_CTESTS=ON`：编译 `cpp/ctests/` 下的 GTest 用例
      （验证 §3.4 原生 C++ API 的唯一手段）；
    - `-DFLAGGEMS_USE_EXTERNAL_TRITON_JIT=ON -DTritonJIT_ROOT=<path>`：
      使用外部预装的 `libtriton_jit`。
@@ -146,7 +169,7 @@ Triton JIT 运行时逻辑（参数特化、内核缓存和发射），
    `-DFLAGGEMS_BUILD_CTESTS=ON`，然后运行 `ctest`：
 
    ```shell
-   BUILD_DIR=$(ls -d build/*/ | head -n 1)
+   BUILD_DIR=$(ls -d cpp/build/*/ | head -n 1)
    ctest --test-dir "${BUILD_DIR}" --output-on-failure
    ```
 
@@ -239,7 +262,7 @@ at::Tensor c = flag_gems::mm_tensor(a, b);
 at::Tensor y = flag_gems::rms_norm(x, weight, eps);
 ```
 
-仓库中 `ctests/` 下的 GTest 用例（例如 `ctests/test_triton_mm.cpp`）正是以这种方式调用 FlagGems 的算子的。
+仓库中 `cpp/ctests/` 下的 GTest 用例（例如 `cpp/ctests/test_triton_mm.cpp`）正是以这种方式调用 FlagGems 的算子的。
 当你希望把 FlagGems 嵌入到一个非 Python 的 C++ 应用中，或者需要写 C++ 单元测试时，这就是合适的路径。
 
 ### 小结


### PR DESCRIPTION
The [wheel packaging split](#4745) restructured C++ extensions into a
`cpp/` subdirectory with per-vendor packages
(`flag-gems-cpp-cuda`, `flag-gems-cpp-musa`, etc.). The documentation
still described the old monolithic build — this PR brings the install,
C++ usage, and packaging guides up to date.

### Changes

**Install guides** (`en/` + `zh-cn/`):
- Section 2 (PyPI): replaced "you must build from source" note with
  instructions for `pip install "flag-gems[cpp-cuda]"` via extras
- Section 3.4 (C++ extensions): rewritten with two options —
  (A) `ENABLE_CPP=1 ./setup.sh` and (B) manual build from `cpp/`
  using `tools/set_cpp_vendor.sh` + `CMAKE_ARGS`
- Section 4.4: added note that the main package uses `setuptools`;
  `scikit-build-core` only applies to `cpp/` builds

**C++ usage guides** (`en/` + `zh-cn/`):
- Updated all source path references:
  `src/flag_gems/csrc/` → `cpp/csrc/`,
  `lib/` → `cpp/lib/`, `ctests/` → `cpp/ctests/`
- Rewrote build step 1 to show three paths: `ENABLE_CPP=1`,
  prebuilt wheel via extras, and manual `cd cpp/` build
- Fixed `BUILD_DIR` → `cpp/build/`

**Packaging guides** (`en/` + `zh-cn/`):
- Intro paragraph: build-backend is now `setuptools` for main,
  `scikit-build-core` for `cpp/`
- New section 3: "Building C++ extension wheels" with per-vendor
  build commands from `cpp/`

### Verification
- Hugo builds cleanly (0 errors)

This PR was written in part with the assistance of generative AI.