### PR TITLE
[KernelGen][Nvidia] Add _flash_attention_forward operator with Triton kernel

### DIFF
--- a/benchmark/test_attention_perf.py
+++ b/benchmark/test_attention_perf.py
@@ -339,6 +339,112 @@ def test_perf_flash_attention_forward():
     bench.run()
 
 
+def flash_attention_forward_quantized_input_fn(config, dtype, device):
+    (
+        batch,
+        num_head,
+        num_head_k,
+        q_seq_len,
+        kv_seq_len,
+        head_size,
+        is_causal,
+        dropout_p,
+        return_debug_mask,
+        window_size_left,
+        window_size_right,
+        use_alibi,
+    ) = config
+
+    q = torch.empty(
+        (batch, q_seq_len, num_head, head_size), device=device, dtype=torch.float16
+    ).uniform_(-0.05, 0.05)
+    k = torch.empty(
+        (batch, kv_seq_len, num_head_k, head_size), device=device, dtype=torch.float16
+    ).uniform_(-0.05, 0.05)
+    v = torch.empty(
+        (batch, kv_seq_len, num_head_k, head_size), device=device, dtype=torch.float16
+    ).uniform_(-0.05, 0.05)
+    q_fp8 = q.to(dtype)
+    k_fp8 = k.to(dtype)
+    v_fp8 = v.to(dtype)
+    q_descale = torch.tensor(1.0, device=device)
+    scale = float(1.0 / math.sqrt(head_size))
+
+    yield (
+        q_fp8,
+        k_fp8,
+        v_fp8,
+        q_descale,
+        scale,
+        is_causal,
+        dropout_p,
+        return_debug_mask,
+    )
+
+
+def gems_flash_attention_forward_quantized(
+    q, k, v, descale, scale, is_causal, dropout_p=0.0, return_debug_mask=False
+):
+    return flag_gems.ops.flash_attention_forward_quantized(
+        q,
+        k,
+        v,
+        None,
+        None,
+        q.shape[-3],
+        k.shape[-3],
+        dropout_p,
+        is_causal,
+        return_debug_mask,
+        descale,
+        descale,
+        descale,
+        scale=scale,
+    )
+
+
+def torch_flash_attention_forward_quantized(
+    q, k, v, descale, scale, is_causal, dropout_p=0.0, return_debug_mask=False
+):
+    # Reference speed baseline: dequantize to fp16 then run the standard kernel.
+    d = descale.to(torch.float16)
+    q = q.to(torch.float16) * d
+    k = k.to(torch.float16) * d
+    v = v.to(torch.float16) * d
+    return torch.ops.aten._flash_attention_forward(
+        q,
+        k,
+        v,
+        None,
+        None,
+        q.shape[-3],
+        k.shape[-3],
+        dropout_p,
+        is_causal,
+        return_debug_mask,
+        scale=scale,
+    )
+
+
+@pytest.mark.skipif(
+    SkipVersion("torch", "<2.4"),
+    reason="Low Pytorch Version.",
+)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+@pytest.mark.skipif(flag_gems.device == "cpu", reason="Unsupported in CPU mode")
+@pytest.mark.skipif(not hasattr(torch, "float8_e4m3fn"), reason="FP8 dtype unavailable")
+@pytest.mark.flash_attention_forward_quantized
+def test_perf_flash_attention_forward_quantized():
+    bench = FlashAttentionForwardBenchmark(
+        op_name="flash_attention_forward_quantized",
+        input_fn=flash_attention_forward_quantized_input_fn,
+        torch_op=torch_flash_attention_forward_quantized,
+        dtypes=[torch.float8_e4m3fn, torch.float8_e5m2],
+    )
+    bench.set_gems(gems_flash_attention_forward_quantized)
+    bench.run()
+
+
 # @pytest.mark.skipif(vendor_name == "kunlunxin", reason="RESULT TODOFIX")
 # @pytest.mark.skipif(vendor_name == "hygon", reason="RuntimeError")
 @pytest.mark.scaled_dot_product_attention

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -1839,6 +1839,20 @@ ops:
       - NeuralNetwork
     stages:
       - stable: '3.0'
+  - name: flash_attention_forward_quantized
+    description: |
+      A low-precision (FP8) variant of `flash_attention_forward()` that
+      accepts quantized query/key/value tensors together with their descale
+      factors.
+    for:
+      - _flash_attention_forward.quantized
+    labels:
+      - aten
+      - KernelGen
+    kind:
+      - NeuralNetwork
+    stages:
+      - stable: '3.0'
   - name: flash_attn_varlen_func
     description: |
       Compute attention for sequences of variable lengths within a single batch.

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -35,6 +35,7 @@ _FULL_CONFIG = (
     ("_assert_async", _assert_async),
     ("_conv_depthwise2d", _conv_depthwise2d),
     ("_flash_attention_forward", flash_attention_forward),
+    ("_flash_attention_forward.quantized", flash_attention_forward_quantized),
     (
         "_functional_sym_constrain_range_for_size",
         _functional_sym_constrain_range_for_size,

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -33,6 +33,7 @@ from flag_gems.ops.atan2 import atan2, atan2_out
 from flag_gems.ops.attention import (
     ScaleDotProductAttention,
     flash_attention_forward,
+    flash_attention_forward_quantized,
     flash_attn_varlen_func,
     flash_attn_varlen_opt_func,
     scaled_dot_product_attention,
@@ -475,6 +476,7 @@ __all__ = [
     "fill_tensor_",
     "fill_tensor_out",
     "flash_attention_forward",
+    "flash_attention_forward_quantized",
     "flash_attn_varlen_func",
     "flash_attn_varlen_opt_func",
     "flip",

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -1174,6 +1174,76 @@ def flash_attention_forward(
     return (out, lse, philox_seed, philox_offset, p)
 
 
+def flash_attention_forward_quantized(
+    query,
+    key,
+    value,
+    cumulative_sequence_length_q,
+    cumulative_sequence_length_k,
+    max_q,
+    max_k,
+    dropout_p,
+    is_causal,
+    return_debug_mask,
+    q_descale=None,
+    k_descale=None,
+    v_descale=None,
+    *,
+    scale=None,
+    softcap=0.0,
+    window_size_left=None,
+    window_size_right=None,
+    seqused_k=None,
+    alibi_slopes=None,
+    disable_splitkv=False,
+):
+    logger.debug("GEMS FLASH_ATTENTION_FORWARD QUANTIZED")
+    # The low-precision (FP8) inputs are dequantized to a compute dtype and then
+    # forwarded to the standard flash-attention kernel. Dequantization is linear
+    # (q = q_fp8 * q_descale), so applying it before the QK^T / PV matmuls yields
+    # the same result as scaling inside the kernel.
+    compute_dtype = torch.float16
+
+    def dequantize(t, descale):
+        if t is None:
+            return t
+        if t.dtype in (
+            torch.float8_e4m3fn,
+            torch.float8_e5m2,
+            torch.float8_e4m3fnuz,
+            torch.float8_e5m2fnuz,
+        ):
+            t = t.to(compute_dtype)
+            if descale is not None:
+                t = t * descale.to(compute_dtype)
+            return t
+        return t.to(compute_dtype)
+
+    query = dequantize(query, q_descale)
+    key = dequantize(key, k_descale)
+    value = dequantize(value, v_descale)
+
+    return flash_attention_forward(
+        query,
+        key,
+        value,
+        cumulative_sequence_length_q,
+        cumulative_sequence_length_k,
+        max_q,
+        max_k,
+        dropout_p,
+        is_causal,
+        return_debug_mask,
+        scale=scale,
+        softcap=softcap,
+        window_size_left=window_size_left,
+        window_size_right=window_size_right,
+        seqused_k=seqused_k,
+        alibi_slopes=alibi_slopes,
+        disable_splitkv=disable_splitkv,
+    )
+
+
 # Adapted from https://github.com/vllm-project/flash-attention/blob/main/vllm_flash_attn/flash_attn_interface.py
 def maybe_contiguous(x):
     return x.contiguous() if x is not None and x.stride(-1) != 1 else x

--- a/tests/test_flash_attention.py
+++ b/tests/test_flash_attention.py
@@ -217,6 +217,76 @@ def test_flash_attention_foward_nonsquare_qk(
     utils.gems_assert_close(gems_lse, torch_lse, torch.float)
 
 
+@pytest.mark.skipif(cfg.TO_CPU, reason="Unsupported in CPU mode")
+@pytest.mark.skipif(not hasattr(torch, "float8_e4m3fn"), reason="FP8 dtype unavailable")
+@pytest.mark.flash_attention_forward_quantized
+@pytest.mark.parametrize(
+    ["batch", "num_head", "q_seq_len", "kv_seq_len"],
+    [(1, 1, 128, 2048), (4, 8, 1024, 128), (4, 8, 17, 1030)],
+)
+@pytest.mark.parametrize("head_size", [64, 128, 256])
+@pytest.mark.parametrize("is_causal", [False, True])
+@pytest.mark.parametrize("fp8_dtype", [torch.float8_e4m3fn, torch.float8_e5m2])
+def test_flash_attention_forward_quantized(
+    batch, num_head, q_seq_len, kv_seq_len, head_size, is_causal, fp8_dtype
+):
+    device = torch_device_fn.current_device()
+    # small magnitude keeps the FP8 quantization well inside the representable
+    # range so the dequantized tensors are a faithful reference.
+    q, k, v = make_input(
+        batch,
+        num_head,
+        num_head,
+        q_seq_len,
+        kv_seq_len,
+        head_size,
+        torch.float16,
+        device,
+    )
+    q_descale = 0.5
+    k_descale = 0.7
+    v_descale = 0.3
+    q_fp8 = (q / q_descale).to(fp8_dtype)
+    k_fp8 = (k / k_descale).to(fp8_dtype)
+    v_fp8 = (v / v_descale).to(fp8_dtype)
+
+    # reference: dequantize with the same descale factors and run the standard
+    # (already-verified) flash-attention kernel, matching the quantized path's math.
+    ref_q = q_fp8.to(torch.float16) * q_descale
+    ref_k = k_fp8.to(torch.float16) * k_descale
+    ref_v = v_fp8.to(torch.float16) * v_descale
+    scale = float(1.0 / np.sqrt(head_size))
+
+    torch_out, torch_lse, _, _, _ = torch_flash_fwd(
+        ref_q, ref_k, ref_v, scale, is_causal
+    )
+
+    td_q = torch.tensor(q_descale, device=device)
+    td_k = torch.tensor(k_descale, device=device)
+    td_v = torch.tensor(v_descale, device=device)
+    gems_out, gems_lse, _, _, _ = flag_gems.ops.flash_attention_forward_quantized(
+        q_fp8.transpose(1, 2),
+        k_fp8.transpose(1, 2),
+        v_fp8.transpose(1, 2),
+        None,
+        None,
+        q_seq_len,
+        kv_seq_len,
+        0.0,
+        is_causal,
+        False,
+        td_q,
+        td_k,
+        td_v,
+        scale=scale,
+    )
+
+    utils.gems_assert_close(gems_out, torch_out, torch.float16)
+    if vendor_name == "iluvatar":
+        return
+    utils.gems_assert_close(gems_lse, torch_lse, torch.float)
+
+
 # Adapted from https://github.com/Dao-AILab/flash-attention/blob/main/tests/test_flash_attn.py
 def construct_local_mask(
     seqlen_q,


### PR DESCRIPTION
Closed: will be redone following the official skill-based workflow. See new PRs for each operator.