### PR TITLE
Fix tensor_split copying the first slice into every output

### DIFF
--- a/src/flag_gems/ops/tensor_split.py
+++ b/src/flag_gems/ops/tensor_split.py
@@ -33,6 +33,7 @@ def split_copy_kernel(
     split_dim: tl.constexpr,
     dim_prod_pre: tl.constexpr,
     dim_prod_post: tl.constexpr,
+    dim_start,
     BLOCK_SIZE: tl.constexpr,
 ):
     """Kernel to copy a split from input to output tensor."""
@@ -57,9 +58,11 @@ def split_copy_kernel(
     post_idx = idx % dim_prod_post
 
     # Compute input index
-    # The split dimension offset is already accounted for in the output tensor layout
+    # Offset the split-dimension index by this split's start in the input
     input_idx = (
-        pre_idx * dim_size_input * dim_prod_post + split_idx * dim_prod_post + post_idx
+        pre_idx * dim_size_input * dim_prod_post
+        + (dim_start + split_idx) * dim_prod_post
+        + post_idx
     )
 
     # Load from input and store to output
@@ -217,6 +220,7 @@ def tensor_split(
             dim,  # split_dim
             dim_prod_pre,
             dim_prod_post,
+            current_dim_idx,  # dim_start
             BLOCK_SIZE=BLOCK_SIZE,
         )
 

--- a/tests/test_tensor_split.py
+++ b/tests/test_tensor_split.py
@@ -17,6 +17,12 @@ import torch
 
 import flag_gems
 
+# aten::tensor_split has no "default" overload, so the bare-name registration
+# does not take effect and torch.tensor_split under use_gems() still runs the
+# eager implementation. Call the FlagGems implementation directly so the tests
+# actually exercise it.
+from flag_gems.ops.tensor_split import tensor_split
+
 from . import accuracy_utils as utils
 from . import conftest as cfg
 
@@ -47,8 +53,7 @@ def test_tensor_split_by_int(shape, dtype):
     sections = 3
     ref_out = torch.tensor_split(ref_inp, sections, dim=0)
 
-    with flag_gems.use_gems():
-        res_out = torch.tensor_split(inp, sections, dim=0)
+    res_out = tensor_split(inp, sections, dim=0)
 
     # Compare number of outputs
     assert len(res_out) == len(ref_out)
@@ -70,8 +75,7 @@ def test_tensor_split_by_list(shape, dtype):
     indices = [shape[0] // 3, shape[0] * 2 // 3]
     ref_out = torch.tensor_split(ref_inp, indices, dim=0)
 
-    with flag_gems.use_gems():
-        res_out = torch.tensor_split(inp, indices, dim=0)
+    res_out = tensor_split(inp, indices, dim=0)
 
     # Compare number of outputs
     assert len(res_out) == len(ref_out)
@@ -96,8 +100,7 @@ def test_tensor_split_dim(shape, dtype):
     sections = 2
     ref_out = torch.tensor_split(ref_inp, sections, dim=1)
 
-    with flag_gems.use_gems():
-        res_out = torch.tensor_split(inp, sections, dim=1)
+    res_out = tensor_split(inp, sections, dim=1)
 
     # Compare number of outputs
     assert len(res_out) == len(ref_out)
@@ -120,8 +123,7 @@ def test_tensor_split_uneven(dtype):
     sections = 3
     ref_out = torch.tensor_split(ref_inp, sections, dim=0)
 
-    with flag_gems.use_gems():
-        res_out = torch.tensor_split(inp, sections, dim=0)
+    res_out = tensor_split(inp, sections, dim=0)
 
     # Compare number of outputs
     assert len(res_out) == len(ref_out)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description

`split_copy_kernel` maps each output element back to the input without adding the slice's start offset along the split dimension, so every launch reads the input from offset 0: slice 0 is correct by accident, and every later slice is a copy of slice 0. The wrapper already tracks exactly the needed offset (`current_dim_idx`) but never passes it to the kernel.

Changes:

- `src/flag_gems/ops/tensor_split.py`: add a `dim_start` argument to `split_copy_kernel`, pass the wrapper's `current_dim_idx`, and compute the input index with `(dim_start + split_idx) * dim_prod_post` — the same mapping `narrow_copy_kernel` already uses (`inp_dim_idx = dim_idx + start`). `dim_start` is a runtime argument rather than `tl.constexpr` so an even split keeps sharing one compiled kernel across all its launches.
- `tests/test_tensor_split.py`: call `flag_gems.ops.tensor_split` directly. `aten::tensor_split` has no `default` overload, so the bare-name registration does not take effect and `torch.tensor_split` under `use_gems()` still runs the eager implementation — the tests were comparing eager against eager, which is why this was never caught.

Worst-slice `max|torch.tensor_split - flag_gems|`, fp32:

| case | before | after |
|---|---|---|
| `tensor_split(arange(6.), 3)` | 4.0 (returns `[[0,1],[0,1],[0,1]]`) | 0 |
| `tensor_split(randn(4,12,5), 3, dim=1)` | 4.28 | 0 |
| `tensor_split(randn(10,20), 3)` — uneven `[4,3,3]` | 3.60 | 0 |
| `tensor_split(randn(9,7), [2,5])` | 2.86 | 0 |

Tests: with the kernel change reverted, all 36 parametrized cases in `tests/test_tensor_split.py` fail; with it, 36 pass (3 pre-existing skips for 1D shapes in the dim test).

### Issue

Resolves #5214

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

The extra index arithmetic is free: with `sections=1` (identical memory traffic before/after) `triton.testing.do_bench` on an L40S gives 0.2183–0.2186 ms before vs 0.2172–0.2191 ms after for a 16Mi-element fp32 copy — noise. Multi-slice wall time goes up (e.g. 0.128 → 0.214 ms for `(16384, 1024)` fp32 split into 4) only because the buggy kernel re-read the same L2-resident region for every slice, while the fixed kernel reads each slice's own region — that extra DRAM traffic is the correct workload.

### Environment

- FlagGems master (75cf3ea)
- NVIDIA L40S and H100 NVL
- torch 2.6.0+cu124, triton 3.2.0
