### PR TITLE
Relax numpy and packing version constraint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,10 +65,11 @@ classifiers = [
 ]
 
 dependencies = [
-    "packaging==26.0",
+    "packaging>=26.0",
     "PyYAML==6.0.1",
     "sqlalchemy==2.0.48",
-    "numpy>2",
+    # Iluvatar requires numpy < 2, while upper layer requires numpy>2 ..
+    "numpy",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
### PR Category

Other

### Type of Change

Other

### Description

The numpy version is a big problem. Some backends require lower version, some backends require higher version. Relax our constraints at the moment.