### PR TITLE
fix: resolve_conj performance test failure on mthreads backend.

### DIFF
--- a/src/flag_gems/runtime/backend/_mthreads/ops/resolve_conj.py
+++ b/src/flag_gems/runtime/backend/_mthreads/ops/resolve_conj.py
@@ -255,9 +255,19 @@ def resolve_conj_triton(x: torch.Tensor, is_conj: bool) -> torch.Tensor:
 def resolve_conj(A: torch.Tensor):
     logger.debug("GEMS_MTHREADS RESOLVE_CONJ")
     if A.is_conj():
-        if len(A.shape) in (2, 3):
-            return resolve_conj_triton(A, is_conj=True)
-        else:
-            return torch.complex(A.real, A.imag.neg())
+        # Aligned with the common op (src/flag_gems/ops/resolve_conj.py):
+        # Use clone() to resolve conjugation physically at the C++ aten::clone
+        # level, bypassing Python dispatch entirely.
+        #
+        # Previous implementation attempted Triton kernel for 2D/3D and used
+        # torch.complex(A.real, A.imag.neg()) as fallback, both of which cause
+        # infinite recursion because accessing conjugated tensor data at Python
+        # level triggers aten::resolve_conj dispatch back to this function.
+        #
+        # if len(A.shape) in (2, 3):
+        #     return resolve_conj_triton(A, is_conj=True)
+        # else:
+        #     return torch.complex(A.real, A.imag.neg())
+        return A.clone()
     else:
         return A


### PR DESCRIPTION
### PR Category
<!-- [ Operator | OP Test | Model Test | Benchmark | CI/CD | User Experience | Other] -->
Operator

### Type of Change
<!-- [ Bug Fix | New Feature | Performance Optimization | Refactor | Documentation Update | Other] -->
Bug Fix

### Description
<!-- Briefly describe the changes and the purpose of the changes.-->
Fix infinite recursion in mthreads `resolve_conj` operator for conjugated tensors.

The previous implementation used `resolve_conj_triton(A, is_conj=True)` for 2D/3D tensors and `torch.complex(A.real, A.imag.neg())` as fallback. Both paths trigger `aten::resolve_conj` dispatch back to this function when accessing conjugated tensor data at Python level, causing infinite recursion.

Fix: use `A.clone()` to resolve conjugation physically at the C++ `aten::clone` level, bypassing Python dispatch entirely. This is aligned with the common op implementation (`src/flag_gems/ops/resolve_conj.py`).

### Issue

<!--
List any related issues that this PR resolves, if applicable, for example:
- Resolves #123
- Associated with Feature #456
-->

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance
<!-- Please describe any performance tests you have added or the results of any benchmarks. -->
Performance test (`benchmark/test_resolve_conj.py`) now passes on mthreads. Previously failed with `maximum recursion depth exceeded`.
<img width="788" height="238" alt="image" src="https://github.com/user-attachments/assets/b2a2e45a-70d2-4cc3-9fd1-eeadd439c712" />

### Accuracy
<img width="837" height="152" alt="image" src="https://github.com/user-attachments/assets/f100b4d4-67f0-46aa-bdd5-2edb61c33c50" />

