### PR TITLE
[Runtime][AMD] Add RDNA4 autotune configs and match arch by exact GPU target

### DIFF
--- a/src/flag_gems/runtime/backend/__init__.py
+++ b/src/flag_gems/runtime/backend/__init__.py
@@ -169,22 +169,36 @@ class BackendArchEvent(BackendEventBase):
             return
         arch_map = _state.vendor_module.ARCH_MAP
         arch_string = os.environ.get("ARCH", "")
-        arch_string_num = arch_string.split("_")[-1][0] if arch_string else arch_string
-        if not arch_string_num:
+        # Candidate keys ordered from the most to the least specific. The last
+        # one is the major version alone, so a map that lists whole families
+        # keeps matching the same devices it did before.
+        keys = []
+        if arch_string:
+            keys.append(arch_string.split("_")[-1][0])
+        else:
             try:
                 if not _state.torch_device_object.is_available():
                     return False
                 props = _state.torch_device_object.get_device_properties(device)
-                arch_string_num = str(props.major)
+                # AMD reports the exact target here, sometimes with feature
+                # suffixes such as "gfx942:sramecc+:xnack-". Other vendors do
+                # not expose this attribute at all.
+                gcn_arch = (getattr(props, "gcnArchName", "") or "").strip()
+                if gcn_arch:
+                    keys.append(gcn_arch.split(":")[0])
+                keys.append(f"{props.major}.{props.minor}")
+                keys.append(str(props.major))
             except Exception:
                 self.has_arch = False
-        if arch_string_num not in arch_map:
-            print(
-                f"[INFO] : FlagGems Unsupported GPU arch {arch_string} specialization"
-            )
-        else:
-            self.has_arch = True
-            return arch_map[arch_string_num]
+
+        for key in keys:
+            if key in arch_map:
+                self.has_arch = True
+                return arch_map[key]
+        print(
+            "[INFO] : FlagGems Unsupported GPU arch "
+            f"{arch_string or (keys[0] if keys else 'unknown')} specialization"
+        )
 
     def _get_supported_archs(self, path=None):
         path = Path(path or _state.vendor_module.__path__[0])

--- a/src/flag_gems/runtime/backend/_amd/__init__.py
+++ b/src/flag_gems/runtime/backend/_amd/__init__.py
@@ -20,6 +20,22 @@ vendor_info = VendorDescriptor(
     device_query_cmd="rocm-smi",
 )
 
+"""
+Mapping from the major version torch reports for an AMD GPU to the directory
+holding that architecture's specialized configuration.
+
+Only the major version is matched, so an entry covers a whole gfx family rather
+than a single target. An architecture absent from the map falls back to the
+vendor-wide configuration.
+
+Example:
+  gfx1200, gfx1201 (RDNA4) -> major 12 -> rdna4
+"""
+
+ARCH_MAP = {
+    "12": "rdna4",
+}
+
 CUSTOMIZED_UNUSED_OPS = (
     "add",
     "cos",

--- a/src/flag_gems/runtime/backend/_amd/__init__.py
+++ b/src/flag_gems/runtime/backend/_amd/__init__.py
@@ -21,19 +21,22 @@ vendor_info = VendorDescriptor(
 )
 
 """
-Mapping from the major version torch reports for an AMD GPU to the directory
-holding that architecture's specialized configuration.
+Mapping from an AMD GPU architecture to the directory holding that
+architecture's specialized configuration.
 
-Only the major version is matched, so an entry covers a whole gfx family rather
-than a single target. An architecture absent from the map falls back to the
-vendor-wide configuration.
+Keys are looked up from the most to the least specific: the exact target torch
+reports in gcnArchName, then "major.minor", then the major version alone. An
+architecture absent from the map falls back to the vendor-wide configuration.
 
-Example:
-  gfx1200, gfx1201 (RDNA4) -> major 12 -> rdna4
+Targets are listed individually because the major version alone is too coarse:
+gfx1250 and gfx1251 also report major 12, yet they form the separate GFX12.5
+family (LLVM keeps them out of gfx12-generic) with a much larger addressable
+LDS, so the RDNA4 candidates would be a poor fit for them.
 """
 
 ARCH_MAP = {
-    "12": "rdna4",
+    "gfx1200": "rdna4",
+    "gfx1201": "rdna4",
 }
 
 CUSTOMIZED_UNUSED_OPS = (

--- a/src/flag_gems/runtime/backend/_amd/rdna4/__init__.py
+++ b/src/flag_gems/runtime/backend/_amd/rdna4/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/src/flag_gems/runtime/backend/_amd/rdna4/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_amd/rdna4/tune_configs.yaml
@@ -1,0 +1,184 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Autotune candidates for the gfx12 family (RDNA4). Ops listed here replace the
+# vendor-wide list in _amd/tune_configs.yaml; anything absent falls back to it
+# unchanged. Arch selection matches on the major version alone, so these apply
+# to every gfx12 target even though they were measured only on gfx1201.
+#
+# The candidates come from an exhaustive sweep of the tile/warp/stage space:
+# every configuration that won at least one benchmarked shape, plus a few
+# covering the sizes in between so the table does not overfit those shapes. The
+# space is bounded by the 64 KiB of LDS a workgroup may use, which caps
+# (BLOCK_M + BLOCK_N) * BLOCK_K; num_stages stays at 1-2 because deeper
+# pipelines ranked poorly throughout the sweep.
+
+mm:
+  - META:
+      BLOCK_M: 32
+      BLOCK_N: 64
+      BLOCK_K: 64
+    num_stages: 1
+    num_warps: 4
+  - META:
+      BLOCK_M: 64
+      BLOCK_N: 64
+      BLOCK_K: 64
+    num_stages: 1
+    num_warps: 4
+  - META:
+      BLOCK_M: 64
+      BLOCK_N: 128
+      BLOCK_K: 32
+    num_stages: 1
+    num_warps: 4
+  - META:
+      BLOCK_M: 64
+      BLOCK_N: 128
+      BLOCK_K: 64
+    num_stages: 1
+    num_warps: 4
+  - META:
+      BLOCK_M: 128
+      BLOCK_N: 64
+      BLOCK_K: 64
+    num_stages: 1
+    num_warps: 4
+  - META:
+      BLOCK_M: 128
+      BLOCK_N: 128
+      BLOCK_K: 64
+    num_stages: 1
+    num_warps: 4
+  - META:
+      BLOCK_M: 128
+      BLOCK_N: 128
+      BLOCK_K: 32
+    num_stages: 2
+    num_warps: 4
+  - META:
+      BLOCK_M: 64
+      BLOCK_N: 256
+      BLOCK_K: 32
+    num_stages: 1
+    num_warps: 4
+  - META:
+      BLOCK_M: 64
+      BLOCK_N: 256
+      BLOCK_K: 64
+    num_stages: 1
+    num_warps: 8
+  - META:
+      BLOCK_M: 128
+      BLOCK_N: 256
+      BLOCK_K: 32
+    num_stages: 1
+    num_warps: 8
+  - META:
+      BLOCK_M: 128
+      BLOCK_N: 256
+      BLOCK_K: 64
+    num_stages: 2
+    num_warps: 8
+  - META:
+      BLOCK_M: 256
+      BLOCK_N: 128
+      BLOCK_K: 64
+    num_stages: 2
+    num_warps: 8
+bmm:
+  - META:
+      TILE_M: 32
+      TILE_N: 64
+      TILE_K: 64
+      GROUP_M: 2
+    num_warps: 4
+    num_stages: 1
+  - META:
+      TILE_M: 64
+      TILE_N: 64
+      TILE_K: 64
+      GROUP_M: 2
+    num_warps: 4
+    num_stages: 1
+  - META:
+      TILE_M: 64
+      TILE_N: 64
+      TILE_K: 32
+      GROUP_M: 2
+    num_warps: 8
+    num_stages: 1
+  - META:
+      TILE_M: 64
+      TILE_N: 128
+      TILE_K: 32
+      GROUP_M: 2
+    num_warps: 4
+    num_stages: 1
+  - META:
+      TILE_M: 128
+      TILE_N: 128
+      TILE_K: 32
+      GROUP_M: 2
+    num_warps: 4
+    num_stages: 1
+  - META:
+      TILE_M: 128
+      TILE_N: 128
+      TILE_K: 32
+      GROUP_M: 2
+    num_warps: 4
+    num_stages: 2
+  - META:
+      TILE_M: 128
+      TILE_N: 128
+      TILE_K: 32
+      GROUP_M: 4
+    num_warps: 4
+    num_stages: 2
+  - META:
+      TILE_M: 128
+      TILE_N: 128
+      TILE_K: 64
+      GROUP_M: 2
+    num_warps: 4
+    num_stages: 2
+  - META:
+      TILE_M: 64
+      TILE_N: 256
+      TILE_K: 32
+      GROUP_M: 2
+    num_warps: 4
+    num_stages: 1
+  - META:
+      TILE_M: 128
+      TILE_N: 256
+      TILE_K: 32
+      GROUP_M: 2
+    num_warps: 8
+    num_stages: 2
+  - META:
+      TILE_M: 128
+      TILE_N: 256
+      TILE_K: 32
+      GROUP_M: 4
+    num_warps: 8
+    num_stages: 2
+  - META:
+      TILE_M: 256
+      TILE_N: 128
+      TILE_K: 32
+      GROUP_M: 2
+    num_warps: 8
+    num_stages: 1

--- a/src/flag_gems/runtime/backend/_amd/rdna4/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_amd/rdna4/tune_configs.yaml
@@ -12,10 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Autotune candidates for the gfx12 family (RDNA4). Ops listed here replace the
-# vendor-wide list in _amd/tune_configs.yaml; anything absent falls back to it
-# unchanged. Arch selection matches on the major version alone, so these apply
-# to every gfx12 target even though they were measured only on gfx1201.
+# Autotune candidates for RDNA4, that is gfx1200 and gfx1201, measured on
+# gfx1201. Ops listed here replace the vendor-wide list in
+# _amd/tune_configs.yaml; anything absent falls back to it unchanged.
+# _amd/__init__.py maps those two targets by name, so the GFX12.5 parts that
+# report the same major version do not read this file.
 #
 # The candidates come from an exhaustive sweep of the tile/warp/stage space:
 # every configuration that won at least one benchmarked shape, plus a few


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->

Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->

Performance Optimization

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

Adds an architecture-specialized autotune candidate table for `mm` and `bmm` on AMD RDNA4, and registers the `ARCH_MAP` entry that makes arch specialization reachable on the AMD backend at all.

Selecting that table needs one change in shared runtime code. `get_arch()` keyed `ARCH_MAP` on the major version torch reports, which buckets a whole gfx family into a single entry, and that bucket is too coarse here: `gfx1250` and `gfx1251` also report major 12, yet LLVM keeps them out of `gfx12-generic` as the separate GFX12.5 family, with a much larger addressable LDS. Candidates measured on gfx1201 and bounded by its 64 KiB would be a poor fit for them. `get_arch()` now tries the exact target from `gcnArchName`, then `major.minor`, then the major version alone, and `_amd` lists `gfx1200` and `gfx1201` by name.

That lookup is backward compatible, because the last candidate it tries is exactly the key used before: `_nvidia` (`"9"`, `"8"`) and `_enflame` (`"3"`, `"4"`) still match the devices they matched previously, and the 13 vendors that define no `ARCH_MAP` return before reaching any of the new code. Checked on gfx1201, plus stand-in device properties for H100, A100, sm_86, sm_89, Enflame's `ARCH` env path, gfx1250, gfx1251 and `gfx942:sramecc+:xnack-`.

No kernel code is touched, and the vendor-wide `_amd/tune_configs.yaml` is left as is, so every AMD device other than gfx1200 and gfx1201 keeps its current behaviour. Ops absent from the arch table keep falling back to the vendor table.

How the candidate table differs from the vendor-wide one:
| axis | vendor-wide | this PR |
|---|---|---|
| `mm` `BLOCK_M` | 16 / 32 / 64 / 128 | 32 / 64 / 128 / 256 |
| `mm` `BLOCK_N` | 64 / 128 | 64 / 128 / 256 |
| `mm` `BLOCK_K` | 32 / 64 / 128 / 256 | 32 / 64 |
| `mm` `num_stages` | 3 / 4 / 5 | 1 / 2 |
| `bmm` `TILE_N` | 32 / 64 / 128 | 64 / 128 / 256 |
| `bmm` `TILE_K` | 32 | 32 / 64 |
| `bmm` `GROUP_M` | 1 / 2 | 2 / 4 |
| `bmm` `num_stages` | 2 / 3 | 1 / 2 |

Three findings drive the table:
1. Deep pipelining is a net loss on RDNA4, which has no async global-to-LDS copy. Almost every top-ranked config in the sweep uses `num_stages` 1 or 2.  This is the single largest factor.
2. The vendor-wide table caps `BLOCK_N` at 128, but large shapes want 256.
3. `num_warps` has to track tile area. Tiles up to 128x128 are faster with 4 warps; only 256-wide tiles need 8.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->

Test machine:
| item | value |
|---|---|
| GPU | AMD Radeon, `gfx1201` |
| ROCm | 7.2.3 |
| PyTorch | 2.10.0+rocm7.2.3 |
| Triton | 3.6.0+rocm7.2.3 |
| Python / OS | 3.12.3 / Linux 6.17 x86_64 |


Shapes are the official `benchmark/core_shapes.yaml` `BlasBenchmark` set, and timing mirrors `benchmark/base.py`: `triton.testing.do_bench(warmup=1000, rep=500, return_mode="median")`. Both sides autotune from an empty cache in the
same session on an otherwise idle GPU.

**Correctness.** `pytest tests/test_mm.py tests/test_bmm.py -q --quick --ref cpu` gives 9 passed, 1 skipped; the full run without `--quick` gives 91 passed, 1 skipped.
This also fixes 3 pre-existing FP32 `mm` failures on RDNA4. The vendor-wide table contains `BLOCK_K=256` entries, which in FP32 need `(16 + 64) * 256 * 4 = 80 KiB` of LDS for the A and B tiles alone and exceed the 64 KiB limit; no entry in that table is usable for FP32 `mm`. The new table caps `BLOCK_K` at 64, so its smallest config needs 24 KiB. Launching all 12 `mm` entries directly confirms all of them are usable in FP16 and BF16, and 10 of 12 in FP32, where the autotuner skips the two 256-wide `num_stages=2` entries. Devices other than gfx1200 and gfx1201 are
unaffected by this PR and still hit the failure.


**Speedup over the vendor-wide table**, i.e. old latency / new latency, fastest
of 3 runs:
| op | dtype | median over shapes | 
|---|---|---|
| mm | float16 | 1.273x |
| mm | bfloat16 | 1.292x | 
| bmm | float16 | 1.030x | 
| bmm | bfloat16 | 1.035x | 

**Against PyTorch**, median of 3 runs, higher is better:
| op | dtype | vendor-wide table | this PR |
|---|---|---|---|
| mm | float16 | 0.749x | 0.977x |
| mm | bfloat16 | 0.779x | 0.978x |
| bmm | float16 | 0.934x | 0.961x |
| bmm | bfloat16 | 0.952x | 0.977x |
<details>
<summary>Per-shape latency (ms, fastest of 3)</summary>

| op | dtype | shape | vendor-wide | this PR | speedup |
|---|---|---|---|---|---|
| mm | float16 | `[384,384]` | 0.0123 | 0.0115 | 1.066x |
| mm | float16 | `[1024,1024]` | 0.0478 | 0.0406 | 1.179x |
| mm | float16 | `[2048,2048]` | 0.2544 | 0.1861 | 1.367x |
| mm | float16 | `[4096,4096]` | 1.6874 | 1.3157 | 1.283x |
| mm | float16 | `[4096,4096]` | 1.6993 | 1.3354 | 1.273x |
| mm | bfloat16 | `[384,384]` | 0.0124 | 0.0122 | 1.023x |
| mm | bfloat16 | `[1024,1024]` | 0.0474 | 0.0407 | 1.164x |
| mm | bfloat16 | `[2048,2048]` | 0.2811 | 0.1884 | 1.492x |
| mm | bfloat16 | `[4096,4096]` | 1.6907 | 1.3090 | 1.292x |
| mm | bfloat16 | `[4096,4096]` | 1.6978 | 1.3130 | 1.293x |
| bmm | float16 | `[2,384,384]` | 0.0157 | 0.0139 | 1.133x |
| bmm | float16 | `[2,4096,4096]` | 2.6440 | 2.5665 | 1.030x |
| bmm | float16 | `[16,1024,1024]` | 0.3892 | 0.3858 | 1.009x |
| bmm | float16 | `[16,2048,2048]` | 2.6852 | 2.6126 | 1.028x |
| bmm | float16 | `[16,4096,4096]` | 21.3453 | 20.6503 | 1.034x |
| bmm | bfloat16 | `[2,384,384]` | 0.0157 | 0.0139 | 1.133x |
| bmm | bfloat16 | `[2,4096,4096]` | 2.6062 | 2.5190 | 1.035x |
| bmm | bfloat16 | `[16,1024,1024]` | 0.3957 | 0.3867 | 1.023x |
| bmm | bfloat16 | `[16,2048,2048]` | 2.6496 | 2.5911 | 1.023x |
| bmm | bfloat16 | `[16,4096,4096]` | 21.0187 | 20.2519 | 1.038x |
</details>


The gain is concentrated in medium and large `mm`, where `2048` and above move from roughly 0.70x of PyTorch to 0.88x-1.03x. `bmm` gains only 2-4%: the sweep shows its optimum already sits close to the edge of the configurable space, so there is little left to win from candidate selection alone.


### Not covered here, and follow-ups
- **GFX12.5 (`gfx1250`, `gfx1251`) is deliberately excluded.** It reports the same major version as RDNA4 but is a different generation, and no such hardware was available to measure on, so it keeps using the vendor-wide table. Adding a directory plus one `ARCH_MAP` entry is all it will take later, with no further runtime change.
- **`GROUP_M` for `mm` is not tunable.** `general_mm()` passes `GROUP_M=8` explicitly, so the value never reaches the autotuner and cannot be expressed in the YAML. A separate sweep shows `GROUP_M=1` is better for large shapes on gfx1201, but exposing it means changing the generic kernel, which is out of scope for a config-only PR.
- **AMD-specific per-config options are not used.** `waves_per_eu` gives a measurable gain on small shapes, but it cannot be shipped through the YAML today: the persistent tuning cache derives its SQLite schema from the first config it writes, so a table where only some entries carry the extra key fails to persist and then raises `KeyError` on lookup. Making that robust means changing `utils/models/sql.py` for every vendor, so it is deferred. The same applies to `kpack` and `matrix_instr_nonkdim`.
- **Only `mm` and `bmm` are tuned.** They are the two most used BLAS ops, so they went first. Everything else keeps using the vendor-wide table, and more ops will follow in later PRs.