### PR TITLE
fix(pointwise_dynamic): use original pointer dtype for block-ptr store

### DIFF
--- a/src/flag_gems/utils/pointwise_dynamic.py
+++ b/src/flag_gems/utils/pointwise_dynamic.py
@@ -545,7 +545,13 @@ class KernelGenerator:
                 f"out{i}_ptr, ({shape}), ({strides}), ({offsets}), ({tile_sizes}), order=({order}))"
             )
             code.writeline(
-                f"tl.store(out{i}_bptr, out{i}.to(out{i}_bptr.type.element_ty), boundary_check=({order}))"
+                # Use the original pointer's element dtype, not the block
+                # pointer's. In Triton >= 3.2 a block pointer's ``.type`` is a
+                # ``_aggregate_type`` that has no ``element_ty`` attribute, so
+                # ``out{i}_bptr.type.element_ty`` raises AttributeError during
+                # codegen. This mirrors the load path above, which already uses
+                # ``in{i}_ptr.type.element_ty`` for the same reason.
+                f"tl.store(out{i}_bptr, out{i}.to(out{i}_ptr.type.element_ty), boundary_check=({order}))"
             )
 
     def gen_body_gsl_with_bptr(self, code):


### PR DESCRIPTION
## Summary

`pointwise_dynamic`'s block-pointer **store** codegen casts the result with
`out{i}_bptr.type.element_ty`. On Triton >= 3.2 a block pointer's `.type` is a
`_aggregate_type` that has **no** `element_ty` attribute, so codegen raises:

```
AttributeError: '_aggregate_type' object has no attribute 'element_ty'
triton.compiler.errors.CompilationError: at NN:MM:
        out0_bptr = tl.make_block_ptr(out0_ptr, ...)
        tl.store(out0_bptr, out0.to(out0_bptr.type.element_ty), boundary_check=(...))
                                     ^
```

This breaks **every** `pointwise_dynamic` op that takes the block-pointer
codegen path on newer Triton (e.g. `silu_and_mul`), regardless of GPU vendor.

## Root cause

The **load** path in the same function already handles this correctly and even
documents why — it uses the *original pointer's* dtype rather than the block
pointer's:

```python
in{i} = tl.load(in{i}_bptr, boundary_check=(...)).to(in{i}_ptr.type.element_ty)
# workaround the bug on bool, we should use the original pointer's dtype(instead of block pointer's)
```

The **store** path was missed and still dereferenced `out{i}_bptr.type.element_ty`.

## Fix

Cast the stored value with the original pointer's element dtype
(`out{i}_ptr.type.element_ty`), mirroring the load path. One-line change.

## Verification

- `silu_and_mul` (both the fused-MoE `_silu_and_mul_kernel` and the ATen op)
  now compiles and matches the torch reference:
  - `torch.float32` / `torch.float16` / `torch.bfloat16`: `allclose=True`.
- `tests/test_silu_and_mul.py::test_silu_and_mul_out` — 11/11 pass (all
  `POINTWISE_SHAPES` × float dtypes).
- `tests/test_pointwise_dynamic.py` — pass.

Environment where reproduced: Triton 3.6/3.7 on ROCm; the root cause is
vendor-independent (any Triton >= 3.2 hitting the block-pointer store path).
