### PR TITLE
test: Skip CPU tests for _fused_rms_norm_backward

### DIFF
--- a/tools/test-op.sh
+++ b/tools/test-op.sh
@@ -50,6 +50,7 @@ NO_QUICK_CPU_TESTS=(
   "tests/test_shape_utils.py"
   "tests/test_tensor_wrapper.py"
   "tests/test_conv_depthwise2d.py"
+  "tests/test_fused_rms_norm_backward.py"
 )
 
 # Extract test cases from CHANGED_FILES


### PR DESCRIPTION
## Summary

Add `_fused_rms_norm_backward` to the `NO_QUICK_CPU_TESTS` list in `tools/test-op.sh`.

## Problem

PR #5074 fails the `python-op` CI check. The `test-op.sh` script runs a quick-cpu reference pass (`--ref=cpu --quick`) for changed operator tests, but `_fused_rms_norm_backward` is a CUDA-only aten operator with no CPU backend registration:

```
NotImplementedError: Could not run 'aten::_fused_rms_norm_backward' with arguments
from the 'CPU' backend. ... 'aten::_fused_rms_norm_backward' is only available for
these backends: [CUDA, Meta, BackendSelect, Python, ...].
```

## Solution

Add `tests/test_fused_rms_norm_backward.py` to the `NO_QUICK_CPU_TESTS` exclusion list, consistent with existing CUDA-only entries such as `test_flash_attention_backward.py`. The GPU accuracy and benchmark runs are unaffected.

## Verification

Confirmed on the aten dispatch level:

- `torch.ops.aten._fused_rms_norm_backward` raises `NotImplementedError` on CPU (only CUDA/Meta registered).

## Scope note

An earlier revision of this PR also listed `_dyn_quant_pack_4bit_weight`, `as_strided_scatter`, and `istft`. On closer inspection those three do run on CPU — their quick-cpu failures have unrelated root causes (test device handling, numerical tolerance, and a test-side dtype-filter bug respectively), not missing CPU backends. They have been removed from this PR and will be addressed separately in their own operator PRs.

## Related PRs

Unblocks:
- #5074 (`_fused_rms_norm_backward`)
