### PR TITLE
Add wheel to build tools

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@
 # Combined with the setuptools<77 pin above, `pip install .` then fails during
 # "Getting requirements to build wheel" with
 # `AttributeError: ignore_egg_info_in_manifest`. 9.x has no such integration.
-requires = ["setuptools>=64.0,<77", "setuptools-scm>=8,<10"]
+requires = ["setuptools>=64.0,<77", "setuptools-scm>=8,<10", "wheel==0.45.0"]
 
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

We recently capped the setuptools to <77 so that the generated wheel package can be recognized by tools like 'twine'. However, these lower versions of setuptools don't have 'wheel' built in. When installing FlagGems (even from source), the installation might fail in some isolated environments.

This PR fixes this problem.
