### PR TITLE
feat:add te_fused_topk_with_score_function_fwd support

### DIFF
--- a/benchmark/test_te_fused_topk_with_score_function_fwd.py
+++ b/benchmark/test_te_fused_topk_with_score_function_fwd.py
@@ -1,0 +1,185 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0
+
+import pytest
+import torch
+
+from flag_gems.fused.te_fused_topk_with_score_function_fwd import (
+    te_fused_topk_with_score_function_fwd,
+)
+
+from . import base
+
+try:
+    from transformer_engine.pytorch import cpp_extensions as tex
+
+    TE_FWD = getattr(tex, "fused_topk_with_score_function_fwd", None)
+except ImportError:
+    TE_FWD = None
+
+SCORE_NAMES = {0: "sigmoid", 1: "softmax", 2: "sqrtsoftplus"}
+
+
+def _sqrtsoftplus(x):
+    sp = torch.where(x > 20.0, x, torch.log1p(torch.exp(x)))
+    return torch.sqrt(sp)
+
+
+def _make_routing_map(indices, num_experts):
+    routing_map = torch.zeros(
+        indices.shape[0],
+        num_experts,
+        dtype=torch.bool,
+        device=indices.device,
+    )
+    routing_map.scatter_(1, indices, True)
+    return routing_map
+
+
+def _torch_reference_fwd(
+    logits,
+    topk,
+    use_pre_softmax=True,
+    num_groups=None,
+    group_topk=None,
+    scaling_factor=1.0,
+    score_function=1,
+    expert_bias=None,
+):
+    _ = num_groups, group_topk
+    x = logits.float()
+    num_experts = x.shape[1]
+
+    if score_function == 0:
+        intermediate = torch.sigmoid(x)
+        scores = intermediate
+        if expert_bias is not None:
+            scores = scores + expert_bias.float()
+        indices = scores.topk(topk, dim=-1).indices
+        routing_map = _make_routing_map(indices, num_experts)
+        selected = torch.where(routing_map, intermediate, torch.zeros_like(x))
+        if topk > 1:
+            selected = selected / (selected.sum(dim=-1, keepdim=True) + 1e-20)
+        return (selected * scaling_factor).to(logits.dtype), routing_map, intermediate
+
+    if score_function == 1 and use_pre_softmax:
+        intermediate = torch.softmax(x, dim=-1)
+        indices = intermediate.topk(topk, dim=-1).indices
+        routing_map = _make_routing_map(indices, num_experts)
+        probs = torch.where(routing_map, intermediate * scaling_factor, 0.0)
+        return probs.to(logits.dtype), routing_map, intermediate
+
+    if score_function == 1:
+        indices = x.topk(topk, dim=-1).indices
+        routing_map = _make_routing_map(indices, num_experts)
+        selected_logits = x.gather(1, indices)
+        selected_probs = torch.softmax(selected_logits, dim=-1)
+        probs = torch.zeros_like(x)
+        probs.scatter_(1, indices, selected_probs * scaling_factor)
+        intermediate = torch.full_like(x, float("-inf"))
+        intermediate.scatter_(1, indices, selected_probs)
+        return probs.to(logits.dtype), routing_map, intermediate
+
+    intermediate = x
+    act = _sqrtsoftplus(x)
+    scores = act
+    if expert_bias is not None:
+        scores = scores + expert_bias.float()
+    indices = scores.topk(topk, dim=-1).indices
+    routing_map = _make_routing_map(indices, num_experts)
+    selected = torch.where(routing_map, act, torch.zeros_like(x))
+    if topk > 1:
+        selected = selected / (selected.sum(dim=-1, keepdim=True) + 1e-20)
+    return (selected * scaling_factor).to(logits.dtype), routing_map, intermediate
+
+
+def _baseline_fwd(*args, **kwargs):
+    if TE_FWD is None:
+        return _torch_reference_fwd(*args, **kwargs)
+    logits = args[0]
+    topk = args[1]
+    use_pre_softmax = args[2]
+    num_groups = args[3]
+    group_topk = args[4]
+    scaling_factor = args[5]
+    score_function = args[6]
+    expert_bias = args[7]
+    try:
+        return TE_FWD(
+            logits,
+            topk,
+            use_pre_softmax,
+            num_groups,
+            group_topk,
+            scaling_factor,
+            SCORE_NAMES[score_function],
+            expert_bias,
+            0,
+            None,
+        )
+    except TypeError:
+        return _torch_reference_fwd(*args, **kwargs)
+
+
+class FusedTopkWithScoreFunctionFwdBenchmark(base.Benchmark):
+    DEFAULT_SHAPE_DESC = "num_tokens, num_experts, topk"
+
+    def __init__(self, score_function, use_pre_softmax=True):
+        self.score_function = score_function
+        self.use_pre_softmax = use_pre_softmax
+        super().__init__(
+            op_name="te_fused_topk_with_score_function_fwd",
+            torch_op=_baseline_fwd,
+            gems_op=te_fused_topk_with_score_function_fwd,
+            dtypes=[torch.float16, torch.bfloat16, torch.float32],
+        )
+
+    def set_shapes(self, shape_file_path=None):
+        _ = shape_file_path
+        self.shapes = [
+            (1, 64, 8),
+            (16, 64, 8),
+            (128, 64, 8),
+            (512, 128, 8),
+            (1024, 128, 8),
+            (2048, 256, 8),
+            (4096, 256, 8),
+        ]
+        self.shape_desc = self.DEFAULT_SHAPE_DESC
+
+    def get_input_iter(self, dtype):
+        for num_tokens, num_experts, topk in self.shapes:
+            torch.manual_seed(0)
+            logits = torch.randn(
+                num_tokens,
+                num_experts,
+                device=self.device,
+                dtype=dtype,
+            )
+            yield (
+                logits,
+                topk,
+                self.use_pre_softmax,
+                None,
+                None,
+                1.0,
+                self.score_function,
+                None,
+            )
+
+
+@pytest.mark.te_fused_topk_with_score_function_fwd
+@pytest.mark.parametrize(
+    ("score_function", "use_pre_softmax"),
+    [(0, True), (1, True), (1, False), (2, True)],
+    ids=["sigmoid", "softmax_pre", "softmax_post", "sqrtsoftplus"],
+)
+def test_te_fused_topk_with_score_function_fwd_benchmark(
+    score_function,
+    use_pre_softmax,
+):
+    FusedTopkWithScoreFunctionFwdBenchmark(
+        score_function=score_function,
+        use_pre_softmax=use_pre_softmax,
+    ).run()

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -3898,6 +3898,20 @@ ops:
       - MoE
     stages:
       - stable: '5.0'
+  - id: te_fused_topk_with_score_function_fwd
+    description: |
+      Forward pass for TransformerEngine-compatible fused top-k routing with score function.
+      Produces sparse routing probabilities, routing map, and intermediate values for backward.
+      Supports sigmoid, softmax, and sqrtsoftplus score functions.
+    for:
+      - te_fused_topk_with_score_function_fwd
+    labels:
+      - fused
+      - MoE
+    kind:
+      - MoE
+    stages:
+      - alpha: '5.4'
   - id: gt
     description: Computes that `input` is greater than `other` element-wise.
     for:

--- a/src/flag_gems/fused/__init__.py
+++ b/src/flag_gems/fused/__init__.py
@@ -106,6 +106,9 @@ from flag_gems.fused.stage_deepseek_v4_mega_moe_inputs import (
     stage_deepseek_v4_mega_moe_inputs,
 )
 from flag_gems.fused.swiglu import dswiglu, swiglu
+from flag_gems.fused.te_fused_topk_with_score_function_fwd import (
+    te_fused_topk_with_score_function_fwd,
+)
 from flag_gems.fused.top_k_per_row_decode import top_k_per_row_decode
 from flag_gems.fused.top_k_per_row_prefill import top_k_per_row_prefill
 from flag_gems.fused.topk_softmax import topk_softmax
@@ -189,6 +192,7 @@ __all__ = [
     "swiglu",
     "top_k_per_row_decode",
     "top_k_per_row_prefill",
+    "te_fused_topk_with_score_function_fwd",
     "topk_softmax",
     "topk_softplus_sqrt",
     "unpack_seq_triton",

--- a/src/flag_gems/fused/te_fused_topk_with_score_function_fwd.py
+++ b/src/flag_gems/fused/te_fused_topk_with_score_function_fwd.py
@@ -1,0 +1,407 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0
+#
+# Forward pass for fused top-k with score function (training path).
+# Reference: NVIDIA TransformerEngine fused_router/fused_topk_with_score_function.cu
+#
+# This kernel produces the outputs needed for backward:
+#   probs: [T, E] sparse: only topk positions have values, rest are 0
+#   routing_map: [T, E] bool: True at selected expert positions
+#   intermediate_output: [T, E] float32: saved activations for backward
+#
+# Flow per score_function:
+#   sigmoid (0):      sigmoid -> [+bias] -> topk -> normalize(topk) -> *scale
+#   softmax (1):      pre:  softmax(all) -> topk -> *scale
+#                     post: topk -> softmax(topk) -> *scale
+#   sqrtsoftplus (2): sqrtsoftplus -> [+bias] -> topk -> normalize(topk) -> *scale
+#
+# For grouped_topk (num_groups > 0), delegates to te_grouped_topk which uses
+# the high-performance two-kernel approach.
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+EPSILON = 1.0e-20
+
+_SCORE_FUNCTIONS = {
+    "sigmoid": 0,
+    "softmax": 1,
+    "sqrtsoftplus": 2,
+}
+
+
+@libentry()
+@triton.jit
+def _fused_topk_fwd_sigmoid_kernel(
+    logits_ptr,
+    expert_bias_ptr,
+    probs_ptr,
+    routing_map_ptr,
+    intermediate_ptr,
+    num_tokens,
+    num_experts,
+    scaling_factor,
+    HAS_BIAS: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+):
+    """Forward: sigmoid score function."""
+    pid = tl.program_id(0)
+    if pid >= num_tokens:
+        return
+
+    expert_offsets = tl.arange(0, BLOCK_E)
+    mask = expert_offsets < num_experts
+    row_base = pid * num_experts
+
+    x = tl.load(logits_ptr + row_base + expert_offsets, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    act = 1.0 / (1.0 + tl.exp(-x))
+    tl.store(intermediate_ptr + row_base + expert_offsets, act, mask=mask)
+
+    if HAS_BIAS:
+        bias = tl.load(expert_bias_ptr + expert_offsets, mask=mask, other=0.0).to(
+            tl.float32
+        )
+        scores = act + bias
+    else:
+        scores = act
+
+    topk_mask = _topk_selection(
+        tl.where(mask, scores, -float("inf")),
+        expert_offsets,
+        TOPK,
+        BLOCK_E=BLOCK_E,
+    )
+    selected_act = tl.where(topk_mask == 1, act, 0.0)
+
+    if TOPK > 1:
+        sum_selected = tl.sum(selected_act, axis=0) + EPSILON
+        normalized = selected_act / sum_selected
+    else:
+        normalized = selected_act
+
+    probs_out = normalized * scaling_factor
+    tl.store(
+        probs_ptr + row_base + expert_offsets,
+        probs_out.to(probs_ptr.dtype.element_ty),
+        mask=mask,
+    )
+    tl.store(routing_map_ptr + row_base + expert_offsets, topk_mask == 1, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _fused_topk_fwd_softmax_pre_kernel(
+    logits_ptr,
+    probs_ptr,
+    routing_map_ptr,
+    intermediate_ptr,
+    num_tokens,
+    num_experts,
+    scaling_factor,
+    TOPK: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+):
+    """Forward: softmax pre-softmax mode."""
+    pid = tl.program_id(0)
+    if pid >= num_tokens:
+        return
+
+    expert_offsets = tl.arange(0, BLOCK_E)
+    mask = expert_offsets < num_experts
+    row_base = pid * num_experts
+
+    x = tl.load(
+        logits_ptr + row_base + expert_offsets, mask=mask, other=-float("inf")
+    ).to(tl.float32)
+    row_max = tl.max(tl.where(mask, x, -float("inf")), axis=0)
+    exp_vals = tl.where(mask, tl.exp(x - row_max), 0.0)
+    softmax_out = exp_vals / (tl.sum(exp_vals, axis=0) + EPSILON)
+
+    tl.store(intermediate_ptr + row_base + expert_offsets, softmax_out, mask=mask)
+
+    topk_mask = _topk_selection(
+        tl.where(mask, softmax_out, -float("inf")),
+        expert_offsets,
+        TOPK,
+        BLOCK_E=BLOCK_E,
+    )
+
+    probs_out = tl.where(topk_mask == 1, softmax_out * scaling_factor, 0.0)
+    tl.store(
+        probs_ptr + row_base + expert_offsets,
+        probs_out.to(probs_ptr.dtype.element_ty),
+        mask=mask,
+    )
+    tl.store(routing_map_ptr + row_base + expert_offsets, topk_mask == 1, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _fused_topk_fwd_softmax_post_kernel(
+    logits_ptr,
+    probs_ptr,
+    routing_map_ptr,
+    intermediate_ptr,
+    num_tokens,
+    num_experts,
+    scaling_factor,
+    TOPK: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+):
+    """Forward: softmax post-softmax mode."""
+    pid = tl.program_id(0)
+    if pid >= num_tokens:
+        return
+
+    expert_offsets = tl.arange(0, BLOCK_E)
+    mask = expert_offsets < num_experts
+    row_base = pid * num_experts
+
+    x = tl.load(
+        logits_ptr + row_base + expert_offsets, mask=mask, other=-float("inf")
+    ).to(tl.float32)
+
+    topk_mask = _topk_selection(
+        tl.where(mask, x, -float("inf")),
+        expert_offsets,
+        TOPK,
+        BLOCK_E=BLOCK_E,
+    )
+
+    selected_logits = tl.where(topk_mask == 1, x, -float("inf"))
+    row_max = tl.max(selected_logits, axis=0)
+    exp_vals = tl.where(topk_mask == 1, tl.exp(selected_logits - row_max), 0.0)
+    softmax_out = exp_vals / (tl.sum(exp_vals, axis=0) + EPSILON)
+
+    intermediate_out = tl.where(topk_mask == 1, softmax_out, -float("inf"))
+    tl.store(intermediate_ptr + row_base + expert_offsets, intermediate_out, mask=mask)
+
+    probs_out = tl.where(topk_mask == 1, softmax_out * scaling_factor, 0.0)
+    tl.store(
+        probs_ptr + row_base + expert_offsets,
+        probs_out.to(probs_ptr.dtype.element_ty),
+        mask=mask,
+    )
+    tl.store(routing_map_ptr + row_base + expert_offsets, topk_mask == 1, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _fused_topk_fwd_sqrtsoftplus_kernel(
+    logits_ptr,
+    expert_bias_ptr,
+    probs_ptr,
+    routing_map_ptr,
+    intermediate_ptr,
+    num_tokens,
+    num_experts,
+    scaling_factor,
+    HAS_BIAS: tl.constexpr,
+    TOPK: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+):
+    """Forward: sqrtsoftplus score function."""
+    pid = tl.program_id(0)
+    if pid >= num_tokens:
+        return
+
+    expert_offsets = tl.arange(0, BLOCK_E)
+    mask = expert_offsets < num_experts
+    row_base = pid * num_experts
+
+    x = tl.load(logits_ptr + row_base + expert_offsets, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    tl.store(intermediate_ptr + row_base + expert_offsets, x, mask=mask)
+
+    sp = tl.where(x > 20.0, x, tl.log(1.0 + tl.exp(x)))
+    act = tl.sqrt(sp)
+
+    if HAS_BIAS:
+        bias = tl.load(expert_bias_ptr + expert_offsets, mask=mask, other=0.0).to(
+            tl.float32
+        )
+        scores = act + bias
+    else:
+        scores = act
+
+    topk_mask = _topk_selection(
+        tl.where(mask, scores, -float("inf")),
+        expert_offsets,
+        TOPK,
+        BLOCK_E=BLOCK_E,
+    )
+    selected_act = tl.where(topk_mask == 1, act, 0.0)
+
+    if TOPK > 1:
+        sum_selected = tl.sum(selected_act, axis=0) + EPSILON
+        normalized = selected_act / sum_selected
+    else:
+        normalized = selected_act
+
+    probs_out = normalized * scaling_factor
+    tl.store(
+        probs_ptr + row_base + expert_offsets,
+        probs_out.to(probs_ptr.dtype.element_ty),
+        mask=mask,
+    )
+    tl.store(routing_map_ptr + row_base + expert_offsets, topk_mask == 1, mask=mask)
+
+
+@triton.jit
+def _topk_selection(scores, expert_offsets, TOPK: tl.constexpr, BLOCK_E: tl.constexpr):
+    """Select topk positions from scores, return mask [BLOCK_E] of int32 (0/1)."""
+    topk_mask = tl.zeros([BLOCK_E], dtype=tl.int32)
+    s = scores
+    for _k in range(TOPK):
+        max_score = tl.max(s, axis=0)
+        is_max = s == max_score
+        match_priority = tl.where(is_max, BLOCK_E - expert_offsets, 0)
+        best_slot = BLOCK_E - tl.max(match_priority, axis=0)
+        eidx = best_slot.to(tl.int32)
+        topk_mask = tl.where(expert_offsets == eidx, 1, topk_mask)
+        s = tl.where(expert_offsets == eidx, -float("inf"), s)
+    return topk_mask
+
+
+def te_fused_topk_with_score_function_fwd(
+    logits: torch.Tensor,
+    topk: int,
+    use_pre_softmax: bool = True,
+    num_groups: int = None,
+    group_topk: int = None,
+    scaling_factor: float = 1.0,
+    score_function: int | str = 1,
+    expert_bias: torch.Tensor = None,
+    *_,
+) -> tuple:
+    """Forward pass for fused top-k with score function (training path).
+
+    Produces outputs compatible with te_fused_topk_with_score_function_bwd.
+
+    For grouped_topk (num_groups > 0), delegates to te_grouped_topk which
+    uses the high-performance two-kernel approach.
+
+    Args:
+        logits: [num_tokens, num_experts] input logits.
+        topk: number of experts selected per token.
+        use_pre_softmax: (softmax only) apply softmax before topk.
+        num_groups: number of groups for grouped topk (-1 = disabled).
+        group_topk: number of groups to select (-1 = disabled).
+        scaling_factor: output scaling factor.
+        score_function: 0=sigmoid, 1=softmax, 2=sqrtsoftplus.
+        expert_bias: optional [num_experts] bias (sigmoid/sqrtsoftplus only).
+
+    Returns:
+        probs: [num_tokens, num_experts] sparse output (same dtype as logits).
+        routing_map: [num_tokens, num_experts] bool, True at selected positions.
+        intermediate_output: [num_tokens, num_experts] float32, for backward.
+    """
+    logger.debug("GEMS TE_FUSED_TOPK_WITH_SCORE_FUNCTION FWD")
+    if isinstance(score_function, str):
+        score_function = _SCORE_FUNCTIONS[score_function]
+    assert score_function in (
+        0,
+        1,
+        2,
+    ), f"score_function must be 0, 1, or 2, got {score_function}"
+    num_groups = -1 if num_groups is None else int(num_groups)
+    group_topk = -1 if group_topk is None else int(group_topk)
+
+    # Delegate grouped_topk to the high-performance two-kernel path
+    if group_topk > 0 and num_groups > 0:
+        from flag_gems.fused.te_grouped_topk import te_grouped_topk
+
+        return te_grouped_topk(
+            logits,
+            topk,
+            num_groups,
+            group_topk,
+            use_pre_softmax,
+            scaling_factor,
+            score_function,
+            expert_bias,
+        )
+
+    num_tokens, num_experts = logits.shape
+    probs = torch.zeros(
+        num_tokens, num_experts, dtype=logits.dtype, device=logits.device
+    )
+    routing_map = torch.zeros(
+        num_tokens, num_experts, dtype=torch.bool, device=logits.device
+    )
+    intermediate = torch.empty(
+        num_tokens, num_experts, dtype=torch.float32, device=logits.device
+    )
+
+    BLOCK_E = triton.next_power_of_2(num_experts)
+    grid = (num_tokens,)
+
+    with torch_device_fn.device(logits.device):
+        if score_function == 0:
+            _fused_topk_fwd_sigmoid_kernel[grid](
+                logits,
+                expert_bias if expert_bias is not None else logits,
+                probs,
+                routing_map,
+                intermediate,
+                num_tokens,
+                num_experts,
+                scaling_factor,
+                HAS_BIAS=expert_bias is not None,
+                TOPK=topk,
+                BLOCK_E=BLOCK_E,
+            )
+        elif score_function == 1:
+            if use_pre_softmax:
+                _fused_topk_fwd_softmax_pre_kernel[grid](
+                    logits,
+                    probs,
+                    routing_map,
+                    intermediate,
+                    num_tokens,
+                    num_experts,
+                    scaling_factor,
+                    TOPK=topk,
+                    BLOCK_E=BLOCK_E,
+                )
+            else:
+                _fused_topk_fwd_softmax_post_kernel[grid](
+                    logits,
+                    probs,
+                    routing_map,
+                    intermediate,
+                    num_tokens,
+                    num_experts,
+                    scaling_factor,
+                    TOPK=topk,
+                    BLOCK_E=BLOCK_E,
+                )
+        else:
+            _fused_topk_fwd_sqrtsoftplus_kernel[grid](
+                logits,
+                expert_bias if expert_bias is not None else logits,
+                probs,
+                routing_map,
+                intermediate,
+                num_tokens,
+                num_experts,
+                scaling_factor,
+                HAS_BIAS=expert_bias is not None,
+                TOPK=topk,
+                BLOCK_E=BLOCK_E,
+            )
+
+    return probs, routing_map, intermediate

--- a/src/flag_gems/fused/te_grouped_topk.py
+++ b/src/flag_gems/fused/te_grouped_topk.py
@@ -1,0 +1,451 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0
+#
+# TE-compatible grouped topk forward for training.
+# Combines the high-performance grouped_topk selection (two-kernel approach)
+# with score_function computation and TE-format output generation.
+#
+# This avoids fusing grouped_topk into a single kernel (which performs poorly
+# in Triton due to nested loops over sub-arrays) and instead takes a two-step
+# approach:
+#   Step 1: Use existing grouped_topk kernel to get topk_indices [T, K]
+#   Step 2: A scatter kernel computes probs, routing_map, intermediate_output
+#           from logits + topk_indices + score_function parameters
+
+import logging
+
+import torch
+import triton
+import triton.language as tl
+
+from flag_gems.runtime import torch_device_fn
+from flag_gems.utils import libentry
+
+logger = logging.getLogger(__name__)
+
+EPSILON = 1.0e-20
+
+_SCORE_FUNCTIONS = {
+    "sigmoid": 0,
+    "softmax": 1,
+    "sqrtsoftplus": 2,
+}
+
+
+# =============================================================================
+# Step 2 kernels: given topk_indices, compute probs/routing_map/intermediate
+# =============================================================================
+
+
+@libentry()
+@triton.jit
+def _te_grouped_topk_scatter_sigmoid_kernel(
+    logits_ptr,
+    topk_indices_ptr,
+    probs_ptr,
+    routing_map_ptr,
+    intermediate_ptr,
+    num_tokens,
+    num_experts,
+    scaling_factor,
+    TOPK: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Scatter kernel for sigmoid: compute outputs from logits + topk_indices."""
+    pid = tl.program_id(0)
+    if pid >= num_tokens:
+        return
+
+    expert_offsets = tl.arange(0, BLOCK_E)
+    mask = expert_offsets < num_experts
+    row_base = pid * num_experts
+    k_offsets = tl.arange(0, BLOCK_K)
+    k_mask = k_offsets < TOPK
+
+    # Load logits and compute sigmoid for all experts
+    x = tl.load(logits_ptr + row_base + expert_offsets, mask=mask, other=0.0).to(
+        tl.float32
+    )
+    act = 1.0 / (1.0 + tl.exp(-x))
+
+    # Save sigmoid output for backward
+    tl.store(intermediate_ptr + row_base + expert_offsets, act, mask=mask)
+
+    # Load topk indices for this token
+    indices = tl.load(
+        topk_indices_ptr + pid * TOPK + k_offsets, mask=k_mask, other=0
+    ).to(tl.int32)
+
+    # Build routing_map: 1 at selected positions
+    # For each expert, check if it's in the topk_indices
+    # Use broadcast: expert_offsets[BLOCK_E] vs indices[BLOCK_K]
+    is_selected = (
+        tl.sum((expert_offsets[:, None] == indices[None, :]).to(tl.int32), axis=1) > 0
+    )
+
+    # Gather activations at selected positions for normalization
+    selected_act = tl.where(is_selected & mask, act, 0.0)
+
+    # Normalize (topk > 1)
+    if TOPK > 1:
+        sum_selected = tl.sum(selected_act, axis=0) + EPSILON
+        normalized = selected_act / sum_selected
+    else:
+        normalized = selected_act
+
+    # Write outputs
+    probs_out = tl.where(is_selected & mask, normalized * scaling_factor, 0.0)
+    tl.store(
+        probs_ptr + row_base + expert_offsets,
+        probs_out.to(probs_ptr.dtype.element_ty),
+        mask=mask,
+    )
+    tl.store(routing_map_ptr + row_base + expert_offsets, is_selected, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _te_grouped_topk_scatter_softmax_pre_kernel(
+    logits_ptr,
+    topk_indices_ptr,
+    probs_ptr,
+    routing_map_ptr,
+    intermediate_ptr,
+    num_tokens,
+    num_experts,
+    scaling_factor,
+    TOPK: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Scatter kernel for pre-softmax: softmax(all) then select topk."""
+    pid = tl.program_id(0)
+    if pid >= num_tokens:
+        return
+
+    expert_offsets = tl.arange(0, BLOCK_E)
+    mask = expert_offsets < num_experts
+    row_base = pid * num_experts
+    k_offsets = tl.arange(0, BLOCK_K)
+    k_mask = k_offsets < TOPK
+
+    x = tl.load(
+        logits_ptr + row_base + expert_offsets, mask=mask, other=-float("inf")
+    ).to(tl.float32)
+
+    # Softmax over all experts
+    row_max = tl.max(tl.where(mask, x, -float("inf")), axis=0)
+    exp_vals = tl.exp(x - row_max)
+    exp_vals = tl.where(mask, exp_vals, 0.0)
+    sum_exp = tl.sum(exp_vals, axis=0) + EPSILON
+    softmax_out = exp_vals / sum_exp
+
+    # Save softmax output for backward
+    tl.store(intermediate_ptr + row_base + expert_offsets, softmax_out, mask=mask)
+
+    # Load topk indices
+    indices = tl.load(
+        topk_indices_ptr + pid * TOPK + k_offsets, mask=k_mask, other=0
+    ).to(tl.int32)
+
+    is_selected = (
+        tl.sum((expert_offsets[:, None] == indices[None, :]).to(tl.int32), axis=1) > 0
+    )
+
+    # probs = scaling * softmax at selected, 0 elsewhere
+    probs_out = tl.where(is_selected & mask, softmax_out * scaling_factor, 0.0)
+    tl.store(
+        probs_ptr + row_base + expert_offsets,
+        probs_out.to(probs_ptr.dtype.element_ty),
+        mask=mask,
+    )
+    tl.store(routing_map_ptr + row_base + expert_offsets, is_selected, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _te_grouped_topk_scatter_softmax_post_kernel(
+    logits_ptr,
+    topk_indices_ptr,
+    probs_ptr,
+    routing_map_ptr,
+    intermediate_ptr,
+    num_tokens,
+    num_experts,
+    scaling_factor,
+    TOPK: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Scatter kernel for post-softmax: softmax only over selected experts."""
+    pid = tl.program_id(0)
+    if pid >= num_tokens:
+        return
+
+    expert_offsets = tl.arange(0, BLOCK_E)
+    mask = expert_offsets < num_experts
+    row_base = pid * num_experts
+    k_offsets = tl.arange(0, BLOCK_K)
+    k_mask = k_offsets < TOPK
+
+    x = tl.load(
+        logits_ptr + row_base + expert_offsets, mask=mask, other=-float("inf")
+    ).to(tl.float32)
+
+    # Load topk indices
+    indices = tl.load(
+        topk_indices_ptr + pid * TOPK + k_offsets, mask=k_mask, other=0
+    ).to(tl.int32)
+
+    is_selected = (
+        tl.sum((expert_offsets[:, None] == indices[None, :]).to(tl.int32), axis=1) > 0
+    )
+
+    # Softmax only over selected positions
+    selected_logits = tl.where(is_selected & mask, x, -float("inf"))
+    row_max = tl.max(selected_logits, axis=0)
+    exp_vals = tl.exp(selected_logits - row_max)
+    exp_vals = tl.where(is_selected & mask, exp_vals, 0.0)
+    sum_exp = tl.sum(exp_vals, axis=0) + EPSILON
+    softmax_out = exp_vals / sum_exp
+
+    # intermediate: softmax at selected, -inf elsewhere
+    intermediate_out = tl.where(is_selected & mask, softmax_out, -float("inf"))
+    tl.store(intermediate_ptr + row_base + expert_offsets, intermediate_out, mask=mask)
+
+    probs_out = tl.where(is_selected & mask, softmax_out * scaling_factor, 0.0)
+    tl.store(
+        probs_ptr + row_base + expert_offsets,
+        probs_out.to(probs_ptr.dtype.element_ty),
+        mask=mask,
+    )
+    tl.store(routing_map_ptr + row_base + expert_offsets, is_selected, mask=mask)
+
+
+@libentry()
+@triton.jit
+def _te_grouped_topk_scatter_sqrtsoftplus_kernel(
+    logits_ptr,
+    topk_indices_ptr,
+    probs_ptr,
+    routing_map_ptr,
+    intermediate_ptr,
+    num_tokens,
+    num_experts,
+    scaling_factor,
+    TOPK: tl.constexpr,
+    BLOCK_E: tl.constexpr,
+    BLOCK_K: tl.constexpr,
+):
+    """Scatter kernel for sqrtsoftplus: compute outputs from logits + topk_indices."""
+    pid = tl.program_id(0)
+    if pid >= num_tokens:
+        return
+
+    expert_offsets = tl.arange(0, BLOCK_E)
+    mask = expert_offsets < num_experts
+    row_base = pid * num_experts
+    k_offsets = tl.arange(0, BLOCK_K)
+    k_mask = k_offsets < TOPK
+
+    x = tl.load(logits_ptr + row_base + expert_offsets, mask=mask, other=0.0).to(
+        tl.float32
+    )
+
+    # Save original logits for backward
+    tl.store(intermediate_ptr + row_base + expert_offsets, x, mask=mask)
+
+    # Sqrtsoftplus
+    sp = tl.where(x > 20.0, x, tl.log(1.0 + tl.exp(x)))
+    act = tl.sqrt(sp)
+
+    # Load topk indices
+    indices = tl.load(
+        topk_indices_ptr + pid * TOPK + k_offsets, mask=k_mask, other=0
+    ).to(tl.int32)
+
+    is_selected = (
+        tl.sum((expert_offsets[:, None] == indices[None, :]).to(tl.int32), axis=1) > 0
+    )
+
+    # Gather activations at selected positions for normalization
+    selected_act = tl.where(is_selected & mask, act, 0.0)
+
+    # Normalize (topk > 1)
+    if TOPK > 1:
+        sum_selected = tl.sum(selected_act, axis=0) + EPSILON
+        normalized = selected_act / sum_selected
+    else:
+        normalized = selected_act
+
+    probs_out = tl.where(is_selected & mask, normalized * scaling_factor, 0.0)
+    tl.store(
+        probs_ptr + row_base + expert_offsets,
+        probs_out.to(probs_ptr.dtype.element_ty),
+        mask=mask,
+    )
+    tl.store(routing_map_ptr + row_base + expert_offsets, is_selected, mask=mask)
+
+
+# =============================================================================
+# Python entry point
+# =============================================================================
+
+
+def te_grouped_topk(
+    logits: torch.Tensor,
+    topk: int,
+    num_groups: int,
+    group_topk: int,
+    use_pre_softmax: bool = True,
+    scaling_factor: float = 1.0,
+    score_function: int | str = 1,
+    expert_bias: torch.Tensor = None,
+) -> tuple:
+    """TE-compatible grouped topk forward for training.
+
+    Two-step approach for performance:
+      1. Use FlagGems grouped_topk kernel to get topk_indices
+      2. Scatter kernel computes probs/routing_map/intermediate from topk_indices
+
+    Args:
+        logits: [num_tokens, num_experts] input logits.
+        topk: total number of experts selected per token.
+        num_groups: number of expert groups.
+        group_topk: number of groups to select.
+        use_pre_softmax: (softmax only) apply softmax before topk.
+        scaling_factor: output scaling factor.
+        score_function: 0=sigmoid, 1=softmax, 2=sqrtsoftplus.
+        expert_bias: [num_experts] bias tensor (required for grouped_topk selection).
+
+    Returns:
+        probs: [num_tokens, num_experts] sparse output (same dtype as logits).
+        routing_map: [num_tokens, num_experts] bool, True at selected positions.
+        intermediate_output: [num_tokens, num_experts] float32, for backward.
+    """
+    from flag_gems.fused.grouped_topk import grouped_topk
+
+    logger.debug("GEMS TE_GROUPED_TOPK")
+    if isinstance(score_function, str):
+        score_function = _SCORE_FUNCTIONS[score_function]
+    assert score_function in (0, 1, 2)
+    assert num_groups > 0 and group_topk > 0
+    assert logits.shape[1] % num_groups == 0
+    assert topk % group_topk == 0
+
+    num_tokens, num_experts = logits.shape
+
+    # Step 1: Use existing grouped_topk to get topk_indices
+    # grouped_topk expects scores after score_function applied (for selection with bias)
+    # and scoring_func=1 means apply sigmoid internally, scoring_func=0 means no transform.
+    # For TE compatibility, we handle score_function ourselves:
+    if score_function == 0:  # sigmoid
+        scores_for_selection = torch.sigmoid(logits.float()).to(logits.dtype)
+        scoring_func_flag = 0  # no additional transform in grouped_topk
+    elif score_function == 2:  # sqrtsoftplus
+        x_f = logits.float()
+        sp = torch.where(x_f > 20.0, x_f, torch.log1p(torch.exp(x_f)))
+        scores_for_selection = torch.sqrt(sp).to(logits.dtype)
+        scoring_func_flag = 0
+    else:  # softmax: grouped_topk selection on raw logits or softmax output
+        if use_pre_softmax:
+            scores_for_selection = torch.softmax(logits.float(), dim=-1).to(
+                logits.dtype
+            )
+        else:
+            scores_for_selection = logits
+        scoring_func_flag = 0
+
+    if expert_bias is None:
+        expert_bias = torch.zeros(num_experts, dtype=logits.dtype, device=logits.device)
+
+    # grouped_topk returns (topk_values [T,K], topk_indices [T,K])
+    # renormalize=False because we do normalization ourselves in the scatter kernel
+    _, topk_indices = grouped_topk(
+        scores=scores_for_selection,
+        n_group=num_groups,
+        topk_group=group_topk,
+        topk=topk,
+        renormalize=False,
+        routed_scaling_factor=1.0,
+        bias=expert_bias,
+        scoring_func=scoring_func_flag,
+    )
+
+    # Step 2: Scatter kernel to produce TE-format outputs
+    probs = torch.zeros(
+        num_tokens, num_experts, dtype=logits.dtype, device=logits.device
+    )
+    routing_map = torch.zeros(
+        num_tokens, num_experts, dtype=torch.bool, device=logits.device
+    )
+    intermediate = torch.empty(
+        num_tokens, num_experts, dtype=torch.float32, device=logits.device
+    )
+
+    BLOCK_E = triton.next_power_of_2(num_experts)
+    BLOCK_K = triton.next_power_of_2(topk)
+    grid = (num_tokens,)
+
+    with torch_device_fn.device(logits.device):
+        if score_function == 0:
+            _te_grouped_topk_scatter_sigmoid_kernel[grid](
+                logits,
+                topk_indices,
+                probs,
+                routing_map,
+                intermediate,
+                num_tokens,
+                num_experts,
+                scaling_factor,
+                TOPK=topk,
+                BLOCK_E=BLOCK_E,
+                BLOCK_K=BLOCK_K,
+            )
+        elif score_function == 1:
+            if use_pre_softmax:
+                _te_grouped_topk_scatter_softmax_pre_kernel[grid](
+                    logits,
+                    topk_indices,
+                    probs,
+                    routing_map,
+                    intermediate,
+                    num_tokens,
+                    num_experts,
+                    scaling_factor,
+                    TOPK=topk,
+                    BLOCK_E=BLOCK_E,
+                    BLOCK_K=BLOCK_K,
+                )
+            else:
+                _te_grouped_topk_scatter_softmax_post_kernel[grid](
+                    logits,
+                    topk_indices,
+                    probs,
+                    routing_map,
+                    intermediate,
+                    num_tokens,
+                    num_experts,
+                    scaling_factor,
+                    TOPK=topk,
+                    BLOCK_E=BLOCK_E,
+                    BLOCK_K=BLOCK_K,
+                )
+        else:
+            _te_grouped_topk_scatter_sqrtsoftplus_kernel[grid](
+                logits,
+                topk_indices,
+                probs,
+                routing_map,
+                intermediate,
+                num_tokens,
+                num_experts,
+                scaling_factor,
+                TOPK=topk,
+                BLOCK_E=BLOCK_E,
+                BLOCK_K=BLOCK_K,
+            )
+
+    return probs, routing_map, intermediate

--- a/tests/test_te_fused_topk_with_score_function_fwd.py
+++ b/tests/test_te_fused_topk_with_score_function_fwd.py
@@ -1,0 +1,210 @@
+# Copyright 2026 FlagOS Contributors
+#
+# Licensed under the Apache License, Version 2.0
+
+import pytest
+import torch
+
+from flag_gems.fused.te_fused_topk_with_score_function_fwd import (
+    te_fused_topk_with_score_function_fwd,
+)
+
+try:
+    from transformer_engine.pytorch import cpp_extensions as tex
+
+    TE_FWD = getattr(tex, "fused_topk_with_score_function_fwd", None)
+except ImportError:
+    TE_FWD = None
+
+pytestmark = pytest.mark.te_fused_topk_with_score_function_fwd
+
+SCORE_NAMES = {0: "sigmoid", 1: "softmax", 2: "sqrtsoftplus"}
+
+
+def _sqrtsoftplus(x):
+    sp = torch.where(x > 20.0, x, torch.log1p(torch.exp(x)))
+    return torch.sqrt(sp)
+
+
+def _make_routing_map(indices, num_experts):
+    routing_map = torch.zeros(
+        indices.shape[0],
+        num_experts,
+        dtype=torch.bool,
+        device=indices.device,
+    )
+    routing_map.scatter_(1, indices, True)
+    return routing_map
+
+
+def _torch_reference_fwd(
+    logits,
+    topk,
+    use_pre_softmax,
+    scaling_factor,
+    score_function,
+    expert_bias=None,
+):
+    x = logits.float()
+    num_experts = x.shape[1]
+
+    if score_function == 0:
+        intermediate = torch.sigmoid(x)
+        scores = intermediate
+        if expert_bias is not None:
+            scores = scores + expert_bias.float()
+        indices = scores.topk(topk, dim=-1).indices
+        routing_map = _make_routing_map(indices, num_experts)
+        selected = torch.where(routing_map, intermediate, torch.zeros_like(x))
+        if topk > 1:
+            selected = selected / (selected.sum(dim=-1, keepdim=True) + 1e-20)
+        probs = selected * scaling_factor
+        return probs.to(logits.dtype), routing_map, intermediate
+
+    if score_function == 1 and use_pre_softmax:
+        intermediate = torch.softmax(x, dim=-1)
+        indices = intermediate.topk(topk, dim=-1).indices
+        routing_map = _make_routing_map(indices, num_experts)
+        probs = torch.where(routing_map, intermediate * scaling_factor, 0.0)
+        return probs.to(logits.dtype), routing_map, intermediate
+
+    if score_function == 1:
+        indices = x.topk(topk, dim=-1).indices
+        routing_map = _make_routing_map(indices, num_experts)
+        selected_logits = x.gather(1, indices)
+        selected_probs = torch.softmax(selected_logits, dim=-1)
+        probs = torch.zeros_like(x)
+        probs.scatter_(1, indices, selected_probs * scaling_factor)
+        intermediate = torch.full_like(x, float("-inf"))
+        intermediate.scatter_(1, indices, selected_probs)
+        return probs.to(logits.dtype), routing_map, intermediate
+
+    intermediate = x
+    act = _sqrtsoftplus(x)
+    scores = act
+    if expert_bias is not None:
+        scores = scores + expert_bias.float()
+    indices = scores.topk(topk, dim=-1).indices
+    routing_map = _make_routing_map(indices, num_experts)
+    selected = torch.where(routing_map, act, torch.zeros_like(x))
+    if topk > 1:
+        selected = selected / (selected.sum(dim=-1, keepdim=True) + 1e-20)
+    probs = selected * scaling_factor
+    return probs.to(logits.dtype), routing_map, intermediate
+
+
+def _reference_fwd(
+    logits,
+    topk,
+    use_pre_softmax,
+    scaling_factor,
+    score_function,
+    expert_bias=None,
+):
+    if TE_FWD is None:
+        return _torch_reference_fwd(
+            logits,
+            topk,
+            use_pre_softmax,
+            scaling_factor,
+            score_function,
+            expert_bias,
+        )
+
+    try:
+        return TE_FWD(
+            logits,
+            topk,
+            use_pre_softmax,
+            None,
+            None,
+            scaling_factor,
+            SCORE_NAMES[score_function],
+            expert_bias,
+            0,
+            None,
+        )
+    except TypeError:
+        return _torch_reference_fwd(
+            logits,
+            topk,
+            use_pre_softmax,
+            scaling_factor,
+            score_function,
+            expert_bias,
+        )
+
+
+@pytest.mark.parametrize("num_tokens", [1, 16, 128])
+@pytest.mark.parametrize("num_experts", [8, 64, 256])
+@pytest.mark.parametrize("topk", [1, 2, 8])
+@pytest.mark.parametrize(
+    ("score_function", "use_pre_softmax"),
+    [(0, True), (1, True), (1, False), (2, True)],
+    ids=["sigmoid", "softmax_pre", "softmax_post", "sqrtsoftplus"],
+)
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_te_fused_topk_with_score_function_fwd(
+    num_tokens,
+    num_experts,
+    topk,
+    score_function,
+    use_pre_softmax,
+    dtype,
+):
+    if topk > num_experts:
+        pytest.skip("topk > num_experts")
+
+    torch.manual_seed(0)
+    logits = torch.randn(num_tokens, num_experts, device="cuda", dtype=dtype)
+
+    result = te_fused_topk_with_score_function_fwd(
+        logits,
+        topk,
+        use_pre_softmax=use_pre_softmax,
+        scaling_factor=1.0,
+        score_function=score_function,
+    )
+    expected = _reference_fwd(
+        logits,
+        topk,
+        use_pre_softmax,
+        1.0,
+        score_function,
+    )
+
+    torch.testing.assert_close(result[0], expected[0], rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(result[1].bool(), expected[1].bool())
+    torch.testing.assert_close(result[2], expected[2].float(), rtol=1e-2, atol=1e-2)
+
+
+@pytest.mark.parametrize("score_function", [0, 2], ids=["sigmoid", "sqrtsoftplus"])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16, torch.float32])
+def test_te_fused_topk_with_score_function_fwd_with_expert_bias(
+    score_function,
+    dtype,
+):
+    torch.manual_seed(0)
+    num_tokens, num_experts, topk = 16, 64, 8
+    logits = torch.randn(num_tokens, num_experts, device="cuda", dtype=dtype)
+    expert_bias = torch.randn(num_experts, device="cuda", dtype=dtype)
+
+    result = te_fused_topk_with_score_function_fwd(
+        logits,
+        topk,
+        scaling_factor=1.0,
+        score_function=score_function,
+        expert_bias=expert_bias,
+    )
+    expected = _reference_fwd(
+        logits,
+        topk,
+        True,
+        1.0,
+        score_function,
+        expert_bias,
+    )
+
+    torch.testing.assert_close(result[0], expected[0], rtol=1e-2, atol=1e-2)
+    torch.testing.assert_close(result[1].bool(), expected[1].bool())
+    torch.testing.assert_close(result[2], expected[2].float(), rtol=1e-2, atol=1e-2)


### PR DESCRIPTION
### PR Category

Operator, OP Test, Benchmark

### Type of Change

New Feature

### Description

This PR adds `te_fused_topk_with_score_function_fwd`, a Triton implementation of the TransformerEngine-compatible fused MoE top-k routing forward operator.

The operator supports:

- Sigmoid, softmax, and sqrtsoftplus score functions.
- Pre-top-k and post-top-k softmax modes.
- Routing scaling factor.
- Optional expert bias for sigmoid and sqrtsoftplus routing.
- Grouped top-k routing through `num_groups` and `group_topk`.
- FP16, BF16, and FP32 input logits.
- Outputs compatible with the backward operator: `probs`, `routing_map`, and `intermediate_output`.

The new operator is exported through `flag_gems.fused` and added to `conf/operators.yaml`.

Correctness tests compare the Triton implementation against TransformerEngine native CUDA implementation when TE is available, and fall back to a PyTorch reference implementation when TE is not installed.

### Performance

A benchmark has been added for `te_fused_topk_with_score_function_fwd`.

The benchmark compares the FlagGems Triton implementation with:

- TransformerEngine native CUDA implementation when TE is available.
- PyTorch reference implementation when TE is not installed.

It covers:

- Sigmoid.
- Pre-top-k softmax.
- Post-top-k softmax.
- Sqrtsoftplus.
- FP16, BF16, and FP32.
- Token counts from 1 to 4096.
- Expert counts from 64 to 256.
- `topk = 8`.

Run the benchmark with:

```bash
python -m pytest -v -s -rs benchmark/test_te_fused_topk_with_score_function_fwd.py --level comprehensive
```
benchmark result:

```
================================================= test session starts ==================================================
platform linux -- Python 3.12.3, pytest-8.1.1, pluggy-1.6.0 -- /home/secure/venvs/flaggems/bin/python
cachedir: .pytest_cache
hypothesis profile 'default' -> database=DirectoryBasedExampleDatabase(PosixPath('/workspace/FlagGems/.hypothesis/examples'))
rootdir: /workspace/FlagGems
configfile: pytest.ini
plugins: typeguard-4.4.4, anyio-4.12.0, xdist-3.8.0, flakefinder-1.1.0, xdoctest-1.0.2, shard-0.1.2, hypothesis-6.130.8, rerunfailures-16.1
collected 4 items / 3 deselected / 1 selected                                                                          
Running 1 items in this shard: benchmark/test_te_fused_topk_with_score_function_fwd.py::test_te_fused_topk_with_score_function_fwd_benchmark[sigmoid]

benchmark/test_te_fused_topk_with_score_function_fwd.py::test_te_fused_topk_with_score_function_fwd_benchmark[sigmoid] 
Operator: te_fused_topk_with_score_function_fwd  Performance Test (dtype=torch.float16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.977824            0.010656             185.607          [torch.Size([1, 64]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.660896            0.010336             160.690          [torch.Size([16, 64]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.641312            0.010528             155.900          [torch.Size([128, 64]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.645856            0.012160             135.350          [torch.Size([512, 128]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.643264            0.015072             109.028          [torch.Size([1024, 128]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.664080            0.023104              72.026          [torch.Size([2048, 256]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.656096            0.034048              48.640          [torch.Size([4096, 256]), 8, True, 0, 0, 1.0, 0, None]


Operator: te_fused_topk_with_score_function_fwd  Performance Test (dtype=torch.bfloat16, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.983488            0.010080             196.775          [torch.Size([1, 64]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.646752            0.010688             154.075          [torch.Size([16, 64]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.659808            0.011840             140.186          [torch.Size([128, 64]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.657280            0.013120             126.317          [torch.Size([512, 128]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.653344            0.014720             112.320          [torch.Size([1024, 128]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.663648            0.023008              72.307          [torch.Size([2048, 256]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.665856            0.035104              47.455          [torch.Size([4096, 256]), 8, True, 0, 0, 1.0, 0, None]


Operator: te_fused_topk_with_score_function_fwd  Performance Test (dtype=torch.float32, mode=kernel,level=comprehensive)
Status       Torch Latency (ms)    Gems Latency (ms)         Gems Speedup          Size Detail
-----------------------------------------------------------------------------------------------
SUCCESS               1.959376            0.010560             185.547          [torch.Size([1, 64]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.627200            0.010336             157.430          [torch.Size([16, 64]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.628048            0.010976             148.328          [torch.Size([128, 64]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.623936            0.011840             137.157          [torch.Size([512, 128]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.634912            0.016256             100.573          [torch.Size([1024, 128]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.636224            0.022592              72.425          [torch.Size([2048, 256]), 8, True, 0, 0, 1.0, 0, None]
SUCCESS               1.633888            0.035296              46.291          [torch.Size([4096, 256]), 8, True, 0, 0, 1.0, 0, None]

PASSED

=========================================== 1 passed, 3 deselected in 39.22s ===========================================