### PR TITLE
fix hygon OPs bug

### DIFF
--- a/src/flag_gems/runtime/backend/_hygon/ops/__init__.py
+++ b/src/flag_gems/runtime/backend/_hygon/ops/__init__.py
@@ -21,8 +21,28 @@ from .attention import (
     scaled_dot_product_attention_backward,
     scaled_dot_product_attention_forward,
 )
+from .div import (
+    div_mode,
+    div_mode_,
+    floor_divide,
+    floor_divide_,
+    remainder,
+    remainder_,
+    true_divide,
+    true_divide_,
+    true_divide_out,
+    trunc_divide,
+    trunc_divide_,
+)
 from .exponential_ import exponential_
-from .fill import fill_scalar, fill_scalar_, fill_tensor, fill_tensor_
+from .fill import (
+    fill_scalar,
+    fill_scalar_,
+    fill_scalar_out,
+    fill_tensor,
+    fill_tensor_,
+    fill_tensor_out,
+)
 from .gelu import gelu, gelu_
 from .hadamard_transform import hadamard_transform
 from .isin import isin
@@ -51,13 +71,19 @@ __all__ = [
     "any",
     "any_dim",
     "any_dims",
+    "div_mode",
+    "div_mode_",
     "exponential_",
     "fill_scalar",
     "fill_scalar_",
+    "fill_scalar_out",
     "fill_tensor",
     "fill_tensor_",
+    "fill_tensor_out",
     "flash_attention_forward",
     "flash_attn_varlen_func",
+    "floor_divide",
+    "floor_divide_",
     "gelu",
     "gelu_",
     "hadamard_transform",
@@ -74,6 +100,8 @@ __all__ = [
     "pow_tensor_tensor",
     "pow_tensor_tensor_",
     "randperm",
+    "remainder",
+    "remainder_",
     "scaled_dot_product_attention",
     "scaled_dot_product_attention_backward",
     "scaled_dot_product_attention_forward",
@@ -82,5 +110,10 @@ __all__ = [
     "silu_backward",
     "sort",
     "sort_stable",
+    "true_divide",
+    "true_divide_",
+    "true_divide_out",
+    "trunc_divide",
+    "trunc_divide_",
     "upsample_nearest2d",
 ]

--- a/src/flag_gems/runtime/backend/_hygon/ops/div.py
+++ b/src/flag_gems/runtime/backend/_hygon/ops/div.py
@@ -19,16 +19,64 @@ import triton
 import triton.language as tl
 
 from flag_gems.utils import pointwise_dynamic, tl_extra_shim
+from flag_gems.utils.pointwise_dynamic import ComplexMode
 
 logger = logging.getLogger(__name__)
 fmod = tl_extra_shim.fmod
 trunc = tl_extra_shim.trunc
 
 
+@pointwise_dynamic(
+    is_tensor=[True, True, True, True],
+    num_outputs=2,
+    promotion_methods=[
+        (0, 1, 2, 3, "INT_TO_FLOAT"),
+        (0, 1, 2, 3, "INT_TO_FLOAT"),
+    ],
+)
+@triton.jit
+def div_complex_kernel_hygon_fp64(ar, ai, br, bi):
+    # Smith's method avoids overflow by dividing by the larger component.
+    ar = ar.to(tl.float64)
+    ai = ai.to(tl.float64)
+    br = br.to(tl.float64)
+    bi = bi.to(tl.float64)
+
+    abs_br = tl.abs(br)
+    abs_bi = tl.abs(bi)
+    use_br = abs_br >= abs_bi
+
+    safe_br = tl.where(br == 0, 1.0, br)
+    safe_bi = tl.where(bi == 0, 1.0, bi)
+
+    ratio1 = tl.where(br == 0, 0.0, bi / safe_br)
+    denom1 = br + bi * ratio1
+    selected_denom1 = tl.where(use_br, denom1, 1.0)
+    real1 = (ar + ai * ratio1) / selected_denom1
+    imag1 = (ai - ar * ratio1) / selected_denom1
+
+    ratio2 = tl.where(bi == 0, 0.0, br / safe_bi)
+    denom2 = bi + br * ratio2
+    selected_denom2 = tl.where(use_br, 1.0, denom2)
+    real2 = (ar * ratio2 + ai) / selected_denom2
+    imag2 = (ai * ratio2 - ar) / selected_denom2
+
+    return tl.where(use_br, real1, real2), tl.where(use_br, imag1, imag2)
+
+
 @pointwise_dynamic(promotion_methods=[(0, 1, "INT_TO_FLOAT")])
 @triton.jit
 def true_div_func(x, y):
     return x / y
+
+
+@pointwise_dynamic(promotion_methods=[(0, 1, "INT_TO_FLOAT")])
+@triton.jit
+def complex_real_div_fp64_func(x, y):
+    is_zero = y == 0.0
+    safe_y = tl.where(is_zero, 1.0, y)
+    quotient = x.to(tl.float64) / safe_y.to(tl.float64)
+    return tl.where(is_zero, float("nan"), quotient)
 
 
 @pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "INT_TO_FLOAT")])
@@ -43,8 +91,29 @@ def true_div_func_scalar_tensor(x, y):
     return x / y
 
 
+true_div_func.register_complex(
+    mode=ComplexMode.CROSS, cross_kernel=div_complex_kernel_hygon_fp64
+)
+true_div_func_tensor_scalar.register_complex(
+    mode=ComplexMode.CROSS, tensorize_scalars=True, fallback_target=true_div_func
+)
+true_div_func_scalar_tensor.register_complex(
+    mode=ComplexMode.CROSS, tensorize_scalars=True, fallback_target=true_div_func
+)
+
+
 def true_divide(A, B):
     logger.debug("GEMS_HYGON TRUE_DIVIDE")
+    if (
+        isinstance(A, torch.Tensor)
+        and A.is_complex()
+        and isinstance(B, torch.Tensor)
+        and not B.is_complex()
+    ):
+        return torch.complex(
+            complex_real_div_fp64_func(A.real, B),
+            complex_real_div_fp64_func(A.imag, B),
+        )
     if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
         return true_div_func(A, B)
     elif isinstance(A, torch.Tensor):
@@ -54,6 +123,18 @@ def true_divide(A, B):
     else:
         # Both scalar
         return torch.tensor(A / B)
+
+
+def true_divide_out(A, B, out):
+    logger.debug("GEMS_HYGON TRUE_DIVIDE OUT")
+    if isinstance(A, torch.Tensor) and isinstance(B, torch.Tensor):
+        return true_div_func(A, B, out0=out)
+    elif isinstance(A, torch.Tensor):
+        return true_div_func_tensor_scalar(A, B, out0=out)
+    elif isinstance(B, torch.Tensor):
+        return true_div_func_scalar_tensor(A, B, out0=out)
+    else:
+        return torch.tensor(A / B) if out is None else out.fill_(A / B)
 
 
 def true_divide_(A, B):
@@ -106,7 +187,7 @@ def trunc_divide_(A, B):
 
 
 @triton.jit
-def _int_floordiv(x, y):
+def _hygon_int_floordiv_v3(x, y):
     # TODO: request Triton to add an integer remainder builtin
     # The semantic of Triton floordiv differs from Pytorch/Numpy
     # Triton floordiv equates to
@@ -120,10 +201,25 @@ def _int_floordiv(x, y):
     # whereas in Pytorch x // 0 returns -1 if x >=0 and -2 if x < 0
     # but this special case is coalesced into the c1 and c2 check so
     # there's extra handling.
-    r = x % y
+    is_zero = y == 0
+    safe_y = tl.where(is_zero, 1, y)
+    r = x % safe_y
     c1 = r != 0
-    c2 = (x < 0) ^ (y < 0)
-    return tl.where(c1 & c2, x // y - 1, x // y)
+    c2 = (x < 0) ^ (safe_y < 0)
+    quotient = tl.where(c1 & c2, x // safe_y - 1, x // safe_y)
+    zero_quotient = tl.where(x < 0, x - 2, tl.where(x == 0, 2, x + 1))
+    return tl.where(is_zero, zero_quotient, quotient)
+
+
+@triton.jit
+def _hygon_int16_floordiv(x, y):
+    x = x.to(tl.int32)
+    y = y.to(tl.int32)
+    quotient = _hygon_int_floordiv_v3(x, y)
+    # torch.int16 floor_divide on Hygon has dtype-specific division-by-zero
+    # behavior.  Preserve it while widening normal arithmetic to int32.
+    zero_quotient = tl.where(x < 0, x - 2, tl.where(x == 0, 2, x + 1))
+    return tl.where(y == 0, zero_quotient, quotient)
 
 
 # TO be consistent with python, numpy and torch, we have to implement it in the
@@ -136,6 +232,12 @@ def _int_floordiv(x, y):
 # https://github.com/pytorch/pytorch/blob/d6d9183456cd07ca0b361a194b98c2fb196e7c36/c10/util/generic_math.h#L23
 @triton.jit
 def _float_floordiv(x, y):
+    # Hygon's libdevice fmod only accepts matching fp32/fp64 operands.
+    # Pointwise scalar promotion can otherwise produce (fp16/bf16, fp32).
+    orig_dtype = x.dtype
+    x = x.to(tl.float32)
+    y = y.to(tl.float32)
+
     # NOTE: fmod's sign is the same as the dividend
     remainder = fmod(x, y)
     imperfect = remainder != 0.0
@@ -156,19 +258,19 @@ def _float_floordiv(x, y):
     is_div_by_zero = y == 0.0
     float_division = x / y
     out = tl.where(is_div_by_zero, float_division, floor_q)
-    return out
+    return out.to(orig_dtype)
 
 
 @pointwise_dynamic(promotion_methods=[(0, 1, "DEFAULT")])
 @triton.jit
 def floor_div_func(x, y):
-    if x.type.scalar.is_int() & x.type.scalar.is_int():
+    if x.type.scalar.is_int() & y.type.scalar.is_int():
         if x.type.scalar.is_int16():
-            return _int_floordiv(x.to(tl.int32), y)
+            return _hygon_int16_floordiv(x, y)
         elif x.type.scalar.is_uint16():
-            return _int_floordiv(x.to(tl.uint32), y)
+            return _hygon_int_floordiv_v3(x.to(tl.uint32), y.to(tl.uint32))
         else:
-            return _int_floordiv(x, y)
+            return _hygon_int_floordiv_v3(x, y)
     else:
         return _float_floordiv(x, y)
 
@@ -176,13 +278,13 @@ def floor_div_func(x, y):
 @pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "DEFAULT")])
 @triton.jit
 def floor_div_func_tensor_scalar(x, y):
-    if x.type.scalar.is_int() & x.type.scalar.is_int():
+    if x.type.scalar.is_int() & y.type.scalar.is_int():
         if x.type.scalar.is_int16():
-            return _int_floordiv(x.to(tl.int32), y)
+            return _hygon_int16_floordiv(x, y)
         elif x.type.scalar.is_uint16():
-            return _int_floordiv(x.to(tl.uint32), y)
+            return _hygon_int_floordiv_v3(x.to(tl.uint32), y.to(tl.uint32))
         else:
-            return _int_floordiv(x, y)
+            return _hygon_int_floordiv_v3(x, y)
     else:
         return _float_floordiv(x, y)
 
@@ -190,13 +292,13 @@ def floor_div_func_tensor_scalar(x, y):
 @pointwise_dynamic(is_tensor=[False, True], promotion_methods=[(0, 1, "DEFAULT")])
 @triton.jit
 def floor_div_func_scalar_tensor(x, y):
-    if x.type.scalar.is_int() & x.type.scalar.is_int():
+    if x.type.scalar.is_int() & y.type.scalar.is_int():
         if x.type.scalar.is_int16():
-            return _int_floordiv(x.to(tl.int32), y)
+            return _hygon_int16_floordiv(x, y)
         elif x.type.scalar.is_uint16():
-            return _int_floordiv(x.to(tl.uint32), y)
+            return _hygon_int_floordiv_v3(x.to(tl.uint32), y.to(tl.uint32))
         else:
-            return _int_floordiv(x, y)
+            return _hygon_int_floordiv_v3(x, y)
     else:
         return _float_floordiv(x, y)
 

--- a/src/flag_gems/runtime/backend/_hygon/ops/fill.py
+++ b/src/flag_gems/runtime/backend/_hygon/ops/fill.py
@@ -48,6 +48,15 @@ def fill_scalar(input, value):
         return fill_scalar_func(input, value, out0=out)
 
 
+def fill_scalar_out(input, value, *, out=None):
+    logger.debug("GEMS_HYGON FILL_SCALAR_OUT")
+    if out is None:
+        return fill_scalar(input, value)
+    with torch_device_fn.device(input.device):
+        fill_scalar_func(input, value, out0=out)
+    return out
+
+
 def fill_tensor(input, value):
     if not value.is_cuda:
         return fill_scalar(input, value.item())
@@ -59,6 +68,21 @@ def fill_tensor(input, value):
     out = torch.empty_like(input)
     with torch_device_fn.device(input.device):
         return fill_tensor_func(input, value, out0=out)
+
+
+def fill_tensor_out(input, value, *, out=None):
+    logger.debug("GEMS_HYGON FILL_TENSOR_OUT")
+    if out is None:
+        return fill_tensor(input, value)
+    if not value.is_cuda:
+        return fill_scalar_out(input, value.item(), out=out)
+    if value.ndim != 0:
+        raise RuntimeError(
+            f"fill_ only supports 0-dimension value tensor but got tensor with {value.ndim} dimensions."
+        )
+    with torch_device_fn.device(input.device):
+        fill_tensor_func(input, value, out0=out)
+    return out
 
 
 def fill_tensor_(self, value):

--- a/src/flag_gems/runtime/backend/_hygon/ops/mm.py
+++ b/src/flag_gems/runtime/backend/_hygon/ops/mm.py
@@ -18,9 +18,8 @@ import torch
 import triton
 import triton.language as tl
 
-from flag_gems import runtime
 from flag_gems.runtime import torch_device_fn
-from flag_gems.utils import libentry, libtuner
+from flag_gems.utils import libentry
 from flag_gems.utils import triton_lang_extension as ext
 
 logger = logging.getLogger(__name__)
@@ -33,12 +32,7 @@ def prev_multiple_of(a, b):
 
 
 @libentry()
-@libtuner(
-    configs=runtime.get_tuned_config("mm"),
-    key=["M", "N", "K"],
-    strategy=["log", "log", "log"],
-)
-@triton.jit
+@triton.jit(do_not_specialize=["M", "N", "K"])
 def mm_kernel(
     a_ptr,
     b_ptr,
@@ -197,7 +191,13 @@ def mm(a, b):
             b.stride(1),
             c.stride(0),
             c.stride(1),
+            BLOCK_M=64,
+            BLOCK_N=64,
+            BLOCK_K=32,
             GROUP_M=8,
+            num_stages=1,
+            num_warps=4,
+            num_ldmatrixes=0,
         )
     return c
 
@@ -233,6 +233,12 @@ def mm_out(a, b, *, out):
             b.stride(1),
             c.stride(0),
             c.stride(1),
+            BLOCK_M=64,
+            BLOCK_N=64,
+            BLOCK_K=32,
             GROUP_M=8,
+            num_stages=1,
+            num_warps=4,
+            num_ldmatrixes=0,
         )
     return c

--- a/src/flag_gems/runtime/backend/_hygon/tune_configs.yaml
+++ b/src/flag_gems/runtime/backend/_hygon/tune_configs.yaml
@@ -1050,18 +1050,10 @@ weight_norm_kernel_last:
     num_warps: warps
   warps:
   - 4
-  - 8
-  - 16
   block_m:
-  - 512
-  - 1024
-  - 2048
+  - 256
   block_n:
   - 1
-  - 2
-  - 4
-  - 8
-  - 32
 weight_norm_kernel_first:
 - gen: true
   param_map:
@@ -1071,18 +1063,10 @@ weight_norm_kernel_first:
     num_warps: warps
   warps:
   - 4
-  - 8
-  - 16
   block_m:
   - 1
-  - 2
-  - 4
-  - 8
-  - 32
   block_n:
-  - 512
-  - 1024
-  - 2048
+  - 256
 weight_norm_kernel:
 - gen: true
   param_map:
@@ -1092,19 +1076,10 @@ weight_norm_kernel:
     num_warps: warps
   warps:
   - 4
-  - 8
-  - 16
   block_m:
   - 1
-  - 2
-  - 4
-  - 8
-  - 32
   block_n:
   - 256
-  - 512
-  - 1024
-  - 2048
 vector_norm:
 - gen: true
   param_map:


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description
Fix Hygon-specific division, fill, weight norm, and MM issues without changing generic operators:

  - Improved complex, mixed-precision, zero-division, in-place, and out handling for division and floor division.
  - Added missing Hygon fill.out registrations.
  - Restricted unsafe weight-norm tuning configurations to prevent GPU memory-access faults.
  - Replaced per-shape MM autotuning with a safe static configuration and disabled M/N/K specialization, reducing the MM test runtime
    from over 60 minutes to about 59 seconds.

  All original reproduction commands pass on Hygon GPUs.

### Issue
N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
benchmark on BW1000
```
FlagGems/benchmark# pytest -vs -m div_scalar_mode
/usr/local/lib/python3.10/dist-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
======================================================== test session starts =========================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/workspace/FlagGems/benchmark/.hypothesis/examples')
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.9.0, hypothesis-5.35.1, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting 360 items                                                                                                                 Uncaught exception in compile_worker subprocess
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/compile_worker/__main__.py", line 38, in main
    pre_fork_setup()
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/async_compile.py", line 62, in pre_fork_setup
    from triton.compiler.compiler import triton_key
ImportError: cannot import name 'triton_key' from 'triton.compiler.compiler' (/usr/local/lib/python3.10/dist-packages/triton/compiler/compiler.py)
collected 965 items / 962 deselected / 3 selected                                                                                    

test_div.py::test_div_scalar_mode[None] 
Operator: div_scalar_mode  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               4.239194            3.339675               1.269          [torch.Size([1073741824]), -2.5]
SUCCESS               0.008000            0.031840               0.251          [torch.Size([64, 64]), -2.5]
SUCCESS               0.072160            0.063680               1.133          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.074400            0.063840               1.165          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               4.239115            3.342556               1.268          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               1.064319            0.835199               1.274          [torch.Size([268435456]), -2.5]
SUCCESS               0.008960            0.027200               0.329          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.016320            0.056640               0.288          [torch.Size([10000, 256]), -2.5]
SUCCESS               2.589757            2.014318               1.286          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.008960            0.047120               0.190          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.016320            0.053600               0.304          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               2.589757            2.014477               1.286          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               6.415832            7.094551               0.904          [torch.Size([1073741824]), -2.5]
SUCCESS               0.008000            0.027680               0.289          [torch.Size([64, 64]), -2.5]
SUCCESS               0.102559            0.101760               1.008          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.102559            0.101760               1.008          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               6.416153            7.118231               0.901          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               1.604318            1.644958               0.975          [torch.Size([268435456]), -2.5]
SUCCESS               0.008960            0.027520               0.326          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.019520            0.025600               0.763          [torch.Size([10000, 256]), -2.5]
SUCCESS               3.913036            4.213275               0.929          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.008960            0.027040               0.331          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.019520            0.026560               0.735          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               3.914155            4.211355               0.929          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               4.239035            3.514796               1.206          [torch.Size([1073741824]), -2.5]
SUCCESS               0.008000            0.027040               0.296          [torch.Size([64, 64]), -2.5]
SUCCESS               0.072320            0.069600               1.039          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.072320            0.069600               1.039          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               4.239355            3.515436               1.206          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               1.064319            0.933119               1.141          [torch.Size([268435456]), -2.5]
SUCCESS               0.009120            0.026720               0.341          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.016320            0.026080               0.626          [torch.Size([10000, 256]), -2.5]
SUCCESS               2.589917            2.156957               1.201          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.009120            0.026720               0.341          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.016320            0.026560               0.614          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               2.589917            2.156798               1.201          [torch.Size([100, 65536, 100]), -2.5]

PASSED
test_div.py::test_div_scalar_mode[trunc] 
Operator: div_scalar_mode  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               6.417513            7.101431               0.904          [torch.Size([1073741824]), -2.5]
SUCCESS               0.008000            0.025120               0.318          [torch.Size([64, 64]), -2.5]
SUCCESS               0.102400            0.101920               1.005          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.102400            0.101920               1.005          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               6.415512            7.102391               0.903          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               1.604558            1.645918               0.975          [torch.Size([268435456]), -2.5]
SUCCESS               0.008960            0.025120               0.357          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.019520            0.022880               0.853          [torch.Size([10000, 256]), -2.5]
SUCCESS               3.900156            4.209675               0.926          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.008800            0.020160               0.437          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.019520            0.022880               0.853          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               3.902796            4.206075               0.928          [torch.Size([100, 65536, 100]), -2.5]

PASSED
test_div.py::test_div_scalar_mode[floor] 
Operator: div_scalar_mode  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               6.201113            8.886389               0.698          [torch.Size([1073741824]), -2.5]
SUCCESS               0.008000            0.025440               0.314          [torch.Size([64, 64]), -2.5]
SUCCESS               0.105120            0.157760               0.666          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.105280            0.158079               0.666          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               6.201272            8.885669               0.698          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               1.556318            2.273917               0.684          [torch.Size([268435456]), -2.5]
SUCCESS               0.009760            0.018880               0.517          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.023200            0.042880               0.541          [torch.Size([10000, 256]), -2.5]
SUCCESS               3.787835            5.464154               0.693          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.009920            0.019200               0.517          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.023200            0.030400               0.763          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               3.787516            5.464474               0.693          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               6.215193            8.547829               0.727          [torch.Size([1073741824]), -2.5]
SUCCESS               0.008000            0.019840               0.403          [torch.Size([64, 64]), -2.5]
SUCCESS               0.104319            0.152800               0.683          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.104160            0.152800               0.682          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               6.215513            8.545750               0.727          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               1.558478            2.189118               0.712          [torch.Size([268435456]), -2.5]
SUCCESS               0.009920            0.020160               0.492          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.022240            0.030560               0.728          [torch.Size([10000, 256]), -2.5]
SUCCESS               3.798476            5.277434               0.720          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.009760            0.020640               0.473          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.022240            0.029600               0.751          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               3.797675            5.255993               0.723          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               7.578071            9.298549               0.815          [torch.Size([1073741824]), -2.5]
SUCCESS               0.008000            0.027040               0.296          [torch.Size([64, 64]), -2.5]
SUCCESS               0.126880            0.164800               0.770          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.127040            0.164800               0.771          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               7.577511            9.298949               0.815          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               1.901118            2.380797               0.799          [torch.Size([268435456]), -2.5]
SUCCESS               0.010080            0.020480               0.492          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.026720            0.031360               0.852          [torch.Size([10000, 256]), -2.5]
SUCCESS               4.628794            5.717433               0.810          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.010080            0.023200               0.434          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.026560            0.045120               0.589          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               4.628155            5.716873               0.810          [torch.Size([100, 65536, 100]), -2.5]

PASSED

=========================================== 3 passed, 962 deselected in 146.29s (0:02:26) ============================================
```
```
FlagGems/benchmark# pytest -vs -m div_scalar_mode_
/usr/local/lib/python3.10/dist-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
======================================================== test session starts =========================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/workspace/FlagGems/benchmark/.hypothesis/examples')
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.9.0, hypothesis-5.35.1, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting 360 items                                                                                                                 Uncaught exception in compile_worker subprocess
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/compile_worker/__main__.py", line 38, in main
    pre_fork_setup()
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/async_compile.py", line 62, in pre_fork_setup
    from triton.compiler.compiler import triton_key
ImportError: cannot import name 'triton_key' from 'triton.compiler.compiler' (/usr/local/lib/python3.10/dist-packages/triton/compiler/compiler.py)
collected 965 items / 962 deselected / 3 selected                                                                                    

test_div.py::test_div_scalar_mode_inplace[None] 
Operator: div_scalar_mode_  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               4.239994            3.420956               1.239          [torch.Size([1073741824]), -2.5]
SUCCESS               0.008000            0.006560               1.220          [torch.Size([64, 64]), -2.5]
SUCCESS               0.073120            0.064480               1.134          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.073280            0.064480               1.136          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               4.379514            3.423036               1.279          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               1.065279            0.851199               1.252          [torch.Size([268435456]), -2.5]
SUCCESS               0.008960            0.006560               1.366          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.016960            0.014720               1.152          [torch.Size([10000, 256]), -2.5]
SUCCESS               2.590876            2.065438               1.254          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.008960            0.006560               1.366          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.016960            0.014720               1.152          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               2.590557            2.065278               1.254          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode_  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               6.592552            7.182551               0.918          [torch.Size([1073741824]), -2.5]
SUCCESS               0.008000            0.006560               1.220          [torch.Size([64, 64]), -2.5]
SUCCESS               0.104960            0.104960               1.000          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.104960            0.104000               1.009          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               6.591832            7.173112               0.919          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               1.649918            1.684318               0.980          [torch.Size([268435456]), -2.5]
SUCCESS               0.008800            0.006560               1.341          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.019840            0.019360               1.025          [torch.Size([10000, 256]), -2.5]
SUCCESS               4.025755            4.270955               0.943          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.008800            0.006560               1.341          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.019840            0.019360               1.025          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               4.026555            4.274394               0.942          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode_  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               4.240315            3.551036               1.194          [torch.Size([1073741824]), -2.5]
SUCCESS               0.008000            0.006560               1.220          [torch.Size([64, 64]), -2.5]
SUCCESS               0.073280            0.070240               1.043          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.073280            0.070240               1.043          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               4.240155            3.550955               1.194          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               1.065279            0.950559               1.121          [torch.Size([268435456]), -2.5]
SUCCESS               0.008960            0.006560               1.366          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.016960            0.016000               1.060          [torch.Size([10000, 256]), -2.5]
SUCCESS               2.590717            2.178077               1.189          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.008960            0.006560               1.366          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.016960            0.016000               1.060          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               2.590717            2.177598               1.190          [torch.Size([100, 65536, 100]), -2.5]

PASSED
test_div.py::test_div_scalar_mode_inplace[trunc] 
Operator: div_scalar_mode_  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               6.596952            7.178071               0.919          [torch.Size([1073741824]), -2.5]
SUCCESS               0.008000            0.006560               1.220          [torch.Size([64, 64]), -2.5]
SUCCESS               0.104960            0.105280               0.997          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.104960            0.105279               0.997          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               6.596153            7.179991               0.919          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               1.649598            1.684158               0.979          [torch.Size([268435456]), -2.5]
SUCCESS               0.008800            0.006560               1.341          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.019840            0.019520               1.016          [torch.Size([10000, 256]), -2.5]
SUCCESS               4.025755            4.276715               0.941          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.008960            0.006560               1.366          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.019840            0.019520               1.016          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               4.025435            4.274075               0.942          [torch.Size([100, 65536, 100]), -2.5]

PASSED
test_div.py::test_div_scalar_mode_inplace[floor] 
Operator: div_scalar_mode_  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               4.907034            7.661351               0.640          [torch.Size([1073741824]), -2.5]
SUCCESS               0.008000            0.007840               1.020          [torch.Size([64, 64]), -2.5]
SUCCESS               0.085120            0.131360               0.648          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.085120            0.131360               0.648          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               4.906875            7.661831               0.640          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               1.233278            1.966878               0.627          [torch.Size([268435456]), -2.5]
SUCCESS               0.009760            0.006560               1.488          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.020160            0.026080               0.773          [torch.Size([10000, 256]), -2.5]
SUCCESS               2.998396            4.715994               0.636          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.009760            0.006560               1.488          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.020160            0.026080               0.773          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               2.998396            4.716074               0.636          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode_  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               6.443032            7.497751               0.859          [torch.Size([1073741824]), -2.5]
SUCCESS               0.008000            0.006560               1.220          [torch.Size([64, 64]), -2.5]
SUCCESS               0.105120            0.131040               0.802          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.105120            0.131040               0.802          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               6.441193            7.493592               0.860          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               1.609998            1.915678               0.840          [torch.Size([268435456]), -2.5]
SUCCESS               0.009760            0.006560               1.488          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.021120            0.026400               0.800          [torch.Size([10000, 256]), -2.5]
SUCCESS               3.930075            4.577115               0.859          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.009760            0.006560               1.488          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.021120            0.026400               0.800          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               3.927196            4.577675               0.858          [torch.Size([100, 65536, 100]), -2.5]


Operator: div_scalar_mode_  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               4.241115            8.090950               0.524          [torch.Size([1073741824]), -2.5]
SUCCESS               0.008000            0.006560               1.220          [torch.Size([64, 64]), -2.5]
SUCCESS               0.074080            0.138560               0.535          [torch.Size([4096, 4096]), -2.5]
SUCCESS               0.074240            0.138560               0.536          [torch.Size([64, 512, 512]), -2.5]
SUCCESS               4.240955            8.091991               0.524          [torch.Size([1024, 1024, 1024]), -2.5]
SUCCESS               1.066399            2.078718               0.513          [torch.Size([268435456]), -2.5]
SUCCESS               0.009600            0.006560               1.463          [torch.Size([10000, 1]), -2.5]
SUCCESS               0.018080            0.027200               0.665          [torch.Size([10000, 256]), -2.5]
SUCCESS               2.591837            4.980154               0.520          [torch.Size([10000, 65536]), -2.5]
SUCCESS               0.009600            0.006560               1.463          [torch.Size([100, 1, 100]), -2.5]
SUCCESS               0.018080            0.027360               0.661          [torch.Size([100, 256, 100]), -2.5]
SUCCESS               2.591837            4.980154               0.520          [torch.Size([100, 65536, 100]), -2.5]

PASSED

=========================================== 3 passed, 962 deselected in 139.30s (0:02:19) ============================================
```
```
FlagGems/benchmark# pytest -vs -m div_tensor_mode
/usr/local/lib/python3.10/dist-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
======================================================== test session starts =========================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/workspace/FlagGems/benchmark/.hypothesis/examples')
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.9.0, hypothesis-5.35.1, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting 360 items                                                                                                                 Uncaught exception in compile_worker subprocess
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/compile_worker/__main__.py", line 38, in main
    pre_fork_setup()
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/async_compile.py", line 62, in pre_fork_setup
    from triton.compiler.compiler import triton_key
ImportError: cannot import name 'triton_key' from 'triton.compiler.compiler' (/usr/local/lib/python3.10/dist-packages/triton/compiler/compiler.py)
collected 965 items / 962 deselected / 3 selected                                                                                    

test_div.py::test_div_tensor_mode[None] 
Operator: div_tensor_mode  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               4.798714            5.268473               0.911          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.030560               0.262          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.080800            0.079680               1.014          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.080800            0.079680               1.014          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               4.798554            5.273113               0.910          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               1.204158            1.209119               0.996          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.009120            0.059360               0.154          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.017280            0.058720               0.294          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               2.931357            3.109596               0.943          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.009120            0.031840               0.286          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.017280            0.028160               0.614          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               2.931196            3.109757               0.943          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               9.874229           11.286227               0.875          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.030400               0.263          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.156799            0.157600               0.995          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.156640            0.167680               0.934          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               9.871348           11.278627               0.875          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               2.453757            2.597757               0.945          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.008800            0.025440               0.346          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.027680            0.027360               1.012          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               5.998793            6.803672               0.882          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.008800            0.030160               0.292          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.027680            0.027200               1.018          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               6.002713            6.799272               0.883          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               4.811994            5.247354               0.917          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.028000               0.286          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.081280            0.087360               0.930          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.081280            0.087520               0.929          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               4.811515            5.245193               0.917          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               1.207519            1.226239               0.985          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.009440            0.031520               0.299          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.017600            0.027360               0.643          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               2.939197            3.116636               0.943          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.009440            0.054640               0.173          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.017600            0.059040               0.298          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               2.939037            3.112796               0.944          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]

PASSED
test_div.py::test_div_tensor_mode[trunc] 
Operator: div_tensor_mode  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               9.787669           11.567347               0.846          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.026720               0.299          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.156799            0.157920               0.993          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.156799            0.157920               0.993          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               9.807829           11.605267               0.845          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               2.452637            2.603997               0.942          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.008800            0.027040               0.325          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.027680            0.036640               0.755          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               5.987433            6.874792               0.871          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.008800            0.026400               0.333          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.027680            0.037759               0.733          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               5.985113            6.895672               0.868          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]

PASSED
test_div.py::test_div_tensor_mode[floor] 
Operator: div_tensor_mode  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              12.694865           11.783826               1.077          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.025600               0.313          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.206559            0.196000               1.054          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.206560            0.195840               1.055          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS              12.694705           11.783186               1.077          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               3.179997            2.966237               1.072          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.010720            0.030400               0.353          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.038880            0.035680               1.090          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               7.751671            7.221272               1.073          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.010720            0.026240               0.409          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.038880            0.035680               1.090          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               7.751671            7.221752               1.073          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              11.179027           11.437427               0.977          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.026560               0.301          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.183680            0.193280               0.950          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.183680            0.193280               0.950          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS              11.179187           11.440146               0.977          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               2.801437            2.936156               0.954          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.010240            0.025440               0.403          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.036000            0.036480               0.987          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               6.830712            7.068792               0.966          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.010240            0.028320               0.362          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.036000            0.036480               0.987          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               6.830712            7.068311               0.966          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              14.282143           12.127026               1.178          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.027680               0.289          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.231520            0.200799               1.153          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.231520            0.200640               1.154          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS              14.282063           12.126626               1.178          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               3.576955            3.049037               1.173          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.011040            0.026080               0.423          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.043040            0.036480               1.180          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               8.720468            7.437751               1.172          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.011040            0.026400               0.418          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.043040            0.036480               1.180          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               8.720470            7.438712               1.172          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]

PASSED

=========================================== 3 passed, 962 deselected in 151.46s (0:02:31) ============================================
```
```
FlagGems/benchmark# pytest -vs -m div_tensor_mode_
/usr/local/lib/python3.10/dist-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
======================================================== test session starts =========================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/workspace/FlagGems/benchmark/.hypothesis/examples')
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.9.0, hypothesis-5.35.1, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting 360 items                                                                                                                 Uncaught exception in compile_worker subprocess
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/compile_worker/__main__.py", line 38, in main
    pre_fork_setup()
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/async_compile.py", line 62, in pre_fork_setup
    from triton.compiler.compiler import triton_key
ImportError: cannot import name 'triton_key' from 'triton.compiler.compiler' (/usr/local/lib/python3.10/dist-packages/triton/compiler/compiler.py)
collected 965 items / 962 deselected / 3 selected                                                                                    

test_div.py::test_div_tensor_mode_inplace[None] 
Operator: div_tensor_mode_  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               4.872313            5.284312               0.922          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.006560               1.220          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.081760            0.080480               1.016          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.081760            0.080480               1.016          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               4.871674            5.334553               0.913          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               1.222158            1.222879               0.999          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.009120            0.006560               1.390          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.017120            0.016000               1.070          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               2.976156            3.132636               0.950          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.009280            0.006560               1.415          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.017120            0.016000               1.070          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               2.975997            3.128636               0.951          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode_  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               9.923668           11.295907               0.879          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.006560               1.220          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.157759            0.158399               0.996          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.157600            0.158560               0.994          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               9.928309           10.903827               0.911          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               2.469277            2.609357               0.946          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.008800            0.006560               1.341          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.027680            0.027040               1.024          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               6.039833            6.654472               0.908          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.008800            0.006560               1.341          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.027680            0.027040               1.024          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               6.037113            6.644392               0.909          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode_  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               4.883995            5.301514               0.921          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.006560               1.220          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.082240            0.088800               0.926          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.082240            0.088800               0.926          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               4.884155            5.282794               0.925          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               1.225439            1.239519               0.989          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.009440            0.006560               1.439          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.017440            0.017440               1.000          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               2.983517            3.135036               0.952          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.009440            0.006560               1.439          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.017440            0.017440               1.000          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               2.983516            3.139356               0.950          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]

PASSED
test_div.py::test_div_tensor_mode_inplace[trunc] 
Operator: div_tensor_mode_  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               9.863188           11.606787               0.850          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.006560               1.220          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.157600            0.158560               0.994          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.157600            0.158560               0.994          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               9.864149           11.608867               0.850          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               2.468157            2.613437               0.944          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.008800            0.006560               1.341          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.027680            0.027360               1.012          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               6.021593            6.923192               0.870          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.008800            0.006560               1.341          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.027680            0.027360               1.012          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               6.024233            6.917352               0.871          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]

PASSED
test_div.py::test_div_tensor_mode_inplace[floor] 
Operator: div_tensor_mode_  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              13.410705           12.102226               1.108          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.006560               1.220          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.204799            0.193440               1.059          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.204960            0.193440               1.060          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS              13.402384           12.102226               1.107          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               3.218876            2.960316               1.087          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.010560            0.006720               1.571          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.038720            0.035520               1.090          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS               8.043511            7.320792               1.099          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.010560            0.006720               1.571          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.038720            0.035519               1.090          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS               8.043510            7.319991               1.099          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode_  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              23.373972           22.958533               1.018          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008960            0.007520               1.191          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.243520            0.222239               1.096          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.245120            0.222080               1.104          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS              23.373972           22.957733               1.018          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               5.409114            5.079674               1.065          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.010560            0.007200               1.467          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.044160            0.039680               1.113          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS              14.024464           13.651505               1.027          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.010240            0.007360               1.391          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.044480            0.039840               1.116          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS              14.023984           13.653105               1.027          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]


Operator: div_tensor_mode_  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              26.543568           23.887892               1.111          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008960            0.007360               1.217          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.293920            0.231359               1.270          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.301600            0.231200               1.304          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS              26.544768           23.887893               1.111          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               6.304953            5.405834               1.166          [torch.Size([268435456]), torch.Size([268435456])]
SUCCESS               0.011040            0.007840               1.408          [torch.Size([10000, 1]), torch.Size([10000, 1])]
SUCCESS               0.052320            0.040160               1.303          [torch.Size([10000, 256]), torch.Size([10000, 256])]
SUCCESS              16.119262           14.328703               1.125          [torch.Size([10000, 65536]), torch.Size([10000, 65536])]
SUCCESS               0.011520            0.007200               1.600          [torch.Size([100, 1, 100]), torch.Size([100, 1, 100])]
SUCCESS               0.085920            0.041920               2.050          [torch.Size([100, 256, 100]), torch.Size([100, 256, 100])]
SUCCESS              16.119502           14.327503               1.125          [torch.Size([100, 65536, 100]), torch.Size([100, 65536, 100])]

PASSED

=========================================== 3 passed, 962 deselected in 155.55s (0:02:35) ============================================
```
```
FlagGems/benchmark# pytest -vs -m fill_scalar_out
/usr/local/lib/python3.10/dist-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
======================================================== test session starts =========================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/workspace/FlagGems/benchmark/.hypothesis/examples')
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.9.0, hypothesis-5.35.1, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting 360 items                                                                                                                 Uncaught exception in compile_worker subprocess
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/compile_worker/__main__.py", line 38, in main
    pre_fork_setup()
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/async_compile.py", line 62, in pre_fork_setup
    from triton.compiler.compiler import triton_key
ImportError: cannot import name 'triton_key' from 'triton.compiler.compiler' (/usr/local/lib/python3.10/dist-packages/triton/compiler/compiler.py)
collected 965 items / 964 deselected / 1 selected                                                                                    

test_fill.py::test_fill_scalar_out 
Operator: fill_scalar_out  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              11.244465            1.744158               6.447          ([torch.Size([1073741824]), 3.14159], {'out': torch.Size([1073741824])})
SUCCESS               0.010720            0.006560               1.634          ([torch.Size([64, 64]), 3.14159], {'out': torch.Size([64, 64])})
SUCCESS               0.183040            0.033440               5.474          ([torch.Size([4096, 4096]), 3.14159], {'out': torch.Size([4096, 4096])})
SUCCESS               0.183040            0.033440               5.474          ([torch.Size([64, 512, 512]), 3.14159], {'out': torch.Size([64, 512, 512])})
SUCCESS              11.246066            1.746718               6.438          ([torch.Size([1024, 1024, 1024]), 3.14159], {'out': torch.Size([1024, 1024, 1024])})
SUCCESS               2.817116            0.398799               7.064          ([torch.Size([268435456]), 3.14159], {'out': torch.Size([268435456])})
SUCCESS               0.010720            0.006880               1.558          ([torch.Size([10000, 1]), 3.14159], {'out': torch.Size([10000, 1])})
SUCCESS               0.034240            0.009920               3.452          ([torch.Size([10000, 256]), 3.14159], {'out': torch.Size([10000, 256])})
SUCCESS               6.866712            1.015519               6.762          ([torch.Size([10000, 65536]), 3.14159], {'out': torch.Size([10000, 65536])})
SUCCESS               0.010720            0.006560               1.634          ([torch.Size([100, 1, 100]), 3.14159], {'out': torch.Size([100, 1, 100])})
SUCCESS               0.034240            0.009920               3.452          ([torch.Size([100, 256, 100]), 3.14159], {'out': torch.Size([100, 256, 100])})
SUCCESS               6.866711            1.014799               6.767          ([torch.Size([100, 65536, 100]), 3.14159], {'out': torch.Size([100, 65536, 100])})


Operator: fill_scalar_out  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              17.522860            3.718395               4.712          ([torch.Size([1073741824]), 3.14159], {'out': torch.Size([1073741824])})
SUCCESS               0.010720            0.006560               1.634          ([torch.Size([64, 64]), 3.14159], {'out': torch.Size([64, 64])})
SUCCESS               0.281120            0.051040               5.508          ([torch.Size([4096, 4096]), 3.14159], {'out': torch.Size([4096, 4096])})
SUCCESS               0.281279            0.051040               5.511          ([torch.Size([64, 512, 512]), 3.14159], {'out': torch.Size([64, 512, 512])})
SUCCESS              17.522858            3.709755               4.723          ([torch.Size([1024, 1024, 1024]), 3.14159], {'out': torch.Size([1024, 1024, 1024])})
SUCCESS               4.386075            0.827839               5.298          ([torch.Size([268435456]), 3.14159], {'out': torch.Size([268435456])})
SUCCESS               0.010560            0.006560               1.610          ([torch.Size([10000, 1]), 3.14159], {'out': torch.Size([10000, 1])})
SUCCESS               0.049280            0.011520               4.278          ([torch.Size([10000, 256]), 3.14159], {'out': torch.Size([10000, 256])})
SUCCESS              10.696467            2.150397               4.974          ([torch.Size([10000, 65536]), 3.14159], {'out': torch.Size([10000, 65536])})
SUCCESS               0.010560            0.006560               1.610          ([torch.Size([100, 1, 100]), 3.14159], {'out': torch.Size([100, 1, 100])})
SUCCESS               0.049280            0.011520               4.278          ([torch.Size([100, 256, 100]), 3.14159], {'out': torch.Size([100, 256, 100])})
SUCCESS              10.698707            2.152557               4.970          ([torch.Size([100, 65536, 100]), 3.14159], {'out': torch.Size([100, 65536, 100])})


Operator: fill_scalar_out  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS              11.245906            1.745037               6.445          ([torch.Size([1073741824]), 3.14159], {'out': torch.Size([1073741824])})
SUCCESS               0.010560            0.006560               1.610          ([torch.Size([64, 64]), 3.14159], {'out': torch.Size([64, 64])})
SUCCESS               0.183199            0.033440               5.478          ([torch.Size([4096, 4096]), 3.14159], {'out': torch.Size([4096, 4096])})
SUCCESS               0.183040            0.033600               5.448          ([torch.Size([64, 512, 512]), 3.14159], {'out': torch.Size([64, 512, 512])})
SUCCESS              11.244467            1.745518               6.442          ([torch.Size([1024, 1024, 1024]), 3.14159], {'out': torch.Size([1024, 1024, 1024])})
SUCCESS               2.817117            0.398799               7.064          ([torch.Size([268435456]), 3.14159], {'out': torch.Size([268435456])})
SUCCESS               0.010720            0.006560               1.634          ([torch.Size([10000, 1]), 3.14159], {'out': torch.Size([10000, 1])})
SUCCESS               0.034240            0.009920               3.452          ([torch.Size([10000, 256]), 3.14159], {'out': torch.Size([10000, 256])})
SUCCESS               6.866712            1.015359               6.763          ([torch.Size([10000, 65536]), 3.14159], {'out': torch.Size([10000, 65536])})
SUCCESS               0.010720            0.006560               1.634          ([torch.Size([100, 1, 100]), 3.14159], {'out': torch.Size([100, 1, 100])})
SUCCESS               0.034240            0.009920               3.452          ([torch.Size([100, 256, 100]), 3.14159], {'out': torch.Size([100, 256, 100])})
SUCCESS               6.866712            1.016159               6.758          ([torch.Size([100, 65536, 100]), 3.14159], {'out': torch.Size([100, 65536, 100])})

PASSED

============================================ 1 passed, 964 deselected in 67.38s (0:01:07) ============================================
```
```
FlagGems/benchmark# pytest -vs -m floor_divide_tensor
/usr/local/lib/python3.10/dist-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
======================================================== test session starts =========================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/workspace/FlagGems/benchmark/.hypothesis/examples')
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.9.0, hypothesis-5.35.1, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting 360 items                                                                                                                 Uncaught exception in compile_worker subprocess
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/compile_worker/__main__.py", line 38, in main
    pre_fork_setup()
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/async_compile.py", line 62, in pre_fork_setup
    from triton.compiler.compiler import triton_key
ImportError: cannot import name 'triton_key' from 'triton.compiler.compiler' (/usr/local/lib/python3.10/dist-packages/triton/compiler/compiler.py)
collected 965 items / 964 deselected / 1 selected                                                                                    

test_floor_divide.py::test_floor_divide_tensor 
Operator: floor_divide_tensor  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS              11.194064           11.491182               0.974               0.187          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.015200               0.526               0.001          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.183840            0.193440               0.950               0.173          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.183840            0.193440               0.950               0.173          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS              11.193983           11.489183               0.974               0.187          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.008000            0.017920               0.446               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.008000            0.019040               0.420               0.002          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.011680            0.019360               0.603               0.027          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.053280            0.054560               0.977               0.154          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.708159            0.743359               0.953               0.181          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.008000            0.018240               0.439               0.000          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.008000            0.018880               0.424               0.007          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.020000            0.059360               0.337               0.035          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.183840            0.193440               0.950               0.173          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               2.803995            2.939836               0.954               0.183          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]


Operator: floor_divide_tensor  Performance Test (dtype=torch.int16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               6.341909            7.542467               0.841               0.285          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.020000               0.400               0.000          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.107040            0.134399               0.796               0.250          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.107040            0.133120               0.804               0.252          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               6.344310            7.543188               0.841               0.285          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.008000            0.020320               0.394               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.008000            0.020640               0.388               0.002          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.008640            0.020160               0.429               0.026          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.032960            0.039039               0.844               0.215          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.404159            0.511520               0.790               0.262          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.008000            0.048000               0.167               0.000          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.008000            0.019280               0.415               0.007          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.013760            0.057119               0.241               0.037          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.107040            0.134240               0.797               0.250          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               1.591837            1.930076               0.825               0.278          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]


Operator: floor_divide_tensor  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               9.731984           11.447101               0.850               0.188          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.019520               0.410               0.000          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.157120            0.164639               0.954               0.204          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.157279            0.164480               0.956               0.204          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               9.734543           11.459661               0.849               0.187          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.008000            0.020160               0.397               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.008000            0.019040               0.420               0.002          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.009280            0.020320               0.457               0.026          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.043680            0.045760               0.955               0.183          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.612959            0.634719               0.966               0.211          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.008000            0.018720               0.427               0.000          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.008000            0.019520               0.410               0.007          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.015840            0.019680               0.805               0.107          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.157280            0.164480               0.956               0.204          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               2.434876            2.591516               0.940               0.207          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]

PASSED

=========================================== 1 passed, 964 deselected in 160.54s (0:02:40) ============================================
```
```
FlagGems/benchmark# pytest -vs -m floor_divide_tensor_
/usr/local/lib/python3.10/dist-packages/pytest_asyncio/plugin.py:217: PytestDeprecationWarning: The configuration option "asyncio_default_fixture_loop_scope" is unset.
The event loop scope for asynchronous fixtures will default to the fixture caching scope. Future versions of pytest-asyncio will default the loop scope for asynchronous fixtures to function scope. Set the default fixture loop scope explicitly in order to avoid unexpected behavior in the future. Valid fixture loop scopes are: "function", "class", "module", "package", "session"

  warnings.warn(PytestDeprecationWarning(_DEFAULT_FIXTURE_LOOP_SCOPE_UNSET))
======================================================== test session starts =========================================================
platform linux -- Python 3.10.12, pytest-8.3.5, pluggy-1.5.0 -- /usr/bin/python3
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase('/workspace/FlagGems/benchmark/.hypothesis/examples')
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: anyio-4.9.0, hypothesis-5.35.1, asyncio-0.26.0
asyncio: mode=strict, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collecting 360 items                                                                                                                 Uncaught exception in compile_worker subprocess
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/compile_worker/__main__.py", line 38, in main
    pre_fork_setup()
  File "/usr/local/lib/python3.10/dist-packages/torch/_inductor/async_compile.py", line 62, in pre_fork_setup
    from triton.compiler.compiler import triton_key
ImportError: cannot import name 'triton_key' from 'triton.compiler.compiler' (/usr/local/lib/python3.10/dist-packages/triton/compiler/compiler.py)
collected 965 items / 964 deselected / 1 selected                                                                                    

test_floor_divide.py::test_floor_divide_tensor_inplace 
Operator: floor_divide_tensor_  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS              23.376923           23.010525               1.016               0.093          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008640            0.007360               1.174               0.001          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.242719            0.219679               1.105               0.153          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.241919            0.219040               1.104               0.153          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS              23.372444           22.960684               1.018               0.094          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.008960            0.006560               1.366               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.008800            0.007680               1.146               0.004          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.012960            0.011360               1.141               0.046          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.065280            0.058879               1.109               0.142          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               1.116319            0.994479               1.123               0.135          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.008800            0.007680               1.146               0.001          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.009600            0.008160               1.176               0.016          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.023840            0.021440               1.112               0.098          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.241600            0.218880               1.104               0.153          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               5.415192            5.065592               1.069               0.106          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]


Operator: floor_divide_tensor_  Performance Test (dtype=torch.int16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               6.379190            7.539188               0.846               0.285          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.006560               1.220               0.001          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.107680            0.134719               0.799               0.249          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.107679            0.134720               0.799               0.249          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               6.381590            7.542548               0.846               0.285          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.008000            0.006560               1.220               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.008000            0.006560               1.220               0.005          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.008480            0.007520               1.128               0.070          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.032960            0.039040               0.844               0.215          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.406400            0.512480               0.793               0.262          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.008000            0.006560               1.220               0.001          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.008000            0.006720               1.190               0.020          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.013760            0.056960               0.242               0.037          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.107680            0.134720               0.799               0.249          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               1.601117            1.931197               0.829               0.278          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]


Operator: floor_divide_tensor_  Performance Test (dtype=torch.int32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup               TFLOPS          Size Detail
--------------------------------------------------------------------------------------------------------------------
SUCCESS               9.779184           11.480462               0.852               0.187          [torch.Size([1073741824]), torch.Size([1073741824])]
SUCCESS               0.008000            0.006560               1.220               0.001          [torch.Size([64, 64]), torch.Size([64, 64])]
SUCCESS               0.157920            0.165440               0.955               0.203          [torch.Size([4096, 4096]), torch.Size([4096, 4096])]
SUCCESS               0.158079            0.165280               0.956               0.203          [torch.Size([64, 512, 512]), torch.Size([64, 512, 512])]
SUCCESS               9.793425           11.494302               0.852               0.187          [torch.Size([1024, 1024, 1024]), torch.Size([1024, 1024, 1024])]
SUCCESS               0.008000            0.010880               0.735               0.000          [torch.Size([1024, 1]), torch.Size([1024, 1])]
SUCCESS               0.008000            0.011520               0.694               0.003          [torch.Size([1024, 16]), torch.Size([1024, 16])]
SUCCESS               0.009280            0.012000               0.773               0.044          [torch.Size([1024, 256]), torch.Size([1024, 256])]
SUCCESS               0.043840            0.046080               0.951               0.182          [torch.Size([1024, 4096]), torch.Size([1024, 4096])]
SUCCESS               0.616719            0.638079               0.967               0.210          [torch.Size([1024, 65536]), torch.Size([1024, 65536])]
SUCCESS               0.008000            0.006560               1.220               0.001          [torch.Size([64, 64, 1]), torch.Size([64, 64, 1])]
SUCCESS               0.008000            0.006880               1.163               0.019          [torch.Size([64, 64, 16]), torch.Size([64, 64, 16])]
SUCCESS               0.015840            0.016320               0.971               0.129          [torch.Size([64, 64, 256]), torch.Size([64, 64, 256])]
SUCCESS               0.158080            0.165280               0.956               0.203          [torch.Size([64, 64, 4096]), torch.Size([64, 64, 4096])]
SUCCESS               2.451356            2.600156               0.943               0.206          [torch.Size([64, 64, 65536]), torch.Size([64, 64, 65536])]

PASSED

=========================================== 1 passed, 964 deselected in 161.39s (0:02:41) ============================================
```