### PR TITLE
Fix nearest-exact upsampling using the plain-nearest index formula

### DIFF
--- a/src/flag_gems/ops/_upsample_nearest_exact1d.py
+++ b/src/flag_gems/ops/_upsample_nearest_exact1d.py
@@ -39,8 +39,7 @@ def _upsample_nearest_exact1d_kernel(
     sN_out,
     sC_out,
     sW_out,
-    use_scales: tl.constexpr,
-    scale_w,
+    reciprocal_scale_w,
     BLOCK_W: tl.constexpr,
 ):
     pid_w = tl.program_id(0)
@@ -57,14 +56,11 @@ def _upsample_nearest_exact1d_kernel(
     base_in = n * sN_in + c * sC_in
     base_out = n * sN_out + c * sC_out
 
-    # Compute source indices iw for each output index ow
-    iw = tl.zeros([BLOCK_W], dtype=tl.int32)
-    if use_scales:
-        ow_f = offs_w.to(tl.float32)
-        iw_f = tl.floor(ow_f / scale_w)
-        iw = iw_f.to(tl.int32)
-    else:
-        iw = (offs_w * IW) // OW
+    # Compute source indices iw for each output index ow, using the
+    # "nearest exact" formula from PyTorch:
+    # src_index = min(floor((dst_index + 0.5) * (IW / OW)), IW - 1)
+    iw_f = tl.floor((offs_w.to(tl.float32) + 0.5) * reciprocal_scale_w)
+    iw = iw_f.to(tl.int32)
     iw = tl.minimum(iw, IW - 1)
 
     in_ptrs = in_ptr + base_in + iw * sW_in
@@ -127,8 +123,11 @@ def _launch_upsample_nearest_exact1d_kernel(input, out, output_size=None, scale=
     BLOCK_W = 256
     grid = (triton.cdiv(OW, BLOCK_W), N * C)
 
+    # The source-index formula uses the IW / OW ratio; a given scale factor is
+    # OW / IW, so its reciprocal is that ratio. Computed here, in the same
+    # order as ATen, so the float rounding matches.
     use_scales = scale is not None and output_size is None
-    scale_w = float(scale) if use_scales else 1.0
+    reciprocal_scale_w = 1.0 / float(scale) if use_scales else IW / OW
 
     _upsample_nearest_exact1d_kernel[grid](
         input,
@@ -143,8 +142,7 @@ def _launch_upsample_nearest_exact1d_kernel(input, out, output_size=None, scale=
         sN_out,
         sC_out,
         sW_out,
-        use_scales=use_scales,
-        scale_w=scale_w,
+        reciprocal_scale_w=reciprocal_scale_w,
         BLOCK_W=BLOCK_W,
     )
     return out

--- a/src/flag_gems/ops/_upsample_nearest_exact2d.py
+++ b/src/flag_gems/ops/_upsample_nearest_exact2d.py
@@ -27,9 +27,8 @@ def _upsample_nearest_exact2d_kernel(
     sC_out,
     sH_out,
     sW_out,
-    use_scales: tl.constexpr,
-    scale_h,
-    scale_w,
+    reciprocal_scale_h,
+    reciprocal_scale_w,
     BLOCK_SIZE: tl.constexpr,
 ):
     pid = tl.program_id(axis=0)
@@ -41,13 +40,11 @@ def _upsample_nearest_exact2d_kernel(
     ow = idx % OW
     oh = idx // OW % OH
 
-    # Compute source indices ih, iw for each output index oh, ow
-    if use_scales:
-        ih = tl.floor(oh.to(tl.float32) / scale_h).to(tl.int32)
-        iw = tl.floor(ow.to(tl.float32) / scale_w).to(tl.int32)
-    else:
-        ih = (oh * IH) // OH
-        iw = (ow * IW) // OW
+    # Compute source indices ih, iw for each output index oh, ow, using the
+    # "nearest exact" formula from PyTorch:
+    # src_index = min(floor((dst_index + 0.5) * (IN / OUT)), IN - 1)
+    ih = tl.floor((oh.to(tl.float32) + 0.5) * reciprocal_scale_h).to(tl.int32)
+    iw = tl.floor((ow.to(tl.float32) + 0.5) * reciprocal_scale_w).to(tl.int32)
     ih = tl.minimum(ih, IH - 1)
     iw = tl.minimum(iw, IW - 1)
 
@@ -139,9 +136,12 @@ def _launch_upsample_nearest_exact2d_kernel(input, out, output_size=None, scale=
         triton.cdiv(N * C, 4),
     )
 
+    # The source-index formula uses the IN / OUT ratio; a given scale factor is
+    # OUT / IN, so its reciprocal is that ratio. Computed here, in the same
+    # order as ATen, so the float rounding matches.
     use_scales = scale is not None and output_size is None
-    scale_h = float(scale[0]) if use_scales else 1.0
-    scale_w = float(scale[1]) if use_scales else 1.0
+    reciprocal_scale_h = 1.0 / float(scale[0]) if use_scales else IH / OH
+    reciprocal_scale_w = 1.0 / float(scale[1]) if use_scales else IW / OW
 
     _upsample_nearest_exact2d_kernel[grid](
         input,
@@ -160,9 +160,8 @@ def _launch_upsample_nearest_exact2d_kernel(input, out, output_size=None, scale=
         out.stride(1),
         out.stride(2),
         out.stride(3),
-        use_scales=use_scales,
-        scale_h=scale_h,
-        scale_w=scale_w,
+        reciprocal_scale_h=reciprocal_scale_h,
+        reciprocal_scale_w=reciprocal_scale_w,
         BLOCK_SIZE=BLOCK_SIZE,
     )
     return out

--- a/src/flag_gems/ops/_upsample_nearest_exact2d_backward.py
+++ b/src/flag_gems/ops/_upsample_nearest_exact2d_backward.py
@@ -55,9 +55,10 @@ def _upsample_nearest_exact2d_backward_kernel(
     ow = idx % OW
     oh = idx // OW
 
-    # Compute corresponding input indices
-    ih = (oh * reciprocal_scale_h).to(tl.int32)
-    iw = (ow * reciprocal_scale_w).to(tl.int32)
+    # Compute corresponding input indices, using the "nearest exact" formula
+    # from PyTorch: src_index = min(floor((dst_index + 0.5) * (IN / OUT)), IN - 1)
+    ih = tl.floor((oh.to(tl.float32) + 0.5) * reciprocal_scale_h).to(tl.int32)
+    iw = tl.floor((ow.to(tl.float32) + 0.5) * reciprocal_scale_w).to(tl.int32)
 
     # Clamp to valid range
     ih = tl.minimum(ih, IH - 1)

--- a/tests/test_upsample_nearest_exact1d.py
+++ b/tests/test_upsample_nearest_exact1d.py
@@ -29,11 +29,11 @@ else:
 @pytest.mark.upsample_nearest_exact1d
 @pytest.mark.parametrize("shape", UPSAMPLE_NEAREST1D_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
-@pytest.mark.parametrize("factor", [2, 3])
+@pytest.mark.parametrize("factor", [2, 3, 1.5, 2.5])
 def test_accuracy__upsample_nearest_exact1d(shape, dtype, factor):
     x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     ref_x = utils.to_reference(x)
-    out_size = [shape[-1] * factor]
+    out_size = [int(shape[-1] * factor)]
 
     ref_out = torch.ops.aten._upsample_nearest_exact1d(ref_x, out_size, None)
     with flag_gems.use_gems():

--- a/tests/test_upsample_nearest_exact2d.py
+++ b/tests/test_upsample_nearest_exact2d.py
@@ -9,11 +9,11 @@ from . import accuracy_utils as utils
 @pytest.mark.upsample_nearest_exact2d
 @pytest.mark.parametrize("shape", utils.UPSAMPLE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
-@pytest.mark.parametrize("factor", [2, 3])
+@pytest.mark.parametrize("factor", [2, 3, 1.5, 2.5])
 def test_upsample_nearest_exact2d(shape, dtype, factor):
     x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     ref_x = utils.to_reference(x)
-    out_size = [shape[2] * factor, shape[3] * factor]
+    out_size = [int(shape[2] * factor), int(shape[3] * factor)]
     ref_out = torch.ops.aten._upsample_nearest_exact2d(ref_x, out_size, None, None)
     with flag_gems.use_gems():
         res_out = torch.ops.aten._upsample_nearest_exact2d(x, out_size, None, None)
@@ -23,13 +23,13 @@ def test_upsample_nearest_exact2d(shape, dtype, factor):
 @pytest.mark.upsample_nearest_exact2d
 @pytest.mark.parametrize("shape", utils.UPSAMPLE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
-@pytest.mark.parametrize("factor", [2, 3])
+@pytest.mark.parametrize("factor", [2, 3, 1.5, 2.5])
 def test_upsample_nearest_exact2d_out(shape, dtype, factor):
     op_label = "_upsample_nearest_exact2d_out"
     assert op_label
     x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     ref_x = utils.to_reference(x)
-    out_size = [shape[2] * factor, shape[3] * factor]
+    out_size = [int(shape[2] * factor), int(shape[3] * factor)]
     out_shape = (shape[0], shape[1], out_size[0], out_size[1])
     ref_out = torch.empty(out_shape, dtype=dtype, device=ref_x.device)
     torch.ops.aten._upsample_nearest_exact2d.out(

--- a/tests/test_upsample_nearest_exact2d_backward.py
+++ b/tests/test_upsample_nearest_exact2d_backward.py
@@ -23,14 +23,15 @@ from . import accuracy_utils as utils
 @pytest.mark.upsample_nearest_exact2d_backward
 @pytest.mark.parametrize("shape", utils.UPSAMPLE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
-def test_upsample_nearest_exact2d_backward(shape, dtype):
+@pytest.mark.parametrize("factor", [2, 1.5])
+def test_upsample_nearest_exact2d_backward(shape, dtype, factor):
     # Create input tensor and upsample it to get output size
     x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     ref_x = utils.to_reference(x)
 
     # Forward pass to get output size
-    out_h = shape[2] * 2
-    out_w = shape[3] * 2
+    out_h = int(shape[2] * factor)
+    out_w = int(shape[3] * factor)
     output_size = (out_h, out_w)
 
     # Compute reference forward output using torch.ops.aten
@@ -59,14 +60,15 @@ def test_upsample_nearest_exact2d_backward(shape, dtype):
 @pytest.mark.upsample_nearest_exact2d_backward
 @pytest.mark.parametrize("shape", utils.UPSAMPLE_SHAPES)
 @pytest.mark.parametrize("dtype", utils.FLOAT_DTYPES)
-def test_upsample_nearest_exact2d_backward_with_scales(shape, dtype):
+@pytest.mark.parametrize("scale", [2.0, 1.5])
+def test_upsample_nearest_exact2d_backward_with_scales(shape, dtype, scale):
     # Test with explicit scales
     x = torch.randn(shape, dtype=dtype, device=flag_gems.device)
     ref_x = utils.to_reference(x)
 
     # Use scales instead of output_size
-    scale_h = 2.0
-    scale_w = 2.0
+    scale_h = scale
+    scale_w = scale
     out_h = int(shape[2] * scale_h)
     out_w = int(shape[3] * scale_w)
     output_size = (out_h, out_w)


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description

`nearest-exact` differs from `nearest` only by a half-pixel offset in the source index: `floor((dst + 0.5) * IN / OUT)` instead of `floor(dst * IN / OUT)`. The 1-D forward, 2-D forward and 2-D backward kernels for the `_upsample_nearest_exact*` ops all use the plain-`nearest` form, so under `use_gems()` those ops silently return `nearest` results and `nearest` gradients. The 3-D kernel already implements the correct law.

Changes:

- `src/flag_gems/ops/_upsample_nearest_exact1d.py`, `src/flag_gems/ops/_upsample_nearest_exact2d.py`: add the half pixel, and pass the `IN / OUT` ratio in from the host instead of branching on `use_scales` inside the kernel. ATen computes that ratio once as a `float` and then multiplies; forming it the same way keeps the rounding identical. Computing it in the kernel instead disagrees with ATen by one index at ratios such as `26 -> 11`, where the rounded ratio and the exact one fall on opposite sides of an integer.
- `src/flag_gems/ops/_upsample_nearest_exact2d_backward.py`: add the half pixel. This kernel already receives the ratio from the host.
- `tests/`: parametrize the three test files over non-integer factors as the 3-D test file already does. The backward tests were pinned to a 2x ratio in both directions.

Against eager ATen, fp32:

| case | before | after |
|---|---|---|
| 1-D `4 -> 6` | `[0, 0, 1, 2, 2, 3]`, i.e. the `nearest` result | `[0, 1, 1, 2, 3, 3]`, exact |
| 2-D `(2,3,12,12) -> (16,16)` | 672/1536 elements wrong | exact |
| 2-D backward `(1,1,3,3) <- (4,4)` | 16/18 cells wrong | exact |
| 2-D backward with `scales=1.5` | all 32 cells wrong | exact |

### Issue

Resolves #5228

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Performance

Neutral. The index math goes from an integer div/mod pair to one float multiply and a floor. Interleaved `triton.testing.do_bench` x3 on an L40S, fp32: 2-D `(32,16,128,128) -> (192,192)` 0.1962–0.1969 ms before vs 0.1961–0.1965 ms after; 2-D `(3,7,1023,1025) -> (1534,1537)` 0.4626–0.4628 ms vs 0.4626–0.4631 ms. Both within noise.

### Tests

The suites covered integer factors only (`[2, 3]` in the 1-D and 2-D files, a hard-coded 2x ratio in the backward file) — the one regime where the two laws agree. They now also run non-integer factors. With the three kernels reverted to their current form, 78 of the new cases fail; with the fix, all 216 pass.

Note that `test_upsample_nearest_exact2d_out` still passes either way: only the default overload is registered, so `torch.ops.aten._upsample_nearest_exact2d.out` runs eager ATen and that test compares eager against eager. Left as is here.

### Environment

- FlagGems master (75cf3ea)
- NVIDIA L40S and H100 NVL
- torch 2.6.0+cu124, triton 3.2.0
