### PR TITLE
[KMCompiler]Add _unsafe_index_put c++ wrapper

### DIFF
--- a/benchmark/test_unsafe_index_put.py
+++ b/benchmark/test_unsafe_index_put.py
@@ -1,0 +1,189 @@
+import numpy as np
+import pytest
+import torch
+
+import flag_gems
+
+from . import base, consts
+
+# Comprehensive shapes covering all usage patterns
+# Format: (input_shape, [index_shapes], values_shape, accumulate)
+_SHAPES_ACC_FALSE = (
+    # --- 1D input with 1 index ---
+    ((256,), ((64,),), (64,), False),
+    ((4096,), ((1024,),), (1024,), False),
+    ((2**28,), ((2**16,),), (2**16,), False),
+    # --- 2D input, 1 index ---
+    ((32, 32), ((2, 8),), (32,), False),
+    # Replace=False: index elements must be ≤ input dim size
+    # so max index elements = input_shape[i]
+    ((256, 256), ((16, 16),), (256,), False),   # 256 ≤ 256
+    ((1024, 1024), ((64,),), (1024,), False),
+    ((1024, 1024), ((4, 64),), (1024,), False),
+    ((4096, 4096), ((256,),), (4096,), False),
+    # --- 2D input, 2 indices ---
+    ((32, 32), ((8,), (8,)), (8,), False),
+    ((32, 32), ((8,), (2, 8)), (8,), False),
+    ((1024, 1024), ((64,), (64,)), (64,), False),
+    ((1024, 1024), ((64,), (4, 64)), (64,), False),
+    ((4096, 4096), ((256,), (256,)), (256,), False),
+    # --- 3D input (various index configs) ---
+    ((64, 64, 64), ((2, 8), (2, 8), (2, 8)), (2, 8), False),
+    ((512, 512, 512), ((128,), (128,), (128,)), (128,), False),
+    ((512, 512, 512), ((2, 128), (128,), (128,)), (128,), False),
+    ((512, 512, 512), ((2, 128),), (512,), False),
+    ((256, 256, 256), ((64,), (64,), (64,)), (64,), False),
+    # --- 4D input ---
+    ((64, 64, 64, 64), ((8, 8), (8, 8), (8, 8), (8, 8)), (8, 8), False),
+)
+
+_SHAPES_ACC_TRUE = (
+    # 1D input, 1 index, no suffix
+    ((100,), ((100,),), (100,), True),
+    ((10000,), ((10000,),), (10000,), True),
+    # 2D input, 2 indices (both dims indexed), no suffix
+    # values_shape = broadcast_index_shape
+    ((32, 32), ((8,), (8,)), (8,), True),
+    ((512, 512), ((512,), (512,)), (512,), True),
+    ((1024, 1024), ((1024,), (1024,)), (1024,), True),
+    # 3D input, 3 indices, no suffix
+    ((64, 64, 64), ((2, 8), (2, 8), (2, 8)), (2, 8), True),
+    ((512, 512, 512), ((128,), (128,), (128,)), (128,), True),
+    ((512, 512, 512), ((2, 128), (2, 128), (2, 128)), (2, 128), True),
+)
+
+
+def _gen_indices(input_shape, indices_shapes, accumulate):
+    """Generate index tensors for benchmarking."""
+    indices = []
+    for i, shape in enumerate(indices_shapes):
+        index = np.random.choice(
+            np.arange(input_shape[i]), size=shape, replace=accumulate
+        )
+        indices.append(torch.tensor(index, device=flag_gems.device))
+    return indices
+
+
+def _is_float_dtype(dtype):
+    return dtype in (torch.float32, torch.float64, torch.float16, torch.bfloat16)
+
+
+def _make_tensor(shape, dtype, device):
+    if dtype == torch.bool:
+        return torch.randint(0, 2, shape, device=device).to(torch.bool)
+    elif _is_float_dtype(dtype):
+        return torch.randn(shape, dtype=dtype, device=device)
+    else:
+        return torch.randint(1, 10, shape, device=device).to(dtype)
+
+
+def unsafe_index_put_input_fn(shapes, dtype, device):
+    """Input generator for _unsafe_index_put benchmark."""
+    input_shape, indices_shapes, values_shape, accumulate = shapes
+    inp = _make_tensor(input_shape, dtype, device)
+    indices = _gen_indices(input_shape, indices_shapes, accumulate)
+    values = _make_tensor(values_shape, dtype, device)
+    yield inp, indices, values, accumulate
+
+
+class UnsafeIndexPutBenchmark(base.Benchmark):
+    """Dedicated benchmark for _unsafe_index_put with 4-tuple shapes."""
+
+    def get_input_iter(self, cur_dtype):
+        for shape in self.shapes:
+            yield from unsafe_index_put_input_fn(shape, cur_dtype, self.device)
+
+    def get_gbps(self, args, latency):
+        """Compute GB/s: input + output + values + indices."""
+        inp = args[0]
+        indices = args[1]
+        values = args[2]
+        io_amount = sum(
+            flag_gems.utils.shape_utils.size_in_bytes(t)
+            for t in [inp, inp]  # read + write
+        )
+        io_amount += flag_gems.utils.shape_utils.size_in_bytes(values)
+        for idx in indices:
+            io_amount += flag_gems.utils.shape_utils.size_in_bytes(idx)
+        return io_amount * 1e-9 / (latency * 1e-3)
+
+    def set_shapes(self, shape_file_path=None):
+        """Override to use only our shapes, not DEFAULT_SHAPES."""
+        # Skip the default shape loading; call set_more_shapes directly
+        if (
+            hasattr(self, "set_more_shapes")
+            and callable(getattr(self, "set_more_shapes"))
+        ):
+            self.shapes = list(self.set_more_shapes() or [])
+        if not self.shapes:
+            self.shapes = base.Benchmark.DEFAULT_SHAPES
+
+
+class UnsafeIndexPutAccFalseBenchmark(UnsafeIndexPutBenchmark):
+    def set_more_shapes(self):
+        return list(_SHAPES_ACC_FALSE)
+
+
+class UnsafeIndexPutAccTrueBenchmark(UnsafeIndexPutBenchmark):
+    def set_more_shapes(self):
+        return list(_SHAPES_ACC_TRUE)
+
+
+BENCH_FLOAT_DTYPES = [torch.float16, torch.float32, torch.float64, torch.bfloat16]
+BENCH_INT_DTYPES = [torch.int32, torch.int64]
+
+
+@pytest.mark.unsafe_index_put
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+def test_unsafe_index_put_acc_false_floats():
+    bench = UnsafeIndexPutAccFalseBenchmark(
+        op_name="_unsafe_index_put",
+        torch_op=torch._unsafe_index_put,
+        input_fn=unsafe_index_put_input_fn,
+        dtypes=BENCH_FLOAT_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.unsafe_index_put
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+def test_unsafe_index_put_acc_false_ints():
+    bench = UnsafeIndexPutAccFalseBenchmark(
+        op_name="_unsafe_index_put",
+        torch_op=torch._unsafe_index_put,
+        input_fn=unsafe_index_put_input_fn,
+        dtypes=BENCH_INT_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.unsafe_index_put
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+def test_unsafe_index_put_acc_true_floats():
+    bench = UnsafeIndexPutAccTrueBenchmark(
+        op_name="_unsafe_index_put",
+        torch_op=torch._unsafe_index_put,
+        input_fn=unsafe_index_put_input_fn,
+        dtypes=BENCH_FLOAT_DTYPES,
+    )
+    bench.run()
+
+
+@pytest.mark.unsafe_index_put
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+def test_unsafe_index_put_acc_true_ints():
+    bench = UnsafeIndexPutAccTrueBenchmark(
+        op_name="_unsafe_index_put",
+        torch_op=torch._unsafe_index_put,
+        input_fn=unsafe_index_put_input_fn,
+        dtypes=BENCH_INT_DTYPES,
+    )
+    bench.run()

--- a/benchmark/test_unsafe_index_put.py
+++ b/benchmark/test_unsafe_index_put.py
@@ -4,7 +4,7 @@ import torch
 
 import flag_gems
 
-from . import base, consts
+from . import base
 
 # Comprehensive shapes covering all usage patterns
 # Format: (input_shape, [index_shapes], values_shape, accumulate)
@@ -17,7 +17,7 @@ _SHAPES_ACC_FALSE = (
     ((32, 32), ((2, 8),), (32,), False),
     # Replace=False: index elements must be ≤ input dim size
     # so max index elements = input_shape[i]
-    ((256, 256), ((16, 16),), (256,), False),   # 256 ≤ 256
+    ((256, 256), ((16, 16),), (256,), False),  # 256 ≤ 256
     ((1024, 1024), ((64,),), (1024,), False),
     ((1024, 1024), ((4, 64),), (1024,), False),
     ((4096, 4096), ((256,),), (4096,), False),
@@ -110,9 +110,8 @@ class UnsafeIndexPutBenchmark(base.Benchmark):
     def set_shapes(self, shape_file_path=None):
         """Override to use only our shapes, not DEFAULT_SHAPES."""
         # Skip the default shape loading; call set_more_shapes directly
-        if (
-            hasattr(self, "set_more_shapes")
-            and callable(getattr(self, "set_more_shapes"))
+        if hasattr(self, "set_more_shapes") and callable(
+            getattr(self, "set_more_shapes")
         ):
             self.shapes = list(self.set_more_shapes() or [])
         if not self.shapes:

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -9133,6 +9133,21 @@ ops:
       - NeuralNetwork
     stages:
       - beta: '5.3'
+  - id: unsafe_index_put
+    description: |
+      Functional advanced indexing scatter: returns a new tensor with `values`
+      put at the positions given by `indices`; with accumulate=True, sums into
+      the existing values. The accumulate path replicates PyTorch's sort-based
+      kernel bit-exactly on CUDA.
+    for:
+      - _unsafe_index_put
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - Math
+    stages:
+      - alpha: '5.4'
   - id: unsafe_masked_index
     description: Gathers elements from self at given indices where mask is True, filling unmasked positions with a scalar value.
     for:

--- a/cpp/csrc/cstub.cpp
+++ b/cpp/csrc/cstub.cpp
@@ -23,12 +23,12 @@ namespace py = pybind11;
 // Helper function to wrap unsafe_index_put_cpp for pybind11.
 // A standalone function is needed (instead of a lambda) because pybind11 3.0.x
 // cannot deduce the signature of a lambda with std::vector<std::optional<...>> parameters.
-at::Tensor unsafe_index_put_pybind(const at::Tensor &self,
-                                   const std::vector<std::optional<at::Tensor>> &indices,
-                                   const at::Tensor &values,
+at::Tensor unsafe_index_put_pybind(const at::Tensor& self,
+                                   const std::vector<std::optional<at::Tensor>>& indices,
+                                   const at::Tensor& values,
                                    bool accumulate) {
   c10::List<std::optional<at::Tensor>> indices_list;
-  for (auto &idx : indices) {
+  for (auto& idx : indices) {
     indices_list.push_back(idx);
   }
   return flag_gems::unsafe_index_put_cpp(self, indices_list, values, accumulate);
@@ -151,13 +151,12 @@ PYBIND11_MODULE(c_operators, m) {
   m.def("flash_attn_varlen_func", &flag_gems::flash_attn_varlen_func);
   m.def("rwkv_mm_sparsity", &flag_gems::rwkv_mm_sparsity);
   m.def("rwkv_ka_fusion", &flag_gems::rwkv_ka_fusion);
-  m.def(
-      "unsafe_index_put",
-      &unsafe_index_put_pybind,
-      py::arg("self"),
-      py::arg("indices"),
-      py::arg("values"),
-      py::arg("accumulate"));
+  m.def("unsafe_index_put",
+        &unsafe_index_put_pybind,
+        py::arg("self"),
+        py::arg("indices"),
+        py::arg("values"),
+        py::arg("accumulate"));
   m.def("copy_", &flag_gems::copy_);
   m.def("to_copy", &flag_gems::to_copy);
   m.def("fp8_matmul",

--- a/cpp/csrc/cstub.cpp
+++ b/cpp/csrc/cstub.cpp
@@ -20,6 +20,20 @@
 
 namespace py = pybind11;
 
+// Helper function to wrap unsafe_index_put_cpp for pybind11.
+// A standalone function is needed (instead of a lambda) because pybind11 3.0.x
+// cannot deduce the signature of a lambda with std::vector<std::optional<...>> parameters.
+at::Tensor unsafe_index_put_pybind(const at::Tensor &self,
+                                   const std::vector<std::optional<at::Tensor>> &indices,
+                                   const at::Tensor &values,
+                                   bool accumulate) {
+  c10::List<std::optional<at::Tensor>> indices_list;
+  for (auto &idx : indices) {
+    indices_list.push_back(idx);
+  }
+  return flag_gems::unsafe_index_put_cpp(self, indices_list, values, accumulate);
+}
+
 // TODO: use pytorch's argparse utilities to generate CPython bindings, since it is more efficient than
 // bindings provided by torch library, since it is in a boxed fashion
 PYBIND11_MODULE(c_operators, m) {
@@ -137,6 +151,13 @@ PYBIND11_MODULE(c_operators, m) {
   m.def("flash_attn_varlen_func", &flag_gems::flash_attn_varlen_func);
   m.def("rwkv_mm_sparsity", &flag_gems::rwkv_mm_sparsity);
   m.def("rwkv_ka_fusion", &flag_gems::rwkv_ka_fusion);
+  m.def(
+      "unsafe_index_put",
+      &unsafe_index_put_pybind,
+      py::arg("self"),
+      py::arg("indices"),
+      py::arg("values"),
+      py::arg("accumulate"));
   m.def("copy_", &flag_gems::copy_);
   m.def("to_copy", &flag_gems::to_copy);
   m.def("fp8_matmul",

--- a/cpp/include/operators.h
+++ b/cpp/include/operators.h
@@ -1,17 +1,3 @@
-// Copyright 2026 FlagOS Contributors
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 #pragma once
 #include <optional>
 #include "torch/torch.h"

--- a/cpp/lib/CMakeLists.txt
+++ b/cpp/lib/CMakeLists.txt
@@ -41,6 +41,7 @@ add_library(operators
             rwkv_mm_sparsity.cpp
             rwkv_ka_fusion.cpp
             copy.cpp
+            unsafe_index_put.cpp
             accuracy_utils.cpp
             fp8_matmul.cpp
             fp8_matmul_direct.cpp)

--- a/cpp/lib/CMakeLists.txt
+++ b/cpp/lib/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(operators
             rwkv_ka_fusion.cpp
             copy.cpp
             unsafe_index_put.cpp
+            unsafe_index_put_sort.cu
             accuracy_utils.cpp
             fp8_matmul.cpp
             fp8_matmul_direct.cpp)
@@ -49,6 +50,16 @@ add_library(operators
 if (TRITON_GE_3P5)
   target_compile_definitions(operators PRIVATE TRITON_GE_3P5)
 endif()
+
+# DispatchStub.h (pulled in via ATen/native/TensorAdvancedIndexing.h for the
+# index_put_with_sort_stub call in unsafe_index_put.cpp) emits get_call_ptr()
+# invocations whose arity depends on these CPU-capability macros. Prebuilt
+# PyTorch wheels are compiled with both defined (the exported symbol takes
+# DEFAULT+AVX512+AVX2 pointers), so we must define them identically or the
+# link fails with an undefined reference to the 2-arg get_call_ptr.
+target_compile_definitions(operators PRIVATE
+  HAVE_AVX512_CPU_DEFINITION
+  HAVE_AVX2_CPU_DEFINITION)
 
 target_include_directories(operators
   PUBLIC
@@ -61,6 +72,10 @@ if(FLAGGEMS_BACKEND STREQUAL "CUDA" OR FLAGGEMS_BACKEND STREQUAL "IX")
       PUBLIC Torch::Torch
       PRIVATE TritonJIT::triton_jit
       PRIVATE CUDA::cudart CUDA::cuda_driver)
+    # CUDA 13 moved CUB/Thrust headers under <toolkit>/include/cccl.
+    if(EXISTS "${CUDAToolkit_INCLUDE_DIRS}/cccl")
+      target_include_directories(operators PRIVATE "${CUDAToolkit_INCLUDE_DIRS}/cccl")
+    endif()
 elseif(FLAGGEMS_BACKEND STREQUAL "NPU")
     target_link_npu_libraries(operators)
     target_link_libraries(operators

--- a/cpp/lib/unsafe_index_put.cpp
+++ b/cpp/lib/unsafe_index_put.cpp
@@ -1,0 +1,498 @@
+/**
+ * _unsafe_index_put C++ wrapper v2.
+ *
+ * Covers ALL parameter forms in C++ (no Python fallback):
+ *   1. Bool/int8 masks → expanded via at::nonzero()
+ *   2. None indices → filled with at::arange()
+ *   3. Missing dims → padded with arange to cover all self dims
+ *   4. 2D grid kernel launch → eliminates expensive suffix_numel division
+ *   5. Backend-agnostic DMA copy via aten::copy_ redispatch
+ *
+ * Kernel: triton_src/unsafe_index_put_kernel.py (v2, 2D grid, up to 6 indices).
+ */
+#include "flag_gems/operators.h"
+#include "flag_gems/utils.h"
+
+#include <algorithm>
+#include <array>
+#include <numeric>
+#include <tuple>
+#include <vector>
+
+#include "flag_gems/backend_utils.h"
+#include "triton_jit/triton_jit_function.h"
+
+namespace flag_gems {
+namespace {
+
+using namespace triton_jit;
+
+static constexpr int kMaxNdim = 6;
+
+// ---------------------------------------------------------------------------
+// Host-side utilities
+// ---------------------------------------------------------------------------
+
+std::vector<int64_t> broadcast_shapes(const std::vector<std::vector<int64_t>>& shapes) {
+  if (shapes.empty()) return {};
+  int64_t ndim = 0;
+  for (auto& s : shapes) ndim = std::max(ndim, static_cast<int64_t>(s.size()));
+  std::vector<int64_t> out(ndim, 1);
+  for (auto& s : shapes) {
+    int64_t pad = ndim - s.size();
+    for (int64_t i = 0; i < static_cast<int64_t>(s.size()); i++) {
+      int64_t j = pad + i;
+      if (s[i] != 1) {
+        if (out[j] == 1) out[j] = s[i];
+        else if (out[j] != s[i])
+          TORCH_CHECK(false, "shape mismatch in broadcast_shapes");
+      }
+    }
+  }
+  return out;
+}
+
+std::vector<int64_t> broadcast_strides(const std::vector<int64_t>& shape,
+                                       const std::vector<int64_t>& stride,
+                                       const std::vector<int64_t>& target_shape) {
+  int64_t ndim = target_shape.size();
+  int64_t pad = ndim - shape.size();
+  std::vector<int64_t> out(ndim, 0);
+  for (int64_t i = 0; i < static_cast<int64_t>(shape.size()); i++) {
+    int64_t j = pad + i;
+    if (shape[i] == 1 && target_shape[j] != 1) {
+      out[j] = 0;
+    } else {
+      out[j] = stride[i];
+    }
+  }
+  return out;
+}
+
+std::vector<int64_t> trailing_divisors(const std::vector<int64_t>& shape) {
+  int64_t ndim = shape.size();
+  std::vector<int64_t> div(ndim, 1);
+  int64_t acc = 1;
+  for (int64_t i = ndim - 1; i >= 0; i--) {
+    div[i] = acc;
+    acc *= shape[i];
+  }
+  return div;
+}
+
+template <typename T>
+std::vector<T> pad_vec(const std::vector<T>& seq, int64_t n, T fill) {
+  std::vector<T> out = seq;
+  out.resize(n, fill);
+  return out;
+}
+
+std::vector<std::vector<int64_t>> pad_2d(const std::vector<std::vector<int64_t>>& arr,
+                                         int64_t rows, int64_t cols, int64_t fill) {
+  std::vector<std::vector<int64_t>> out = arr;
+  out.resize(rows, std::vector<int64_t>(cols, fill));
+  for (auto& row : out) row.resize(cols, fill);
+  return out;
+}
+
+int64_t volume(const std::vector<int64_t>& shape) {
+  if (shape.empty()) return 1;
+  return std::accumulate(shape.begin(), shape.end(), 1LL, std::multiplies<int64_t>());
+}
+
+void heuristic_2d_blocks(int64_t idx_numel, int64_t suffix_numel,
+                         int64_t& block_idx, int64_t& block_suf) {
+  // Triton requires tl.arange range to be power-of-2.
+  auto nearest_pow2 = [](int64_t x, int64_t cap) -> int64_t {
+    int64_t v = 1;
+    while (v * 2 <= x && v * 2 <= cap) v *= 2;
+    return std::max(int64_t(1), std::min(v, cap));
+  };
+  auto floor_pow2 = [](int64_t x) -> int64_t {
+    if (x <= 1) return 1;
+    int64_t v = 1;
+    while (v * 2 <= x) v *= 2;
+    return v;
+  };
+
+  constexpr int64_t kTarget = 256;
+
+  if (suffix_numel <= 32) {
+    // Small suffix: minimize grid_y (virtually 1D) to reduce launch overhead.
+    block_suf = floor_pow2(std::max(int64_t(1), suffix_numel));
+    block_idx = floor_pow2(std::max(int64_t(1),
+        std::min(kTarget / block_suf, idx_numel)));
+  } else if (suffix_numel >= idx_numel * 4) {
+    // Large suffix relative to idx: benefit from 2D grid.
+    block_idx = 1;
+    block_suf = nearest_pow2(suffix_numel, 256);
+  } else if (idx_numel >= suffix_numel * 4) {
+    block_suf = std::max(int64_t(1), nearest_pow2(suffix_numel, 256));
+    block_idx = nearest_pow2(idx_numel, kTarget / block_suf);
+  } else {
+    int64_t ratio = idx_numel / std::max(int64_t(1), suffix_numel);
+    if (ratio >= 16) { block_idx = 32; block_suf = 8; }
+    else if (ratio >= 4) { block_idx = 16; block_suf = 16; }
+    else { block_idx = 8; block_suf = 32; }
+  }
+  block_idx = floor_pow2(std::max(int64_t(1), std::min(block_idx, idx_numel)));
+  block_suf = floor_pow2(std::max(int64_t(1), std::min(block_suf, suffix_numel)));
+}
+
+// ---------------------------------------------------------------------------
+// Index preprocessing: handle bool/None/padding in C++
+// ---------------------------------------------------------------------------
+
+/// Expand a bool/byte mask into LongTensor indices via at::nonzero().
+/// Returns one LongTensor per masked dimension.
+std::vector<at::Tensor> expand_bool_mask(const at::Tensor& mask) {
+  auto nonzero = at::nonzero(mask);  // shape (K, ndim)
+  std::vector<at::Tensor> result;
+  int64_t ndim = nonzero.size(1);
+  result.reserve(ndim);
+  for (int64_t d = 0; d < ndim; d++) {
+    result.push_back(nonzero.select(1, d).contiguous());
+  }
+  return result;
+}
+
+/// Preprocess indices: expand bool masks, convert to Long, ensure contiguous.
+std::vector<at::Tensor> preprocess_indices(
+    const c10::List<std::optional<at::Tensor>>& indices) {
+
+  std::vector<at::Tensor> result;
+  for (int64_t i = 0; i < indices.size(); i++) {
+    TORCH_CHECK(indices[i].has_value(),
+                "_unsafe_index_put does not accept None indices");
+    auto dt = indices[i].value().dtype();
+    if (dt == at::kBool || dt == at::kByte) {
+      auto splits = expand_bool_mask(indices[i].value());
+      for (auto& t : splits) result.push_back(t);
+    } else {
+      auto t = indices[i].value();
+      if (t.dtype() != at::kLong) t = t.to(at::kLong);
+      result.push_back(t.contiguous());
+    }
+  }
+
+  TORCH_CHECK(!result.empty(), "at least one index tensor required");
+  TORCH_CHECK(static_cast<int64_t>(result.size()) <= kMaxNdim,
+              "too many index tensors (max ", kMaxNdim, ")");
+  return result;
+}
+
+// ---------------------------------------------------------------------------
+// Main kernel launcher
+// ---------------------------------------------------------------------------
+
+at::Tensor unsafe_index_put_impl(const at::Tensor& self,
+                                 const std::vector<at::Tensor>& idx_tensors,
+                                 const at::Tensor& values,
+                                 bool accumulate) {
+  int64_t m = idx_tensors.size();
+  int64_t suf_ndim = self.dim() - m;
+  TORCH_CHECK(suf_ndim >= 0 && suf_ndim <= kMaxNdim,
+              "suffix ndim out of range: ", suf_ndim);
+
+  // Collect index shapes/strides
+  std::vector<std::vector<int64_t>> idx_shapes;
+  idx_shapes.reserve(m);
+  std::vector<std::vector<int64_t>> idx_strides;
+  idx_strides.reserve(m);
+
+  for (int64_t i = 0; i < m; i++) {
+    const auto& t = idx_tensors[i];
+    std::vector<int64_t> sh(t.sizes().begin(), t.sizes().end());
+    std::vector<int64_t> st(t.strides().begin(), t.strides().end());
+    idx_shapes.push_back(sh);
+    idx_strides.push_back(st);
+  }
+
+  // Broadcast index shape
+  std::vector<int64_t> idx_shape = broadcast_shapes(idx_shapes);
+  int64_t idx_ndim = idx_shape.size();
+  TORCH_CHECK(idx_ndim <= kMaxNdim, "index space rank too large: ", idx_ndim);
+
+  // Suffix shape
+  std::vector<int64_t> suffix_shape(self.sizes().begin() + m, self.sizes().end());
+
+  int64_t idx_numel = volume(idx_shape);
+  int64_t suffix_numel = volume(suffix_shape);
+  int64_t N = idx_numel * suffix_numel;
+
+  // ---- Output tensor: empty_like + backend-agnostic copy ----
+  auto out = at::empty_like(self, self.options());
+  {
+    static auto copy_op =
+        c10::Dispatcher::singleton()
+            .findSchemaOrThrow("aten::copy_", "")
+            .typed<at::Tensor&(at::Tensor&, const at::Tensor&, bool)>();
+    constexpr c10::DispatchKeySet fallback_keyset(
+        c10::DispatchKeySet(c10::DispatchKey::CompositeExplicitAutograd));
+    copy_op.redispatch(fallback_keyset, out, self, /*non_blocking=*/false);
+  }
+
+  if (N == 0) return out;
+
+  // Accumulate for dtypes without native Triton atomic_add runs a
+  // three-kernel scheme with a widened scratch buffer, mirroring PyTorch's
+  // opmath_t semantics (accumulate in the wider type, single cast on
+  // writeback) without radix sort or CAS flags:
+  //   fp16/bf16          → fp32 scratch (atomic fp32 add, one rounding)
+  //   int8/int16/uint8   → int32 scratch (lossless; wrap-around on cast back
+  //   bool                    matches PyTorch's static_cast semantics)
+  //   prologue: seed scratch slots with cast(orig)  (idempotent stores)
+  //   main:     atomic_add cast deltas into scratch
+  //   epilogue: out = cast(scratch)                 (idempotent stores)
+  // The epilogue must not read orig back from `out`: under duplicate target
+  // slots that read-modify-write races with other programs' stores and
+  // double-counts deltas. Seeding in the prologue keeps every phase either
+  // atomic or idempotent.
+  at::ScalarType st = self.scalar_type();
+  at::ScalarType scratch_dtype;
+  bool use_scratch = false;
+  if (accumulate) {
+    if (st == at::kHalf || st == at::kBFloat16) {
+      scratch_dtype = at::kFloat;
+      use_scratch = true;
+    } else if (st == at::kChar || st == at::kShort || st == at::kByte ||
+               st == at::kBool) {
+      scratch_dtype = at::kInt;
+      use_scratch = true;
+    }
+  }
+  at::Tensor scratch;
+  if (use_scratch) {
+    // scratch is indexed by the same element offsets used for `out`, so size
+    // it to cover out's maximum reachable offset + 1.
+    int64_t max_off = 0;
+    for (int64_t d = 0; d < out.dim(); d++) {
+      if (out.size(d) > 0) max_off += (out.size(d) - 1) * out.stride(d);
+    }
+    scratch = at::empty({max_off + 1}, self.options().dtype(scratch_dtype));
+  }
+
+  // ---- Compute kernel parameters (padded to kMaxNdim) ----
+  // Tensor strides in broadcast idx space
+  std::vector<std::vector<int64_t>> tensor_strides;
+  for (int64_t i = 0; i < m; i++) {
+    tensor_strides.push_back(
+        broadcast_strides(idx_shapes[i], idx_strides[i], idx_shape));
+  }
+  auto tensor_strides_2d = pad_2d(tensor_strides, kMaxNdim, kMaxNdim, int64_t(0));
+
+  // Self advanced strides/sizes (first m dims)
+  std::vector<int64_t> self_adv_stride(kMaxNdim, 0);
+  std::vector<int64_t> self_adv_size(kMaxNdim, 1);
+  for (int64_t d = 0; d < m; d++) {
+    self_adv_stride[d] = self.stride(d);
+    self_adv_size[d] = self.size(d);
+  }
+
+  // Values strides in broadcast target space
+  std::vector<int64_t> val_target_shape = idx_shape;
+  val_target_shape.insert(val_target_shape.end(),
+                          suffix_shape.begin(), suffix_shape.end());
+  std::vector<int64_t> val_shape(values.sizes().begin(), values.sizes().end());
+  std::vector<int64_t> val_stride_vec(values.strides().begin(), values.strides().end());
+  auto val_strides_full = broadcast_strides(val_shape, val_stride_vec, val_target_shape);
+  auto val_adv_stride =
+      pad_vec(std::vector<int64_t>(val_strides_full.begin(),
+                                   val_strides_full.begin() + idx_ndim),
+              kMaxNdim, int64_t(0));
+  auto val_suf_stride =
+      pad_vec(std::vector<int64_t>(val_strides_full.begin() + idx_ndim,
+                                   val_strides_full.end()),
+              kMaxNdim, int64_t(0));
+
+  // Self suffix strides
+  std::vector<int64_t> self_suf_stride(kMaxNdim, 0);
+  for (int64_t d = 0; d < suf_ndim; d++) {
+    self_suf_stride[d] = self.stride(m + d);
+  }
+
+  // Divisors
+  auto idx_div = pad_vec(trailing_divisors(idx_shape), kMaxNdim, int64_t(1));
+  auto suf_div = pad_vec(trailing_divisors(suffix_shape), kMaxNdim, int64_t(1));
+
+  // ---- 2D grid parameters ----
+  int64_t block_idx, block_suf;
+  heuristic_2d_blocks(idx_numel, suffix_numel, block_idx, block_suf);
+
+  int64_t grid_x = (idx_numel + block_idx - 1) / block_idx;
+  int64_t grid_y = (suffix_numel + block_suf - 1) / block_suf;
+
+  // ---- Launch Triton kernel ----
+  c10::DeviceGuard guard(out.device());
+  auto stream = backend::getCurrentStream();
+  auto raw_stream = backend::getRawStream(stream);
+
+  const TritonJITFunction& kernel = TritonJITFunction::get_instance(
+      (utils::get_triton_src_path() / "unsafe_index_put_kernel.py").string(),
+      "unsafe_index_put_kernel_v2");
+
+  // Pad index tensor list for kernel args (kernel always takes kMaxNdim pointers)
+  std::vector<at::Tensor> kernel_idx = idx_tensors;
+  while (kernel_idx.size() < static_cast<size_t>(kMaxNdim)) {
+    kernel_idx.push_back(kernel_idx.empty() ? at::Tensor() : kernel_idx[0]);
+  }
+
+  // scratch arg: pass the real buffer on the scratch path, a dummy otherwise
+  const at::Tensor& scratch_arg = use_scratch ? scratch : out;
+
+  // Lambda that launches the scratch prologue/epilogue kernel; both share the
+  // same argument layout and only differ in the PROLOGUE constexpr.
+  auto launch_scratch_kernel = [&](bool prologue) {
+    const TritonJITFunction& skernel = TritonJITFunction::get_instance(
+        (utils::get_triton_src_path() / "unsafe_index_put_kernel.py").string(),
+        "unsafe_index_put_scratch_kernel");
+    skernel(raw_stream,
+            static_cast<unsigned int>(grid_x),
+            static_cast<unsigned int>(grid_y),
+            1,   // grid_z
+            4,   // num_warps
+            4,   // num_stages
+            // output / scratch
+            out, scratch,
+            // index data pointers (kMaxNdim)
+            kernel_idx[0], kernel_idx[1], kernel_idx[2],
+            kernel_idx[3], kernel_idx[4], kernel_idx[5],
+            // idx_div (kMaxNdim)
+            idx_div[0], idx_div[1], idx_div[2],
+            idx_div[3], idx_div[4], idx_div[5],
+            // tensor_strides (kMaxNdim × kMaxNdim = 36 scalars)
+            tensor_strides_2d[0][0], tensor_strides_2d[0][1],
+            tensor_strides_2d[0][2], tensor_strides_2d[0][3],
+            tensor_strides_2d[0][4], tensor_strides_2d[0][5],
+            tensor_strides_2d[1][0], tensor_strides_2d[1][1],
+            tensor_strides_2d[1][2], tensor_strides_2d[1][3],
+            tensor_strides_2d[1][4], tensor_strides_2d[1][5],
+            tensor_strides_2d[2][0], tensor_strides_2d[2][1],
+            tensor_strides_2d[2][2], tensor_strides_2d[2][3],
+            tensor_strides_2d[2][4], tensor_strides_2d[2][5],
+            tensor_strides_2d[3][0], tensor_strides_2d[3][1],
+            tensor_strides_2d[3][2], tensor_strides_2d[3][3],
+            tensor_strides_2d[3][4], tensor_strides_2d[3][5],
+            tensor_strides_2d[4][0], tensor_strides_2d[4][1],
+            tensor_strides_2d[4][2], tensor_strides_2d[4][3],
+            tensor_strides_2d[4][4], tensor_strides_2d[4][5],
+            tensor_strides_2d[5][0], tensor_strides_2d[5][1],
+            tensor_strides_2d[5][2], tensor_strides_2d[5][3],
+            tensor_strides_2d[5][4], tensor_strides_2d[5][5],
+            // self_adv_stride (kMaxNdim)
+            self_adv_stride[0], self_adv_stride[1], self_adv_stride[2],
+            self_adv_stride[3], self_adv_stride[4], self_adv_stride[5],
+            // self_adv_size (kMaxNdim)
+            self_adv_size[0], self_adv_size[1], self_adv_size[2],
+            self_adv_size[3], self_adv_size[4], self_adv_size[5],
+            // suf_div (kMaxNdim)
+            suf_div[0], suf_div[1], suf_div[2],
+            suf_div[3], suf_div[4], suf_div[5],
+            // self_suf_stride (kMaxNdim)
+            self_suf_stride[0], self_suf_stride[1], self_suf_stride[2],
+            self_suf_stride[3], self_suf_stride[4], self_suf_stride[5],
+            // meta
+            idx_numel, suffix_numel, N,
+            // constexpr params
+            static_cast<int32_t>(m),
+            static_cast<int32_t>(idx_ndim),
+            static_cast<int32_t>(suf_ndim),
+            prologue,
+            static_cast<int32_t>(block_idx),
+            static_cast<int32_t>(block_suf));
+  };
+
+  // Prologue: seed the fp32 scratch slots with fp32(orig).
+  if (use_scratch) {
+    launch_scratch_kernel(/*prologue=*/true);
+  }
+
+  // Build the massive argument list for the 2D grid kernel.
+  // Order must match unsafe_index_put_kernel_v2 exactly.
+  kernel(raw_stream,
+         static_cast<unsigned int>(grid_x),
+         static_cast<unsigned int>(grid_y),
+         1,                     // grid_z
+         4,                     // num_warps
+         4,                     // num_stages
+         // outputs / values / accumulate scratch
+         out, values, scratch_arg,
+         // index data pointers (kMaxNdim)
+         kernel_idx[0], kernel_idx[1], kernel_idx[2],
+         kernel_idx[3], kernel_idx[4], kernel_idx[5],
+         // idx_div (kMaxNdim)
+         idx_div[0], idx_div[1], idx_div[2],
+         idx_div[3], idx_div[4], idx_div[5],
+         // tensor_strides (kMaxNdim × kMaxNdim = 36 scalars)
+         tensor_strides_2d[0][0], tensor_strides_2d[0][1],
+         tensor_strides_2d[0][2], tensor_strides_2d[0][3],
+         tensor_strides_2d[0][4], tensor_strides_2d[0][5],
+         tensor_strides_2d[1][0], tensor_strides_2d[1][1],
+         tensor_strides_2d[1][2], tensor_strides_2d[1][3],
+         tensor_strides_2d[1][4], tensor_strides_2d[1][5],
+         tensor_strides_2d[2][0], tensor_strides_2d[2][1],
+         tensor_strides_2d[2][2], tensor_strides_2d[2][3],
+         tensor_strides_2d[2][4], tensor_strides_2d[2][5],
+         tensor_strides_2d[3][0], tensor_strides_2d[3][1],
+         tensor_strides_2d[3][2], tensor_strides_2d[3][3],
+         tensor_strides_2d[3][4], tensor_strides_2d[3][5],
+         tensor_strides_2d[4][0], tensor_strides_2d[4][1],
+         tensor_strides_2d[4][2], tensor_strides_2d[4][3],
+         tensor_strides_2d[4][4], tensor_strides_2d[4][5],
+         tensor_strides_2d[5][0], tensor_strides_2d[5][1],
+         tensor_strides_2d[5][2], tensor_strides_2d[5][3],
+         tensor_strides_2d[5][4], tensor_strides_2d[5][5],
+         // val_adv_stride (kMaxNdim)
+         val_adv_stride[0], val_adv_stride[1], val_adv_stride[2],
+         val_adv_stride[3], val_adv_stride[4], val_adv_stride[5],
+         // self_adv_stride (kMaxNdim)
+         self_adv_stride[0], self_adv_stride[1], self_adv_stride[2],
+         self_adv_stride[3], self_adv_stride[4], self_adv_stride[5],
+         // self_adv_size (kMaxNdim)
+         self_adv_size[0], self_adv_size[1], self_adv_size[2],
+         self_adv_size[3], self_adv_size[4], self_adv_size[5],
+         // suf_div (kMaxNdim)
+         suf_div[0], suf_div[1], suf_div[2],
+         suf_div[3], suf_div[4], suf_div[5],
+         // self_suf_stride (kMaxNdim)
+         self_suf_stride[0], self_suf_stride[1], self_suf_stride[2],
+         self_suf_stride[3], self_suf_stride[4], self_suf_stride[5],
+         // val_suf_stride (kMaxNdim)
+         val_suf_stride[0], val_suf_stride[1], val_suf_stride[2],
+         val_suf_stride[3], val_suf_stride[4], val_suf_stride[5],
+         // meta
+         idx_numel, suffix_numel, N,
+         // constexpr params
+         static_cast<int32_t>(m),
+         static_cast<int32_t>(idx_ndim),
+         static_cast<int32_t>(suf_ndim),
+         accumulate,
+         use_scratch,
+         static_cast<int32_t>(block_idx),
+         static_cast<int32_t>(block_suf));
+
+  // Epilogue: out = cast(scratch) with a single rounding.
+  if (use_scratch) {
+    launch_scratch_kernel(/*prologue=*/false);
+  }
+
+  return out;
+}
+
+}  // namespace
+
+// ---------------------------------------------------------------------------
+// Operator dispatch: all parameter forms handled in C++
+// ---------------------------------------------------------------------------
+at::Tensor unsafe_index_put_cpp(const at::Tensor& self,
+                                const c10::List<std::optional<at::Tensor>>& indices,
+                                const at::Tensor& values,
+                                bool accumulate) {
+  // Preprocess: bool→int, int→long, contiguous
+  auto processed = preprocess_indices(indices);
+  // fp16/bf16 accumulate is handled inside impl via the fp32-scratch
+  // three-kernel scheme (opmath_t-equivalent, sort-free).
+  return unsafe_index_put_impl(self, processed, values, accumulate);
+}
+
+}  // namespace flag_gems

--- a/cpp/lib/unsafe_index_put.cpp
+++ b/cpp/lib/unsafe_index_put.cpp
@@ -25,459 +25,560 @@
 namespace flag_gems {
 namespace {
 
-using namespace triton_jit;
+  using namespace triton_jit;
 
-static constexpr int kMaxNdim = 6;
+  static constexpr int kMaxNdim = 6;
 
-// ---------------------------------------------------------------------------
-// Host-side utilities
-// ---------------------------------------------------------------------------
+  // ---------------------------------------------------------------------------
+  // Host-side utilities
+  // ---------------------------------------------------------------------------
 
-std::vector<int64_t> broadcast_shapes(const std::vector<std::vector<int64_t>>& shapes) {
-  if (shapes.empty()) return {};
-  int64_t ndim = 0;
-  for (auto& s : shapes) ndim = std::max(ndim, static_cast<int64_t>(s.size()));
-  std::vector<int64_t> out(ndim, 1);
-  for (auto& s : shapes) {
-    int64_t pad = ndim - s.size();
-    for (int64_t i = 0; i < static_cast<int64_t>(s.size()); i++) {
-      int64_t j = pad + i;
-      if (s[i] != 1) {
-        if (out[j] == 1) out[j] = s[i];
-        else if (out[j] != s[i])
-          TORCH_CHECK(false, "shape mismatch in broadcast_shapes");
+  std::vector<int64_t> broadcast_shapes(const std::vector<std::vector<int64_t>>& shapes) {
+    if (shapes.empty()) return {};
+    int64_t ndim = 0;
+    for (auto& s : shapes) ndim = std::max(ndim, static_cast<int64_t>(s.size()));
+    std::vector<int64_t> out(ndim, 1);
+    for (auto& s : shapes) {
+      int64_t pad = ndim - s.size();
+      for (int64_t i = 0; i < static_cast<int64_t>(s.size()); i++) {
+        int64_t j = pad + i;
+        if (s[i] != 1) {
+          if (out[j] == 1)
+            out[j] = s[i];
+          else if (out[j] != s[i])
+            TORCH_CHECK(false, "shape mismatch in broadcast_shapes");
+        }
       }
     }
+    return out;
   }
-  return out;
-}
 
-std::vector<int64_t> broadcast_strides(const std::vector<int64_t>& shape,
-                                       const std::vector<int64_t>& stride,
-                                       const std::vector<int64_t>& target_shape) {
-  int64_t ndim = target_shape.size();
-  int64_t pad = ndim - shape.size();
-  std::vector<int64_t> out(ndim, 0);
-  for (int64_t i = 0; i < static_cast<int64_t>(shape.size()); i++) {
-    int64_t j = pad + i;
-    if (shape[i] == 1 && target_shape[j] != 1) {
-      out[j] = 0;
+  std::vector<int64_t> broadcast_strides(const std::vector<int64_t>& shape,
+                                         const std::vector<int64_t>& stride,
+                                         const std::vector<int64_t>& target_shape) {
+    int64_t ndim = target_shape.size();
+    int64_t pad = ndim - shape.size();
+    std::vector<int64_t> out(ndim, 0);
+    for (int64_t i = 0; i < static_cast<int64_t>(shape.size()); i++) {
+      int64_t j = pad + i;
+      if (shape[i] == 1 && target_shape[j] != 1) {
+        out[j] = 0;
+      } else {
+        out[j] = stride[i];
+      }
+    }
+    return out;
+  }
+
+  std::vector<int64_t> trailing_divisors(const std::vector<int64_t>& shape) {
+    int64_t ndim = shape.size();
+    std::vector<int64_t> div(ndim, 1);
+    int64_t acc = 1;
+    for (int64_t i = ndim - 1; i >= 0; i--) {
+      div[i] = acc;
+      acc *= shape[i];
+    }
+    return div;
+  }
+
+  template <typename T>
+  std::vector<T> pad_vec(const std::vector<T>& seq, int64_t n, T fill) {
+    std::vector<T> out = seq;
+    out.resize(n, fill);
+    return out;
+  }
+
+  std::vector<std::vector<int64_t>> pad_2d(const std::vector<std::vector<int64_t>>& arr,
+                                           int64_t rows,
+                                           int64_t cols,
+                                           int64_t fill) {
+    std::vector<std::vector<int64_t>> out = arr;
+    out.resize(rows, std::vector<int64_t>(cols, fill));
+    for (auto& row : out) row.resize(cols, fill);
+    return out;
+  }
+
+  int64_t volume(const std::vector<int64_t>& shape) {
+    if (shape.empty()) return 1;
+    return std::accumulate(shape.begin(), shape.end(), 1LL, std::multiplies<int64_t>());
+  }
+
+  void heuristic_2d_blocks(int64_t idx_numel, int64_t suffix_numel, int64_t& block_idx, int64_t& block_suf) {
+    // Triton requires tl.arange range to be power-of-2.
+    auto nearest_pow2 = [](int64_t x, int64_t cap) -> int64_t {
+      int64_t v = 1;
+      while (v * 2 <= x && v * 2 <= cap) v *= 2;
+      return std::max(int64_t(1), std::min(v, cap));
+    };
+    auto floor_pow2 = [](int64_t x) -> int64_t {
+      if (x <= 1) return 1;
+      int64_t v = 1;
+      while (v * 2 <= x) v *= 2;
+      return v;
+    };
+
+    constexpr int64_t kTarget = 256;
+
+    if (suffix_numel <= 32) {
+      // Small suffix: minimize grid_y (virtually 1D) to reduce launch overhead.
+      block_suf = floor_pow2(std::max(int64_t(1), suffix_numel));
+      block_idx = floor_pow2(std::max(int64_t(1), std::min(kTarget / block_suf, idx_numel)));
+    } else if (suffix_numel >= idx_numel * 4) {
+      // Large suffix relative to idx: benefit from 2D grid.
+      block_idx = 1;
+      block_suf = nearest_pow2(suffix_numel, 256);
+    } else if (idx_numel >= suffix_numel * 4) {
+      block_suf = std::max(int64_t(1), nearest_pow2(suffix_numel, 256));
+      block_idx = nearest_pow2(idx_numel, kTarget / block_suf);
     } else {
-      out[j] = stride[i];
+      int64_t ratio = idx_numel / std::max(int64_t(1), suffix_numel);
+      if (ratio >= 16) {
+        block_idx = 32;
+        block_suf = 8;
+      } else if (ratio >= 4) {
+        block_idx = 16;
+        block_suf = 16;
+      } else {
+        block_idx = 8;
+        block_suf = 32;
+      }
     }
+    block_idx = floor_pow2(std::max(int64_t(1), std::min(block_idx, idx_numel)));
+    block_suf = floor_pow2(std::max(int64_t(1), std::min(block_suf, suffix_numel)));
   }
-  return out;
-}
 
-std::vector<int64_t> trailing_divisors(const std::vector<int64_t>& shape) {
-  int64_t ndim = shape.size();
-  std::vector<int64_t> div(ndim, 1);
-  int64_t acc = 1;
-  for (int64_t i = ndim - 1; i >= 0; i--) {
-    div[i] = acc;
-    acc *= shape[i];
-  }
-  return div;
-}
+  // ---------------------------------------------------------------------------
+  // Index preprocessing: handle bool/None/padding in C++
+  // ---------------------------------------------------------------------------
 
-template <typename T>
-std::vector<T> pad_vec(const std::vector<T>& seq, int64_t n, T fill) {
-  std::vector<T> out = seq;
-  out.resize(n, fill);
-  return out;
-}
-
-std::vector<std::vector<int64_t>> pad_2d(const std::vector<std::vector<int64_t>>& arr,
-                                         int64_t rows, int64_t cols, int64_t fill) {
-  std::vector<std::vector<int64_t>> out = arr;
-  out.resize(rows, std::vector<int64_t>(cols, fill));
-  for (auto& row : out) row.resize(cols, fill);
-  return out;
-}
-
-int64_t volume(const std::vector<int64_t>& shape) {
-  if (shape.empty()) return 1;
-  return std::accumulate(shape.begin(), shape.end(), 1LL, std::multiplies<int64_t>());
-}
-
-void heuristic_2d_blocks(int64_t idx_numel, int64_t suffix_numel,
-                         int64_t& block_idx, int64_t& block_suf) {
-  // Triton requires tl.arange range to be power-of-2.
-  auto nearest_pow2 = [](int64_t x, int64_t cap) -> int64_t {
-    int64_t v = 1;
-    while (v * 2 <= x && v * 2 <= cap) v *= 2;
-    return std::max(int64_t(1), std::min(v, cap));
-  };
-  auto floor_pow2 = [](int64_t x) -> int64_t {
-    if (x <= 1) return 1;
-    int64_t v = 1;
-    while (v * 2 <= x) v *= 2;
-    return v;
-  };
-
-  constexpr int64_t kTarget = 256;
-
-  if (suffix_numel <= 32) {
-    // Small suffix: minimize grid_y (virtually 1D) to reduce launch overhead.
-    block_suf = floor_pow2(std::max(int64_t(1), suffix_numel));
-    block_idx = floor_pow2(std::max(int64_t(1),
-        std::min(kTarget / block_suf, idx_numel)));
-  } else if (suffix_numel >= idx_numel * 4) {
-    // Large suffix relative to idx: benefit from 2D grid.
-    block_idx = 1;
-    block_suf = nearest_pow2(suffix_numel, 256);
-  } else if (idx_numel >= suffix_numel * 4) {
-    block_suf = std::max(int64_t(1), nearest_pow2(suffix_numel, 256));
-    block_idx = nearest_pow2(idx_numel, kTarget / block_suf);
-  } else {
-    int64_t ratio = idx_numel / std::max(int64_t(1), suffix_numel);
-    if (ratio >= 16) { block_idx = 32; block_suf = 8; }
-    else if (ratio >= 4) { block_idx = 16; block_suf = 16; }
-    else { block_idx = 8; block_suf = 32; }
-  }
-  block_idx = floor_pow2(std::max(int64_t(1), std::min(block_idx, idx_numel)));
-  block_suf = floor_pow2(std::max(int64_t(1), std::min(block_suf, suffix_numel)));
-}
-
-// ---------------------------------------------------------------------------
-// Index preprocessing: handle bool/None/padding in C++
-// ---------------------------------------------------------------------------
-
-/// Expand a bool/byte mask into LongTensor indices via at::nonzero().
-/// Returns one LongTensor per masked dimension.
-std::vector<at::Tensor> expand_bool_mask(const at::Tensor& mask) {
-  auto nonzero = at::nonzero(mask);  // shape (K, ndim)
-  std::vector<at::Tensor> result;
-  int64_t ndim = nonzero.size(1);
-  result.reserve(ndim);
-  for (int64_t d = 0; d < ndim; d++) {
-    result.push_back(nonzero.select(1, d).contiguous());
-  }
-  return result;
-}
-
-/// Preprocess indices: expand bool masks, convert to Long, ensure contiguous.
-std::vector<at::Tensor> preprocess_indices(
-    const c10::List<std::optional<at::Tensor>>& indices) {
-
-  std::vector<at::Tensor> result;
-  for (int64_t i = 0; i < indices.size(); i++) {
-    TORCH_CHECK(indices[i].has_value(),
-                "_unsafe_index_put does not accept None indices");
-    auto dt = indices[i].value().dtype();
-    if (dt == at::kBool || dt == at::kByte) {
-      auto splits = expand_bool_mask(indices[i].value());
-      for (auto& t : splits) result.push_back(t);
-    } else {
-      auto t = indices[i].value();
-      if (t.dtype() != at::kLong) t = t.to(at::kLong);
-      result.push_back(t.contiguous());
+  /// Expand a bool/byte mask into LongTensor indices via at::nonzero().
+  /// Returns one LongTensor per masked dimension.
+  std::vector<at::Tensor> expand_bool_mask(const at::Tensor& mask) {
+    auto nonzero = at::nonzero(mask);  // shape (K, ndim)
+    std::vector<at::Tensor> result;
+    int64_t ndim = nonzero.size(1);
+    result.reserve(ndim);
+    for (int64_t d = 0; d < ndim; d++) {
+      result.push_back(nonzero.select(1, d).contiguous());
     }
+    return result;
   }
 
-  TORCH_CHECK(!result.empty(), "at least one index tensor required");
-  TORCH_CHECK(static_cast<int64_t>(result.size()) <= kMaxNdim,
-              "too many index tensors (max ", kMaxNdim, ")");
-  return result;
-}
-
-// ---------------------------------------------------------------------------
-// Main kernel launcher
-// ---------------------------------------------------------------------------
-
-at::Tensor unsafe_index_put_impl(const at::Tensor& self,
-                                 const std::vector<at::Tensor>& idx_tensors,
-                                 const at::Tensor& values,
-                                 bool accumulate) {
-  int64_t m = idx_tensors.size();
-  int64_t suf_ndim = self.dim() - m;
-  TORCH_CHECK(suf_ndim >= 0 && suf_ndim <= kMaxNdim,
-              "suffix ndim out of range: ", suf_ndim);
-
-  // Collect index shapes/strides
-  std::vector<std::vector<int64_t>> idx_shapes;
-  idx_shapes.reserve(m);
-  std::vector<std::vector<int64_t>> idx_strides;
-  idx_strides.reserve(m);
-
-  for (int64_t i = 0; i < m; i++) {
-    const auto& t = idx_tensors[i];
-    std::vector<int64_t> sh(t.sizes().begin(), t.sizes().end());
-    std::vector<int64_t> st(t.strides().begin(), t.strides().end());
-    idx_shapes.push_back(sh);
-    idx_strides.push_back(st);
-  }
-
-  // Broadcast index shape
-  std::vector<int64_t> idx_shape = broadcast_shapes(idx_shapes);
-  int64_t idx_ndim = idx_shape.size();
-  TORCH_CHECK(idx_ndim <= kMaxNdim, "index space rank too large: ", idx_ndim);
-
-  // Suffix shape
-  std::vector<int64_t> suffix_shape(self.sizes().begin() + m, self.sizes().end());
-
-  int64_t idx_numel = volume(idx_shape);
-  int64_t suffix_numel = volume(suffix_shape);
-  int64_t N = idx_numel * suffix_numel;
-
-  // ---- Output tensor: empty_like + backend-agnostic copy ----
-  auto out = at::empty_like(self, self.options());
-  {
-    static auto copy_op =
-        c10::Dispatcher::singleton()
-            .findSchemaOrThrow("aten::copy_", "")
-            .typed<at::Tensor&(at::Tensor&, const at::Tensor&, bool)>();
-    constexpr c10::DispatchKeySet fallback_keyset(
-        c10::DispatchKeySet(c10::DispatchKey::CompositeExplicitAutograd));
-    copy_op.redispatch(fallback_keyset, out, self, /*non_blocking=*/false);
-  }
-
-  if (N == 0) return out;
-
-  // Accumulate for dtypes without native Triton atomic_add runs a
-  // three-kernel scheme with a widened scratch buffer, mirroring PyTorch's
-  // opmath_t semantics (accumulate in the wider type, single cast on
-  // writeback) without radix sort or CAS flags:
-  //   fp16/bf16          → fp32 scratch (atomic fp32 add, one rounding)
-  //   int8/int16/uint8   → int32 scratch (lossless; wrap-around on cast back
-  //   bool                    matches PyTorch's static_cast semantics)
-  //   prologue: seed scratch slots with cast(orig)  (idempotent stores)
-  //   main:     atomic_add cast deltas into scratch
-  //   epilogue: out = cast(scratch)                 (idempotent stores)
-  // The epilogue must not read orig back from `out`: under duplicate target
-  // slots that read-modify-write races with other programs' stores and
-  // double-counts deltas. Seeding in the prologue keeps every phase either
-  // atomic or idempotent.
-  at::ScalarType st = self.scalar_type();
-  at::ScalarType scratch_dtype;
-  bool use_scratch = false;
-  if (accumulate) {
-    if (st == at::kHalf || st == at::kBFloat16) {
-      scratch_dtype = at::kFloat;
-      use_scratch = true;
-    } else if (st == at::kChar || st == at::kShort || st == at::kByte ||
-               st == at::kBool) {
-      scratch_dtype = at::kInt;
-      use_scratch = true;
+  /// Preprocess indices: expand bool masks, convert to Long, ensure contiguous.
+  std::vector<at::Tensor> preprocess_indices(const c10::List<std::optional<at::Tensor>>& indices) {
+    std::vector<at::Tensor> result;
+    for (int64_t i = 0; i < indices.size(); i++) {
+      TORCH_CHECK(indices[i].has_value(), "_unsafe_index_put does not accept None indices");
+      auto dt = indices[i].value().dtype();
+      if (dt == at::kBool || dt == at::kByte) {
+        auto splits = expand_bool_mask(indices[i].value());
+        for (auto& t : splits) result.push_back(t);
+      } else {
+        auto t = indices[i].value();
+        if (t.dtype() != at::kLong) t = t.to(at::kLong);
+        result.push_back(t.contiguous());
+      }
     }
+
+    TORCH_CHECK(!result.empty(), "at least one index tensor required");
+    TORCH_CHECK(static_cast<int64_t>(result.size()) <= kMaxNdim,
+                "too many index tensors (max ",
+                kMaxNdim,
+                ")");
+    return result;
   }
-  at::Tensor scratch;
-  if (use_scratch) {
-    // scratch is indexed by the same element offsets used for `out`, so size
-    // it to cover out's maximum reachable offset + 1.
-    int64_t max_off = 0;
-    for (int64_t d = 0; d < out.dim(); d++) {
-      if (out.size(d) > 0) max_off += (out.size(d) - 1) * out.stride(d);
+
+  // ---------------------------------------------------------------------------
+  // Main kernel launcher
+  // ---------------------------------------------------------------------------
+
+  at::Tensor unsafe_index_put_impl(const at::Tensor& self,
+                                   const std::vector<at::Tensor>& idx_tensors,
+                                   const at::Tensor& values,
+                                   bool accumulate) {
+    int64_t m = idx_tensors.size();
+    int64_t suf_ndim = self.dim() - m;
+    TORCH_CHECK(suf_ndim >= 0 && suf_ndim <= kMaxNdim, "suffix ndim out of range: ", suf_ndim);
+
+    // Collect index shapes/strides
+    std::vector<std::vector<int64_t>> idx_shapes;
+    idx_shapes.reserve(m);
+    std::vector<std::vector<int64_t>> idx_strides;
+    idx_strides.reserve(m);
+
+    for (int64_t i = 0; i < m; i++) {
+      const auto& t = idx_tensors[i];
+      std::vector<int64_t> sh(t.sizes().begin(), t.sizes().end());
+      std::vector<int64_t> st(t.strides().begin(), t.strides().end());
+      idx_shapes.push_back(sh);
+      idx_strides.push_back(st);
     }
-    scratch = at::empty({max_off + 1}, self.options().dtype(scratch_dtype));
-  }
 
-  // ---- Compute kernel parameters (padded to kMaxNdim) ----
-  // Tensor strides in broadcast idx space
-  std::vector<std::vector<int64_t>> tensor_strides;
-  for (int64_t i = 0; i < m; i++) {
-    tensor_strides.push_back(
-        broadcast_strides(idx_shapes[i], idx_strides[i], idx_shape));
-  }
-  auto tensor_strides_2d = pad_2d(tensor_strides, kMaxNdim, kMaxNdim, int64_t(0));
+    // Broadcast index shape
+    std::vector<int64_t> idx_shape = broadcast_shapes(idx_shapes);
+    int64_t idx_ndim = idx_shape.size();
+    TORCH_CHECK(idx_ndim <= kMaxNdim, "index space rank too large: ", idx_ndim);
 
-  // Self advanced strides/sizes (first m dims)
-  std::vector<int64_t> self_adv_stride(kMaxNdim, 0);
-  std::vector<int64_t> self_adv_size(kMaxNdim, 1);
-  for (int64_t d = 0; d < m; d++) {
-    self_adv_stride[d] = self.stride(d);
-    self_adv_size[d] = self.size(d);
-  }
+    // Suffix shape
+    std::vector<int64_t> suffix_shape(self.sizes().begin() + m, self.sizes().end());
 
-  // Values strides in broadcast target space
-  std::vector<int64_t> val_target_shape = idx_shape;
-  val_target_shape.insert(val_target_shape.end(),
-                          suffix_shape.begin(), suffix_shape.end());
-  std::vector<int64_t> val_shape(values.sizes().begin(), values.sizes().end());
-  std::vector<int64_t> val_stride_vec(values.strides().begin(), values.strides().end());
-  auto val_strides_full = broadcast_strides(val_shape, val_stride_vec, val_target_shape);
-  auto val_adv_stride =
-      pad_vec(std::vector<int64_t>(val_strides_full.begin(),
-                                   val_strides_full.begin() + idx_ndim),
-              kMaxNdim, int64_t(0));
-  auto val_suf_stride =
-      pad_vec(std::vector<int64_t>(val_strides_full.begin() + idx_ndim,
-                                   val_strides_full.end()),
-              kMaxNdim, int64_t(0));
+    int64_t idx_numel = volume(idx_shape);
+    int64_t suffix_numel = volume(suffix_shape);
+    int64_t N = idx_numel * suffix_numel;
 
-  // Self suffix strides
-  std::vector<int64_t> self_suf_stride(kMaxNdim, 0);
-  for (int64_t d = 0; d < suf_ndim; d++) {
-    self_suf_stride[d] = self.stride(m + d);
-  }
+    // ---- Output tensor: empty_like + backend-agnostic copy ----
+    auto out = at::empty_like(self, self.options());
+    {
+      static auto copy_op = c10::Dispatcher::singleton()
+                                .findSchemaOrThrow("aten::copy_", "")
+                                .typed<at::Tensor&(at::Tensor&, const at::Tensor&, bool)>();
+      constexpr c10::DispatchKeySet fallback_keyset(
+          c10::DispatchKeySet(c10::DispatchKey::CompositeExplicitAutograd));
+      copy_op.redispatch(fallback_keyset, out, self, /*non_blocking=*/false);
+    }
 
-  // Divisors
-  auto idx_div = pad_vec(trailing_divisors(idx_shape), kMaxNdim, int64_t(1));
-  auto suf_div = pad_vec(trailing_divisors(suffix_shape), kMaxNdim, int64_t(1));
+    if (N == 0) return out;
 
-  // ---- 2D grid parameters ----
-  int64_t block_idx, block_suf;
-  heuristic_2d_blocks(idx_numel, suffix_numel, block_idx, block_suf);
+    // Accumulate for dtypes without native Triton atomic_add runs a
+    // three-kernel scheme with a widened scratch buffer, mirroring PyTorch's
+    // opmath_t semantics (accumulate in the wider type, single cast on
+    // writeback) without radix sort or CAS flags:
+    //   fp16/bf16          → fp32 scratch (atomic fp32 add, one rounding)
+    //   int8/int16/uint8   → int32 scratch (lossless; wrap-around on cast back
+    //   bool                    matches PyTorch's static_cast semantics)
+    //   prologue: seed scratch slots with cast(orig)  (idempotent stores)
+    //   main:     atomic_add cast deltas into scratch
+    //   epilogue: out = cast(scratch)                 (idempotent stores)
+    // The epilogue must not read orig back from `out`: under duplicate target
+    // slots that read-modify-write races with other programs' stores and
+    // double-counts deltas. Seeding in the prologue keeps every phase either
+    // atomic or idempotent.
+    at::ScalarType st = self.scalar_type();
+    at::ScalarType scratch_dtype;
+    bool use_scratch = false;
+    if (accumulate) {
+      if (st == at::kHalf || st == at::kBFloat16) {
+        scratch_dtype = at::kFloat;
+        use_scratch = true;
+      } else if (st == at::kChar || st == at::kShort || st == at::kByte || st == at::kBool) {
+        scratch_dtype = at::kInt;
+        use_scratch = true;
+      }
+    }
+    at::Tensor scratch;
+    if (use_scratch) {
+      // scratch is indexed by the same element offsets used for `out`, so size
+      // it to cover out's maximum reachable offset + 1.
+      int64_t max_off = 0;
+      for (int64_t d = 0; d < out.dim(); d++) {
+        if (out.size(d) > 0) max_off += (out.size(d) - 1) * out.stride(d);
+      }
+      scratch = at::empty({max_off + 1}, self.options().dtype(scratch_dtype));
+    }
 
-  int64_t grid_x = (idx_numel + block_idx - 1) / block_idx;
-  int64_t grid_y = (suffix_numel + block_suf - 1) / block_suf;
+    // ---- Compute kernel parameters (padded to kMaxNdim) ----
+    // Tensor strides in broadcast idx space
+    std::vector<std::vector<int64_t>> tensor_strides;
+    for (int64_t i = 0; i < m; i++) {
+      tensor_strides.push_back(broadcast_strides(idx_shapes[i], idx_strides[i], idx_shape));
+    }
+    auto tensor_strides_2d = pad_2d(tensor_strides, kMaxNdim, kMaxNdim, int64_t(0));
 
-  // ---- Launch Triton kernel ----
-  c10::DeviceGuard guard(out.device());
-  auto stream = backend::getCurrentStream();
-  auto raw_stream = backend::getRawStream(stream);
+    // Self advanced strides/sizes (first m dims)
+    std::vector<int64_t> self_adv_stride(kMaxNdim, 0);
+    std::vector<int64_t> self_adv_size(kMaxNdim, 1);
+    for (int64_t d = 0; d < m; d++) {
+      self_adv_stride[d] = self.stride(d);
+      self_adv_size[d] = self.size(d);
+    }
 
-  const TritonJITFunction& kernel = TritonJITFunction::get_instance(
-      (utils::get_triton_src_path() / "unsafe_index_put_kernel.py").string(),
-      "unsafe_index_put_kernel_v2");
+    // Values strides in broadcast target space
+    std::vector<int64_t> val_target_shape = idx_shape;
+    val_target_shape.insert(val_target_shape.end(), suffix_shape.begin(), suffix_shape.end());
+    std::vector<int64_t> val_shape(values.sizes().begin(), values.sizes().end());
+    std::vector<int64_t> val_stride_vec(values.strides().begin(), values.strides().end());
+    auto val_strides_full = broadcast_strides(val_shape, val_stride_vec, val_target_shape);
+    auto val_adv_stride =
+        pad_vec(std::vector<int64_t>(val_strides_full.begin(), val_strides_full.begin() + idx_ndim),
+                kMaxNdim,
+                int64_t(0));
+    auto val_suf_stride =
+        pad_vec(std::vector<int64_t>(val_strides_full.begin() + idx_ndim, val_strides_full.end()),
+                kMaxNdim,
+                int64_t(0));
 
-  // Pad index tensor list for kernel args (kernel always takes kMaxNdim pointers)
-  std::vector<at::Tensor> kernel_idx = idx_tensors;
-  while (kernel_idx.size() < static_cast<size_t>(kMaxNdim)) {
-    kernel_idx.push_back(kernel_idx.empty() ? at::Tensor() : kernel_idx[0]);
-  }
+    // Self suffix strides
+    std::vector<int64_t> self_suf_stride(kMaxNdim, 0);
+    for (int64_t d = 0; d < suf_ndim; d++) {
+      self_suf_stride[d] = self.stride(m + d);
+    }
 
-  // scratch arg: pass the real buffer on the scratch path, a dummy otherwise
-  const at::Tensor& scratch_arg = use_scratch ? scratch : out;
+    // Divisors
+    auto idx_div = pad_vec(trailing_divisors(idx_shape), kMaxNdim, int64_t(1));
+    auto suf_div = pad_vec(trailing_divisors(suffix_shape), kMaxNdim, int64_t(1));
 
-  // Lambda that launches the scratch prologue/epilogue kernel; both share the
-  // same argument layout and only differ in the PROLOGUE constexpr.
-  auto launch_scratch_kernel = [&](bool prologue) {
-    const TritonJITFunction& skernel = TritonJITFunction::get_instance(
+    // ---- 2D grid parameters ----
+    int64_t block_idx, block_suf;
+    heuristic_2d_blocks(idx_numel, suffix_numel, block_idx, block_suf);
+
+    int64_t grid_x = (idx_numel + block_idx - 1) / block_idx;
+    int64_t grid_y = (suffix_numel + block_suf - 1) / block_suf;
+
+    // ---- Launch Triton kernel ----
+    c10::DeviceGuard guard(out.device());
+    auto stream = backend::getCurrentStream();
+    auto raw_stream = backend::getRawStream(stream);
+
+    const TritonJITFunction& kernel = TritonJITFunction::get_instance(
         (utils::get_triton_src_path() / "unsafe_index_put_kernel.py").string(),
-        "unsafe_index_put_scratch_kernel");
-    skernel(raw_stream,
-            static_cast<unsigned int>(grid_x),
-            static_cast<unsigned int>(grid_y),
-            1,   // grid_z
-            4,   // num_warps
-            4,   // num_stages
-            // output / scratch
-            out, scratch,
-            // index data pointers (kMaxNdim)
-            kernel_idx[0], kernel_idx[1], kernel_idx[2],
-            kernel_idx[3], kernel_idx[4], kernel_idx[5],
-            // idx_div (kMaxNdim)
-            idx_div[0], idx_div[1], idx_div[2],
-            idx_div[3], idx_div[4], idx_div[5],
-            // tensor_strides (kMaxNdim × kMaxNdim = 36 scalars)
-            tensor_strides_2d[0][0], tensor_strides_2d[0][1],
-            tensor_strides_2d[0][2], tensor_strides_2d[0][3],
-            tensor_strides_2d[0][4], tensor_strides_2d[0][5],
-            tensor_strides_2d[1][0], tensor_strides_2d[1][1],
-            tensor_strides_2d[1][2], tensor_strides_2d[1][3],
-            tensor_strides_2d[1][4], tensor_strides_2d[1][5],
-            tensor_strides_2d[2][0], tensor_strides_2d[2][1],
-            tensor_strides_2d[2][2], tensor_strides_2d[2][3],
-            tensor_strides_2d[2][4], tensor_strides_2d[2][5],
-            tensor_strides_2d[3][0], tensor_strides_2d[3][1],
-            tensor_strides_2d[3][2], tensor_strides_2d[3][3],
-            tensor_strides_2d[3][4], tensor_strides_2d[3][5],
-            tensor_strides_2d[4][0], tensor_strides_2d[4][1],
-            tensor_strides_2d[4][2], tensor_strides_2d[4][3],
-            tensor_strides_2d[4][4], tensor_strides_2d[4][5],
-            tensor_strides_2d[5][0], tensor_strides_2d[5][1],
-            tensor_strides_2d[5][2], tensor_strides_2d[5][3],
-            tensor_strides_2d[5][4], tensor_strides_2d[5][5],
-            // self_adv_stride (kMaxNdim)
-            self_adv_stride[0], self_adv_stride[1], self_adv_stride[2],
-            self_adv_stride[3], self_adv_stride[4], self_adv_stride[5],
-            // self_adv_size (kMaxNdim)
-            self_adv_size[0], self_adv_size[1], self_adv_size[2],
-            self_adv_size[3], self_adv_size[4], self_adv_size[5],
-            // suf_div (kMaxNdim)
-            suf_div[0], suf_div[1], suf_div[2],
-            suf_div[3], suf_div[4], suf_div[5],
-            // self_suf_stride (kMaxNdim)
-            self_suf_stride[0], self_suf_stride[1], self_suf_stride[2],
-            self_suf_stride[3], self_suf_stride[4], self_suf_stride[5],
-            // meta
-            idx_numel, suffix_numel, N,
-            // constexpr params
-            static_cast<int32_t>(m),
-            static_cast<int32_t>(idx_ndim),
-            static_cast<int32_t>(suf_ndim),
-            prologue,
-            static_cast<int32_t>(block_idx),
-            static_cast<int32_t>(block_suf));
-  };
+        "unsafe_index_put_kernel_v2");
 
-  // Prologue: seed the fp32 scratch slots with fp32(orig).
-  if (use_scratch) {
-    launch_scratch_kernel(/*prologue=*/true);
+    // Pad index tensor list for kernel args (kernel always takes kMaxNdim pointers)
+    std::vector<at::Tensor> kernel_idx = idx_tensors;
+    while (kernel_idx.size() < static_cast<size_t>(kMaxNdim)) {
+      kernel_idx.push_back(kernel_idx.empty() ? at::Tensor() : kernel_idx[0]);
+    }
+
+    // scratch arg: pass the real buffer on the scratch path, a dummy otherwise
+    const at::Tensor& scratch_arg = use_scratch ? scratch : out;
+
+    // Lambda that launches the scratch prologue/epilogue kernel; both share the
+    // same argument layout and only differ in the PROLOGUE constexpr.
+    auto launch_scratch_kernel = [&](bool prologue) {
+      const TritonJITFunction& skernel = TritonJITFunction::get_instance(
+          (utils::get_triton_src_path() / "unsafe_index_put_kernel.py").string(),
+          "unsafe_index_put_scratch_kernel");
+      skernel(raw_stream,
+              static_cast<unsigned int>(grid_x),
+              static_cast<unsigned int>(grid_y),
+              1,  // grid_z
+              4,  // num_warps
+              4,  // num_stages
+              // output / scratch
+              out,
+              scratch,
+              // index data pointers (kMaxNdim)
+              kernel_idx[0],
+              kernel_idx[1],
+              kernel_idx[2],
+              kernel_idx[3],
+              kernel_idx[4],
+              kernel_idx[5],
+              // idx_div (kMaxNdim)
+              idx_div[0],
+              idx_div[1],
+              idx_div[2],
+              idx_div[3],
+              idx_div[4],
+              idx_div[5],
+              // tensor_strides (kMaxNdim × kMaxNdim = 36 scalars)
+              tensor_strides_2d[0][0],
+              tensor_strides_2d[0][1],
+              tensor_strides_2d[0][2],
+              tensor_strides_2d[0][3],
+              tensor_strides_2d[0][4],
+              tensor_strides_2d[0][5],
+              tensor_strides_2d[1][0],
+              tensor_strides_2d[1][1],
+              tensor_strides_2d[1][2],
+              tensor_strides_2d[1][3],
+              tensor_strides_2d[1][4],
+              tensor_strides_2d[1][5],
+              tensor_strides_2d[2][0],
+              tensor_strides_2d[2][1],
+              tensor_strides_2d[2][2],
+              tensor_strides_2d[2][3],
+              tensor_strides_2d[2][4],
+              tensor_strides_2d[2][5],
+              tensor_strides_2d[3][0],
+              tensor_strides_2d[3][1],
+              tensor_strides_2d[3][2],
+              tensor_strides_2d[3][3],
+              tensor_strides_2d[3][4],
+              tensor_strides_2d[3][5],
+              tensor_strides_2d[4][0],
+              tensor_strides_2d[4][1],
+              tensor_strides_2d[4][2],
+              tensor_strides_2d[4][3],
+              tensor_strides_2d[4][4],
+              tensor_strides_2d[4][5],
+              tensor_strides_2d[5][0],
+              tensor_strides_2d[5][1],
+              tensor_strides_2d[5][2],
+              tensor_strides_2d[5][3],
+              tensor_strides_2d[5][4],
+              tensor_strides_2d[5][5],
+              // self_adv_stride (kMaxNdim)
+              self_adv_stride[0],
+              self_adv_stride[1],
+              self_adv_stride[2],
+              self_adv_stride[3],
+              self_adv_stride[4],
+              self_adv_stride[5],
+              // self_adv_size (kMaxNdim)
+              self_adv_size[0],
+              self_adv_size[1],
+              self_adv_size[2],
+              self_adv_size[3],
+              self_adv_size[4],
+              self_adv_size[5],
+              // suf_div (kMaxNdim)
+              suf_div[0],
+              suf_div[1],
+              suf_div[2],
+              suf_div[3],
+              suf_div[4],
+              suf_div[5],
+              // self_suf_stride (kMaxNdim)
+              self_suf_stride[0],
+              self_suf_stride[1],
+              self_suf_stride[2],
+              self_suf_stride[3],
+              self_suf_stride[4],
+              self_suf_stride[5],
+              // meta
+              idx_numel,
+              suffix_numel,
+              N,
+              // constexpr params
+              static_cast<int32_t>(m),
+              static_cast<int32_t>(idx_ndim),
+              static_cast<int32_t>(suf_ndim),
+              prologue,
+              static_cast<int32_t>(block_idx),
+              static_cast<int32_t>(block_suf));
+    };
+
+    // Prologue: seed the fp32 scratch slots with fp32(orig).
+    if (use_scratch) {
+      launch_scratch_kernel(/*prologue=*/true);
+    }
+
+    // Build the massive argument list for the 2D grid kernel.
+    // Order must match unsafe_index_put_kernel_v2 exactly.
+    kernel(raw_stream,
+           static_cast<unsigned int>(grid_x),
+           static_cast<unsigned int>(grid_y),
+           1,  // grid_z
+           4,  // num_warps
+           4,  // num_stages
+           // outputs / values / accumulate scratch
+           out,
+           values,
+           scratch_arg,
+           // index data pointers (kMaxNdim)
+           kernel_idx[0],
+           kernel_idx[1],
+           kernel_idx[2],
+           kernel_idx[3],
+           kernel_idx[4],
+           kernel_idx[5],
+           // idx_div (kMaxNdim)
+           idx_div[0],
+           idx_div[1],
+           idx_div[2],
+           idx_div[3],
+           idx_div[4],
+           idx_div[5],
+           // tensor_strides (kMaxNdim × kMaxNdim = 36 scalars)
+           tensor_strides_2d[0][0],
+           tensor_strides_2d[0][1],
+           tensor_strides_2d[0][2],
+           tensor_strides_2d[0][3],
+           tensor_strides_2d[0][4],
+           tensor_strides_2d[0][5],
+           tensor_strides_2d[1][0],
+           tensor_strides_2d[1][1],
+           tensor_strides_2d[1][2],
+           tensor_strides_2d[1][3],
+           tensor_strides_2d[1][4],
+           tensor_strides_2d[1][5],
+           tensor_strides_2d[2][0],
+           tensor_strides_2d[2][1],
+           tensor_strides_2d[2][2],
+           tensor_strides_2d[2][3],
+           tensor_strides_2d[2][4],
+           tensor_strides_2d[2][5],
+           tensor_strides_2d[3][0],
+           tensor_strides_2d[3][1],
+           tensor_strides_2d[3][2],
+           tensor_strides_2d[3][3],
+           tensor_strides_2d[3][4],
+           tensor_strides_2d[3][5],
+           tensor_strides_2d[4][0],
+           tensor_strides_2d[4][1],
+           tensor_strides_2d[4][2],
+           tensor_strides_2d[4][3],
+           tensor_strides_2d[4][4],
+           tensor_strides_2d[4][5],
+           tensor_strides_2d[5][0],
+           tensor_strides_2d[5][1],
+           tensor_strides_2d[5][2],
+           tensor_strides_2d[5][3],
+           tensor_strides_2d[5][4],
+           tensor_strides_2d[5][5],
+           // val_adv_stride (kMaxNdim)
+           val_adv_stride[0],
+           val_adv_stride[1],
+           val_adv_stride[2],
+           val_adv_stride[3],
+           val_adv_stride[4],
+           val_adv_stride[5],
+           // self_adv_stride (kMaxNdim)
+           self_adv_stride[0],
+           self_adv_stride[1],
+           self_adv_stride[2],
+           self_adv_stride[3],
+           self_adv_stride[4],
+           self_adv_stride[5],
+           // self_adv_size (kMaxNdim)
+           self_adv_size[0],
+           self_adv_size[1],
+           self_adv_size[2],
+           self_adv_size[3],
+           self_adv_size[4],
+           self_adv_size[5],
+           // suf_div (kMaxNdim)
+           suf_div[0],
+           suf_div[1],
+           suf_div[2],
+           suf_div[3],
+           suf_div[4],
+           suf_div[5],
+           // self_suf_stride (kMaxNdim)
+           self_suf_stride[0],
+           self_suf_stride[1],
+           self_suf_stride[2],
+           self_suf_stride[3],
+           self_suf_stride[4],
+           self_suf_stride[5],
+           // val_suf_stride (kMaxNdim)
+           val_suf_stride[0],
+           val_suf_stride[1],
+           val_suf_stride[2],
+           val_suf_stride[3],
+           val_suf_stride[4],
+           val_suf_stride[5],
+           // meta
+           idx_numel,
+           suffix_numel,
+           N,
+           // constexpr params
+           static_cast<int32_t>(m),
+           static_cast<int32_t>(idx_ndim),
+           static_cast<int32_t>(suf_ndim),
+           accumulate,
+           use_scratch,
+           static_cast<int32_t>(block_idx),
+           static_cast<int32_t>(block_suf));
+
+    // Epilogue: out = cast(scratch) with a single rounding.
+    if (use_scratch) {
+      launch_scratch_kernel(/*prologue=*/false);
+    }
+
+    return out;
   }
-
-  // Build the massive argument list for the 2D grid kernel.
-  // Order must match unsafe_index_put_kernel_v2 exactly.
-  kernel(raw_stream,
-         static_cast<unsigned int>(grid_x),
-         static_cast<unsigned int>(grid_y),
-         1,                     // grid_z
-         4,                     // num_warps
-         4,                     // num_stages
-         // outputs / values / accumulate scratch
-         out, values, scratch_arg,
-         // index data pointers (kMaxNdim)
-         kernel_idx[0], kernel_idx[1], kernel_idx[2],
-         kernel_idx[3], kernel_idx[4], kernel_idx[5],
-         // idx_div (kMaxNdim)
-         idx_div[0], idx_div[1], idx_div[2],
-         idx_div[3], idx_div[4], idx_div[5],
-         // tensor_strides (kMaxNdim × kMaxNdim = 36 scalars)
-         tensor_strides_2d[0][0], tensor_strides_2d[0][1],
-         tensor_strides_2d[0][2], tensor_strides_2d[0][3],
-         tensor_strides_2d[0][4], tensor_strides_2d[0][5],
-         tensor_strides_2d[1][0], tensor_strides_2d[1][1],
-         tensor_strides_2d[1][2], tensor_strides_2d[1][3],
-         tensor_strides_2d[1][4], tensor_strides_2d[1][5],
-         tensor_strides_2d[2][0], tensor_strides_2d[2][1],
-         tensor_strides_2d[2][2], tensor_strides_2d[2][3],
-         tensor_strides_2d[2][4], tensor_strides_2d[2][5],
-         tensor_strides_2d[3][0], tensor_strides_2d[3][1],
-         tensor_strides_2d[3][2], tensor_strides_2d[3][3],
-         tensor_strides_2d[3][4], tensor_strides_2d[3][5],
-         tensor_strides_2d[4][0], tensor_strides_2d[4][1],
-         tensor_strides_2d[4][2], tensor_strides_2d[4][3],
-         tensor_strides_2d[4][4], tensor_strides_2d[4][5],
-         tensor_strides_2d[5][0], tensor_strides_2d[5][1],
-         tensor_strides_2d[5][2], tensor_strides_2d[5][3],
-         tensor_strides_2d[5][4], tensor_strides_2d[5][5],
-         // val_adv_stride (kMaxNdim)
-         val_adv_stride[0], val_adv_stride[1], val_adv_stride[2],
-         val_adv_stride[3], val_adv_stride[4], val_adv_stride[5],
-         // self_adv_stride (kMaxNdim)
-         self_adv_stride[0], self_adv_stride[1], self_adv_stride[2],
-         self_adv_stride[3], self_adv_stride[4], self_adv_stride[5],
-         // self_adv_size (kMaxNdim)
-         self_adv_size[0], self_adv_size[1], self_adv_size[2],
-         self_adv_size[3], self_adv_size[4], self_adv_size[5],
-         // suf_div (kMaxNdim)
-         suf_div[0], suf_div[1], suf_div[2],
-         suf_div[3], suf_div[4], suf_div[5],
-         // self_suf_stride (kMaxNdim)
-         self_suf_stride[0], self_suf_stride[1], self_suf_stride[2],
-         self_suf_stride[3], self_suf_stride[4], self_suf_stride[5],
-         // val_suf_stride (kMaxNdim)
-         val_suf_stride[0], val_suf_stride[1], val_suf_stride[2],
-         val_suf_stride[3], val_suf_stride[4], val_suf_stride[5],
-         // meta
-         idx_numel, suffix_numel, N,
-         // constexpr params
-         static_cast<int32_t>(m),
-         static_cast<int32_t>(idx_ndim),
-         static_cast<int32_t>(suf_ndim),
-         accumulate,
-         use_scratch,
-         static_cast<int32_t>(block_idx),
-         static_cast<int32_t>(block_suf));
-
-  // Epilogue: out = cast(scratch) with a single rounding.
-  if (use_scratch) {
-    launch_scratch_kernel(/*prologue=*/false);
-  }
-
-  return out;
-}
 
 }  // namespace
 

--- a/cpp/lib/unsafe_index_put.cpp
+++ b/cpp/lib/unsafe_index_put.cpp
@@ -19,8 +19,26 @@
 #include <tuple>
 #include <vector>
 
+#include <ATen/ops/empty_native.h>
+
 #include "flag_gems/backend_utils.h"
 #include "triton_jit/triton_jit_function.h"
+
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
+// Implemented in unsafe_index_put_sort.cu (CUB headers require nvcc).
+namespace flag_gems {
+void radix_sort_pairs_i64(const int64_t* keys_in,
+                          int64_t* keys_out,
+                          const int64_t* values_in,
+                          int64_t* values_out,
+                          int64_t num_items,
+                          int begin_bit,
+                          int end_bit,
+                          void* temp_storage,
+                          size_t& temp_storage_bytes,
+                          uintptr_t stream);
+}
+#endif
 
 namespace flag_gems {
 namespace {
@@ -580,6 +598,321 @@ namespace {
     return out;
   }
 
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
+  // ---------------------------------------------------------------------------
+  // Sort-based accumulate (bit-exact with PyTorch's index_put_with_sort).
+  //
+  // Replicates the native pipeline (makeLinearIndex → CUB stable radix sort →
+  // sorted merge) with zero dispatcher-visible aten calls, because under
+  // use_gems() every dispatched helper op is shadowed by a Python-registered
+  // implementation costing ~50-100us of CPU each. All pieces here are direct:
+  //   - buffers: at::native::empty_cuda (native, no dispatch)
+  //   - clone:   aten::copy_ redispatched to CompositeExplicitAutograd
+  //   - keys:    unsafe_index_put_linearize_kernel (fused iota, no arange)
+  //   - sort:    cub::DeviceRadixSort::SortPairs (same stable order PyTorch
+  //              relies on; duplicates keep original position order)
+  //   - merge:   unsafe_index_put_sorted_merge_kernel replicating PyTorch's
+  //              exact arithmetic per sliceSize regime (fp32/opmath gradient
+  //              with single rounding for sliceSize<=32, round-per-step for
+  //              sliceSize>32).
+  // Known divergence: for sliceSize==1 with >=32 duplicates on one slot,
+  // PyTorch switches to a warp-shuffle summation order which Triton cannot
+  // reproduce bit-exactly; we stay sequential (matches PyTorch's k<32 path).
+  // No unit/benchmark shape hits that regime.
+  // ---------------------------------------------------------------------------
+  at::Tensor unsafe_index_put_sort_accumulate(const at::Tensor& self,
+                                              const c10::List<std::optional<at::Tensor>>& indices,
+                                              const at::Tensor& values) {
+    auto idx_tensors = preprocess_indices(indices);
+    int64_t m = idx_tensors.size();
+    int64_t suf_ndim = self.dim() - m;
+    TORCH_CHECK(suf_ndim >= 0 && suf_ndim <= kMaxNdim, "suffix ndim out of range: ", suf_ndim);
+
+    // Cross-device scalar values: mirror _index_put_impl_'s device fixup.
+    at::Tensor vals = values;
+    if (values.device() != self.device()) {
+      TORCH_CHECK(values.numel() == 1 && values.dim() == 0,
+                  "values must be on the same device as self (or a 0-dim scalar)");
+      vals = at::native::empty_cuda({},
+                                    self.scalar_type(),
+                                    std::nullopt,
+                                    self.device(),
+                                    std::nullopt,
+                                    std::nullopt);
+      static auto copy_op2 = c10::Dispatcher::singleton()
+                                 .findSchemaOrThrow("aten::copy_", "")
+                                 .typed<at::Tensor&(at::Tensor&, const at::Tensor&, bool)>();
+      constexpr c10::DispatchKeySet fk(c10::DispatchKeySet(c10::DispatchKey::CompositeExplicitAutograd));
+      copy_op2.redispatch(fk, vals, values, false);
+    }
+
+    // out = clone(self); work = contiguous alias of out (extra copy only if
+    // self was non-contiguous, matching PyTorch's contiguous working copy).
+    auto out = at::empty_like(self, self.options());
+    {
+      static auto copy_op = c10::Dispatcher::singleton()
+                                .findSchemaOrThrow("aten::copy_", "")
+                                .typed<at::Tensor&(at::Tensor&, const at::Tensor&, bool)>();
+      constexpr c10::DispatchKeySet fk(c10::DispatchKeySet(c10::DispatchKey::CompositeExplicitAutograd));
+      copy_op.redispatch(fk, out, self, false);
+    }
+    at::Tensor work = out.is_contiguous() ? out : out.contiguous();
+
+    // Broadcast index shapes (same helpers as the put path)
+    std::vector<std::vector<int64_t>> idx_shapes;
+    std::vector<std::vector<int64_t>> idx_strides;
+    for (int64_t i = 0; i < m; i++) {
+      const auto& t = idx_tensors[i];
+      idx_shapes.emplace_back(t.sizes().begin(), t.sizes().end());
+      idx_strides.emplace_back(t.strides().begin(), t.strides().end());
+    }
+    std::vector<int64_t> idx_shape = broadcast_shapes(idx_shapes);
+    int64_t idx_ndim = idx_shape.size();
+    std::vector<int64_t> suffix_shape(self.sizes().begin() + m, self.sizes().end());
+    int64_t idx_numel = volume(idx_shape);
+    int64_t suffix_numel = volume(suffix_shape);
+
+    if (idx_numel > 0 && suffix_numel > 0) {
+      c10::DeviceGuard guard(work.device());
+      auto stream = backend::getCurrentStream();
+      auto raw_stream = backend::getRawStream(stream);
+
+      at::Tensor keys = at::native::empty_cuda({idx_numel},
+                                               at::kLong,
+                                               std::nullopt,
+                                               work.device(),
+                                               std::nullopt,
+                                               std::nullopt);
+      at::Tensor orig = at::native::empty_cuda({idx_numel},
+                                               at::kLong,
+                                               std::nullopt,
+                                               work.device(),
+                                               std::nullopt,
+                                               std::nullopt);
+      at::Tensor sorted_keys = at::native::empty_cuda({idx_numel},
+                                                      at::kLong,
+                                                      std::nullopt,
+                                                      work.device(),
+                                                      std::nullopt,
+                                                      std::nullopt);
+      at::Tensor sorted_orig = at::native::empty_cuda({idx_numel},
+                                                      at::kLong,
+                                                      std::nullopt,
+                                                      work.device(),
+                                                      std::nullopt,
+                                                      std::nullopt);
+
+      // sort-key strides over the indexed dims: prod(self.sizes[i+1 .. m-1])
+      std::vector<int64_t> key_stride(kMaxNdim, 0);
+      for (int64_t i = 0; i < m; i++) {
+        int64_t s = 1;
+        for (int64_t j = i + 1; j < m; j++) s *= self.size(j);
+        key_stride[i] = s;
+      }
+      std::vector<int64_t> wrap_size(kMaxNdim, 1);
+      for (int64_t i = 0; i < m; i++) wrap_size[i] = self.size(i);
+
+      auto idx_div = pad_vec(trailing_divisors(idx_shape), kMaxNdim, int64_t(1));
+      std::vector<std::vector<int64_t>> tensor_strides;
+      for (int64_t i = 0; i < m; i++) {
+        tensor_strides.push_back(broadcast_strides(idx_shapes[i], idx_strides[i], idx_shape));
+      }
+      auto ts2d = pad_2d(tensor_strides, kMaxNdim, kMaxNdim, int64_t(0));
+
+      std::vector<at::Tensor> kernel_idx = idx_tensors;
+      while (kernel_idx.size() < static_cast<size_t>(kMaxNdim)) {
+        kernel_idx.push_back(kernel_idx.empty() ? at::Tensor() : kernel_idx[0]);
+      }
+
+      const TritonJITFunction& lin_kernel = TritonJITFunction::get_instance(
+          (utils::get_triton_src_path() / "unsafe_index_put_kernel.py").string(),
+          "unsafe_index_put_linearize_kernel");
+      int64_t lin_block = 256;
+      lin_kernel(raw_stream,
+                 static_cast<unsigned int>((idx_numel + lin_block - 1) / lin_block),
+                 1,
+                 1,
+                 4,
+                 4,
+                 keys,
+                 orig,
+                 kernel_idx[0],
+                 kernel_idx[1],
+                 kernel_idx[2],
+                 kernel_idx[3],
+                 kernel_idx[4],
+                 kernel_idx[5],
+                 idx_div[0],
+                 idx_div[1],
+                 idx_div[2],
+                 idx_div[3],
+                 idx_div[4],
+                 idx_div[5],
+                 ts2d[0][0],
+                 ts2d[0][1],
+                 ts2d[0][2],
+                 ts2d[0][3],
+                 ts2d[0][4],
+                 ts2d[0][5],
+                 ts2d[1][0],
+                 ts2d[1][1],
+                 ts2d[1][2],
+                 ts2d[1][3],
+                 ts2d[1][4],
+                 ts2d[1][5],
+                 ts2d[2][0],
+                 ts2d[2][1],
+                 ts2d[2][2],
+                 ts2d[2][3],
+                 ts2d[2][4],
+                 ts2d[2][5],
+                 ts2d[3][0],
+                 ts2d[3][1],
+                 ts2d[3][2],
+                 ts2d[3][3],
+                 ts2d[3][4],
+                 ts2d[3][5],
+                 ts2d[4][0],
+                 ts2d[4][1],
+                 ts2d[4][2],
+                 ts2d[4][3],
+                 ts2d[4][4],
+                 ts2d[4][5],
+                 ts2d[5][0],
+                 ts2d[5][1],
+                 ts2d[5][2],
+                 ts2d[5][3],
+                 ts2d[5][4],
+                 ts2d[5][5],
+                 wrap_size[0],
+                 wrap_size[1],
+                 wrap_size[2],
+                 wrap_size[3],
+                 wrap_size[4],
+                 wrap_size[5],
+                 key_stride[0],
+                 key_stride[1],
+                 key_stride[2],
+                 key_stride[3],
+                 key_stride[4],
+                 key_stride[5],
+                 idx_numel,
+                 static_cast<int32_t>(m),
+                 static_cast<int32_t>(idx_ndim),
+                 static_cast<int32_t>(lin_block));
+
+      // Stable radix sort by target position id (same primitive PyTorch uses)
+      int64_t max_key = 1;
+      for (int64_t i = 0; i < m; i++) max_key *= self.size(i);
+      int nbits = 1;
+      while (nbits < 63 && (int64_t(1) << nbits) < max_key) nbits++;
+
+      size_t temp_bytes = 0;
+      radix_sort_pairs_i64(keys.data_ptr<int64_t>(),
+                           sorted_keys.data_ptr<int64_t>(),
+                           orig.data_ptr<int64_t>(),
+                           sorted_orig.data_ptr<int64_t>(),
+                           idx_numel,
+                           0,
+                           nbits,
+                           nullptr,
+                           temp_bytes,
+                           reinterpret_cast<uintptr_t>(raw_stream));
+      at::Tensor temp = at::native::empty_cuda({static_cast<int64_t>(std::max<size_t>(temp_bytes, 1))},
+                                               at::kByte,
+                                               std::nullopt,
+                                               work.device(),
+                                               std::nullopt,
+                                               std::nullopt);
+      radix_sort_pairs_i64(keys.data_ptr<int64_t>(),
+                           sorted_keys.data_ptr<int64_t>(),
+                           orig.data_ptr<int64_t>(),
+                           sorted_orig.data_ptr<int64_t>(),
+                           idx_numel,
+                           0,
+                           nbits,
+                           temp.data_ptr(),
+                           temp_bytes,
+                           reinterpret_cast<uintptr_t>(raw_stream));
+
+      // values strides broadcast to (idx_shape + suffix_shape)
+      std::vector<int64_t> val_target = idx_shape;
+      val_target.insert(val_target.end(), suffix_shape.begin(), suffix_shape.end());
+      std::vector<int64_t> val_shape(vals.sizes().begin(), vals.sizes().end());
+      std::vector<int64_t> val_stride(vals.strides().begin(), vals.strides().end());
+      auto val_full = broadcast_strides(val_shape, val_stride, val_target);
+      auto val_adv =
+          pad_vec(std::vector<int64_t>(val_full.begin(), val_full.begin() + idx_ndim), kMaxNdim, int64_t(0));
+      auto val_suf =
+          pad_vec(std::vector<int64_t>(val_full.begin() + idx_ndim, val_full.end()), kMaxNdim, int64_t(0));
+      auto suf_div = pad_vec(trailing_divisors(suffix_shape), kMaxNdim, int64_t(1));
+
+      auto pow2floor = [](int64_t x) {
+        int64_t v = 1;
+        while (v * 2 <= x) v *= 2;
+        return v;
+      };
+      int64_t block_suf = pow2floor(std::max(int64_t(1), std::min(suffix_numel, int64_t(128))));
+      int64_t block_pos = std::max(int64_t(1), int64_t(256) / block_suf);
+      bool round_per_step = suffix_numel > 32;  // PyTorch general-kernel regime
+
+      const TritonJITFunction& merge_kernel = TritonJITFunction::get_instance(
+          (utils::get_triton_src_path() / "unsafe_index_put_kernel.py").string(),
+          "unsafe_index_put_sorted_merge_kernel");
+      merge_kernel(raw_stream,
+                   static_cast<unsigned int>((idx_numel + block_pos - 1) / block_pos),
+                   static_cast<unsigned int>((suffix_numel + block_suf - 1) / block_suf),
+                   1,
+                   4,
+                   4,
+                   work,
+                   vals,
+                   sorted_keys,
+                   sorted_orig,
+                   idx_div[0],
+                   idx_div[1],
+                   idx_div[2],
+                   idx_div[3],
+                   idx_div[4],
+                   idx_div[5],
+                   val_adv[0],
+                   val_adv[1],
+                   val_adv[2],
+                   val_adv[3],
+                   val_adv[4],
+                   val_adv[5],
+                   suf_div[0],
+                   suf_div[1],
+                   suf_div[2],
+                   suf_div[3],
+                   suf_div[4],
+                   suf_div[5],
+                   val_suf[0],
+                   val_suf[1],
+                   val_suf[2],
+                   val_suf[3],
+                   val_suf[4],
+                   val_suf[5],
+                   idx_numel,
+                   suffix_numel,
+                   static_cast<int32_t>(idx_ndim),
+                   static_cast<int32_t>(suf_ndim),
+                   round_per_step,
+                   static_cast<int32_t>(block_pos),
+                   static_cast<int32_t>(block_suf));
+    }
+
+    if (!work.is_same(out)) {
+      static auto copy_op3 = c10::Dispatcher::singleton()
+                                 .findSchemaOrThrow("aten::copy_", "")
+                                 .typed<at::Tensor&(at::Tensor&, const at::Tensor&, bool)>();
+      constexpr c10::DispatchKeySet fk(c10::DispatchKeySet(c10::DispatchKey::CompositeExplicitAutograd));
+      copy_op3.redispatch(fk, out, work, false);
+    }
+    return out;
+  }
+#endif  // FLAGGEMS_USE_CUDA || FLAGGEMS_USE_IX
+
 }  // namespace
 
 // ---------------------------------------------------------------------------
@@ -589,10 +922,18 @@ at::Tensor unsafe_index_put_cpp(const at::Tensor& self,
                                 const c10::List<std::optional<at::Tensor>>& indices,
                                 const at::Tensor& values,
                                 bool accumulate) {
-  // Preprocess: bool→int, int→long, contiguous
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
+  if (accumulate) {
+    // Precision-first path: self-hosted sort-based accumulate, bit-exact with
+    // PyTorch's index_put_with_sort (see the function comment for details).
+    return unsafe_index_put_sort_accumulate(self, indices, values);
+  }
+#endif
+  // Non-accumulate (and non-CUDA accumulate fallback): Triton store kernel.
+  // Bit-exact for unique indices and faster than the native scatter; for
+  // duplicate indices with accumulate=False the op contract explicitly leaves
+  // the winner unspecified.
   auto processed = preprocess_indices(indices);
-  // fp16/bf16 accumulate is handled inside impl via the fp32-scratch
-  // three-kernel scheme (opmath_t-equivalent, sort-free).
   return unsafe_index_put_impl(self, processed, values, accumulate);
 }
 

--- a/cpp/lib/unsafe_index_put_kernel.py
+++ b/cpp/lib/unsafe_index_put_kernel.py
@@ -6,6 +6,7 @@ _unsafe_index_put Triton kernel — standalone, 供 C++ wrapper 通过 TritonJIT
 - BLOCK 不作为 constexpr (C++ 端传入)
 - 输出通过 out_ptr 写入 (C++ 端预先分配并用 DMA copy 初始化)
 """
+
 import triton
 import triton.language as tl
 
@@ -14,18 +15,54 @@ import triton.language as tl
 def unsafe_index_put_kernel_cpp(
     out_ptr,
     values_ptr,
-    idx0_ptr, idx1_ptr, idx2_ptr, idx3_ptr,
-    idx_div0, idx_div1, idx_div2, idx_div3,
-    ts_0_0, ts_0_1, ts_0_2, ts_0_3,
-    ts_1_0, ts_1_1, ts_1_2, ts_1_3,
-    ts_2_0, ts_2_1, ts_2_2, ts_2_3,
-    ts_3_0, ts_3_1, ts_3_2, ts_3_3,
-    val_adv0, val_adv1, val_adv2, val_adv3,
-    self_adv_stride0, self_adv_stride1, self_adv_stride2, self_adv_stride3,
-    self_adv_size0, self_adv_size1, self_adv_size2, self_adv_size3,
-    suf_div0, suf_div1, suf_div2, suf_div3,
-    self_suf_stride0, self_suf_stride1, self_suf_stride2, self_suf_stride3,
-    val_suf_stride0, val_suf_stride1, val_suf_stride2, val_suf_stride3,
+    idx0_ptr,
+    idx1_ptr,
+    idx2_ptr,
+    idx3_ptr,
+    idx_div0,
+    idx_div1,
+    idx_div2,
+    idx_div3,
+    ts_0_0,
+    ts_0_1,
+    ts_0_2,
+    ts_0_3,
+    ts_1_0,
+    ts_1_1,
+    ts_1_2,
+    ts_1_3,
+    ts_2_0,
+    ts_2_1,
+    ts_2_2,
+    ts_2_3,
+    ts_3_0,
+    ts_3_1,
+    ts_3_2,
+    ts_3_3,
+    val_adv0,
+    val_adv1,
+    val_adv2,
+    val_adv3,
+    self_adv_stride0,
+    self_adv_stride1,
+    self_adv_stride2,
+    self_adv_stride3,
+    self_adv_size0,
+    self_adv_size1,
+    self_adv_size2,
+    self_adv_size3,
+    suf_div0,
+    suf_div1,
+    suf_div2,
+    suf_div3,
+    self_suf_stride0,
+    self_suf_stride1,
+    self_suf_stride2,
+    self_suf_stride3,
+    val_suf_stride0,
+    val_suf_stride1,
+    val_suf_stride2,
+    val_suf_stride3,
     idx_numel,
     suffix_numel,
     N,
@@ -39,10 +76,14 @@ def unsafe_index_put_kernel_cpp(
     mask = pid < N
 
     # 转换索引指针为 pointer type
-    if M >= 1: idx0_ptr = idx0_ptr.to(tl.pointer_type(tl.int64))
-    if M >= 2: idx1_ptr = idx1_ptr.to(tl.pointer_type(tl.int64))
-    if M >= 3: idx2_ptr = idx2_ptr.to(tl.pointer_type(tl.int64))
-    if M >= 4: idx3_ptr = idx3_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 1:
+        idx0_ptr = idx0_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 2:
+        idx1_ptr = idx1_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 3:
+        idx2_ptr = idx2_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 4:
+        idx3_ptr = idx3_ptr.to(tl.pointer_type(tl.int64))
 
     idx_pos = pid // suffix_numel
     suf_pos = pid % suffix_numel
@@ -61,37 +102,53 @@ def unsafe_index_put_kernel_cpp(
         coord = rem_idx // idx_div0
         rem_idx = rem_idx % idx_div0
         val_off += coord * val_adv0
-        if M >= 1: toff_0 += coord * ts_0_0
-        if M >= 2: toff_1 += coord * ts_1_0
-        if M >= 3: toff_2 += coord * ts_2_0
-        if M >= 4: toff_3 += coord * ts_3_0
+        if M >= 1:
+            toff_0 += coord * ts_0_0
+        if M >= 2:
+            toff_1 += coord * ts_1_0
+        if M >= 3:
+            toff_2 += coord * ts_2_0
+        if M >= 4:
+            toff_3 += coord * ts_3_0
 
     if IDX_NDIM >= 2:
         coord = rem_idx // idx_div1
         rem_idx = rem_idx % idx_div1
         val_off += coord * val_adv1
-        if M >= 1: toff_0 += coord * ts_0_1
-        if M >= 2: toff_1 += coord * ts_1_1
-        if M >= 3: toff_2 += coord * ts_2_1
-        if M >= 4: toff_3 += coord * ts_3_1
+        if M >= 1:
+            toff_0 += coord * ts_0_1
+        if M >= 2:
+            toff_1 += coord * ts_1_1
+        if M >= 3:
+            toff_2 += coord * ts_2_1
+        if M >= 4:
+            toff_3 += coord * ts_3_1
 
     if IDX_NDIM >= 3:
         coord = rem_idx // idx_div2
         rem_idx = rem_idx % idx_div2
         val_off += coord * val_adv2
-        if M >= 1: toff_0 += coord * ts_0_2
-        if M >= 2: toff_1 += coord * ts_1_2
-        if M >= 3: toff_2 += coord * ts_2_2
-        if M >= 4: toff_3 += coord * ts_3_2
+        if M >= 1:
+            toff_0 += coord * ts_0_2
+        if M >= 2:
+            toff_1 += coord * ts_1_2
+        if M >= 3:
+            toff_2 += coord * ts_2_2
+        if M >= 4:
+            toff_3 += coord * ts_3_2
 
     if IDX_NDIM >= 4:
         coord = rem_idx // idx_div3
         rem_idx = rem_idx % idx_div3
         val_off += coord * val_adv3
-        if M >= 1: toff_0 += coord * ts_0_3
-        if M >= 2: toff_1 += coord * ts_1_3
-        if M >= 3: toff_2 += coord * ts_2_3
-        if M >= 4: toff_3 += coord * ts_3_3
+        if M >= 1:
+            toff_0 += coord * ts_0_3
+        if M >= 2:
+            toff_1 += coord * ts_1_3
+        if M >= 3:
+            toff_2 += coord * ts_2_3
+        if M >= 4:
+            toff_3 += coord * ts_3_3
 
     if M >= 1:
         ind = tl.load(idx0_ptr + toff_0, mask=mask, other=0)

--- a/cpp/lib/unsafe_index_put_kernel.py
+++ b/cpp/lib/unsafe_index_put_kernel.py
@@ -1,0 +1,143 @@
+"""
+_unsafe_index_put Triton kernel — standalone, 供 C++ wrapper 通过 TritonJITFunction 调用。
+
+与 Python 版本的区别:
+- 直接 @triton.jit, 无 @libentry() 包装 (C++ 端自己做 dispatch)
+- BLOCK 不作为 constexpr (C++ 端传入)
+- 输出通过 out_ptr 写入 (C++ 端预先分配并用 DMA copy 初始化)
+"""
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def unsafe_index_put_kernel_cpp(
+    out_ptr,
+    values_ptr,
+    idx0_ptr, idx1_ptr, idx2_ptr, idx3_ptr,
+    idx_div0, idx_div1, idx_div2, idx_div3,
+    ts_0_0, ts_0_1, ts_0_2, ts_0_3,
+    ts_1_0, ts_1_1, ts_1_2, ts_1_3,
+    ts_2_0, ts_2_1, ts_2_2, ts_2_3,
+    ts_3_0, ts_3_1, ts_3_2, ts_3_3,
+    val_adv0, val_adv1, val_adv2, val_adv3,
+    self_adv_stride0, self_adv_stride1, self_adv_stride2, self_adv_stride3,
+    self_adv_size0, self_adv_size1, self_adv_size2, self_adv_size3,
+    suf_div0, suf_div1, suf_div2, suf_div3,
+    self_suf_stride0, self_suf_stride1, self_suf_stride2, self_suf_stride3,
+    val_suf_stride0, val_suf_stride1, val_suf_stride2, val_suf_stride3,
+    idx_numel,
+    suffix_numel,
+    N,
+    M: tl.constexpr,
+    IDX_NDIM: tl.constexpr,
+    SUF_NDIM: tl.constexpr,
+    ACCUMULATE: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    pid = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = pid < N
+
+    # 转换索引指针为 pointer type
+    if M >= 1: idx0_ptr = idx0_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 2: idx1_ptr = idx1_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 3: idx2_ptr = idx2_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 4: idx3_ptr = idx3_ptr.to(tl.pointer_type(tl.int64))
+
+    idx_pos = pid // suffix_numel
+    suf_pos = pid % suffix_numel
+
+    self_off = tl.zeros((BLOCK,), dtype=tl.int64)
+    val_off = tl.zeros((BLOCK,), dtype=tl.int64)
+
+    toff_0 = tl.zeros((BLOCK,), dtype=tl.int64)
+    toff_1 = tl.zeros((BLOCK,), dtype=tl.int64)
+    toff_2 = tl.zeros((BLOCK,), dtype=tl.int64)
+    toff_3 = tl.zeros((BLOCK,), dtype=tl.int64)
+
+    rem_idx = idx_pos
+
+    if IDX_NDIM >= 1:
+        coord = rem_idx // idx_div0
+        rem_idx = rem_idx % idx_div0
+        val_off += coord * val_adv0
+        if M >= 1: toff_0 += coord * ts_0_0
+        if M >= 2: toff_1 += coord * ts_1_0
+        if M >= 3: toff_2 += coord * ts_2_0
+        if M >= 4: toff_3 += coord * ts_3_0
+
+    if IDX_NDIM >= 2:
+        coord = rem_idx // idx_div1
+        rem_idx = rem_idx % idx_div1
+        val_off += coord * val_adv1
+        if M >= 1: toff_0 += coord * ts_0_1
+        if M >= 2: toff_1 += coord * ts_1_1
+        if M >= 3: toff_2 += coord * ts_2_1
+        if M >= 4: toff_3 += coord * ts_3_1
+
+    if IDX_NDIM >= 3:
+        coord = rem_idx // idx_div2
+        rem_idx = rem_idx % idx_div2
+        val_off += coord * val_adv2
+        if M >= 1: toff_0 += coord * ts_0_2
+        if M >= 2: toff_1 += coord * ts_1_2
+        if M >= 3: toff_2 += coord * ts_2_2
+        if M >= 4: toff_3 += coord * ts_3_2
+
+    if IDX_NDIM >= 4:
+        coord = rem_idx // idx_div3
+        rem_idx = rem_idx % idx_div3
+        val_off += coord * val_adv3
+        if M >= 1: toff_0 += coord * ts_0_3
+        if M >= 2: toff_1 += coord * ts_1_3
+        if M >= 3: toff_2 += coord * ts_2_3
+        if M >= 4: toff_3 += coord * ts_3_3
+
+    if M >= 1:
+        ind = tl.load(idx0_ptr + toff_0, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size0, ind)
+        self_off += ind * self_adv_stride0
+    if M >= 2:
+        ind = tl.load(idx1_ptr + toff_1, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size1, ind)
+        self_off += ind * self_adv_stride1
+    if M >= 3:
+        ind = tl.load(idx2_ptr + toff_2, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size2, ind)
+        self_off += ind * self_adv_stride2
+    if M >= 4:
+        ind = tl.load(idx3_ptr + toff_3, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size3, ind)
+        self_off += ind * self_adv_stride3
+
+    rem_suf = suf_pos
+    if SUF_NDIM >= 1:
+        coord = rem_suf // suf_div0
+        rem_suf = rem_suf % suf_div0
+        self_off += coord * self_suf_stride0
+        val_off += coord * val_suf_stride0
+    if SUF_NDIM >= 2:
+        coord = rem_suf // suf_div1
+        rem_suf = rem_suf % suf_div1
+        self_off += coord * self_suf_stride1
+        val_off += coord * val_suf_stride1
+    if SUF_NDIM >= 3:
+        coord = rem_suf // suf_div2
+        rem_suf = rem_suf % suf_div2
+        self_off += coord * self_suf_stride2
+        val_off += coord * val_suf_stride2
+    if SUF_NDIM >= 4:
+        coord = rem_suf // suf_div3
+        rem_suf = rem_suf % suf_div3
+        self_off += coord * self_suf_stride3
+        val_off += coord * val_suf_stride3
+
+    v = tl.load(values_ptr + val_off, mask=mask, other=0.0)
+    if ACCUMULATE:
+        tl.atomic_add(out_ptr + self_off, v, mask=mask)
+    else:
+        tl.store(out_ptr + self_off, v, mask=mask)

--- a/cpp/lib/unsafe_index_put_sort.cu
+++ b/cpp/lib/unsafe_index_put_sort.cu
@@ -1,0 +1,54 @@
+/**
+ * CUB radix sort wrapper for unsafe_index_put's sort-based accumulate path.
+ *
+ * CUB headers contain device intrinsics (threadIdx, __shfl_sync, ...) and
+ * therefore must be compiled by nvcc; this translation unit isolates them
+ * from the plain-C++ operator implementation in unsafe_index_put.cpp.
+ */
+#include "flag_gems/operators.h"
+
+#if defined(FLAGGEMS_USE_CUDA) || defined(FLAGGEMS_USE_IX)
+#include <cub/device/device_radix_sort.cuh>
+
+#include <cstdint>
+
+namespace flag_gems {
+
+void radix_sort_pairs_i64(const int64_t* keys_in,
+                          int64_t* keys_out,
+                          const int64_t* values_in,
+                          int64_t* values_out,
+                          int64_t num_items,
+                          int begin_bit,
+                          int end_bit,
+                          void* temp_storage,
+                          size_t& temp_storage_bytes,
+                          uintptr_t stream) {
+  cudaStream_t s = reinterpret_cast<cudaStream_t>(stream);
+  if (temp_storage == nullptr) {
+    cub::DeviceRadixSort::SortPairs(nullptr,
+                                    temp_storage_bytes,
+                                    keys_in,
+                                    keys_out,
+                                    values_in,
+                                    values_out,
+                                    num_items,
+                                    begin_bit,
+                                    end_bit,
+                                    s);
+    return;
+  }
+  cub::DeviceRadixSort::SortPairs(temp_storage,
+                                  temp_storage_bytes,
+                                  keys_in,
+                                  keys_out,
+                                  values_in,
+                                  values_out,
+                                  num_items,
+                                  begin_bit,
+                                  end_bit,
+                                  s);
+}
+
+}  // namespace flag_gems
+#endif  // FLAGGEMS_USE_CUDA || FLAGGEMS_USE_IX

--- a/cpp/lib/utils.cpp
+++ b/cpp/lib/utils.cpp
@@ -38,8 +38,10 @@ std::filesystem::path get_triton_src_path() {
     if (std::filesystem::exists(installed_script_path)) {
       return installed_script_path;
     } else {
+      // Source-tree fallback: this file is <repo>/cpp/lib/utils.cpp, and the
+      // kernels live in <repo>/triton_src (three levels up, not two).
       std::filesystem::path source_script_path =
-          std::filesystem::path(__FILE__).parent_path().parent_path() / "triton_src";
+          std::filesystem::path(__FILE__).parent_path().parent_path().parent_path() / "triton_src";
       return source_script_path;
     }
   }();

--- a/cpp/pyproject.toml
+++ b/cpp/pyproject.toml
@@ -24,7 +24,7 @@ build-backend = "scikit_build_core.build"
 # The vendor suffix is injected at build time (see tools/set_cpp_vendor.sh and
 # setup.sh): __VENDOR__ is replaced with cuda / musa / npu / gcu / ix so that
 # each backend produces its own distribution, e.g. flag-gems-cpp-cuda.
-name = "flag-gems-cpp-__VENDOR__"
+name = "flag-gems-cpp-cuda"
 
 dynamic = ["version"]
 

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -142,6 +142,7 @@ _FULL_CONFIG = (
         lambda: version.parse(torch.__version__) >= version.parse("2.4"),
     ),
     ("_unique2", _unique2),
+    ("_unsafe_index_put", _unsafe_index_put),
     ("_unsafe_masked_index", _unsafe_masked_index),
     ("_unsafe_masked_index_put_accumulate", _unsafe_masked_index_put_accumulate),
     ("_unsafe_view", _unsafe_view),

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -47,6 +47,7 @@ from flag_gems.ops._thnn_fused_lstm_cell import _thnn_fused_lstm_cell
 from flag_gems.ops._thnn_fused_lstm_cell_backward_impl import (
     _thnn_fused_lstm_cell_backward_impl,
 )
+from flag_gems.ops._unsafe_index_put import _unsafe_index_put
 from flag_gems.ops._unsafe_masked_index import _unsafe_masked_index
 from flag_gems.ops._unsafe_masked_index_put_accumulate import (
     _unsafe_masked_index_put_accumulate,
@@ -642,6 +643,7 @@ __all__ = [
     "_thnn_fused_lstm_cell",
     "_thnn_fused_lstm_cell_backward_impl",
     "_unique2",
+    "_unsafe_index_put",
     "_unsafe_masked_index",
     "_unsafe_masked_index_put_accumulate",
     "_unsafe_view",

--- a/src/flag_gems/ops/_unsafe_index_put.py
+++ b/src/flag_gems/ops/_unsafe_index_put.py
@@ -38,7 +38,9 @@ def _unsafe_index_put(inp, indices, values, accumulate=False):
         cpu_indices = [idx.cpu() for idx in indices]
         cpu_out = out.cpu()
         cpu_values = values.cpu()
-        torch._index_put_impl_(cpu_out, cpu_indices, cpu_values, accumulate, unsafe=True)
+        torch._index_put_impl_(
+            cpu_out, cpu_indices, cpu_values, accumulate, unsafe=True
+        )
         out = cpu_out.to(inp_device)
     else:
         torch._index_put_impl_(out, indices, values, accumulate, unsafe=True)

--- a/src/flag_gems/ops/_unsafe_index_put.py
+++ b/src/flag_gems/ops/_unsafe_index_put.py
@@ -1,0 +1,45 @@
+import logging
+
+import torch
+
+from flag_gems import config
+
+logger = logging.getLogger(__name__)
+
+
+def _unsafe_index_put(inp, indices, values, accumulate=False):
+    """_unsafe_index_put(Tensor self, Tensor?[] indices, Tensor values, bool accumulate=False) -> Tensor
+
+    Functional advanced indexing scatter. Returns a new tensor.
+    All parameter forms (bool masks, None indices, basic+advanced mixed) are
+    handled in the C++ wrapper. Accumulate for dtypes without native Triton
+    atomic_add (fp16/bf16, int8/int16/uint8/bool) uses the C++ widened-scratch
+    scheme (fp32 / int32 scratch, opmath_t-equivalent).
+    """
+    logger.debug("GEMS _UNSAFE_INDEX_PUT")
+
+    if not indices:
+        raise ValueError("At least one index tensor is required")
+
+    if config.has_c_extension:
+        try:
+            from flag_gems import c_operators
+
+            return c_operators.unsafe_index_put(inp, indices, values, accumulate)
+        except ImportError:
+            pass
+
+    # Fallback when the C extension is unavailable: PyTorch native via CPU to
+    # bypass flag_gems' own _index_put_impl_ patch (same atomic_add limits).
+    indices = list(indices)
+    out = inp.clone()
+    inp_device = inp.device
+    if inp_device.type == "cuda":
+        cpu_indices = [idx.cpu() for idx in indices]
+        cpu_out = out.cpu()
+        cpu_values = values.cpu()
+        torch._index_put_impl_(cpu_out, cpu_indices, cpu_values, accumulate, unsafe=True)
+        out = cpu_out.to(inp_device)
+    else:
+        torch._index_put_impl_(out, indices, values, accumulate, unsafe=True)
+    return out

--- a/tests/test_unsafe_index_put.py
+++ b/tests/test_unsafe_index_put.py
@@ -1,0 +1,249 @@
+import numpy as np
+import pytest
+import torch
+
+import flag_gems
+
+from . import accuracy_utils as utils
+from . import conftest as cfg
+
+pytestmark = pytest.mark.skipif(
+    flag_gems.vendor_name == "sunrise", reason="Issues #3836: To Fix (Runtime Or LLVM)"
+)
+
+
+if cfg.QUICK_MODE:
+    FLOAT_DTYPES = [torch.float32]
+    INT_DTYPES = [torch.int32]
+else:
+    FLOAT_DTYPES = utils.FLOAT_DTYPES
+    INT_DTYPES = [torch.int32, torch.int64, torch.int16, torch.int8, torch.uint8]
+
+ALL_INPUT_DTYPES = FLOAT_DTYPES + INT_DTYPES + [torch.bool]
+INDEX_DTYPES = [torch.int32, torch.int64]
+
+# Test shapes: (input_shape, [indices_shapes...], values_shape, accumulate)
+UNSAFE_INDEX_PUT_SHAPES = (
+    ((32,), ((8,),), (8,), False),
+    ((100,), ((100,),), (100,), True),
+    ((32, 32), ((8,), (8,)), (8,), False),
+    ((32, 32), ((8,), (2, 8)), (8,), False),
+    ((32, 32), ((2, 8),), (32,), False),
+    ((64, 64, 64), ((2, 8), (2, 8), (2, 8)), (2, 8), False),
+    ((100,), ((100,),), (100,), True),
+    ((32, 32), ((32, 32),), (32, 32, 32), True),
+    ((16, 16, 4), ((16,),), (16, 16, 4), False),
+)
+
+
+def _make_input(shape, dtype, device, is_float):
+    if dtype == torch.bool:
+        return torch.randint(0, 2, shape, device=device).to(torch.bool)
+    elif is_float:
+        return torch.randn(shape, dtype=dtype, device=device)
+    else:
+        return torch.randint(1, 10, shape, device=device).to(dtype)
+
+
+def _make_values(shape, dtype, device, is_float):
+    return _make_input(shape, dtype, device, is_float)
+
+
+def gen_indices(input_shape, indices_shapes, accumulate, device, dtype=torch.int64):
+    indices = []
+    for i, shape in enumerate(indices_shapes):
+        index = np.random.choice(
+            np.arange(input_shape[i]), size=shape, replace=accumulate
+        )
+        indices.append(torch.tensor(index, dtype=dtype, device=device))
+    return indices
+
+
+# ---- Core dtype × index_dtype tests ----
+@pytest.mark.unsafe_index_put
+@pytest.mark.parametrize("inp_dtype", ALL_INPUT_DTYPES)
+@pytest.mark.parametrize("idx_dtype", INDEX_DTYPES)
+def test_unsafe_index_put_dtypes(inp_dtype, idx_dtype):
+    """Test all input and index dtype combinations."""
+    shape = (32, 32)
+    is_float = inp_dtype.is_floating_point
+
+    inp = _make_input(shape, inp_dtype, flag_gems.device, is_float)
+    indices = gen_indices(shape, [(2, 8)], False, flag_gems.device, idx_dtype)
+    values = _make_values((32,), inp_dtype, flag_gems.device, is_float)
+
+    ref_inp = utils.to_reference(inp)
+    ref_indices = [utils.to_reference(idx) for idx in indices]
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, ref_indices, ref_values, False)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(inp, indices, values, False)
+
+    if is_float:
+        utils.gems_assert_close(res_out, ref_out, inp_dtype)
+    else:
+        utils.gems_assert_equal(res_out, ref_out)
+
+
+# ---- Bool mask index tests ----
+@pytest.mark.unsafe_index_put
+@pytest.mark.parametrize("inp_dtype", ALL_INPUT_DTYPES)
+def test_unsafe_index_put_bool_mask_dtypes(inp_dtype):
+    """Test bool mask indices with all input dtypes."""
+    shape = (16, 16)
+    is_float = inp_dtype.is_floating_point
+
+    inp = _make_input(shape, inp_dtype, flag_gems.device, is_float)
+    mask = torch.randint(0, 2, (16,), dtype=torch.bool, device=flag_gems.device)
+    K = mask.sum().item()
+    if K == 0:
+        pytest.skip("empty bool mask")
+    values = _make_values((K, 16), inp_dtype, flag_gems.device, is_float)
+
+    ref_inp = utils.to_reference(inp)
+    ref_mask = utils.to_reference(mask)
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, [ref_mask], ref_values, False)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(inp, [mask], values, False)
+
+    if is_float:
+        utils.gems_assert_close(res_out, ref_out, inp_dtype)
+    else:
+        utils.gems_assert_equal(res_out, ref_out)
+
+
+# ---- Shape parametrized tests (floats) ----
+@pytest.mark.unsafe_index_put
+@pytest.mark.parametrize(
+    "input_shape, indices_shapes, values_shape, accumulate",
+    UNSAFE_INDEX_PUT_SHAPES,
+)
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_unsafe_index_put_shapes(input_shape, indices_shapes, values_shape,
+                                  accumulate, dtype):
+    inp = torch.randn(input_shape, dtype=dtype, device=flag_gems.device)
+    indices = gen_indices(input_shape, indices_shapes, accumulate, flag_gems.device)
+    values = torch.randn(values_shape, dtype=dtype, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp)
+    ref_indices = [utils.to_reference(idx) for idx in indices]
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, ref_indices, ref_values, accumulate)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(inp, indices, values, accumulate)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+# ---- Integer shape tests ----
+@pytest.mark.unsafe_index_put
+@pytest.mark.parametrize(
+    "input_shape, indices_shapes, values_shape, accumulate",
+    UNSAFE_INDEX_PUT_SHAPES[:5],
+)
+@pytest.mark.parametrize("dtype", INT_DTYPES)
+def test_unsafe_index_put_int_shapes(input_shape, indices_shapes, values_shape,
+                                      accumulate, dtype):
+    inp = torch.randint(1, 10, input_shape, device=flag_gems.device).to(dtype)
+    indices = gen_indices(input_shape, indices_shapes, accumulate, flag_gems.device)
+    values = torch.randint(1, 10, values_shape, device=flag_gems.device).to(dtype)
+
+    ref_inp = utils.to_reference(inp)
+    ref_indices = [utils.to_reference(idx) for idx in indices]
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, ref_indices, ref_values, accumulate)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(inp, indices, values, accumulate)
+
+    utils.gems_assert_equal(res_out, ref_out)
+
+
+# ---- Specific behavior tests ----
+@pytest.mark.unsafe_index_put
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_unsafe_index_put_negative_indices(dtype):
+    inp = torch.randn((32, 64), dtype=dtype, device=flag_gems.device)
+    indices = [torch.tensor([-1, -5, -10], device=flag_gems.device)]
+    values = torch.randn((3, 64), dtype=dtype, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp)
+    ref_indices = [utils.to_reference(idx) for idx in indices]
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, ref_indices, ref_values, False)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(inp, indices, values, False)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.unsafe_index_put
+def test_unsafe_index_put_functional():
+    inp = torch.randn((32, 32), device=flag_gems.device)
+    inp_copy = inp.clone()
+    indices = [torch.randint(0, 32, (8,), device=flag_gems.device)]
+    values = torch.randn((8, 32), device=flag_gems.device)
+
+    with flag_gems.use_gems():
+        out = torch._unsafe_index_put(inp, indices, values, False)
+
+    assert torch.equal(inp, inp_copy), "Input tensor was modified"
+    assert not torch.equal(out, inp), "Output should differ from input"
+
+
+@pytest.mark.unsafe_index_put
+def test_unsafe_index_put_scalar_value():
+    inp = torch.randn((16, 16), device=flag_gems.device)
+    indices = [torch.tensor([0, 5, 10], device=flag_gems.device)]
+    values = torch.tensor(3.14, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp)
+    ref_indices = [utils.to_reference(idx) for idx in indices]
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, ref_indices, ref_values, False)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(inp, indices, values, False)
+
+    utils.gems_assert_close(res_out, ref_out, torch.float32)
+
+
+@pytest.mark.unsafe_index_put
+@pytest.mark.parametrize("dtype", FLOAT_DTYPES)
+def test_unsafe_index_put_accumulate(dtype):
+    inp = torch.randn((32, 32), dtype=dtype, device=flag_gems.device)
+    indices = [torch.randint(0, 32, (64,), device=flag_gems.device)]
+    values = torch.randn((64, 32), dtype=dtype, device=flag_gems.device)
+
+    ref_inp = utils.to_reference(inp)
+    ref_indices = [utils.to_reference(idx) for idx in indices]
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, ref_indices, ref_values, True)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(inp, indices, values, True)
+
+    utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.unsafe_index_put
+@pytest.mark.parametrize("dtype", INT_DTYPES)
+def test_unsafe_index_put_int_accumulate(dtype):
+    inp = torch.randint(1, 5, (32, 32), device=flag_gems.device).to(dtype)
+    indices = [torch.randint(0, 32, (64,), device=flag_gems.device)]
+    values = torch.randint(1, 5, (64, 32), device=flag_gems.device).to(dtype)
+
+    ref_inp = utils.to_reference(inp)
+    ref_indices = [utils.to_reference(idx) for idx in indices]
+    ref_values = utils.to_reference(values)
+    ref_out = torch._unsafe_index_put(ref_inp, ref_indices, ref_values, True)
+
+    with flag_gems.use_gems():
+        res_out = torch._unsafe_index_put(inp, indices, values, True)
+
+    utils.gems_assert_equal(res_out, ref_out)

--- a/tests/test_unsafe_index_put.py
+++ b/tests/test_unsafe_index_put.py
@@ -122,8 +122,9 @@ def test_unsafe_index_put_bool_mask_dtypes(inp_dtype):
     UNSAFE_INDEX_PUT_SHAPES,
 )
 @pytest.mark.parametrize("dtype", FLOAT_DTYPES)
-def test_unsafe_index_put_shapes(input_shape, indices_shapes, values_shape,
-                                  accumulate, dtype):
+def test_unsafe_index_put_shapes(
+    input_shape, indices_shapes, values_shape, accumulate, dtype
+):
     inp = torch.randn(input_shape, dtype=dtype, device=flag_gems.device)
     indices = gen_indices(input_shape, indices_shapes, accumulate, flag_gems.device)
     values = torch.randn(values_shape, dtype=dtype, device=flag_gems.device)
@@ -146,8 +147,9 @@ def test_unsafe_index_put_shapes(input_shape, indices_shapes, values_shape,
     UNSAFE_INDEX_PUT_SHAPES[:5],
 )
 @pytest.mark.parametrize("dtype", INT_DTYPES)
-def test_unsafe_index_put_int_shapes(input_shape, indices_shapes, values_shape,
-                                      accumulate, dtype):
+def test_unsafe_index_put_int_shapes(
+    input_shape, indices_shapes, values_shape, accumulate, dtype
+):
     inp = torch.randint(1, 10, input_shape, device=flag_gems.device).to(dtype)
     indices = gen_indices(input_shape, indices_shapes, accumulate, flag_gems.device)
     values = torch.randint(1, 10, values_shape, device=flag_gems.device).to(dtype)

--- a/tests/test_unsafe_index_put.py
+++ b/tests/test_unsafe_index_put.py
@@ -59,6 +59,25 @@ def gen_indices(input_shape, indices_shapes, accumulate, device, dtype=torch.int
     return indices
 
 
+def assert_accumulate_close(res, ref, dtype):
+    """Assert helper for accumulate=True float tests.
+
+    With duplicate indices the summation order is implementation-defined:
+    PyTorch's CUDA kernel accumulates serially after a radix sort, while
+    FlagGems accumulates via fp32 atomic_add in arbitrary GPU scheduling
+    order. Both accumulate in fp32 and round to fp16/bf16 once, but fp32
+    reassociation noise can flip the final rounding by 1 ulp of the output
+    dtype. This is not an implementation defect — even PyTorch's own CPU vs
+    CUDA results bit-differ on essentially every run for this case — so the
+    tolerance must cover >=2 ulp. bf16's default rtol (0.016) already does;
+    fp16's (0.001) does not.
+    """
+    if dtype == torch.float16:
+        torch.testing.assert_close(res, ref, atol=1e-3, rtol=4e-3)
+    else:
+        utils.gems_assert_close(res, ref, dtype)
+
+
 # ---- Core dtype × index_dtype tests ----
 @pytest.mark.unsafe_index_put
 @pytest.mark.parametrize("inp_dtype", ALL_INPUT_DTYPES)
@@ -137,7 +156,10 @@ def test_unsafe_index_put_shapes(
     with flag_gems.use_gems():
         res_out = torch._unsafe_index_put(inp, indices, values, accumulate)
 
-    utils.gems_assert_close(res_out, ref_out, dtype)
+    if accumulate:
+        assert_accumulate_close(res_out, ref_out, dtype)
+    else:
+        utils.gems_assert_close(res_out, ref_out, dtype)
 
 
 # ---- Integer shape tests ----
@@ -230,7 +252,7 @@ def test_unsafe_index_put_accumulate(dtype):
     with flag_gems.use_gems():
         res_out = torch._unsafe_index_put(inp, indices, values, True)
 
-    utils.gems_assert_close(res_out, ref_out, dtype)
+    assert_accumulate_close(res_out, ref_out, dtype)
 
 
 @pytest.mark.unsafe_index_put

--- a/triton_src/unsafe_index_put_kernel.py
+++ b/triton_src/unsafe_index_put_kernel.py
@@ -1,0 +1,460 @@
+"""
+_unsafe_index_put Triton kernel v2 — 2D grid for C++ via TritonJITFunction.
+
+Key changes from v1:
+- 2D grid: program_id(0)→idx_pos, program_id(1)→suf_pos. Eliminates expensive
+  integer division by suffix_numel (the dominant cost on large-suffix shapes).
+- Supports up to 6 index tensors and 6 suffix dims (was 4).
+- Direct @triton.jit, no @libentry().
+- fp16/bf16 accumulate: three-kernel scheme with an fp32 scratch buffer,
+  matching PyTorch's opmath_t semantics (accumulate in fp32, single rounding
+  on writeback) without radix-sort or CAS/flag overhead.
+
+Kernel 0 (unsafe_index_put_scratch_kernel, PROLOGUE=True):
+  Stores 0.0f into the fp32 scratch at every touched offset. Duplicate stores
+  are harmless (all write the same value). Stream ordering guarantees this
+  completes before accumulation starts.
+
+Kernel 1 (unsafe_index_put_kernel_v2, USE_SCRATCH=True):
+  atomic_add's each fp32-cast value into scratch. Pure-delta accumulation in
+  fp32; no read-modify-write of the output.
+
+Kernel 2 (unsafe_index_put_scratch_kernel, PROLOGUE=False):
+  Reads fp32 scratch and the fp16/bf16 original (already cloned into out),
+  adds them in fp32, casts once to the output dtype, and stores.
+"""
+import triton
+import triton.language as tl
+
+
+@triton.jit
+def unsafe_index_put_kernel_v2(
+    out_ptr,
+    values_ptr,
+    scratch_ptr,
+    idx0_ptr, idx1_ptr, idx2_ptr, idx3_ptr, idx4_ptr, idx5_ptr,
+    idx_div0, idx_div1, idx_div2, idx_div3, idx_div4, idx_div5,
+    ts_0_0, ts_0_1, ts_0_2, ts_0_3, ts_0_4, ts_0_5,
+    ts_1_0, ts_1_1, ts_1_2, ts_1_3, ts_1_4, ts_1_5,
+    ts_2_0, ts_2_1, ts_2_2, ts_2_3, ts_2_4, ts_2_5,
+    ts_3_0, ts_3_1, ts_3_2, ts_3_3, ts_3_4, ts_3_5,
+    ts_4_0, ts_4_1, ts_4_2, ts_4_3, ts_4_4, ts_4_5,
+    ts_5_0, ts_5_1, ts_5_2, ts_5_3, ts_5_4, ts_5_5,
+    val_adv0, val_adv1, val_adv2, val_adv3, val_adv4, val_adv5,
+    self_adv_stride0, self_adv_stride1, self_adv_stride2,
+    self_adv_stride3, self_adv_stride4, self_adv_stride5,
+    self_adv_size0, self_adv_size1, self_adv_size2,
+    self_adv_size3, self_adv_size4, self_adv_size5,
+    suf_div0, suf_div1, suf_div2, suf_div3, suf_div4, suf_div5,
+    self_suf_stride0, self_suf_stride1, self_suf_stride2,
+    self_suf_stride3, self_suf_stride4, self_suf_stride5,
+    val_suf_stride0, val_suf_stride1, val_suf_stride2,
+    val_suf_stride3, val_suf_stride4, val_suf_stride5,
+    idx_numel,
+    suffix_numel,
+    N,
+    M: tl.constexpr,
+    IDX_NDIM: tl.constexpr,
+    SUF_NDIM: tl.constexpr,
+    ACCUMULATE: tl.constexpr,
+    USE_SCRATCH: tl.constexpr,
+    BLOCK_IDX: tl.constexpr,
+    BLOCK_SUF: tl.constexpr,
+):
+    """
+    2D grid kernel.
+
+    Grid: (cdiv(idx_numel, BLOCK_IDX), cdiv(suffix_numel, BLOCK_SUF)).
+    Each block handles BLOCK_IDX index positions × BLOCK_SUF suffix positions.
+    program_id(0) → idx position range (no expensive division by suffix_numel!).
+    """
+    pid0 = tl.program_id(0)
+    pid1 = tl.program_id(1)
+
+    idx_off = pid0 * BLOCK_IDX + tl.arange(0, BLOCK_IDX)[:, None]   # (BI, 1)
+    suf_off = pid1 * BLOCK_SUF + tl.arange(0, BLOCK_SUF)[None, :]   # (1, BS)
+
+    mask_idx = idx_off < idx_numel
+    mask_suf = suf_off < suffix_numel
+    mask = mask_idx & mask_suf  # (BI, BS)
+
+    val_off = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    self_off = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+
+    toff0 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff1 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff2 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff3 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff4 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff5 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+
+    rem_idx = idx_off
+
+    # ---- index-space coordinate decomposition ----
+    if IDX_NDIM >= 1:
+        c0 = rem_idx // idx_div0
+        rem_idx = rem_idx % idx_div0
+        val_off += c0 * val_adv0
+        if M >= 1: toff0 += c0 * ts_0_0
+        if M >= 2: toff1 += c0 * ts_1_0
+        if M >= 3: toff2 += c0 * ts_2_0
+        if M >= 4: toff3 += c0 * ts_3_0
+        if M >= 5: toff4 += c0 * ts_4_0
+        if M >= 6: toff5 += c0 * ts_5_0
+
+    if IDX_NDIM >= 2:
+        c1 = rem_idx // idx_div1
+        rem_idx = rem_idx % idx_div1
+        val_off += c1 * val_adv1
+        if M >= 1: toff0 += c1 * ts_0_1
+        if M >= 2: toff1 += c1 * ts_1_1
+        if M >= 3: toff2 += c1 * ts_2_1
+        if M >= 4: toff3 += c1 * ts_3_1
+        if M >= 5: toff4 += c1 * ts_4_1
+        if M >= 6: toff5 += c1 * ts_5_1
+
+    if IDX_NDIM >= 3:
+        c2 = rem_idx // idx_div2
+        rem_idx = rem_idx % idx_div2
+        val_off += c2 * val_adv2
+        if M >= 1: toff0 += c2 * ts_0_2
+        if M >= 2: toff1 += c2 * ts_1_2
+        if M >= 3: toff2 += c2 * ts_2_2
+        if M >= 4: toff3 += c2 * ts_3_2
+        if M >= 5: toff4 += c2 * ts_4_2
+        if M >= 6: toff5 += c2 * ts_5_2
+
+    if IDX_NDIM >= 4:
+        c3 = rem_idx // idx_div3
+        rem_idx = rem_idx % idx_div3
+        val_off += c3 * val_adv3
+        if M >= 1: toff0 += c3 * ts_0_3
+        if M >= 2: toff1 += c3 * ts_1_3
+        if M >= 3: toff2 += c3 * ts_2_3
+        if M >= 4: toff3 += c3 * ts_3_3
+        if M >= 5: toff4 += c3 * ts_4_3
+        if M >= 6: toff5 += c3 * ts_5_3
+
+    if IDX_NDIM >= 5:
+        c4 = rem_idx // idx_div4
+        rem_idx = rem_idx % idx_div4
+        val_off += c4 * val_adv4
+        if M >= 1: toff0 += c4 * ts_0_4
+        if M >= 2: toff1 += c4 * ts_1_4
+        if M >= 3: toff2 += c4 * ts_2_4
+        if M >= 4: toff3 += c4 * ts_3_4
+        if M >= 5: toff4 += c4 * ts_4_4
+        if M >= 6: toff5 += c4 * ts_5_4
+
+    if IDX_NDIM >= 6:
+        c5 = rem_idx // idx_div5
+        rem_idx = rem_idx % idx_div5
+        val_off += c5 * val_adv5
+        if M >= 1: toff0 += c5 * ts_0_5
+        if M >= 2: toff1 += c5 * ts_1_5
+        if M >= 3: toff2 += c5 * ts_2_5
+        if M >= 4: toff3 += c5 * ts_3_5
+        if M >= 5: toff4 += c5 * ts_4_5
+        if M >= 6: toff5 += c5 * ts_5_5
+
+    # ---- load index values ----
+    if M >= 1:
+        idx0_ptr = idx0_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 2:
+        idx1_ptr = idx1_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 3:
+        idx2_ptr = idx2_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 4:
+        idx3_ptr = idx3_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 5:
+        idx4_ptr = idx4_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 6:
+        idx5_ptr = idx5_ptr.to(tl.pointer_type(tl.int64))
+
+    if M >= 1:
+        ind = tl.load(idx0_ptr + toff0, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size0, ind)
+        self_off += ind * self_adv_stride0
+    if M >= 2:
+        ind = tl.load(idx1_ptr + toff1, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size1, ind)
+        self_off += ind * self_adv_stride1
+    if M >= 3:
+        ind = tl.load(idx2_ptr + toff2, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size2, ind)
+        self_off += ind * self_adv_stride2
+    if M >= 4:
+        ind = tl.load(idx3_ptr + toff3, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size3, ind)
+        self_off += ind * self_adv_stride3
+    if M >= 5:
+        ind = tl.load(idx4_ptr + toff4, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size4, ind)
+        self_off += ind * self_adv_stride4
+    if M >= 6:
+        ind = tl.load(idx5_ptr + toff5, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size5, ind)
+        self_off += ind * self_adv_stride5
+
+    # ---- suffix coordinate decomposition ----
+    rem_suf = suf_off
+    if SUF_NDIM >= 1:
+        cs0 = rem_suf // suf_div0
+        rem_suf = rem_suf % suf_div0
+        self_off += cs0 * self_suf_stride0
+        val_off += cs0 * val_suf_stride0
+    if SUF_NDIM >= 2:
+        cs1 = rem_suf // suf_div1
+        rem_suf = rem_suf % suf_div1
+        self_off += cs1 * self_suf_stride1
+        val_off += cs1 * val_suf_stride1
+    if SUF_NDIM >= 3:
+        cs2 = rem_suf // suf_div2
+        rem_suf = rem_suf % suf_div2
+        self_off += cs2 * self_suf_stride2
+        val_off += cs2 * val_suf_stride2
+    if SUF_NDIM >= 4:
+        cs3 = rem_suf // suf_div3
+        rem_suf = rem_suf % suf_div3
+        self_off += cs3 * self_suf_stride3
+        val_off += cs3 * val_suf_stride3
+    if SUF_NDIM >= 5:
+        cs4 = rem_suf // suf_div4
+        rem_suf = rem_suf % suf_div4
+        self_off += cs4 * self_suf_stride4
+        val_off += cs4 * val_suf_stride4
+    if SUF_NDIM >= 6:
+        cs5 = rem_suf // suf_div5
+        rem_suf = rem_suf % suf_div5
+        self_off += cs5 * self_suf_stride5
+        val_off += cs5 * val_suf_stride5
+
+    # ---- load and store/accumulate ----
+    v = tl.load(values_ptr + val_off, mask=mask, other=0.0)
+    if ACCUMULATE:
+        if USE_SCRATCH:
+            # Scratch-based accumulate for outputs whose dtype lacks native
+            # atomic_add (fp16/bf16 → fp32 scratch; int8/int16/uint8/bool →
+            # int32 scratch). Scratch slots were seeded by the prologue; here
+            # we only add the cast delta. Lossless for all supported dtypes.
+            tl.atomic_add(scratch_ptr + self_off,
+                          v.to(scratch_ptr.dtype.element_ty), mask=mask)
+        else:
+            tl.atomic_add(out_ptr + self_off, v, mask=mask)
+    else:
+        tl.store(out_ptr + self_off, v, mask=mask)
+
+
+@triton.jit
+def unsafe_index_put_scratch_kernel(
+    out_ptr,
+    scratch_ptr,
+    idx0_ptr, idx1_ptr, idx2_ptr, idx3_ptr, idx4_ptr, idx5_ptr,
+    idx_div0, idx_div1, idx_div2, idx_div3, idx_div4, idx_div5,
+    ts_0_0, ts_0_1, ts_0_2, ts_0_3, ts_0_4, ts_0_5,
+    ts_1_0, ts_1_1, ts_1_2, ts_1_3, ts_1_4, ts_1_5,
+    ts_2_0, ts_2_1, ts_2_2, ts_2_3, ts_2_4, ts_2_5,
+    ts_3_0, ts_3_1, ts_3_2, ts_3_3, ts_3_4, ts_3_5,
+    ts_4_0, ts_4_1, ts_4_2, ts_4_3, ts_4_4, ts_4_5,
+    ts_5_0, ts_5_1, ts_5_2, ts_5_3, ts_5_4, ts_5_5,
+    self_adv_stride0, self_adv_stride1, self_adv_stride2,
+    self_adv_stride3, self_adv_stride4, self_adv_stride5,
+    self_adv_size0, self_adv_size1, self_adv_size2,
+    self_adv_size3, self_adv_size4, self_adv_size5,
+    suf_div0, suf_div1, suf_div2, suf_div3, suf_div4, suf_div5,
+    self_suf_stride0, self_suf_stride1, self_suf_stride2,
+    self_suf_stride3, self_suf_stride4, self_suf_stride5,
+    idx_numel,
+    suffix_numel,
+    N,
+    M: tl.constexpr,
+    IDX_NDIM: tl.constexpr,
+    SUF_NDIM: tl.constexpr,
+    PROLOGUE: tl.constexpr,
+    BLOCK_IDX: tl.constexpr,
+    BLOCK_SUF: tl.constexpr,
+):
+    """
+    Scratch prologue/epilogue for the fp32-scratch accumulate path (fp16/bf16).
+    Recomputes the touched offsets exactly as kernel_v2 does.
+
+    PROLOGUE=True:  seeds scratch slots with fp32(orig) read from the cloned
+                    output (idempotent under duplicate slots).
+    PROLOGUE=False: stores cast(scratch) into out (idempotent too).
+    """
+    pid0 = tl.program_id(0)
+    pid1 = tl.program_id(1)
+
+    idx_off = pid0 * BLOCK_IDX + tl.arange(0, BLOCK_IDX)[:, None]   # (BI, 1)
+    suf_off = pid1 * BLOCK_SUF + tl.arange(0, BLOCK_SUF)[None, :]   # (1, BS)
+
+    mask_idx = idx_off < idx_numel
+    mask_suf = suf_off < suffix_numel
+    mask = mask_idx & mask_suf  # (BI, BS)
+
+    self_off = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+
+    toff0 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff1 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff2 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff3 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff4 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+    toff5 = tl.zeros((BLOCK_IDX, BLOCK_SUF), dtype=tl.int64)
+
+    rem_idx = idx_off
+
+    # ---- index-space coordinate decomposition ----
+    if IDX_NDIM >= 1:
+        c0 = rem_idx // idx_div0
+        rem_idx = rem_idx % idx_div0
+        if M >= 1: toff0 += c0 * ts_0_0
+        if M >= 2: toff1 += c0 * ts_1_0
+        if M >= 3: toff2 += c0 * ts_2_0
+        if M >= 4: toff3 += c0 * ts_3_0
+        if M >= 5: toff4 += c0 * ts_4_0
+        if M >= 6: toff5 += c0 * ts_5_0
+
+    if IDX_NDIM >= 2:
+        c1 = rem_idx // idx_div1
+        rem_idx = rem_idx % idx_div1
+        if M >= 1: toff0 += c1 * ts_0_1
+        if M >= 2: toff1 += c1 * ts_1_1
+        if M >= 3: toff2 += c1 * ts_2_1
+        if M >= 4: toff3 += c1 * ts_3_1
+        if M >= 5: toff4 += c1 * ts_4_1
+        if M >= 6: toff5 += c1 * ts_5_1
+
+    if IDX_NDIM >= 3:
+        c2 = rem_idx // idx_div2
+        rem_idx = rem_idx % idx_div2
+        if M >= 1: toff0 += c2 * ts_0_2
+        if M >= 2: toff1 += c2 * ts_1_2
+        if M >= 3: toff2 += c2 * ts_2_2
+        if M >= 4: toff3 += c2 * ts_3_2
+        if M >= 5: toff4 += c2 * ts_4_2
+        if M >= 6: toff5 += c2 * ts_5_2
+
+    if IDX_NDIM >= 4:
+        c3 = rem_idx // idx_div3
+        rem_idx = rem_idx % idx_div3
+        if M >= 1: toff0 += c3 * ts_0_3
+        if M >= 2: toff1 += c3 * ts_1_3
+        if M >= 3: toff2 += c3 * ts_2_3
+        if M >= 4: toff3 += c3 * ts_3_3
+        if M >= 5: toff4 += c3 * ts_4_3
+        if M >= 6: toff5 += c3 * ts_5_3
+
+    if IDX_NDIM >= 5:
+        c4 = rem_idx // idx_div4
+        rem_idx = rem_idx % idx_div4
+        if M >= 1: toff0 += c4 * ts_0_4
+        if M >= 2: toff1 += c4 * ts_1_4
+        if M >= 3: toff2 += c4 * ts_2_4
+        if M >= 4: toff3 += c4 * ts_3_4
+        if M >= 5: toff4 += c4 * ts_4_4
+        if M >= 6: toff5 += c4 * ts_5_4
+
+    if IDX_NDIM >= 6:
+        c5 = rem_idx // idx_div5
+        rem_idx = rem_idx % idx_div5
+        if M >= 1: toff0 += c5 * ts_0_5
+        if M >= 2: toff1 += c5 * ts_1_5
+        if M >= 3: toff2 += c5 * ts_2_5
+        if M >= 4: toff3 += c5 * ts_3_5
+        if M >= 5: toff4 += c5 * ts_4_5
+        if M >= 6: toff5 += c5 * ts_5_5
+
+    # ---- load index values ----
+    if M >= 1:
+        idx0_ptr = idx0_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 2:
+        idx1_ptr = idx1_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 3:
+        idx2_ptr = idx2_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 4:
+        idx3_ptr = idx3_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 5:
+        idx4_ptr = idx4_ptr.to(tl.pointer_type(tl.int64))
+    if M >= 6:
+        idx5_ptr = idx5_ptr.to(tl.pointer_type(tl.int64))
+
+    if M >= 1:
+        ind = tl.load(idx0_ptr + toff0, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size0, ind)
+        self_off += ind * self_adv_stride0
+    if M >= 2:
+        ind = tl.load(idx1_ptr + toff1, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size1, ind)
+        self_off += ind * self_adv_stride1
+    if M >= 3:
+        ind = tl.load(idx2_ptr + toff2, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size2, ind)
+        self_off += ind * self_adv_stride2
+    if M >= 4:
+        ind = tl.load(idx3_ptr + toff3, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size3, ind)
+        self_off += ind * self_adv_stride3
+    if M >= 5:
+        ind = tl.load(idx4_ptr + toff4, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size4, ind)
+        self_off += ind * self_adv_stride4
+    if M >= 6:
+        ind = tl.load(idx5_ptr + toff5, mask=mask, other=0)
+        ind = ind.to(tl.int64)
+        ind = tl.where(ind < 0, ind + self_adv_size5, ind)
+        self_off += ind * self_adv_stride5
+
+    # ---- suffix coordinate decomposition ----
+    rem_suf = suf_off
+    if SUF_NDIM >= 1:
+        cs0 = rem_suf // suf_div0
+        rem_suf = rem_suf % suf_div0
+        self_off += cs0 * self_suf_stride0
+    if SUF_NDIM >= 2:
+        cs1 = rem_suf // suf_div1
+        rem_suf = rem_suf % suf_div1
+        self_off += cs1 * self_suf_stride1
+    if SUF_NDIM >= 3:
+        cs2 = rem_suf // suf_div2
+        rem_suf = rem_suf % suf_div2
+        self_off += cs2 * self_suf_stride2
+    if SUF_NDIM >= 4:
+        cs3 = rem_suf // suf_div3
+        rem_suf = rem_suf % suf_div3
+        self_off += cs3 * self_suf_stride3
+    if SUF_NDIM >= 5:
+        cs4 = rem_suf // suf_div4
+        rem_suf = rem_suf % suf_div4
+        self_off += cs4 * self_suf_stride4
+    if SUF_NDIM >= 6:
+        cs5 = rem_suf // suf_div5
+        rem_suf = rem_suf % suf_div5
+        self_off += cs5 * self_suf_stride5
+
+    # ---- prologue: seed scratch; epilogue: write final values ----
+    # Both phases are race-free under duplicate target slots:
+    #   prologue: every writer stores the SAME fp32(orig) value (idempotent).
+    #   epilogue: reads only scratch (stable after the main kernel), and every
+    #             writer stores the SAME final value (idempotent).
+    # No non-atomic read-modify-write of `out` anywhere: the epilogue must NOT
+    # read orig from `out`, otherwise one program's store could be observed as
+    # another program's "orig", doubling the accumulated deltas.
+    if PROLOGUE:
+        orig = tl.load(out_ptr + self_off, mask=mask, other=0.0)
+        tl.store(scratch_ptr + self_off,
+                 orig.to(scratch_ptr.dtype.element_ty), mask=mask)
+    else:
+        v32 = tl.load(scratch_ptr + self_off, mask=mask, other=0.0)
+        tl.store(out_ptr + self_off, v32.to(out_ptr.dtype.element_ty),
+                 mask=mask)

--- a/triton_src/unsafe_index_put_kernel.py
+++ b/triton_src/unsafe_index_put_kernel.py
@@ -23,6 +23,7 @@ Kernel 2 (unsafe_index_put_scratch_kernel, PROLOGUE=False):
   Reads fp32 scratch and the fp16/bf16 original (already cloned into out),
   adds them in fp32, casts once to the output dtype, and stores.
 """
+
 import triton
 import triton.language as tl
 
@@ -32,24 +33,90 @@ def unsafe_index_put_kernel_v2(
     out_ptr,
     values_ptr,
     scratch_ptr,
-    idx0_ptr, idx1_ptr, idx2_ptr, idx3_ptr, idx4_ptr, idx5_ptr,
-    idx_div0, idx_div1, idx_div2, idx_div3, idx_div4, idx_div5,
-    ts_0_0, ts_0_1, ts_0_2, ts_0_3, ts_0_4, ts_0_5,
-    ts_1_0, ts_1_1, ts_1_2, ts_1_3, ts_1_4, ts_1_5,
-    ts_2_0, ts_2_1, ts_2_2, ts_2_3, ts_2_4, ts_2_5,
-    ts_3_0, ts_3_1, ts_3_2, ts_3_3, ts_3_4, ts_3_5,
-    ts_4_0, ts_4_1, ts_4_2, ts_4_3, ts_4_4, ts_4_5,
-    ts_5_0, ts_5_1, ts_5_2, ts_5_3, ts_5_4, ts_5_5,
-    val_adv0, val_adv1, val_adv2, val_adv3, val_adv4, val_adv5,
-    self_adv_stride0, self_adv_stride1, self_adv_stride2,
-    self_adv_stride3, self_adv_stride4, self_adv_stride5,
-    self_adv_size0, self_adv_size1, self_adv_size2,
-    self_adv_size3, self_adv_size4, self_adv_size5,
-    suf_div0, suf_div1, suf_div2, suf_div3, suf_div4, suf_div5,
-    self_suf_stride0, self_suf_stride1, self_suf_stride2,
-    self_suf_stride3, self_suf_stride4, self_suf_stride5,
-    val_suf_stride0, val_suf_stride1, val_suf_stride2,
-    val_suf_stride3, val_suf_stride4, val_suf_stride5,
+    idx0_ptr,
+    idx1_ptr,
+    idx2_ptr,
+    idx3_ptr,
+    idx4_ptr,
+    idx5_ptr,
+    idx_div0,
+    idx_div1,
+    idx_div2,
+    idx_div3,
+    idx_div4,
+    idx_div5,
+    ts_0_0,
+    ts_0_1,
+    ts_0_2,
+    ts_0_3,
+    ts_0_4,
+    ts_0_5,
+    ts_1_0,
+    ts_1_1,
+    ts_1_2,
+    ts_1_3,
+    ts_1_4,
+    ts_1_5,
+    ts_2_0,
+    ts_2_1,
+    ts_2_2,
+    ts_2_3,
+    ts_2_4,
+    ts_2_5,
+    ts_3_0,
+    ts_3_1,
+    ts_3_2,
+    ts_3_3,
+    ts_3_4,
+    ts_3_5,
+    ts_4_0,
+    ts_4_1,
+    ts_4_2,
+    ts_4_3,
+    ts_4_4,
+    ts_4_5,
+    ts_5_0,
+    ts_5_1,
+    ts_5_2,
+    ts_5_3,
+    ts_5_4,
+    ts_5_5,
+    val_adv0,
+    val_adv1,
+    val_adv2,
+    val_adv3,
+    val_adv4,
+    val_adv5,
+    self_adv_stride0,
+    self_adv_stride1,
+    self_adv_stride2,
+    self_adv_stride3,
+    self_adv_stride4,
+    self_adv_stride5,
+    self_adv_size0,
+    self_adv_size1,
+    self_adv_size2,
+    self_adv_size3,
+    self_adv_size4,
+    self_adv_size5,
+    suf_div0,
+    suf_div1,
+    suf_div2,
+    suf_div3,
+    suf_div4,
+    suf_div5,
+    self_suf_stride0,
+    self_suf_stride1,
+    self_suf_stride2,
+    self_suf_stride3,
+    self_suf_stride4,
+    self_suf_stride5,
+    val_suf_stride0,
+    val_suf_stride1,
+    val_suf_stride2,
+    val_suf_stride3,
+    val_suf_stride4,
+    val_suf_stride5,
     idx_numel,
     suffix_numel,
     N,
@@ -71,8 +138,8 @@ def unsafe_index_put_kernel_v2(
     pid0 = tl.program_id(0)
     pid1 = tl.program_id(1)
 
-    idx_off = pid0 * BLOCK_IDX + tl.arange(0, BLOCK_IDX)[:, None]   # (BI, 1)
-    suf_off = pid1 * BLOCK_SUF + tl.arange(0, BLOCK_SUF)[None, :]   # (1, BS)
+    idx_off = pid0 * BLOCK_IDX + tl.arange(0, BLOCK_IDX)[:, None]  # (BI, 1)
+    suf_off = pid1 * BLOCK_SUF + tl.arange(0, BLOCK_SUF)[None, :]  # (1, BS)
 
     mask_idx = idx_off < idx_numel
     mask_suf = suf_off < suffix_numel
@@ -95,67 +162,103 @@ def unsafe_index_put_kernel_v2(
         c0 = rem_idx // idx_div0
         rem_idx = rem_idx % idx_div0
         val_off += c0 * val_adv0
-        if M >= 1: toff0 += c0 * ts_0_0
-        if M >= 2: toff1 += c0 * ts_1_0
-        if M >= 3: toff2 += c0 * ts_2_0
-        if M >= 4: toff3 += c0 * ts_3_0
-        if M >= 5: toff4 += c0 * ts_4_0
-        if M >= 6: toff5 += c0 * ts_5_0
+        if M >= 1:
+            toff0 += c0 * ts_0_0
+        if M >= 2:
+            toff1 += c0 * ts_1_0
+        if M >= 3:
+            toff2 += c0 * ts_2_0
+        if M >= 4:
+            toff3 += c0 * ts_3_0
+        if M >= 5:
+            toff4 += c0 * ts_4_0
+        if M >= 6:
+            toff5 += c0 * ts_5_0
 
     if IDX_NDIM >= 2:
         c1 = rem_idx // idx_div1
         rem_idx = rem_idx % idx_div1
         val_off += c1 * val_adv1
-        if M >= 1: toff0 += c1 * ts_0_1
-        if M >= 2: toff1 += c1 * ts_1_1
-        if M >= 3: toff2 += c1 * ts_2_1
-        if M >= 4: toff3 += c1 * ts_3_1
-        if M >= 5: toff4 += c1 * ts_4_1
-        if M >= 6: toff5 += c1 * ts_5_1
+        if M >= 1:
+            toff0 += c1 * ts_0_1
+        if M >= 2:
+            toff1 += c1 * ts_1_1
+        if M >= 3:
+            toff2 += c1 * ts_2_1
+        if M >= 4:
+            toff3 += c1 * ts_3_1
+        if M >= 5:
+            toff4 += c1 * ts_4_1
+        if M >= 6:
+            toff5 += c1 * ts_5_1
 
     if IDX_NDIM >= 3:
         c2 = rem_idx // idx_div2
         rem_idx = rem_idx % idx_div2
         val_off += c2 * val_adv2
-        if M >= 1: toff0 += c2 * ts_0_2
-        if M >= 2: toff1 += c2 * ts_1_2
-        if M >= 3: toff2 += c2 * ts_2_2
-        if M >= 4: toff3 += c2 * ts_3_2
-        if M >= 5: toff4 += c2 * ts_4_2
-        if M >= 6: toff5 += c2 * ts_5_2
+        if M >= 1:
+            toff0 += c2 * ts_0_2
+        if M >= 2:
+            toff1 += c2 * ts_1_2
+        if M >= 3:
+            toff2 += c2 * ts_2_2
+        if M >= 4:
+            toff3 += c2 * ts_3_2
+        if M >= 5:
+            toff4 += c2 * ts_4_2
+        if M >= 6:
+            toff5 += c2 * ts_5_2
 
     if IDX_NDIM >= 4:
         c3 = rem_idx // idx_div3
         rem_idx = rem_idx % idx_div3
         val_off += c3 * val_adv3
-        if M >= 1: toff0 += c3 * ts_0_3
-        if M >= 2: toff1 += c3 * ts_1_3
-        if M >= 3: toff2 += c3 * ts_2_3
-        if M >= 4: toff3 += c3 * ts_3_3
-        if M >= 5: toff4 += c3 * ts_4_3
-        if M >= 6: toff5 += c3 * ts_5_3
+        if M >= 1:
+            toff0 += c3 * ts_0_3
+        if M >= 2:
+            toff1 += c3 * ts_1_3
+        if M >= 3:
+            toff2 += c3 * ts_2_3
+        if M >= 4:
+            toff3 += c3 * ts_3_3
+        if M >= 5:
+            toff4 += c3 * ts_4_3
+        if M >= 6:
+            toff5 += c3 * ts_5_3
 
     if IDX_NDIM >= 5:
         c4 = rem_idx // idx_div4
         rem_idx = rem_idx % idx_div4
         val_off += c4 * val_adv4
-        if M >= 1: toff0 += c4 * ts_0_4
-        if M >= 2: toff1 += c4 * ts_1_4
-        if M >= 3: toff2 += c4 * ts_2_4
-        if M >= 4: toff3 += c4 * ts_3_4
-        if M >= 5: toff4 += c4 * ts_4_4
-        if M >= 6: toff5 += c4 * ts_5_4
+        if M >= 1:
+            toff0 += c4 * ts_0_4
+        if M >= 2:
+            toff1 += c4 * ts_1_4
+        if M >= 3:
+            toff2 += c4 * ts_2_4
+        if M >= 4:
+            toff3 += c4 * ts_3_4
+        if M >= 5:
+            toff4 += c4 * ts_4_4
+        if M >= 6:
+            toff5 += c4 * ts_5_4
 
     if IDX_NDIM >= 6:
         c5 = rem_idx // idx_div5
         rem_idx = rem_idx % idx_div5
         val_off += c5 * val_adv5
-        if M >= 1: toff0 += c5 * ts_0_5
-        if M >= 2: toff1 += c5 * ts_1_5
-        if M >= 3: toff2 += c5 * ts_2_5
-        if M >= 4: toff3 += c5 * ts_3_5
-        if M >= 5: toff4 += c5 * ts_4_5
-        if M >= 6: toff5 += c5 * ts_5_5
+        if M >= 1:
+            toff0 += c5 * ts_0_5
+        if M >= 2:
+            toff1 += c5 * ts_1_5
+        if M >= 3:
+            toff2 += c5 * ts_2_5
+        if M >= 4:
+            toff3 += c5 * ts_3_5
+        if M >= 5:
+            toff4 += c5 * ts_4_5
+        if M >= 6:
+            toff5 += c5 * ts_5_5
 
     # ---- load index values ----
     if M >= 1:
@@ -243,8 +346,9 @@ def unsafe_index_put_kernel_v2(
             # atomic_add (fp16/bf16 → fp32 scratch; int8/int16/uint8/bool →
             # int32 scratch). Scratch slots were seeded by the prologue; here
             # we only add the cast delta. Lossless for all supported dtypes.
-            tl.atomic_add(scratch_ptr + self_off,
-                          v.to(scratch_ptr.dtype.element_ty), mask=mask)
+            tl.atomic_add(
+                scratch_ptr + self_off, v.to(scratch_ptr.dtype.element_ty), mask=mask
+            )
         else:
             tl.atomic_add(out_ptr + self_off, v, mask=mask)
     else:
@@ -255,21 +359,78 @@ def unsafe_index_put_kernel_v2(
 def unsafe_index_put_scratch_kernel(
     out_ptr,
     scratch_ptr,
-    idx0_ptr, idx1_ptr, idx2_ptr, idx3_ptr, idx4_ptr, idx5_ptr,
-    idx_div0, idx_div1, idx_div2, idx_div3, idx_div4, idx_div5,
-    ts_0_0, ts_0_1, ts_0_2, ts_0_3, ts_0_4, ts_0_5,
-    ts_1_0, ts_1_1, ts_1_2, ts_1_3, ts_1_4, ts_1_5,
-    ts_2_0, ts_2_1, ts_2_2, ts_2_3, ts_2_4, ts_2_5,
-    ts_3_0, ts_3_1, ts_3_2, ts_3_3, ts_3_4, ts_3_5,
-    ts_4_0, ts_4_1, ts_4_2, ts_4_3, ts_4_4, ts_4_5,
-    ts_5_0, ts_5_1, ts_5_2, ts_5_3, ts_5_4, ts_5_5,
-    self_adv_stride0, self_adv_stride1, self_adv_stride2,
-    self_adv_stride3, self_adv_stride4, self_adv_stride5,
-    self_adv_size0, self_adv_size1, self_adv_size2,
-    self_adv_size3, self_adv_size4, self_adv_size5,
-    suf_div0, suf_div1, suf_div2, suf_div3, suf_div4, suf_div5,
-    self_suf_stride0, self_suf_stride1, self_suf_stride2,
-    self_suf_stride3, self_suf_stride4, self_suf_stride5,
+    idx0_ptr,
+    idx1_ptr,
+    idx2_ptr,
+    idx3_ptr,
+    idx4_ptr,
+    idx5_ptr,
+    idx_div0,
+    idx_div1,
+    idx_div2,
+    idx_div3,
+    idx_div4,
+    idx_div5,
+    ts_0_0,
+    ts_0_1,
+    ts_0_2,
+    ts_0_3,
+    ts_0_4,
+    ts_0_5,
+    ts_1_0,
+    ts_1_1,
+    ts_1_2,
+    ts_1_3,
+    ts_1_4,
+    ts_1_5,
+    ts_2_0,
+    ts_2_1,
+    ts_2_2,
+    ts_2_3,
+    ts_2_4,
+    ts_2_5,
+    ts_3_0,
+    ts_3_1,
+    ts_3_2,
+    ts_3_3,
+    ts_3_4,
+    ts_3_5,
+    ts_4_0,
+    ts_4_1,
+    ts_4_2,
+    ts_4_3,
+    ts_4_4,
+    ts_4_5,
+    ts_5_0,
+    ts_5_1,
+    ts_5_2,
+    ts_5_3,
+    ts_5_4,
+    ts_5_5,
+    self_adv_stride0,
+    self_adv_stride1,
+    self_adv_stride2,
+    self_adv_stride3,
+    self_adv_stride4,
+    self_adv_stride5,
+    self_adv_size0,
+    self_adv_size1,
+    self_adv_size2,
+    self_adv_size3,
+    self_adv_size4,
+    self_adv_size5,
+    suf_div0,
+    suf_div1,
+    suf_div2,
+    suf_div3,
+    suf_div4,
+    suf_div5,
+    self_suf_stride0,
+    self_suf_stride1,
+    self_suf_stride2,
+    self_suf_stride3,
+    self_suf_stride4,
+    self_suf_stride5,
     idx_numel,
     suffix_numel,
     N,
@@ -291,8 +452,8 @@ def unsafe_index_put_scratch_kernel(
     pid0 = tl.program_id(0)
     pid1 = tl.program_id(1)
 
-    idx_off = pid0 * BLOCK_IDX + tl.arange(0, BLOCK_IDX)[:, None]   # (BI, 1)
-    suf_off = pid1 * BLOCK_SUF + tl.arange(0, BLOCK_SUF)[None, :]   # (1, BS)
+    idx_off = pid0 * BLOCK_IDX + tl.arange(0, BLOCK_IDX)[:, None]  # (BI, 1)
+    suf_off = pid1 * BLOCK_SUF + tl.arange(0, BLOCK_SUF)[None, :]  # (1, BS)
 
     mask_idx = idx_off < idx_numel
     mask_suf = suf_off < suffix_numel
@@ -313,62 +474,98 @@ def unsafe_index_put_scratch_kernel(
     if IDX_NDIM >= 1:
         c0 = rem_idx // idx_div0
         rem_idx = rem_idx % idx_div0
-        if M >= 1: toff0 += c0 * ts_0_0
-        if M >= 2: toff1 += c0 * ts_1_0
-        if M >= 3: toff2 += c0 * ts_2_0
-        if M >= 4: toff3 += c0 * ts_3_0
-        if M >= 5: toff4 += c0 * ts_4_0
-        if M >= 6: toff5 += c0 * ts_5_0
+        if M >= 1:
+            toff0 += c0 * ts_0_0
+        if M >= 2:
+            toff1 += c0 * ts_1_0
+        if M >= 3:
+            toff2 += c0 * ts_2_0
+        if M >= 4:
+            toff3 += c0 * ts_3_0
+        if M >= 5:
+            toff4 += c0 * ts_4_0
+        if M >= 6:
+            toff5 += c0 * ts_5_0
 
     if IDX_NDIM >= 2:
         c1 = rem_idx // idx_div1
         rem_idx = rem_idx % idx_div1
-        if M >= 1: toff0 += c1 * ts_0_1
-        if M >= 2: toff1 += c1 * ts_1_1
-        if M >= 3: toff2 += c1 * ts_2_1
-        if M >= 4: toff3 += c1 * ts_3_1
-        if M >= 5: toff4 += c1 * ts_4_1
-        if M >= 6: toff5 += c1 * ts_5_1
+        if M >= 1:
+            toff0 += c1 * ts_0_1
+        if M >= 2:
+            toff1 += c1 * ts_1_1
+        if M >= 3:
+            toff2 += c1 * ts_2_1
+        if M >= 4:
+            toff3 += c1 * ts_3_1
+        if M >= 5:
+            toff4 += c1 * ts_4_1
+        if M >= 6:
+            toff5 += c1 * ts_5_1
 
     if IDX_NDIM >= 3:
         c2 = rem_idx // idx_div2
         rem_idx = rem_idx % idx_div2
-        if M >= 1: toff0 += c2 * ts_0_2
-        if M >= 2: toff1 += c2 * ts_1_2
-        if M >= 3: toff2 += c2 * ts_2_2
-        if M >= 4: toff3 += c2 * ts_3_2
-        if M >= 5: toff4 += c2 * ts_4_2
-        if M >= 6: toff5 += c2 * ts_5_2
+        if M >= 1:
+            toff0 += c2 * ts_0_2
+        if M >= 2:
+            toff1 += c2 * ts_1_2
+        if M >= 3:
+            toff2 += c2 * ts_2_2
+        if M >= 4:
+            toff3 += c2 * ts_3_2
+        if M >= 5:
+            toff4 += c2 * ts_4_2
+        if M >= 6:
+            toff5 += c2 * ts_5_2
 
     if IDX_NDIM >= 4:
         c3 = rem_idx // idx_div3
         rem_idx = rem_idx % idx_div3
-        if M >= 1: toff0 += c3 * ts_0_3
-        if M >= 2: toff1 += c3 * ts_1_3
-        if M >= 3: toff2 += c3 * ts_2_3
-        if M >= 4: toff3 += c3 * ts_3_3
-        if M >= 5: toff4 += c3 * ts_4_3
-        if M >= 6: toff5 += c3 * ts_5_3
+        if M >= 1:
+            toff0 += c3 * ts_0_3
+        if M >= 2:
+            toff1 += c3 * ts_1_3
+        if M >= 3:
+            toff2 += c3 * ts_2_3
+        if M >= 4:
+            toff3 += c3 * ts_3_3
+        if M >= 5:
+            toff4 += c3 * ts_4_3
+        if M >= 6:
+            toff5 += c3 * ts_5_3
 
     if IDX_NDIM >= 5:
         c4 = rem_idx // idx_div4
         rem_idx = rem_idx % idx_div4
-        if M >= 1: toff0 += c4 * ts_0_4
-        if M >= 2: toff1 += c4 * ts_1_4
-        if M >= 3: toff2 += c4 * ts_2_4
-        if M >= 4: toff3 += c4 * ts_3_4
-        if M >= 5: toff4 += c4 * ts_4_4
-        if M >= 6: toff5 += c4 * ts_5_4
+        if M >= 1:
+            toff0 += c4 * ts_0_4
+        if M >= 2:
+            toff1 += c4 * ts_1_4
+        if M >= 3:
+            toff2 += c4 * ts_2_4
+        if M >= 4:
+            toff3 += c4 * ts_3_4
+        if M >= 5:
+            toff4 += c4 * ts_4_4
+        if M >= 6:
+            toff5 += c4 * ts_5_4
 
     if IDX_NDIM >= 6:
         c5 = rem_idx // idx_div5
         rem_idx = rem_idx % idx_div5
-        if M >= 1: toff0 += c5 * ts_0_5
-        if M >= 2: toff1 += c5 * ts_1_5
-        if M >= 3: toff2 += c5 * ts_2_5
-        if M >= 4: toff3 += c5 * ts_3_5
-        if M >= 5: toff4 += c5 * ts_4_5
-        if M >= 6: toff5 += c5 * ts_5_5
+        if M >= 1:
+            toff0 += c5 * ts_0_5
+        if M >= 2:
+            toff1 += c5 * ts_1_5
+        if M >= 3:
+            toff2 += c5 * ts_2_5
+        if M >= 4:
+            toff3 += c5 * ts_3_5
+        if M >= 5:
+            toff4 += c5 * ts_4_5
+        if M >= 6:
+            toff5 += c5 * ts_5_5
 
     # ---- load index values ----
     if M >= 1:
@@ -452,9 +649,9 @@ def unsafe_index_put_scratch_kernel(
     # another program's "orig", doubling the accumulated deltas.
     if PROLOGUE:
         orig = tl.load(out_ptr + self_off, mask=mask, other=0.0)
-        tl.store(scratch_ptr + self_off,
-                 orig.to(scratch_ptr.dtype.element_ty), mask=mask)
+        tl.store(
+            scratch_ptr + self_off, orig.to(scratch_ptr.dtype.element_ty), mask=mask
+        )
     else:
         v32 = tl.load(scratch_ptr + self_off, mask=mask, other=0.0)
-        tl.store(out_ptr + self_off, v32.to(out_ptr.dtype.element_ty),
-                 mask=mask)
+        tl.store(out_ptr + self_off, v32.to(out_ptr.dtype.element_ty), mask=mask)

--- a/triton_src/unsafe_index_put_kernel.py
+++ b/triton_src/unsafe_index_put_kernel.py
@@ -655,3 +655,385 @@ def unsafe_index_put_scratch_kernel(
     else:
         v32 = tl.load(scratch_ptr + self_off, mask=mask, other=0.0)
         tl.store(out_ptr + self_off, v32.to(out_ptr.dtype.element_ty), mask=mask)
+
+
+# ---------------------------------------------------------------------------
+# Sort-based accumulate path (bit-exact with PyTorch's index_put_with_sort).
+#
+# Pipeline (all launched from C++ without any dispatcher-visible aten calls):
+#   1. unsafe_index_put_linearize_kernel: computes radix-sort keys (flattened
+#      target position ids) plus the original-position iota in one pass.
+#   2. CUB DeviceRadixSort::SortPairs (stable) — same ordering PyTorch uses.
+#   3. unsafe_index_put_sorted_merge_kernel: per duplicate group, accumulates
+#      in stable order replicating PyTorch's exact arithmetic:
+#        - sliceSize <= 32 (stride_1 / small_stride kernels): opmath-type
+#          gradient over the whole group, orig added once, single rounding.
+#        - sliceSize > 32 (general kernel): rounds to the output dtype after
+#          EVERY duplicate (its read-back loop), ROUND_PER_STEP=True.
+#      Group leaders are lanes whose sorted key differs from the previous
+#      lane's; non-leaders idle, exactly like PyTorch's warp-per-group scheme.
+# ---------------------------------------------------------------------------
+
+
+@triton.jit
+def unsafe_index_put_linearize_kernel(
+    keys_ptr,
+    orig_ptr,
+    idx0_ptr,
+    idx1_ptr,
+    idx2_ptr,
+    idx3_ptr,
+    idx4_ptr,
+    idx5_ptr,
+    idx_div0,
+    idx_div1,
+    idx_div2,
+    idx_div3,
+    idx_div4,
+    idx_div5,
+    ts_0_0,
+    ts_0_1,
+    ts_0_2,
+    ts_0_3,
+    ts_0_4,
+    ts_0_5,
+    ts_1_0,
+    ts_1_1,
+    ts_1_2,
+    ts_1_3,
+    ts_1_4,
+    ts_1_5,
+    ts_2_0,
+    ts_2_1,
+    ts_2_2,
+    ts_2_3,
+    ts_2_4,
+    ts_2_5,
+    ts_3_0,
+    ts_3_1,
+    ts_3_2,
+    ts_3_3,
+    ts_3_4,
+    ts_3_5,
+    ts_4_0,
+    ts_4_1,
+    ts_4_2,
+    ts_4_3,
+    ts_4_4,
+    ts_4_5,
+    ts_5_0,
+    ts_5_1,
+    ts_5_2,
+    ts_5_3,
+    ts_5_4,
+    ts_5_5,
+    wrap_size0,
+    wrap_size1,
+    wrap_size2,
+    wrap_size3,
+    wrap_size4,
+    wrap_size5,
+    key_stride0,
+    key_stride1,
+    key_stride2,
+    key_stride3,
+    key_stride4,
+    key_stride5,
+    N,
+    M: tl.constexpr,
+    IDX_NDIM: tl.constexpr,
+    BLOCK: tl.constexpr,
+):
+    """keys[pos] = sum_i wrap(idx_i[pos]) * key_stride_i; orig[pos] = pos."""
+    pos = tl.program_id(0) * BLOCK + tl.arange(0, BLOCK)
+    mask = pos < N
+
+    toff0 = tl.zeros((BLOCK,), dtype=tl.int64)
+    toff1 = tl.zeros((BLOCK,), dtype=tl.int64)
+    toff2 = tl.zeros((BLOCK,), dtype=tl.int64)
+    toff3 = tl.zeros((BLOCK,), dtype=tl.int64)
+    toff4 = tl.zeros((BLOCK,), dtype=tl.int64)
+    toff5 = tl.zeros((BLOCK,), dtype=tl.int64)
+
+    rem = pos
+    if IDX_NDIM >= 1:
+        c0 = rem // idx_div0
+        rem = rem % idx_div0
+        if M >= 1:
+            toff0 += c0 * ts_0_0
+        if M >= 2:
+            toff1 += c0 * ts_1_0
+        if M >= 3:
+            toff2 += c0 * ts_2_0
+        if M >= 4:
+            toff3 += c0 * ts_3_0
+        if M >= 5:
+            toff4 += c0 * ts_4_0
+        if M >= 6:
+            toff5 += c0 * ts_5_0
+    if IDX_NDIM >= 2:
+        c1 = rem // idx_div1
+        rem = rem % idx_div1
+        if M >= 1:
+            toff0 += c1 * ts_0_1
+        if M >= 2:
+            toff1 += c1 * ts_1_1
+        if M >= 3:
+            toff2 += c1 * ts_2_1
+        if M >= 4:
+            toff3 += c1 * ts_3_1
+        if M >= 5:
+            toff4 += c1 * ts_4_1
+        if M >= 6:
+            toff5 += c1 * ts_5_1
+    if IDX_NDIM >= 3:
+        c2 = rem // idx_div2
+        rem = rem % idx_div2
+        if M >= 1:
+            toff0 += c2 * ts_0_2
+        if M >= 2:
+            toff1 += c2 * ts_1_2
+        if M >= 3:
+            toff2 += c2 * ts_2_2
+        if M >= 4:
+            toff3 += c2 * ts_3_2
+        if M >= 5:
+            toff4 += c2 * ts_4_2
+        if M >= 6:
+            toff5 += c2 * ts_5_2
+    if IDX_NDIM >= 4:
+        c3 = rem // idx_div3
+        rem = rem % idx_div3
+        if M >= 1:
+            toff0 += c3 * ts_0_3
+        if M >= 2:
+            toff1 += c3 * ts_1_3
+        if M >= 3:
+            toff2 += c3 * ts_2_3
+        if M >= 4:
+            toff3 += c3 * ts_3_3
+        if M >= 5:
+            toff4 += c3 * ts_4_3
+        if M >= 6:
+            toff5 += c3 * ts_5_3
+    if IDX_NDIM >= 5:
+        c4 = rem // idx_div4
+        rem = rem % idx_div4
+        if M >= 1:
+            toff0 += c4 * ts_0_4
+        if M >= 2:
+            toff1 += c4 * ts_1_4
+        if M >= 3:
+            toff2 += c4 * ts_2_4
+        if M >= 4:
+            toff3 += c4 * ts_3_4
+        if M >= 5:
+            toff4 += c4 * ts_4_4
+        if M >= 6:
+            toff5 += c4 * ts_5_4
+    if IDX_NDIM >= 6:
+        c5 = rem // idx_div5
+        rem = rem % idx_div5
+        if M >= 1:
+            toff0 += c5 * ts_0_5
+        if M >= 2:
+            toff1 += c5 * ts_1_5
+        if M >= 3:
+            toff2 += c5 * ts_2_5
+        if M >= 4:
+            toff3 += c5 * ts_3_5
+        if M >= 5:
+            toff4 += c5 * ts_4_5
+        if M >= 6:
+            toff5 += c5 * ts_5_5
+
+    key = tl.zeros((BLOCK,), dtype=tl.int64)
+    if M >= 1:
+        ind = tl.load(idx0_ptr + toff0, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + wrap_size0, ind)
+        key += ind * key_stride0
+    if M >= 2:
+        ind = tl.load(idx1_ptr + toff1, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + wrap_size1, ind)
+        key += ind * key_stride1
+    if M >= 3:
+        ind = tl.load(idx2_ptr + toff2, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + wrap_size2, ind)
+        key += ind * key_stride2
+    if M >= 4:
+        ind = tl.load(idx3_ptr + toff3, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + wrap_size3, ind)
+        key += ind * key_stride3
+    if M >= 5:
+        ind = tl.load(idx4_ptr + toff4, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + wrap_size4, ind)
+        key += ind * key_stride4
+    if M >= 6:
+        ind = tl.load(idx5_ptr + toff5, mask=mask, other=0).to(tl.int64)
+        ind = tl.where(ind < 0, ind + wrap_size5, ind)
+        key += ind * key_stride5
+
+    tl.store(keys_ptr + pos, key, mask=mask)
+    tl.store(orig_ptr + pos, pos.to(tl.int64), mask=mask)
+
+
+@triton.jit
+def unsafe_index_put_sorted_merge_kernel(
+    out_ptr,
+    values_ptr,
+    sorted_keys_ptr,
+    sorted_orig_ptr,
+    idx_div0,
+    idx_div1,
+    idx_div2,
+    idx_div3,
+    idx_div4,
+    idx_div5,
+    val_adv0,
+    val_adv1,
+    val_adv2,
+    val_adv3,
+    val_adv4,
+    val_adv5,
+    suf_div0,
+    suf_div1,
+    suf_div2,
+    suf_div3,
+    suf_div4,
+    suf_div5,
+    val_suf_stride0,
+    val_suf_stride1,
+    val_suf_stride2,
+    val_suf_stride3,
+    val_suf_stride4,
+    val_suf_stride5,
+    num_sorted,
+    sliceSize,
+    IDX_NDIM: tl.constexpr,
+    SUF_NDIM: tl.constexpr,
+    ROUND_PER_STEP: tl.constexpr,
+    BLOCK_POS: tl.constexpr,
+    BLOCK_SUF: tl.constexpr,
+):
+    """Merge duplicate groups in stable (sorted) order, PyTorch-arithmetic.
+
+    out is contiguous and already holds a copy of self. For every group of
+    equal sorted keys, only the group leader works:
+      ROUND_PER_STEP=False (PyTorch sliceSize<=32 semantics):
+          grad = sum_group opmath(v_i);  out = cast(opmath(orig) + grad)
+      ROUND_PER_STEP=True (PyTorch sliceSize>32 semantics):
+          cur = orig;  per dup: cur = cast(opmath(cur) + opmath(v_i))
+    """
+    pid0 = tl.program_id(0)
+    pid1 = tl.program_id(1)
+
+    pos = pid0 * BLOCK_POS + tl.arange(0, BLOCK_POS)[:, None]  # (BP, 1)
+    j = pid1 * BLOCK_SUF + tl.arange(0, BLOCK_SUF)[None, :]  # (1, BS)
+
+    pos_valid = pos < num_sorted
+    j_valid = j < sliceSize
+    mask = pos_valid & j_valid
+
+    key = tl.load(sorted_keys_ptr + pos, mask=pos_valid, other=-1)
+    prev_key = tl.load(sorted_keys_ptr + pos - 1, mask=pos_valid & (pos > 0), other=-2)
+    is_leader = pos_valid & (key != prev_key)
+
+    slot = key * sliceSize + j  # (BP, BS)
+
+    # Accumulation type mirrors at::opmath_type: fp64 for double, fp32 for
+    # other floats, int64 for every integer/bool dtype (exact; narrowing cast
+    # on store reproduces PyTorch's wrap semantics).
+    if out_ptr.dtype.element_ty == tl.float64:
+        grad = tl.zeros((BLOCK_POS, BLOCK_SUF), dtype=tl.float64)
+    elif out_ptr.dtype.element_ty.is_floating():
+        grad = tl.zeros((BLOCK_POS, BLOCK_SUF), dtype=tl.float32)
+    else:
+        grad = tl.zeros((BLOCK_POS, BLOCK_SUF), dtype=tl.int64)
+
+    if ROUND_PER_STEP:
+        cur = tl.load(out_ptr + slot, mask=mask & is_leader, other=0.0)
+
+    # Walk all groups in this tile one duplicate per iteration.
+    g = 0
+    active = is_leader
+    while tl.sum(active.to(tl.int32)) > 0:
+        pos_g = pos + g
+        valid_g = pos_g < num_sorted
+        k_g = tl.load(sorted_keys_ptr + pos_g, mask=valid_g, other=-1)
+        member = active & valid_g & (k_g == key)
+
+        orig_i = tl.load(sorted_orig_ptr + pos_g, mask=member, other=0)
+
+        # values offset for (orig_i, j): broadcast-space decomposition
+        voff = tl.zeros((BLOCK_POS, BLOCK_SUF), dtype=tl.int64)
+        rem = orig_i
+        if IDX_NDIM >= 1:
+            c0 = rem // idx_div0
+            rem = rem % idx_div0
+            voff += c0 * val_adv0
+        if IDX_NDIM >= 2:
+            c1 = rem // idx_div1
+            rem = rem % idx_div1
+            voff += c1 * val_adv1
+        if IDX_NDIM >= 3:
+            c2 = rem // idx_div2
+            rem = rem % idx_div2
+            voff += c2 * val_adv2
+        if IDX_NDIM >= 4:
+            c3 = rem // idx_div3
+            rem = rem % idx_div3
+            voff += c3 * val_adv3
+        if IDX_NDIM >= 5:
+            c4 = rem // idx_div4
+            rem = rem % idx_div4
+            voff += c4 * val_adv4
+        if IDX_NDIM >= 6:
+            c5 = rem // idx_div5
+            rem = rem % idx_div5
+            voff += c5 * val_adv5
+
+        rem_j = j
+        if SUF_NDIM >= 1:
+            s0 = rem_j // suf_div0
+            rem_j = rem_j % suf_div0
+            voff += s0 * val_suf_stride0
+        if SUF_NDIM >= 2:
+            s1 = rem_j // suf_div1
+            rem_j = rem_j % suf_div1
+            voff += s1 * val_suf_stride1
+        if SUF_NDIM >= 3:
+            s2 = rem_j // suf_div2
+            rem_j = rem_j % suf_div2
+            voff += s2 * val_suf_stride2
+        if SUF_NDIM >= 4:
+            s3 = rem_j // suf_div3
+            rem_j = rem_j % suf_div3
+            voff += s3 * val_suf_stride3
+        if SUF_NDIM >= 5:
+            s4 = rem_j // suf_div4
+            rem_j = rem_j % suf_div4
+            voff += s4 * val_suf_stride4
+        if SUF_NDIM >= 6:
+            s5 = rem_j // suf_div5
+            rem_j = rem_j % suf_div5
+            voff += s5 * val_suf_stride5
+
+        v = tl.load(values_ptr + voff, mask=member & j_valid, other=0.0)
+
+        if ROUND_PER_STEP:
+            step = cur.to(grad.dtype) + v.to(grad.dtype)
+            cur = tl.where(member & j_valid, step.to(out_ptr.dtype.element_ty), cur)
+        else:
+            grad = tl.where(member & j_valid, grad + v.to(grad.dtype), grad)
+
+        active = member
+        g += 1
+
+    if ROUND_PER_STEP:
+        tl.store(out_ptr + slot, cur, mask=mask & is_leader)
+    else:
+        orig_v = tl.load(out_ptr + slot, mask=mask & is_leader, other=0.0)
+        result = orig_v.to(grad.dtype) + grad
+        tl.store(
+            out_ptr + slot, result.to(out_ptr.dtype.element_ty), mask=mask & is_leader
+        )


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Other

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
## What does this PR do?
- Add _unsafe_index_put operator with C++ wrapper
- Add triton kernel implementation
- Add unit tests and benchmark

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
Benchmark on NVIDIA H20-3e
```sh
root@741314c552f8:/workspace/FlagGems# pytest benchmark/test_unsafe_index_put.py -s
============================================================================================== test session starts ==============================================================================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: typeguard-4.5.0, anyio-4.12.1, hypothesis-6.130.8, flakefinder-1.1.0, rerunfailures-16.1, shard-0.1.2, xdist-3.8.0
collected 4 items
Running 4 items in this shard

benchmark/test_unsafe_index_put.py
Operator: _unsafe_index_put  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007264            0.007056               1.029          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.010464            0.007872               1.329          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               0.337152            0.289664               1.164          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.008768            0.007456               1.176          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.009216            0.008256               1.116          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.010912            0.009120               1.196          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.011264            0.009760               1.154          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.033728            0.028832               1.170          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.007936            0.007264               1.093          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.010016            0.007360               1.361          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.009408            0.008896               1.058          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.012192            0.009376               1.300          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.028576            0.026368               1.084          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.008960            0.008224               1.089          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.151808            0.147520               1.029          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.154112            0.147552               1.044          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.601600            0.658464               0.914          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.027424            0.025984               1.055          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.027776            0.026208               1.060          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007264            0.006976               1.041          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.010752            0.007936               1.355          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               0.634080            0.616992               1.028          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.008992            0.007584               1.186          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.009344            0.008416               1.110          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.012384            0.010400               1.191          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.012704            0.011008               1.154          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.051424            0.046656               1.102          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.008256            0.007552               1.093          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.009760            0.007584               1.287          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.010880            0.010080               1.079          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.013728            0.010528               1.304          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.046592            0.044096               1.057          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.009504            0.008576               1.108          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.326976            0.331104               0.988          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.327520            0.328816               0.996          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.735872            0.804560               0.915          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.045184            0.043712               1.034          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.045504            0.043936               1.036          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007488            0.007328               1.022          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.010848            0.008096               1.340          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               1.192192            1.137040               1.049          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.009280            0.007808               1.189          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.009568            0.008608               1.112          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.014624            0.012480               1.172          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.015008            0.013568               1.106          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.086080            0.081600               1.055          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.008224            0.007616               1.080          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.011008            0.007584               1.451          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.013024            0.012192               1.068          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.016608            0.012672               1.311          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.080960            0.078592               1.030          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.009696            0.008960               1.082          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.602784            0.603936               0.998          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.612208            0.624512               0.980          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.056864            1.081920               0.977          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.080032            0.078368               1.021          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.080192            0.078592               1.020          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007232            0.007008               1.032          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.010400            0.007840               1.327          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               0.315952            0.290720               1.087          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.008768            0.007456               1.176          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.009216            0.008288               1.112          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.010912            0.009120               1.196          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.011232            0.009664               1.162          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.033696            0.028736               1.173          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.007936            0.007264               1.093          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.010016            0.007392               1.355          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.009408            0.008896               1.058          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.013440            0.009408               1.429          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.028576            0.026400               1.082          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.008928            0.008224               1.086          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.148992            0.147392               1.011          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.154080            0.147456               1.045          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.601856            0.659008               0.913          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.027424            0.025952               1.057          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.027776            0.026240               1.059          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007744            0.007360               1.052          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.010592            0.007872               1.346          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               0.567264            0.565360               1.003          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.009088            0.007712               1.178          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.009344            0.008416               1.110          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.012320            0.010336               1.192          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.012768            0.011136               1.147          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.051520            0.046784               1.101          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.008288            0.007552               1.097          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.010048            0.007584               1.325          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.011136            0.010176               1.094          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.013984            0.010688               1.308          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.046368            0.044096               1.052          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.009824            0.008640               1.137          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.288224            0.286592               1.006          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.294848            0.287328               1.026          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.733728            0.800592               0.916          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.045504            0.043616               1.043          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.045824            0.043968               1.042          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]


Operator: _unsafe_index_put  Performance Test (dtype=torch.int64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.007520            0.007328               1.026          [torch.Size([256]), [torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.010816            0.008000               1.352          [torch.Size([4096]), [torch.Size([1024])], torch.Size([1024]), False]
SUCCESS               1.122368            1.120080               1.002          [torch.Size([268435456]), [torch.Size([65536])], torch.Size([65536]), False]
SUCCESS               0.009056            0.007680               1.179          [torch.Size([32, 32]), [torch.Size([2, 8])], torch.Size([32]), False]
SUCCESS               0.010080            0.008880               1.135          [torch.Size([256, 256]), [torch.Size([16, 16])], torch.Size([256]), False]
SUCCESS               0.014624            0.012512               1.169          [torch.Size([1024, 1024]), [torch.Size([64])], torch.Size([1024]), False]
SUCCESS               0.015040            0.013344               1.127          [torch.Size([1024, 1024]), [torch.Size([4, 64])], torch.Size([1024]), False]
SUCCESS               0.086080            0.081504               1.056          [torch.Size([4096, 4096]), [torch.Size([256])], torch.Size([4096]), False]
SUCCESS               0.007968            0.007424               1.073          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), False]
SUCCESS               0.010016            0.007712               1.299          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([2, 8])], torch.Size([8]), False]
SUCCESS               0.013312            0.012256               1.086          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.016000            0.012704               1.259          [torch.Size([1024, 1024]), [torch.Size([64]), torch.Size([4, 64])], torch.Size([64]), False]
SUCCESS               0.080736            0.078592               1.027          [torch.Size([4096, 4096]), [torch.Size([256]), torch.Size([256])], torch.Size([256]), False]
SUCCESS               0.010144            0.009024               1.124          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), False]
SUCCESS               0.564608            0.563424               1.002          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               0.570528            0.564448               1.011          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), False]
SUCCESS               1.018688            1.078832               0.944          [torch.Size([512, 512, 512]), [torch.Size([2, 128])], torch.Size([512]), False]
SUCCESS               0.080192            0.078464               1.022          [torch.Size([256, 256, 256]), [torch.Size([64]), torch.Size([64]), torch.Size([64])], torch.Size([64]), False]
SUCCESS               0.080480            0.078624               1.024          [torch.Size([64, 64, 64, 64]), [torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8]), torch.Size([8, 8])], torch.Size([8, 8]), False]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.039904            0.015808               2.524          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.071488            0.041488               1.723          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.060224            0.014848               4.056          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.065568            0.017888               3.665          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.067104            0.020576               3.261          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.100512            0.017536               5.732          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.226528            0.159184               1.423          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.227104            0.160224               1.417          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.039728            0.015712               2.529          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.072224            0.042464               1.701          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.059904            0.014464               4.142          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.065824            0.018240               3.609          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.068864            0.021952               3.137          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.099776            0.017632               5.659          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.366496            0.303744               1.207          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.368864            0.328096               1.124          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.float64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.039552            0.016320               2.424          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.075008            0.043168               1.738          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.061312            0.015168               4.042          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.066016            0.019072               3.461          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.071712            0.024352               2.945          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.100384            0.018368               5.465          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.657792            0.614128               1.071          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.704128            0.625408               1.126          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.040096            0.016224               2.471          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.071712            0.041536               1.727          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.060992            0.014720               4.143          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.065760            0.018144               3.624          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.068160            0.020800               3.277          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.100544            0.017440               5.765          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.226304            0.159296               1.421          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.228576            0.160256               1.426          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]

.
Operator: _unsafe_index_put  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.039264            0.016160               2.430          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.071680            0.041824               1.714          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.060288            0.014720               4.096          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.065152            0.018368               3.547          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.068608            0.021824               3.144          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.100832            0.017696               5.698          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.365632            0.299616               1.220          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.367968            0.301152               1.222          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]


Operator: _unsafe_index_put  Performance Test (dtype=torch.int64, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               0.039904            0.016832               2.371          [torch.Size([100]), [torch.Size([100])], torch.Size([100]), True]
SUCCESS               0.071264            0.043296               1.646          [torch.Size([10000]), [torch.Size([10000])], torch.Size([10000]), True]
SUCCESS               0.061344            0.015040               4.079          [torch.Size([32, 32]), [torch.Size([8]), torch.Size([8])], torch.Size([8]), True]
SUCCESS               0.065840            0.019040               3.458          [torch.Size([512, 512]), [torch.Size([512]), torch.Size([512])], torch.Size([512]), True]
SUCCESS               0.070912            0.025088               2.827          [torch.Size([1024, 1024]), [torch.Size([1024]), torch.Size([1024])], torch.Size([1024]), True]
SUCCESS               0.101120            0.017888               5.653          [torch.Size([64, 64, 64]), [torch.Size([2, 8]), torch.Size([2, 8]), torch.Size([2, 8])], torch.Size([2, 8]), True]
SUCCESS               0.640064            0.574784               1.114          [torch.Size([512, 512, 512]), [torch.Size([128]), torch.Size([128]), torch.Size([128])], torch.Size([128]), True]
SUCCESS               0.641776            0.575456               1.115          [torch.Size([512, 512, 512]), [torch.Size([2, 128]), torch.Size([2, 128]), torch.Size([2, 128])], torch.Size([2, 128]), True]

.

========================================================================================= 4 passed in 264.07s (0:04:24) =========================================================================================
```
