### PR TITLE
fix: vector_norm accuracy test failure on mthreads backend

### DIFF
--- a/tests/test_vector_norm.py
+++ b/tests/test_vector_norm.py
@@ -69,6 +69,14 @@ def test_accuracy_vectornorm(shape, ord, dim, keepdim, dtype):
     with flag_gems.use_gems():
         res_out = torch.linalg.vector_norm(inp, ord, dim, keepdim)
 
+    # On mthreads with --ref cpu (TO_CPU=True), the reference is computed on CPU.
+    # For large reduce_dim (e.g. 8M elements with ord=1), torch GPU (mthreads native)
+    # and FlagGems Triton kernel produce consistent results, but both diverge from
+    # torch CPU due to float32 accumulation precision differences between CPU and
+    # GPU implementations. This is not a Triton kernel correctness issue.
+    # Relax atol from default 1e-4 to 5e-3 only in this scenario.
+    atol = 5e-3 if (flag_gems.vendor_name == "mthreads" and cfg.TO_CPU) else 1e-4
+
     utils.gems_assert_close(
-        res_out, ref_out, dtype, reduce_dim=_get_reduce_dim(shape, dim)
+        res_out, ref_out, dtype, reduce_dim=_get_reduce_dim(shape, dim), atol=atol
     )


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
OP Test

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Relax `atol` for `vector_norm` accuracy test on mthreads backend when `--ref cpu` is enabled.

For large reduce dimensions (e.g. 8M elements with ord=1), torch GPU (mthreads native) and FlagGems Triton kernel produce consistent results, but both diverge from torch CPU due to float32 accumulation precision differences between CPU and GPU implementations. This is not a Triton kernel correctness issue.

Only affects the `--ref cpu` scenario (used by `run_tests.py`); direct pytest without `--ref cpu` still uses strict tolerance.

<img width="1011" height="322" alt="img_v3_02144_5369b863-e961-4297-8c82-85064985bdbg" src="https://github.com/user-attachments/assets/726f608f-4c93-4037-9850-3fc032106300" />

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
N/A (test tolerance adjustment only, no kernel change)
