### PR TITLE
fix: resolve copy op accuracy failure on mthreads backend

### DIFF
--- a/tests/test_copy.py
+++ b/tests/test_copy.py
@@ -107,6 +107,10 @@ def test_copy_inplace_dtype_fallback():
 @pytest.mark.skipif(
     flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
 )
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "mthreads",
+    reason="mthreads does not support float8_e8m0fnu dtype",
+)
 @pytest.mark.parametrize("shape", [(8,), (4, 4), (2, 3, 4)])
 def test_copy_inplace_float8_e8m0fnu(shape):
     """Test that copy_ works correctly with float8_e8m0fnu (e8m0) dtype tensors.
@@ -140,6 +144,10 @@ def test_copy_inplace_float8_e8m0fnu(shape):
 )
 @pytest.mark.skipif(
     flag_gems.vendor_name == "tsingmicro", reason="Issue #4131: not working"
+)
+@pytest.mark.skipif(
+    flag_gems.vendor_name == "mthreads",
+    reason="mthreads does not support float8_e8m0fnu dtype",
 )
 def test_copy_inplace_float8_e8m0fnu_to_float32():
     """Test copy_ from float8_e8m0fnu to float32."""


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
OP Test

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Skip `float8_e8m0fnu` related test cases for `copy_` operator on mthreads backend.

MThreads does not support the `float8_e8m0fnu` dtype, causing accuracy test failures. Skip `test_copy_inplace_float8_e8m0fnu` and `test_copy_inplace_float8_e8m0fnu_to_float32` on mthreads.

<img width="1129" height="61" alt="img_v3_02143_9d6db924-bbae-4d1c-9881-e7bef1a679fg" src="https://github.com/user-attachments/assets/1b9557b6-2f15-4d50-bda5-d03424faebc3" />

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
N/A (test skip only, no kernel change)

