### PR TITLE
fix(ci): correct setup-flaggems input name in random-test.yaml

### DIFF
--- a/.github/workflows/random-test.yaml
+++ b/.github/workflows/random-test.yaml
@@ -86,7 +86,7 @@ jobs:
       - uses: ./.github/actions/checkout-retry
       - uses: ./.github/actions/setup-flaggems
         with:
-          vendor: ${{ steps.resolve.outputs.BACKEND }}
+          backend: ${{ steps.resolve.outputs.BACKEND }}
           gpu_check_script: tools/gpu_check_${{ steps.resolve.outputs.VENDOR }}.sh
 
       - name: Run tests


### PR DESCRIPTION
## Problem

`random-test.yaml` passes `vendor: ${{ steps.resolve.outputs.BACKEND }}`
to the `setup-flaggems` action, but the action declares its input as
`backend`. The misnamed parameter is silently ignored, so the workflow
would fall back to whatever backend detection happens by default rather
than using the resolved backend.

## Fix

Rename `vendor:` → `backend:` to match the action's input definition.

This PR was written in part with the assistance of generative AI.