### PR TITLE
Fix CI job to runner mapping

### DIFF
--- a/.github/backends.json
+++ b/.github/backends.json
@@ -1,7 +1,14 @@
 [
   {
     "backend": "ascend-cann850",
-    "runner_label": "ascend",
+    "runner_label": "cann850",
+    "label": "vendor/Ascend",
+    "gpu_check": "tools/gpu_check_ascend.sh",
+    "enabled": true
+  },
+  {
+    "backend": "ascend-cann900",
+    "runner_label": "cann9",
     "label": "vendor/Ascend",
     "gpu_check": "tools/gpu_check_ascend.sh",
     "enabled": true


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

Currently, all ascend-cann850 CI jobs are dispatched to runners with label 'ascend'. However, we have both 'cann850' and 'cann9' runners. The CI job may be dispatched to an inappropriate runner.