### PR TITLE
docs: fix typos

### DIFF
--- a/docs/content/en/_index.md
+++ b/docs/content/en/_index.md
@@ -39,7 +39,7 @@ This convenience allows developers to engage in the development of *FlagGems* wi
 - Review [platforms supported](/FlagGems/overview/platforms/)
 - [Getting started with FlagGems](/FlagGems/getting-started/)
 - Check the project [changelog](/FlagGems/references/changelog/)
-- Review the list of [operators suppored](/FlagGems/references/changelog/)
+- Review the list of [operators supported](/FlagGems/references/changelog/)
 
 ## Supported models
 

--- a/docs/content/en/contribution/backend.md
+++ b/docs/content/en/contribution/backend.md
@@ -70,7 +70,7 @@ vendor_info = VendorDescriptor(
 The important properties for `VendorDescriptor` are:
 
 - `vendor_name`: the vendor name at your choice, e.g. `nvidia`;
-- `device_name`: the name for your acclerator device, e.g. `cuda`;
+- `device_name`: the name for your accelerator device, e.g. `cuda`;
 - `device_query_cmd`: the command line that is used to check the hardware devices
   on the node, e.g. `nvidia-smi`.
 - `dispatch_key`: an optional property for registering operators to `torch.library.Library`

--- a/docs/content/en/contribution/overview.md
+++ b/docs/content/en/contribution/overview.md
@@ -45,7 +45,7 @@ Other fields for an operator include:
   - A new, hand-written operator usually starts with a `beta` stage.
   - A new, AI generated operator (labelled with `KernelGen`) usually starts with an `alpha` stage.
   - When an operator has been continuously tested without significant issues for a release cycle,
-    it may get promoted to the next stage in the followin release. For example, consider an operator
+    it may get promoted to the next stage in the following release. For example, consider an operator
     introduced in version *5.0* as `alpha`, if it works without serious flaws for at least one
     release cycle, it may get promoted to `beta` in the next release, i.e. *5.1*.
   - An existing operator may get demoted from `stable` to `beta` or `alpha` if its starts to

--- a/docs/content/en/overview/pointwise-dynamic.md
+++ b/docs/content/en/overview/pointwise-dynamic.md
@@ -54,7 +54,7 @@ The principles of our design are:
 
 The result is a decorator `@pointwise_dynamic`.
 It provides a common wrapper for pointwise operator and a mechanism to generate triton kernels
-and corresponding wrappers based on the operation and the input configureations.
+and corresponding wrappers based on the operation and the input configurations.
 
 ## 2. Code generation
 
@@ -102,11 +102,11 @@ and is ready for the computation.
 
 Since pointwise operators shares similar logic at meta data computation,
 which has been implemented as a common function used by all `PointwiseDynamicFunction`s.
-It involes:
+It involves:
 
 - *shape inference*: infer the output shape by broadcasting input tensor shape;
 
-- *ouput layout inference*: infer an appropriate layout (stride order) for output tensors if necessary;
+- *output layout inference*: infer an appropriate layout (stride order) for output tensors if necessary;
 
 - *type promotion*: infer output dtypes according to prescribed rules;
 
@@ -116,13 +116,13 @@ It involes:
 
 - *infer the rank of the task-space*.
   This is a factor related to the code generation which depends on the arguments.
-  It also involes trying to reduce the dimension of task-space to `1`
+  It also involves trying to reduce the dimension of task-space to `1`
   when all pre-allocated tensors are dense and non-overlapping and have the same size
   and stride for each dimension.
 
 Pre-allocated output tensors can also be passed into `PointwiseDynamicFunctions`.
 In the cases where there are pre-allocated tensors in output tensors, the shape, layout,
-dtype and device of theses pre-allocated tensors are respected and checked.
+dtype and device of these pre-allocated tensors are respected and checked.
 
 The metadata computation can also be skipped, but when doing so you should ensure that
 the outputs have correct metadata and are pre-allocated, and you have to provide the rank of the task-space.
@@ -155,15 +155,15 @@ def abs_func(x):
 ```
 
 Since the decorated function does not provide enough information for the code generation,
-we supply other necessary information by passing arguemnts to `pointwise_dynamic`.
+we supply other necessary information by passing arguments to `pointwise_dynamic`.
 
 ### 5.2 Tensor/Non-Tensor
 
-By default, `@pointwise_dynamic` treats each arguemnt as tensor, and generates code to load/store them.
+By default, `@pointwise_dynamic` treats each argument as tensor, and generates code to load/store them.
 But it can be configured by passing a list of boolean values to the parameter `is_tensor`
 to indicate whether the corresponding argument is tensor or nor.
 
-For non-tensor arguments, its type can be specfied by passing `dtypes` to the decorator, although not required.
+For non-tensor arguments, its type can be specified by passing `dtypes` to the decorator, although not required.
 For tensor arguments, the corresponding value in `dtypes` is ignored, since its dtype is dynamic
 and Triton can dispatch according to it.
 
@@ -188,7 +188,7 @@ add_func(a, b, 0.2)
 ### 5.3 Output dtypes
 
 For pointwise operators to allocate outputs with correct dtype, `promotion_methods` is required.
-Since the output dtype may be depedent on the input dtypes with some rules,
+Since the output dtype may be dependent on the input dtypes with some rules,
 specifying the rule is more expressive than providing output dtypes directly.
 
 `promotion_methods` is a list of tuples (one per output), each of which consists of

--- a/docs/content/en/performance/database.md
+++ b/docs/content/en/performance/database.md
@@ -42,7 +42,7 @@ export FLAGGEMS_DB_URL=sqlite:///${DB_PATH}
 ```
 
 If you don't want to maintain or reuse the cached data in your current environment,
-you can choose to use SQLLite as an in-memory database. This can be achieved
+you can choose to use SQLite as an in-memory database. This can be achieved
 by setting the environment variable `FLAGGEMS_DB_URL` as shown below:
 
 ```shell
@@ -55,7 +55,7 @@ When the session ends, the database would be lost.
 ## 2. PostgreSQL
 
 As an embedded database, *SQLite3* doesn't support multi-writers at the same time.
-However, having multiple writers writing performace data is a common use case.
+However, having multiple writers writing performance data is a common use case.
 For this reason, we also support using *PostgreSQL* as the backend database.
 Different from the embedded database, *PostgreSQL* requires an additional setup
 step before being used. You could refer to the

--- a/docs/content/en/usage/distributed.md
+++ b/docs/content/en/usage/distributed.md
@@ -30,7 +30,7 @@ to support large model sizes and high-throughput inference.
 
 For **single-node deployments**, the [enablement of FlagGems](/FlagGems/usage/basic/)
 is straightforward. You can import `flag_gems` and invoke `flag_gems.enable()`
-at the beginning of your program or use the context manager when apprpriate.
+at the beginning of your program or use the context manager when appropriate.
 The *FlagGems* acceleration is then enabled without requiring any additional changes
 to your code.
 

--- a/docs/content/en/usage/selective.md
+++ b/docs/content/en/usage/selective.md
@@ -77,7 +77,7 @@ certain operators.
   | `include`      | `List[str]` | Explicitly enable specific operators.  |
   | `exclude`      | `List[str]` | Explicitly disable specific operators. |
 
-  The `include` parameter, when specified, behaves indentically to that of
+  The `include` parameter, when specified, behaves identically to that of
   the `only_enable(include=...)` interface. Similarly, the `exclude` parameter,
   when specified, behaves identically to that of the `enable(unused=...)` interface.
   For example, the following code only enable the *FlagGems* acceleration

--- a/docs/content/zh-cn/_index.md
+++ b/docs/content/zh-cn/_index.md
@@ -61,7 +61,7 @@ Triton 编程语言在代码可读性、用户友好性上都有很好表现，�
 - Review [platforms supported](/FlagGems/overview/platforms/)
 - [Getting started with FlagGems](/FlagGems/getting-started/)
 - Check the project [changelog](/FlagGems/references/changelog/)
-- Review the list of [operators suppored](/FlagGems/references/changelog/)
+- Review the list of [operators supported](/FlagGems/references/changelog/)
 -->
 ## 下一步
 

--- a/docs/content/zh-cn/contribution/backend.md
+++ b/docs/content/zh-cn/contribution/backend.md
@@ -106,7 +106,7 @@ vendor_info = VendorDescriptor(
 The important properties for `VendorDescriptor` are:
 
 - `vendor_name`: the vendor name at your choice, e.g. `nvidia`;
-- `device_name`: the name for your acclerator device, e.g. `cuda`;
+- `device_name`: the name for your accelerator device, e.g. `cuda`;
 - `device_query_cmd`: the command line that is used to check the hardware devices
   on the node, e.g. `nvidia-smi`.
 - `dispatch_key`: an optional property for registering operators to `torch.library.Library`

--- a/docs/content/zh-cn/contribution/overview.md
+++ b/docs/content/zh-cn/contribution/overview.md
@@ -80,7 +80,7 @@ Other fields for an operator include:
   - 一个新的、AI 生成的算子通常以 `alpha` 阶段作为起点。
   <!--
   - When an operator has been continuously tested without significant issues for a release cycle,
-    it may get promoted to the next stage in the followin release. For example, consider an operator
+    it may get promoted to the next stage in the following release. For example, consider an operator
     introduced in version *5.0* as `alpha`, if it works without serious flaws for at least one
     release cycle, it may get promoted to `beta` in the next release, i.e. *5.1*.
   -->

--- a/docs/content/zh-cn/overview/pointwise-dynamic.md
+++ b/docs/content/zh-cn/overview/pointwise-dynamic.md
@@ -181,7 +181,7 @@ and is ready for the computation.
 
 Since pointwise operators shares similar logic at metadata computation,
 which has been implemented as a common function used by all `PointwiseDynamicFunction`s.
-It involes:
+It involves:
 -->
 ## 3. 元数据计算  {#metadata-computation}
 
@@ -191,7 +191,7 @@ It involes:
 <!--
 - *shape inference*: infer the output shape by broadcasting input tensor shape;
 
-- *ouput layout inference*: infer an appropriate layout (stride order) for output tensors if necessary;
+- *output layout inference*: infer an appropriate layout (stride order) for output tensors if necessary;
 
 - *type promotion*: infer output dtypes according to prescribed rules;
 
@@ -201,7 +201,7 @@ It involes:
 
 - *infer the rank of the task-space*.
   This is a factor related to the code generation which depends on the arguments.
-  It also involes trying to reduce the dimension of task-space to `1`
+  It also involves trying to reduce the dimension of task-space to `1`
   when all pre-allocated tensors are dense and non-overlapping and have the same size
   and stride for each dimension.
 -->
@@ -217,7 +217,7 @@ It involes:
 <!--
 Pre-allocated output tensors can also be passed into `PointwiseDynamicFunctions`.
 In the cases where there are pre-allocated tensors in output tensors, the shape, layout,
-dtype and device of theses pre-allocated tensors are respected and checked.
+dtype and device of these pre-allocated tensors are respected and checked.
 
 The metadata computation can also be skipped, but when doing so you should ensure that
 the outputs have correct metadata and are pre-allocated, and you have to provide the rank of the task-space.
@@ -280,7 +280,7 @@ def abs_func(x):
 
 <!--
 Since the decorated function does not provide enough information for the code generation,
-we supply other necessary information by passing arguemnts to `pointwise_dynamic`.
+we supply other necessary information by passing arguments to `pointwise_dynamic`.
 -->
 由于被修饰的函数无法为代码生成提供足够的信息，我们会通过为 `pointwise_dynamic`
 传递参数来提供必要的信息。
@@ -299,7 +299,7 @@ to indicate whether the corresponding argument is tensor or nor.
 标示是否对应的参数是一个张量。
 
 <!--
-For non-tensor arguments, its type can be specfied by passing `dtypes` to the decorator, although not required.
+For non-tensor arguments, its type can be specified by passing `dtypes` to the decorator, although not required.
 For tensor arguments, the corresponding value in `dtypes` is ignored, since its dtype is dynamic
 and Triton can dispatch according to it.
 -->
@@ -333,7 +333,7 @@ add_func(a, b, 0.2)
 ### 5.3 Output dtypes
 
 For pointwise operators to allocate outputs with correct dtype, `promotion_methods` is required.
-Since the output dtype may be depedent on the input dtypes with some rules,
+Since the output dtype may be dependent on the input dtypes with some rules,
 specifying the rule is more expressive than providing output dtypes directly.
 -->
 ### 5.3 输出数据类型  {#output-dtypes}
@@ -450,7 +450,7 @@ using keyword arguments.
 
 由于 `@pointwise_dynamic` 修饰符会生成封装逻辑，将算子的输出作为参数，
 我们可以用它来实现原地（in-place）计算操作。
-对于所有的 `PointwiseDynamicFunction` 对象，你都可以使用关键字参数（keyword aruments）
+对于所有的 `PointwiseDynamicFunction` 对象，你都可以使用关键字参数（keyword arguments）
 将输出参数传递给它。为了区分输入参数和输出参数，我们遵循一个基本的原则：
 所有输入参数都要使用位置参数（positional arguments）来传递，
 而所有输出参数都要使用关键字参数来传递。

--- a/docs/content/zh-cn/performance/database.md
+++ b/docs/content/zh-cn/performance/database.md
@@ -81,7 +81,7 @@ When the session ends, the database would be lost.
 ## 2. PostgreSQL
 
 As an embedded database, *SQLite3* doesn't support multi-writers at the same time.
-However, having multiple writers writing performace data is a common use case.
+However, having multiple writers writing performance data is a common use case.
 For this reason, we also support using *PostgreSQL* as the backend database.
 Different from the embedded database, *PostgreSQL* requires an additional setup
 step before being used. You could refer to the

--- a/docs/content/zh-cn/usage/cpp.md
+++ b/docs/content/zh-cn/usage/cpp.md
@@ -40,7 +40,7 @@ in latency-sensitive or high-throughput scenarios.
 To address this, *FlagGems* provides a C++ runtime solution that encapsulates
 the operator's wrapper logic, registration mechanism, and runtime management in C++,
 while still reusing the underlying Triton kernels for the actual computation.
-This approach preseves the kernel-level efficiency from Triton
+This approach preserves the kernel-level efficiency from Triton
 while significantly reducing Python-related overhead, enabling tighter integration
 with low-level CUDA workflows and improving overall inference performance.
 -->

--- a/docs/content/zh-cn/usage/selective.md
+++ b/docs/content/zh-cn/usage/selective.md
@@ -130,7 +130,7 @@ certain operators.
   | `exclude`      | `List[str]` | 显式地禁用指定的算子   |
 
   <!--
-  The `include` parameter, when specified, behaves indentically to that of
+  The `include` parameter, when specified, behaves identically to that of
   the `only_enable(include=...)` interface. Similarly, the `exclude` parameter,
   when specified, behaves identically to that of the `enable(unused=...)` interface.
   For example, the following code only enable the *FlagGems* acceleration


### PR DESCRIPTION
Ran codespell over `docs/`, verified each match manually. 30 typos across `docs/content/en/` and `docs/content/zh-cn/` markdown, no content changes.

Also fixed `SQLLite` to `SQLite` (official spelling has one L; codespell suggested `sqlite` which is wrong for the brand name).