### PR TITLE
Pick MXFP4 MoE block_m by padding cost, not an absolute M cutoff

### DIFF
--- a/src/flag_gems/fused/fused_marlin_moe.py
+++ b/src/flag_gems/fused/fused_marlin_moe.py
@@ -150,6 +150,12 @@ def _routed_tokens_per_expert(M: int, E: int, top_k: int) -> int:
     return max(M * max(top_k, 1) // max(E, 1), 1)
 
 
+def _block_m_padding_ratio(M: int, E: int, top_k: int, block_m: int) -> float:
+    """Padded rows issued (E * block_m, since every expert pads on its own) over
+    the rows actually routed."""
+    return E * block_m / max(M * max(top_k, 1), 1)
+
+
 def _select_block_m(
     M: int,
     E: int,
@@ -225,6 +231,14 @@ def _select_mxfp4_kernel_policy(
     routed_tokens_per_expert = _routed_tokens_per_expert(M, E, top_k)
     block_m = _select_block_m(M, E, top_k, 8 if swap_ab else 16)
     if is_reduced_hopper and M <= 128 and routed_tokens_per_expert < 8:
+        block_m = 8
+    elif (
+        is_reduced_hopper
+        and block_m == 16
+        # Halve the tile once padding costs more than the smaller tile's lower
+        # per-CTA efficiency; the crossover sits around 2.5x.
+        and _block_m_padding_ratio(M, E, top_k, block_m) >= 2.5
+    ):
         block_m = 8
 
     if is_reduced_hopper and M == 1:


### PR DESCRIPTION
### PR Category

Operator (MoE / MXFP4 W4A16)

### Type of Change

Performance Optimization

### Description

Pick `block_m` for the MXFP4 fused Marlin MoE path by padding cost instead of an absolute `M` cutoff.

`_select_mxfp4_kernel_policy` drops to `block_m=8` only for `M <= 128`. But every expert pads its own token rows up to a multiple of `block_m`, so the work issued is `E * block_m` — it does not shrink with `M`, it only halves when `block_m` does. With `E=256 / top_k=6` the shapes just past the cutoff pay for a full 16-row tile while routing far fewer rows:

| M | block_m | padded rows (`E * block_m`) | real rows (`M * top_k`) | padding |
|---|---|---|---|---|
| 128 | 8 | 2048 | 768 | 2.7x |
| **136** | **16** | **4096** | **816** | **5.0x** |
| 368 | 16 | 4096 | 2208 | 1.9x |

Latency is therefore flat across `M=136..368` while Marlin's grows with `M`, so speedup dips to ~1.00 at the start of each tier and climbs to its end.

This PR keeps the smaller tile while the padding it removes outweighs the smaller tile's lower per-CTA efficiency, thresholded at **2.5x** the real rows — the measured crossover, where the smaller tile still wins by +5.55% at 2.67x and loses by −3.74% at 2.37x. The existing `M <= 128` branch is untouched, and scope is limited to the `16 -> 8` step.

### Issue

N/A

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

Hardware: **H20-3e**, bf16, **CUDA Graph ON**, `return_mode=median`, `USE_FLAGTUNE=0`. Baseline = current `master`. `Speedup = T_vLLM(Marlin) / T_Gems`; `Δ% = (T_base − T_opt) / T_base`.

Shapes: **53 deduped shapes from a real DeepSeek-V4-Flash trace** (`prefill=32768`), geometry `(M, E=256, H=4096, I=256, top_k=6)`, `M ∈ [1, 16384]`, `Count` = real call count.

| | Baseline | Optimized |
|---|---|---|
| Average speedup | 1.027 | **1.062** (+3.37%) |
| Call-weighted speedup | 1.078 | **1.110** |

Split by whether `block_m` actually changes:

| Group | Shapes | Baseline | Optimized | Avg Δ% | Min Δ% | Max Δ% |
|---|---|---|---|---|---|---|
| `block_m` 16 → 8 (M=136..272) | 17 | 0.928 | **1.034** | **+10.06%** | +1.00% | +14.23% |
| unchanged | 36 | 1.074 | 1.076 | +0.21% | −0.27% | +1.34% |

The thin tier that used to sit at \~1.00 now lands at 1.14~1.18 (`M=136`: 1.004 → **1.165**). No shape regresses beyond noise, worst −0.27%.

<details>
<summary><b>Full per-shape data</b> — 53 shapes, 10105 calls (click to expand)</summary>

| M | Count | block_m | vLLM (ms) | Baseline Gems (ms) | Baseline Speedup | Optimized Gems (ms) | Optimized Speedup | Δ% |
|---|---|---|---|---|---|---|---|---|
| 1 | 172 | 8 | 0.0316 | 0.0222 | 1.427 | 0.0222 | 1.423 | -0.10% |
| 2 | 172 | 8 | 0.0375 | 0.0418 | 0.896 | 0.0420 | 0.894 | -0.26% |
| 4 | 172 | 8 | 0.0532 | 0.0563 | 0.948 | 0.0563 | 0.944 | -0.03% |
| 8 | 172 | 8 | 0.0799 | 0.0840 | 0.946 | 0.0842 | 0.949 | -0.16% |
| 16 | 172 | 8 | 0.1257 | 0.1279 | 0.987 | 0.1278 | 0.983 | +0.06% |
| 24 | 172 | 8 | 0.1497 | 0.1494 | 1.003 | 0.1496 | 1.001 | -0.14% |
| 32 | 172 | 8 | 0.1850 | 0.1772 | 1.043 | 0.1772 | 1.045 | +0.02% |
| 40 | 172 | 8 | 0.2145 | 0.2130 | 1.009 | 0.2132 | 1.006 | -0.10% |
| 48 | 172 | 8 | 0.2369 | 0.2339 | 1.013 | 0.2339 | 1.013 | -0.01% |
| 56 | 172 | 8 | 0.2545 | 0.2409 | 1.058 | 0.2409 | 1.056 | +0.01% |
| 64 | 172 | 8 | 0.2617 | 0.2570 | 1.018 | 0.2572 | 1.017 | -0.08% |
| 72 | 172 | 8 | 0.2781 | 0.2643 | 1.052 | 0.2642 | 1.053 | +0.03% |
| 80 | 172 | 8 | 0.2896 | 0.2823 | 1.027 | 0.2816 | 1.029 | +0.26% |
| 88 | 172 | 8 | 0.2911 | 0.2836 | 1.031 | 0.2833 | 1.027 | +0.11% |
| 96 | 172 | 8 | 0.3004 | 0.2879 | 1.044 | 0.2887 | 1.041 | -0.27% |
| 104 | 172 | 8 | 0.3011 | 0.2895 | 1.036 | 0.2896 | 1.040 | -0.04% |
| 112 | 172 | 8 | 0.3120 | 0.3042 | 1.026 | 0.3040 | 1.026 | +0.07% |
| 120 | 172 | 8 | 0.3206 | 0.3074 | 1.043 | 0.3068 | 1.045 | +0.18% |
| 128 | 172 | 8 | 0.3284 | 0.3110 | 1.056 | 0.3105 | 1.057 | +0.16% |
| 136 | 172 | 16 → 8 | 0.3200 | 0.3575 | 0.897 | 0.3094 | 1.034 | +13.44% |
| 144 | 172 | 16 → 8 | 0.3293 | 0.3642 | 0.897 | 0.3124 | 1.054 | +14.23% |
| 152 | 172 | 16 → 8 | 0.3228 | 0.3605 | 0.896 | 0.3108 | 1.039 | +13.80% |
| 160 | 172 | 16 → 8 | 0.3287 | 0.3657 | 0.898 | 0.3149 | 1.044 | +13.89% |
| 168 | 172 | 16 → 8 | 0.3338 | 0.3672 | 0.910 | 0.3275 | 1.019 | +10.83% |
| 176 | 172 | 16 → 8 | 0.3431 | 0.3827 | 0.896 | 0.3323 | 1.032 | +13.18% |
| 184 | 172 | 16 → 8 | 0.3421 | 0.3680 | 0.933 | 0.3329 | 1.028 | +9.54% |
| 192 | 172 | 16 → 8 | 0.3444 | 0.3835 | 0.901 | 0.3336 | 1.032 | +13.00% |
| 200 | 172 | 16 → 8 | 0.3497 | 0.3812 | 0.918 | 0.3353 | 1.043 | +12.04% |
| 208 | 172 | 16 → 8 | 0.3535 | 0.3829 | 0.921 | 0.3424 | 1.033 | +10.58% |
| 216 | 172 | 16 → 8 | 0.3453 | 0.3859 | 0.890 | 0.3375 | 1.023 | +12.53% |
| 224 | 172 | 16 → 8 | 0.3546 | 0.3878 | 0.917 | 0.3438 | 1.032 | +11.36% |
| 232 | 172 | 16 → 8 | 0.3678 | 0.3839 | 0.961 | 0.3569 | 1.031 | +7.03% |
| 240 | 172 | 16 → 8 | 0.3661 | 0.3835 | 0.954 | 0.3581 | 1.022 | +6.63% |
| 248 | 172 | 16 → 8 | 0.3840 | 0.3849 | 0.989 | 0.3749 | 1.024 | +2.58% |
| 256 | 172 | 16 → 8 | 0.3787 | 0.3849 | 0.977 | 0.3643 | 1.040 | +5.36% |
| 272 | 172 | 16 → 8 | 0.4009 | 0.3876 | 1.026 | 0.3837 | 1.045 | +1.00% |
| 288 | 172 | 16 | 0.4176 | 0.3891 | 1.072 | 0.3856 | 1.083 | +0.89% |
| 304 | 172 | 16 | 0.4283 | 0.3907 | 1.095 | 0.3868 | 1.107 | +1.01% |
| 320 | 172 | 16 | 0.4497 | 0.3912 | 1.150 | 0.3876 | 1.160 | +0.93% |
| 336 | 172 | 16 | 0.4537 | 0.3931 | 1.152 | 0.3891 | 1.166 | +1.02% |
| 352 | 172 | 16 | 0.4533 | 0.3942 | 1.156 | 0.3904 | 1.161 | +0.94% |
| 368 | 172 | 16 | 0.4578 | 0.3976 | 1.153 | 0.3922 | 1.167 | +1.34% |
| 384 | 172 | 32 | 0.4656 | 0.4782 | 0.974 | 0.4774 | 0.975 | +0.17% |
| 400 | 172 | 32 | 0.4628 | 0.4789 | 0.966 | 0.4785 | 0.967 | +0.09% |
| 416 | 172 | 32 | 0.4615 | 0.4798 | 0.961 | 0.4792 | 0.963 | +0.11% |
| 432 | 172 | 32 | 0.4730 | 0.4811 | 0.983 | 0.4812 | 0.983 | -0.00% |
| 448 | 172 | 32 | 0.4683 | 0.4816 | 0.973 | 0.4808 | 0.974 | +0.17% |
| 464 | 172 | 32 | 0.4817 | 0.4831 | 0.997 | 0.4824 | 0.998 | +0.14% |
| 480 | 172 | 32 | 0.4928 | 0.4837 | 1.018 | 0.4830 | 1.020 | +0.14% |
| 496 | 344 | 32 | 0.4977 | 0.4851 | 1.026 | 0.4844 | 1.028 | +0.15% |
| 512 | 344 | 32 | 0.5046 | 0.4859 | 1.039 | 0.4821 | 1.047 | +0.80% |
| 2048 | 43 | 32 | 1.5365 | 1.0133 | 1.527 | 1.0129 | 1.517 | +0.04% |
| 16384 | 946 | 64 | 9.6670 | 5.4678 | 1.765 | 5.4660 | 1.769 | +0.03% |
| **avg** | 10105 | — | — | — | **1.027** | — | **1.062** | +3.37% |

</details>