### PR TITLE
Bump wheel version for CVE

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@
 # Combined with the setuptools<77 pin above, `pip install .` then fails during
 # "Getting requirements to build wheel" with
 # `AttributeError: ignore_egg_info_in_manifest`. 9.x has no such integration.
-requires = ["setuptools>=64.0,<77", "setuptools-scm>=8,<10", "wheel==0.45.0"]
+requires = ["setuptools>=64.0,<77", "setuptools-scm>=8,<10", "wheel==0.46.2"]
 
 build-backend = "setuptools.build_meta"
 


### PR DESCRIPTION
### PR Category

Other

### Type of Change

Other

### Description

The wheel version we pinned has a known CVE (Path Traversal (CWE-22) leading to Arbitrary File Permission Modification.), so we have to bump it.