### PR TITLE
Fix rot90 producing wrong results for inputs with more than 2 dims

### DIFF
--- a/src/flag_gems/ops/rot90.py
+++ b/src/flag_gems/ops/rot90.py
@@ -60,60 +60,67 @@ def rot90_kernel_2d(
     m_minus_1 = M - 1
     n_minus_1 = N - 1
 
+    # Product of the dims after the rotation plane [D2 * D3 * ...] (1 for 2D input)
+    trailing = n_elements // (M * N)
+
     if k_norm == 0:
         # Identity case - output same shape as input [M, N, ...]
         stride_0 = n_elements // M
         out_dim0 = offsets // stride_0
         remainder = offsets % stride_0
-        out_dim1 = remainder % N
+        out_dim1 = remainder // trailing
+        trailing_offset = remainder % trailing
 
         in_dim0 = out_dim0
         in_dim1 = out_dim1
 
         stride_0_in = n_elements // M
-        in_offset = in_dim0 * stride_0_in + in_dim1 * (stride_0_in // N)
+        in_offset = in_dim0 * stride_0_in + in_dim1 * trailing + trailing_offset
 
     elif k_norm == 1:
         # 90° clockwise - output shape [N, M, ...]
         stride_0 = n_elements // N
         out_dim0 = offsets // stride_0
         remainder = offsets % stride_0
-        out_dim1 = remainder % M
+        out_dim1 = remainder // trailing
+        trailing_offset = remainder % trailing
 
         # out[i,j] = in[j, N-1-i] where i=out_dim0, j=out_dim1
         in_dim0 = out_dim1
         in_dim1 = n_minus_1 - out_dim0
 
         stride_0_in = n_elements // M
-        in_offset = in_dim0 * stride_0_in + in_dim1 * (stride_0_in // N)
+        in_offset = in_dim0 * stride_0_in + in_dim1 * trailing + trailing_offset
 
     elif k_norm == 2:
         # 180° - output same shape as input [M, N, ...]
         stride_0 = n_elements // M
         out_dim0 = offsets // stride_0
         remainder = offsets % stride_0
-        out_dim1 = remainder % N
+        out_dim1 = remainder // trailing
+        trailing_offset = remainder % trailing
 
         # out[i,j] = in[M-1-i, N-1-j]
         in_dim0 = m_minus_1 - out_dim0
         in_dim1 = n_minus_1 - out_dim1
 
         stride_0_in = n_elements // M
-        in_offset = in_dim0 * stride_0_in + in_dim1 * (stride_0_in // N)
+        in_offset = in_dim0 * stride_0_in + in_dim1 * trailing + trailing_offset
 
     else:  # k_norm == 3
         # 270° clockwise - output shape [N, M, ...]
         stride_0 = n_elements // N
         out_dim0 = offsets // stride_0
         remainder = offsets % stride_0
-        out_dim1 = remainder % M
+        out_dim1 = remainder // trailing
+        trailing_offset = remainder % trailing
 
         # out[i,j] = in[M-1-j, i]
         in_dim0 = m_minus_1 - out_dim1
         in_dim1 = out_dim0
 
         stride_0_in = n_elements // M
-        in_offset = in_dim0 * stride_0_in + in_dim1 * (stride_0_in // N)
+        in_offset = in_dim0 * stride_0_in + in_dim1 * trailing + trailing_offset
 
     x = tl.load(in_ptr + in_offset, mask=mask)
     tl.store(out_ptr + offsets, x, mask=mask)

--- a/tests/test_rot90.py
+++ b/tests/test_rot90.py
@@ -20,17 +20,18 @@ import flag_gems
 from . import accuracy_utils as utils
 from . import conftest as cfg
 
-# rot90 test shapes - only 2D for now since the kernel only handles 2D case
+# rot90 test shapes - the rotation plane is dims=[0, 1]; higher-rank shapes
+# check that the trailing dims are carried through unchanged
 if cfg.QUICK_MODE:
-    ROT90_SHAPES_2D = [(2, 3), (100, 128)]
+    ROT90_SHAPES = [(2, 3), (100, 128), (2, 3, 2), (16, 24, 3, 5)]
     ROT90_K_VALUES = [0, 1, -1]
 else:
-    ROT90_SHAPES_2D = [(2, 3), (5, 7), (100, 128)]
+    ROT90_SHAPES = [(2, 3), (5, 7), (100, 128), (2, 3, 2), (5, 7, 3), (16, 24, 3, 5)]
     ROT90_K_VALUES = [0, 1, 2, 3, -1, -2]
 
 
 @pytest.mark.rot90
-@pytest.mark.parametrize("shape", ROT90_SHAPES_2D)
+@pytest.mark.parametrize("shape", ROT90_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
 @pytest.mark.parametrize("k", ROT90_K_VALUES)
 def test_rot90(shape, dtype, k):


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description

`rot90_kernel_2d` decodes the flat output index into only two coordinates: for an input of shape `(M, N, *trailing)` it recovers the second coordinate with `remainder % M` (or `% N`) instead of `remainder // trailing`, and never adds the position inside the trailing dims to the input offset. Both mistakes are no-ops exactly when the input is 2-D, and the op is registered as the aten `rot90` override with no rank guard — so under `use_gems()` every 3-D or higher input returns a tensor of the right shape with wrong contents, for every `k`, including the identity `k=0`.

Changes:

- `src/flag_gems/ops/rot90.py`: compute `trailing = n_elements // (M * N)` (the product of the dims after the rotation plane, 1 for 2-D), decode `out_dim1 = remainder // trailing` and `trailing_offset = remainder % trailing`, and add `trailing_offset` to the input offset — in all four `k` branches. The kernel signature and the wrapper are unchanged.
- `tests/test_rot90.py`: add 3-D and 4-D shapes (`(2, 3, 2)`, `(5, 7, 3)`, `(16, 24, 3, 5)`) to the parametrization; drop the "only 2D for now" restriction comment.

Against eager `torch.rot90`, fp32:

| case | before | after |
|---|---|---|
| `rot90(arange(12).reshape(2,3,2), 0)` — identity | 10/12 elements wrong | exact |
| `rot90(arange(12).reshape(2,3,2), k)` for k=1,2,3 | all wrong | exact |
| `rot90(randn(32,32,3,16), 1)` | 49120/49152 elements wrong, max abs diff 5.70 | exact |

Tests: the existing suite only used 2-D shapes, the one regime where the two decode errors cancel. With the kernel change reverted, all 54 new higher-rank cases in `tests/test_rot90.py` fail; with it, all 108 pass.

### Issue

Resolves #5226

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

2-D inputs (`trailing == 1`, identical memory traffic before/after) are unaffected: interleaved `triton.testing.do_bench` x3 on an L40S for `(4096, 4096)` fp32 gives k=1: 0.3395–0.3403 ms before vs 0.3345–0.3358 ms after; k=2: 0.2156–0.2158 ms vs 0.2151–0.2157 ms — noise. The new decode adds one integer div/mod pair but drops a division from the offset composition.

### Environment

- FlagGems master (75cf3ea)
- NVIDIA L40S and H100 NVL
- torch 2.6.0+cu124, triton 3.2.0
