### PR TITLE
Fix pdist int32 pair-count overflow and 1024-feature truncation

### DIFF
--- a/src/flag_gems/ops/pdist.py
+++ b/src/flag_gems/ops/pdist.py
@@ -37,6 +37,8 @@ def _pdist_forward_p2_kernel(
     stride_x,
     stride_out,
     BLOCK_M: tl.constexpr,
+    NUM_TILES: tl.constexpr,
+    WIDE_INDEX: tl.constexpr,
 ):
     """Forward kernel for p=2 (Euclidean distance) case."""
     # Each program handles one pair of rows
@@ -46,6 +48,12 @@ def _pdist_forward_p2_kernel(
     # pdist output indices: for row i, pairs are (i, i+1), (i, i+2), ..., (i, n-1)
     # Total pairs before row i: i * N - (i * (i + 1)) // 2
     # Within row i's pairs: j - i - 1
+
+    # The pair count and the pair decode overflow int32 once N*(N-1) exceeds
+    # 2^31 (N >= 46342). 64-bit arithmetic costs about 2x on this search, so
+    # the host requests it only when the 32-bit form would overflow.
+    if WIDE_INDEX:
+        N = N.to(tl.int64)
 
     # Binary search to find row i for this output index
     # N*(N-1)//2 total pairs
@@ -57,7 +65,10 @@ def _pdist_forward_p2_kernel(
     # Find which row this pair belongs to
     # We need smallest i such that i * N - (i * (i + 1)) // 2 > pid
     # This is the cumulative count of pairs up to row i-1
-    lo = 0
+    if WIDE_INDEX:
+        lo = tl.full([], 0, dtype=tl.int64)
+    else:
+        lo = 0
     hi = N - 1
     while lo < hi:
         mid = (lo + hi) // 2
@@ -67,31 +78,34 @@ def _pdist_forward_p2_kernel(
         else:
             hi = mid
 
-    i = lo - 1 if lo > 0 else 0
+    i = tl.maximum(lo - 1, 0)
     pairs_before_i = i * N - (i * (i + 1)) // 2
     j = pid - pairs_before_i + i + 1
 
     if i >= N or j >= N:
         return
 
-    # Load row i and row j
+    # Load row i and row j, accumulating over feature tiles: BLOCK_M is capped
+    # at 1024, so a single tile would silently drop every feature beyond it.
     i_offset = i * stride_x
     j_offset = j * stride_x
 
-    m_offsets = tl.arange(0, BLOCK_M)
-    m_mask = m_offsets < M
+    dist = 0.0
+    for tile in tl.static_range(NUM_TILES):
+        m_offsets = tile * BLOCK_M + tl.arange(0, BLOCK_M)
+        m_mask = m_offsets < M
 
-    xi_vals = tl.load(x_ptr + i_offset + m_offsets, mask=m_mask, other=0.0).to(
-        tl.float32
-    )
-    xj_vals = tl.load(x_ptr + j_offset + m_offsets, mask=m_mask, other=0.0).to(
-        tl.float32
-    )
+        xi_vals = tl.load(x_ptr + i_offset + m_offsets, mask=m_mask, other=0.0).to(
+            tl.float32
+        )
+        xj_vals = tl.load(x_ptr + j_offset + m_offsets, mask=m_mask, other=0.0).to(
+            tl.float32
+        )
 
-    # Compute Euclidean distance: sum((xi - xj)^2)
-    diff = xi_vals - xj_vals
-    sq_dist = diff * diff
-    dist = tl.sum(sq_dist, axis=0)
+        # Compute Euclidean distance: sum((xi - xj)^2)
+        diff = xi_vals - xj_vals
+        sq_dist = diff * diff
+        dist += tl.sum(sq_dist, axis=0)
     dist = tl.sqrt(dist)
 
     out_idx = pid * stride_out
@@ -108,16 +122,25 @@ def _pdist_forward_p1_kernel(
     stride_x,
     stride_out,
     BLOCK_M: tl.constexpr,
+    NUM_TILES: tl.constexpr,
+    WIDE_INDEX: tl.constexpr,
 ):
     """Forward kernel for p=1 (Manhattan distance) case."""
     pid = tle.program_id(0)
+
+    # 64-bit index arithmetic only when needed; see _pdist_forward_p2_kernel.
+    if WIDE_INDEX:
+        N = N.to(tl.int64)
 
     num_pairs = N * (N - 1) // 2
 
     if pid >= num_pairs:
         return
 
-    lo = 0
+    if WIDE_INDEX:
+        lo = tl.full([], 0, dtype=tl.int64)
+    else:
+        lo = 0
     hi = N - 1
     while lo < hi:
         mid = (lo + hi) // 2
@@ -127,7 +150,7 @@ def _pdist_forward_p1_kernel(
         else:
             hi = mid
 
-    i = lo - 1 if lo > 0 else 0
+    i = tl.maximum(lo - 1, 0)
     pairs_before_i = i * N - (i * (i + 1)) // 2
     j = pid - pairs_before_i + i + 1
 
@@ -137,19 +160,21 @@ def _pdist_forward_p1_kernel(
     i_offset = i * stride_x
     j_offset = j * stride_x
 
-    m_offsets = tl.arange(0, BLOCK_M)
-    m_mask = m_offsets < M
+    dist = 0.0
+    for tile in tl.static_range(NUM_TILES):
+        m_offsets = tile * BLOCK_M + tl.arange(0, BLOCK_M)
+        m_mask = m_offsets < M
 
-    xi_vals = tl.load(x_ptr + i_offset + m_offsets, mask=m_mask, other=0.0).to(
-        tl.float32
-    )
-    xj_vals = tl.load(x_ptr + j_offset + m_offsets, mask=m_mask, other=0.0).to(
-        tl.float32
-    )
+        xi_vals = tl.load(x_ptr + i_offset + m_offsets, mask=m_mask, other=0.0).to(
+            tl.float32
+        )
+        xj_vals = tl.load(x_ptr + j_offset + m_offsets, mask=m_mask, other=0.0).to(
+            tl.float32
+        )
 
-    # Compute Manhattan distance: sum(|xi - xj|)
-    diff = tl.abs(xi_vals - xj_vals)
-    dist = tl.sum(diff, axis=0)
+        # Compute Manhattan distance: sum(|xi - xj|)
+        diff = tl.abs(xi_vals - xj_vals)
+        dist += tl.sum(diff, axis=0)
 
     out_idx = pid * stride_out
     tl.store(out_ptr + out_idx, dist.to(out_ptr.dtype.element_ty))
@@ -165,16 +190,25 @@ def _pdist_forward_inf_kernel(
     stride_x,
     stride_out,
     BLOCK_M: tl.constexpr,
+    NUM_TILES: tl.constexpr,
+    WIDE_INDEX: tl.constexpr,
 ):
     """Forward kernel for p=inf (Chebyshev distance) case."""
     pid = tle.program_id(0)
+
+    # 64-bit index arithmetic only when needed; see _pdist_forward_p2_kernel.
+    if WIDE_INDEX:
+        N = N.to(tl.int64)
 
     num_pairs = N * (N - 1) // 2
 
     if pid >= num_pairs:
         return
 
-    lo = 0
+    if WIDE_INDEX:
+        lo = tl.full([], 0, dtype=tl.int64)
+    else:
+        lo = 0
     hi = N - 1
     while lo < hi:
         mid = (lo + hi) // 2
@@ -184,7 +218,7 @@ def _pdist_forward_inf_kernel(
         else:
             hi = mid
 
-    i = lo - 1 if lo > 0 else 0
+    i = tl.maximum(lo - 1, 0)
     pairs_before_i = i * N - (i * (i + 1)) // 2
     j = pid - pairs_before_i + i + 1
 
@@ -194,19 +228,21 @@ def _pdist_forward_inf_kernel(
     i_offset = i * stride_x
     j_offset = j * stride_x
 
-    m_offsets = tl.arange(0, BLOCK_M)
-    m_mask = m_offsets < M
+    dist = 0.0
+    for tile in tl.static_range(NUM_TILES):
+        m_offsets = tile * BLOCK_M + tl.arange(0, BLOCK_M)
+        m_mask = m_offsets < M
 
-    xi_vals = tl.load(x_ptr + i_offset + m_offsets, mask=m_mask, other=0.0).to(
-        tl.float32
-    )
-    xj_vals = tl.load(x_ptr + j_offset + m_offsets, mask=m_mask, other=0.0).to(
-        tl.float32
-    )
+        xi_vals = tl.load(x_ptr + i_offset + m_offsets, mask=m_mask, other=0.0).to(
+            tl.float32
+        )
+        xj_vals = tl.load(x_ptr + j_offset + m_offsets, mask=m_mask, other=0.0).to(
+            tl.float32
+        )
 
-    # Compute Chebyshev distance: max(|xi - xj|)
-    diff = tl.abs(xi_vals - xj_vals)
-    dist = tl.max(diff, axis=0)
+        # Compute Chebyshev distance: max(|xi - xj|)
+        diff = tl.abs(xi_vals - xj_vals)
+        dist = tl.maximum(dist, tl.max(diff, axis=0))
 
     out_idx = pid * stride_out
     tl.store(out_ptr + out_idx, dist.to(out_ptr.dtype.element_ty))
@@ -223,16 +259,25 @@ def _pdist_forward_general_kernel(
     stride_x,
     stride_out,
     BLOCK_M: tl.constexpr,
+    NUM_TILES: tl.constexpr,
+    WIDE_INDEX: tl.constexpr,
 ):
     """Forward kernel for general p value."""
     pid = tle.program_id(0)
+
+    # 64-bit index arithmetic only when needed; see _pdist_forward_p2_kernel.
+    if WIDE_INDEX:
+        N = N.to(tl.int64)
 
     num_pairs = N * (N - 1) // 2
 
     if pid >= num_pairs:
         return
 
-    lo = 0
+    if WIDE_INDEX:
+        lo = tl.full([], 0, dtype=tl.int64)
+    else:
+        lo = 0
     hi = N - 1
     while lo < hi:
         mid = (lo + hi) // 2
@@ -242,7 +287,7 @@ def _pdist_forward_general_kernel(
         else:
             hi = mid
 
-    i = lo - 1 if lo > 0 else 0
+    i = tl.maximum(lo - 1, 0)
     pairs_before_i = i * N - (i * (i + 1)) // 2
     j = pid - pairs_before_i + i + 1
 
@@ -252,27 +297,34 @@ def _pdist_forward_general_kernel(
     i_offset = i * stride_x
     j_offset = j * stride_x
 
-    m_offsets = tl.arange(0, BLOCK_M)
-    m_mask = m_offsets < M
+    acc = 0.0
+    for tile in tl.static_range(NUM_TILES):
+        m_offsets = tile * BLOCK_M + tl.arange(0, BLOCK_M)
+        m_mask = m_offsets < M
 
-    xi_vals = tl.load(x_ptr + i_offset + m_offsets, mask=m_mask, other=0.0).to(
-        tl.float32
-    )
-    xj_vals = tl.load(x_ptr + j_offset + m_offsets, mask=m_mask, other=0.0).to(
-        tl.float32
-    )
+        xi_vals = tl.load(x_ptr + i_offset + m_offsets, mask=m_mask, other=0.0).to(
+            tl.float32
+        )
+        xj_vals = tl.load(x_ptr + j_offset + m_offsets, mask=m_mask, other=0.0).to(
+            tl.float32
+        )
 
-    # Compute p-norm distance
-    diff = tl.abs(xi_vals - xj_vals)
+        # Compute p-norm distance
+        diff = tl.abs(xi_vals - xj_vals)
 
-    # For p=0 (Hamming-like), count non-zero elements
+        # For p=0 (Hamming-like), count non-zero elements
+        if p_val == 0.0:
+            acc += tl.sum(tl.where(diff != 0.0, 1.0, 0.0), axis=0)
+        else:
+            # General case: accumulate sum(|diff|^p)
+            powered = tl.where(diff > 0.0, tl.exp(p_val * tl.log(diff)), 0.0)
+            acc += tl.sum(powered, axis=0)
+
     if p_val == 0.0:
-        dist = tl.sum(tl.where(diff != 0.0, 1.0, 0.0), axis=0)
+        dist = acc
     else:
-        # General case: (sum(|diff|^p))^(1/p)
-        powered = tl.where(diff > 0.0, tl.exp(p_val * tl.log(diff)), 0.0)
-        sum_powered = tl.sum(powered, axis=0)
-        dist = tl.where(sum_powered > 0.0, tl.exp(tl.log(sum_powered) / p_val), 0.0)
+        # (sum(|diff|^p))^(1/p)
+        dist = tl.where(acc > 0.0, tl.exp(tl.log(acc) / p_val), 0.0)
 
     out_idx = pid * stride_out
     tl.store(out_ptr + out_idx, dist.to(out_ptr.dtype.element_ty))
@@ -306,6 +358,10 @@ def pdist(x, p=2.0):
     out = torch.empty(num_pairs, dtype=x.dtype, device=x.device)
 
     BLOCK_M = min(triton.next_power_of_2(M), 1024)
+    # One program per pair reads the whole feature axis in NUM_TILES tiles.
+    # The pair-index arithmetic must go 64-bit once N * (N - 1) overflows int32.
+    NUM_TILES = triton.cdiv(M, BLOCK_M)
+    WIDE_INDEX = N * (N - 1) >= 2**31
 
     with torch_device_fn.device(x.device):
         if p == 2.0:
@@ -317,6 +373,8 @@ def pdist(x, p=2.0):
                 x.stride(0),
                 out.stride(0),
                 BLOCK_M=BLOCK_M,
+                NUM_TILES=NUM_TILES,
+                WIDE_INDEX=WIDE_INDEX,
             )
         elif p == 1.0:
             _pdist_forward_p1_kernel[(num_pairs,)](
@@ -327,6 +385,8 @@ def pdist(x, p=2.0):
                 x.stride(0),
                 out.stride(0),
                 BLOCK_M=BLOCK_M,
+                NUM_TILES=NUM_TILES,
+                WIDE_INDEX=WIDE_INDEX,
             )
         elif math.isinf(p):
             _pdist_forward_inf_kernel[(num_pairs,)](
@@ -337,6 +397,8 @@ def pdist(x, p=2.0):
                 x.stride(0),
                 out.stride(0),
                 BLOCK_M=BLOCK_M,
+                NUM_TILES=NUM_TILES,
+                WIDE_INDEX=WIDE_INDEX,
             )
         else:
             _pdist_forward_general_kernel[(num_pairs,)](
@@ -348,6 +410,8 @@ def pdist(x, p=2.0):
                 x.stride(0),
                 out.stride(0),
                 BLOCK_M=BLOCK_M,
+                NUM_TILES=NUM_TILES,
+                WIDE_INDEX=WIDE_INDEX,
             )
 
     return out

--- a/tests/test_pdist.py
+++ b/tests/test_pdist.py
@@ -2,15 +2,18 @@ import pytest
 import torch
 
 import flag_gems
+from flag_gems.utils import get_device_properties
 
 from . import accuracy_utils as utils
 
 # pdist CUDA kernel only supports float32; Half/BFloat16 raise RuntimeError
 PDIST_SHAPES = utils.PDIST_SHAPES
+# Wider than the kernels' 1024-lane feature tile, so the tile loop is exercised
+PDIST_WIDE_SHAPES = [(2, 1025), (8, 2048), (16, 4100)]
 
 
 @pytest.mark.pdist
-@pytest.mark.parametrize("shape", PDIST_SHAPES)
+@pytest.mark.parametrize("shape", PDIST_SHAPES + PDIST_WIDE_SHAPES)
 # pdist CUDA kernel only supports float32; Half/BFloat16 raise RuntimeError
 @pytest.mark.parametrize("dtype", [torch.float32])
 def test_pdist(shape, dtype):
@@ -28,7 +31,7 @@ def test_pdist(shape, dtype):
 
 
 @pytest.mark.pdist
-@pytest.mark.parametrize("shape", PDIST_SHAPES)
+@pytest.mark.parametrize("shape", PDIST_SHAPES + PDIST_WIDE_SHAPES)
 # pdist CUDA kernel only supports float32; Half/BFloat16 raise RuntimeError
 @pytest.mark.parametrize("dtype", [torch.float32])
 def test_pdist_p1(shape, dtype):
@@ -46,7 +49,7 @@ def test_pdist_p1(shape, dtype):
 
 
 @pytest.mark.pdist
-@pytest.mark.parametrize("shape", PDIST_SHAPES)
+@pytest.mark.parametrize("shape", PDIST_SHAPES + PDIST_WIDE_SHAPES)
 # pdist CUDA kernel only supports float32; Half/BFloat16 raise RuntimeError
 @pytest.mark.parametrize("dtype", [torch.float32])
 def test_pdist_pinf(shape, dtype):
@@ -64,7 +67,7 @@ def test_pdist_pinf(shape, dtype):
 
 
 @pytest.mark.pdist
-@pytest.mark.parametrize("shape", PDIST_SHAPES)
+@pytest.mark.parametrize("shape", PDIST_SHAPES + PDIST_WIDE_SHAPES)
 # pdist CUDA kernel only supports float32; Half/BFloat16 raise RuntimeError
 @pytest.mark.parametrize("dtype", [torch.float32])
 def test_pdist_p_general(shape, dtype):
@@ -82,7 +85,7 @@ def test_pdist_p_general(shape, dtype):
 
 
 @pytest.mark.pdist
-@pytest.mark.parametrize("shape", PDIST_SHAPES)
+@pytest.mark.parametrize("shape", PDIST_SHAPES + PDIST_WIDE_SHAPES)
 # pdist CUDA kernel only supports float32; Half/BFloat16 raise RuntimeError
 @pytest.mark.parametrize("dtype", [torch.float32])
 def test_pdist_p0(shape, dtype):
@@ -100,7 +103,7 @@ def test_pdist_p0(shape, dtype):
 
 
 @pytest.mark.pdist
-@pytest.mark.parametrize("shape", PDIST_SHAPES)
+@pytest.mark.parametrize("shape", PDIST_SHAPES + PDIST_WIDE_SHAPES)
 # pdist CUDA kernel only supports float32; Half/BFloat16 raise RuntimeError
 @pytest.mark.parametrize("dtype", [torch.float32])
 def test_pdist_p_large(shape, dtype):
@@ -115,3 +118,28 @@ def test_pdist_p_large(shape, dtype):
         res_out = torch.pdist(inp, p=p)
 
     utils.gems_assert_close(res_out, ref_out, dtype)
+
+
+@pytest.mark.pdist
+@pytest.mark.skipif(
+    get_device_properties(0).total_memory < (16 * 1024**3),
+    reason="the pdist output alone is 4.3 GB at this row count",
+)
+def test_pdist_pair_count_beyond_int32():
+    # N * (N - 1) exceeds int32 here; with 32-bit pair arithmetic the kernels
+    # returned without writing a single element. Spot-check pairs against
+    # directly computed distances rather than materializing a second 4.3 GB
+    # reference; the last pair only decodes correctly with 64-bit indexing.
+    N = 46342
+    x = torch.randn(N, 1, dtype=torch.float32, device=flag_gems.device)
+    with flag_gems.use_gems():
+        res = torch.pdist(x)
+
+    assert res.numel() == N * (N - 1) // 2
+    xf = x.flatten()
+
+    def flat_index(i, j):
+        return i * N - (i * (i + 1)) // 2 + (j - i - 1)
+
+    for i, j in [(0, 1), (23170, 23171), (0, N - 1), (N - 2, N - 1)]:
+        torch.testing.assert_close(res[flat_index(i, j)], (xf[i] - xf[j]).abs())


### PR DESCRIPTION
### PR Category
Operator

### Type of Change
Bug Fix

### Description

Two silent-corruption bugs in the four `_pdist_forward_*_kernel`s of `src/flag_gems/ops/pdist.py` (the `pdist` aten override; the newer `_pdist_forward.py` op in the same directory has neither):

1. Each kernel recomputes `num_pairs = N * (N - 1) // 2` from its 32-bit `N` argument, and decodes the pair index with the same 32-bit products. At `N >= 46342` the product wraps negative, the guard `pid >= num_pairs` is true for every program, and the caller silently receives the raw `torch.empty` allocation.
2. The feature axis is read as a single tile capped at `BLOCK_M = 1024`, with no loop over further tiles, so every feature beyond the 1024th is silently dropped from the distances.

Changes:

- 64-bit pair-index arithmetic, gated behind a `WIDE_INDEX: tl.constexpr` the host sets only when `N * (N - 1) >= 2**31`. The gate matters: measured on the row binary search, unconditional 64-bit arithmetic costs about 2x on narrow inputs, while with the gate the shipped int32 fast path compiles as before.
- The feature axis is accumulated over `tl.static_range(NUM_TILES)` tiles (`NUM_TILES = cdiv(M, BLOCK_M)`, constexpr). At one tile — every width that worked before — the loop unrolls to the original straight-line body; multiple tiles only occur where the old kernel truncated. Same pattern as `_pdist_forward.py` and `_euclidean_dist.py`.
- The pair decode's `i = lo - 1 if lo > 0 else 0` became the equivalent `i = tl.maximum(lo - 1, 0)` so the expression types check under both index widths.
- `tests/test_pdist.py`: three wider-than-1024 shapes added to all six p-norm tests, plus a pair-count test at `N = 46342` (skipped below 16 GB device memory) that spot-checks pairs — including the last one, whose index only decodes correctly in 64-bit — against directly computed distances.

Verification through public `torch.pdist` under `use_gems()`:

| case | before | after |
|---|---|---|
| `(46342, 4)` — pair count past int32 | all 1,073,767,311 output cells left uninitialized (allocator sentinel intact), max err vs eager 1.24e+04 | every cell written, max err 9.5e-07 |
| `(46341, 4)` — one row below the threshold, control | correct | correct |
| `(2, 1025)` | bit-identical to `torch.pdist` over only the first 1024 features | matches eager (diff 4e-06) |
| `(64, 2048)` / `(64, 4096)` | max err 21.7 / 48.2 (values ~64 / ~90) | 0 / 0 |

### Issue

Resolves #5232, resolves #5233

### Progress

- [ ] Change is properly reviewed (1 reviewer required, 2 recommended).
- [x] Change is responded to an issue.
- [x] Change is fully covered by a UT.

### Tests

`PDIST_SHAPES` stops at `(128, 256)` — the largest tested width is four times below the tile cap and the largest row count 360 times below the overflow threshold, which is why both bugs shipped. With only the kernel file reverted to master, 15 of the new cases fail (the wide shapes across p = 2, 1, 0, inf and 3 — p = 100 is max-like, so a dropped tail rarely moves it past tolerance — plus the pair-count test); with the fix, the file's 55 tests all pass.

### Performance

`triton.testing.do_bench` on `torch.pdist` under `use_gems()`, fp32, L40S, three interleaved runs per variant. The first three widths fit one tile, so before/after do identical memory traffic:

| shape | before (ms) | after (ms) |
|---|---|---|
| (4096, 64) | 7.632 / 7.543 / 7.369 | 7.522 / 7.600 / 7.516 |
| (1024, 256) | 0.4363 / 0.4362 / 0.4354 | 0.4364 / 0.4346 / 0.4346 |
| (2048, 1024) | 2.492 / 2.504 / 2.484 | 2.488 / 2.406 / 2.446 |
| (128, 4096) | 0.0163 / 0.0161 / 0.0158 | 0.0448 / 0.0438 / 0.0439 |

The first three rows are within noise. The `(128, 4096)` increase is the fix itself: the old kernel read only the first quarter of each feature vector; the new one reads all of it.

### Environment

- FlagGems master (75cf3ea)
- NVIDIA L40S
- torch 2.6.0+cu124, triton 3.2.0
