### PR TITLE
Make upload-artifact step optional in on-demand test workflow

### DIFF
--- a/.github/workflows/command.yaml
+++ b/.github/workflows/command.yaml
@@ -188,11 +188,13 @@ jobs:
       - id: upload-results
         # uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         uses: actions/upload-artifact@v7.0.0
+        continue-on-error: true
         with:
           name: ${{ needs.preprocess.outputs.op }}-${{ env.BACKEND }}
           path: results/
 
       - id: attach-result-link
+        if: steps.upload-results.outcome == 'success'
         run: |
           echo -e "\n---\n" >> report.md
           echo -e "📎 Download the full log [here](${{ steps.upload-results.outputs.artifact-url }})" >> report.md


### PR DESCRIPTION
The `actions/upload-artifact` action depends on `windows.net` which cannot be reliably reached from our self-hosted runners, causing spurious job failures. This PR:

- Adds `continue-on-error: true` to the `upload-results` step so the job continues even when the upload fails
- Gates the `attach-result-link` step on `steps.upload-results.outcome == 'success'` to avoid embedding an empty artifact URL

The test results comment is still posted regardless of upload success — only the "Download the full log" link is omitted when the upload fails.

> AI-assisted change.