### PR TITLE
fix: add tsingmicro/txda to device detection

### DIFF
--- a/.github/backends.json
+++ b/.github/backends.json
@@ -1,7 +1,14 @@
 [
   {
     "backend": "ascend-cann850",
-    "runner_label": "ascend",
+    "runner_label": "cann850",
+    "label": "vendor/Ascend",
+    "gpu_check": "tools/gpu_check_ascend.sh",
+    "enabled": true
+  },
+  {
+    "backend": "ascend-cann900",
+    "runner_label": "cann9",
     "label": "vendor/Ascend",
     "gpu_check": "tools/gpu_check_ascend.sh",
     "enabled": true

--- a/src/flag_gems/runtime/backend/device_finder.py
+++ b/src/flag_gems/runtime/backend/device_finder.py
@@ -81,6 +81,11 @@ class DeviceDetector:
         except ImportError:
             torch_module = torch
 
+        try:
+            import torch_txda  # noqa: F401 — trigger txda backend registration on torch
+        except ImportError:
+            pass
+
         for vendor_name, attr in _VENDOR_TORCH_ATTR.items():
             if hasattr(torch_module, attr):
                 return str(vendor_name)

--- a/src/flag_gems/runtime/common.py
+++ b/src/flag_gems/runtime/common.py
@@ -165,6 +165,7 @@ _VENDOR_TORCH_ATTR = {
     "iluvatar": "corex",
     "mthreads": "musa",
     "sunrise": "ptpu",
+    "tsingmicro": "txda",
 }
 
 __all__ = [


### PR DESCRIPTION
_VENDOR_TORCH_ATTR was missing tsingmicro → txda mapping, so
`_get_vendor_from_quick_cmd()` never detected tsingmicro devices
on import. Also add `import torch_txda` in device_finder.py
so that `hasattr(torch, 'txda')` returns True — txda needs
an explicit import to register the backend on torch (same
pattern as ascend's torch_npu).

Verified on TSM hardware: `torch_txda.device_count() = 32` after
containerd cleanup, but flag_gems import crashed with
"No device were detected on your machine."

### Changes
- src/flag_gems/runtime/common.py: add tsingmicro → txda to _VENDOR_TORCH_ATTR
- src/flag_gems/runtime/backend/device_finder.py: import torch_txda before vendor attr check

🤖 Generated with [Claude Code](https://claude.com/claude-code)