### PR TITLE
fix: forward the RNG generator to kernels instead of dropping it (rand/randn/normal/multinomial)

### DIFF
--- a/src/flag_gems/ops/multinomial.py
+++ b/src/flag_gems/ops/multinomial.py
@@ -65,7 +65,7 @@ def multinomial_with_replacement(
     tl.store(out_ptr + y_off + n, start, mask=n < N)
 
 
-def multinomial(prob, n_samples, with_replacement=False, *, gen=None):
+def multinomial(prob, n_samples, with_replacement=False, *, generator=None):
     logger.debug("GEMS MULTINOMIAL")
     assert prob.dtype in (torch.float16, torch.float32, torch.bfloat16, torch.float64)
     assert 0 < prob.dim() <= 2, "prob_dist must be 1 or 2 dim"
@@ -85,7 +85,7 @@ def multinomial(prob, n_samples, with_replacement=False, *, gen=None):
         prob_f32.clamp_(min=1e-12)  # avoid 0/q=0 ties for zero-prob categories
         q = torch.empty(
             prob.shape, dtype=torch.float32, device=prob.device
-        ).exponential_(1.0)
+        ).exponential_(1.0, generator=generator)
         q.clamp_(min=1e-20)  # prevent division overflow
         s = prob_f32 / q
         if n_samples == 1:
@@ -108,7 +108,9 @@ def multinomial(prob, n_samples, with_replacement=False, *, gen=None):
     # The CTA level parallelism is framed in a 2d grid of blocks with grid.y
     # indexing into distributions and grid.x output sample batches
     increment = n_dist * n_samples
-    philox_seed, philox_offset = philox_backend_seed_offset(increment, generator=gen)
+    philox_seed, philox_offset = philox_backend_seed_offset(
+        increment, generator=generator
+    )
     grid = lambda META: (triton.cdiv(n_samples, META["NBLOCK"]), n_dist)
     multinomial_with_replacement[grid](
         cum_prob, out, n_categories, n_samples, philox_seed, philox_offset

--- a/src/flag_gems/ops/normal.py
+++ b/src/flag_gems/ops/normal.py
@@ -78,15 +78,15 @@ def normal_tensor_tensor(mean, std, *, generator=None):
     logger.debug("GEMS NORMAL_TENSOR_TENSOR")
     shape = broadcast_shapes([mean.shape, std.shape])
     device = mean.device
-    out = normal_distribution(shape, device)
+    out = normal_distribution(shape, device, generator=generator)
     return transform_func_tensor_tensor(out, std, mean)
 
 
-def normal_tensor_float(mean, std, *, generator=None):
+def normal_tensor_float(mean, std=1.0, *, generator=None):
     logger.debug("GEMS NORMAL_TENSOR_FLOAT")
     shape = mean.shape
     device = mean.device
-    out = normal_distribution(shape, device)
+    out = normal_distribution(shape, device, generator=generator)
     return transform_func_tensor_float(out, std, mean)
 
 
@@ -94,7 +94,7 @@ def normal_float_tensor(mean, std, *, generator=None):
     logger.debug("GEMS NORMAL_FLOAT_TENSOR")
     shape = std.shape
     device = std.device
-    out = normal_distribution(shape, device)
+    out = normal_distribution(shape, device, generator=generator)
     return transform_func_float_tensor(out, std, mean)
 
 
@@ -102,6 +102,6 @@ def normal_(self, mean=0, std=1, *, generator=None):
     logger.debug("GEMS NORMAL_")
     shape = self.shape
     device = self.device
-    self = normal_distribution(shape, device, generator=None, out=self)
+    self = normal_distribution(shape, device, generator=generator, out=self)
     transform_func_float_float(self, std, mean, out0=self)
     return self

--- a/src/flag_gems/ops/rand.py
+++ b/src/flag_gems/ops/rand.py
@@ -64,7 +64,9 @@ def rand_kernel(
 UNROLL = 4
 
 
-def rand(size, *, dtype=None, layout=None, device=None, pin_memory=None):
+def rand(
+    size, *, generator=None, dtype=None, layout=None, device=None, pin_memory=None
+):
     logger.debug("GEMS RAND")
     if dtype is None:
         dtype = torch.get_default_dtype()
@@ -77,7 +79,9 @@ def rand(size, *, dtype=None, layout=None, device=None, pin_memory=None):
     # (TODO) Using Triton autotuner makes kernel parameters opaque to the caller,
     # hence we cannot obtain the per thread offset as in Pytorch.
     increment = triton.cdiv(N, UNROLL)
-    philox_seed, philox_offset = philox_backend_seed_offset(increment)
+    philox_seed, philox_offset = philox_backend_seed_offset(
+        increment, generator=generator
+    )
     with torch_device_fn.device(device):
         rand_kernel[grid_fn](out, N, philox_seed, philox_offset)
     return out

--- a/src/flag_gems/ops/randn.py
+++ b/src/flag_gems/ops/randn.py
@@ -108,7 +108,9 @@ def randn_kernel(
 UNROLL = 4
 
 
-def randn(size, *, dtype=None, layout=None, device=None, pin_memory=None):
+def randn(
+    size, *, generator=None, dtype=None, layout=None, device=None, pin_memory=None
+):
     logger.debug("GEMS RANDN")
     if dtype is None:
         dtype = torch.get_default_dtype()
@@ -120,7 +122,9 @@ def randn(size, *, dtype=None, layout=None, device=None, pin_memory=None):
     # (TODO) Using Triton autotuner makes kernel parameters opaque to the caller,
     # hence we cannot obtain the per thread offset as in Pytorch.
     increment = triton.cdiv(N, UNROLL)
-    philox_seed, philox_offset = philox_backend_seed_offset(increment)
+    philox_seed, philox_offset = philox_backend_seed_offset(
+        increment, generator=generator
+    )
     with torch_device_fn.device(device):
         randn_kernel[grid_fn](out, N, philox_seed, philox_offset)
     return out

--- a/tests/test_rng_generator.py
+++ b/tests/test_rng_generator.py
@@ -1,0 +1,130 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Verify RNG ops actually use the user-supplied `generator=` argument.
+
+Each test asserts two properties:
+  - Two calls with same-seeded generators produce identical output.
+  - Two calls with differently-seeded generators produce different output.
+
+The first property catches the case where `generator=` is accepted in the
+signature but silently dropped: both calls would then fall back to the
+default generator, which advances between calls, so outputs differ and
+the equality assert fires.
+"""
+
+import pytest
+import torch
+
+import flag_gems
+
+device = flag_gems.device
+
+
+def _gen(seed):
+    return torch.Generator(device=device).manual_seed(seed)
+
+
+@pytest.mark.rand
+def test_rand_generator_propagation():
+    shape = (128, 128)
+    with flag_gems.use_gems():
+        out_a = torch.rand(shape, device=device, generator=_gen(42))
+        out_b = torch.rand(shape, device=device, generator=_gen(42))
+        out_c = torch.rand(shape, device=device, generator=_gen(999))
+    assert torch.equal(out_a, out_b)
+    assert not torch.equal(out_a, out_c)
+
+
+@pytest.mark.randn
+def test_randn_generator_propagation():
+    shape = (128, 128)
+    with flag_gems.use_gems():
+        out_a = torch.randn(shape, device=device, generator=_gen(42))
+        out_b = torch.randn(shape, device=device, generator=_gen(42))
+        out_c = torch.randn(shape, device=device, generator=_gen(999))
+    assert torch.equal(out_a, out_b)
+    assert not torch.equal(out_a, out_c)
+
+
+@pytest.mark.normal_
+def test_normal_inplace_generator_propagation():
+    shape = (128, 128)
+    with flag_gems.use_gems():
+        buf = torch.empty(shape, device=device)
+        buf.normal_(0.0, 1.0, generator=_gen(42))
+        out_a = buf.clone()
+        buf.normal_(0.0, 1.0, generator=_gen(42))
+        out_b = buf.clone()
+        buf.normal_(0.0, 1.0, generator=_gen(999))
+        out_c = buf.clone()
+    assert torch.equal(out_a, out_b)
+    assert not torch.equal(out_a, out_c)
+
+
+@pytest.mark.normal_tensor_tensor
+def test_normal_tensor_tensor_generator_propagation():
+    shape = (128, 128)
+    mean = torch.zeros(shape, device=device)
+    std = torch.ones(shape, device=device)
+    with flag_gems.use_gems():
+        out_a = torch.normal(mean, std, generator=_gen(42))
+        out_b = torch.normal(mean, std, generator=_gen(42))
+        out_c = torch.normal(mean, std, generator=_gen(999))
+    assert torch.equal(out_a, out_b)
+    assert not torch.equal(out_a, out_c)
+
+
+@pytest.mark.normal_tensor_float
+def test_normal_tensor_float_generator_propagation():
+    shape = (128, 128)
+    mean = torch.zeros(shape, device=device)
+    with flag_gems.use_gems():
+        out_a = torch.normal(mean, 1.0, generator=_gen(42))
+        out_b = torch.normal(mean, 1.0, generator=_gen(42))
+        out_c = torch.normal(mean, 1.0, generator=_gen(999))
+    assert torch.equal(out_a, out_b)
+    assert not torch.equal(out_a, out_c)
+
+
+@pytest.mark.normal_float_tensor
+def test_normal_float_tensor_generator_propagation():
+    shape = (128, 128)
+    std = torch.ones(shape, device=device)
+    with flag_gems.use_gems():
+        out_a = torch.normal(0.0, std, generator=_gen(42))
+        out_b = torch.normal(0.0, std, generator=_gen(42))
+        out_c = torch.normal(0.0, std, generator=_gen(999))
+    assert torch.equal(out_a, out_b)
+    assert not torch.equal(out_a, out_c)
+
+
+@pytest.mark.multinomial
+def test_multinomial_generator_propagation():
+    # Cover both code paths: replacement=True and replacement=False (default),
+    # since they use different RNG entry points internally.
+    probs = torch.rand(64, device=device) + 0.1
+    with flag_gems.use_gems():
+        for replacement in (True, False):
+            out_a = torch.multinomial(
+                probs, 8, replacement=replacement, generator=_gen(42)
+            )
+            out_b = torch.multinomial(
+                probs, 8, replacement=replacement, generator=_gen(42)
+            )
+            out_c = torch.multinomial(
+                probs, 8, replacement=replacement, generator=_gen(999)
+            )
+            assert torch.equal(out_a, out_b), f"replacement={replacement}"
+            assert not torch.equal(out_a, out_c), f"replacement={replacement}"


### PR DESCRIPTION
## Summary

`torch.rand`, `torch.randn`, `torch.normal`, `Tensor.normal_`, and `torch.multinomial` currently drop the user-supplied `generator=` argument when routed through FlagGems. A `torch.Generator` is a per-instance RNG state (its own seed and offset). Right now FlagGems silently ignores it and sampling falls back to the default generator anyway. This PR wires `generator=` through to the underlying kernels.

The plumbing is actually already there. `philox_backend_seed_offset` in `src/flag_gems/utils/random_utils.py` uses the caller-supplied generator when given one, and falls back to the current device's default only when the argument is `None`:

```python
def philox_backend_seed_offset(increment, generator=None):
    if generator is None:
        device = torch_device_fn.current_device()
        generator = torch_device_fn.default_generators[device]
    state_copy = generator.get_state()
    ...
```

All the ops touched by this PR already end up calling this helper. They were just dropping the argument (or never accepting it) on the way in, so the `if generator is None` branch was always taken.

## Details

### 1. rand / randn have no `generator=` in the signature

`src/flag_gems/ops/rand.py` and `randn.py` do not accept the argument at all:

```python
def rand(size, *, dtype=None, layout=None, device=None, pin_memory=None):
    ...
    philox_seed, philox_offset = philox_backend_seed_offset(increment)
```

Upstream `torch.rand(..., generator=g)` and `torch.randn(..., generator=g)` do accept it. Sibling ops in this repo (`randint`, `randperm`, `bernoulli`, `uniform_`) already handle it correctly.

### 2. normal.* accept `generator=` but never forward it

`normal_tensor_tensor`, `normal_tensor_float`, `normal_float_tensor`, and `normal_` all declare `generator=None` in the signature but never pass it down. `normal_` even hard-codes it to `None`:

```python
def normal_(self, mean=0, std=1, *, generator=None):
    ...
    self = normal_distribution(shape, device, generator=None, out=self)  # hard-coded
```

Signature looks right, behavior is wrong. User passes a custom generator, result silently uses the default one.

### 3. multinomial uses `gen=` instead of `generator=`

The aten schema is `multinomial(Tensor self, int num_samples, bool replacement=False, *, Generator? generator=None)`. The dispatcher passes kwonly arguments by name, and FlagGems' Python impl declares `gen=None`, so this crashes:

```
>>> torch.multinomial(probs, 2, generator=g)
TypeError: multinomial() got an unexpected keyword argument 'generator'
```

Two changes here, both about actually honoring `generator=`:

1. Rename `gen` to `generator` in the Python signature so the dispatcher's kwarg call can reach the impl at all.
2. `multinomial` has several internal code paths. One of them draws random noise via `torch.empty(...).exponential_(1.0)` without forwarding the generator, so that path always uses the default one. Forward `generator` into that `.exponential_(...)` call as well.

## Upstream API check

Checked upstream PyTorch 2.6.0 by introspection to see which factory / in-place RNG APIs actually accept `generator=`:

| API                                                                                             | accepts `generator=` |
|-------------------------------------------------------------------------------------------------|:--------------------:|
| `torch.rand` / `randn` / `randint` / `randperm`                                                 | yes                  |
| `torch.rand_like` / `randn_like` / `randint_like`                                               | no (TypeError)       |
| `torch.normal` (all four overloads)                                                             | yes                  |
| `torch.bernoulli` / `multinomial` / `poisson`                                                   | yes                  |
| `Tensor.normal_` / `uniform_` / `bernoulli_` / `cauchy_` / `exponential_` / `geometric_` / `log_normal_` | yes           |

Which means:

* `rand`, `randn`, `normal.*`, `multinomial`: upstream supports it, FlagGems should too. Fixed here.
* `rand_like`, `randn_like`, `randint_like`: upstream explicitly rejects `generator=` (raises `TypeError`). FlagGems does not add it either, on purpose. Not part of this PR.

## Changes

Host-side glue only. No Triton kernels touched.

* `src/flag_gems/ops/rand.py`, `randn.py`: add `generator=None` to the signature and forward it to `philox_backend_seed_offset`.
* `src/flag_gems/ops/normal.py`: the four call sites now forward `generator=generator` instead of dropping it or hard-coding `None`. `normal_tensor_float` also gains a `std=1.0` default value (see note below).
* `src/flag_gems/ops/multinomial.py`: rename `gen=` to `generator=` to match the aten schema, and forward it to the internal `exponential_(...)` call in the without-replacement path.

The pattern matches how `randint.py` and `bernoulli.py` already handle `generator=`.

### Note: normal_tensor_float now defaults std to 1.0

The new generator test for `normal_tensor_float` uses the most common calling shape, `torch.normal(mean, 1.0, generator=g)` (unit-variance sampling, which is what people actually write). That shape happens to trigger a second, independent bug in FlagGems that has nothing to do with `generator=` per se; the test would otherwise crash before it could verify anything, so this PR fixes that bug too.

The second bug: aten schema is `normal.Tensor_float(Tensor mean, float std=1., *, Generator? generator=None)`. The dispatcher elides positional arguments whose value equals the schema default, so `torch.normal(mean, 1.0, generator=g)` reaches the Python impl as `args=(mean,), kwargs={'generator': g}`. The old signature `def normal_tensor_float(mean, std, *, generator=None)` cannot fill in `std` and raises `TypeError: missing 1 required positional argument: 'std'`. Adding `std=1.0` as the Python default matches the schema default and fixes it. No existing test called with `std=1.0`, which is why the bug lived undetected.

## Tests

There is currently no test that verifies `generator=` is actually honored. The existing `test_rand.py` / `test_randn.py` / `test_normal.py` only check distributional properties (value range, mean, std), so a silently-dropped `generator=` would never trigger a CI failure and this whole class of bug can regress freely. This PR adds `tests/test_rng_generator.py` to close that gap.

For every op touched, the new file asserts two things:

* Two calls with same-seeded generators produce bit-exact identical output.
* Two calls with differently-seeded generators produce different output.

The equality assertion is what catches "generator= silently dropped": in that case both calls end up on the default generator, whose offset advances between calls, so the outputs differ and the assert fires.

Local results (Nvidia CUDA, PyTorch 2.6.0):

* new tests: 7/7 pass
* existing `test_rand.py` / `test_randn.py` / `test_normal.py`: 21/21 pass, no regressions
