### PR TITLE
Fix im2col launch grid to match autotuned tile sizes

### DIFF
--- a/src/flag_gems/ops/im2col.py
+++ b/src/flag_gems/ops/im2col.py
@@ -68,13 +68,13 @@ def im2col_kernel(
     outW,
     rows_total,  # C * kH * kW
     L,  # outH * outW
-    num_row_tiles,  # ceil_div(rows_total, BLOCK_M)
     BLOCK_M: tl.constexpr,
     BLOCK_N: tl.constexpr,
 ):
     pid0 = tl.program_id(0)
     pid1 = tl.program_id(1)
 
+    num_row_tiles = tl.cdiv(rows_total, BLOCK_M)
     n = pid0 // num_row_tiles
     row_tile = pid0 % num_row_tiles
 
@@ -143,9 +143,13 @@ def _launch_im2col_kernel(x, out, kH, kW, dH, dW, pH, pW, sH, sW):
     if rows_total == 0 or L == 0 or N == 0:
         return  # Nothing to do
 
-    num_row_tiles = triton.cdiv(rows_total, 64)  # BLOCK_M default
-    num_col_tiles = triton.cdiv(L, 128)  # BLOCK_N default
-    grid = (N * num_row_tiles, num_col_tiles)
+    # BLOCK_M / BLOCK_N are chosen by the autotuner, so the grid must be
+    # derived from the selected config; a grid sized for fixed tile sizes
+    # leaves part of the output unwritten when a smaller config wins.
+    grid = lambda meta: (
+        N * triton.cdiv(rows_total, meta["BLOCK_M"]),
+        triton.cdiv(L, meta["BLOCK_N"]),
+    )
 
     im2col_kernel[grid](
         x,
@@ -166,7 +170,6 @@ def _launch_im2col_kernel(x, out, kH, kW, dH, dW, pH, pW, sH, sW):
         outW,
         rows_total,
         L,
-        num_row_tiles,
     )
 
 

--- a/tests/test_im2col.py
+++ b/tests/test_im2col.py
@@ -12,12 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import importlib
+
 import pytest
 import torch
 
 import flag_gems
 
 from . import accuracy_utils as utils
+
+im2col_module = importlib.import_module("flag_gems.ops.im2col")
 
 # Cover 3D input, small/large 4D inputs for representative im2col testing
 IM2COL_SHAPES = [(3, 8, 8), (1, 3, 16, 16), (16, 64, 64), (32, 128, 128)]
@@ -43,3 +47,41 @@ def test_im2col(shape, dtype, kernel_size, dilation, padding, stride):
         act_out = torch.ops.aten.im2col(x, kernel_size, dilation, padding, stride)
 
     utils.gems_assert_close(act_out, ref_out, dtype=dtype)
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is not available")
+@pytest.mark.im2col
+@pytest.mark.parametrize(
+    "config",
+    im2col_module.im2col_kernel.fn.configs,
+    ids=lambda c: "-".join(f"{k}{v}" for k, v in sorted(c.kwargs.items())),
+)
+def test_im2col_every_autotune_config_writes_full_output(config):
+    # The launch grid must cover the whole output for whichever tile sizes the
+    # autotuner selects. A single tuning config sidesteps the benchmark sweep,
+    # which otherwise hides under-coverage on the first call per shape: the
+    # sweep runs every candidate (including a fully covering one) against the
+    # same output buffer, so only calls after the sweep expose the winner's
+    # real coverage. The second call below also exercises the cached-kernel
+    # launch path.
+    tuner = im2col_module.im2col_kernel.fn
+    saved_configs = tuner.configs
+    tuner.configs = [config]
+    tuner.cache.clear()
+    for kernel_cache in im2col_module.im2col_kernel.kernel_cache:
+        kernel_cache.clear()
+    try:
+        # rows_total = 8*3*3 = 72 and L = 32*32 = 1024 are not covered by a
+        # grid sized for other tile dimensions than the selected ones.
+        x = torch.randn((1, 8, 32, 32), dtype=torch.float32, device=flag_gems.device)
+        ref_x = utils.to_reference(x)
+        ref_out = torch.ops.aten.im2col(ref_x, (3, 3), (1, 1), (1, 1), (1, 1))
+        with flag_gems.use_gems():
+            for _ in range(2):
+                act_out = torch.ops.aten.im2col(x, (3, 3), (1, 1), (1, 1), (1, 1))
+                utils.gems_assert_close(act_out, ref_out, dtype=torch.float32)
+    finally:
+        tuner.configs = saved_configs
+        tuner.cache.clear()
+        for kernel_cache in im2col_module.im2col_kernel.kernel_cache:
+            kernel_cache.clear()


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description

`im2col_kernel` is autotuned over five `(BLOCK_M, BLOCK_N)` configs, but `_launch_im2col_kernel` sizes the grid with hard-coded tile sizes (64, 128). Four of the five configs are smaller on one axis, so whenever any of them wins the timing race, the launch covers only part of the output and the rest of the `torch.empty` buffer is returned as uninitialized memory. The autotune benchmark sweep hides this on the first call per shape (every candidate, including the covering (64,128), writes the same buffer); from the second call on, only the cached winner runs and the corruption appears.

Changes:

- `src/flag_gems/ops/im2col.py`: derive the grid from the selected config (`grid = lambda meta: ...`, the pattern `max_unpool2d.py` already uses), and compute `num_row_tiles` inside the kernel with `tl.cdiv(rows_total, BLOCK_M)` instead of passing a value computed for the wrong tile size.
- `tests/test_im2col.py`: add a test that pins the autotuner to each shipped config in turn and verifies the full output is written, on the first call and on a second (cached-kernel) call.

Max abs diff of the second `F.unfold(x, kernel_size=3, padding=1)` call under `use_gems()` vs eager, fp32:

| input shape | before (L40S / H100) | after |
|---|---|---|
| (1, 4, 16, 16) | 3.32 / 3.32 | 0 |
| (1, 8, 32, 32) | 4.00 / 0* | 0 |
| (1, 64, 28, 28) | 4.17 / 3.95 | 0 |
| (1, 32, 64, 64) | 4.41 / 4.41 | 0 |

*the autotuner happened to pick the covering config for that shape on H100 — the failure set is timing-dependent, which is why this went unnoticed.

Tests: the existing tests make one call per parameter set, which the benchmark sweep always makes look correct. The new test pins a single config (no sweep, so the first call behaves like every post-autotune call) and sweeps the live tuning table. With the kernel change reverted, 4 of its 5 config cases fail (only (64,128) passes); with the fix, all 53 cases in the file pass.

Note: #4727 bundles an equivalent wrapper change inside the `im2col_out` promotion. This PR is the minimal fix plus the regression test that the corruption was missing, independent of the promotion decision — happy to close whichever lands second.

### Issue

Resolves #5224

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

With the config pinned to (64,128) — the one case where the old and new grid are identical, isolating the fix's own overhead — interleaved `triton.testing.do_bench` x3 on an L40S: `(8, 64, 56, 56)` 0.1724–0.1727 ms before vs 0.1725–0.1728 ms after; `(32, 16, 128, 128)` 0.5864–0.5874 ms vs 0.5873–0.5884 ms — noise. When an under-covering config wins, the fixed grid launches proportionally more blocks; that is the work the old launch was skipping, and the autotuner now times every config on the full output, so the cached choice is made fairly.

### Environment

- FlagGems master (75cf3ea)
- NVIDIA L40S and H100 NVL
- torch 2.6.0+cu124, triton 3.2.0
