### PR TITLE
Add wheel to setup.sh for some backends

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -99,8 +99,9 @@ source tools/env.sh "${BACKEND}"
 # ── Install build tools ──────────────────────────────────────
 printf "Installing build tools ..."
 uv pip install -q \
-  "setuptools>=64.0" \
-  "setuptools-scm>=8" \
+  "wheel==0.45.0" \
+  "setuptools>=64.0,<77" \
+  "setuptools-scm>=8,<10" \
   "scikit-build-core==0.12.2" \
   "pybind11==3.0.3" \
   "cmake>=3.20,<4" \


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Other

### Description

The setup.sh installs flag_gems with --no-build-isolation, so the previously added 'wheel==0.45.0' isn't working. We need to preinstall it along with setuptools.
