### PR TITLE
Fix IX gate by pinning numpy version < 2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,6 +108,7 @@ iluvatar = [
     "torch==2.7.1+corex.4.4.0",
     "torchaudio==2.7.1+corex.4.4.0",
     "torchvision==0.22.1+corex.4.4.0",
+    "numpy<2",
 ]
 
 kunlunxin = [

--- a/src/flag_gems/backends.yaml
+++ b/src/flag_gems/backends.yaml
@@ -146,6 +146,7 @@ backends:
       - torch==2.7.1+corex.4.4.0
       - torchaudio==2.7.1+corex.4.4.0
       - torchvision==0.22.1+corex.4.4.0
+      - numpy<2
 
   kunlunxin:
     python: "3.10"


### PR DESCRIPTION
### PR Category

CI/CD

### Type of Change

Bug Fix

### Description

Ping numpy to <2 for iluvatar backend for CI.