### PR TITLE
[KernelGen][Nvidia] Add _scaled_dot_product_flash_attention operator with Triton kernel

### DIFF
--- a/benchmark/test_attention_perf.py
+++ b/benchmark/test_attention_perf.py
@@ -339,6 +339,42 @@ def test_perf_flash_attention_forward():
     bench.run()
 
 
+@pytest.mark.skipif(
+    SkipVersion("torch", "<2.4"),
+    reason="Low Pytorch Version.",
+)
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+@pytest.mark.skipif(flag_gems.device == "cpu", reason="Unsupported in CPU mode")
+@pytest.mark.scaled_dot_product_flash_attention
+@pytest.mark.parametrize("is_causal", [True, False])
+def test_perf_scaled_dot_product_flash_attention(is_causal):
+    # query/key/value are (batch, num_head, seq_len, head_size).
+    def sdpfa_input_fn(shape, dtype, device):
+        query = torch.randn(shape, device=device, dtype=dtype)
+        key = torch.randn(shape, device=device, dtype=dtype)
+        value = torch.randn(shape, device=device, dtype=dtype)
+        yield query, key, value
+
+    def torch_sdpfa(query, key, value):
+        return torch.ops.aten._scaled_dot_product_flash_attention(
+            query, key, value, 0.0, is_causal, False
+        )
+
+    def gems_sdpfa(query, key, value):
+        return flag_gems.ops.scaled_dot_product_flash_attention(
+            query, key, value, 0.0, is_causal, False
+        )
+
+    bench = AttentionBenchmark(
+        op_name="scaled_dot_product_flash_attention",
+        input_fn=sdpfa_input_fn,
+        torch_op=torch_sdpfa,
+        dtypes=[torch.float16, torch.bfloat16],
+    )
+    bench.set_gems(gems_sdpfa)
+    bench.run()
+
+
 # @pytest.mark.skipif(vendor_name == "kunlunxin", reason="RESULT TODOFIX")
 # @pytest.mark.skipif(vendor_name == "hygon", reason="RuntimeError")
 @pytest.mark.scaled_dot_product_attention

--- a/conf/operators.yaml
+++ b/conf/operators.yaml
@@ -4193,6 +4193,21 @@ ops:
       - NeuralNetwork
     stages:
       - stable: '2.2'
+  - name: scaled_dot_product_flash_attention
+    description: |
+      The flash-attention forward implementation backing
+      `scaled_dot_product_attention`. Returns the attention output together
+      with the log-sum-exp and the sequence-length / RNG metadata.
+    for:
+      - _scaled_dot_product_flash_attention
+    labels:
+      - aten
+      - Attention
+      - KernelGen
+    kind:
+      - NeuralNetwork
+    stages:
+      - stable: '2.2'
   - name: scaled_softmax_backward
     description: |
       The backward pass for a scaled softmax function, commonly used in Scaled Dot-Product Attention (SDPA)

--- a/src/flag_gems/__init__.py
+++ b/src/flag_gems/__init__.py
@@ -45,6 +45,10 @@ _FULL_CONFIG = (
     ("_log_softmax", log_softmax),
     ("_log_softmax_backward_data", log_softmax_backward),
     ("_safe_softmax", _safe_softmax),
+    (
+        "_scaled_dot_product_flash_attention",
+        scaled_dot_product_flash_attention,
+    ),
     ("_softmax", softmax),
     ("_softmax_backward_data", softmax_backward),
     (

--- a/src/flag_gems/ops/__init__.py
+++ b/src/flag_gems/ops/__init__.py
@@ -38,6 +38,7 @@ from flag_gems.ops.attention import (
     scaled_dot_product_attention,
     scaled_dot_product_attention_backward,
     scaled_dot_product_attention_forward,
+    scaled_dot_product_flash_attention,
 )
 from flag_gems.ops.avg_pool2d import avg_pool2d, avg_pool2d_backward
 from flag_gems.ops.baddbmm import baddbmm
@@ -658,6 +659,7 @@ __all__ = [
     "scaled_dot_product_attention",
     "scaled_dot_product_attention_backward",
     "scaled_dot_product_attention_forward",
+    "scaled_dot_product_flash_attention",
     "scaled_softmax_backward",
     "scaled_softmax_forward",
     "scatter",

--- a/src/flag_gems/ops/attention.py
+++ b/src/flag_gems/ops/attention.py
@@ -1174,6 +1174,57 @@ def flash_attention_forward(
     return (out, lse, philox_seed, philox_offset, p)
 
 
+def scaled_dot_product_flash_attention(
+    query,
+    key,
+    value,
+    dropout_p=0.0,
+    is_causal=False,
+    return_debug_mask=False,
+    *,
+    scale=None,
+):
+    logger.debug("GEMS SCALED_DOT_PRODUCT_FLASH_ATTENTION")
+    # query/key/value are (batch, num_head, seq_len, head_dim); the underlying
+    # flash-attention kernel expects (batch, seq_len, num_head, head_dim), so
+    # transpose in and transpose the output back.
+    max_q = query.shape[-2]
+    max_k = key.shape[-2]
+
+    q = query.transpose(1, 2)
+    k = key.transpose(1, 2)
+    v = value.transpose(1, 2)
+
+    out, logsumexp, rng_state, unused, debug_attn_mask = flash_attention_forward(
+        q,
+        k,
+        v,
+        None,
+        None,
+        max_q,
+        max_k,
+        dropout_p,
+        is_causal,
+        return_debug_mask,
+        scale=scale,
+    )
+    out = out.transpose(1, 2)
+
+    # cum_seq_q / cum_seq_k are only populated for the varlen path, which this
+    # (dense) overload does not use, so they are None to match the reference.
+    return (
+        out,
+        logsumexp,
+        None,
+        None,
+        max_q,
+        max_k,
+        rng_state,
+        unused,
+        debug_attn_mask,
+    )
+
+
 # Adapted from https://github.com/vllm-project/flash-attention/blob/main/vllm_flash_attn/flash_attn_interface.py
 def maybe_contiguous(x):
     return x.contiguous() if x is not None and x.stride(-1) != 1 else x

--- a/tests/test_scaled_dot_product_attention.py
+++ b/tests/test_scaled_dot_product_attention.py
@@ -347,3 +347,35 @@ def test_scaled_dot_product_attention_nonsquare_qk(
         gems_result = torch_sdpa(q, k, v, scale, is_causal)
 
     utils.gems_assert_close(gems_result, torch_result, dtype)
+
+
+@pytest.mark.skipif(cfg.TO_CPU, reason="Unsupported in CPU mode")
+@pytest.mark.scaled_dot_product_flash_attention
+@pytest.mark.parametrize(
+    ["batch", "num_head", "q_seq_len", "kv_seq_len"],
+    [(1, 1, 128, 2048), (4, 8, 1024, 128), (4, 8, 17, 1030)],
+)
+@pytest.mark.parametrize("head_size", [64, 128, 256])
+@pytest.mark.parametrize("is_causal", [False, True])
+@pytest.mark.parametrize("dtype", [torch.float16, torch.bfloat16])
+def test_scaled_dot_product_flash_attention(
+    batch, num_head, q_seq_len, kv_seq_len, head_size, is_causal, dtype
+):
+    device = torch_device_fn.current_device()
+    q, k, v = make_input(
+        batch, num_head, num_head, q_seq_len, kv_seq_len, head_size, dtype, device
+    )
+    scale = float(1.0 / np.sqrt(head_size))
+
+    # reference: the native ATen flash-attention op (outside the gems context).
+    ref_out, ref_lse, *_ = torch.ops.aten._scaled_dot_product_flash_attention(
+        q, k, v, 0.0, is_causal, False, scale=scale
+    )
+
+    with flag_gems.use_gems():
+        gems_out, gems_lse, *_ = torch.ops.aten._scaled_dot_product_flash_attention(
+            q, k, v, 0.0, is_causal, False, scale=scale
+        )
+
+    utils.gems_assert_close(gems_out, ref_out, dtype)
+    utils.gems_assert_close(gems_lse, ref_lse, torch.float)


### PR DESCRIPTION
Closed: will be redone following the official skill-based workflow. See new PRs for each operator.