### PR TITLE
[Ascend] Fix ascend ops when running Qwen3.6 vLLM with flagtree ascend3.5

### DIFF
--- a/src/flag_gems/runtime/backend/_ascend/__init__.py
+++ b/src/flag_gems/runtime/backend/_ascend/__init__.py
@@ -47,6 +47,8 @@ CUSTOMIZED_UNUSED_OPS = (
     "sort",
     "sort_stable",
     "topk",
+    "cat",  # TODO: Err occurred when running Qwen3.6 vLLM with flagtree ascend3.5
+    "exponential_",  # TODO: Err occurred when running Qwen3.6 vLLM with flagtree ascend3.5
 )
 
 

--- a/src/flag_gems/runtime/backend/_ascend/ops/pow.py
+++ b/src/flag_gems/runtime/backend/_ascend/ops/pow.py
@@ -27,7 +27,13 @@ logger = logging.getLogger(__name__)
 @pointwise_dynamic(promotion_methods=[(0, 1, "BOOL_TO_LONG")])
 @triton.jit
 def pow_func(x, exponent):
-    return _pow(x.to(tl.float32), exponent)
+    if (
+        tl.constexpr(exponent.dtype.is_fp32())
+        or tl.constexpr(exponent.dtype.is_fp16())
+        or tl.constexpr(exponent.dtype.is_bf16())
+    ):
+        return _pow(x.to(tl.float32), exponent)
+    return _pow(x.to(tl.float32), exponent.to(tl.float32))
 
 
 def pow_tensor_tensor(A, exponent):
@@ -45,7 +51,13 @@ def pow_tensor_tensor_(A, exponent):
 @pointwise_dynamic(is_tensor=[True, False], promotion_methods=[(0, 1, "BOOL_TO_LONG")])
 @triton.jit
 def pow_func_tensor_scalar(x, exponent):
-    return _pow(x.to(tl.float32), exponent)
+    if (
+        tl.constexpr(exponent.dtype.is_fp32())
+        or tl.constexpr(exponent.dtype.is_fp16())
+        or tl.constexpr(exponent.dtype.is_bf16())
+    ):
+        return _pow(x.to(tl.float32), exponent)
+    return _pow(x.to(tl.float32), exponent.to(tl.float32))
 
 
 def pow_tensor_scalar(A, exponent):
@@ -63,7 +75,13 @@ def pow_tensor_scalar_(A, exponent):
 @pointwise_dynamic(is_tensor=[False, True], promotion_methods=[(0, 1, "BOOL_TO_LONG")])
 @triton.jit
 def pow_func_scalar_tensor(x, exponent):
-    return _pow(x.to(tl.float32), exponent)
+    if (
+        tl.constexpr(exponent.dtype.is_fp32())
+        or tl.constexpr(exponent.dtype.is_fp16())
+        or tl.constexpr(exponent.dtype.is_bf16())
+    ):
+        return _pow(x.to(tl.float32), exponent)
+    return _pow(x.to(tl.float32), exponent.to(tl.float32))
 
 
 def pow_scalar(A, exponent):


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description
Fix ascend ops when running Qwen3.6 vLLM with flagtree ascend3.5
Fix pow.py. Unuse cat, exponential_.

### Issue

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [ ] Change is responded to an issue.
- [ ] Change is fully covered by a UT.

### Performance

