### PR TITLE
Cap setuptools-scm below 10 to fix `pip install .` build failure

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,14 @@
 # setuptools is capped below 77: from 77.0 onward it adopts PEP 639 and emits
 # `License-File`, which bumps the wheel to Metadata-Version 2.4. Some package
 # indexes (e.g. Nexus) reject 2.4; <77 keeps the pure-Python wheel at 2.2.
-requires = ["setuptools>=64.0,<77", "setuptools-scm>=8"]
+#
+# setuptools-scm is capped below 10: the 10.x line added an egg_info
+# file-finder integration (setuptools_scm/_integration/egg_info.py) that reads
+# `ignore_egg_info_in_manifest`, an attribute only present on newer setuptools.
+# Combined with the setuptools<77 pin above, `pip install .` then fails during
+# "Getting requirements to build wheel" with
+# `AttributeError: ignore_egg_info_in_manifest`. 9.x has no such integration.
+requires = ["setuptools>=64.0,<77", "setuptools-scm>=8,<10"]
 
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

`pip install .` started failing in the weekly build (run dated 2026-07-19) during
the "Getting requirements to build wheel" step:

```
AttributeError: ignore_egg_info_in_manifest
  File ".../setuptools_scm/_integration/egg_info.py", line 106, in find_sources
    mm.ignore_egg_info_dir = self.ignore_egg_info_in_manifest
```

**Root cause**

- Since #4745 switched the main package's build backend to `setuptools.build_meta`,
  `pip install .` now runs setuptools' `egg_info` command, which invokes
  setuptools-scm's file-finder integration.
- `setuptools-scm>=8` is unpinned on the upper bound, so it now resolves to the
  **10.x** line (10.2.0, released 2026-06-25). The 10.x line added
  `setuptools_scm/_integration/egg_info.py`, whose `find_sources()` reads
  `egg_info.ignore_egg_info_in_manifest` — an attribute only present on newer
  setuptools. `setuptools-scm` 9.x has no such file.
- The build pins `setuptools<77`, and the setuptools used in the CI build lacks
  that attribute, so the `egg_info` step raises `AttributeError`.

**Fix**

Cap `setuptools-scm>=8,<10` (resolves to 9.2.2, which has no egg_info
integration). This keeps the existing `setuptools<77` pin intact and restores the
previously-green build.

`cpp/pyproject.toml` is intentionally left unchanged: it builds with
`scikit-build-core`, which never runs setuptools' `egg_info`, so it does not hit
this path.

**How to verify**

`pip install .` (or `pip install -e .`) in the weekly build environment now
completes the "Getting requirements to build wheel" step instead of raising
`AttributeError: ignore_egg_info_in_manifest`.

### Issue

Weekly build failure:
https://github.com/flagos-ai/FlagGems/actions/runs/29696348290/job/88217684481

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT. (N/A — build-system metadata only.)

### Performance

N/A — build-system dependency pin only; no runtime code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
