### PR TITLE
Bump numpy version to 2.3.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ dependencies = [
     "packaging==26.0",
     "PyYAML==6.0.1",
     "sqlalchemy==2.0.48",
-    "numpy==1.26.4",
+    "numpy==2.3.5",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### PR Category

Other

### Type of Change

Other

### Description

This PR bumps our numpy version requirement to 2.3.5, matching what `opencv_python_headless-5.0.0.93` requires. `opencv_python_headleass` is a dependency of `vllm==0.20.2`. We bump `numpy` to a version larger than `2.0` to make it happy.

Scanned all 12 backends we support for numpy version constraints. There is no conflict on this. This bump is safe.