### PR TITLE
fix(cpp): disable aten-patch static registration to avoid dispatch table corruption

### DIFF
--- a/cpp/csrc/aten_patch.cpp
+++ b/cpp/csrc/aten_patch.cpp
@@ -76,9 +76,9 @@ TORCH_LIBRARY_IMPL(aten, FLAGGEMS_DISPATCH_KEY, m) {
   // REGISTER_AND_LOG("max", max);
   // REGISTER_AND_LOG("sum", sum);
   // REGISTER_AND_LOG("zeros", zeros);
-  REGISTER_AND_LOG("_to_copy", to_copy);
-  REGISTER_AND_LOG("copy_", copy_);
-  REGISTER_AND_LOG("nonzero", nonzero);
+  // REGISTER_AND_LOG("_to_copy", to_copy);
+  // REGISTER_AND_LOG("copy_", copy_);
+  // REGISTER_AND_LOG("nonzero", nonzero);
 }
 
 }  // namespace flag_gems


### PR DESCRIPTION
## Problem

The `TORCH_LIBRARY_IMPL(aten, ...)` macro in `aten_patch.cpp` executes at
`.so` load time and replaces the vendor torch package's entire dispatch table
for the (aten, dispatch_key) slot — not just the explicitly registered operators.

On NPU/MUSA/GCU backends (`PrivateUse1` dispatch key), this causes segfaults
because vendor packages (torch_npu, etc.) use PrivateUse1 as their primary
dispatch key, and the replacement drops the vendor's own kernel registrations
(e.g. `aten::_copy_from`, which is needed internally for device-to-device
transfers).

## Repro

- Build + install cpp wheel for NPU backend
- `import flag_gems` → `aten_patch.so` loads → `TORCH_LIBRARY_IMPL` fires
- Any NPU tensor operation → `aten::_copy_from` handler lost → segfault

## Fix

Comment out the three remaining `REGISTER_AND_LOG` calls so the
`TORCH_LIBRARY_IMPL` block is empty and harmless. The block itself is kept
(builds fine with zero registrations) as a clear place to add back any
aten-level C++ kernels that may be needed in the future.

FlagGems aten operators continue to work through the Python registration path
(`use_gems()` → `torch.library.Library`). C++ operators under the
`flag_gems` namespace (`c_operators.so`) are unaffected.

## Verified

Tested on ascend-cann9.0.0 (NPU, hw25):
- `import flag_gems` → tensor ops work ✓ (was segfault)
- `use_gems()` + tensor ops → work ✓
- `USE_C_EXTENSION=1` + `use_gems()` → work ✓ (cpp extension loaded, no crash)
- `c_operators` exports all 35 functions as expected ✓

This is independent of but complementary to PR #4959 (lazy c_operators import).

This PR was written in part with the assistance of generative AI.