### PR TITLE
fix(kunlunxin): remove --fg_mode operator from performance benchmark

### DIFF
--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -744,8 +744,6 @@ def run_benchmark_q(gpu_id, op):
 
     dur = time.time()
     cmd = f'pytest -m "{op}" --level core --record json --output benchmark_{op}.json --continue-on-collection-errors'
-    if ENV_INFO["flag_gems"]["vendor"] == "kunlunxin":
-        cmd += " --fg_mode operator"
     code = run_cmd(op, cmd, cwd=benchmark_dir, env=env, flavor="performance")
     dur = time.time() - dur
 


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

The benchmark runner in `tools/run_tests.py` appends `--fg_mode operator` to the
pytest command for the kunlunxin vendor, which lowers kunlunxin accelerator
benchmark performance:

```python
if ENV_INFO["flag_gems"]["vendor"] == "kunlunxin":
    cmd += " --fg_mode operator"
```

These two lines were originally removed in #4854. However, #4829 was branched
from an older master (before that fix) and merged **after** #4854, silently
reintroducing the lines — no merge conflict was raised because the stale branch
never saw the deletion. As a result the kunlunxin speedup did not take effect
and the performance numbers regressed again.

This PR removes the two lines again, based on the **latest `master`**, so the
fix is not reverted.

### Issue

Re-applies the fix from #4854, which was inadvertently reverted by #4829.

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

Removing `--fg_mode operator` restores the kunlunxin benchmark to its intended
run mode, recovering the performance that regressed after #4829 merged.
