### PR TITLE
test(benchmark): clear_l2_cache and use shm

### DIFF
--- a/benchmark/base.py
+++ b/benchmark/base.py
@@ -14,9 +14,11 @@
 
 import gc
 import math
+import multiprocessing
 import os
 import time
 from dataclasses import asdict
+from datetime import datetime, timezone
 from typing import Any, Generator, List, Optional, Tuple
 
 import pytest
@@ -52,6 +54,17 @@ else:
         torch_backend_device.matmul.allow_tf32 = False
     except Exception:
         pass
+
+
+def generate_prof_dir() -> str:
+    """Generate a unique profiling directory path under /dev/shm for do_bench_npu."""
+    process = multiprocessing.current_process()
+    pid = process.pid
+    process_name = process.name
+    timestamp = datetime.now(tz=timezone.utc).strftime("%Y%m%d_%H%M%S")
+    base_path = "/dev/shm"
+    torch_path = os.path.join(base_path, f"prof_{timestamp}_{process_name}-{pid}")
+    return torch_path
 
 
 def get_iter_count(fn):
@@ -312,6 +325,8 @@ class Benchmark:
                     fn,
                     warmup=Config.warm_up,
                     active=Config.repetition,
+                    clear_l2_cache=False,
+                    prof_dir=generate_prof_dir(),
                 )
             else:
                 do_bench = triton.testing.do_bench


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Benchmark

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Performance Optimization

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->

In do_bench_npu, enabling the clear_l2_cache option increases benchmarking accuracy, and using /dev/shm for read/write operations boosts performance.

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
